### PR TITLE
Fix missing check for deleted default constructor in template specializations

### DIFF
--- a/src/AstNodeTypes.h
+++ b/src/AstNodeTypes.h
@@ -2577,6 +2577,15 @@ public:
 		return enclosing_class_;
 	}
 
+	// Deleted special member function tracking
+	void mark_deleted_default_constructor() { has_deleted_default_constructor_ = true; }
+	void mark_deleted_copy_constructor() { has_deleted_copy_constructor_ = true; }
+	void mark_deleted_move_constructor() { has_deleted_move_constructor_ = true; }
+
+	bool has_deleted_default_constructor() const { return has_deleted_default_constructor_; }
+	bool has_deleted_copy_constructor() const { return has_deleted_copy_constructor_; }
+	bool has_deleted_move_constructor() const { return has_deleted_move_constructor_; }
+
 	bool is_nested() const {
 		return enclosing_class_ != nullptr;
 	}
@@ -2614,6 +2623,9 @@ private:
 	bool is_class_;  // true for class, false for struct
 	bool is_union_;  // true for union, false for struct/class
 	bool is_final_ = false;  // true if declared with 'final' keyword
+	bool has_deleted_default_constructor_ = false;  // Track deleted default constructor
+	bool has_deleted_copy_constructor_ = false;     // Track deleted copy constructor
+	bool has_deleted_move_constructor_ = false;     // Track deleted move constructor
 	std::vector<DeferredStaticAssert> deferred_static_asserts_;  // Static_asserts deferred during template definition
 };
 

--- a/tests/test_template_spec_deleted_ctor_fail.cpp
+++ b/tests/test_template_spec_deleted_ctor_fail.cpp
@@ -1,0 +1,21 @@
+// Test that template specializations with deleted default constructors
+// cannot be instantiated with empty initializer lists
+// This is a _fail test - it should fail to compile
+
+template<typename T>
+struct Foo {
+    int value;
+};
+
+// Specialization with deleted default constructor
+template<typename T>
+struct Foo<T*> {
+    Foo() = delete;
+    int value = 42;
+};
+
+int main() {
+    // This should be a compile error - attempting to use deleted default constructor
+    Foo<int*> f{};
+    return 0;
+}


### PR DESCRIPTION
The template specialization handling code was missing a check for deleted
default constructors when determining whether to allow empty brace initialization.

Problem:
- Empty initializer lists ({}) on template specializations with deleted default
  constructors were incorrectly allowed
- The code would either generate a trivial constructor or use direct member
  initialization, both of which should not be allowed for deleted constructors

Changes:
1. Added deleted constructor tracking to StructDeclarationNode AST (AstNodeTypes.h:2580-2629)
   - Added has_deleted_default_constructor_, has_deleted_copy_constructor_,
     has_deleted_move_constructor_ fields
   - Added mark_deleted_*() and has_deleted_*() methods

2. Updated partial specialization parsing to mark deleted constructors (Parser.cpp:29045-29102)
   - Detect deleted constructors during parsing
   - Mark the AST node appropriately based on constructor type
   - Copy deleted constructor flags from pattern AST node to struct_info during
     template instantiation (Parser.cpp:37899-37940)

3. Added checks in code generation (CodeGen.h:818, 6433-6438)
   - Prevent trivial constructor generation for structs with deleted default constructors
   - Error when attempting to default-initialize a struct with deleted default constructor
   - Check in special case for empty initializer lists (line 6180)

Test case:
- tests/test_template_spec_deleted_ctor_fail.cpp validates the fix

https://claude.ai/code/session_01Fyifp5JB6hbacY2PjjE5wH
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/608">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
