### PR TITLE
Fix runtime crash when using reference casts with struct types

### DIFF
--- a/tests/EXPECTED_RETURN_VALUES.md
+++ b/tests/EXPECTED_RETURN_VALUES.md
@@ -11,9 +11,9 @@ Many test files in the `tests/` directory follow the naming convention `test_nam
 **Last Run:** 2026-01-29
 
 **Total files tested:** 961
-**Valid returns:** 947
+**Valid returns:** 948
 **Return mismatches:** 12
-**Runtime crashes:** 2
+**Runtime crashes:** 1
 **Ignored files:** 0
 **Compile failures:** 0
 **Link failures:** 0
@@ -37,7 +37,6 @@ Many test files in the `tests/` directory follow the naming convention `test_nam
 ## Runtime Crashes
 
   test_exceptions_nested_ret0.cpp
-  test_xvalue_all_casts_ret0.cpp
 
 ## Notes
 


### PR DESCRIPTION
This commit fixes a crash in test_xvalue_all_casts_ret0.cpp when using
reference initialization and dynamic_cast with derived class references.

The fix addresses three issues:

1. Reference variable initialization from struct types:
   - References were incorrectly going through the copy constructor path
   - Fixed by excluding references from is_copy_init_for_struct check
   - Now uses LValueAddress context to get address of initializer

2. dynamic_cast to reference types:
   - Source expression was being dereferenced when it should use address
   - Fixed by using LValueAddress context for reference target types

3. dynamic_cast result size for references:
   - Was returning struct size instead of pointer size (64 bits)
   - Fixed by returning 64-bit size for reference cast results

https://claude.ai/code/session_01HtUzUoQ6q6npLkSDn267KL
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/609">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
