### PR TITLE
Refactor C++ cast operators to eliminate code duplication

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -759,6 +759,16 @@ public:  // Public methods for template instantiation
         ParseResult parse_postfix_expression(ExpressionContext context);  // Phase 3: New postfix operator layer
         ParseResult apply_postfix_operators(ASTNode& result);  // Apply postfix operators (., ->, [], (), ++, --) to existing result
         ParseResult parse_unary_expression(ExpressionContext context);
+
+        // C++ cast operators helper
+        enum class CppCastKind {
+            Static,
+            Dynamic,
+            Const,
+            Reinterpret
+        };
+        ParseResult parse_cpp_cast_expression(CppCastKind kind, std::string_view cast_name, const Token& cast_token);
+
         ParseResult parse_qualified_identifier();  // Parse namespace::identifier
         ParseResult parse_qualified_identifier_after_template(const Token& template_base_token, bool* had_template_keyword = nullptr);  // Parse Template<T>::member
         


### PR DESCRIPTION
Consolidate the parsing logic for static_cast, dynamic_cast, const_cast,
and reinterpret_cast into a unified helper function parse_cpp_cast_expression().
The four cast operators had nearly identical implementations with ~70 lines
of duplicated code each.

Changes:
- Add CppCastKind enum to represent the four cast types
- Implement parse_cpp_cast_expression() helper in Parser.cpp
- Update all four cast operator handlers to use the new helper
- Net reduction of 149 lines of code (243 removed, 94 added)

All existing tests pass with expected exit codes.

https://claude.ai/code/session_01GNcgKfAAxNmKEPGFMpf4Em
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/619">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
