### PR TITLE
[Sonnet4.5] Fixed the bug where member function calls from within other member functions didn't pass the this pointer

### DIFF
--- a/tests/test_base_class_member_function_call.cpp
+++ b/tests/test_base_class_member_function_call.cpp
@@ -1,0 +1,29 @@
+// Test: Base class member function calls from derived class member functions should receive implicit 'this'
+
+struct Base {
+    int value;
+    
+    int getValue() {
+        return value;
+    }
+    
+    void setValue(int v) {
+        value = v;
+    }
+};
+
+struct Derived : Base {
+    int multiplier;
+    
+    int compute() {
+        setValue(10);        // Call base class member function - should pass 'this'
+        return getValue() * multiplier;  // Call base class member function - should pass 'this'
+    }
+};
+
+int main() {
+    Derived d;
+    d.multiplier = 5;
+    int result = d.compute();
+    return result;  // Should return 50 (10 * 5)
+}


### PR DESCRIPTION
Root Cause: When register_member_functions_in_scope() added all member functions to the symbol table during delayed parsing, the parser's symbol lookup would find these functions and set identifierType. However, the code that detected member function calls with implicit this was inside an if (!identifierType) block, so it never ran when the function was already in the symbol table.

Solution: Added code at line 20747-20774 that:

Detects when we're in a member function context and the identifier is a member function (even when identifierType is already set) Sets a found_member_function_in_context flag
Immediately handles the function call by:
Consuming the ( token
Parsing the function arguments
Creating an implicit this expression
Creating a MemberFunctionCallNode with the implicit this as the object Returning the result
This ensures that member function calls like add() and multiply() from within compute() are correctly recognized as member function calls with implicit this, and the this pointer is passed as the first argument in the generated IR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/639">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
