### PR TITLE
Fixed array-to-pointer decay and improved built-in (w)char_t types

### DIFF
--- a/src/AstNodeTypes.h
+++ b/src/AstNodeTypes.h
@@ -106,11 +106,27 @@ enum class ReferenceQualifier : uint8_t {
 	RValueReference = 1 << 1,  // &&
 };
 
+// Target data model - controls the size of 'long' and 'wchar_t' types
+// Windows uses LLP64: long is 32-bit, wchar_t is 16-bit unsigned
+// Linux/Unix uses LP64: long is 64-bit, wchar_t is 32-bit signed
+enum class TargetDataModel {
+	LLP64,     // Windows x64: long = 32 bits, wchar_t = 16 bits unsigned (COFF)
+	LP64       // Linux/Unix x64: long = 64 bits, wchar_t = 32 bits signed (ELF)
+};
+
+// Global data model setting - set by main.cpp based on target platform
+// Default is platform-dependent
+extern TargetDataModel g_target_data_model;
+
 enum class Type : int_fast16_t {
 	Void,
 	Bool,
 	Char,
 	UnsignedChar,
+	WChar,             // wchar_t - distinct built-in type (mangled as 'w')
+	Char8,             // char8_t (C++20) - distinct built-in type (mangled as 'Du')
+	Char16,            // char16_t (C++11) - distinct built-in type (mangled as 'Ds')
+	Char32,            // char32_t (C++11) - distinct built-in type (mangled as 'Di')
 	Short,
 	UnsignedShort,
 	Int,
@@ -152,6 +168,10 @@ inline std::string_view getTypeName(Type t) {
 		case Type::UnsignedShort: return "unsigned short";
 		case Type::Char: return "char";
 		case Type::UnsignedChar: return "unsigned char";
+		case Type::WChar: return "wchar_t";
+		case Type::Char8: return "char8_t";
+		case Type::Char16: return "char16_t";
+		case Type::Char32: return "char32_t";
 		case Type::Bool: return "bool";
 		case Type::Float: return "float";
 		case Type::Double: return "double";
@@ -171,9 +191,15 @@ inline bool isSignedType(Type t) {
 		case Type::Long:
 		case Type::LongLong:
 			return true;
+		// wchar_t is target-dependent: signed on Linux (LP64), unsigned on Windows (LLP64)
+		case Type::WChar:
+			return g_target_data_model != TargetDataModel::LLP64;  // signed on LP64, unsigned on LLP64
 		// Explicitly unsigned types
 		case Type::Bool:
 		case Type::UnsignedChar:
+		case Type::Char8:     // char8_t is always unsigned (C++20)
+		case Type::Char16:    // char16_t is always unsigned
+		case Type::Char32:    // char32_t is always unsigned
 		case Type::UnsignedShort:
 		case Type::UnsignedInt:
 		case Type::UnsignedLong:
@@ -1211,21 +1237,14 @@ bool is_struct_type(Type type);  // Check if type is Struct or UserDefined
 int get_integer_rank(Type type);
 int get_floating_point_rank(Type type);
 
-// Target data model - controls the size of 'long' type
-// Windows uses LLP64: long is 32-bit, long long is 64-bit
-// Linux/Unix uses LP64: long is 64-bit, long long is 64-bit
-enum class TargetDataModel {
-	LLP64,     // Windows x64: long = 32 bits (COFF)
-	LP64       // Linux/Unix x64: long = 64 bits (ELF)
-};
-
-// Global data model setting - set by main.cpp based on target platform
-// Default is platform-dependent
-extern TargetDataModel g_target_data_model;
-
 // Get the size of 'long' in bits based on the target data model
 inline int get_long_size_bits() {
 	return (g_target_data_model == TargetDataModel::LLP64) ? 32 : 64;
+}
+
+// wchar_t is 16-bit unsigned on Windows (LLP64), 32-bit signed on Linux (LP64)
+inline int get_wchar_size_bits() {
+	return (g_target_data_model == TargetDataModel::LLP64) ? 16 : 32;
 }
 
 int get_type_size_bits(Type type);

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -155,6 +155,10 @@ void appendTypeCode(OutputType& output, const TypeSpecifierNode& type_node) {
 		case Type::Bool: output += "_N"; break;  // bool
 		case Type::Char: output += 'D'; break;   // char
 		case Type::UnsignedChar: output += 'E'; break;  // unsigned char
+		case Type::WChar: output += "_W"; break;  // wchar_t (MSVC native type)
+		case Type::Char8: output += "_Q"; break;  // char8_t (C++20)
+		case Type::Char16: output += "_S"; break;  // char16_t
+		case Type::Char32: output += "_U"; break;  // char32_t
 		case Type::Short: output += 'F'; break;  // short
 		case Type::UnsignedShort: output += 'G'; break;  // unsigned short
 		case Type::Int: output += 'H'; break;    // int
@@ -256,6 +260,10 @@ inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& t
 			}
 			break;
 		case Type::UnsignedChar: output += 'h'; break;
+		case Type::WChar:      output += 'w'; break;   // wchar_t
+		case Type::Char8:      output += "Du"; break;  // char8_t (C++20)
+		case Type::Char16:     output += "Ds"; break;  // char16_t
+		case Type::Char32:     output += "Di"; break;  // char32_t
 		case Type::Short:      output += 's'; break;
 		case Type::UnsignedShort: output += 't'; break;
 		case Type::Int:        output += 'i'; break;


### PR DESCRIPTION
The issue had two parts:
	1.	Array-to-pointer decay bug: Unsized arrays (wchar_t str[] = L"World") weren’t properly decaying to pointers because the code checked decl->array_size().has_value() instead of decl->is_array(). For unsized arrays, array_size() returns std::nullopt even though is_unsized_array_ is true.
	2.	Type representation: wchar_t was being treated as Type::Int, losing its identity as a distinct type needed for correct overload resolution and name mangling.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/652" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
