### PR TITLE
Remove non-standard "--eager-template-instantiation" flag

### DIFF
--- a/src/CommandLineParser.h
+++ b/src/CommandLineParser.h
@@ -43,7 +43,6 @@ inline constexpr CliOptionInfo all_cli_flags[] = {
 	{"fgcc-compat", "", "Use GCC/Clang compatible built-in macros", "", false},
 	{"fclang-compat", "", "Use GCC/Clang compatible built-in macros", "", true},
 	{"fno-exceptions", "", "Disable exception handling", "", false},
-	{"eager-template-instantiation", "", "Instantiate all template members eagerly (default: lazy)", "", false},
 };
 
 // Compile-time lookup: _opt user-defined literal.

--- a/src/CompileContext.h
+++ b/src/CompileContext.h
@@ -245,17 +245,6 @@ public:
 		return false;
 	}
 
-	// Getter and setter for lazy template instantiation mode
-	// When enabled, template member functions are instantiated only when used (C++ standard behavior)
-	// When disabled, all template members are instantiated eagerly (for testing/debugging)
-	bool isLazyTemplateInstantiationEnabled() const {
-		return enableLazyTemplateInstantiation_;
-	}
-
-	void setLazyTemplateInstantiation(bool enable) {
-		enableLazyTemplateInstantiation_ = enable;
-	}
-
 private:
 	std::vector<std::string> includeDirs_;
 	std::optional<std::string> inputFile_;
@@ -263,7 +252,6 @@ private:
 	bool verboseMode_ = false;
 	bool preprocessorOnlyMode_ = false; // Added member variable for -E option
 	bool disableAccessControl_ = false; // Disable access control checking (for debugging)
-	bool enableLazyTemplateInstantiation_ = true; // Enable lazy template member instantiation (default: on)
 	CompilerMode compilerMode_ =
 #if defined(_WIN32) || defined(_WIN64)
 		CompilerMode::MSVC;	// Windows default

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -221,13 +221,6 @@ int main_impl(int argc, char* argv[]) {
 	// Set global debug flag (also enabled by verbose mode)
 	g_enable_debug_output = show_debug || context.isVerboseMode();
 
-	// Lazy template instantiation mode (enabled by default, can be disabled for testing)
-	bool lazy_instantiation = !argsparser.hasFlag("eager-template-instantiation"_opt);
-	context.setLazyTemplateInstantiation(lazy_instantiation);
-	if (!lazy_instantiation && context.isVerboseMode()) {
-		FLASH_LOG(General, Info, "Eager template instantiation mode enabled (all template members instantiated immediately)");
-	}
-
 	// Process input file arguments here...
 	const auto& inputFileArgs = argsparser.inputFileArgs();
 	if (inputFileArgs.empty()) {
@@ -278,12 +271,12 @@ int main_impl(int argc, char* argv[]) {
 		}
 	}
 #else
-		// On Windows, add MSVC STL and UCRT include directories
-		// Discover MSVC toolset version dynamically
+	// On Windows, add MSVC STL and UCRT include directories
+	// Discover MSVC toolset version dynamically
 	{
 		const std::filesystem::path msvc_base = "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Tools/MSVC";
 		if (std::filesystem::exists(msvc_base)) {
-				// Find the latest toolset version directory
+			// Find the latest toolset version directory
 			std::string latest_version;
 			for (const auto& entry : std::filesystem::directory_iterator(msvc_base)) {
 				if (entry.is_directory()) {
@@ -301,7 +294,7 @@ int main_impl(int argc, char* argv[]) {
 			}
 		}
 
-			// Add UCRT include directory
+		// Add UCRT include directory
 		const std::filesystem::path winsdk_base = "C:/Program Files (x86)/Windows Kits/10/Include";
 		if (std::filesystem::exists(winsdk_base)) {
 			std::string latest_version;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -587,10 +587,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Proceed without in_progress tracking
 	}
 
-	// Determine if we should use lazy instantiation early in the function
-	// This flag controls whether static members and member functions are instantiated eagerly or on-demand
-	// Can be overridden by force_eager parameter (used for explicit instantiation)
-	bool use_lazy_instantiation = context_.isLazyTemplateInstantiationEnabled() && !force_eager;
+	// Track whether this is a normal implicit instantiation or an explicit-instantiation
+	// definition that must force member materialization (C++20 [temp.explicit]).
+	bool is_implicit_instantiation = !force_eager;
 
 	// Helper lambda delegates to extracted member function for non-type template parameter substitution
 	auto substitute_template_param_in_initializer = [this](
@@ -4549,7 +4548,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Check if this static member should be lazily instantiated
 			bool member_needs_complex_substitution = needs_complex_substitution(static_member.initializer);
 
-			if (use_lazy_instantiation && member_needs_complex_substitution) {
+			if (is_implicit_instantiation && member_needs_complex_substitution) {
 				// Register for lazy instantiation instead of processing now
 				FLASH_LOG(Templates, Debug, "Registering static member '", static_member.getName(),
 						  "' for lazy instantiation");
@@ -5639,7 +5638,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	// Log lazy instantiation status (already determined earlier in the function)
-	if (use_lazy_instantiation) {
+	if (is_implicit_instantiation) {
 		FLASH_LOG(Templates, Debug, "Using LAZY instantiation for ", instantiated_name, " - registering ",
 				  class_decl.member_functions().size(), " member functions for on-demand instantiation");
 	} else if (force_eager) {
@@ -5672,7 +5671,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			const DeclarationNode& decl = func_decl.decl_node();
 
 			// For lazy instantiation, register function for later instantiation instead of instantiating now
-			if (use_lazy_instantiation &&
+			if (is_implicit_instantiation &&
 				instantiated_name.view().find("::") == std::string_view::npos &&
 				StringTable::getStringView(class_decl.name()).find("::") == std::string_view::npos &&
 				(func_decl.get_definition().has_value() || func_decl.has_template_body_position())) {


### PR DESCRIPTION
Remove the non-standard CLI flag --eager-template-instantiation and its CompileContext toggle. Implicit template instantiation now follows on-demand (lazy) semantics; explicit instantiation definitions still force full materialization
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
