### PR TITLE
Implemented pack/default-aware primary variable-template instantiation

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -980,8 +980,67 @@ private:
 		const TypeInfo& placeholder_info,
 		const TemplateParamsContainer& template_params,
 		const TemplateArgsContainer& template_args) {
-		std::vector<TemplateTypeArg> concrete_args =
-			materializeTemplateArgs(placeholder_info, template_params, template_args);
+		auto appendExpandedPackArgs =
+			[&](const TypeInfo::TemplateArgInfo& arg_info,
+				std::vector<TemplateTypeArg>& out_args) -> bool {
+			if (!arg_info.dependent_name.isValid()) {
+				return false;
+			}
+
+			size_t arg_index = 0;
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				if (!template_params[i].template is<TemplateParameterNode>()) {
+					continue;
+				}
+
+				const auto& param =
+					template_params[i].template as<TemplateParameterNode>();
+				if (param.is_variadic()) {
+					size_t remaining_args = arg_index < template_args.size()
+						? template_args.size() - arg_index
+						: 0;
+					size_t required_after =
+						countRequiredTemplateArgsAfter<
+							TemplateParamsContainer,
+							TemplateArgsContainer>(template_params, i + 1);
+					size_t pack_size = remaining_args > required_after
+						? remaining_args - required_after
+						: 0;
+
+					if (param.nameHandle() == arg_info.dependent_name) {
+						for (size_t pack_index = 0;
+							 pack_index < pack_size &&
+							 (arg_index + pack_index) < template_args.size();
+							 ++pack_index) {
+							out_args.push_back(rebindDependentTemplateTypeArg(
+								template_args[arg_index + pack_index],
+								arg_info));
+						}
+						return true;
+					}
+
+					arg_index += pack_size;
+					continue;
+				}
+
+				if (arg_index >= template_args.size()) {
+					break;
+				}
+				++arg_index;
+			}
+
+			return false;
+		};
+
+		std::vector<TemplateTypeArg> concrete_args;
+		concrete_args.reserve(placeholder_info.templateArgs().size());
+		for (const auto& arg_info : placeholder_info.templateArgs()) {
+			if (appendExpandedPackArgs(arg_info, concrete_args)) {
+				continue;
+			}
+			concrete_args.push_back(
+				materializeTemplateArg(arg_info, template_params, template_args));
+		}
 
 		const auto resolveConcreteBaseHandle = [&](std::string_view base_name) -> StringHandle {
 			auto base_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(base_name));

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -814,13 +814,187 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		}
 	}
 
+	auto template_opt = gTemplateRegistry.lookupVariableTemplate(template_name);
+	if (!template_opt.has_value() && template_name != simple_template_name) {
+		template_opt = gTemplateRegistry.lookupVariableTemplate(simple_template_name);
+	}
+	if (!template_opt.has_value()) {
+		FLASH_LOG(Templates, Error, "Variable template '", template_name, "' not found");
+		return std::nullopt;
+	}
+
+	if (!template_opt->is<TemplateVariableDeclarationNode>()) {
+		FLASH_LOG(Templates, Error, "Expected TemplateVariableDeclarationNode");
+		return std::nullopt;
+	}
+
+	const TemplateVariableDeclarationNode& var_template = template_opt->as<TemplateVariableDeclarationNode>();
+	const auto& template_params = var_template.template_parameters();
+
+	auto fill_missing_variable_template_args =
+		[&](const std::vector<TemplateTypeArg>& input_args) -> std::optional<std::vector<TemplateTypeArg>> {
+		bool has_parameter_pack = false;
+		size_t non_variadic_param_count = 0;
+		for (const auto& param_node : template_params) {
+			if (!param_node.is<TemplateParameterNode>()) {
+				continue;
+			}
+
+			const auto& param = param_node.as<TemplateParameterNode>();
+			if (param.is_variadic()) {
+				has_parameter_pack = true;
+				continue;
+			}
+			++non_variadic_param_count;
+		}
+
+		if (has_parameter_pack) {
+			size_t minimum_required_args = 0;
+			for (const auto& param_node : template_params) {
+				if (!param_node.is<TemplateParameterNode>()) {
+					continue;
+				}
+
+				const auto& param = param_node.as<TemplateParameterNode>();
+				if (param.is_variadic() || param.has_default()) {
+					continue;
+				}
+				++minimum_required_args;
+			}
+
+			if (input_args.size() < minimum_required_args) {
+				FLASH_LOG(Templates, Error, "Too few arguments for variadic variable template '",
+						  template_name, "' (got ", input_args.size(), ", need at least ", minimum_required_args, ")");
+				return std::nullopt;
+			}
+		} else if (input_args.size() > non_variadic_param_count) {
+			FLASH_LOG(Templates, Error, "Too many arguments for variable template '",
+					  template_name, "' (got ", input_args.size(), ", max ", non_variadic_param_count, ")");
+			return std::nullopt;
+		}
+
+		auto materialize_default_arg =
+			[&](const TemplateParameterNode& param, const std::vector<TemplateTypeArg>& bound_args) -> std::optional<TemplateTypeArg> {
+			if (!param.has_default()) {
+				return std::nullopt;
+			}
+
+			const ASTNode& default_node = param.default_value();
+			InlineVector<TemplateTypeArg, 4> bound_args_inline = toInlineTemplateArgs(bound_args);
+			ASTNode substituted_default = substituteTemplateParameters(default_node, template_params, bound_args_inline);
+
+			if (param.kind() == TemplateParameterKind::Type) {
+				if (substituted_default.is<TypeSpecifierNode>()) {
+					return TemplateTypeArg(substituted_default.as<TypeSpecifierNode>());
+				}
+				if (default_node.is<TypeSpecifierNode>()) {
+					return TemplateTypeArg(default_node.as<TypeSpecifierNode>());
+				}
+				FLASH_LOG(Templates, Error, "Failed to materialize type default for variable template parameter '",
+						  param.name(), "'");
+				return std::nullopt;
+			}
+
+			if (param.kind() == TemplateParameterKind::NonType) {
+				if (!substituted_default.is<ExpressionNode>()) {
+					FLASH_LOG(Templates, Error, "Failed to substitute non-type default for variable template parameter '",
+							  param.name(), "'");
+					return std::nullopt;
+				}
+
+				ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
+				auto eval_result = ConstExpr::Evaluator::evaluate(substituted_default, eval_ctx);
+				if (!eval_result.success()) {
+					FLASH_LOG(Templates, Error, "Failed to evaluate non-type default for variable template parameter '",
+							  param.name(), "'");
+					return std::nullopt;
+				}
+
+				if (const auto* bool_value = std::get_if<bool>(&eval_result.value)) {
+					return TemplateTypeArg(*bool_value ? 1LL : 0LL, TypeCategory::Bool);
+				}
+				if (const auto* uint_value = std::get_if<unsigned long long>(&eval_result.value)) {
+					TypeCategory value_category = eval_result.exact_type.has_value()
+						? eval_result.exact_type->category()
+						: TypeCategory::UnsignedLongLong;
+					return TemplateTypeArg(static_cast<int64_t>(*uint_value), value_category);
+				}
+				if (eval_result.exact_type.has_value()) {
+					return TemplateTypeArg(eval_result.as_int(), eval_result.exact_type->category());
+				}
+				return TemplateTypeArg(eval_result.as_int());
+			}
+
+			FLASH_LOG(Templates, Error, "Unsupported variable template parameter kind for default argument on '",
+					  param.name(), "'");
+			return std::nullopt;
+		};
+
+		std::vector<TemplateTypeArg> filled_args;
+		filled_args.reserve(std::max(input_args.size(), template_params.size()));
+		size_t arg_index = 0;
+
+		for (size_t i = 0; i < template_params.size(); ++i) {
+			if (!template_params[i].is<TemplateParameterNode>()) {
+				continue;
+			}
+
+			const auto& param = template_params[i].as<TemplateParameterNode>();
+			if (param.is_variadic()) {
+				size_t remaining_args = arg_index < input_args.size()
+					? input_args.size() - arg_index
+					: 0;
+				size_t required_after = countRequiredTemplateArgsAfter<InlineVector<ASTNode, 4>, std::vector<TemplateTypeArg>>(
+					template_params, i + 1);
+				size_t pack_size = remaining_args > required_after
+					? remaining_args - required_after
+					: 0;
+				for (size_t pack_index = 0; pack_index < pack_size; ++pack_index) {
+					filled_args.push_back(input_args[arg_index + pack_index]);
+				}
+				arg_index += pack_size;
+				continue;
+			}
+
+			if (arg_index < input_args.size()) {
+				filled_args.push_back(input_args[arg_index]);
+				++arg_index;
+				continue;
+			}
+
+			auto default_arg = materialize_default_arg(param, filled_args);
+			if (!default_arg.has_value()) {
+				FLASH_LOG(Templates, Error, "Variable template '", template_name,
+						  "': missing argument for parameter '", param.name(), "'");
+				return std::nullopt;
+			}
+
+			filled_args.push_back(*default_arg);
+		}
+
+		if (arg_index != input_args.size()) {
+			FLASH_LOG(Templates, Error, "Too many arguments for variable template '",
+					  template_name, "' after canonical binding (consumed ", arg_index,
+					  " of ", input_args.size(), ")");
+			return std::nullopt;
+		}
+
+		return filled_args;
+	};
+
+	auto filled_args_opt = fill_missing_variable_template_args(resolved_args);
+	if (!filled_args_opt.has_value()) {
+		return std::nullopt;
+	}
+	const std::vector<TemplateTypeArg>& filled_args = *filled_args_opt;
+
 	// Structural pattern matching: find the best matching partial specialization
 	// Uses TemplatePattern::matches() which handles qualifier matching, multi-arg,
 	// and proper template parameter deduction without string-based pattern keys.
-	auto structural_match = gTemplateRegistry.findVariableTemplateSpecialization(simple_template_name, resolved_args);
+	auto structural_match = gTemplateRegistry.findVariableTemplateSpecialization(simple_template_name, filled_args);
 	// Also try qualified name if simple name didn't match
 	if (!structural_match.has_value() && template_name != simple_template_name) {
-		structural_match = gTemplateRegistry.findVariableTemplateSpecialization(template_name, resolved_args);
+		structural_match = gTemplateRegistry.findVariableTemplateSpecialization(template_name, filled_args);
 	}
 
 	if (structural_match.has_value() && structural_match->node.is<TemplateVariableDeclarationNode>()) {
@@ -828,7 +1002,7 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		const TemplateVariableDeclarationNode& spec_template = structural_match->node.as<TemplateVariableDeclarationNode>();
 		const VariableDeclarationNode& spec_var_decl = spec_template.variable_decl_node();
 		const Token& orig_token = spec_var_decl.declaration().identifier_token();
-		std::string_view persistent_name = FlashCpp::generateInstantiatedNameFromArgs(simple_template_name, resolved_args);
+		std::string_view persistent_name = FlashCpp::generateInstantiatedNameFromArgs(simple_template_name, filled_args);
 
 		if (gSymbolTable.lookup(persistent_name).has_value()) {
 			return gSymbolTable.lookup(persistent_name);
@@ -851,10 +1025,10 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 						converted_args.push_back(it->second);
 					} else {
 						// Fallback: use resolved arg with qualifiers stripped
-						if (converted_args.size() < resolved_args.size()) {
+						if (converted_args.size() < filled_args.size()) {
 							FLASH_LOG(Templates, Debug, "Deduction fallback for param '",
 									  tp.name(), "': using arg[", converted_args.size(), "] with qualifiers stripped");
-							TemplateTypeArg deduced = resolved_args[converted_args.size()];
+							TemplateTypeArg deduced = filled_args[converted_args.size()];
 							deduced.ref_qualifier = ReferenceQualifier::None;
 							deduced.pointer_depth = 0;
 							deduced.pointer_cv_qualifiers.clear();
@@ -896,147 +1070,35 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		return var_decl_node;
 	}
 
-	// No partial specialization found - use the primary template
-	auto template_opt = gTemplateRegistry.lookupVariableTemplate(template_name);
-	if (!template_opt.has_value()) {
-		FLASH_LOG(Templates, Error, "Variable template '", template_name, "' not found");
-		return std::nullopt;
-	}
-
-	if (!template_opt->is<TemplateVariableDeclarationNode>()) {
-		FLASH_LOG(Templates, Error, "Expected TemplateVariableDeclarationNode");
-		return std::nullopt;
-	}
-
-	const TemplateVariableDeclarationNode& var_template = template_opt->as<TemplateVariableDeclarationNode>();
-
 	// Generate unique name for the instantiation using hash-based naming
 	// This ensures consistent naming with class template instantiations
-	std::string_view persistent_name = FlashCpp::generateInstantiatedNameFromArgs(simple_template_name, resolved_args);
+	std::string_view persistent_name = FlashCpp::generateInstantiatedNameFromArgs(simple_template_name, filled_args);
 
 	// Check if already instantiated
 	if (gSymbolTable.lookup(persistent_name).has_value()) {
 		return gSymbolTable.lookup(persistent_name);
 	}
 
-	// Perform template substitution
-	const auto& template_params = var_template.template_parameters();
-	if (resolved_args.size() != template_params.size()) {
-		FLASH_LOG(Templates, Error, "Template argument count mismatch: expected ", template_params.size(),
-				  ", got ", resolved_args.size());
-		return std::nullopt;
-	}
-
 	// Get the original variable declaration
 	const VariableDeclarationNode& orig_var_decl = var_template.variable_decl_node();
 	const DeclarationNode& orig_decl = orig_var_decl.declaration();
-	const TypeSpecifierNode& orig_type = orig_decl.type_node().as<TypeSpecifierNode>();
-
-	// Build a map from template parameter type_index to concrete type for substitution
-	std::unordered_map<TypeIndex, TemplateTypeArg> type_substitution_map;
-	// Build a map from non-type template parameter name to value for substitution
-	std::unordered_map<std::string_view, int64_t> nontype_substitution_map;
-
-	// Substitute template parameter with concrete type
-	// For now, assume simple case where the type is just the template parameter
-	TypeSpecifierNode substituted_type = orig_type;
-
-	// Build substitution maps for all template parameters
-	for (size_t i = 0; i < template_params.size(); ++i) {
-		if (!template_params[i].is<TemplateParameterNode>())
-			continue;
-
-		const auto& tparam = template_params[i].as<TemplateParameterNode>();
-
-		if (tparam.kind() == TemplateParameterKind::Type) {
-			// For type template parameters, look up the type_index in gTypeInfo
-			// The template parameter name was registered as a type during parsing
-			const TemplateTypeArg& arg = resolved_args[i];
-
-			// Find the type_index for this template parameter by name
-			// During template parsing, template parameters are added to gTypeInfo
-			// We need to find the type_index that corresponds to this template parameter name
-			std::string_view param_name = tparam.name();
-			TypeIndex param_type_index{};
-			bool found_param = false;
-
-			// IMPORTANT: If orig_type refers to a template parameter (Type::UserDefined),
-			// we should use orig_type.type_index() directly, as it's the correct type_index
-			// for THIS template's parameter. Searching by name can find the wrong type_index
-			// when multiple templates use the same parameter name (e.g., 'T').
-			if (orig_type.category() == TypeCategory::UserDefined || orig_type.category() == TypeCategory::TypeAlias || orig_type.category() == TypeCategory::Template) {
-				// Check if orig_type's type name matches this template parameter
-				if (const TypeInfo* orig_type_info = tryGetTypeInfo(orig_type.type_index())) {
-					std::string_view orig_type_name = StringTable::getStringView(orig_type_info->name());
-					if (orig_type_name == param_name) {
-						// Use the type_index from orig_type directly
-						param_type_index = orig_type.type_index();
-						found_param = true;
-					}
-				}
-			}
-
-			// If we didn't find it from orig_type, use the placeholder type_index captured
-			// when this template parameter was parsed.
-			if (!found_param) {
-				TypeIndex registered_param_type_index = tparam.registered_type_index();
-				if (registered_param_type_index.is_valid()) {
-					param_type_index = registered_param_type_index;
-					found_param = true;
-				}
-			}
-
-			// Add to substitution map if we found the type_index
-			if (found_param) {
-				type_substitution_map[param_type_index] = arg;
-				FLASH_LOG(Templates, Debug, "Added type parameter substitution: ", param_name,
-						  " (type_index=", param_type_index, ") -> ", arg.toString());
-			}
-
-			// Also check if the variable's return type itself is the template parameter
-			// (for cases like template<typename T> T value = T();)
-			if ((orig_type.category() == TypeCategory::UserDefined || orig_type.category() == TypeCategory::TypeAlias || orig_type.category() == TypeCategory::Template) && orig_type.type_index() == param_type_index) {
-				// Use original token info for better diagnostics
-				const Token& orig_token = orig_decl.identifier_token();
-				substituted_type = TypeSpecifierNode(
-					arg.typeEnum(),
-					TypeQualifier::None,
-					get_type_size_bits(arg.category()),
-					orig_token, CVQualifier::None);
-				// Apply cv-qualifiers, references, and pointers from template argument
-				substituted_type.set_reference_qualifier(arg.ref_qualifier);
-				for (size_t p = 0; p < arg.pointer_depth; ++p) {
-					substituted_type.add_pointer_level(CVQualifier::None);
-				}
-			} else {
-				FLASH_LOG(Templates, Debug, "Type does NOT match - skipping substitution for '", template_name, "'");
-			}
-		} else if (tparam.kind() == TemplateParameterKind::NonType) {
-			// Handle non-type template parameters
-			const TemplateTypeArg& arg = resolved_args[i];
-			if (arg.is_value) {
-				// Add to non-type substitution map
-				nontype_substitution_map[tparam.name()] = arg.value;
-				FLASH_LOG(Templates, Debug, "Added non-type parameter substitution: ", tparam.name(), " -> ", arg.value);
-			}
-		}
-	}
+	InlineVector<TemplateTypeArg, 4> filled_args_inline = toInlineTemplateArgs(filled_args);
+	ASTNode substituted_type = substituteTemplateParameters(orig_decl.type_node(), template_params, filled_args_inline);
 
 	// Create new declaration with substituted type and instantiated name
 	// Use original token's line/column/file info for better diagnostics
 	const Token& orig_token = orig_decl.identifier_token();
 	Token instantiated_name_token(Token::Type::Identifier, persistent_name, orig_token.line(), orig_token.column(), orig_token.file_index());
-	auto new_type_node = emplace_node<TypeSpecifierNode>(substituted_type);
-	auto new_decl_node = emplace_node<DeclarationNode>(new_type_node, instantiated_name_token);
+	auto new_decl_node = emplace_node<DeclarationNode>(substituted_type, instantiated_name_token);
 
 	// Substitute template parameters in initializer expression
 	std::optional<ASTNode> new_initializer = std::nullopt;
 	if (orig_var_decl.initializer().has_value()) {
 		FLASH_LOG(Templates, Debug, "Substituting initializer expression for variable template");
-		new_initializer = substitute_template_params_in_expression(
+		new_initializer = substituteTemplateParameters(
 			orig_var_decl.initializer().value(),
-			type_substitution_map,
-			nontype_substitution_map);
+			template_params,
+			filled_args_inline);
 		FLASH_LOG(Templates, Debug, "Initializer substitution complete");
 
 		// PHASE 3 FIX: After substitution, trigger instantiation of any class templates
@@ -1082,20 +1144,20 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 						// Try to instantiate the struct/class referenced in the qualified identifier
 						// Look it up to see if it's a template
 						auto inner_template_opt = gTemplateRegistry.lookupTemplate(template_name_to_lookup);
-						if (inner_template_opt.has_value() && resolved_args.size() > 0) {
+						if (inner_template_opt.has_value() && filled_args.size() > 0) {
 							// This is a template - try to instantiate it with the concrete arguments
 							// The template arguments from the variable template should be used
 							FLASH_LOG(Templates, Debug, "Phase 3: Triggering instantiation of '", template_name_to_lookup,
-									  "' with ", resolved_args.size(), " args from variable template initializer");
+									  "' with ", filled_args.size(), " args from variable template initializer");
 
-							auto instantiated = try_instantiate_class_template(template_name_to_lookup, resolved_args);
+							auto instantiated = try_instantiate_class_template(template_name_to_lookup, filled_args);
 							if (instantiated.has_value() && instantiated->is<StructDeclarationNode>()) {
 								// Add to AST so it gets codegen
 								registerAndNormalizeLateMaterializedTopLevelNode(*instantiated);
 
 								// Now update the qualified identifier to use the correct instantiated name
 								// Get the instantiated class name (e.g., "is_pointer_impl_intP")
-								std::string_view instantiated_name = get_instantiated_class_name(template_name_to_lookup, resolved_args);
+								std::string_view instantiated_name = get_instantiated_class_name(template_name_to_lookup, filled_args);
 								FLASH_LOG(Templates, Debug, "Phase 3: Instantiated class name: '", instantiated_name, "'");
 
 								// Create a new qualified identifier with the updated namespace
@@ -1125,7 +1187,7 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 	// Mark as constexpr to match the template pattern
 	instantiated_var_decl.as<VariableDeclarationNode>().set_is_thread_local(orig_var_decl.is_thread_local());
 	instantiated_var_decl.as<VariableDeclarationNode>().set_is_constexpr(true);
-	setOuterTemplateBindingsFromParams(instantiated_var_decl.as<VariableDeclarationNode>(), template_params, resolved_args);
+	setOuterTemplateBindingsFromParams(instantiated_var_decl.as<VariableDeclarationNode>(), template_params, filled_args);
 
 	// Register the VariableDeclarationNode in symbol table (not just DeclarationNode)
 	// This allows constexpr evaluation to find and evaluate the variable

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -431,11 +431,8 @@ std::string_view Parser::instantiate_and_register_base_template(
 
 				const ASTNode& default_node = param.default_value();
 				if (param.kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
-					InlineVector<TemplateTypeArg, 4> filled_args_inline;
-					filled_args_inline.reserve(filled_args.size());
-					for (const auto& filled_arg : filled_args) {
-						filled_args_inline.push_back(filled_arg);
-					}
+					InlineVector<TemplateTypeArg, 4> filled_args_inline =
+						toInlineTemplateArgs(filled_args);
 					ASTNode substituted_default_node = substituteTemplateParameters(
 						default_node,
 						primary_params,
@@ -887,9 +884,6 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 				if (substituted_default.is<TypeSpecifierNode>()) {
 					return TemplateTypeArg(substituted_default.as<TypeSpecifierNode>());
 				}
-				if (default_node.is<TypeSpecifierNode>()) {
-					return TemplateTypeArg(default_node.as<TypeSpecifierNode>());
-				}
 				FLASH_LOG(Templates, Error, "Failed to materialize type default for variable template parameter '",
 						  param.name(), "'");
 				return std::nullopt;
@@ -1144,20 +1138,33 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 						// Try to instantiate the struct/class referenced in the qualified identifier
 						// Look it up to see if it's a template
 						auto inner_template_opt = gTemplateRegistry.lookupTemplate(template_name_to_lookup);
-						if (inner_template_opt.has_value() && filled_args.size() > 0) {
-							// This is a template - try to instantiate it with the concrete arguments
-							// The template arguments from the variable template should be used
-							FLASH_LOG(Templates, Debug, "Phase 3: Triggering instantiation of '", template_name_to_lookup,
-									  "' with ", filled_args.size(), " args from variable template initializer");
+						if (inner_template_opt.has_value()) {
+							std::vector<TemplateTypeArg> inner_template_args = resolved_args;
+							auto inner_type_it = getTypesByNameMap().find(
+								StringTable::getOrInternStringHandle(struct_name_view));
+							if (inner_type_it != getTypesByNameMap().end() &&
+								inner_type_it->second != nullptr &&
+								inner_type_it->second->isTemplateInstantiation()) {
+								inner_template_args = materializePlaceholderTemplateArgs(
+									*inner_type_it->second,
+									template_params,
+									filled_args);
+							}
 
-							auto instantiated = try_instantiate_class_template(template_name_to_lookup, filled_args);
+							// This is a template - try to instantiate it with the concrete arguments
+							// Use the referenced placeholder's own template arguments so outer
+							// defaults are only forwarded when the inner template actually uses them.
+							FLASH_LOG(Templates, Debug, "Phase 3: Triggering instantiation of '", template_name_to_lookup,
+									  "' with ", inner_template_args.size(), " args from variable template initializer");
+
+							auto instantiated = try_instantiate_class_template(template_name_to_lookup, inner_template_args);
 							if (instantiated.has_value() && instantiated->is<StructDeclarationNode>()) {
 								// Add to AST so it gets codegen
 								registerAndNormalizeLateMaterializedTopLevelNode(*instantiated);
 
 								// Now update the qualified identifier to use the correct instantiated name
 								// Get the instantiated class name (e.g., "is_pointer_impl_intP")
-								std::string_view instantiated_name = get_instantiated_class_name(template_name_to_lookup, filled_args);
+								std::string_view instantiated_name = get_instantiated_class_name(template_name_to_lookup, inner_template_args);
 								FLASH_LOG(Templates, Debug, "Phase 3: Instantiated class name: '", instantiated_name, "'");
 
 								// Create a new qualified identifier with the updated namespace

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -14,14 +14,14 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<numbers>` | N/A | ✅ Compiled | ~510ms |
 | `<initializer_list>` | N/A | ✅ Compiled | ~32ms |
 | `<ratio>` | `test_std_ratio.cpp` | ✅ Compiled | ~639ms. The header still compiles, but `std::ratio_less` remains blocked because non-type default template arguments that depend on qualified constexpr members (for example `__ratio_less_impl`'s bool defaults) are still not fully instantiated/evaluated. |
-| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~2474ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
+| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~2236ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
 | `<any>` | `test_std_any.cpp` | ❌ Codegen Error | ~607ms (retested 2026-04-11). Targeted test now fails with "Expected symbol '_Arg' to exist in code generation" in `std::any` constructor. |
 | `<utility>` | `test_std_utility.cpp` | ❌ Codegen Error | ~830ms (retested 2026-04-11). Targeted test now fails with codegen errors from template deduction / Non-type parameter issues. |
 | `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~540ms |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~625ms |
 | `<string_view>` | `test_std_string_view.cpp` | ❌ Compile Error | ~1460ms (retested 2026-04-11). Call to deleted function 'swap' in `stl_pair.h:308`. Blocked by eager inline member body parsing during implicit template class instantiation (std::pair::swap tries to swap const members). |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~2192ms (retested 2026-04-11). Call to deleted function 'swap' — same `stl_pair.h:308` blocker as `<string_view>`. |
-| `<array>` | `test_std_array.cpp` | ❌ Parse Error | ~2468ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
+| `<array>` | `test_std_array.cpp` | ❌ Parse Error | ~2273ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
 | `<algorithm>` | `test_std_algorithm.cpp` | ❌ Compile Error | ~2051ms (retested 2026-04-11). "Operator- not defined for operand types". |
 | `<span>` | `test_std_span.cpp` | ✅ Compiled | ~41ms (retested 2026-04-11). **NEW: Now compiles successfully!** Previous iterator/ranges codegen blockers are resolved. |
 | `<tuple>` | `test_std_tuple.cpp` | ❌ Compile Error | ~1564ms (retested 2026-04-11). "unsupported PackExpansionExprNode reached semantic analysis". |
@@ -31,10 +31,10 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<queue>` | `test_std_queue.cpp` | 💥 Crash | ~2522ms (retested 2026-04-11). |
 | `<stack>` | `test_std_stack.cpp` | 💥 Crash | ~2464ms (retested 2026-04-11). |
 | `<memory>` | `test_std_memory.cpp` | 💥 Crash | ~5108ms (retested 2026-04-11). |
-| `<functional>` | `test_std_functional.cpp` | ❌ Parse Error | ~3456ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
-| `<map>` | `test_std_map.cpp` | ❌ Parse Error | ~2752ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
-| `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2404ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
-| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~3117ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
+| `<functional>` | `test_std_functional.cpp` | ❌ Parse Error | ~3265ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<map>` | `test_std_map.cpp` | ❌ Parse Error | ~2754ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2350ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
+| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~2906ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
 | `<iostream>` | `test_std_iostream.cpp` | 💥 Crash | ~4559ms (retested 2026-04-11). |
 | `<sstream>` | `test_std_sstream.cpp` | 💥 Crash | ~4565ms (retested 2026-04-11). |
 | `<fstream>` | `test_std_fstream.cpp` | 💥 Crash | ~4642ms (retested 2026-04-11). |
@@ -47,7 +47,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ❌ Codegen Error | ~2299ms (retested 2026-04-11). Targeted test now fails with codegen errors. |
 | `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~2481ms (retested 2026-04-11). Call to deleted function 'swap'. |
-| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~2802ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
+| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~2659ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
 | `<stdfloat>` | N/A | ✅ Compiled | ~16ms (C++23) |
@@ -131,8 +131,8 @@ This directory contains test files for C++ standard library headers to assess Fl
 #### 2026-04-12 Retests
 
 - Variable-template primary instantiation now canonicalizes explicit arguments with parameter packs and defaults before substitution, and primary variable-template initializers now go through the generic pack-aware template substitutor instead of the old fixed-arity map path. The new focused regressions `tests/test_var_template_variadic_primary_ret42.cpp` and `tests/test_var_template_default_dependent_primary_ret42.cpp` both pass alongside the older variable-template coverage.
-- Re-checking `<array>` (~2.47s), `<optional>` (~2.47s), `<variant>` (~2.80s), `<functional>` (~3.46s), and `<map>` (~2.75s) shows that the old `_Is_any_of_v` / "Template argument count mismatch: expected 2, got 17" stop is gone. These headers now reach a later parser gap in MSVC `<type_traits>` at `using _Is_invocable_r_ = typename _Select_invoke_traits<_Callable, _Args...>::template _Is_invocable_r<_Rx>;`.
-- Re-checking `<set>` (~2.40s) and `<ranges>` (~3.12s) shows that the same variable-template blocker is gone there too. Both headers now get further into the Windows UCRT path and currently stop on `__stdio_common_vfwprintf` overload resolution instead of the earlier template-arity failure.
+- Re-checking `<array>` (~2.27s), `<optional>` (~2.24s), `<variant>` (~2.66s), `<functional>` (~3.27s), and `<map>` (~2.75s) shows that the old `_Is_any_of_v` / "Template argument count mismatch: expected 2, got 17" stop is gone. These headers now reach a later parser gap in MSVC `<type_traits>` at `struct is_nothrow_invocable_r : _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx>`.
+- Re-checking `<set>` (~2.35s) and `<ranges>` (~2.91s) shows that the same variable-template blocker is gone there too. Both headers now get further into the Windows UCRT path and currently stop on `__stdio_common_vfwprintf` overload resolution instead of the earlier template-arity failure.
 
 #### 2026-04-07 Retests
 
@@ -151,7 +151,7 @@ The overall header counts above still reflect the older full sweep and need a fu
 
 The most impactful blockers preventing more headers from compiling, ordered by impact:
 
-As of the 2026-04-12 targeted retest, the newly unblocked MSVC headers now hit a higher-value parser gap around dependent alias-template targets after a template-id (`Template<...>::template Alias<...>`). `<array>`, `<optional>`, `<variant>`, `<functional>`, and `<map>` all now stop first at `type_traits:1824`, while `<set>` / `<ranges>` have moved further into later Windows UCRT overload-resolution fallout.
+As of the 2026-04-12 targeted retest, the newly unblocked MSVC headers now hit a higher-value parser gap around dependent member-template lookup after a template-id (`Template<...>::template Member<...>`). `<array>`, `<optional>`, `<variant>`, `<functional>`, and `<map>` all now stop first at `type_traits:1865`, while `<set>` / `<ranges>` have moved further into later Windows UCRT overload-resolution fallout.
 
 1. **Template deduction / semantic follow-on failures after the earlier mangling blockers**: In the 2026-03-31 targeted retest, `<algorithm>` no longer failed first on unresolved- `auto` mangling. It now gets further and then fails on concepts/ranges diagnostics followed by explicit-constructor copy-initialization errors. The same family of deeper issues likely explains several headers previously bucketed under the stale unresolved- `auto` note.
 

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -14,14 +14,14 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<numbers>` | N/A | ✅ Compiled | ~510ms |
 | `<initializer_list>` | N/A | ✅ Compiled | ~32ms |
 | `<ratio>` | `test_std_ratio.cpp` | ✅ Compiled | ~639ms. The header still compiles, but `std::ratio_less` remains blocked because non-type default template arguments that depend on qualified constexpr members (for example `__ratio_less_impl`'s bool defaults) are still not fully instantiated/evaluated. |
-| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~1054ms (retested 2026-04-11). "Expected primary expression" at `emplace(*__t)` inside a template member body during class template instantiation. |
+| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~2474ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
 | `<any>` | `test_std_any.cpp` | ❌ Codegen Error | ~607ms (retested 2026-04-11). Targeted test now fails with "Expected symbol '_Arg' to exist in code generation" in `std::any` constructor. |
 | `<utility>` | `test_std_utility.cpp` | ❌ Codegen Error | ~830ms (retested 2026-04-11). Targeted test now fails with codegen errors from template deduction / Non-type parameter issues. |
 | `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~540ms |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~625ms |
 | `<string_view>` | `test_std_string_view.cpp` | ❌ Compile Error | ~1460ms (retested 2026-04-11). Call to deleted function 'swap' in `stl_pair.h:308`. Blocked by eager inline member body parsing during implicit template class instantiation (std::pair::swap tries to swap const members). |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~2192ms (retested 2026-04-11). Call to deleted function 'swap' — same `stl_pair.h:308` blocker as `<string_view>`. |
-| `<array>` | `test_std_array.cpp` | ❌ Compile Error | ~885ms (retested 2026-04-11). Call to deleted function 'swap' — same `stl_pair.h:308` blocker. |
+| `<array>` | `test_std_array.cpp` | ❌ Parse Error | ~2468ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
 | `<algorithm>` | `test_std_algorithm.cpp` | ❌ Compile Error | ~2051ms (retested 2026-04-11). "Operator- not defined for operand types". |
 | `<span>` | `test_std_span.cpp` | ✅ Compiled | ~41ms (retested 2026-04-11). **NEW: Now compiles successfully!** Previous iterator/ranges codegen blockers are resolved. |
 | `<tuple>` | `test_std_tuple.cpp` | ❌ Compile Error | ~1564ms (retested 2026-04-11). "unsupported PackExpansionExprNode reached semantic analysis". |
@@ -31,10 +31,10 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<queue>` | `test_std_queue.cpp` | 💥 Crash | ~2522ms (retested 2026-04-11). |
 | `<stack>` | `test_std_stack.cpp` | 💥 Crash | ~2464ms (retested 2026-04-11). |
 | `<memory>` | `test_std_memory.cpp` | 💥 Crash | ~5108ms (retested 2026-04-11). |
-| `<functional>` | `test_std_functional.cpp` | ❌ Compile Error | ~2670ms (retested 2026-04-11). Call to deleted function 'swap' — same `stl_pair.h:308` blocker. |
-| `<map>` | `test_std_map.cpp` | ❌ Compile Error | ~2133ms (retested 2026-04-11). Call to deleted function 'swap'. |
-| `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2139ms (retested 2026-04-11). Call to deleted function 'swap'. |
-| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~2548ms (retested 2026-04-11). Call to deleted function 'swap'. |
+| `<functional>` | `test_std_functional.cpp` | ❌ Parse Error | ~3456ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
+| `<map>` | `test_std_map.cpp` | ❌ Parse Error | ~2752ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
+| `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2404ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
+| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~3117ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
 | `<iostream>` | `test_std_iostream.cpp` | 💥 Crash | ~4559ms (retested 2026-04-11). |
 | `<sstream>` | `test_std_sstream.cpp` | 💥 Crash | ~4565ms (retested 2026-04-11). |
 | `<fstream>` | `test_std_fstream.cpp` | 💥 Crash | ~4642ms (retested 2026-04-11). |
@@ -47,7 +47,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ❌ Codegen Error | ~2299ms (retested 2026-04-11). Targeted test now fails with codegen errors. |
 | `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~2481ms (retested 2026-04-11). Call to deleted function 'swap'. |
-| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~1098ms (retested 2026-04-11). "Expected primary expression" at `make_index_sequence<variant_size_v<_Next>>()`. |
+| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~2802ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `_Is_invocable_r_ = typename _Select_invoke_traits<...>::template _Is_invocable_r<_Rx>;` with "Expected ';' after alias template declaration". |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
 | `<stdfloat>` | N/A | ✅ Compiled | ~16ms (C++23) |
@@ -128,6 +128,12 @@ This directory contains test files for C++ standard library headers to assess Fl
 - Function-template instantiation now shares dependent default-template-argument recovery between explicit-argument and call-argument deduction paths, including dependent type aliases/conditionals and dependent non-type defaults such as `sizeof(T)`. The new focused regressions `tests/test_func_template_dependent_default_alias_ret0.cpp`, `tests/test_func_template_dependent_default_conditional_ret0.cpp`, and `tests/test_func_template_dependent_default_nontype_sizeof_ret0.cpp` all pass.
 - Re-checking `<set>` (~2.27s), `<functional>` (~2.77s), `<deque>` (~2.97s), and `<memory>` (~4.85s) shows that the old `alloc_traits.h:904` `__make_move_if_noexcept_iterator` stop is gone. `<set>` and `<functional>` now fail later at `bits/node_handle.h:285` on deleted `swap(_M_pkey, __nh._M_pkey)`, while `<deque>` and `<memory>` run deeper and currently crash after repeated zero-size dependent `sizeof` static-assert fallout (`__is_integer_nonstrict::__value` / allocator-style completeness checks).
 
+#### 2026-04-12 Retests
+
+- Variable-template primary instantiation now canonicalizes explicit arguments with parameter packs and defaults before substitution, and primary variable-template initializers now go through the generic pack-aware template substitutor instead of the old fixed-arity map path. The new focused regressions `tests/test_var_template_variadic_primary_ret42.cpp` and `tests/test_var_template_default_dependent_primary_ret42.cpp` both pass alongside the older variable-template coverage.
+- Re-checking `<array>` (~2.47s), `<optional>` (~2.47s), `<variant>` (~2.80s), `<functional>` (~3.46s), and `<map>` (~2.75s) shows that the old `_Is_any_of_v` / "Template argument count mismatch: expected 2, got 17" stop is gone. These headers now reach a later parser gap in MSVC `<type_traits>` at `using _Is_invocable_r_ = typename _Select_invoke_traits<_Callable, _Args...>::template _Is_invocable_r<_Rx>;`.
+- Re-checking `<set>` (~2.40s) and `<ranges>` (~3.12s) shows that the same variable-template blocker is gone there too. Both headers now get further into the Windows UCRT path and currently stop on `__stdio_common_vfwprintf` overload resolution instead of the earlier template-arity failure.
+
 #### 2026-04-07 Retests
 
 - `<atomic>` and `<latch>` were re-checked after teaching sema/parser to preserve user-defined enum identity for overloaded binary operators and parenthesized functional casts. That clears the old `memory_order | __memory_order_modifier(...)` semantic stop from `bits/atomic_base.h`, so both headers now progress into later atomic-wait codegen fallout instead of failing during scoped-enum checking. `<atomic>` currently stops on the same deeper `_M_do_wait` / missing default-argument / dependent-payload-size / `memory_order_seq_cst` symbol issues summarized in the table, while `<latch>` now fails even later on `_M_do_wait`, `__mutex_base` constructor recovery, integer-conversion gaps in wait helpers, and missing `memory_order_relaxed` symbol recovery.
@@ -144,6 +150,8 @@ The overall header counts above still reflect the older full sweep and need a fu
 ### Known Blockers
 
 The most impactful blockers preventing more headers from compiling, ordered by impact:
+
+As of the 2026-04-12 targeted retest, the newly unblocked MSVC headers now hit a higher-value parser gap around dependent alias-template targets after a template-id (`Template<...>::template Alias<...>`). `<array>`, `<optional>`, `<variant>`, `<functional>`, and `<map>` all now stop first at `type_traits:1824`, while `<set>` / `<ranges>` have moved further into later Windows UCRT overload-resolution fallout.
 
 1. **Template deduction / semantic follow-on failures after the earlier mangling blockers**: In the 2026-03-31 targeted retest, `<algorithm>` no longer failed first on unresolved- `auto` mangling. It now gets further and then fails on concepts/ranges diagnostics followed by explicit-constructor copy-initialization errors. The same family of deeper issues likely explains several headers previously bucketed under the stale unresolved- `auto` note.
 

--- a/tests/test_var_template_default_dependent_primary_ret42.cpp
+++ b/tests/test_var_template_default_dependent_primary_ret42.cpp
@@ -1,0 +1,30 @@
+template <bool Condition, typename Type = void>
+struct enable_if { };
+
+template <typename Type>
+struct enable_if<true, Type> {
+	using type = Type;
+};
+
+template <typename A, typename B>
+inline constexpr bool is_same_v = false;
+
+template <typename A>
+inline constexpr bool is_same_v<A, A> = true;
+
+template <typename T, typename U = T, bool Matches = is_same_v<T, U>>
+inline constexpr bool defaulted_matches_v = Matches;
+
+template <typename T, typename = typename enable_if<defaulted_matches_v<T>, int>::type>
+int select_match(int) {
+	return 42;
+}
+
+template <typename T>
+int select_match(...) {
+	return 0;
+}
+
+int main() {
+	return select_match<int>(0);
+}

--- a/tests/test_var_template_inner_impl_defaulted_outer_arg_ret42.cpp
+++ b/tests/test_var_template_inner_impl_defaulted_outer_arg_ret42.cpp
@@ -1,0 +1,11 @@
+template <typename T>
+struct inner_trait {
+	static constexpr int value = 42;
+};
+
+template <typename T, typename U = void>
+inline constexpr int outer_trait_v = inner_trait<T>::value;
+
+int main() {
+	return outer_trait_v<int>;
+}

--- a/tests/test_var_template_inner_impl_empty_pack_ret42.cpp
+++ b/tests/test_var_template_inner_impl_empty_pack_ret42.cpp
@@ -1,0 +1,12 @@
+template <typename... Types>
+struct pack_trait {
+	static constexpr int value = sizeof...(Types) == 0 ? 42 : 7;
+};
+
+template <typename... Types>
+inline constexpr int pack_trait_v = pack_trait<Types...>::value;
+
+int main() {
+	int value = pack_trait_v<>;
+	return value >= 0 ? 42 : 0;
+}

--- a/tests/test_var_template_variadic_primary_ret42.cpp
+++ b/tests/test_var_template_variadic_primary_ret42.cpp
@@ -1,0 +1,24 @@
+template <bool Condition, typename Type = void>
+struct enable_if { };
+
+template <typename Type>
+struct enable_if<true, Type> {
+	using type = Type;
+};
+
+template <typename T, typename... Types>
+inline constexpr bool matches_pack_count_v = sizeof...(Types) == 3;
+
+template <typename T, typename = typename enable_if<matches_pack_count_v<T, int, float, char>, int>::type>
+int select_overload(int) {
+	return 42;
+}
+
+template <typename T>
+int select_overload(...) {
+	return 0;
+}
+
+int main() {
+	return select_overload<int>(0);
+}


### PR DESCRIPTION
Primary variable templates now canonicalize arguments like class templates do, so variadic packs and omitted default parameters are bound before substitution, and their initializers go through the generic pack-aware template substitutor instead of the old fixed-arity map path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1241" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
