### PR TITLE
Support for dependent Owner<Args...>::template Member<T> base-specifier chains

### DIFF
--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -832,7 +832,7 @@ public:
 
 	void add_deferred_template_base_class(StringHandle base_template_name,
 										  std::vector<TemplateArgumentNodeInfo> args,
-										  std::vector<StringHandle> member_type_chain,
+										  std::vector<QualifiedTypeMemberAccess> member_type_chain,
 										  AccessSpecifier access,
 										  bool is_virtual = false,
 										  bool is_pack_expansion = false) {

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -930,7 +930,7 @@ struct TemplateArgumentNodeInfo {
 
 struct QualifiedTypeMemberAccess {
 	StringHandle member_name;
-	std::vector<TemplateTypeArg> template_arguments;
+	std::shared_ptr<std::vector<TemplateTypeArg>> template_arguments;
 	std::vector<TemplateArgumentNodeInfo> template_argument_infos;
 	bool has_template_arguments = false;
 };

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -928,17 +928,24 @@ struct TemplateArgumentNodeInfo {
 	bool is_dependent = false;
 };
 
+struct QualifiedTypeMemberAccess {
+	StringHandle member_name;
+	std::vector<TemplateTypeArg> template_arguments;
+	std::vector<TemplateArgumentNodeInfo> template_argument_infos;
+	bool has_template_arguments = false;
+};
+
 struct DeferredTemplateBaseClassSpecifier {
 	StringHandle base_template_name;
 	std::vector<TemplateArgumentNodeInfo> template_arguments;
-	std::vector<StringHandle> member_type_chain; // e.g., ::type::type
+	std::vector<QualifiedTypeMemberAccess> member_type_chain; // e.g., ::type::template rebind<U>::other
 	AccessSpecifier access;
 	bool is_virtual;
 	bool is_pack_expansion = false; // e.g., Base<Args>...
 
 	DeferredTemplateBaseClassSpecifier(StringHandle name,
 									   std::vector<TemplateArgumentNodeInfo> args,
-									   std::vector<StringHandle> member_chain,
+									   std::vector<QualifiedTypeMemberAccess> member_chain,
 									   AccessSpecifier acc,
 									   bool virt,
 									   bool pack_expansion = false)
@@ -958,8 +965,11 @@ struct FunctionSignature {
 	std::vector<TypeIndex> parameter_type_indices;
 	Linkage linkage = Linkage::None;			 // C vs C++ linkage
 	std::optional<std::string> class_name;	   // For member function pointers
+	CallingConvention calling_convention = CallingConvention::Default;
 	bool is_const = false;					   // For const member functions
 	bool is_volatile = false;				  // For volatile member functions
+	ReferenceQualifier function_reference_qualifier = ReferenceQualifier::None;
+	bool is_noexcept = false;
 
 	// Accessor helpers
 	TypeCategory returnType() const { return return_type_index.category(); }

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1734,6 +1734,7 @@ private:	 // Resume private methods
 	bool skip_asm_suffix(std::optional<std::string_view>* asm_symbol_name = nullptr); // Skip declaration-suffix __asm("...") / __asm__("...")
 	void parse_variable_declarator_suffixes(DeclarationNode& decl);
 	void skip_noexcept_specifier();				// Skip noexcept or noexcept(expr) specifier
+	bool parse_noexcept_value();				// Parse noexcept or noexcept(expr), returning evaluated bool
 	void skip_function_trailing_specifiers(FlashCpp::MemberQualifiers& out_quals);	   // Skip all trailing specifiers after function parameters (stops before 'requires')
 	void skip_trailing_requires_clause();		  // Parse and discard trailing requires clause (if present)
 	std::optional<ASTNode> parse_trailing_requires_clause();	 // Parse trailing requires clause, return RequiresClauseNode

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -267,7 +267,7 @@ struct QualifiedIdParseResult {
 // Result of consuming ::member type access and ... pack expansion after template arguments
 // in a base class specifier. Shared across all base class parsing sites.
 struct BaseClassPostTemplateInfo {
-	std::vector<StringHandle> member_type_chain;
+	std::vector<QualifiedTypeMemberAccess> member_type_chain;
 	std::optional<Token> member_name_token;
 	bool is_pack_expansion = false;
 };
@@ -1800,7 +1800,7 @@ private:	 // Resume private methods
 	std::optional<BaseClassPostTemplateInfo> consume_base_class_qualifiers_after_template_args();
 	const TypeInfo* resolveBaseClassMemberTypeChain(
 		std::string_view base_class_name,
-		const std::vector<StringHandle>& member_type_chain);
+		const std::vector<QualifiedTypeMemberAccess>& member_type_chain);
 
 		// Helper: Build TemplateArgumentNodeInfo vector from parsed template args and AST nodes.
 		// Shared across all base class deferral sites.

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -407,9 +407,12 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 						auto post_info = *post_info_opt;
 						if (!post_info.member_type_chain.empty()) {
 							StringBuilder member_chain_builder;
-							for (StringHandle member_name : post_info.member_type_chain) {
+							for (const QualifiedTypeMemberAccess& member_access : post_info.member_type_chain) {
 								member_chain_builder.append("::");
-								member_chain_builder.append(StringTable::getStringView(member_name));
+								member_chain_builder.append(StringTable::getStringView(member_access.member_name));
+								if (member_access.has_template_arguments) {
+									member_chain_builder.append("<...>");
+								}
 							}
 							std::string_view member_chain = member_chain_builder.commit();
 							FLASH_LOG_FORMAT(Templates, Debug, "Found member type access after template args: {}{}", full_name, member_chain);
@@ -521,9 +524,12 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				auto post_info = *post_info_opt;
 				if (!post_info.member_type_chain.empty()) {
 					StringBuilder member_chain_builder;
-					for (StringHandle member_name : post_info.member_type_chain) {
+					for (const QualifiedTypeMemberAccess& member_access : post_info.member_type_chain) {
 						member_chain_builder.append("::");
-						member_chain_builder.append(StringTable::getStringView(member_name));
+						member_chain_builder.append(StringTable::getStringView(member_access.member_name));
+						if (member_access.has_template_arguments) {
+							member_chain_builder.append("<...>");
+						}
 					}
 					std::string_view member_chain = member_chain_builder.commit();
 					FLASH_LOG_FORMAT(Templates, Debug, "Found member type access after template args: {}{}", base_class_name, member_chain);
@@ -676,11 +682,12 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 						resolveBaseClassMemberTypeChain(base_class_name, post_info.member_type_chain);
 					if (resolved_type == nullptr) {
 						std::string_view unresolved_base_name = base_class_name;
-						for (StringHandle member_name : post_info.member_type_chain) {
+						for (const QualifiedTypeMemberAccess& member_access : post_info.member_type_chain) {
 							unresolved_base_name = StringBuilder()
 								.append(unresolved_base_name)
 								.append("::")
-								.append(StringTable::getStringView(member_name))
+								.append(StringTable::getStringView(member_access.member_name))
+								.append(member_access.has_template_arguments ? "<...>" : "")
 								.commit();
 						}
 						return ParseResult::error(

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -599,14 +599,32 @@ std::optional<BaseClassPostTemplateInfo> Parser::consume_base_class_qualifiers_a
 	// the new current_token_ for the member name.
 	while (peek() == "::"_tok) {
 		advance(); // consume ::, now current_token_ is the token after ::
-		if (current_token_.kind().is_identifier()) {
-			info.member_type_chain.push_back(current_token_.handle());
-			info.member_name_token = current_token_;
-			advance(); // consume member name
-		} else {
+		if (current_token_.value() == "template") {
+			advance(); // consume optional template disambiguator
+		}
+		if (!current_token_.kind().is_identifier()) {
 			// '::' not followed by identifier is a parse error
 			return std::nullopt;
 		}
+
+		QualifiedTypeMemberAccess member_access;
+		member_access.member_name = current_token_.handle();
+		info.member_name_token = current_token_;
+		advance(); // consume member name
+
+		if (peek() == "<"_tok) {
+			std::vector<ASTNode> member_template_arg_nodes;
+			auto member_template_args = parse_explicit_template_arguments(&member_template_arg_nodes);
+			if (!member_template_args.has_value()) {
+				return std::nullopt;
+			}
+			member_access.has_template_arguments = true;
+			member_access.template_arguments = *member_template_args;
+			member_access.template_argument_infos =
+				build_template_arg_infos(member_access.template_arguments, member_template_arg_nodes);
+		}
+
+		info.member_type_chain.push_back(std::move(member_access));
 	}
 
 	// Pack expansion '...' must be consumed AFTER ::member (handles both
@@ -621,25 +639,92 @@ std::optional<BaseClassPostTemplateInfo> Parser::consume_base_class_qualifiers_a
 
 const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 	std::string_view base_class_name,
-	const std::vector<StringHandle>& member_type_chain) {
+	const std::vector<QualifiedTypeMemberAccess>& member_type_chain) {
 	if (member_type_chain.empty()) {
 		return findTypeByName(StringTable::getOrInternStringHandle(base_class_name));
 	}
 
+	auto hasRegisteredMemberTemplate = [](std::string_view qualified_name) {
+		return gTemplateRegistry.lookup_alias_template(qualified_name).has_value() ||
+			   gTemplateRegistry.lookupTemplate(qualified_name).has_value();
+	};
+	auto buildQualifiedMemberName = [](std::string_view owner_name, StringHandle member_name_handle) {
+		return StringBuilder()
+			.append(owner_name)
+			.append("::")
+			.append(StringTable::getStringView(member_name_handle))
+			.commit();
+	};
+
 	const TypeInfo* resolved_type = nullptr;
 	std::string_view current_base_name = base_class_name;
-	for (StringHandle member_name_handle : member_type_chain) {
-		std::string_view member_name = StringTable::getStringView(member_name_handle);
+	for (const QualifiedTypeMemberAccess& member_access : member_type_chain) {
+		std::string_view member_name = StringTable::getStringView(member_access.member_name);
+		if (member_access.has_template_arguments) {
+			std::string_view qualified_member_template_name =
+				buildQualifiedMemberName(current_base_name, member_access.member_name);
+			if (!hasRegisteredMemberTemplate(qualified_member_template_name)) {
+				StringHandle current_base_handle =
+					StringTable::getOrInternStringHandle(current_base_name);
+				auto current_base_it = getTypesByNameMap().find(current_base_handle);
+				if (current_base_it != getTypesByNameMap().end() && current_base_it->second != nullptr) {
+					if (auto pattern_name_opt = gTemplateRegistry.get_instantiation_pattern(current_base_handle);
+						pattern_name_opt.has_value()) {
+						std::string_view pattern_member_name =
+							StringBuilder()
+								.append(*pattern_name_opt)
+								.append("::")
+								.append(member_name)
+								.commit();
+						if (hasRegisteredMemberTemplate(pattern_member_name)) {
+							qualified_member_template_name = pattern_member_name;
+						}
+					}
+
+					if (!hasRegisteredMemberTemplate(qualified_member_template_name) &&
+						current_base_it->second->isTemplateInstantiation()) {
+						std::string_view primary_member_name =
+							StringBuilder()
+								.append(StringTable::getStringView(current_base_it->second->baseTemplateName()))
+								.append("::")
+								.append(member_name)
+								.commit();
+						if (hasRegisteredMemberTemplate(primary_member_name)) {
+							qualified_member_template_name = primary_member_name;
+						}
+					}
+				}
+			}
+
+			if (!hasRegisteredMemberTemplate(qualified_member_template_name)) {
+				return nullptr;
+			}
+
+			AliasTemplateMaterializationResult materialized_member =
+				materializeTemplateInstantiationForLookup(
+					qualified_member_template_name,
+					member_access.template_arguments);
+			if (materialized_member.instantiated_name.empty()) {
+				return nullptr;
+			}
+
+			resolved_type = materialized_member.resolved_type_info;
+			if (resolved_type == nullptr) {
+				resolved_type = findTypeByName(
+					StringTable::getOrInternStringHandle(materialized_member.instantiated_name));
+			}
+			if (resolved_type == nullptr) {
+				return nullptr;
+			}
+			current_base_name = StringTable::getStringView(resolved_type->name());
+			continue;
+		}
+
 		StringHandle qualified_member_handle = StringTable::getOrInternStringHandle(
-			StringBuilder()
-				.append(current_base_name)
-				.append("::")
-				.append(member_name)
-				.commit());
+			buildQualifiedMemberName(current_base_name, member_access.member_name));
 
 		auto alias_it = getTypesByNameMap().find(qualified_member_handle);
-		resolved_type =
-			alias_it != getTypesByNameMap().end() ? alias_it->second : nullptr;
+		resolved_type = alias_it != getTypesByNameMap().end() ? alias_it->second : nullptr;
 		if (resolved_type == nullptr) {
 			resolved_type = lookup_inherited_type_alias(current_base_name, member_name);
 		}
@@ -983,14 +1068,16 @@ TypeIndex Parser::substitute_template_parameter(
 			return qualified_member_type;
 		}
 
-		std::vector<StringHandle> member_type_chain;
+		std::vector<QualifiedTypeMemberAccess> member_type_chain;
 		while (!member_chain.empty()) {
 			size_t next_separator = member_chain.find("::");
 			std::string_view member_name = member_chain.substr(0, next_separator);
 			if (size_t template_pos = member_name.find('<'); template_pos != std::string_view::npos) {
 				member_name = member_name.substr(0, template_pos);
 			}
-			member_type_chain.push_back(StringTable::getOrInternStringHandle(member_name));
+			QualifiedTypeMemberAccess member_access;
+			member_access.member_name = StringTable::getOrInternStringHandle(member_name);
+			member_type_chain.push_back(std::move(member_access));
 			if (next_separator == std::string_view::npos) {
 				break;
 			}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -599,7 +599,7 @@ std::optional<BaseClassPostTemplateInfo> Parser::consume_base_class_qualifiers_a
 	// the new current_token_ for the member name.
 	while (peek() == "::"_tok) {
 		advance(); // consume ::, now current_token_ is the token after ::
-		if (current_token_.value() == "template") {
+		if (current_token_.kind() == "template"_tok) {
 			advance(); // consume optional template disambiguator
 		}
 		if (!current_token_.kind().is_identifier()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -619,9 +619,9 @@ std::optional<BaseClassPostTemplateInfo> Parser::consume_base_class_qualifiers_a
 				return std::nullopt;
 			}
 			member_access.has_template_arguments = true;
-			member_access.template_arguments = *member_template_args;
+			member_access.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>(std::move(member_template_args).value());
 			member_access.template_argument_infos =
-				build_template_arg_infos(member_access.template_arguments, member_template_arg_nodes);
+				build_template_arg_infos(*member_access.template_arguments, member_template_arg_nodes);
 		}
 
 		info.member_type_chain.push_back(std::move(member_access));
@@ -703,7 +703,7 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 			AliasTemplateMaterializationResult materialized_member =
 				materializeTemplateInstantiationForLookup(
 					qualified_member_template_name,
-					member_access.template_arguments);
+					*member_access.template_arguments);
 			if (materialized_member.instantiated_name.empty()) {
 				return nullptr;
 			}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -1380,7 +1380,7 @@ ParseResult Parser::parse_template_declaration() {
 					std::string_view base_class_name = base_class_name_builder.commit();
 					std::vector<ASTNode> template_arg_nodes;
 					std::optional<std::vector<TemplateTypeArg>> base_template_args_opt;
-					std::vector<StringHandle> member_type_chain;
+					std::vector<QualifiedTypeMemberAccess> member_type_chain;
 					std::optional<Token> member_name_token;
 
 					// Check if this is a template base class (e.g., Base<T>)
@@ -1434,11 +1434,12 @@ ParseResult Parser::parse_template_declaration() {
 								resolveBaseClassMemberTypeChain(base_class_name, member_type_chain);
 							if (resolved_type == nullptr) {
 								std::string_view unresolved_base_name = base_class_name;
-								for (StringHandle member_name : member_type_chain) {
+								for (const QualifiedTypeMemberAccess& member_access : member_type_chain) {
 									unresolved_base_name = StringBuilder()
 										.append(unresolved_base_name)
 										.append("::")
-										.append(StringTable::getStringView(member_name))
+										.append(StringTable::getStringView(member_access.member_name))
+										.append(member_access.has_template_arguments ? "<...>" : "")
 										.commit();
 								}
 								return ParseResult::error("Base class '" + std::string(unresolved_base_name) + "' not found", member_name_token.value_or(base_name_token));

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -441,7 +441,12 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 						}
 
 						advance(); // consume '(' or '{'
-						TokenKind close_kind = is_paren ? ")"_tok : "}"_tok;
+						TokenKind close_kind{};
+						if (is_paren) {
+							close_kind = ")"_tok;
+						} else {
+							close_kind = "}"_tok;
+						}
 
 						// Parse arguments so they can be substituted at instantiation time
 						std::vector<ASTNode> init_args;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2133,14 +2133,158 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::string_view final_base_name = base_inst_name;
 					const TypeInfo* final_base_type = nullptr;
 					if (!deferred_base.member_type_chain.empty()) {
+						std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
+						resolved_member_chain.reserve(deferred_base.member_type_chain.size());
+						for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
+							QualifiedTypeMemberAccess resolved_member = member_access;
+							if (member_access.has_template_arguments) {
+								resolved_member.template_arguments.clear();
+								for (const auto& member_arg_info : member_access.template_argument_infos) {
+									if (member_arg_info.is_pack) {
+										auto try_expand = [&](StringHandle pack_name) -> bool {
+											auto it = spec_pack_subst_map.find(pack_name);
+											if (it != spec_pack_subst_map.end()) {
+												resolved_member.template_arguments.insert(
+													resolved_member.template_arguments.end(),
+													it->second.begin(),
+													it->second.end());
+												return true;
+											}
+											return false;
+										};
+
+										bool expanded = false;
+										if (member_arg_info.node.is<ExpressionNode>()) {
+											const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+											if (const auto* template_parameter_reference = std::get_if<TemplateParameterReferenceNode>(&expr)) {
+												expanded = try_expand(template_parameter_reference->param_name());
+											} else if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
+												expanded = try_expand(StringTable::getOrInternStringHandle(identifier->name()));
+											}
+										} else if (member_arg_info.node.is<TypeSpecifierNode>()) {
+											TypeIndex idx = member_arg_info.node.as<TypeSpecifierNode>().type_index();
+											if (idx.is_valid()) {
+												if (const TypeInfo* idx_ti = tryGetTypeInfo(idx)) {
+													expanded = try_expand(idx_ti->name_);
+												}
+											}
+										}
+
+										if (!expanded) {
+											resolution_failed = true;
+											break;
+										}
+										continue;
+									}
+
+									bool member_arg_resolved = false;
+									if (member_arg_info.node.is<TypeSpecifierNode>()) {
+										const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
+										if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
+											if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
+												auto it = spec_name_subst_map.find(StringTable::getStringView(ts_ti->name()));
+												if (it != spec_name_subst_map.end()) {
+													TemplateTypeArg a = it->second;
+													a.pointer_depth = ts.pointer_depth();
+													a.ref_qualifier = ts.reference_qualifier();
+													a.cv_qualifier = ts.cv_qualifier();
+													resolved_member.template_arguments.push_back(a);
+													member_arg_resolved = true;
+												}
+											}
+										}
+										if (!member_arg_resolved) {
+											resolved_member.template_arguments.emplace_back(ts);
+											member_arg_resolved = true;
+										}
+									} else if (member_arg_info.node.is<ExpressionNode>()) {
+										const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+										if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
+											std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
+											auto it = spec_name_subst_map.find(pname);
+											if (it != spec_name_subst_map.end()) {
+												resolved_member.template_arguments.push_back(it->second);
+												member_arg_resolved = true;
+											}
+										} else if (std::holds_alternative<IdentifierNode>(expr)) {
+											std::string_view iname = std::get<IdentifierNode>(expr).name();
+											auto sit = spec_name_subst_map.find(iname);
+											if (sit != spec_name_subst_map.end()) {
+												resolved_member.template_arguments.push_back(sit->second);
+												member_arg_resolved = true;
+											} else {
+												StringHandle h = StringTable::getOrInternStringHandle(iname);
+												auto type_it = getTypesByNameMap().find(h);
+												if (type_it != getTypesByNameMap().end()) {
+													TemplateTypeArg a;
+													a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
+													resolved_member.template_arguments.push_back(a);
+													member_arg_resolved = true;
+												}
+											}
+										}
+
+										if (!member_arg_resolved) {
+											auto makeValueArg = [](int64_t value, TypeCategory type) {
+												TemplateTypeArg va;
+												va.is_value = true;
+												va.value = value;
+												va.type_index = nativeTypeIndex(type);
+												return va;
+											};
+
+											if (std::holds_alternative<NumericLiteralNode>(expr)) {
+												const NumericLiteralNode& num_lit = std::get<NumericLiteralNode>(expr);
+												NumericLiteralValue nv = num_lit.value();
+												int64_t int_val = std::holds_alternative<unsigned long long>(nv)
+													? static_cast<int64_t>(std::get<unsigned long long>(nv))
+													: static_cast<int64_t>(std::get<double>(nv));
+												resolved_member.template_arguments.push_back(makeValueArg(int_val, num_lit.type()));
+												member_arg_resolved = true;
+											} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
+												resolved_member.template_arguments.push_back(makeValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
+												member_arg_resolved = true;
+											} else {
+												ASTNode substituted_expr = substituteTemplateParameters(
+													member_arg_info.node,
+													template_params,
+													template_args);
+												auto evaluated_value = try_evaluate_constant_expression(substituted_expr);
+												if (evaluated_value.has_value()) {
+													resolved_member.template_arguments.push_back(
+														makeValueArg(evaluated_value->value, evaluated_value->type));
+													member_arg_resolved = true;
+												}
+											}
+										}
+									}
+
+									if (!member_arg_resolved) {
+										resolution_failed = true;
+										break;
+									}
+								}
+								if (resolution_failed) {
+									break;
+								}
+							}
+							resolved_member_chain.push_back(std::move(resolved_member));
+						}
+						if (resolution_failed) {
+							FLASH_LOG(Templates, Warning, "Could not resolve member template args for deferred base '", base_tpl_name, "' - skipping");
+							continue;
+						}
 						final_base_type =
-							resolveBaseClassMemberTypeChain(base_inst_name, deferred_base.member_type_chain);
+							resolveBaseClassMemberTypeChain(base_inst_name, resolved_member_chain);
 						if (final_base_type == nullptr) {
 							StringBuilder unresolved_base_builder;
 							unresolved_base_builder.append(base_inst_name);
-							for (StringHandle member_name : deferred_base.member_type_chain) {
+							for (const QualifiedTypeMemberAccess& member_access : resolved_member_chain) {
 								unresolved_base_builder.append("::");
-								unresolved_base_builder.append(StringTable::getStringView(member_name));
+								unresolved_base_builder.append(StringTable::getStringView(member_access.member_name));
+								if (member_access.has_template_arguments) {
+									unresolved_base_builder.append("<...>");
+								}
 							}
 							FLASH_LOG(Templates, Warning, "Deferred template base alias not found after instantiation: '",
 									  unresolved_base_builder.commit(), "'");
@@ -4530,14 +4674,141 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			std::string_view final_base_name = base_template_name;
 			if (!deferred_base.member_type_chain.empty()) {
+				ensure_substitution_maps();
+				std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
+				resolved_member_chain.reserve(deferred_base.member_type_chain.size());
+				bool unresolved_member_arg = false;
+				for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
+					QualifiedTypeMemberAccess resolved_member = member_access;
+					if (member_access.has_template_arguments) {
+						resolved_member.template_arguments.clear();
+						for (const auto& member_arg_info : member_access.template_argument_infos) {
+							if (member_arg_info.is_pack) {
+								auto try_expand = [&](StringHandle pack_name) -> bool {
+									auto it = pack_substitution_map.find(pack_name);
+									if (it != pack_substitution_map.end()) {
+										resolved_member.template_arguments.insert(
+											resolved_member.template_arguments.end(),
+											it->second.begin(),
+											it->second.end());
+										return true;
+									}
+									return false;
+								};
+
+								bool expanded = false;
+								if (member_arg_info.node.is<ExpressionNode>()) {
+									const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+									if (const auto* template_parameter_reference = std::get_if<TemplateParameterReferenceNode>(&expr)) {
+										expanded = try_expand(template_parameter_reference->param_name());
+									} else if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
+										expanded = try_expand(StringTable::getOrInternStringHandle(identifier->name()));
+									}
+								} else if (member_arg_info.node.is<TypeSpecifierNode>()) {
+									TypeIndex idx = member_arg_info.node.as<TypeSpecifierNode>().type_index();
+									if (idx.is_valid()) {
+										if (const TypeInfo* idx_ti = tryGetTypeInfo(idx)) {
+											expanded = try_expand(idx_ti->name_);
+										}
+									}
+								}
+
+								if (!expanded) {
+									unresolved_member_arg = true;
+									break;
+								}
+								continue;
+							}
+
+							bool member_arg_resolved = false;
+							if (member_arg_info.node.is<TypeSpecifierNode>()) {
+								const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
+								if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
+									if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
+										auto it = name_substitution_map.find(StringTable::getStringView(ts_ti->name()));
+										if (it != name_substitution_map.end()) {
+											TemplateTypeArg a = it->second;
+											a.pointer_depth = ts.pointer_depth();
+											a.ref_qualifier = ts.reference_qualifier();
+											a.cv_qualifier = ts.cv_qualifier();
+											resolved_member.template_arguments.push_back(a);
+											member_arg_resolved = true;
+										}
+									}
+								}
+								if (!member_arg_resolved) {
+									resolved_member.template_arguments.emplace_back(ts);
+									member_arg_resolved = true;
+								}
+							} else if (member_arg_info.node.is<ExpressionNode>()) {
+								const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+								if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
+									std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
+									auto it = name_substitution_map.find(pname);
+									if (it != name_substitution_map.end()) {
+										resolved_member.template_arguments.push_back(it->second);
+										member_arg_resolved = true;
+									}
+								} else if (std::holds_alternative<IdentifierNode>(expr)) {
+									std::string_view iname = std::get<IdentifierNode>(expr).name();
+									auto sit = name_substitution_map.find(iname);
+									if (sit != name_substitution_map.end()) {
+										resolved_member.template_arguments.push_back(sit->second);
+										member_arg_resolved = true;
+									} else {
+										StringHandle h = StringTable::getOrInternStringHandle(iname);
+										auto type_it = getTypesByNameMap().find(h);
+										if (type_it != getTypesByNameMap().end()) {
+											TemplateTypeArg a;
+											a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
+											resolved_member.template_arguments.push_back(a);
+											member_arg_resolved = true;
+										}
+									}
+								}
+
+								if (!member_arg_resolved) {
+									ExpressionSubstitutor substitutor(
+										name_substitution_map,
+										pack_substitution_map,
+										*this,
+										template_param_order);
+									ASTNode substituted_node = substitutor.substitute(member_arg_info.node);
+									if (auto value = try_evaluate_constant_expression(substituted_node)) {
+										TemplateTypeArg val_arg(value->value, value->type);
+										resolved_member.template_arguments.push_back(val_arg);
+										member_arg_resolved = true;
+									}
+								}
+							}
+
+							if (!member_arg_resolved) {
+								unresolved_member_arg = true;
+								break;
+							}
+						}
+						if (unresolved_member_arg) {
+							break;
+						}
+					}
+					resolved_member_chain.push_back(std::move(resolved_member));
+				}
+				if (unresolved_member_arg) {
+					FLASH_LOG(Templates, Debug, "Deferred template base member args not fully resolved for '",
+							  StringTable::getStringView(deferred_base.base_template_name), "'");
+					continue;
+				}
 				const TypeInfo* resolved_type =
-					resolveBaseClassMemberTypeChain(base_template_name, deferred_base.member_type_chain);
+					resolveBaseClassMemberTypeChain(base_template_name, resolved_member_chain);
 				if (resolved_type == nullptr) {
 					StringBuilder unresolved_base_builder;
 					unresolved_base_builder.append(base_template_name);
-					for (StringHandle member_name : deferred_base.member_type_chain) {
+					for (const QualifiedTypeMemberAccess& member_access : resolved_member_chain) {
 						unresolved_base_builder.append("::");
-						unresolved_base_builder.append(StringTable::getStringView(member_name));
+						unresolved_base_builder.append(StringTable::getStringView(member_access.member_name));
+						if (member_access.has_template_arguments) {
+							unresolved_base_builder.append("<...>");
+						}
 					}
 					std::string_view unresolved_base_name = unresolved_base_builder.commit();
 					FLASH_LOG(Templates, Debug, "Deferred template base alias not found: ",

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -127,19 +127,7 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 
 					if (!member_arg_resolved) {
 						const ASTNode substituted_expr = substitute_expression(member_arg_info.node);
-						if (std::holds_alternative<NumericLiteralNode>(expr)) {
-							const NumericLiteralNode& num_lit = std::get<NumericLiteralNode>(expr);
-							NumericLiteralValue value = num_lit.value();
-							int64_t int_value = std::holds_alternative<unsigned long long>(value)
-								? static_cast<int64_t>(std::get<unsigned long long>(value))
-								: static_cast<int64_t>(std::get<double>(value));
-							resolved_member.template_arguments->push_back(makeDeferredBaseValueArg(int_value, num_lit.type()));
-							member_arg_resolved = true;
-						} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
-							resolved_member.template_arguments->push_back(
-								makeDeferredBaseValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
-							member_arg_resolved = true;
-						} else if (auto evaluated_value = evaluate_constant_expression(substituted_expr)) {
+						if (auto evaluated_value = evaluate_constant_expression(substituted_expr)) {
 							resolved_member.template_arguments->push_back(
 								makeDeferredBaseValueArg(evaluated_value->value, evaluated_value->type));
 							member_arg_resolved = true;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2138,14 +2138,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
 							QualifiedTypeMemberAccess resolved_member = member_access;
 							if (member_access.has_template_arguments) {
-								resolved_member.template_arguments.clear();
+								resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
+								resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
 								for (const auto& member_arg_info : member_access.template_argument_infos) {
 									if (member_arg_info.is_pack) {
 										auto try_expand = [&](StringHandle pack_name) -> bool {
 											auto it = spec_pack_subst_map.find(pack_name);
 											if (it != spec_pack_subst_map.end()) {
-												resolved_member.template_arguments.insert(
-													resolved_member.template_arguments.end(),
+												resolved_member.template_arguments->insert(
+													resolved_member.template_arguments->end(),
 													it->second.begin(),
 													it->second.end());
 												return true;
@@ -2188,13 +2189,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 													a.pointer_depth = ts.pointer_depth();
 													a.ref_qualifier = ts.reference_qualifier();
 													a.cv_qualifier = ts.cv_qualifier();
-													resolved_member.template_arguments.push_back(a);
+													resolved_member.template_arguments->push_back(a);
 													member_arg_resolved = true;
 												}
 											}
 										}
 										if (!member_arg_resolved) {
-											resolved_member.template_arguments.emplace_back(ts);
+											resolved_member.template_arguments->emplace_back(ts);
 											member_arg_resolved = true;
 										}
 									} else if (member_arg_info.node.is<ExpressionNode>()) {
@@ -2203,14 +2204,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
 											auto it = spec_name_subst_map.find(pname);
 											if (it != spec_name_subst_map.end()) {
-												resolved_member.template_arguments.push_back(it->second);
+												resolved_member.template_arguments->push_back(it->second);
 												member_arg_resolved = true;
 											}
 										} else if (std::holds_alternative<IdentifierNode>(expr)) {
 											std::string_view iname = std::get<IdentifierNode>(expr).name();
 											auto sit = spec_name_subst_map.find(iname);
 											if (sit != spec_name_subst_map.end()) {
-												resolved_member.template_arguments.push_back(sit->second);
+												resolved_member.template_arguments->push_back(sit->second);
 												member_arg_resolved = true;
 											} else {
 												StringHandle h = StringTable::getOrInternStringHandle(iname);
@@ -2218,7 +2219,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 												if (type_it != getTypesByNameMap().end()) {
 													TemplateTypeArg a;
 													a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
-													resolved_member.template_arguments.push_back(a);
+													resolved_member.template_arguments->push_back(a);
 													member_arg_resolved = true;
 												}
 											}
@@ -2239,10 +2240,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 												int64_t int_val = std::holds_alternative<unsigned long long>(nv)
 													? static_cast<int64_t>(std::get<unsigned long long>(nv))
 													: static_cast<int64_t>(std::get<double>(nv));
-												resolved_member.template_arguments.push_back(makeValueArg(int_val, num_lit.type()));
+												resolved_member.template_arguments->push_back(makeValueArg(int_val, num_lit.type()));
 												member_arg_resolved = true;
 											} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
-												resolved_member.template_arguments.push_back(makeValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
+												resolved_member.template_arguments->push_back(makeValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
 												member_arg_resolved = true;
 											} else {
 												ASTNode substituted_expr = substituteTemplateParameters(
@@ -2251,7 +2252,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 													template_args);
 												auto evaluated_value = try_evaluate_constant_expression(substituted_expr);
 												if (evaluated_value.has_value()) {
-													resolved_member.template_arguments.push_back(
+													resolved_member.template_arguments->push_back(
 														makeValueArg(evaluated_value->value, evaluated_value->type));
 													member_arg_resolved = true;
 												}
@@ -4681,14 +4682,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
 					QualifiedTypeMemberAccess resolved_member = member_access;
 					if (member_access.has_template_arguments) {
-						resolved_member.template_arguments.clear();
+						resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
+						resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
 						for (const auto& member_arg_info : member_access.template_argument_infos) {
 							if (member_arg_info.is_pack) {
 								auto try_expand = [&](StringHandle pack_name) -> bool {
 									auto it = pack_substitution_map.find(pack_name);
 									if (it != pack_substitution_map.end()) {
-										resolved_member.template_arguments.insert(
-											resolved_member.template_arguments.end(),
+										resolved_member.template_arguments->insert(
+											resolved_member.template_arguments->end(),
 											it->second.begin(),
 											it->second.end());
 										return true;
@@ -4731,13 +4733,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											a.pointer_depth = ts.pointer_depth();
 											a.ref_qualifier = ts.reference_qualifier();
 											a.cv_qualifier = ts.cv_qualifier();
-											resolved_member.template_arguments.push_back(a);
+											resolved_member.template_arguments->push_back(a);
 											member_arg_resolved = true;
 										}
 									}
 								}
 								if (!member_arg_resolved) {
-									resolved_member.template_arguments.emplace_back(ts);
+									resolved_member.template_arguments->emplace_back(ts);
 									member_arg_resolved = true;
 								}
 							} else if (member_arg_info.node.is<ExpressionNode>()) {
@@ -4746,14 +4748,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
 									auto it = name_substitution_map.find(pname);
 									if (it != name_substitution_map.end()) {
-										resolved_member.template_arguments.push_back(it->second);
+										resolved_member.template_arguments->push_back(it->second);
 										member_arg_resolved = true;
 									}
 								} else if (std::holds_alternative<IdentifierNode>(expr)) {
 									std::string_view iname = std::get<IdentifierNode>(expr).name();
 									auto sit = name_substitution_map.find(iname);
 									if (sit != name_substitution_map.end()) {
-										resolved_member.template_arguments.push_back(sit->second);
+										resolved_member.template_arguments->push_back(sit->second);
 										member_arg_resolved = true;
 									} else {
 										StringHandle h = StringTable::getOrInternStringHandle(iname);
@@ -4761,7 +4763,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										if (type_it != getTypesByNameMap().end()) {
 											TemplateTypeArg a;
 											a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
-											resolved_member.template_arguments.push_back(a);
+											resolved_member.template_arguments->push_back(a);
 											member_arg_resolved = true;
 										}
 									}
@@ -4776,7 +4778,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									ASTNode substituted_node = substitutor.substitute(member_arg_info.node);
 									if (auto value = try_evaluate_constant_expression(substituted_node)) {
 										TemplateTypeArg val_arg(value->value, value->type);
-										resolved_member.template_arguments.push_back(val_arg);
+										resolved_member.template_arguments->push_back(val_arg);
 										member_arg_resolved = true;
 									}
 								}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2136,7 +2136,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
 						resolved_member_chain.reserve(deferred_base.member_type_chain.size());
 						for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
-							QualifiedTypeMemberAccess resolved_member = member_access;
+							QualifiedTypeMemberAccess resolved_member;
+							resolved_member.member_name = member_access.member_name;
+							resolved_member.has_template_arguments = member_access.has_template_arguments;
 							if (member_access.has_template_arguments) {
 								resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
 								resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
@@ -4680,7 +4682,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				resolved_member_chain.reserve(deferred_base.member_type_chain.size());
 				bool unresolved_member_arg = false;
 				for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
-					QualifiedTypeMemberAccess resolved_member = member_access;
+					QualifiedTypeMemberAccess resolved_member;
+					resolved_member.member_name = member_access.member_name;
+					resolved_member.has_template_arguments = member_access.has_template_arguments;
 					if (member_access.has_template_arguments) {
 						resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
 						resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -12,6 +12,153 @@
 
 static constexpr size_t kMaxAliasUnwrapIterations = 64;
 
+using TemplateArgSubstitutionMap = std::unordered_map<std::string_view, TemplateTypeArg>;
+using TemplateArgPackSubstitutionMap =
+	std::unordered_map<StringHandle, std::vector<TemplateTypeArg>, TransparentStringHash, std::equal_to<>>;
+
+static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeCategory type) {
+	TemplateTypeArg arg;
+	arg.is_value = true;
+	arg.value = value;
+	arg.type_index = nativeTypeIndex(type);
+	return arg;
+}
+
+template <typename SubstituteExpressionFn, typename EvaluateConstantExpressionFn>
+static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBaseMemberTypeChain(
+	const std::vector<QualifiedTypeMemberAccess>& member_type_chain,
+	const TemplateArgSubstitutionMap& name_substitution_map,
+	const TemplateArgPackSubstitutionMap& pack_substitution_map,
+	SubstituteExpressionFn&& substitute_expression,
+	EvaluateConstantExpressionFn&& evaluate_constant_expression) {
+	std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
+	resolved_member_chain.reserve(member_type_chain.size());
+
+	for (const QualifiedTypeMemberAccess& member_access : member_type_chain) {
+		QualifiedTypeMemberAccess resolved_member;
+		resolved_member.member_name = member_access.member_name;
+		resolved_member.has_template_arguments = member_access.has_template_arguments;
+		if (member_access.has_template_arguments) {
+			resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
+			resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
+			for (const auto& member_arg_info : member_access.template_argument_infos) {
+				if (member_arg_info.is_pack) {
+					auto try_expand = [&](StringHandle pack_name) -> bool {
+						auto it = pack_substitution_map.find(pack_name);
+						if (it != pack_substitution_map.end()) {
+							resolved_member.template_arguments->insert(
+								resolved_member.template_arguments->end(),
+								it->second.begin(),
+								it->second.end());
+							return true;
+						}
+						return false;
+					};
+
+					bool expanded = false;
+					if (member_arg_info.node.is<ExpressionNode>()) {
+						const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+						if (const auto* template_parameter_reference = std::get_if<TemplateParameterReferenceNode>(&expr)) {
+							expanded = try_expand(template_parameter_reference->param_name());
+						} else if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
+							expanded = try_expand(StringTable::getOrInternStringHandle(identifier->name()));
+						}
+					} else if (member_arg_info.node.is<TypeSpecifierNode>()) {
+						TypeIndex idx = member_arg_info.node.as<TypeSpecifierNode>().type_index();
+						if (idx.is_valid()) {
+							if (const TypeInfo* idx_ti = tryGetTypeInfo(idx)) {
+								expanded = try_expand(idx_ti->name_);
+							}
+						}
+					}
+
+					if (!expanded) {
+						return std::nullopt;
+					}
+					continue;
+				}
+
+				bool member_arg_resolved = false;
+				if (member_arg_info.node.is<TypeSpecifierNode>()) {
+					const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
+					if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
+						if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
+							auto it = name_substitution_map.find(StringTable::getStringView(ts_ti->name()));
+							if (it != name_substitution_map.end()) {
+								TemplateTypeArg arg = it->second;
+								arg.pointer_depth = ts.pointer_depth();
+								arg.ref_qualifier = ts.reference_qualifier();
+								arg.cv_qualifier = ts.cv_qualifier();
+								resolved_member.template_arguments->push_back(arg);
+								member_arg_resolved = true;
+							}
+						}
+					}
+					if (!member_arg_resolved) {
+						resolved_member.template_arguments->emplace_back(ts);
+						member_arg_resolved = true;
+					}
+				} else if (member_arg_info.node.is<ExpressionNode>()) {
+					const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
+					if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
+						std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
+						auto it = name_substitution_map.find(pname);
+						if (it != name_substitution_map.end()) {
+							resolved_member.template_arguments->push_back(it->second);
+							member_arg_resolved = true;
+						}
+					} else if (std::holds_alternative<IdentifierNode>(expr)) {
+						std::string_view iname = std::get<IdentifierNode>(expr).name();
+						auto sit = name_substitution_map.find(iname);
+						if (sit != name_substitution_map.end()) {
+							resolved_member.template_arguments->push_back(sit->second);
+							member_arg_resolved = true;
+						} else {
+							StringHandle handle = StringTable::getOrInternStringHandle(iname);
+							auto type_it = getTypesByNameMap().find(handle);
+							if (type_it != getTypesByNameMap().end()) {
+								TemplateTypeArg arg;
+								arg.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
+								resolved_member.template_arguments->push_back(arg);
+								member_arg_resolved = true;
+							}
+						}
+					}
+
+					if (!member_arg_resolved) {
+						const ASTNode substituted_expr = substitute_expression(member_arg_info.node);
+						if (std::holds_alternative<NumericLiteralNode>(expr)) {
+							const NumericLiteralNode& num_lit = std::get<NumericLiteralNode>(expr);
+							NumericLiteralValue value = num_lit.value();
+							int64_t int_value = std::holds_alternative<unsigned long long>(value)
+								? static_cast<int64_t>(std::get<unsigned long long>(value))
+								: static_cast<int64_t>(std::get<double>(value));
+							resolved_member.template_arguments->push_back(makeDeferredBaseValueArg(int_value, num_lit.type()));
+							member_arg_resolved = true;
+						} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
+							resolved_member.template_arguments->push_back(
+								makeDeferredBaseValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
+							member_arg_resolved = true;
+						} else if (auto evaluated_value = evaluate_constant_expression(substituted_expr)) {
+							resolved_member.template_arguments->push_back(
+								makeDeferredBaseValueArg(evaluated_value->value, evaluated_value->type));
+							member_arg_resolved = true;
+						}
+					}
+				}
+
+				if (!member_arg_resolved) {
+					return std::nullopt;
+				}
+			}
+		}
+
+		resolved_member_chain.push_back(std::move(resolved_member));
+	}
+
+	return resolved_member_chain;
+}
+
 // Compute the canonical instantiated lookup name for a member function.
 // For conversion operators (operator with an identifier suffix, e.g. "operator value_type"),
 // the substituted return type gives the canonical name (e.g. "operator int").
@@ -2133,156 +2280,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::string_view final_base_name = base_inst_name;
 					const TypeInfo* final_base_type = nullptr;
 					if (!deferred_base.member_type_chain.empty()) {
-						std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
-						resolved_member_chain.reserve(deferred_base.member_type_chain.size());
-						for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
-							QualifiedTypeMemberAccess resolved_member;
-							resolved_member.member_name = member_access.member_name;
-							resolved_member.has_template_arguments = member_access.has_template_arguments;
-							if (member_access.has_template_arguments) {
-								resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
-								resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
-								for (const auto& member_arg_info : member_access.template_argument_infos) {
-									if (member_arg_info.is_pack) {
-										auto try_expand = [&](StringHandle pack_name) -> bool {
-											auto it = spec_pack_subst_map.find(pack_name);
-											if (it != spec_pack_subst_map.end()) {
-												resolved_member.template_arguments->insert(
-													resolved_member.template_arguments->end(),
-													it->second.begin(),
-													it->second.end());
-												return true;
-											}
-											return false;
-										};
-
-										bool expanded = false;
-										if (member_arg_info.node.is<ExpressionNode>()) {
-											const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
-											if (const auto* template_parameter_reference = std::get_if<TemplateParameterReferenceNode>(&expr)) {
-												expanded = try_expand(template_parameter_reference->param_name());
-											} else if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
-												expanded = try_expand(StringTable::getOrInternStringHandle(identifier->name()));
-											}
-										} else if (member_arg_info.node.is<TypeSpecifierNode>()) {
-											TypeIndex idx = member_arg_info.node.as<TypeSpecifierNode>().type_index();
-											if (idx.is_valid()) {
-												if (const TypeInfo* idx_ti = tryGetTypeInfo(idx)) {
-													expanded = try_expand(idx_ti->name_);
-												}
-											}
-										}
-
-										if (!expanded) {
-											resolution_failed = true;
-											break;
-										}
-										continue;
-									}
-
-									bool member_arg_resolved = false;
-									if (member_arg_info.node.is<TypeSpecifierNode>()) {
-										const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
-										if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
-											if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
-												auto it = spec_name_subst_map.find(StringTable::getStringView(ts_ti->name()));
-												if (it != spec_name_subst_map.end()) {
-													TemplateTypeArg a = it->second;
-													a.pointer_depth = ts.pointer_depth();
-													a.ref_qualifier = ts.reference_qualifier();
-													a.cv_qualifier = ts.cv_qualifier();
-													resolved_member.template_arguments->push_back(a);
-													member_arg_resolved = true;
-												}
-											}
-										}
-										if (!member_arg_resolved) {
-											resolved_member.template_arguments->emplace_back(ts);
-											member_arg_resolved = true;
-										}
-									} else if (member_arg_info.node.is<ExpressionNode>()) {
-										const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
-										if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
-											std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
-											auto it = spec_name_subst_map.find(pname);
-											if (it != spec_name_subst_map.end()) {
-												resolved_member.template_arguments->push_back(it->second);
-												member_arg_resolved = true;
-											}
-										} else if (std::holds_alternative<IdentifierNode>(expr)) {
-											std::string_view iname = std::get<IdentifierNode>(expr).name();
-											auto sit = spec_name_subst_map.find(iname);
-											if (sit != spec_name_subst_map.end()) {
-												resolved_member.template_arguments->push_back(sit->second);
-												member_arg_resolved = true;
-											} else {
-												StringHandle h = StringTable::getOrInternStringHandle(iname);
-												auto type_it = getTypesByNameMap().find(h);
-												if (type_it != getTypesByNameMap().end()) {
-													TemplateTypeArg a;
-													a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
-													resolved_member.template_arguments->push_back(a);
-													member_arg_resolved = true;
-												}
-											}
-										}
-
-										if (!member_arg_resolved) {
-											auto makeValueArg = [](int64_t value, TypeCategory type) {
-												TemplateTypeArg va;
-												va.is_value = true;
-												va.value = value;
-												va.type_index = nativeTypeIndex(type);
-												return va;
-											};
-
-											if (std::holds_alternative<NumericLiteralNode>(expr)) {
-												const NumericLiteralNode& num_lit = std::get<NumericLiteralNode>(expr);
-												NumericLiteralValue nv = num_lit.value();
-												int64_t int_val = std::holds_alternative<unsigned long long>(nv)
-													? static_cast<int64_t>(std::get<unsigned long long>(nv))
-													: static_cast<int64_t>(std::get<double>(nv));
-												resolved_member.template_arguments->push_back(makeValueArg(int_val, num_lit.type()));
-												member_arg_resolved = true;
-											} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
-												resolved_member.template_arguments->push_back(makeValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
-												member_arg_resolved = true;
-											} else {
-												ASTNode substituted_expr = substituteTemplateParameters(
-													member_arg_info.node,
-													template_params,
-													template_args);
-												auto evaluated_value = try_evaluate_constant_expression(substituted_expr);
-												if (evaluated_value.has_value()) {
-													resolved_member.template_arguments->push_back(
-														makeValueArg(evaluated_value->value, evaluated_value->type));
-													member_arg_resolved = true;
-												}
-											}
-										}
-									}
-
-									if (!member_arg_resolved) {
-										resolution_failed = true;
-										break;
-									}
-								}
-								if (resolution_failed) {
-									break;
-								}
-							}
-							resolved_member_chain.push_back(std::move(resolved_member));
-						}
-						if (resolution_failed) {
+						auto resolved_member_chain = resolveDeferredBaseMemberTypeChain(
+							deferred_base.member_type_chain,
+							spec_name_subst_map,
+							spec_pack_subst_map,
+							[&](const ASTNode& node) {
+								return substituteTemplateParameters(node, template_params, template_args);
+							},
+							[&](const ASTNode& node) {
+								return try_evaluate_constant_expression(node);
+							});
+						if (!resolved_member_chain.has_value()) {
 							FLASH_LOG(Templates, Warning, "Could not resolve member template args for deferred base '", base_tpl_name, "' - skipping");
 							continue;
 						}
 						final_base_type =
-							resolveBaseClassMemberTypeChain(base_inst_name, resolved_member_chain);
+							resolveBaseClassMemberTypeChain(base_inst_name, *resolved_member_chain);
 						if (final_base_type == nullptr) {
 							StringBuilder unresolved_base_builder;
 							unresolved_base_builder.append(base_inst_name);
-							for (const QualifiedTypeMemberAccess& member_access : resolved_member_chain) {
+							for (const QualifiedTypeMemberAccess& member_access : *resolved_member_chain) {
 								unresolved_base_builder.append("::");
 								unresolved_base_builder.append(StringTable::getStringView(member_access.member_name));
 								if (member_access.has_template_arguments) {
@@ -4678,138 +4695,32 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::string_view final_base_name = base_template_name;
 			if (!deferred_base.member_type_chain.empty()) {
 				ensure_substitution_maps();
-				std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
-				resolved_member_chain.reserve(deferred_base.member_type_chain.size());
-				bool unresolved_member_arg = false;
-				for (const QualifiedTypeMemberAccess& member_access : deferred_base.member_type_chain) {
-					QualifiedTypeMemberAccess resolved_member;
-					resolved_member.member_name = member_access.member_name;
-					resolved_member.has_template_arguments = member_access.has_template_arguments;
-					if (member_access.has_template_arguments) {
-						resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
-						resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
-						for (const auto& member_arg_info : member_access.template_argument_infos) {
-							if (member_arg_info.is_pack) {
-								auto try_expand = [&](StringHandle pack_name) -> bool {
-									auto it = pack_substitution_map.find(pack_name);
-									if (it != pack_substitution_map.end()) {
-										resolved_member.template_arguments->insert(
-											resolved_member.template_arguments->end(),
-											it->second.begin(),
-											it->second.end());
-										return true;
-									}
-									return false;
-								};
-
-								bool expanded = false;
-								if (member_arg_info.node.is<ExpressionNode>()) {
-									const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
-									if (const auto* template_parameter_reference = std::get_if<TemplateParameterReferenceNode>(&expr)) {
-										expanded = try_expand(template_parameter_reference->param_name());
-									} else if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
-										expanded = try_expand(StringTable::getOrInternStringHandle(identifier->name()));
-									}
-								} else if (member_arg_info.node.is<TypeSpecifierNode>()) {
-									TypeIndex idx = member_arg_info.node.as<TypeSpecifierNode>().type_index();
-									if (idx.is_valid()) {
-										if (const TypeInfo* idx_ti = tryGetTypeInfo(idx)) {
-											expanded = try_expand(idx_ti->name_);
-										}
-									}
-								}
-
-								if (!expanded) {
-									unresolved_member_arg = true;
-									break;
-								}
-								continue;
-							}
-
-							bool member_arg_resolved = false;
-							if (member_arg_info.node.is<TypeSpecifierNode>()) {
-								const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
-								if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
-									if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
-										auto it = name_substitution_map.find(StringTable::getStringView(ts_ti->name()));
-										if (it != name_substitution_map.end()) {
-											TemplateTypeArg a = it->second;
-											a.pointer_depth = ts.pointer_depth();
-											a.ref_qualifier = ts.reference_qualifier();
-											a.cv_qualifier = ts.cv_qualifier();
-											resolved_member.template_arguments->push_back(a);
-											member_arg_resolved = true;
-										}
-									}
-								}
-								if (!member_arg_resolved) {
-									resolved_member.template_arguments->emplace_back(ts);
-									member_arg_resolved = true;
-								}
-							} else if (member_arg_info.node.is<ExpressionNode>()) {
-								const ExpressionNode& expr = member_arg_info.node.as<ExpressionNode>();
-								if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
-									std::string_view pname = std::get<TemplateParameterReferenceNode>(expr).param_name().view();
-									auto it = name_substitution_map.find(pname);
-									if (it != name_substitution_map.end()) {
-										resolved_member.template_arguments->push_back(it->second);
-										member_arg_resolved = true;
-									}
-								} else if (std::holds_alternative<IdentifierNode>(expr)) {
-									std::string_view iname = std::get<IdentifierNode>(expr).name();
-									auto sit = name_substitution_map.find(iname);
-									if (sit != name_substitution_map.end()) {
-										resolved_member.template_arguments->push_back(sit->second);
-										member_arg_resolved = true;
-									} else {
-										StringHandle h = StringTable::getOrInternStringHandle(iname);
-										auto type_it = getTypesByNameMap().find(h);
-										if (type_it != getTypesByNameMap().end()) {
-											TemplateTypeArg a;
-											a.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
-											resolved_member.template_arguments->push_back(a);
-											member_arg_resolved = true;
-										}
-									}
-								}
-
-								if (!member_arg_resolved) {
-									ExpressionSubstitutor substitutor(
-										name_substitution_map,
-										pack_substitution_map,
-										*this,
-										template_param_order);
-									ASTNode substituted_node = substitutor.substitute(member_arg_info.node);
-									if (auto value = try_evaluate_constant_expression(substituted_node)) {
-										TemplateTypeArg val_arg(value->value, value->type);
-										resolved_member.template_arguments->push_back(val_arg);
-										member_arg_resolved = true;
-									}
-								}
-							}
-
-							if (!member_arg_resolved) {
-								unresolved_member_arg = true;
-								break;
-							}
-						}
-						if (unresolved_member_arg) {
-							break;
-						}
-					}
-					resolved_member_chain.push_back(std::move(resolved_member));
-				}
-				if (unresolved_member_arg) {
+				ExpressionSubstitutor member_template_arg_substitutor(
+					name_substitution_map,
+					pack_substitution_map,
+					*this,
+					template_param_order);
+				auto resolved_member_chain = resolveDeferredBaseMemberTypeChain(
+					deferred_base.member_type_chain,
+					name_substitution_map,
+					pack_substitution_map,
+					[&](const ASTNode& node) {
+						return member_template_arg_substitutor.substitute(node);
+					},
+					[&](const ASTNode& node) {
+						return try_evaluate_constant_expression(node);
+					});
+				if (!resolved_member_chain.has_value()) {
 					FLASH_LOG(Templates, Debug, "Deferred template base member args not fully resolved for '",
 							  StringTable::getStringView(deferred_base.base_template_name), "'");
 					continue;
 				}
 				const TypeInfo* resolved_type =
-					resolveBaseClassMemberTypeChain(base_template_name, resolved_member_chain);
+					resolveBaseClassMemberTypeChain(base_template_name, *resolved_member_chain);
 				if (resolved_type == nullptr) {
 					StringBuilder unresolved_base_builder;
 					unresolved_base_builder.append(base_template_name);
-					for (const QualifiedTypeMemberAccess& member_access : resolved_member_chain) {
+					for (const QualifiedTypeMemberAccess& member_access : *resolved_member_chain) {
 						unresolved_base_builder.append("::");
 						unresolved_base_builder.append(StringTable::getStringView(member_access.member_name));
 						if (member_access.has_template_arguments) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -12,6 +12,10 @@
 
 static constexpr size_t kMaxAliasUnwrapIterations = 64;
 
+// The std::string_view keys point at parser-owned/interned template parameter names that outlive
+// each transient substitution map built during instantiation; these maps mirror the existing
+// name-substitution containers used throughout template instantiation, while packs stay keyed by
+// StringHandle because pack lookup already operates on interned handles.
 using TemplateArgSubstitutionMap = std::unordered_map<std::string_view, TemplateTypeArg>;
 using TemplateArgPackSubstitutionMap =
 	std::unordered_map<StringHandle, std::vector<TemplateTypeArg>, TransparentStringHash, std::equal_to<>>;
@@ -24,6 +28,13 @@ static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeCategory type
 	return arg;
 }
 
+// Resolve any stored template arguments on a deferred base member-type chain after a class
+// template's substitution maps are available.
+// Returns std::nullopt when any pack expansion or concrete member argument cannot be resolved.
+// The substitution maps only need to remain valid for the duration of this call.
+// `substitute_expression` must accept `const ASTNode&` and return a substituted `ASTNode`.
+// `evaluate_constant_expression` must accept `const ASTNode&` and return
+// `std::optional<Parser::ConstantValue>` for non-type template arguments.
 template <typename SubstituteExpressionFn, typename EvaluateConstantExpressionFn>
 static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBaseMemberTypeChain(
 	const std::vector<QualifiedTypeMemberAccess>& member_type_chain,
@@ -83,13 +94,13 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 					const TypeSpecifierNode& ts = member_arg_info.node.as<TypeSpecifierNode>();
 					if (is_struct_type(ts.category()) && ts.type_index().is_valid()) {
 						if (const TypeInfo* ts_ti = tryGetTypeInfo(ts.type_index())) {
-							auto it = name_substitution_map.find(StringTable::getStringView(ts_ti->name()));
-							if (it != name_substitution_map.end()) {
-								TemplateTypeArg arg = it->second;
-								arg.pointer_depth = ts.pointer_depth();
-								arg.ref_qualifier = ts.reference_qualifier();
-								arg.cv_qualifier = ts.cv_qualifier();
-								resolved_member.template_arguments->push_back(arg);
+							auto type_subst_it = name_substitution_map.find(StringTable::getStringView(ts_ti->name()));
+							if (type_subst_it != name_substitution_map.end()) {
+								TemplateTypeArg resolved_type_arg = type_subst_it->second;
+								resolved_type_arg.pointer_depth = ts.pointer_depth();
+								resolved_type_arg.ref_qualifier = ts.reference_qualifier();
+								resolved_type_arg.cv_qualifier = ts.cv_qualifier();
+								resolved_member.template_arguments->push_back(resolved_type_arg);
 								member_arg_resolved = true;
 							}
 						}
@@ -109,17 +120,17 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 						}
 					} else if (std::holds_alternative<IdentifierNode>(expr)) {
 						std::string_view iname = std::get<IdentifierNode>(expr).name();
-						auto sit = name_substitution_map.find(iname);
-						if (sit != name_substitution_map.end()) {
-							resolved_member.template_arguments->push_back(sit->second);
+						auto ident_subst_it = name_substitution_map.find(iname);
+						if (ident_subst_it != name_substitution_map.end()) {
+							resolved_member.template_arguments->push_back(ident_subst_it->second);
 							member_arg_resolved = true;
 						} else {
-							StringHandle handle = StringTable::getOrInternStringHandle(iname);
-							auto type_it = getTypesByNameMap().find(handle);
+							StringHandle type_name_handle = StringTable::getOrInternStringHandle(iname);
+							auto type_it = getTypesByNameMap().find(type_name_handle);
 							if (type_it != getTypesByNameMap().end()) {
-								TemplateTypeArg arg;
-								arg.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
-								resolved_member.template_arguments->push_back(arg);
+								TemplateTypeArg resolved_type_arg;
+								resolved_type_arg.type_index = type_it->second->type_index_.withCategory(type_it->second->typeEnum());
+								resolved_member.template_arguments->push_back(resolved_type_arg);
 								member_arg_resolved = true;
 							}
 						}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -5,6 +5,33 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
+// Parse noexcept or noexcept(expr) specifier and return the evaluated boolean value.
+// Assumes the 'noexcept' token has already been consumed by the caller.
+// - Bare 'noexcept' (no parens) → returns true.
+// - 'noexcept(expr)' → tries to parse and evaluate expr as a constant expression.
+//   If expr evaluates to 0/false, returns false. Otherwise (including dependent
+//   expressions that cannot be evaluated), returns true conservatively.
+bool Parser::parse_noexcept_value() {
+	if (peek() != "("_tok) {
+		// bare noexcept (no parens) is noexcept(true)
+		return true;
+	}
+	// noexcept(expr) — try to evaluate; default to true for dependent exprs
+	SaveHandle noexcept_expr_pos = save_token_position();
+	advance(); // consume '('
+	auto noexcept_expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
+	if (!noexcept_expr_result.is_error() && noexcept_expr_result.node().has_value() && peek() == ")"_tok) {
+		advance(); // consume ')'
+		discard_saved_token(noexcept_expr_pos);
+		auto eval = try_evaluate_constant_expression(*noexcept_expr_result.node());
+		return !eval.has_value() || eval->value != 0;
+	}
+	// Expression parsing failed — fall back to skipping balanced parens
+	restore_token_position(noexcept_expr_pos);
+	skip_balanced_parens();
+	return true; // dependent — assume true
+}
+
 ParseResult Parser::parse_template_parameter_list(InlineVector<ASTNode, 4>& out_params) {
 	// Save the current template parameter names so we can restore them later.
 	// This allows nested template declarations to have their own parameter scope.
@@ -1410,11 +1437,8 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 								sig_function_ref_qualifier = ReferenceQualifier::RValueReference;
 								advance();
 							} else if (peek() == "noexcept"_tok) {
-								sig_is_noexcept = true;
 								advance(); // consume 'noexcept'
-								if (peek() == "("_tok) {
-									skip_balanced_parens();
-								}
+								sig_is_noexcept = parse_noexcept_value();
 							} else {
 								break;
 							}
@@ -1512,11 +1536,8 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 						}
 					}
 					if (peek() == "noexcept"_tok) {
-						func_sig.is_noexcept = true;
-						advance();
-						if (peek() == "("_tok) {
-							skip_balanced_parens();
-						}
+						advance(); // consume 'noexcept'
+						func_sig.is_noexcept = parse_noexcept_value();
 					}
 					type_node.set_function_signature(func_sig);
 

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1273,6 +1273,18 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 			}
 		}
 
+		CallingConvention direct_function_calling_convention = CallingConvention::Default;
+		if (peek().is_identifier()) {
+			SaveHandle calling_convention_pos = save_token_position();
+			direct_function_calling_convention = parse_calling_convention();
+			if (direct_function_calling_convention == CallingConvention::Default || peek() != "("_tok) {
+				restore_token_position(calling_convention_pos);
+				direct_function_calling_convention = CallingConvention::Default;
+			} else {
+				discard_saved_token(calling_convention_pos);
+			}
+		}
+
 		// Check for pointer-to-array syntax: T(*)[] or T(*)[N]
 		// AND function pointer/reference syntax: T(&)() or T(*)() or T(&&)()
 		// This is the syntax used for pointer-to-array types and function types in template arguments
@@ -1285,7 +1297,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 			// Skip optional calling convention before ptr-operator, consistent with
 			// parse_declarator() and parse_type_and_name() which call parse_calling_convention()
 			// at the same position. Handles patterns like: _Ret (__cdecl _Arg0::*)(_Types...)
-			parse_calling_convention();
+			CallingConvention paren_calling_convention = parse_calling_convention();
 
 			// Detect what's inside: *, &, &&, or _Class::* (member pointer)
 			bool is_ptr = false;
@@ -1382,6 +1394,8 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 						// For function references: _Res(&)(_ArgTypes...) noexcept
 						bool sig_is_const = false;
 						bool sig_is_volatile = false;
+						ReferenceQualifier sig_function_ref_qualifier = ReferenceQualifier::None;
+						bool sig_is_noexcept = false;
 						while (!peek().is_eof()) {
 							if ((is_member_ptr) && peek() == "const"_tok) {
 								sig_is_const = true;
@@ -1389,9 +1403,14 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 							} else if ((is_member_ptr) && peek() == "volatile"_tok) {
 								sig_is_volatile = true;
 								advance();
-							} else if (is_member_ptr && (peek() == "&"_tok || peek() == "&&"_tok)) {
+							} else if (is_member_ptr && peek() == "&"_tok) {
+								sig_function_ref_qualifier = ReferenceQualifier::LValueReference;
+								advance();
+							} else if (is_member_ptr && peek() == "&&"_tok) {
+								sig_function_ref_qualifier = ReferenceQualifier::RValueReference;
 								advance();
 							} else if (peek() == "noexcept"_tok) {
+								sig_is_noexcept = true;
 								advance(); // consume 'noexcept'
 								if (peek() == "("_tok) {
 									skip_balanced_parens();
@@ -1409,8 +1428,11 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 						func_sig.return_pointer_depth = static_cast<int>(type_node.pointer_depth());
 						func_sig.return_reference_qualifier = type_node.reference_qualifier();
 						func_sig.parameter_type_indices = std::move(param_types);
+						func_sig.calling_convention = paren_calling_convention;
 						func_sig.is_const = sig_is_const;
 						func_sig.is_volatile = sig_is_volatile;
+						func_sig.function_reference_qualifier = sig_function_ref_qualifier;
+						func_sig.is_noexcept = sig_is_noexcept;
 
 						if (is_member_ptr) {
 							type_node.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
@@ -1471,10 +1493,32 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 					func_sig.return_pointer_depth = static_cast<int>(type_node.pointer_depth());
 					func_sig.return_reference_qualifier = type_node.reference_qualifier();
 					func_sig.parameter_type_indices = std::move(func_param_types);
+					func_sig.calling_convention = direct_function_calling_convention;
+					while (!peek().is_eof()) {
+						if (peek() == "const"_tok) {
+							func_sig.is_const = true;
+							advance();
+						} else if (peek() == "volatile"_tok) {
+							func_sig.is_volatile = true;
+							advance();
+						} else if (peek() == "&"_tok) {
+							func_sig.function_reference_qualifier = ReferenceQualifier::LValueReference;
+							advance();
+						} else if (peek() == "&&"_tok) {
+							func_sig.function_reference_qualifier = ReferenceQualifier::RValueReference;
+							advance();
+						} else {
+							break;
+						}
+					}
+					if (peek() == "noexcept"_tok) {
+						func_sig.is_noexcept = true;
+						advance();
+						if (peek() == "("_tok) {
+							skip_balanced_parens();
+						}
+					}
 					type_node.set_function_signature(func_sig);
-
-					// Consume trailing noexcept or noexcept(expr) if present
-					skip_noexcept_specifier();
 
 					discard_saved_token(func_type_saved_pos);
 					discard_saved_token(paren_saved_pos);

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -64,8 +64,11 @@ inline bool equalFunctionSignatureIdentity(const FunctionSignature& lhs, const F
 		lhs.parameter_type_indices.size() != rhs.parameter_type_indices.size() ||
 		lhs.linkage != rhs.linkage ||
 		lhs.class_name != rhs.class_name ||
+		lhs.calling_convention != rhs.calling_convention ||
 		lhs.is_const != rhs.is_const ||
-		lhs.is_volatile != rhs.is_volatile) {
+		lhs.is_volatile != rhs.is_volatile ||
+		lhs.function_reference_qualifier != rhs.function_reference_qualifier ||
+		lhs.is_noexcept != rhs.is_noexcept) {
 		return false;
 	}
 	for (size_t i = 0; i < lhs.parameter_type_indices.size(); ++i) {
@@ -88,8 +91,11 @@ inline size_t hashFunctionSignatureIdentity(const FunctionSignature& sig) {
 	if (sig.class_name.has_value()) {
 		h ^= std::hash<std::string>{}(*sig.class_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	}
+	h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(sig.calling_convention)) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	h ^= std::hash<bool>{}(sig.is_const) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	h ^= std::hash<bool>{}(sig.is_volatile) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(sig.function_reference_qualifier)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	h ^= std::hash<bool>{}(sig.is_noexcept) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	return h;
 }
 

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -14,14 +14,14 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<numbers>` | N/A | ✅ Compiled | ~510ms |
 | `<initializer_list>` | N/A | ✅ Compiled | ~32ms |
 | `<ratio>` | `test_std_ratio.cpp` | ✅ Compiled | ~639ms. The header still compiles, but `std::ratio_less` remains blocked because non-type default template arguments that depend on qualified constexpr members (for example `__ratio_less_impl`'s bool defaults) are still not fully instantiated/evaluated. |
-| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~2236ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~2238ms (retested 2026-04-14). The old `::template _Is_nothrow_invocable_r<_Rx>` base lookup stop and the later `_Function_args<_Ret CALL_OPT(_Types...) ...>` partial-specialization parse stop are both fixed. MSVC `<type_traits>` now gets further and fails at `less::operator() const noexcept(...)` with "Expected '{', ';', '= default', or '= delete' after member function declaration". |
 | `<any>` | `test_std_any.cpp` | ❌ Codegen Error | ~607ms (retested 2026-04-11). Targeted test now fails with "Expected symbol '_Arg' to exist in code generation" in `std::any` constructor. |
 | `<utility>` | `test_std_utility.cpp` | ❌ Codegen Error | ~830ms (retested 2026-04-11). Targeted test now fails with codegen errors from template deduction / Non-type parameter issues. |
 | `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~540ms |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~625ms |
 | `<string_view>` | `test_std_string_view.cpp` | ❌ Compile Error | ~1460ms (retested 2026-04-11). Call to deleted function 'swap' in `stl_pair.h:308`. Blocked by eager inline member body parsing during implicit template class instantiation (std::pair::swap tries to swap const members). |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~2192ms (retested 2026-04-11). Call to deleted function 'swap' — same `stl_pair.h:308` blocker as `<string_view>`. |
-| `<array>` | `test_std_array.cpp` | ❌ Parse Error | ~2273ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<array>` | `test_std_array.cpp` | ❌ Parse Error | ~2121ms (retested 2026-04-14). The old `::template _Is_nothrow_invocable_r<_Rx>` base lookup stop and the later `_Function_args<_Ret CALL_OPT(_Types...) ...>` partial-specialization parse stop are both fixed. MSVC `<type_traits>` now gets further and fails at `less::operator() const noexcept(...)` with "Expected '{', ';', '= default', or '= delete' after member function declaration". |
 | `<algorithm>` | `test_std_algorithm.cpp` | ❌ Compile Error | ~2051ms (retested 2026-04-11). "Operator- not defined for operand types". |
 | `<span>` | `test_std_span.cpp` | ✅ Compiled | ~41ms (retested 2026-04-11). **NEW: Now compiles successfully!** Previous iterator/ranges codegen blockers are resolved. |
 | `<tuple>` | `test_std_tuple.cpp` | ❌ Compile Error | ~1564ms (retested 2026-04-11). "unsupported PackExpansionExprNode reached semantic analysis". |
@@ -31,8 +31,8 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<queue>` | `test_std_queue.cpp` | 💥 Crash | ~2522ms (retested 2026-04-11). |
 | `<stack>` | `test_std_stack.cpp` | 💥 Crash | ~2464ms (retested 2026-04-11). |
 | `<memory>` | `test_std_memory.cpp` | 💥 Crash | ~5108ms (retested 2026-04-11). |
-| `<functional>` | `test_std_functional.cpp` | ❌ Parse Error | ~3265ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
-| `<map>` | `test_std_map.cpp` | ❌ Parse Error | ~2754ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now fails later at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<functional>` | `test_std_functional.cpp` | ❌ Parse Error | ~3009ms (retested 2026-04-14). The old `::template _Is_nothrow_invocable_r<_Rx>` base lookup stop and the later `_Function_args<_Ret CALL_OPT(_Types...) ...>` partial-specialization parse stop are both fixed. MSVC `<type_traits>` now gets further and fails at `less::operator() const noexcept(...)` with "Expected '{', ';', '= default', or '= delete' after member function declaration". |
+| `<map>` | `test_std_map.cpp` | ❌ Parse Error | ~2482ms (retested 2026-04-14). The old `::template _Is_nothrow_invocable_r<_Rx>` base lookup stop and the later `_Function_args<_Ret CALL_OPT(_Types...) ...>` partial-specialization parse stop are both fixed. MSVC `<type_traits>` now gets further and fails at `less::operator() const noexcept(...)` with "Expected '{', ';', '= default', or '= delete' after member function declaration". |
 | `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2350ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
 | `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~2906ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
 | `<iostream>` | `test_std_iostream.cpp` | 💥 Crash | ~4559ms (retested 2026-04-11). |
@@ -47,7 +47,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ❌ Codegen Error | ~2299ms (retested 2026-04-11). Targeted test now fails with codegen errors. |
 | `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~2481ms (retested 2026-04-11). Call to deleted function 'swap'. |
-| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~2659ms (retested 2026-04-12). The old `_Is_any_of_v` variable-template arity stop is fixed; MSVC `<type_traits>` now gets further and fails at `is_nothrow_invocable_r : _Select_invoke_traits<...>::template _Is_nothrow_invocable_r<_Rx>` with "Expected member name after ::". |
+| `<variant>` | `test_std_variant.cpp` | ❌ Parse Error | ~2527ms (retested 2026-04-14). The old `::template _Is_nothrow_invocable_r<_Rx>` base lookup stop and the later `_Function_args<_Ret CALL_OPT(_Types...) ...>` partial-specialization parse stop are both fixed. MSVC `<type_traits>` now gets further and fails at `less::operator() const noexcept(...)` with "Expected '{', ';', '= default', or '= delete' after member function declaration". |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
 | `<stdfloat>` | N/A | ✅ Compiled | ~16ms (C++23) |
@@ -134,6 +134,12 @@ This directory contains test files for C++ standard library headers to assess Fl
 - Re-checking `<array>` (~2.27s), `<optional>` (~2.24s), `<variant>` (~2.66s), `<functional>` (~3.27s), and `<map>` (~2.75s) shows that the old `_Is_any_of_v` / "Template argument count mismatch: expected 2, got 17" stop is gone. These headers now reach a later parser gap in MSVC `<type_traits>` at `struct is_nothrow_invocable_r : _Select_invoke_traits<_Callable, _Args...>::template _Is_nothrow_invocable_r<_Rx>`.
 - Re-checking `<set>` (~2.35s) and `<ranges>` (~2.91s) shows that the same variable-template blocker is gone there too. Both headers now get further into the Windows UCRT path and currently stop on `__stdio_common_vfwprintf` overload resolution instead of the earlier template-arity failure.
 
+#### 2026-04-14 Retests
+
+- Base-specifier parsing/resolution now accepts dependent member-template chains after a template-id (`Owner<Args...>::template Member<T>`), and deferred template-base instantiation preserves/materializes those member template-ids instead of dropping them to plain `::name` chains. Focused regression: `tests/test_dependent_member_template_base_alias_ret42.cpp`.
+- Template-argument parsing now accepts bare non-member function types with a calling convention before the parameter list, plus trailing cv/ref/noexcept qualifiers, so partial specializations like `_Function_args<_Ret __cdecl(_Types...) noexcept>` no longer stop during pattern parsing. Focused regression: `tests/test_nonmember_callconv_function_partial_spec_ret42.cpp`.
+- Re-checking `<array>` (~2.12s), `<optional>` (~2.24s), `<variant>` (~2.53s), `<functional>` (~3.01s), and `<map>` (~2.48s) shows that both earlier `type_traits` parser gaps are gone. These headers now reach a later member-function declaration parser stop in `type_traits:2378-2379` at `less::operator() const noexcept(...)`.
+
 #### 2026-04-07 Retests
 
 - `<atomic>` and `<latch>` were re-checked after teaching sema/parser to preserve user-defined enum identity for overloaded binary operators and parenthesized functional casts. That clears the old `memory_order | __memory_order_modifier(...)` semantic stop from `bits/atomic_base.h`, so both headers now progress into later atomic-wait codegen fallout instead of failing during scoped-enum checking. `<atomic>` currently stops on the same deeper `_M_do_wait` / missing default-argument / dependent-payload-size / `memory_order_seq_cst` symbol issues summarized in the table, while `<latch>` now fails even later on `_M_do_wait`, `__mutex_base` constructor recovery, integer-conversion gaps in wait helpers, and missing `memory_order_relaxed` symbol recovery.
@@ -151,7 +157,7 @@ The overall header counts above still reflect the older full sweep and need a fu
 
 The most impactful blockers preventing more headers from compiling, ordered by impact:
 
-As of the 2026-04-12 targeted retest, the newly unblocked MSVC headers now hit a higher-value parser gap around dependent member-template lookup after a template-id (`Template<...>::template Member<...>`). `<array>`, `<optional>`, `<variant>`, `<functional>`, and `<map>` all now stop first at `type_traits:1865`, while `<set>` / `<ranges>` have moved further into later Windows UCRT overload-resolution fallout.
+As of the 2026-04-14 targeted retest, the earlier `Template<...>::template Member<...>` base lookup gap and the bare non-member calling-convention function-type partial-specialization gap are both fixed. `<array>`, `<optional>`, `<variant>`, `<functional>`, and `<map>` now stop later in MSVC `<type_traits>` at `less::operator() const noexcept(...)`, while `<set>` / `<ranges>` still fail even later in Windows UCRT overload-resolution fallout.
 
 1. **Template deduction / semantic follow-on failures after the earlier mangling blockers**: In the 2026-03-31 targeted retest, `<algorithm>` no longer failed first on unresolved- `auto` mangling. It now gets further and then fails on concepts/ranges diagnostics followed by explicit-constructor copy-initialization errors. The same family of deeper issues likely explains several headers previously bucketed under the stale unresolved- `auto` note.
 

--- a/tests/test_dependent_member_template_base_alias_ret42.cpp
+++ b/tests/test_dependent_member_template_base_alias_ret42.cpp
@@ -12,5 +12,8 @@ struct IsNothrowInvocableR
 	: SelectInvokeTraits<Callable, Args...>::template IsNothrowInvocableR<Rx> {};
 
 int main() {
+	IsNothrowInvocableR<int, void, float> instance;
+	(void)instance;
 	return 42;
 }
+

--- a/tests/test_dependent_member_template_base_alias_ret42.cpp
+++ b/tests/test_dependent_member_template_base_alias_ret42.cpp
@@ -1,0 +1,16 @@
+template <class Callable, class... Args>
+struct SelectInvokeTraits {
+	template <class Rx>
+	struct Box {};
+
+	template <class Rx>
+	using IsNothrowInvocableR = Box<Rx>;
+};
+
+template <class Rx, class Callable, class... Args>
+struct IsNothrowInvocableR
+	: SelectInvokeTraits<Callable, Args...>::template IsNothrowInvocableR<Rx> {};
+
+int main() {
+	return 42;
+}

--- a/tests/test_nonmember_callconv_function_partial_spec_ret42.cpp
+++ b/tests/test_nonmember_callconv_function_partial_spec_ret42.cpp
@@ -1,0 +1,13 @@
+template <class Ty>
+struct FunctionKind {
+	static constexpr int value = 1;
+};
+
+template <class Ret, class... Args>
+struct FunctionKind<Ret __cdecl(Args...) noexcept> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return FunctionKind<int __cdecl(double, char) noexcept>::value;
+}


### PR DESCRIPTION
Implemented: support for dependent Owner<Args...>::template Member<T> base-specifier chains, including deferred template-base materialization, and support for bare non-member function-type template arguments with calling conventions plus trailing cv/ref/noexcept
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1276" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
