### PR TITLE
Handle dependent member alias sizeof constraints

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -18,3 +18,53 @@ that depends on its stack size (e.g. address-of, array indexing, struct layout).
 non-type argument chain.
 **Phase:** This is the exact kind of bug that Phase 2 alias-template
 materialization consolidation is intended to fix.
+
+## Template-template parameters reject mixed parameter kinds
+
+**Repro:**
+```cpp
+template <typename T, int N>
+struct wrap {
+	using type = T;
+};
+
+template <template <typename, int> class W>
+struct probe {};
+```
+**Symptom:** Parsing fails with:
+`error: Expected 'typename' or 'class' in template template parameter form`
+at the non-type parameter position.
+**Impact:** This rejects standard C++20 template-template parameter forms that
+mix type and non-type parameters, which makes it harder to express or test
+real-world template APIs.
+**Standards note:** C++20 permits template-template parameter parameter-lists to
+contain non-type template parameters; restricting them to only `typename`/`class`
+is non-conforming.
+
+## Parser rejects valid dependent `sizeof(type-id)` in nested requirements
+
+**Repro:**
+```cpp
+template <typename T>
+struct identity {
+	using type = T;
+};
+
+template <typename Prefix, template <typename> class Wrap, typename T>
+struct holder {
+	using value_type = typename Wrap<T>::type;
+};
+
+template <typename T>
+concept has_ll_value_type = requires {
+	requires sizeof(typename holder<char, identity, T>::value_type) == 8;
+};
+```
+**Symptom:** Parsing fails with:
+`error: Expected type or expression after 'sizeof('`
+at the end of the dependent `type-id`.
+**Impact:** Valid C++20 nested requirements that use `sizeof(type-id)` on a
+dependent qualified type are rejected, which forced the regression for
+dependent-member `sizeof` constraints into a more indirect shape.
+**Standards note:** `sizeof(type-id)` is valid in a nested requirement, and the
+dependent `type-id` above is well-formed C++20 syntax.

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -894,6 +894,84 @@ inline std::optional<long long> evaluateConstraintExpression(
 					}
 				}
 
+				auto sizeFromConcreteTemplateArg = [](const TemplateTypeArg& concrete_arg) -> std::optional<long long> {
+					if (const TypeInfo* concrete_ti = tryGetTypeInfo(concrete_arg.type_index)) {
+						long long size = static_cast<long long>(toSizeT(concrete_ti->sizeInBytes()));
+						if (size > 0) {
+							return size;
+						}
+					}
+
+					long long size = static_cast<long long>(get_type_size_bits(concrete_arg.category()) / 8);
+					if (size > 0) {
+						return size;
+					}
+					return std::nullopt;
+				};
+
+				auto resolvePrimaryTemplateMemberAliasSize =
+					[&](std::string_view template_name,
+						std::string_view member_name,
+						std::span<const TemplateTypeArg> concrete_member_args) -> std::optional<long long> {
+					auto template_opt = gTemplateRegistry.lookupTemplate(template_name);
+					if (!template_opt.has_value() || !template_opt->is<TemplateClassDeclarationNode>()) {
+						return std::nullopt;
+					}
+
+					const auto& primary_template =
+						template_opt->as<TemplateClassDeclarationNode>();
+					const auto& primary_params = primary_template.template_parameters();
+					const auto& type_aliases =
+						primary_template.class_decl_node().type_aliases();
+
+					for (const auto& type_alias : type_aliases) {
+						if (StringTable::getStringView(type_alias.alias_name) != member_name ||
+							!type_alias.type_node.is<TypeSpecifierNode>()) {
+							continue;
+						}
+
+						const auto& alias_type_spec =
+							type_alias.type_node.as<TypeSpecifierNode>();
+
+						if (alias_type_spec.pointer_depth() == 0 &&
+							alias_type_spec.reference_qualifier() == ReferenceQualifier::None &&
+							!alias_type_spec.is_array()) {
+							std::string_view alias_target_name =
+								alias_type_spec.token().value();
+							for (size_t param_index = 0;
+								 param_index < primary_params.size() &&
+								 param_index < concrete_member_args.size();
+								 ++param_index) {
+								if (!primary_params[param_index].is<TemplateParameterNode>()) {
+									continue;
+								}
+
+								const auto& template_param =
+									primary_params[param_index].as<TemplateParameterNode>();
+								if (template_param.kind() != TemplateParameterKind::Type ||
+									template_param.name() != alias_target_name) {
+									continue;
+								}
+
+								return sizeFromConcreteTemplateArg(
+									concrete_member_args[param_index]);
+							}
+						}
+
+						if (const TypeInfo* alias_type_info =
+								tryGetTypeInfo(alias_type_spec.type_index());
+							alias_type_info && alias_type_info->hasStoredSize()) {
+							long long size =
+								static_cast<long long>(toSizeT(alias_type_info->sizeInBytes()));
+							if (size > 0) {
+								return size;
+							}
+						}
+					}
+
+					return std::nullopt;
+				};
+
 				// Check if this is a placeholder for a dependent nested type like "Op<...>::type"
 				// These are created during parsing as placeholders for template-dependent types
 				// Phase 4: use explicit placeholder_kind_ instead of string heuristic
@@ -935,32 +1013,35 @@ inline std::optional<long long> evaluateConstraintExpression(
 
 								// Now we need to get the instantiated type's member
 								// For HasType<int>::type, we need to get the type alias from HasType<int>
+								InlineVector<TemplateTypeArg, 4> concrete_member_args;
 
 								// Look for the pack argument to get the template argument
 								for (size_t j = i + 1; j < template_args.size(); ++j) {
 									const auto& pack_arg = template_args[j];
 									if (!pack_arg.is_template_template_arg && !pack_arg.is_value) {
+										concrete_member_args.push_back(pack_arg);
 										// Found a type argument - this is what we instantiate the template with
 										FLASH_LOG(Templates, Debug, "  Pack arg type_index=", pack_arg.type_index, ", base_type=", static_cast<int>(pack_arg.typeEnum()));
+									}
+								}
 
-										// For member "type", we need to look up HasType<T>::type which equals T
-										// For HasType, the using type = T; means ::type is the template argument
-										if (member_part == "type") {
-											// For a simple type alias like HasType<T>::type = T,
-											// return the size of the template argument
-											if (const TypeInfo* pack_arg_ti = tryGetTypeInfo(pack_arg.type_index)) {
-												long long size = static_cast<long long>(toSizeT(pack_arg_ti->sizeInBytes()));
-												FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::type) = ", size);
-												return size;
-											}
-											// For built-in types without type_index
-											long long size = static_cast<long long>(get_type_size_bits(pack_arg.category()) / 8);
-											if (size > 0) {
-												FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::type) = ", size, " (from base_type)");
-												return size;
-											}
-										}
-										break;
+								if (std::optional<long long> alias_size =
+										resolvePrimaryTemplateMemberAliasSize(
+											template_name,
+											member_part,
+											concrete_member_args);
+									alias_size.has_value()) {
+									FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::", member_part, ") = ", *alias_size);
+									return *alias_size;
+								}
+
+								if (member_part == "type" && !concrete_member_args.empty()) {
+									if (std::optional<long long> size =
+											sizeFromConcreteTemplateArg(
+												concrete_member_args.front());
+										size.has_value()) {
+										FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::type) = ", *size);
+										return *size;
 									}
 								}
 							}

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -894,40 +894,6 @@ inline std::optional<long long> evaluateConstraintExpression(
 					}
 				}
 
-				auto sizeFromConcreteTemplateArg = [](const TemplateTypeArg& concrete_arg) -> std::optional<long long> {
-					if (concrete_arg.pointer_depth > 0 ||
-						concrete_arg.function_signature.has_value() ||
-						concrete_arg.category() == TypeCategory::FunctionPointer ||
-						concrete_arg.category() == TypeCategory::MemberFunctionPointer ||
-						concrete_arg.category() == TypeCategory::MemberObjectPointer) {
-						return 8;
-					}
-
-					long long size = 0;
-					if (const TypeInfo* concrete_ti = tryGetTypeInfo(concrete_arg.type_index)) {
-						if (const StructTypeInfo* struct_info = concrete_ti->getStructInfo();
-							struct_info && !struct_info->hasCompleteObjectLayout()) {
-							return std::nullopt;
-						}
-						size = static_cast<long long>(toSizeT(concrete_ti->sizeInBytes()));
-					}
-
-					if (size == 0) {
-						size = static_cast<long long>(get_type_size_bits(concrete_arg.category()) / 8);
-					}
-					if (size <= 0) {
-						return std::nullopt;
-					}
-
-					if (concrete_arg.is_array) {
-						if (!concrete_arg.array_size.has_value()) {
-							return std::nullopt;
-						}
-						size *= static_cast<long long>(*concrete_arg.array_size);
-					}
-					return size;
-				};
-
 				auto findConstraintArgByName = [&](std::string_view param_name) -> const TemplateTypeArg* {
 					for (size_t i = 0; i < template_param_names.size() && i < template_args.size(); ++i) {
 						if (template_param_names[i] == param_name) {
@@ -963,176 +929,195 @@ inline std::optional<long long> evaluateConstraintExpression(
 					return concrete_args;
 				};
 
-				auto applyTypeSpecSizeAdjustments =
-					[](const TypeSpecifierNode& type_spec, long long base_size) -> std::optional<long long> {
-					if (type_spec.has_function_signature() && type_spec.pointer_depth() == 0) {
-						return std::nullopt;
-					}
-					if (type_spec.pointer_depth() > 0 ||
-						type_spec.type() == TypeCategory::FunctionPointer ||
-						type_spec.type() == TypeCategory::MemberFunctionPointer ||
-						type_spec.type() == TypeCategory::MemberObjectPointer) {
-						return 8;
-					}
-					if (type_spec.is_array()) {
-						if (type_spec.array_dimensions().empty()) {
-							if (auto single_dim = type_spec.array_size(); single_dim.has_value()) {
-								base_size *= static_cast<long long>(*single_dim);
-							} else {
-								return std::nullopt;
-							}
-						} else {
-							for (size_t dim : type_spec.array_dimensions()) {
-								base_size *= static_cast<long long>(dim);
-							}
-						}
-					}
-					return base_size;
-				};
+				struct MemberAliasSizeResolver {
+					enum { kMaxDepth = 64 };
+					int depth_ = 0;
 
-				auto resolveConcreteTypeMemberAliasSize =
-					[&](const TemplateTypeArg& concrete_base_arg,
-						std::string_view member_name) -> std::optional<long long> {
-					if (concrete_base_arg.is_value ||
-						concrete_base_arg.is_template_template_arg ||
-						!concrete_base_arg.type_index.is_valid()) {
-						return std::nullopt;
-					}
-
-					const TypeInfo* concrete_base_info =
-						tryGetTypeInfo(concrete_base_arg.type_index);
-					if (!concrete_base_info) {
-						return std::nullopt;
-					}
-
-					StringHandle qualified_member_handle =
-						StringTable::getOrInternStringHandle(
-							StringBuilder()
-								.append(concrete_base_info->name())
-								.append("::")
-								.append(member_name)
-								.commit());
-					auto member_it = getTypesByNameMap().find(qualified_member_handle);
-					if (member_it == getTypesByNameMap().end() || member_it->second == nullptr) {
-						return std::nullopt;
-					}
-
-					TypeSpecifierNode member_spec(
-						member_it->second->registeredTypeIndex().withCategory(member_it->second->typeEnum()),
-						member_it->second->hasStoredSize() ? member_it->second->sizeInBits().value : 0,
-						Token(),
-						CVQualifier::None,
-						ReferenceQualifier::None);
-					int size_bits = getTypeSpecSizeBits(member_spec);
-					if (size_bits <= 0 && member_it->second->hasStoredSize()) {
-						size_bits = member_it->second->sizeInBits().value;
-					}
-					return size_bits > 0
-						? std::optional<long long>(static_cast<long long>(size_bits / 8))
-						: std::nullopt;
-				};
-
-				std::function<std::optional<long long>(
-					std::string_view,
-					std::string_view,
-					std::span<const TemplateTypeArg>)> resolvePrimaryTemplateMemberAliasSize;
-
-				std::function<std::optional<long long>(
-					const TypeSpecifierNode&,
-					std::span<const ASTNode>,
-					std::span<const TemplateTypeArg>)> resolveAliasTypeSpecSize;
-
-				resolveAliasTypeSpecSize =
-					[&](const TypeSpecifierNode& alias_type_spec,
-						std::span<const ASTNode> primary_params,
-						std::span<const TemplateTypeArg> concrete_member_args) -> std::optional<long long> {
-					auto findConcreteArgByName =
-						[&](std::string_view param_name) -> const TemplateTypeArg* {
-						for (size_t i = 0; i < primary_params.size() &&
-								i < concrete_member_args.size();
-							 ++i) {
-							if (!primary_params[i].is<TemplateParameterNode>()) {
-								continue;
-							}
-							const auto& param =
-								primary_params[i].as<TemplateParameterNode>();
-							if (param.name() == param_name) {
-								return &concrete_member_args[i];
-							}
-						}
-						return nullptr;
+					struct DepthGuard {
+						int& depth_ref;
+						DepthGuard(int& depth) : depth_ref(depth) { ++depth_ref; }
+						~DepthGuard() { --depth_ref; }
 					};
 
-					auto tryResolveBoundTemplateParam =
-						[&](std::string_view candidate_name) -> std::optional<long long> {
-						const TemplateTypeArg* concrete_arg =
-							findConcreteArgByName(candidate_name);
-						if (!concrete_arg ||
-							concrete_arg->is_value ||
-							concrete_arg->is_template_template_arg) {
+					static std::optional<long long> sizeFromConcreteTemplateArg(
+						const TemplateTypeArg& concrete_arg) {
+						if (concrete_arg.pointer_depth > 0 ||
+							concrete_arg.function_signature.has_value() ||
+							concrete_arg.category() == TypeCategory::FunctionPointer ||
+							concrete_arg.category() == TypeCategory::MemberFunctionPointer ||
+							concrete_arg.category() == TypeCategory::MemberObjectPointer) {
+							return 8;
+						}
+
+						long long size = 0;
+						if (const TypeInfo* concrete_ti = tryGetTypeInfo(concrete_arg.type_index)) {
+							if (const StructTypeInfo* struct_info = concrete_ti->getStructInfo();
+								struct_info && !struct_info->hasCompleteObjectLayout()) {
+								return std::nullopt;
+							}
+							size = static_cast<long long>(toSizeT(concrete_ti->sizeInBytes()));
+						}
+
+						if (size == 0) {
+							size = static_cast<long long>(get_type_size_bits(concrete_arg.category()) / 8);
+						}
+						if (size <= 0) {
 							return std::nullopt;
 						}
 
-						if (std::optional<long long> base_size =
-								sizeFromConcreteTemplateArg(*concrete_arg);
-							base_size.has_value()) {
-							return applyTypeSpecSizeAdjustments(alias_type_spec, *base_size);
+						if (concrete_arg.is_array) {
+							if (!concrete_arg.array_size.has_value()) {
+								return std::nullopt;
+							}
+							size *= static_cast<long long>(*concrete_arg.array_size);
 						}
-						return std::nullopt;
-					};
+						return size;
+					}
 
-					if (alias_type_spec.type_index().is_valid()) {
-						if (const TypeInfo* alias_type_info =
-								tryGetTypeInfo(alias_type_spec.type_index())) {
-							if (std::optional<long long> bound_param_size =
-									tryResolveBoundTemplateParam(
-										StringTable::getStringView(alias_type_info->name()));
-								bound_param_size.has_value()) {
-								return bound_param_size;
+					static std::optional<long long> applyTypeSpecSizeAdjustments(
+						const TypeSpecifierNode& type_spec, long long base_size) {
+						if (type_spec.has_function_signature() && type_spec.pointer_depth() == 0) {
+							return std::nullopt;
+						}
+						if (type_spec.pointer_depth() > 0 ||
+							type_spec.type() == TypeCategory::FunctionPointer ||
+							type_spec.type() == TypeCategory::MemberFunctionPointer ||
+							type_spec.type() == TypeCategory::MemberObjectPointer) {
+							return 8;
+						}
+						if (type_spec.is_array()) {
+							if (type_spec.array_dimensions().empty()) {
+								if (auto single_dim = type_spec.array_size(); single_dim.has_value()) {
+									base_size *= static_cast<long long>(*single_dim);
+								} else {
+									return std::nullopt;
+								}
+							} else {
+								for (size_t dim : type_spec.array_dimensions()) {
+									base_size *= static_cast<long long>(dim);
+								}
+							}
+						}
+						return base_size;
+					}
+
+					static std::optional<long long> resolveConcreteTypeMemberAliasSize(
+						const TemplateTypeArg& concrete_base_arg,
+						std::string_view member_name) {
+						if (concrete_base_arg.is_value ||
+							concrete_base_arg.is_template_template_arg ||
+							!concrete_base_arg.type_index.is_valid()) {
+							return std::nullopt;
+						}
+
+						const TypeInfo* concrete_base_info =
+							tryGetTypeInfo(concrete_base_arg.type_index);
+						if (!concrete_base_info) {
+							return std::nullopt;
+						}
+
+						StringHandle qualified_member_handle =
+							StringTable::getOrInternStringHandle(
+								StringBuilder()
+									.append(concrete_base_info->name())
+									.append("::")
+									.append(member_name)
+									.commit());
+						auto member_it = getTypesByNameMap().find(qualified_member_handle);
+						if (member_it == getTypesByNameMap().end() || member_it->second == nullptr) {
+							return std::nullopt;
+						}
+
+						TypeSpecifierNode member_spec(
+							member_it->second->registeredTypeIndex().withCategory(member_it->second->typeEnum()),
+							member_it->second->hasStoredSize() ? member_it->second->sizeInBits().value : 0,
+							Token(),
+							CVQualifier::None,
+							ReferenceQualifier::None);
+						int size_bits = getTypeSpecSizeBits(member_spec);
+						if (size_bits <= 0 && member_it->second->hasStoredSize()) {
+							size_bits = member_it->second->sizeInBits().value;
+						}
+						return size_bits > 0
+							? std::optional<long long>(static_cast<long long>(size_bits / 8))
+							: std::nullopt;
+					}
+
+					std::optional<long long> resolveAliasTypeSpecSize(
+						const TypeSpecifierNode& alias_type_spec,
+						std::span<const ASTNode> primary_params,
+						std::span<const TemplateTypeArg> concrete_member_args) {
+						if (depth_ >= kMaxDepth) return std::nullopt;
+						DepthGuard guard{depth_};
+
+						auto findConcreteArgByName =
+							[&](std::string_view param_name) -> const TemplateTypeArg* {
+							for (size_t i = 0; i < primary_params.size() &&
+									i < concrete_member_args.size();
+								 ++i) {
+								if (!primary_params[i].is<TemplateParameterNode>()) {
+									continue;
+								}
+								const auto& param =
+									primary_params[i].as<TemplateParameterNode>();
+								if (param.name() == param_name) {
+									return &concrete_member_args[i];
+								}
+							}
+							return nullptr;
+						};
+
+						auto tryResolveBoundTemplateParam =
+							[&](std::string_view candidate_name) -> std::optional<long long> {
+							const TemplateTypeArg* concrete_arg =
+								findConcreteArgByName(candidate_name);
+							if (!concrete_arg ||
+								concrete_arg->is_value ||
+								concrete_arg->is_template_template_arg) {
+								return std::nullopt;
 							}
 
-							if (alias_type_info->isDependentMemberType()) {
-								std::string_view qualified_alias_name =
-									StringTable::getStringView(alias_type_info->name());
-								size_t member_sep =
-									qualified_alias_name.rfind("::");
-								if (member_sep != std::string_view::npos) {
-									std::string_view dependent_member_name =
-										qualified_alias_name.substr(member_sep + 2);
-									std::vector<TemplateTypeArg> nested_args;
-									if (alias_type_info->isTemplateInstantiation()) {
-										nested_args = materializeTemplateArgs(
-											*alias_type_info,
-											primary_params,
-											concrete_member_args);
-									}
+							if (std::optional<long long> base_size =
+									sizeFromConcreteTemplateArg(*concrete_arg);
+								base_size.has_value()) {
+								return applyTypeSpecSizeAdjustments(alias_type_spec, *base_size);
+							}
+							return std::nullopt;
+						};
 
-									std::string_view nested_template_name =
-										StringTable::getStringView(
-											alias_type_info->baseTemplateName());
-									if (!nested_template_name.empty()) {
-										if (std::optional<long long> nested_alias_size =
-												resolvePrimaryTemplateMemberAliasSize(
-													nested_template_name,
-													dependent_member_name,
-													nested_args);
-											nested_alias_size.has_value()) {
-											return applyTypeSpecSizeAdjustments(
-												alias_type_spec,
-												*nested_alias_size);
+						if (alias_type_spec.type_index().is_valid()) {
+							if (const TypeInfo* alias_type_info =
+									tryGetTypeInfo(alias_type_spec.type_index())) {
+								if (std::optional<long long> bound_param_size =
+										tryResolveBoundTemplateParam(
+											StringTable::getStringView(alias_type_info->name()));
+									bound_param_size.has_value()) {
+									return bound_param_size;
+								}
+
+								if (alias_type_info->isDependentMemberType()) {
+									std::string_view qualified_alias_name =
+										StringTable::getStringView(alias_type_info->name());
+									size_t member_sep =
+										qualified_alias_name.rfind("::");
+									if (member_sep != std::string_view::npos) {
+										std::string_view dependent_member_name =
+											qualified_alias_name.substr(member_sep + 2);
+										std::vector<TemplateTypeArg> nested_args;
+										if (alias_type_info->isTemplateInstantiation()) {
+											nested_args = materializeTemplateArgs(
+												*alias_type_info,
+												primary_params,
+												concrete_member_args);
 										}
-									}
 
-									if (!nested_template_name.empty()) {
-										if (const TemplateTypeArg* nested_template_arg =
-												findConcreteArgByName(
-													nested_template_name);
-											nested_template_arg &&
-											nested_template_arg->is_template_template_arg &&
-											nested_template_arg->template_name_handle.isValid()) {
+										std::string_view nested_template_name =
+											StringTable::getStringView(
+												alias_type_info->baseTemplateName());
+										if (!nested_template_name.empty()) {
 											if (std::optional<long long> nested_alias_size =
 													resolvePrimaryTemplateMemberAliasSize(
-														nested_template_arg->template_name_handle.view(),
+														nested_template_name,
 														dependent_member_name,
 														nested_args);
 												nested_alias_size.has_value()) {
@@ -1141,73 +1126,96 @@ inline std::optional<long long> evaluateConstraintExpression(
 													*nested_alias_size);
 											}
 										}
-									}
 
-									std::string_view base_candidate =
-										qualified_alias_name.substr(0, member_sep);
-									if (size_t angle_pos = base_candidate.find("<");
-										angle_pos != std::string_view::npos) {
-										base_candidate =
-											base_candidate.substr(0, angle_pos);
-									}
-									if (const TemplateTypeArg* concrete_base_arg =
-											findConcreteArgByName(base_candidate)) {
-										if (std::optional<long long> concrete_member_size =
-												resolveConcreteTypeMemberAliasSize(
-													*concrete_base_arg,
-													dependent_member_name);
-											concrete_member_size.has_value()) {
-											return applyTypeSpecSizeAdjustments(
-												alias_type_spec,
-												*concrete_member_size);
+										if (!nested_template_name.empty()) {
+											if (const TemplateTypeArg* nested_template_arg =
+													findConcreteArgByName(
+														nested_template_name);
+												nested_template_arg &&
+												nested_template_arg->is_template_template_arg &&
+												nested_template_arg->template_name_handle.isValid()) {
+												if (std::optional<long long> nested_alias_size =
+														resolvePrimaryTemplateMemberAliasSize(
+															nested_template_arg->template_name_handle.view(),
+															dependent_member_name,
+															nested_args);
+													nested_alias_size.has_value()) {
+													return applyTypeSpecSizeAdjustments(
+														alias_type_spec,
+														*nested_alias_size);
+												}
+											}
+										}
+
+										std::string_view base_candidate =
+											qualified_alias_name.substr(0, member_sep);
+										if (size_t angle_pos = base_candidate.find("<");
+											angle_pos != std::string_view::npos) {
+											base_candidate =
+												base_candidate.substr(0, angle_pos);
+										}
+										if (const TemplateTypeArg* concrete_base_arg =
+												findConcreteArgByName(base_candidate)) {
+											if (std::optional<long long> concrete_member_size =
+													resolveConcreteTypeMemberAliasSize(
+														*concrete_base_arg,
+														dependent_member_name);
+												concrete_member_size.has_value()) {
+												return applyTypeSpecSizeAdjustments(
+													alias_type_spec,
+													*concrete_member_size);
+											}
 										}
 									}
 								}
 							}
 						}
-					}
 
-					if (std::optional<long long> bound_param_size =
-							tryResolveBoundTemplateParam(alias_type_spec.token().value());
-						bound_param_size.has_value()) {
-						return bound_param_size;
-					}
-
-					int size_bits = getTypeSpecSizeBits(alias_type_spec);
-					return size_bits > 0
-						? std::optional<long long>(static_cast<long long>(size_bits / 8))
-						: std::nullopt;
-				};
-
-				resolvePrimaryTemplateMemberAliasSize =
-					[&](std::string_view template_name,
-						std::string_view member_name,
-						std::span<const TemplateTypeArg> concrete_member_args) -> std::optional<long long> {
-					auto template_opt = gTemplateRegistry.lookupTemplate(template_name);
-					if (!template_opt.has_value() || !template_opt->is<TemplateClassDeclarationNode>()) {
-						return std::nullopt;
-					}
-
-					const auto& primary_template =
-						template_opt->as<TemplateClassDeclarationNode>();
-					const auto& primary_params =
-						primary_template.template_parameters();
-					const auto& type_aliases =
-						primary_template.class_decl_node().type_aliases();
-
-					for (const auto& type_alias : type_aliases) {
-						if (StringTable::getStringView(type_alias.alias_name) != member_name ||
-							!type_alias.type_node.is<TypeSpecifierNode>()) {
-							continue;
+						if (std::optional<long long> bound_param_size =
+								tryResolveBoundTemplateParam(alias_type_spec.token().value());
+							bound_param_size.has_value()) {
+							return bound_param_size;
 						}
 
-						return resolveAliasTypeSpecSize(
-							type_alias.type_node.as<TypeSpecifierNode>(),
-							primary_params,
-							concrete_member_args);
+						int size_bits = getTypeSpecSizeBits(alias_type_spec);
+						return size_bits > 0
+							? std::optional<long long>(static_cast<long long>(size_bits / 8))
+							: std::nullopt;
 					}
 
-					return std::nullopt;
+					std::optional<long long> resolvePrimaryTemplateMemberAliasSize(
+						std::string_view template_name,
+						std::string_view member_name,
+						std::span<const TemplateTypeArg> concrete_member_args) {
+						if (depth_ >= kMaxDepth) return std::nullopt;
+						DepthGuard guard{depth_};
+
+						auto template_opt = gTemplateRegistry.lookupTemplate(template_name);
+						if (!template_opt.has_value() || !template_opt->is<TemplateClassDeclarationNode>()) {
+							return std::nullopt;
+						}
+
+						const auto& primary_template =
+							template_opt->as<TemplateClassDeclarationNode>();
+						const auto& primary_params =
+							primary_template.template_parameters();
+						const auto& type_aliases =
+							primary_template.class_decl_node().type_aliases();
+
+						for (const auto& type_alias : type_aliases) {
+							if (StringTable::getStringView(type_alias.alias_name) != member_name ||
+								!type_alias.type_node.is<TypeSpecifierNode>()) {
+								continue;
+							}
+
+							return resolveAliasTypeSpecSize(
+								type_alias.type_node.as<TypeSpecifierNode>(),
+								primary_params,
+								concrete_member_args);
+						}
+
+						return std::nullopt;
+					}
 				};
 
 				// Check if this is a placeholder for a dependent nested type like "Op<...>::type"
@@ -1224,6 +1232,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 				}
 
 				if (dependent_member_info != nullptr) {
+					MemberAliasSizeResolver resolver;
 					full_type_name = StringTable::getStringView(dependent_member_info->name());
 					size_t scope_pos = full_type_name.rfind("::");
 					if (scope_pos != std::string_view::npos) {
@@ -1243,7 +1252,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 
 						if (!template_name.empty()) {
 							if (std::optional<long long> alias_size =
-									resolvePrimaryTemplateMemberAliasSize(
+									resolver.resolvePrimaryTemplateMemberAliasSize(
 										template_name,
 										member_part,
 										concrete_member_args);
@@ -1265,7 +1274,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 							if (bound_base_arg->is_template_template_arg &&
 								bound_base_arg->template_name_handle.isValid()) {
 								if (std::optional<long long> alias_size =
-										resolvePrimaryTemplateMemberAliasSize(
+										resolver.resolvePrimaryTemplateMemberAliasSize(
 											bound_base_arg->template_name_handle.view(),
 											member_part,
 											concrete_member_args);
@@ -1274,7 +1283,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 									return *alias_size;
 								}
 							} else if (std::optional<long long> concrete_member_size =
-									resolveConcreteTypeMemberAliasSize(
+									MemberAliasSizeResolver::resolveConcreteTypeMemberAliasSize(
 										*bound_base_arg,
 										member_part);
 								concrete_member_size.has_value()) {

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -895,21 +895,291 @@ inline std::optional<long long> evaluateConstraintExpression(
 				}
 
 				auto sizeFromConcreteTemplateArg = [](const TemplateTypeArg& concrete_arg) -> std::optional<long long> {
+					if (concrete_arg.pointer_depth > 0 ||
+						concrete_arg.function_signature.has_value() ||
+						concrete_arg.category() == TypeCategory::FunctionPointer ||
+						concrete_arg.category() == TypeCategory::MemberFunctionPointer ||
+						concrete_arg.category() == TypeCategory::MemberObjectPointer) {
+						return 8;
+					}
+
+					long long size = 0;
 					if (const TypeInfo* concrete_ti = tryGetTypeInfo(concrete_arg.type_index)) {
-						long long size = static_cast<long long>(toSizeT(concrete_ti->sizeInBytes()));
-						if (size > 0) {
-							return size;
+						if (const StructTypeInfo* struct_info = concrete_ti->getStructInfo();
+							struct_info && !struct_info->hasCompleteObjectLayout()) {
+							return std::nullopt;
+						}
+						size = static_cast<long long>(toSizeT(concrete_ti->sizeInBytes()));
+					}
+
+					if (size == 0) {
+						size = static_cast<long long>(get_type_size_bits(concrete_arg.category()) / 8);
+					}
+					if (size <= 0) {
+						return std::nullopt;
+					}
+
+					if (concrete_arg.is_array) {
+						if (!concrete_arg.array_size.has_value()) {
+							return std::nullopt;
+						}
+						size *= static_cast<long long>(*concrete_arg.array_size);
+					}
+					return size;
+				};
+
+				auto findConstraintArgByName = [&](std::string_view param_name) -> const TemplateTypeArg* {
+					for (size_t i = 0; i < template_param_names.size() && i < template_args.size(); ++i) {
+						if (template_param_names[i] == param_name) {
+							return &template_args[i];
+						}
+					}
+					return nullptr;
+				};
+
+				auto materializeConstraintPlaceholderArgs = [&](const TypeInfo& placeholder_info) {
+					std::vector<TemplateTypeArg> concrete_args;
+					concrete_args.reserve(placeholder_info.templateArgs().size());
+					for (const auto& arg_info : placeholder_info.templateArgs()) {
+						TemplateTypeArg concrete_arg = toTemplateTypeArg(arg_info);
+						std::string_view dependent_arg_name;
+						if (arg_info.dependent_name.isValid()) {
+							dependent_arg_name = StringTable::getStringView(arg_info.dependent_name);
+						} else if (const TypeInfo* dependent_arg_info = tryGetTypeInfo(arg_info.type_index)) {
+							dependent_arg_name = StringTable::getStringView(dependent_arg_info->name());
+						}
+						if (!dependent_arg_name.empty()) {
+							if (const TemplateTypeArg* substituted_arg =
+									findConstraintArgByName(dependent_arg_name)) {
+								if (!arg_info.is_value && !substituted_arg->is_value) {
+									concrete_arg = rebindDependentTemplateTypeArg(*substituted_arg, arg_info);
+								} else {
+									concrete_arg = *substituted_arg;
+								}
+							}
+						}
+						concrete_args.push_back(std::move(concrete_arg));
+					}
+					return concrete_args;
+				};
+
+				auto applyTypeSpecSizeAdjustments =
+					[](const TypeSpecifierNode& type_spec, long long base_size) -> std::optional<long long> {
+					if (type_spec.has_function_signature() && type_spec.pointer_depth() == 0) {
+						return std::nullopt;
+					}
+					if (type_spec.pointer_depth() > 0 ||
+						type_spec.type() == TypeCategory::FunctionPointer ||
+						type_spec.type() == TypeCategory::MemberFunctionPointer ||
+						type_spec.type() == TypeCategory::MemberObjectPointer) {
+						return 8;
+					}
+					if (type_spec.is_array()) {
+						if (type_spec.array_dimensions().empty()) {
+							if (auto single_dim = type_spec.array_size(); single_dim.has_value()) {
+								base_size *= static_cast<long long>(*single_dim);
+							} else {
+								return std::nullopt;
+							}
+						} else {
+							for (size_t dim : type_spec.array_dimensions()) {
+								base_size *= static_cast<long long>(dim);
+							}
+						}
+					}
+					return base_size;
+				};
+
+				auto resolveConcreteTypeMemberAliasSize =
+					[&](const TemplateTypeArg& concrete_base_arg,
+						std::string_view member_name) -> std::optional<long long> {
+					if (concrete_base_arg.is_value ||
+						concrete_base_arg.is_template_template_arg ||
+						!concrete_base_arg.type_index.is_valid()) {
+						return std::nullopt;
+					}
+
+					const TypeInfo* concrete_base_info =
+						tryGetTypeInfo(concrete_base_arg.type_index);
+					if (!concrete_base_info) {
+						return std::nullopt;
+					}
+
+					StringHandle qualified_member_handle =
+						StringTable::getOrInternStringHandle(
+							StringBuilder()
+								.append(concrete_base_info->name())
+								.append("::")
+								.append(member_name)
+								.commit());
+					auto member_it = getTypesByNameMap().find(qualified_member_handle);
+					if (member_it == getTypesByNameMap().end() || member_it->second == nullptr) {
+						return std::nullopt;
+					}
+
+					TypeSpecifierNode member_spec(
+						member_it->second->registeredTypeIndex().withCategory(member_it->second->typeEnum()),
+						member_it->second->hasStoredSize() ? member_it->second->sizeInBits().value : 0,
+						Token(),
+						CVQualifier::None,
+						ReferenceQualifier::None);
+					int size_bits = getTypeSpecSizeBits(member_spec);
+					if (size_bits <= 0 && member_it->second->hasStoredSize()) {
+						size_bits = member_it->second->sizeInBits().value;
+					}
+					return size_bits > 0
+						? std::optional<long long>(static_cast<long long>(size_bits / 8))
+						: std::nullopt;
+				};
+
+				std::function<std::optional<long long>(
+					std::string_view,
+					std::string_view,
+					std::span<const TemplateTypeArg>)> resolvePrimaryTemplateMemberAliasSize;
+
+				std::function<std::optional<long long>(
+					const TypeSpecifierNode&,
+					std::span<const ASTNode>,
+					std::span<const TemplateTypeArg>)> resolveAliasTypeSpecSize;
+
+				resolveAliasTypeSpecSize =
+					[&](const TypeSpecifierNode& alias_type_spec,
+						std::span<const ASTNode> primary_params,
+						std::span<const TemplateTypeArg> concrete_member_args) -> std::optional<long long> {
+					auto findConcreteArgByName =
+						[&](std::string_view param_name) -> const TemplateTypeArg* {
+						for (size_t i = 0; i < primary_params.size() &&
+								i < concrete_member_args.size();
+							 ++i) {
+							if (!primary_params[i].is<TemplateParameterNode>()) {
+								continue;
+							}
+							const auto& param =
+								primary_params[i].as<TemplateParameterNode>();
+							if (param.name() == param_name) {
+								return &concrete_member_args[i];
+							}
+						}
+						return nullptr;
+					};
+
+					auto tryResolveBoundTemplateParam =
+						[&](std::string_view candidate_name) -> std::optional<long long> {
+						const TemplateTypeArg* concrete_arg =
+							findConcreteArgByName(candidate_name);
+						if (!concrete_arg ||
+							concrete_arg->is_value ||
+							concrete_arg->is_template_template_arg) {
+							return std::nullopt;
+						}
+
+						if (std::optional<long long> base_size =
+								sizeFromConcreteTemplateArg(*concrete_arg);
+							base_size.has_value()) {
+							return applyTypeSpecSizeAdjustments(alias_type_spec, *base_size);
+						}
+						return std::nullopt;
+					};
+
+					if (alias_type_spec.type_index().is_valid()) {
+						if (const TypeInfo* alias_type_info =
+								tryGetTypeInfo(alias_type_spec.type_index())) {
+							if (std::optional<long long> bound_param_size =
+									tryResolveBoundTemplateParam(
+										StringTable::getStringView(alias_type_info->name()));
+								bound_param_size.has_value()) {
+								return bound_param_size;
+							}
+
+							if (alias_type_info->isDependentMemberType()) {
+								std::string_view qualified_alias_name =
+									StringTable::getStringView(alias_type_info->name());
+								size_t member_sep =
+									qualified_alias_name.rfind("::");
+								if (member_sep != std::string_view::npos) {
+									std::string_view dependent_member_name =
+										qualified_alias_name.substr(member_sep + 2);
+									std::vector<TemplateTypeArg> nested_args;
+									if (alias_type_info->isTemplateInstantiation()) {
+										nested_args = materializeTemplateArgs(
+											*alias_type_info,
+											primary_params,
+											concrete_member_args);
+									}
+
+									std::string_view nested_template_name =
+										StringTable::getStringView(
+											alias_type_info->baseTemplateName());
+									if (!nested_template_name.empty()) {
+										if (std::optional<long long> nested_alias_size =
+												resolvePrimaryTemplateMemberAliasSize(
+													nested_template_name,
+													dependent_member_name,
+													nested_args);
+											nested_alias_size.has_value()) {
+											return applyTypeSpecSizeAdjustments(
+												alias_type_spec,
+												*nested_alias_size);
+										}
+									}
+
+									if (!nested_template_name.empty()) {
+										if (const TemplateTypeArg* nested_template_arg =
+												findConcreteArgByName(
+													nested_template_name);
+											nested_template_arg &&
+											nested_template_arg->is_template_template_arg &&
+											nested_template_arg->template_name_handle.isValid()) {
+											if (std::optional<long long> nested_alias_size =
+													resolvePrimaryTemplateMemberAliasSize(
+														nested_template_arg->template_name_handle.view(),
+														dependent_member_name,
+														nested_args);
+												nested_alias_size.has_value()) {
+												return applyTypeSpecSizeAdjustments(
+													alias_type_spec,
+													*nested_alias_size);
+											}
+										}
+									}
+
+									std::string_view base_candidate =
+										qualified_alias_name.substr(0, member_sep);
+									if (size_t angle_pos = base_candidate.find("<");
+										angle_pos != std::string_view::npos) {
+										base_candidate =
+											base_candidate.substr(0, angle_pos);
+									}
+									if (const TemplateTypeArg* concrete_base_arg =
+											findConcreteArgByName(base_candidate)) {
+										if (std::optional<long long> concrete_member_size =
+												resolveConcreteTypeMemberAliasSize(
+													*concrete_base_arg,
+													dependent_member_name);
+											concrete_member_size.has_value()) {
+											return applyTypeSpecSizeAdjustments(
+												alias_type_spec,
+												*concrete_member_size);
+										}
+									}
+								}
+							}
 						}
 					}
 
-					long long size = static_cast<long long>(get_type_size_bits(concrete_arg.category()) / 8);
-					if (size > 0) {
-						return size;
+					if (std::optional<long long> bound_param_size =
+							tryResolveBoundTemplateParam(alias_type_spec.token().value());
+						bound_param_size.has_value()) {
+						return bound_param_size;
 					}
-					return std::nullopt;
+
+					int size_bits = getTypeSpecSizeBits(alias_type_spec);
+					return size_bits > 0
+						? std::optional<long long>(static_cast<long long>(size_bits / 8))
+						: std::nullopt;
 				};
 
-				auto resolvePrimaryTemplateMemberAliasSize =
+				resolvePrimaryTemplateMemberAliasSize =
 					[&](std::string_view template_name,
 						std::string_view member_name,
 						std::span<const TemplateTypeArg> concrete_member_args) -> std::optional<long long> {
@@ -920,7 +1190,8 @@ inline std::optional<long long> evaluateConstraintExpression(
 
 					const auto& primary_template =
 						template_opt->as<TemplateClassDeclarationNode>();
-					const auto& primary_params = primary_template.template_parameters();
+					const auto& primary_params =
+						primary_template.template_parameters();
 					const auto& type_aliases =
 						primary_template.class_decl_node().type_aliases();
 
@@ -930,43 +1201,10 @@ inline std::optional<long long> evaluateConstraintExpression(
 							continue;
 						}
 
-						const auto& alias_type_spec =
-							type_alias.type_node.as<TypeSpecifierNode>();
-
-						if (alias_type_spec.pointer_depth() == 0 &&
-							alias_type_spec.reference_qualifier() == ReferenceQualifier::None &&
-							!alias_type_spec.is_array()) {
-							std::string_view alias_target_name =
-								alias_type_spec.token().value();
-							for (size_t param_index = 0;
-								 param_index < primary_params.size() &&
-								 param_index < concrete_member_args.size();
-								 ++param_index) {
-								if (!primary_params[param_index].is<TemplateParameterNode>()) {
-									continue;
-								}
-
-								const auto& template_param =
-									primary_params[param_index].as<TemplateParameterNode>();
-								if (template_param.kind() != TemplateParameterKind::Type ||
-									template_param.name() != alias_target_name) {
-									continue;
-								}
-
-								return sizeFromConcreteTemplateArg(
-									concrete_member_args[param_index]);
-							}
-						}
-
-						if (const TypeInfo* alias_type_info =
-								tryGetTypeInfo(alias_type_spec.type_index());
-							alias_type_info && alias_type_info->hasStoredSize()) {
-							long long size =
-								static_cast<long long>(toSizeT(alias_type_info->sizeInBytes()));
-							if (size > 0) {
-								return size;
-							}
-						}
+						return resolveAliasTypeSpecSize(
+							type_alias.type_node.as<TypeSpecifierNode>(),
+							primary_params,
+							concrete_member_args);
 					}
 
 					return std::nullopt;
@@ -975,77 +1213,74 @@ inline std::optional<long long> evaluateConstraintExpression(
 				// Check if this is a placeholder for a dependent nested type like "Op<...>::type"
 				// These are created during parsing as placeholders for template-dependent types
 				// Phase 4: use explicit placeholder_kind_ instead of string heuristic
-				if (const TypeInfo* full_ti = tryGetTypeInfo(type_idx); full_ti && full_ti->isDependentMemberType()) {
-					// This looks like a nested type access - try to resolve it
-					// Format: "Op<...>::type" or similar
-					size_t scope_pos = full_type_name.find("::");
-					std::string_view base_part = full_type_name.substr(0, scope_pos);
-					std::string_view member_part = full_type_name.substr(scope_pos + 2);
+				const TypeInfo* dependent_member_info = nullptr;
+				if (const ResolvedAliasTypeInfo resolved_type_info = resolveAliasTypeInfo(type_idx);
+					resolved_type_info.terminal_type_info != nullptr &&
+					resolved_type_info.terminal_type_info->isDependentMemberType()) {
+					dependent_member_info = resolved_type_info.terminal_type_info;
+				} else if (const TypeInfo* full_ti = tryGetTypeInfo(type_idx);
+						   full_ti && full_ti->isDependentMemberType()) {
+					dependent_member_info = full_ti;
+				}
 
-					FLASH_LOG(Templates, Debug, "  Nested type access: base='", base_part, "', member='", member_part, "'");
+				if (dependent_member_info != nullptr) {
+					full_type_name = StringTable::getStringView(dependent_member_info->name());
+					size_t scope_pos = full_type_name.rfind("::");
+					if (scope_pos != std::string_view::npos) {
+						std::string_view base_part = full_type_name.substr(0, scope_pos);
+						std::string_view member_part = full_type_name.substr(scope_pos + 2);
 
-					// Check if base_part references a template template parameter like "Op<...>"
-					std::string_view template_param_name;
-					if (base_part.find("<") != std::string_view::npos) {
-						// Extract the template parameter name (e.g., "Op" from "Op<...>")
-						template_param_name = base_part.substr(0, base_part.find("<"));
-					} else {
-						template_param_name = base_part;
-					}
+						FLASH_LOG(Templates, Debug, "  Nested type access: base='", base_part, "', member='", member_part, "'");
 
-					FLASH_LOG(Templates, Debug, "  Template param name: '", template_param_name, "', template_param_names.size()=", template_param_names.size());
-					for (size_t dbg_i = 0; dbg_i < template_param_names.size(); ++dbg_i) {
-						FLASH_LOG(Templates, Debug, "    template_param_names[", dbg_i, "] = '", template_param_names[dbg_i], "'");
-					}
+						std::string_view template_name =
+							dependent_member_info->isTemplateInstantiation()
+								? StringTable::getStringView(dependent_member_info->baseTemplateName())
+								: std::string_view{};
+						std::vector<TemplateTypeArg> concrete_member_args =
+							dependent_member_info->isTemplateInstantiation()
+								? materializeConstraintPlaceholderArgs(*dependent_member_info)
+								: std::vector<TemplateTypeArg>{};
 
-					// Look for the template template parameter in our substitutions
-					for (size_t i = 0; i < template_param_names.size() && i < template_args.size(); ++i) {
-						if (template_param_names[i] == template_param_name) {
-							const auto& arg = template_args[i];
+						if (!template_name.empty()) {
+							if (std::optional<long long> alias_size =
+									resolvePrimaryTemplateMemberAliasSize(
+										template_name,
+										member_part,
+										concrete_member_args);
+								alias_size.has_value()) {
+								FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::", member_part, ") = ", *alias_size);
+								return *alias_size;
+							}
+						}
 
-							FLASH_LOG(Templates, Debug, "  Found template param at index ", i, ", is_template_template_arg=", arg.is_template_template_arg);
+						std::string_view base_param_name = base_part;
+						if (size_t angle_pos = base_param_name.find("<");
+							angle_pos != std::string_view::npos) {
+							base_param_name = base_param_name.substr(0, angle_pos);
+						}
 
-							// Check if this is a template template argument
-							if (arg.is_template_template_arg && arg.template_name_handle.isValid()) {
-								// We have a template template argument like HasType
-								std::string_view template_name = arg.template_name_handle.view();
-								FLASH_LOG(Templates, Debug, "  Found template template arg: '", template_name, "'");
-
-								// Now we need to get the instantiated type's member
-								// For HasType<int>::type, we need to get the type alias from HasType<int>
-								InlineVector<TemplateTypeArg, 4> concrete_member_args;
-
-								// Look for the pack argument to get the template argument
-								for (size_t j = i + 1; j < template_args.size(); ++j) {
-									const auto& pack_arg = template_args[j];
-									if (!pack_arg.is_template_template_arg && !pack_arg.is_value) {
-										concrete_member_args.push_back(pack_arg);
-										// Found a type argument - this is what we instantiate the template with
-										FLASH_LOG(Templates, Debug, "  Pack arg type_index=", pack_arg.type_index, ", base_type=", static_cast<int>(pack_arg.typeEnum()));
-									}
-								}
-
+						if (const TemplateTypeArg* bound_base_arg =
+								findConstraintArgByName(base_param_name);
+							bound_base_arg != nullptr) {
+							if (bound_base_arg->is_template_template_arg &&
+								bound_base_arg->template_name_handle.isValid()) {
 								if (std::optional<long long> alias_size =
 										resolvePrimaryTemplateMemberAliasSize(
-											template_name,
+											bound_base_arg->template_name_handle.view(),
 											member_part,
 											concrete_member_args);
 									alias_size.has_value()) {
-									FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::", member_part, ") = ", *alias_size);
+									FLASH_LOG(Templates, Debug, "  Resolved sizeof(", bound_base_arg->template_name_handle.view(), "<...>::", member_part, ") = ", *alias_size);
 									return *alias_size;
 								}
-
-								if (member_part == "type" && !concrete_member_args.empty()) {
-									if (std::optional<long long> size =
-											sizeFromConcreteTemplateArg(
-												concrete_member_args.front());
-										size.has_value()) {
-										FLASH_LOG(Templates, Debug, "  Resolved sizeof(", template_name, "<...>::type) = ", *size);
-										return *size;
-									}
-								}
+							} else if (std::optional<long long> concrete_member_size =
+									resolveConcreteTypeMemberAliasSize(
+										*bound_base_arg,
+										member_part);
+								concrete_member_size.has_value()) {
+								FLASH_LOG(Templates, Debug, "  Resolved sizeof(", base_param_name, "::", member_part, ") = ", *concrete_member_size);
+								return *concrete_member_size;
 							}
-							break;
 						}
 					}
 				}

--- a/tests/test_requires_sizeof_dependent_member_value_type_ret8.cpp
+++ b/tests/test_requires_sizeof_dependent_member_value_type_ret8.cpp
@@ -1,0 +1,25 @@
+template <typename T>
+struct holder {
+	using value_type = T;
+};
+
+template <template <typename...> class Holder, typename... Args>
+concept HasSizedValueType = requires {
+	typename Holder<Args...>;
+	requires sizeof(typename Holder<Args...>::value_type) == sizeof(long long);
+};
+
+template <typename Default, template <typename...> class Holder, typename... Args>
+struct detector {
+	static constexpr int value = 1;
+};
+
+template <typename Default, template <typename...> class Holder, typename... Args>
+	requires HasSizedValueType<Holder, Args...>
+struct detector<Default, Holder, Args...> {
+	static constexpr int value = 8;
+};
+
+int main() {
+	return detector<int, holder, long long>::value;
+}

--- a/tests/test_requires_sizeof_dependent_member_value_type_ret8.cpp
+++ b/tests/test_requires_sizeof_dependent_member_value_type_ret8.cpp
@@ -1,25 +1,41 @@
 template <typename T>
+struct identity {
+	using type = T;
+};
+
+template <typename Prefix, template <typename> class Wrap, typename T>
 struct holder {
-	using value_type = T;
+	using value_type = typename Wrap<T>::type;
 };
 
-template <template <typename...> class Holder, typename... Args>
+template <template <typename, template <typename> class, typename> class Holder,
+		  typename Prefix,
+		  template <typename> class Wrap,
+		  typename T>
 concept HasSizedValueType = requires {
-	typename Holder<Args...>;
-	requires sizeof(typename Holder<Args...>::value_type) == sizeof(long long);
+	typename Holder<Prefix, Wrap, T>;
+	requires sizeof(typename Holder<Prefix, Wrap, T>::value_type) == sizeof(long long);
 };
 
-template <typename Default, template <typename...> class Holder, typename... Args>
+template <typename Default,
+		  template <typename, template <typename> class, typename> class Holder,
+		  typename Prefix,
+		  template <typename> class Wrap,
+		  typename T>
 struct detector {
 	static constexpr int value = 1;
 };
 
-template <typename Default, template <typename...> class Holder, typename... Args>
-	requires HasSizedValueType<Holder, Args...>
-struct detector<Default, Holder, Args...> {
+template <typename Default,
+		  template <typename, template <typename> class, typename> class Holder,
+		  typename Prefix,
+		  template <typename> class Wrap,
+		  typename T>
+	requires HasSizedValueType<Holder, Prefix, Wrap, T>
+struct detector<Default, Holder, Prefix, Wrap, T> {
 	static constexpr int value = 8;
 };
 
 int main() {
-	return detector<int, holder, long long>::value;
+	return detector<int, holder, char, identity, long long>::value;
 }


### PR DESCRIPTION
TemplateRegistry_Lazy.h now resolves simple dependent member aliases from the primary template during sizeof(...) constraint evaluation, so cases like typename Holder<T>::value_type no longer fall back to size 0. The new test is tests\test_requires_sizeof_dependent_member_value_type_ret8.cpp, and it exercises that path through a constrained partial specialization that returns 8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
