### PR TITLE
Use explicit dependent placeholder state

### DIFF
--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1681,11 +1681,6 @@ inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_
 		resolved_alias.terminal_type_info != nullptr) {
 		return resolved_alias.terminal_type_info->isDependentPlaceholder();
 	}
-
-	if (const TypeInfo* direct_type_info = tryGetTypeInfo(type_index)) {
-		return direct_type_info->isDependentPlaceholder();
-	}
-
 	return false;
 }
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1671,6 +1671,24 @@ inline ResolvedAliasTypeInfo resolveAliasTypeInfo(TypeIndex type_index) {
 	return resolved;
 }
 
+inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_spec) {
+	TypeIndex type_index = type_spec.type_index();
+	if (!type_index.is_valid()) {
+		return false;
+	}
+
+	if (const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_index);
+		resolved_alias.terminal_type_info != nullptr) {
+		return resolved_alias.terminal_type_info->isDependentPlaceholder();
+	}
+
+	if (const TypeInfo* direct_type_info = tryGetTypeInfo(type_index)) {
+		return direct_type_info->isDependentPlaceholder();
+	}
+
+	return false;
+}
+
 inline TypeIndex getCanonicalConversionTargetType(const TypeSpecifierNode& type_spec) {
 	TypeIndex target_type_index = type_spec.type_index();
 	if (!target_type_index.is_valid() && type_spec.type() != TypeCategory::Invalid) {
@@ -2276,6 +2294,9 @@ public:
 	void set_is_deleted(bool deleted) { is_deleted_ = deleted; }
 	bool is_deleted() const { return is_deleted_; }
 
+	void set_is_template_pattern(bool is_template_pattern) { is_template_pattern_ = is_template_pattern; }
+	bool is_template_pattern() const { return is_template_pattern_; }
+
 	// Inline always support (for template instantiations that are pure expressions)
 	// When true, this function should always be inlined and never generate a call
 	void set_inline_always(bool inline_always) { inline_always_ = inline_always; }
@@ -2347,6 +2368,7 @@ private:
 	bool is_consteval_;
 	bool is_noexcept_ = false;  // True if function is declared noexcept
 	bool is_deleted_ = false;  // True if function is declared = delete
+	bool is_template_pattern_ = false;  // True for uninstantiated template pattern function nodes
 	bool is_static_ = false;	 // True if function is a static member function (no 'this' pointer)
 	bool is_const_member_function_ = false;	// True if this function is a const member function (K qualifier)
 	bool is_volatile_member_function_ = false;  // True if this function is a volatile member function (V qualifier)

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -542,7 +542,7 @@ int main_impl(int argc, char* argv[]) {
 					for (const auto& param : node_handle.as<FunctionDeclarationNode>().parameter_nodes()) {
 						if (param.is<DeclarationNode>()) {
 							const auto& pt = param.as<DeclarationNode>().type_node().as<TypeSpecifierNode>();
-							if (pt.category() == TypeCategory::UserDefined && pt.size_in_bits() == 0 && pt.pointer_depth() == 0) {
+							if (typeSpecStillUsesDependentPlaceholder(pt) && pt.pointer_depth() == 0) {
 								has_dependent_params = true;
 								break;
 							}

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -29,6 +29,9 @@ namespace {
 } // namespace
 
 void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) {
+	if (node.is_template_pattern()) {
+		return;
+	}
 	if (!node.get_definition().has_value() && !node.is_implicit()) {
 		return;
 	}

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -779,6 +779,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				}
 
 				// Create the TemplateFunctionDeclarationNode wrapping the function
+				func_decl.set_is_template_pattern(true);
 				auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
 					std::move(template_params),
 					*func_node_ptr,

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -4447,6 +4447,7 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 			const auto& tparam = param.as<TemplateParameterNode>();
 			if (tparam.kind() == TemplateParameterKind::Type) {
 				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0);
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				getTypesByNameMap().emplace(type_info.name(), &type_info);
 				template_scope.addParameter(&type_info);
 			}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -3998,7 +3998,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// SFINAE contexts (e.g. decltype(...) inside a default template arg).
 				// Let the caller reject the overload without emitting a hard parser error.
 				if (in_sfinae_context_) {
-					FLASH_LOG(Templates, Debug, "SFINAE: template instantiation failed for call to '{}'", identifier_token.value());
+					FLASH_LOG_FORMAT(Templates, Debug, "SFINAE: template instantiation failed for call to '{}'", identifier_token.value());
 				} else {
 					FLASH_LOG(Parser, Error, "Template instantiation failed");
 				}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -3994,11 +3994,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 					return ParseResult::success(*result);
 				}
-				// Template instantiation failed - always return error.
-				// In SFINAE context (e.g., requires expression), the caller
-				// (parse_requires_expression) handles errors by marking the
-				// requirement as unsatisfied (false node).
-				FLASH_LOG(Parser, Error, "Template instantiation failed");
+				// Template instantiation failure is an expected substitution failure in
+				// SFINAE contexts (e.g. decltype(...) inside a default template arg).
+				// Let the caller reject the overload without emitting a hard parser error.
+				if (in_sfinae_context_) {
+					FLASH_LOG(Templates, Debug, "SFINAE: template instantiation failed for call to '{}'", identifier_token.value());
+				} else {
+					FLASH_LOG(Parser, Error, "Template instantiation failed");
+				}
 				return ParseResult::error("Failed to instantiate template function", identifier_token);
 			}
 		}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -206,6 +206,7 @@ ParseResult Parser::parse_template_declaration() {
 				// Register the template parameter as a user-defined type temporarily
 				// Create a TypeInfo entry for the template parameter
 				auto& type_info = add_template_param_type(tparam.nameHandle(), tparam.kind() == TemplateParameterKind::Template ? TypeCategory::Template : TypeCategory::UserDefined, 0); // Do we need a correct size here?
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				template_scope.addParameter(&type_info);	 // RAII cleanup on all return paths
 			}
 		}
@@ -4629,6 +4630,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 			const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
 			if (tparam.kind() == TemplateParameterKind::Type) {
 				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0); // Do we need a correct size here?
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				template_scope.addParameter(&type_info);
 			}
 		}

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -20,6 +20,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 		TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
 		if (tparam.kind() == TemplateParameterKind::Type && !tparam.registered_type_index().is_valid()) {
 			TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0);
+			type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 			tparam.set_registered_type_index(type_info.type_index_);
 			template_scope.addParameter(&type_info);
 		}
@@ -164,6 +165,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	std::optional<ASTNode> final_requires_clause = trailing_requires_clause.has_value() ? trailing_requires_clause : requires_clause;
 
 	// Create a template function declaration node
+	func_decl.set_is_template_pattern(true);
 	auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
 		std::move(template_params),
 		*func_result_node,
@@ -250,6 +252,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 			const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
 			if (tparam.kind() == TemplateParameterKind::Type) {
 				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0); // Do we need a correct size here?
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				getTypesByNameMap().emplace(type_info.name(), &type_info);
 				template_scope.addParameter(&type_info);
 			}
@@ -679,6 +682,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 						skip_trailing_requires_clause();
 
 						// Create template function declaration node
+						func_ref.set_is_template_pattern(true);
 						auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
 							std::move(template_params),
 							func_node,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7574,6 +7574,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_func_ref.set_trailing_return_type_position(func_decl.trailing_return_type_position());
 
 				// Create new TemplateFunctionDeclarationNode with inner template params
+				new_func_ref.set_is_template_pattern(true);
 				auto new_template_func = emplace_node<TemplateFunctionDeclarationNode>(
 					template_func.template_parameters(),
 					new_func_node,

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -41,6 +41,40 @@ static ReferenceQualifier collapseTemplateArgumentReferenceQualifier(
 	return ReferenceQualifier::RValueReference;
 }
 
+static void applyRegisteredTypeBindingMetadata(
+	TypeInfo& type_info,
+	const TemplateTypeArg& arg,
+	bool preserve_ref_qualifier) {
+	if (is_builtin_type(arg.typeEnum())) {
+		type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
+	} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+		type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
+	} else {
+		type_info.fallback_size_bits_ = 0;
+	}
+
+	if (preserve_ref_qualifier) {
+		type_info.reference_qualifier_ = arg.is_rvalue_reference()
+											 ? ReferenceQualifier::RValueReference
+											 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
+	}
+}
+
+static TypeInfo& registerTemplateTypeBinding(
+	StringHandle param_name,
+	const TemplateTypeArg& arg) {
+	if (arg.type_index.is_valid()) {
+		return add_type_alias_copy(
+			param_name,
+			arg.type_index.withCategory(arg.typeEnum()),
+			getTypeSizeFromTemplateArgument(arg));
+	}
+	return add_template_param_type(
+		param_name,
+		arg.typeEnum(),
+		getTypeSizeFromTemplateArgument(arg));
+}
+
 static void resetTypeIndirection(TypeSpecifierNode& type_spec) {
 	const TypeSpecifierNode empty_spec;
 	type_spec.copy_indirection_from(empty_spec);
@@ -550,40 +584,14 @@ void registerTypeParamsInScope(
 	const InlineVector<TemplateTypeArg, 4>& type_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
-	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg, bool preserve_ref_qualifier_for_arg) {
-		if (is_builtin_type(arg.typeEnum())) {
-			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
-		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
-		} else {
-			type_info.fallback_size_bits_ = 0;
-		}
-		if (preserve_ref_qualifier_for_arg) {
-			type_info.reference_qualifier_ = arg.is_rvalue_reference()
-												 ? ReferenceQualifier::RValueReference
-												 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
-		}
-	};
-	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
-		if (arg.type_index.is_valid()) {
-			return add_type_alias_copy(
-				param_name,
-				arg.type_index.withCategory(arg.typeEnum()),
-				getTypeSizeFromTemplateArgument(arg));
-		}
-		return add_template_param_type(
-			param_name,
-			arg.typeEnum(),
-			getTypeSizeFromTemplateArgument(arg));
-	};
 	for (size_t i = 0; i < param_names.size() && i < type_args.size(); ++i) {
 		const TemplateTypeArg& arg = type_args[i];
 		if (arg.is_value)
 			continue;  // Non-type (value) params must NOT be registered as TypeInfo
 		if (arg.is_template_template_arg)
 			continue;  // Template-template params don't represent concrete types
-		auto& type_info = register_type_binding(param_names[i], arg);
-		apply_registered_type_binding_metadata(type_info, arg, preserve_ref_qualifier);
+		auto& type_info = registerTemplateTypeBinding(param_names[i], arg);
+		applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 		scope.addParameter(&type_info);
 	}
 }
@@ -601,40 +609,14 @@ void registerTypeParamsInScope(
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
-	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg, bool preserve_ref_qualifier_for_arg) {
-		if (is_builtin_type(arg.typeEnum())) {
-			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
-		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
-		} else {
-			type_info.fallback_size_bits_ = 0;
-		}
-		if (preserve_ref_qualifier_for_arg) {
-			type_info.reference_qualifier_ = arg.is_rvalue_reference()
-												 ? ReferenceQualifier::RValueReference
-												 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
-		}
-	};
-	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
-		if (arg.type_index.is_valid()) {
-			return add_type_alias_copy(
-				param_name,
-				arg.type_index.withCategory(arg.typeEnum()),
-				getTypeSizeFromTemplateArgument(arg));
-		}
-		return add_template_param_type(
-			param_name,
-			arg.typeEnum(),
-			getTypeSizeFromTemplateArgument(arg));
-	};
 	forEachNonPackTemplateParamArgBinding(
 		template_param_nodes,
 		template_args,
 		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
-			auto& type_info = register_type_binding(param.nameHandle(), arg);
-			apply_registered_type_binding_metadata(type_info, arg, preserve_ref_qualifier);
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -644,35 +626,14 @@ void registerTypeParamsInScope(
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
-	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg) {
-		if (is_builtin_type(arg.typeEnum())) {
-			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
-		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
-		} else {
-			type_info.fallback_size_bits_ = 0;
-		}
-	};
-	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
-		if (arg.type_index.is_valid()) {
-			return add_type_alias_copy(
-				param_name,
-				arg.type_index.withCategory(arg.typeEnum()),
-				getTypeSizeFromTemplateArgument(arg));
-		}
-		return add_template_param_type(
-			param_name,
-			arg.typeEnum(),
-			getTypeSizeFromTemplateArgument(arg));
-	};
 	forEachNonPackTemplateParamArgBinding(
 		template_param_nodes,
 		template_args,
 		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
-			auto& type_info = register_type_binding(param.nameHandle(), arg);
-			apply_registered_type_binding_metadata(type_info, arg);
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, true);
 			scope.addParameter(&type_info);
 			if (sfinae_map)
 				(*sfinae_map)[type_info.name()] = arg.type_index;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -550,6 +550,20 @@ void registerTypeParamsInScope(
 	const InlineVector<TemplateTypeArg, 4>& type_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
+	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg, bool preserve_ref_qualifier_for_arg) {
+		if (is_builtin_type(arg.typeEnum())) {
+			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
+		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
+		} else {
+			type_info.fallback_size_bits_ = 0;
+		}
+		if (preserve_ref_qualifier_for_arg) {
+			type_info.reference_qualifier_ = arg.is_rvalue_reference()
+												 ? ReferenceQualifier::RValueReference
+												 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
+		}
+	};
 	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
 		if (arg.type_index.is_valid()) {
 			return add_type_alias_copy(
@@ -569,20 +583,7 @@ void registerTypeParamsInScope(
 		if (arg.is_template_template_arg)
 			continue;  // Template-template params don't represent concrete types
 		auto& type_info = register_type_binding(param_names[i], arg);
-		if (is_builtin_type(arg.typeEnum())) {
-			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
-		} else {
-			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-				type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
-			} else {
-				type_info.fallback_size_bits_ = 0;
-			}
-		}
-		if (preserve_ref_qualifier) {
-			type_info.reference_qualifier_ = arg.is_rvalue_reference()
-												 ? ReferenceQualifier::RValueReference
-												 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
-		}
+		apply_registered_type_binding_metadata(type_info, arg, preserve_ref_qualifier);
 		scope.addParameter(&type_info);
 	}
 }
@@ -600,6 +601,20 @@ void registerTypeParamsInScope(
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
+	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg, bool preserve_ref_qualifier_for_arg) {
+		if (is_builtin_type(arg.typeEnum())) {
+			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
+		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
+		} else {
+			type_info.fallback_size_bits_ = 0;
+		}
+		if (preserve_ref_qualifier_for_arg) {
+			type_info.reference_qualifier_ = arg.is_rvalue_reference()
+												 ? ReferenceQualifier::RValueReference
+												 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
+		}
+	};
 	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
 		if (arg.type_index.is_valid()) {
 			return add_type_alias_copy(
@@ -619,11 +634,7 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = register_type_binding(param.nameHandle(), arg);
-			if (preserve_ref_qualifier) {
-				type_info.reference_qualifier_ = arg.is_rvalue_reference()
-													 ? ReferenceQualifier::RValueReference
-													 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
-			}
+			apply_registered_type_binding_metadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -633,6 +644,15 @@ void registerTypeParamsInScope(
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
+	auto apply_registered_type_binding_metadata = [&](TypeInfo& type_info, const TemplateTypeArg& arg) {
+		if (is_builtin_type(arg.typeEnum())) {
+			type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
+		} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+			type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
+		} else {
+			type_info.fallback_size_bits_ = 0;
+		}
+	};
 	auto register_type_binding = [&](StringHandle param_name, const TemplateTypeArg& arg) -> TypeInfo& {
 		if (arg.type_index.is_valid()) {
 			return add_type_alias_copy(
@@ -652,6 +672,7 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = register_type_binding(param.nameHandle(), arg);
+			apply_registered_type_binding_metadata(type_info, arg);
 			scope.addParameter(&type_info);
 			if (sfinae_map)
 				(*sfinae_map)[type_info.name()] = arg.type_index;
@@ -3598,17 +3619,15 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	// Add to top-level AST so it gets visited by the code generator.
 	// Skip registration in two cases that produce uncompilable nodes:
 	//   1. Bodyless instantiations (forward declarations, SFINAE probes) — no code to emit.
-	//   2. Bodied instantiations where any parameter still has an unresolved dependent type
-	//      (TypeCategory::UserDefined with size=0).  This happens when swap or similar
-	//      helpers are instantiated during default-template-argument analysis with still-
-	//      dependent arguments (e.g., Type=23 during initial parse of detail::test).
+	//   2. Bodied instantiations where any parameter still carries an explicit dependent
+	//      placeholder TypeInfo after substitution/alias resolution.
 	const bool has_unresolved_params = std::invoke([&]() {
 		for (const auto& param : new_func_ref.parameter_nodes()) {
 			if (param.is<DeclarationNode>()) {
 				const auto& type_node = param.as<DeclarationNode>().type_node();
 				if (type_node.is<TypeSpecifierNode>()) {
 					const auto& pt = type_node.as<TypeSpecifierNode>();
-					if (pt.category() == TypeCategory::UserDefined && pt.size_in_bits() == 0) {
+					if (typeSpecStillUsesDependentPlaceholder(pt)) {
 						return true;
 					}
 				}

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -103,6 +103,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 			template_param_names.push_back(tparam.nameHandle());
 			if (tparam.kind() == TemplateParameterKind::Type) {
 				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0);
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				tparam.set_registered_type_index(type_info.type_index_);
 				template_scope.addParameter(&type_info);
 			}
@@ -257,6 +258,7 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 			template_param_names.push_back(tparam.name());
 			if (tparam.kind() == TemplateParameterKind::Type) {
 				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0);
+				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 				tparam.set_registered_type_index(type_info.type_index_);
 				template_scope.addParameter(&type_info);
 			}

--- a/tests/test_sfinae_trailing_return_ref_arg_ret0.cpp
+++ b/tests/test_sfinae_trailing_return_ref_arg_ret0.cpp
@@ -1,0 +1,30 @@
+template <typename T>
+inline constexpr bool is_reference_v = false;
+
+template <typename T>
+inline constexpr bool is_reference_v<T&> = true;
+
+template <typename T>
+inline constexpr bool is_reference_v<T&&> = true;
+
+template <bool B, typename T = void>
+struct enable_if {};
+
+template <typename T>
+struct enable_if<true, T> {
+	using type = T;
+};
+
+template <typename T>
+auto select(T&&) -> typename enable_if<is_reference_v<T>, int>::type {
+	return 42;
+}
+
+int select(...) {
+	return 7;
+}
+
+int main() {
+	int value = 0;
+	return select(value) == 42 ? 0 : 1;
+}

--- a/tests/test_template_instantiation_empty_alias_param_ret42.cpp
+++ b/tests/test_template_instantiation_empty_alias_param_ret42.cpp
@@ -1,0 +1,14 @@
+struct EmptyTag {};
+
+template<typename T>
+using empty_alias = EmptyTag;
+
+template<typename T>
+int take_empty(empty_alias<T>) {
+	return 42;
+}
+
+int main() {
+	EmptyTag tag{};
+	return take_empty<int>(tag);
+}


### PR DESCRIPTION
## Summary
- replace the `UserDefined && size_in_bits() == 0` template-instantiation codegen guard with explicit dependent-placeholder state
- stamp raw template-parameter placeholder types with `DependentPlaceholderKind` so unresolved template params are tracked explicitly across parsing and reparse paths
- keep SFINAE call-instantiation failures non-fatal in SFINAE context and add a regression covering a concrete empty-type alias-template parameter

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1304" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
