### PR TITLE
No longer materializes template constructors or lazy nested ctor bodies during variable-declaration lowering

### DIFF
--- a/docs/2026-04-08-template-instantiation-materialization-plan.md
+++ b/docs/2026-04-08-template-instantiation-materialization-plan.md
@@ -1,7 +1,7 @@
 # Template Instantiation Identity / Materialization Follow-up Plan
 
 **Date:** 2026-04-08  
-**Last Updated:** 2026-04-14  
+**Last Updated:** 2026-04-17  
 **Context:** Follows the branch fix that made `test_integral_constant_comprehensive_ret100.cpp`, `test_integral_constant_pattern_ret42.cpp`, `test_ratio_less_alias_ret0.cpp`, `test_sfinae_enable_if_ret0.cpp`, and `test_sfinae_same_name_overload_ret0.cpp` pass by preserving dependent non-type template-argument identity in template-instantiation keys.
 
 ## Current snapshot
@@ -11,7 +11,7 @@
 - **Phase 2:** **complete**. Alias-template materialization is centralized through `materializeAliasTemplateInstantiation`; duplicated helper logic is routed through shared utilities (`buildSubstitutionParamMap`, `templateTypeArgFromEvalResult`, `substituteAndEvaluateNonTypeDefault`). Dead code removed. Type-specifier deferred alias path now routes through the authoritative alias materialization helper, and the remaining deduction-loop body is extracted into `deduceTemplateArgsFromCall(...)`.
 - **Phase 3:** **complete**. Late materialization lifecycle contract is now documented with explicit lifecycle comments in `Parser.h`. The `registerAndNormalizeLateMaterializedTopLevelNode` family of functions is the canonical registration path. Regression test added (`test_pending_sema_normalization_ret0.cpp`).
 - **Phase 4:** **complete**. Unresolved dependent placeholder states are now represented by the `DependentPlaceholderKind` enum on `TypeInfo`, replacing string-level `name.find("::")` heuristics at all critical consumption sites (SFINAE viability, constexpr sizeof, expression substitution, alias resolution).
-- **Phase 5:** intentionally blocked until Phase 4 is complete. **Now ready to begin.**
+- **Phase 5:** in progress. The first stmt-decl slice is now done: variable-declaration constructor codegen no longer materializes template ctors or lazy ctor bodies itself and instead consumes sema/materialized declarations.
 - **Current Linux validation baseline:** `make main CXX=clang++` and `bash ./tests/run_all_tests.sh` currently pass with **2109 pass / 140 expected-fail**.
 
 ## What has already landed
@@ -36,6 +36,8 @@
 - Template constructor member-initializer lists are parsed and stored.
 - `SemanticAnalysis::tryAnnotateInitListConstructorArgs(...)` now performs template-constructor materialization, matching the constructor-call sema path.
 - Lazy template constructor body re-parse now uses full member-function context (`FunctionParsingScopeGuard`), so common template constructors no longer fall through to the old noop codegen safety net.
+- `SemanticAnalysis` now materializes the selected nested/lazy constructor declaration before publishing it to `ConstructorCallNode` / `InitializerListNode`, and `IrGenerator_Stmt_Decl.cpp` now only consumes that resolved constructor metadata for variable declarations.
+- Nested template out-of-line constructor stubs now preserve a reparsable body position for lazy materialization, covered by `test_template_nested_ctor_materialized_before_codegen_ret42.cpp`.
 
 ### Phase 2 consolidation completed (2026-04-14)
 
@@ -121,10 +123,10 @@ Relates to Phase 5 cleanup of codegen-side heuristics.
 ### Immediate next steps (Phase 5 and beyond)
 
 1. **Start Phase 5 parser/sema ownership move** — placeholder state is now explicit, so sema can branch on `DependentPlaceholderKind` instead of parsing names.
-2. **Remove remaining codegen-triggered template materialization fallbacks** so codegen only consumes already-materialized declarations:
-   - `IrGenerator_Stmt_Decl.cpp` still retains `materialize_template_ctor` and `is_unresolved_noop_ctor` fallbacks
-   - `prepare_nested_template_ctor` lambda still calls back into `parser_->instantiateLazyMemberFunction(...)` from codegen
-   - These should become unnecessary once sema covers all constructor-call shapes
+2. **Stmt-decl constructor fallback slice — DONE (2026-04-17):**
+   - `IrGenerator_Stmt_Decl.cpp` no longer calls `materializeMatchingConstructorTemplate(...)` during variable-declaration IR lowering
+   - the old `is_unresolved_noop_ctor` / `prepare_nested_template_ctor` stmt-decl fallbacks are removed
+   - responsibility moved earlier into sema/lazy materialization for the direct-init and brace-init variable-declaration paths
 3. **Extend `DependentPlaceholderKind` if needed** — if Phase 5 discovers additional placeholder categories (e.g., dependent function pointers, dependent array element types), extend the enum rather than adding new string heuristics.
 4. **Consider removing remaining legitimate `find("::")` structural splits** in favor of a pre-computed `QualifiedIdentifier` stored on the TypeInfo, so the name never needs to be re-parsed for scope components. This is optional but would further improve maintainability.
 5. **Phase 6: unify template-parameter-to-function-parameter deduction mapping** — the positional `deduced_call_arg_index` counter in `try_instantiate_template_explicit` should be replaced with a proper pre-deduction pass.
@@ -139,9 +141,9 @@ Phase 5 is the broader parser/sema ownership move. ~~It should not begin until P
 2. ~~**Complete Phase 3**~~ DONE - late materialization now has one explicit register/enqueue/normalize contract.
 3. ~~**Complete Phase 4**~~ DONE - `DependentPlaceholderKind` enum replaces string heuristics for placeholder detection.
 4. **Shrink the remaining codegen-triggered template materialization surface** so Phase 5 is moving ownership, not debugging mixed ownership:
-   - `IrGenerator_Stmt_Decl.cpp` still retains fallback calls into parser materialization
+   - `IrGenerator_Stmt_Decl.cpp` variable-declaration constructor fallbacks are now removed
    - sema still does not cover every constructor-call shape under one enforced invariant
-   - codegen-side lazy-instantiation bridges still exist as safety nets
+   - codegen-side lazy-instantiation bridges still exist outside this stmt-decl slice as safety nets
 
 ### In other words
 
@@ -156,7 +158,7 @@ After the remaining work:
 2. Alias-template uses are materialized through **one authoritative helper**, not hand-reimplemented at each parser entry point. ✅ DONE (Phase 2)
 3. Any late-materialized AST root that becomes visible to sema, constexpr, or codegen goes through **one explicit registration + normalization path**. ✅ DONE (Phase 3)
 4. Unresolved dependent placeholders are identified by **typed state**, not by best-effort name inspection. ✅ DONE (Phase 4)
-5. Codegen only consumes already-materialized constructor declarations; it does not decide when template constructors get instantiated. **TODO (Phase 5)**
+5. Codegen only consumes already-materialized constructor declarations; it does not decide when template constructors get instantiated. **IN PROGRESS (Phase 5): done for `IrGenerator_Stmt_Decl.cpp` variable-declaration constructor paths.**
 
 ## Short bottom line
 

--- a/docs/2026-04-08-template-instantiation-materialization-plan.md
+++ b/docs/2026-04-08-template-instantiation-materialization-plan.md
@@ -127,6 +127,7 @@ Relates to Phase 5 cleanup of codegen-side heuristics.
    - `IrGenerator_Stmt_Decl.cpp` no longer calls `materializeMatchingConstructorTemplate(...)` during variable-declaration IR lowering
    - the old `is_unresolved_noop_ctor` / `prepare_nested_template_ctor` stmt-decl fallbacks are removed
    - responsibility moved earlier into sema/lazy materialization for the direct-init and brace-init variable-declaration paths
+   - follow-up parser/sema fixes now preserve nested out-of-line ctor initializer lists and attach non-template-class ctor-template instantiations back to the owning struct so codegen emits the materialized specialization
 3. **Extend `DependentPlaceholderKind` if needed** — if Phase 5 discovers additional placeholder categories (e.g., dependent function pointers, dependent array element types), extend the enum rather than adding new string heuristics.
 4. **Consider removing remaining legitimate `find("::")` structural splits** in favor of a pre-computed `QualifiedIdentifier` stored on the TypeInfo, so the name never needs to be re-parsed for scope components. This is optional but would further improve maintainability.
 5. **Phase 6: unify template-parameter-to-function-parameter deduction mapping** — the positional `deduced_call_arg_index` counter in `try_instantiate_template_explicit` should be replaced with a proper pre-deduction pass.
@@ -158,7 +159,7 @@ After the remaining work:
 2. Alias-template uses are materialized through **one authoritative helper**, not hand-reimplemented at each parser entry point. ✅ DONE (Phase 2)
 3. Any late-materialized AST root that becomes visible to sema, constexpr, or codegen goes through **one explicit registration + normalization path**. ✅ DONE (Phase 3)
 4. Unresolved dependent placeholders are identified by **typed state**, not by best-effort name inspection. ✅ DONE (Phase 4)
-5. Codegen only consumes already-materialized constructor declarations; it does not decide when template constructors get instantiated. **IN PROGRESS (Phase 5): done for `IrGenerator_Stmt_Decl.cpp` variable-declaration constructor paths.**
+5. Codegen only consumes already-materialized constructor declarations; it does not decide when template constructors get instantiated. **IN PROGRESS (Phase 5): done for `IrGenerator_Stmt_Decl.cpp` variable-declaration constructor paths, nested out-of-line ctor initializer-list replay, and inline ctor-template materialization for the exercised constructor paths.**
 
 ## Short bottom line
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,27 +1,5 @@
 # Known Issues
 
-## Nested out-of-line template constructors lose member-initializer metadata
-
-**Repro shape:**
-```cpp
-template <typename T>
-struct Outer {
-    struct Inner {
-        T value;
-        template <typename U>
-        Inner(U v);
-    };
-};
-
-template <typename T>
-template <typename U>
-Outer<T>::Inner::Inner(U v) : value(v) {}
-```
-**Symptom:** After the Phase 5 stmt-decl ownership move, nested out-of-line template constructors now materialize their bodies before IR as intended, but the lazy path still drops the out-of-line member-initializer list. The constructor links and the body runs, yet members initialized only through `: value(v)` remain zero-initialized unless the body assigns them explicitly.
-**Impact:** This is narrower than the old codegen fallback problem — direct-init and brace-init variable declarations now resolve/materialize the right constructor declaration — but nested out-of-line constructor definitions that rely on member/base/delegating initializers can still miscompile.
-**Root cause:** The nested template out-of-line-member registration path in `Parser_Templates_Class.cpp` records a delayed body position for lazy constructor materialization, but it still does not preserve constructor initializer-list metadata the way the regular out-of-line constructor path does.
-**Phase:** Adjacent Phase 5 follow-up after removing stmt-decl constructor materialization fallbacks.
-
 ## Alias-chain dependent-bool resolution loses size_bits (Phase 2)
 
 **Test:** `test_alias_chain_dependent_bool_ret1.cpp`

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,27 @@
 # Known Issues
 
+## Nested out-of-line template constructors lose member-initializer metadata
+
+**Repro shape:**
+```cpp
+template <typename T>
+struct Outer {
+    struct Inner {
+        T value;
+        template <typename U>
+        Inner(U v);
+    };
+};
+
+template <typename T>
+template <typename U>
+Outer<T>::Inner::Inner(U v) : value(v) {}
+```
+**Symptom:** After the Phase 5 stmt-decl ownership move, nested out-of-line template constructors now materialize their bodies before IR as intended, but the lazy path still drops the out-of-line member-initializer list. The constructor links and the body runs, yet members initialized only through `: value(v)` remain zero-initialized unless the body assigns them explicitly.
+**Impact:** This is narrower than the old codegen fallback problem — direct-init and brace-init variable declarations now resolve/materialize the right constructor declaration — but nested out-of-line constructor definitions that rely on member/base/delegating initializers can still miscompile.
+**Root cause:** The nested template out-of-line-member registration path in `Parser_Templates_Class.cpp` records a delayed body position for lazy constructor materialization, but it still does not preserve constructor initializer-list metadata the way the regular out-of-line constructor path does.
+**Phase:** Adjacent Phase 5 follow-up after removing stmt-decl constructor materialization fallbacks.
+
 ## Alias-chain dependent-bool resolution loses size_bits (Phase 2)
 
 **Test:** `test_alias_chain_dependent_bool_ret1.cpp`

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -471,6 +471,12 @@ public:
 	}
 	bool has_template_body_position() const { return has_template_body_; }
 	SaveHandle template_body_position() const { return template_body_position_handle_; }
+	void set_template_initializer_list_position(SaveHandle handle) {
+		has_template_initializer_list_ = true;
+		template_initializer_list_position_handle_ = handle;
+	}
+	bool has_template_initializer_list_position() const { return has_template_initializer_list_; }
+	SaveHandle template_initializer_list_position() const { return template_initializer_list_position_handle_; }
 
 	template <typename NameContainer, typename ArgContainer>
 	void set_outer_template_bindings(const NameContainer& template_param_names, const ArgContainer& template_args) {
@@ -520,7 +526,9 @@ private:
 	std::optional<ASTNode> requires_clause_;	 // C++20 trailing requires clause
 	std::vector<ASTNode> template_parameters_;
 	bool has_template_body_ = false;
+	bool has_template_initializer_list_ = false;
 	SaveHandle template_body_position_handle_;  // Handle to saved position for template body
+	SaveHandle template_initializer_list_position_handle_{};  // Handle to saved position for constructor initializer list
 	InlineVector<StringHandle, 4> outer_template_param_names_;
 	InlineVector<TypeInfo::TemplateArgInfo, 4> outer_template_args_;
 	TypeIndex owning_type_index_{};

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -1613,14 +1613,14 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 												FLASH_LOG(Codegen, Debug, "Matched ", prefer_move_ctor ? "move" : "copy", " constructor for ", struct_info.name);
 											}
 										}
+									}
 								}
-							}
 
-							const bool require_sema_resolved_ctor =
-								sema_normalized_current_function_ &&
-								type_info &&
-								type_info->struct_info_ &&
-								type_info->struct_info_->hasUserDefinedConstructor();
+								const bool require_sema_resolved_ctor =
+									sema_normalized_current_function_ &&
+									type_info &&
+									type_info->struct_info_ &&
+									type_info->struct_info_->hasUserDefinedConstructor();
 
 								// SECOND: If no copy constructor matched, prefer the sema annotation.
 								// Only fall back to local type-based/arity-based resolution when sema

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -382,98 +382,17 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 			flush();
 		}
 	} full_expression_temp_flush_guard{flushFullExpressionTemps};
-	auto prepare_nested_template_ctor = [this](const TypeInfo& type_info_ref, const ConstructorDeclarationNode*& ctor) {
+	auto queue_nested_template_ctor = [this](const TypeInfo& type_info_ref, const ConstructorDeclarationNode* ctor) {
 		std::string_view ctor_struct_name = StringTable::getStringView(type_info_ref.name());
 		bool is_nested_template_ctor = (ctor_struct_name.find("::") != std::string_view::npos) &&
 									   (type_info_ref.isTemplateInstantiation() || ctor_struct_name.find('$') != std::string_view::npos);
 		if (!is_nested_template_ctor || !ctor) {
 			return;
 		}
-		if (!ctor->get_definition().has_value() && parser_) {
-			StringHandle ctor_name = ctor->name();
-			if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(type_info_ref.name(), ctor_name, false)) {
-				auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(type_info_ref.name(), ctor_name, false);
-				if (lazy_info_opt.has_value()) {
-					auto instantiated_ctor = parser_->instantiateLazyMemberFunction(*lazy_info_opt);
-					normalizePendingSemanticRoots();
-					if (instantiated_ctor.has_value() && instantiated_ctor->is<ConstructorDeclarationNode>()) {
-						ctor = &instantiated_ctor->as<ConstructorDeclarationNode>();
-						LazyMemberInstantiationRegistry::getInstance().markInstantiated(type_info_ref.name(), ctor_name, false);
-					}
-				}
-			}
-		}
 		DeferredMemberFunctionInfo deferred_info;
 		deferred_info.struct_name = type_info_ref.name();
 		deferred_info.function_node = ASTNode(ctor);
 		deferred_member_functions_.push_back(std::move(deferred_info));
-	};
-	auto materialize_template_ctor = [this](const TypeInfo& type_info_ref, const std::vector<TypeSpecifierNode>& arg_types, const ConstructorDeclarationNode*& ctor) {
-		if (!parser_ || !type_info_ref.getStructInfo()) {
-			return;
-		}
-		bool is_ambiguous = false;
-		ctor = parser_->materializeMatchingConstructorTemplate(
-			type_info_ref.name(),
-			*type_info_ref.getStructInfo(),
-			arg_types,
-			ctor,
-			is_ambiguous);
-		if (is_ambiguous) {
-			throw CompileError(
-				std::string("Ambiguous constructor call for ") +
-				std::string(StringTable::getStringView(type_info_ref.name())));
-		}
-	};
-	auto is_unresolved_noop_ctor = [](const ConstructorDeclarationNode* ctor) -> bool {
-		if (!ctor || (!ctor->has_template_parameters() && !ctor->has_template_body_position()) ||
-			!ctor->member_initializers().empty() || !ctor->base_initializers().empty() ||
-			ctor->delegating_initializer().has_value()) {
-			return false;
-		}
-		if (ctor->get_definition().has_value()) {
-			if (ctor->get_definition()->is<BlockNode>() &&
-				ctor->get_definition()->as<BlockNode>().get_statements().empty()) {
-				return true;
-			}
-			return false;
-		}
-		auto is_template_param_name = [&](std::string_view type_name) {
-			for (const ASTNode& param_node : ctor->template_parameters()) {
-				if (!param_node.is<TemplateParameterNode>()) {
-					continue;
-				}
-				if (param_node.as<TemplateParameterNode>().name() == type_name) {
-					return true;
-				}
-			}
-			for (StringHandle outer_name : ctor->outer_template_param_names()) {
-				if (StringTable::getStringView(outer_name) == type_name) {
-					return true;
-				}
-			}
-			return false;
-		};
-		for (const auto& param : ctor->parameter_nodes()) {
-			if (!param.is<DeclarationNode>()) {
-				continue;
-			}
-			const auto& type_spec = param.as<DeclarationNode>().type_node().as<TypeSpecifierNode>();
-			if ((type_spec.category() == TypeCategory::UserDefined ||
-				 type_spec.category() == TypeCategory::TypeAlias ||
-				 type_spec.category() == TypeCategory::Template) &&
-				type_spec.type_index().is_valid()) {
-				if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
-					std::string_view type_name = StringTable::getStringView(type_info->name());
-					if (type_info->is_incomplete_instantiation_ || is_template_param_name(type_name)) {
-						return true;
-					}
-				}
-			} else if (is_template_param_name(type_spec.token().value())) {
-				return true;
-			}
-		}
-		return false;
 	};
 	auto register_destructor_if_needed = [this](const DeclarationNode& decl, const TypeInfo* type_info) {
 		if (!type_info || !type_info->struct_info_ || !type_info->struct_info_->hasDestructor()) {
@@ -482,34 +401,6 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 		registerVariableWithDestructor(
 			std::string(decl.identifier_token().value()),
 			std::string(StringTable::getStringView(type_info->name())));
-	};
-	auto zero_initialize_noop_ctor_object = [this](const DeclarationNode& decl, const TypeInfo* type_info) {
-		if (!type_info || !type_info->struct_info_) {
-			return;
-		}
-		auto zero_fill_subobject = [this, &decl](auto&& self, const StructTypeInfo& struct_info, int base_offset) -> void {
-			for (const auto& base : struct_info.base_classes) {
-				if (base.is_virtual || !base.type_index.is_valid()) {
-					continue;
-				}
-				if (const StructTypeInfo* base_struct = tryGetStructTypeInfo(base.type_index)) {
-					self(self, *base_struct, base_offset + static_cast<int>(base.offset));
-				}
-			}
-			emitRecursiveZeroFill(struct_info, decl.identifier_token().handle(), base_offset, decl.identifier_token());
-		};
-		zero_fill_subobject(zero_fill_subobject, *type_info->struct_info_, 0);
-		for (const auto& virtual_base : type_info->struct_info_->virtual_bases) {
-			if (!virtual_base.type_index.is_valid()) {
-				continue;
-			}
-			if (const StructTypeInfo* virtual_base_struct = tryGetStructTypeInfo(virtual_base.type_index)) {
-				zero_fill_subobject(
-					zero_fill_subobject,
-					*virtual_base_struct,
-					static_cast<int>(virtual_base.offset));
-			}
-		}
 	};
 
 		// Check if this is a global variable (declared at global scope)
@@ -1722,8 +1613,14 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 												FLASH_LOG(Codegen, Debug, "Matched ", prefer_move_ctor ? "move" : "copy", " constructor for ", struct_info.name);
 											}
 										}
-									}
 								}
+							}
+
+							const bool require_sema_resolved_ctor =
+								sema_normalized_current_function_ &&
+								type_info &&
+								type_info->struct_info_ &&
+								type_info->struct_info_->hasUserDefinedConstructor();
 
 								// SECOND: If no copy constructor matched, prefer the sema annotation.
 								// Only fall back to local type-based/arity-based resolution when sema
@@ -1734,10 +1631,14 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 											has_matching_constructor = true;
 											matching_ctor = resolved_ctor;
 											FLASH_LOG_FORMAT(Codegen, Debug, "Using sema-resolved brace-init constructor for {}", StringTable::getStringView(struct_info.name));
+										} else if (require_sema_resolved_ctor) {
+											reportMismatchedSemaResolvedConstructor(type_info->name(), "brace initialization");
 										}
+									} else if (require_sema_resolved_ctor) {
+										reportMissingSemaResolvedConstructor(type_info->name(), "brace initialization");
 									}
 								}
-								if (!has_matching_constructor) {
+								if (!has_matching_constructor && !require_sema_resolved_ctor) {
 								// Try type-based constructor overload resolution first using the
 								// sema-backed expression typing helper. Legacy lookup fallback
 								// stays isolated behind buildCodegenOverloadResolutionArgType().
@@ -1763,17 +1664,11 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 											if (resolution.has_match) {
 												matching_ctor = resolution.selected_overload;
 											}
-											// Call materialize_template_ctor unconditionally so that template
-											// constructors are instantiated even when resolve_constructor_overload
-											// returns has_match=false (which happens because uninstantiated template
-											// parameter types don't match concrete argument types). Mirrors the
-											// direct-init path in visitVariableDeclarationNode (direct-init branch).
-											materialize_template_ctor(*type_info, arg_types, matching_ctor);
 											has_matching_constructor = (matching_ctor != nullptr);
 										}
 									}
 								}
-								if (!has_matching_constructor) {
+								if (!has_matching_constructor && !require_sema_resolved_ctor) {
 									auto arity_resolution = resolve_constructor_overload_arity(struct_info, num_initializers, true);
 									if (arity_resolution.has_match) {
 										has_matching_constructor = true;
@@ -1783,17 +1678,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							}
 
 							if (has_matching_constructor) {
-								prepare_nested_template_ctor(*type_info, matching_ctor);
-								if (is_unresolved_noop_ctor(matching_ctor)) {
-									for (const ASTNode& init_expr : initializers) {
-										if (init_expr.is<ExpressionNode>()) {
-											visitExpressionNode(init_expr.as<ExpressionNode>());
-										}
-									}
-									zero_initialize_noop_ctor_object(decl, type_info);
-									register_destructor_if_needed(decl, type_info);
-									return;
-								}
+								queue_nested_template_ctor(*type_info, matching_ctor);
 
 								// Generate constructor call with parameters from initializer list
 								ConstructorCallOp ctor_op;
@@ -2530,7 +2415,6 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 											throw CompileError("Ambiguous constructor call");
 										}
 										matching_ctor = resolution.selected_overload;
-										materialize_template_ctor(*type_info, arg_types, matching_ctor);
 									}
 
 									if (!matching_ctor) {
@@ -2608,17 +2492,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							if (!matching_ctor && !allowImplicitDefault) {
 								reportNoMatchingConstructor(type_info->name(), "direct initialization", decl.identifier_token());
 							}
-							prepare_nested_template_ctor(*type_info, matching_ctor);
-							if (is_unresolved_noop_ctor(matching_ctor)) {
-								direct_ctor->arguments().visit([&](ASTNode argument) {
-									if (argument.is<ExpressionNode>()) {
-										visitExpressionNode(argument.as<ExpressionNode>());
-									}
-								});
-								zero_initialize_noop_ctor_object(decl, type_info);
-								register_destructor_if_needed(decl, type_info);
-								return;
-							}
+							queue_nested_template_ctor(*type_info, matching_ctor);
 
 							// Create constructor call with the declared variable as the object
 							ConstructorCallOp ctor_op;

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1283,6 +1283,16 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 					}
 					if (!ctor_has_auto) {
 						visitConstructorDeclarationNode(ctor);
+						if (!ctor.get_definition().has_value() && !ctor.is_implicit() && parser_) {
+							StringHandle member_handle = member_func.getName();
+							if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(current_struct_name_, member_handle, false)) {
+								DeferredMemberFunctionInfo deferred_info;
+								deferred_info.struct_name = current_struct_name_;
+								deferred_info.function_node = func_decl;
+								deferred_member_functions_.push_back(std::move(deferred_info));
+								FLASH_LOG(Codegen, Debug, "[STRUCT] ", struct_name, " - queued lazy constructor for deferred instantiation");
+							}
+						}
 					} else {
 						FLASH_LOG(Codegen, Debug, "[STRUCT] ", struct_name, " - skipping template constructor with auto params (will be instantiated on call)");
 					}

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -290,6 +290,51 @@ size_t AstToIr::generateDeferredMemberFunctions() {
 				normalizePendingSemanticRoots();
 				visitFunctionDeclarationNode(func);
 			} else if (info.function_node.is<ConstructorDeclarationNode>()) {
+				const ConstructorDeclarationNode& ctor = info.function_node.as<ConstructorDeclarationNode>();
+				if (!ctor.get_definition().has_value() && parser_) {
+					StringHandle member_handle = ctor.name();
+					if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(info.struct_name, member_handle, false)) {
+						auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(info.struct_name, member_handle, false);
+						if (lazy_info_opt.has_value()) {
+							auto new_ctor_node = parser_->instantiateLazyMemberFunction(*lazy_info_opt);
+							normalizePendingSemanticRoots();
+							if (new_ctor_node.has_value() && new_ctor_node->is<ConstructorDeclarationNode>()) {
+								LazyMemberInstantiationRegistry::getInstance().markInstantiated(info.struct_name, member_handle, false);
+								visitConstructorDeclarationNode(new_ctor_node->as<ConstructorDeclarationNode>());
+								current_function_name_ = saved_function;
+								current_namespace_stack_ = saved_namespace;
+								continue;
+							}
+						}
+					}
+					bool visited_replacement_ctor = false;
+					if (auto struct_it = getTypesByNameMap().find(info.struct_name);
+						struct_it != getTypesByNameMap().end()) {
+						if (const StructTypeInfo* struct_info = struct_it->second->getStructInfo()) {
+							for (const auto& member_func : struct_info->member_functions) {
+								if (!member_func.is_constructor || !member_func.function_decl.is<ConstructorDeclarationNode>()) {
+									continue;
+								}
+								const auto& replacement_ctor = member_func.function_decl.as<ConstructorDeclarationNode>();
+								if (!replacement_ctor.get_definition().has_value()) {
+									continue;
+								}
+								if (replacement_ctor.name() == ctor.name() &&
+									replacement_ctor.parameter_nodes().size() == ctor.parameter_nodes().size()) {
+									normalizePendingSemanticRoots();
+									visitConstructorDeclarationNode(replacement_ctor);
+									current_function_name_ = saved_function;
+									current_namespace_stack_ = saved_namespace;
+									visited_replacement_ctor = true;
+									break;
+								}
+							}
+						}
+					}
+					if (visited_replacement_ctor) {
+						continue;
+					}
+				}
 				normalizePendingSemanticRoots();
 				visitConstructorDeclarationNode(info.function_node.as<ConstructorDeclarationNode>());
 			} else if (info.function_node.is<DestructorDeclarationNode>()) {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1530,6 +1530,23 @@ private:
 			--namespace_component_count;
 		}
 
+		StringHandle root_name_handle = StringTable::getOrInternStringHandle(components[0]);
+		for (const ASTNode& root_node : ast_nodes_) {
+			if (!root_node.is<StructDeclarationNode>()) {
+				continue;
+			}
+			if (root_node.as<StructDeclarationNode>().name() != root_name_handle) {
+				continue;
+			}
+			if (components.size() == 1) {
+				return root_node;
+			}
+			if (auto nested_symbol = find_nested_struct(root_node, components, 1);
+				nested_symbol.has_value()) {
+				return nested_symbol;
+			}
+		}
+
 		return std::nullopt;
 	}
 

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -102,6 +102,15 @@ LazyMemberFunctionInfo buildLazyNestedMemberFunctionInfo(
 	else
 		id.kind = DeferredMemberIdentity::Kind::Function;
 	appendLazyTemplateSequence(lazy_mem_info.template_params, template_params);
+	if (mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
+		appendLazyTemplateSequence(
+			lazy_mem_info.template_params,
+			mem_func.function_declaration.as<ConstructorDeclarationNode>().template_parameters());
+	} else if (mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
+		appendLazyTemplateSequence(
+			lazy_mem_info.template_params,
+			mem_func.function_declaration.as<TemplateFunctionDeclarationNode>().template_parameters());
+	}
 	appendLazyTemplateSequence(lazy_mem_info.template_args, template_args);
 	lazy_mem_info.access = mem_func.access;
 	lazy_mem_info.is_virtual = mem_func.is_virtual;

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -3535,6 +3535,9 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 		if (delayed.is_member_function_template) {
 			if (delayed.is_constructor && delayed.ctor_node) {
 				delayed.ctor_node->set_template_body_position(delayed.body_start);
+				if (delayed.has_initializer_list) {
+					delayed.ctor_node->set_template_initializer_list_position(delayed.initializer_list_start);
+				}
 			} else if (delayed.func_node) {
 				delayed.func_node->set_template_body_position(delayed.body_start);
 			}

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -289,9 +289,9 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 			}
 		}
 
-		// After parsing initializer list, restore to the body position
-		restore_token_position(delayed.body_start);
 	}
+
+	restore_token_position(delayed.body_start);
 
 	// Parse the function body. For normal functions or member functions with body_start at 'try',
 	// parse_function_body() handles everything.  For constructors/destructors with has_function_try

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -426,9 +426,6 @@ ParseResult Parser::parse_template_declaration() {
 				// Skip trailing requires clause if present
 				skip_trailing_requires_clause();
 
-				// Save body position (includes member initializer list for constructors)
-				SaveHandle body_start = save_token_position();
-
 				// Handle constructor member initializer list: ClassName<T>::ClassName(...) : init1(x), init2(y) { }
 				if (peek() == ":"_tok) {
 					advance(); // consume ':'
@@ -475,6 +472,11 @@ ParseResult Parser::parse_template_declaration() {
 						}
 					}
 				}
+
+				// Save the delayed-parse position right before the function body.
+				// Constructors may have a member-initializer list, so capture this
+				// only after skipping any leading ':' initializers.
+				SaveHandle body_start = save_token_position();
 
 				if (peek() == "{"_tok) {
 					skip_balanced_braces();

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -307,6 +307,7 @@ ParseResult Parser::parse_template_declaration() {
 			// We DON'T call try_parse_out_of_line_template_member because its save/restore
 			// logic conflicts with the nested template parameter scope.
 			std::string_view nested_class_name;
+			std::string nested_qualified_class_name;
 			Token nested_func_name_token;
 			bool found_nested_def = false;
 
@@ -329,12 +330,15 @@ ParseResult Parser::parse_template_declaration() {
 								if (peek().is_identifier()) {
 									// Tentatively record this match
 									nested_class_name = class_token.value();
+									nested_qualified_class_name = std::string(class_token.value());
 									nested_func_name_token = peek_info();
 									advance(); // consume function name
 									// Handle nested :: for deeper nesting
 									while (peek() == "::"_tok) {
 										advance();
 										if (peek().is_identifier()) {
+											nested_qualified_class_name += "::";
+											nested_qualified_class_name += nested_func_name_token.value();
 											nested_class_name = nested_func_name_token.value();
 											nested_func_name_token = peek_info();
 											advance();
@@ -407,8 +411,17 @@ ParseResult Parser::parse_template_declaration() {
 				auto [func_decl_node, func_decl_ref] = emplace_node_ref<DeclarationNode>(void_type, nested_func_name_token);
 				auto [func_node, func_ref] = emplace_node_ref<FunctionDeclarationNode>(func_decl_ref, nested_func_name_token.value());
 
-				// Skip parameter list
-				skip_balanced_parens();
+				// Parse parameter list so delayed constructor/member matching can compare signatures.
+				FlashCpp::ParsedParameterList nested_params;
+				auto nested_param_result = parse_parameter_list(nested_params);
+				if (nested_param_result.is_error()) {
+					cleanup_template_state();
+					return saved_position.success();
+				}
+				for (const auto& param : nested_params.parameters) {
+					func_ref.add_parameter_node(param);
+				}
+				func_ref.set_is_variadic(nested_params.is_variadic);
 				// Skip trailing specifiers
 				FlashCpp::MemberQualifiers quals;
 				skip_function_trailing_specifiers(quals);
@@ -426,8 +439,12 @@ ParseResult Parser::parse_template_declaration() {
 				// Skip trailing requires clause if present
 				skip_trailing_requires_clause();
 
+				SaveHandle initializer_list_start{};
+				bool has_initializer_list = false;
 				// Handle constructor member initializer list: ClassName<T>::ClassName(...) : init1(x), init2(y) { }
 				if (peek() == ":"_tok) {
+					initializer_list_start = save_token_position();
+					has_initializer_list = true;
 					advance(); // consume ':'
 					// Skip member initializer list entries: name(expr), name(expr), ...
 					while (!peek().is_eof()) {
@@ -489,14 +506,16 @@ ParseResult Parser::parse_template_declaration() {
 				out_of_line_member.template_params = template_params;
 				out_of_line_member.function_node = func_node;
 				out_of_line_member.body_start = body_start;
+				out_of_line_member.initializer_list_start = initializer_list_start;
 				out_of_line_member.template_param_names = template_param_names;
 				out_of_line_member.inner_template_params = inner_template_params;
 				out_of_line_member.inner_template_param_names = inner_template_param_names;
+				out_of_line_member.has_initializer_list = has_initializer_list;
 
-				gTemplateRegistry.registerOutOfLineMember(nested_class_name, std::move(out_of_line_member));
+				gTemplateRegistry.registerOutOfLineMember(nested_qualified_class_name, std::move(out_of_line_member));
 
 				FLASH_LOG(Templates, Debug, "Registered nested template out-of-line member: ",
-						  nested_class_name, "::", nested_func_name_token.value(),
+						  nested_qualified_class_name, "::", nested_func_name_token.value(),
 						  " (outer params: ", template_params.size(),
 						  ", inner params: ", inner_template_params.size(), ")");
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -5978,6 +5978,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			StringBuilder original_nested_name_builder;
 			original_nested_name_builder.append(template_name).append("::"sv).append(nested_struct.name());
 			std::string_view original_nested_name = original_nested_name_builder.commit();
+			auto nested_out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(original_nested_name);
+			if (nested_out_of_line_members.empty()) {
+				nested_out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(nested_struct.name());
+			}
 			auto original_nested_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(original_nested_name));
 			if (original_nested_it != getTypesByNameMap().end() && original_nested_it->second->getStructInfo()) {
 				copy_nested_static_members(*original_nested_it->second->getStructInfo());
@@ -5985,6 +5989,28 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				auto simple_nested_it = getTypesByNameMap().find(nested_struct.name());
 				if (simple_nested_it != getTypesByNameMap().end() && simple_nested_it->second->getStructInfo()) {
 					copy_nested_static_members(*simple_nested_it->second->getStructInfo());
+				}
+			}
+
+			for (const auto& out_of_line_member : nested_out_of_line_members) {
+				for (const auto& mem_func : nested_struct.member_functions()) {
+					const bool out_of_line_ctor_stub =
+						out_of_line_member.function_node.is<FunctionDeclarationNode>() &&
+						out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node().identifier_token().value() ==
+							nested_struct.name().view();
+					if (mem_func.function_declaration.is<ConstructorDeclarationNode>() &&
+						(out_of_line_member.function_node.is<ConstructorDeclarationNode>() || out_of_line_ctor_stub)) {
+						ASTNode ctor_node = mem_func.function_declaration;
+						auto& ctor_decl = ctor_node.as<ConstructorDeclarationNode>();
+						size_t out_of_line_template_param_count = out_of_line_member.function_node.is<ConstructorDeclarationNode>()
+							? out_of_line_member.function_node.as<ConstructorDeclarationNode>().template_parameters().size()
+							: out_of_line_member.inner_template_params.size();
+						if (!ctor_decl.get_definition().has_value() &&
+							!ctor_decl.has_template_body_position() &&
+							ctor_decl.template_parameters().size() == out_of_line_template_param_count) {
+							ctor_decl.set_template_body_position(out_of_line_member.body_start);
+						}
+					}
 				}
 			}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -28,6 +28,42 @@ static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeCategory type
 	return arg;
 }
 
+static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param) {
+	if (!param.is<DeclarationNode>()) {
+		return nullptr;
+	}
+	const ASTNode& type_node = param.as<DeclarationNode>().type_node();
+	if (!type_node.is<TypeSpecifierNode>()) {
+		return nullptr;
+	}
+	return &type_node.as<TypeSpecifierNode>();
+}
+
+static bool constructorDeclarationsHaveMatchingParameterShape(
+	const ConstructorDeclarationNode& ctor_decl,
+	const FunctionDeclarationNode& out_of_line_stub) {
+	if (ctor_decl.parameter_nodes().size() != out_of_line_stub.parameter_nodes().size()) {
+		return false;
+	}
+
+	for (size_t i = 0; i < ctor_decl.parameter_nodes().size(); ++i) {
+		const TypeSpecifierNode* ctor_param = getDeclarationParamTypeNode(ctor_decl.parameter_nodes()[i]);
+		const TypeSpecifierNode* stub_param = getDeclarationParamTypeNode(out_of_line_stub.parameter_nodes()[i]);
+		if (!ctor_param || !stub_param) {
+			return false;
+		}
+		if (ctor_param->type() != stub_param->type() ||
+			ctor_param->type_index() != stub_param->type_index() ||
+			ctor_param->pointer_depth() != stub_param->pointer_depth() ||
+			ctor_param->reference_qualifier() != stub_param->reference_qualifier() ||
+			ctor_param->cv_qualifier() != stub_param->cv_qualifier()) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 // Resolve any stored template arguments on a deferred base member-type chain after a class
 // template's substitution maps are available.
 // Returns std::nullopt when any pack expansion or concrete member argument cannot be resolved.
@@ -5979,9 +6015,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			original_nested_name_builder.append(template_name).append("::"sv).append(nested_struct.name());
 			std::string_view original_nested_name = original_nested_name_builder.commit();
 			auto nested_out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(original_nested_name);
-			if (nested_out_of_line_members.empty()) {
-				nested_out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(nested_struct.name());
-			}
 			auto original_nested_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(original_nested_name));
 			if (original_nested_it != getTypesByNameMap().end() && original_nested_it->second->getStructInfo()) {
 				copy_nested_static_members(*original_nested_it->second->getStructInfo());
@@ -6005,10 +6038,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						size_t out_of_line_template_param_count = out_of_line_member.function_node.is<ConstructorDeclarationNode>()
 							? out_of_line_member.function_node.as<ConstructorDeclarationNode>().template_parameters().size()
 							: out_of_line_member.inner_template_params.size();
+						const bool template_param_count_matches =
+							ctor_decl.template_parameters().empty() ||
+							ctor_decl.template_parameters().size() == out_of_line_template_param_count;
+						const FunctionDeclarationNode* out_of_line_ctor_stub_decl =
+							out_of_line_member.function_node.is<FunctionDeclarationNode>()
+								? &out_of_line_member.function_node.as<FunctionDeclarationNode>()
+								: nullptr;
+						const bool out_of_line_ctor_stub_matches =
+							!out_of_line_ctor_stub_decl ||
+							(out_of_line_ctor_stub_decl->parameter_nodes().size() == ctor_decl.parameter_nodes().size() &&
+							 (nested_out_of_line_members.size() == 1 ||
+							  constructorDeclarationsHaveMatchingParameterShape(ctor_decl, *out_of_line_ctor_stub_decl)));
 						if (!ctor_decl.get_definition().has_value() &&
 							!ctor_decl.has_template_body_position() &&
-							ctor_decl.template_parameters().size() == out_of_line_template_param_count) {
+							template_param_count_matches &&
+							out_of_line_ctor_stub_matches) {
 							ctor_decl.set_template_body_position(out_of_line_member.body_start);
+							if (out_of_line_member.has_initializer_list) {
+								ctor_decl.set_template_initializer_list_position(out_of_line_member.initializer_list_start);
+							}
 						}
 					}
 				}
@@ -7299,6 +7348,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_ctor_ref.set_template_parameters(ctor_decl.template_parameters());
 					if (ctor_decl.has_template_body_position()) {
 						new_ctor_ref.set_template_body_position(ctor_decl.template_body_position());
+						if (ctor_decl.has_template_initializer_list_position()) {
+							new_ctor_ref.set_template_initializer_list_position(ctor_decl.template_initializer_list_position());
+						}
 					}
 
 					// Ensure template_param_order is populated (used by ExpressionSubstitutor later)

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -268,6 +268,77 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 	bool& is_ambiguous) {
 	is_ambiguous = false;
 
+	auto findExistingMaterializedCtor = [&](std::string_view mangled_name) -> const ConstructorDeclarationNode* {
+		if (mangled_name.empty()) {
+			return nullptr;
+		}
+		for (const auto& member_func : struct_info.member_functions) {
+			if (!member_func.is_constructor || !member_func.function_decl.is<ConstructorDeclarationNode>()) {
+				continue;
+			}
+			const auto& ctor = member_func.function_decl.as<ConstructorDeclarationNode>();
+			if (ctor.has_template_parameters() || !ctor.get_definition().has_value()) {
+				continue;
+			}
+			if (ctor.mangled_name() == mangled_name) {
+				return &ctor;
+			}
+		}
+		return nullptr;
+	};
+
+	auto attachInstantiatedCtor = [&](const ConstructorDeclarationNode& source_ctor, ASTNode instantiated_node) -> const ConstructorDeclarationNode* {
+		if (!instantiated_node.is<ConstructorDeclarationNode>()) {
+			return nullptr;
+		}
+		auto& instantiated_ctor = instantiated_node.as<ConstructorDeclarationNode>();
+		if (const ConstructorDeclarationNode* existing_ctor = findExistingMaterializedCtor(instantiated_ctor.mangled_name())) {
+			return existing_ctor;
+		}
+
+		AccessSpecifier ctor_access = AccessSpecifier::Public;
+		for (const auto& member_func : struct_info.member_functions) {
+			if (!member_func.is_constructor || !member_func.function_decl.is<ConstructorDeclarationNode>()) {
+				continue;
+			}
+			if (member_func.function_decl.raw_pointer() != static_cast<const void*>(&source_ctor)) {
+				continue;
+			}
+			ctor_access = member_func.access;
+			break;
+		}
+
+		if (auto type_it = getTypesByNameMap().find(instantiated_struct_name);
+			type_it != getTypesByNameMap().end()) {
+			if (StructTypeInfo* mutable_struct_info = type_it->second->getStructInfo()) {
+				mutable_struct_info->addConstructor(instantiated_node, ctor_access);
+			}
+		}
+
+		if (auto struct_root = lookupLateMaterializedOwningStructRoot(instantiated_struct_name);
+			struct_root.has_value() && struct_root->is<StructDeclarationNode>()) {
+			auto& struct_decl = struct_root->as<StructDeclarationNode>();
+			bool already_present = false;
+			for (const auto& member_func : struct_decl.member_functions()) {
+				if (!member_func.is_constructor || !member_func.function_declaration.is<ConstructorDeclarationNode>()) {
+					continue;
+				}
+				const auto& existing_ctor = member_func.function_declaration.as<ConstructorDeclarationNode>();
+				if (existing_ctor.mangled_name() == instantiated_ctor.mangled_name()) {
+					already_present = true;
+					break;
+				}
+			}
+			if (!already_present) {
+				struct_decl.add_constructor(instantiated_node, ctor_access);
+			}
+		}
+
+		registerLateMaterializedOwningStructRoot(instantiated_struct_name);
+		normalizePendingSemanticRootsIfAvailable();
+		return &instantiated_ctor;
+	};
+
 	auto matches_call_arguments = [&](const ConstructorDeclarationNode& ctor) {
 		size_t min_required = countMinRequiredArgs(ctor);
 		if (arg_types.size() < min_required || arg_types.size() > ctor.parameter_nodes().size()) {
@@ -294,9 +365,9 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 			*preferred_ctor,
 			arg_types);
 		if (instantiated.has_value() && instantiated->is<ConstructorDeclarationNode>()) {
-			const auto& concrete_ctor = instantiated->as<ConstructorDeclarationNode>();
-			if (matches_call_arguments(concrete_ctor)) {
-				return &concrete_ctor;
+			const ConstructorDeclarationNode* concrete_ctor = attachInstantiatedCtor(*preferred_ctor, *instantiated);
+			if (concrete_ctor && matches_call_arguments(*concrete_ctor)) {
+				return concrete_ctor;
 			}
 		}
 		// Instantiation failed or the instantiated ctor doesn't match call arguments.
@@ -321,15 +392,15 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 		if (!instantiated.has_value() || !instantiated->is<ConstructorDeclarationNode>()) {
 			continue;
 		}
-		const auto& concrete_ctor = instantiated->as<ConstructorDeclarationNode>();
-		if (!matches_call_arguments(concrete_ctor)) {
+		const ConstructorDeclarationNode* concrete_ctor = attachInstantiatedCtor(ctor_decl, *instantiated);
+		if (!concrete_ctor || !matches_call_arguments(*concrete_ctor)) {
 			continue;
 		}
 		if (instantiated_match != nullptr) {
 			is_ambiguous = true;
 			return nullptr;
 		}
-		instantiated_match = &concrete_ctor;
+		instantiated_match = concrete_ctor;
 	}
 
 	return instantiated_match;

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -30,6 +30,10 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		}
 		auto [new_ctor_node, new_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
 			lazy_info.identity.instantiated_owner_name, ctor_name_handle);
+		if (auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
+			struct_it != getTypesByNameMap().end()) {
+			new_ctor_ref.set_owning_type_index(struct_it->second->type_index_);
+		}
 
 		// Build parameter list, expanding variadic pack parameters into N individual
 		// parameters (args_0, args_1, ...) and populating pack_param_info_ so that
@@ -218,45 +222,38 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			parsing_template_depth_ = 0;
 
 			SaveHandle current_pos = save_token_position();
-			restore_lexer_position_only(ctor_decl.template_body_position());
-
-			auto parse_ctor_body_with_current_context = [&]() {
+			auto parse_ctor_with_current_context = [&]() {
 				FlashCpp::ScopedState guard_subs(template_param_substitutions_);
 				populateTemplateParamSubstitutions(template_param_substitutions_, param_names, lazy_info.template_args);
-				auto block_result = parse_function_body(true /* is_ctor_or_dtor: constructor */);
-				if (!block_result.is_error() && block_result.node().has_value()) {
-					body_to_substitute = block_result.node();
+				DelayedFunctionBody delayed{
+					nullptr,
+					ctor_decl.template_body_position(),
+					ctor_decl.has_template_initializer_list_position() ? ctor_decl.template_initializer_list_position() : SaveHandle{},
+					lazy_info.identity.instantiated_owner_name,
+					{},
+					nullptr,
+					ctor_decl.has_template_initializer_list_position(),
+					true,
+					false,
+					&new_ctor_ref,
+					nullptr,
+					{},
+					false,
+					false,
+					false
+				};
+				if (auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
+					struct_it != getTypesByNameMap().end()) {
+					delayed.struct_type_index = struct_it->second->type_index_;
+				}
+
+				auto block_result = parse_delayed_function_body(delayed, body_to_substitute);
+				if (block_result.is_error()) {
+					body_to_substitute.reset();
 				}
 			};
 
-			// Use FunctionParsingScopeGuard with full member-function context so
-			// that struct members and 'this' are visible during body re-parse.
-			// This mirrors the regular member function lazy path (line ~595).
-			if (auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
-				struct_it != getTypesByNameMap().end()) {
-				FlashCpp::FunctionParsingScopeGuard func_guard(
-					*this,
-					true,
-					true,
-					nullptr,
-					lazy_info.identity.instantiated_owner_name,
-					struct_it->second->type_index_,
-					new_ctor_ref.parameter_nodes(),
-					nullptr);
-				parse_ctor_body_with_current_context();
-			} else {
-				// Struct type not found in gTypesByNameMap — this can happen for
-				// forward-declared types or types whose registration was deferred.
-				// Fall back to a bare function scope without member context;
-				// member-access in the body will fail, but this matches the
-				// pre-fix behavior and avoids a crash.
-				FLASH_LOG(Templates, Warning, "Lazy ctor body: struct type not found for ",
-						  lazy_info.identity.instantiated_owner_name, ", using bare scope");
-				FlashCpp::SymbolTableScope func_scope(ScopeType::Function);
-				register_parameters_in_scope(new_ctor_ref.parameter_nodes());
-				parse_ctor_body_with_current_context();
-			}
-
+			parse_ctor_with_current_context();
 			restore_lexer_position_only(current_pos);
 			discard_saved_token(current_pos);
 		}
@@ -271,9 +268,56 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			lazy_info.template_params,
 			converted_template_args);
 		new_ctor_ref.set_definition(substituted_body);
+		new_ctor_ref.set_mangled_name(NameMangling::generateMangledNameFromNode(
+			new_ctor_ref, {}, NameMangling::ConstructorVariant::Complete).view());
 		pack_param_info_.resize(saved_ctor_pack_info);
 
-		registerAndNormalizeLateMaterializedTopLevelNode(new_ctor_node);
+		registerLateMaterializedOwningStructRoot(lazy_info.identity.instantiated_owner_name);
+		normalizePendingSemanticRootsIfAvailable();
+
+		auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
+		if (struct_it != getTypesByNameMap().end()) {
+			if (StructTypeInfo* struct_info = struct_it->second->getStructInfo()) {
+				for (auto& member_func : struct_info->member_functions) {
+					if (!member_func.is_constructor) {
+						continue;
+					}
+					if (member_func.function_decl.raw_pointer() != lazy_info.identity.original_member_node.raw_pointer()) {
+						if (!member_func.function_decl.is<ConstructorDeclarationNode>()) {
+							continue;
+						}
+						const auto& existing_ctor = member_func.function_decl.as<ConstructorDeclarationNode>();
+						if (existing_ctor.name() != ctor_decl.name() ||
+							existing_ctor.parameter_nodes().size() != ctor_decl.parameter_nodes().size()) {
+							continue;
+						}
+					}
+					member_func.function_decl = new_ctor_node;
+					break;
+				}
+			}
+		}
+		if (auto struct_root = lookupLateMaterializedOwningStructRoot(lazy_info.identity.instantiated_owner_name);
+			struct_root.has_value() && struct_root->is<StructDeclarationNode>()) {
+			for (auto& member_func : struct_root->as<StructDeclarationNode>().member_functions()) {
+				if (!member_func.is_constructor) {
+					continue;
+				}
+				if (member_func.function_declaration.raw_pointer() != lazy_info.identity.original_member_node.raw_pointer()) {
+					if (!member_func.function_declaration.is<ConstructorDeclarationNode>()) {
+						continue;
+					}
+					const auto& root_ctor = member_func.function_declaration.as<ConstructorDeclarationNode>();
+					if (root_ctor.name() != ctor_decl.name() ||
+						root_ctor.parameter_nodes().size() != ctor_decl.parameter_nodes().size()) {
+						continue;
+					}
+				}
+				member_func.function_declaration = new_ctor_node;
+				break;
+			}
+		}
+
 		return new_ctor_node;
 	}
 

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -193,8 +193,12 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 							}
 						}
 					}
-						// Skip member initializer list (for constructors)
+					SaveHandle ctor_initializer_list_start{};
+					bool ctor_has_initializer_list = false;
+					// Skip member initializer list (for constructors)
 					if (peek() == ":"_tok) {
+						ctor_initializer_list_start = save_token_position();
+						ctor_has_initializer_list = true;
 						advance(); // consume ':'
 							// Skip entries: name(args), name{args}, name<T>(args), ...
 							// Brace-init in the list must be skipped as balanced
@@ -243,7 +247,9 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 					out_of_line_ctor.template_params = template_params;
 					out_of_line_ctor.function_node = ctor_func_node;
 					out_of_line_ctor.body_start = ctor_body_start;
+					out_of_line_ctor.initializer_list_start = ctor_initializer_list_start;
 					out_of_line_ctor.template_param_names = template_param_names;
+					out_of_line_ctor.has_initializer_list = ctor_has_initializer_list;
 					out_of_line_ctor.is_defaulted = ctor_is_defaulted;
 					out_of_line_ctor.is_deleted = ctor_is_deleted;
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5271,7 +5271,6 @@ const ConstructorDeclarationNode* SemanticAnalysis::ensureSelectedConstructorMat
 		return ctor;
 	}
 
-	lazy_registry.markInstantiated(struct_info.getName(), ctor_name, false);
 	return &instantiated_ctor->as<ConstructorDeclarationNode>();
 }
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5198,6 +5198,7 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 	if (!resolution.selected_overload) {
 		resolution.selected_overload = resolveUniqueArityConstructor(*struct_info, num_args);
 	}
+	resolution.selected_overload = ensureSelectedConstructorMaterialized(*struct_info, resolution.selected_overload);
 	if (resolution.is_ambiguous && require_constructor_match)
 		throw CompileError(buildConstructorDiagnostic("Ambiguous constructor call", num_args));
 	if (!resolution.selected_overload) {
@@ -5244,6 +5245,34 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 		diagnoseScopedEnumConversion(arg, param_type_id, " in constructor argument", arg_type_id);
 		++i;
 	});
+}
+
+const ConstructorDeclarationNode* SemanticAnalysis::ensureSelectedConstructorMaterialized(
+	const StructTypeInfo& struct_info,
+	const ConstructorDeclarationNode* ctor) {
+	if (!ctor || ctor->get_definition().has_value() || ctor->is_implicit()) {
+		return ctor;
+	}
+
+	auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
+	StringHandle ctor_name = ctor->name();
+	if (!lazy_registry.needsInstantiation(struct_info.getName(), ctor_name, false)) {
+		return ctor;
+	}
+
+	auto lazy_info_opt = lazy_registry.getLazyMemberInfo(struct_info.getName(), ctor_name, false);
+	if (!lazy_info_opt.has_value()) {
+		return ctor;
+	}
+
+	auto instantiated_ctor = parser_.instantiateLazyMemberFunction(*lazy_info_opt);
+	parser_.normalizePendingSemanticRootsIfAvailable();
+	if (!instantiated_ctor.has_value() || !instantiated_ctor->is<ConstructorDeclarationNode>()) {
+		return ctor;
+	}
+
+	lazy_registry.markInstantiated(struct_info.getName(), ctor_name, false);
+	return &instantiated_ctor->as<ConstructorDeclarationNode>();
 }
 
 void SemanticAnalysis::tryAnnotateInitListConstructorArgs(
@@ -5298,6 +5327,7 @@ void SemanticAnalysis::tryAnnotateInitListConstructorArgs(
 	if (!resolution.selected_overload) {
 		resolution.selected_overload = resolveUniqueArityConstructor(struct_info, initializers.size());
 	}
+	resolution.selected_overload = ensureSelectedConstructorMaterialized(struct_info, resolution.selected_overload);
 	if (!resolution.selected_overload) {
 		// No constructor matched — restore the old scoped-enum diagnostic.
 		// If any argument is a scoped enum that couldn't be implicitly converted,

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -303,6 +303,9 @@ private:
 
 	// Annotate constructor-call arguments with their parameter-type conversions.
 	void tryAnnotateConstructorCallArgConversions(const ConstructorCallNode& call_node);
+	const ConstructorDeclarationNode* ensureSelectedConstructorMaterialized(
+		const StructTypeInfo& struct_info,
+		const ConstructorDeclarationNode* ctor);
 
 	// Annotate InitializerListNode elements used as constructor arguments
 	// with their parameter-type conversions (for direct-init syntax like `Type obj(args...)`).

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -35,6 +35,7 @@ struct OutOfLineMemberFunction {
 	InlineVector<ASTNode, 4> template_params; // Template parameters (e.g., <typename T>)
 	ASTNode function_node; // FunctionDeclarationNode
 	SaveHandle body_start; // Handle to saved position of function body for re-parsing
+	SaveHandle initializer_list_start{}; // Handle to saved position at ':' for ctor initializer re-parse
 	InlineVector<StringHandle, 4> template_param_names; // Names of template parameters
 	// For nested templates (member function templates of class templates):
 	// template<typename T> template<typename U> T Container<T>::convert(U u) { ... }
@@ -42,6 +43,7 @@ struct OutOfLineMemberFunction {
 	InlineVector<ASTNode, 4> inner_template_params;
 	InlineVector<StringHandle, 4> inner_template_param_names;
 	// Function specifiers from out-of-line definition (= default, = delete)
+	bool has_initializer_list = false;
 	bool is_defaulted = false;
 	bool is_deleted = false;
 };

--- a/tests/test_template_nested_ctor_materialized_before_codegen_ret42.cpp
+++ b/tests/test_template_nested_ctor_materialized_before_codegen_ret42.cpp
@@ -1,0 +1,28 @@
+// Regression test: nested template constructors must be fully materialized in
+// parser/sema before variable-declaration codegen consumes them. Exercises both
+// paren-init and brace-init variable declarations without relying on a codegen
+// fallback to instantiate the constructor body.
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		T value;
+
+		template<typename U>
+		Inner(U v);
+
+		T get() const { return value; }
+	};
+};
+
+template<typename T>
+template<typename U>
+Outer<T>::Inner::Inner(U v) {
+	value = static_cast<T>(v);
+}
+
+int main() {
+	Outer<int>::Inner paren(40);
+	Outer<int>::Inner brace{2};
+	return paren.get() + brace.get();
+}

--- a/tests/test_template_nested_ctor_materialized_before_codegen_ret42.cpp
+++ b/tests/test_template_nested_ctor_materialized_before_codegen_ret42.cpp
@@ -1,7 +1,7 @@
 // Regression test: nested template constructors must be fully materialized in
 // parser/sema before variable-declaration codegen consumes them. Exercises both
-// paren-init and brace-init variable declarations without relying on a codegen
-// fallback to instantiate the constructor body.
+// paren-init and brace-init variable declarations and verifies that an
+// out-of-line member-initializer list survives lazy constructor materialization.
 
 template<typename T>
 struct Outer {
@@ -17,9 +17,7 @@ struct Outer {
 
 template<typename T>
 template<typename U>
-Outer<T>::Inner::Inner(U v) {
-	value = static_cast<T>(v);
-}
+Outer<T>::Inner::Inner(U v) : value(static_cast<T>(v)) {}
 
 int main() {
 	Outer<int>::Inner paren(40);


### PR DESCRIPTION
sema now resolves/materializes the selected constructor first, and codegen only consumes that declaration.

I moved the handoff into SemanticAnalysis (ensureSelectedConstructorMaterialized(...)), tightened brace-init to require sema-owned constructor metadata in normalized bodies, and removed the stmt-decl materialize_template_ctor, is_unresolved_noop_ctor, and parser-callback fallback path. I also fixed nested out-of-line template ctor body-position capture so lazy ctor materialization can happen before IR, and added tests/test_template_nested_ctor_materialized_before_codegen_ret42.cpp for the exact paren-init/brace-init path.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
