### PR TITLE
out-of-line operator() template links and runs

### DIFF
--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -907,6 +907,9 @@ public:
 
 	// Nested class support
 	void add_nested_class(ASTNode nested_class) {
+		if (nested_class.is<StructDeclarationNode>()) {
+			nested_class.as<StructDeclarationNode>().set_enclosing_class(this);
+		}
 		nested_classes_.push_back(nested_class);
 	}
 

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -946,6 +946,7 @@ private:
 	ParseResult parse_member_struct_template(StructDeclarationNode& struct_node, AccessSpecifier access);  // NEW: Parse member struct/class templates
 	ParseResult parse_member_variable_template(StructDeclarationNode& struct_node, AccessSpecifier access);	// NEW: Parse member variable templates
 	ParseResult parse_member_template_or_function(StructDeclarationNode& struct_node, AccessSpecifier access);  // Helper: Detect and parse member template alias or function
+	StringHandle getStructQualifiedNameForRegistration(const StructDeclarationNode& struct_node) const;
 	ParseResult parse_bitfield_width(std::optional<size_t>& out_width, std::optional<ASTNode>* out_expr = nullptr);	// Helper: Parse ': <const-expr>' for bitfields
 		// Phase 6: Shared helper for template function declaration parsing
 		// Parses: type_and_name + function_declaration + body handling (semicolon or skip braces)

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -152,9 +152,8 @@ void registerNestedMemberFunctionsForLazy(
 				template_params,
 				template_args);
 			LazyMemberInstantiationRegistry::getInstance().registerLazyMember(std::move(lazy_mem_info));
-		} else if (mem_func.function_declaration.is<FunctionDeclarationNode>()) {
-			const FunctionDeclarationNode& func_decl = mem_func.function_declaration.as<FunctionDeclarationNode>();
-			const DeclarationNode& decl = func_decl.decl_node();
+		} else if (const FunctionDeclarationNode* func_decl = get_function_decl_node(mem_func.function_declaration)) {
+			const DeclarationNode& decl = func_decl->decl_node();
 
 			auto lazy_mem_info = buildLazyNestedMemberFunctionInfo(
 				mem_func,
@@ -176,14 +175,25 @@ void registerNestedMemberFunctionsForLazy(
 					fn->set_is_volatile_member_function(mem_func.is_volatile());
 				}
 			}
-			nested_struct_info.addMemberFunction(
-				decl.identifier_token().handle(),
-				mem_func.function_declaration,
-				mem_func.access,
-				mem_func.is_virtual,
-				mem_func.is_pure_virtual,
-				mem_func.is_override,
-				mem_func.is_final);
+			if (mem_func.operator_kind != OverloadableOperator::None) {
+				nested_struct_info.addOperatorOverload(
+					mem_func.operator_kind,
+					mem_func.function_declaration,
+					mem_func.access,
+					mem_func.is_virtual,
+					mem_func.is_pure_virtual,
+					mem_func.is_override,
+					mem_func.is_final);
+			} else {
+				nested_struct_info.addMemberFunction(
+					decl.identifier_token().handle(),
+					mem_func.function_declaration,
+					mem_func.access,
+					mem_func.is_virtual,
+					mem_func.is_pure_virtual,
+					mem_func.is_override,
+					mem_func.is_final);
+			}
 			// cv_qualifier is now auto-derived by propagateAstProperties
 
 			FLASH_LOG(Templates, Debug, "Registered lazy member function for nested type: ",

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -6074,6 +6074,17 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					// Falls back to arity-only selection when argument types cannot be determined.
 					const FunctionDeclarationNode* operator_call_func = nullptr;
 					bool op_explicitly_ambiguous = false;
+					std::vector<TypeSpecifierNode> op_arg_types;
+					bool all_op_types_known = true;
+					for (const auto& arg : args) {
+						auto arg_type = get_expression_type(arg);
+						if (arg_type.has_value()) {
+							op_arg_types.push_back(*arg_type);
+						} else {
+							all_op_types_known = false;
+							break;
+						}
+					}
 
 					// Build candidate list for resolve_overload.
 					std::vector<ASTNode> op_candidates;
@@ -6086,18 +6097,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 					if (!op_candidates.empty()) {
 						// Try type-based overload resolution first.
-						std::vector<TypeSpecifierNode> op_arg_types;
-						bool all_op_types_known = true;
-						for (const auto& arg : args) {
-							auto arg_type = get_expression_type(arg);
-							if (arg_type.has_value()) {
-								op_arg_types.push_back(*arg_type);
-							} else {
-								all_op_types_known = false;
-								break;
-							}
-						}
-
 						if (all_op_types_known) {
 							auto op_result = resolve_overload(op_candidates, op_arg_types);
 							if (op_result.has_match && !op_result.is_ambiguous) {
@@ -6127,6 +6126,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							}
 							if (!operator_call_func && op_candidate_count == 1)
 								operator_call_func = sole_op_candidate;
+						}
+					}
+
+					if (!operator_call_func && !op_explicitly_ambiguous && all_op_types_known) {
+						if (auto instantiated_operator = try_instantiate_member_function_template(
+								StringTable::getStringView(type_info.struct_info_->name),
+								"operator()"sv,
+								op_arg_types);
+							instantiated_operator.has_value() && instantiated_operator->is<FunctionDeclarationNode>()) {
+							operator_call_func = &instantiated_operator->as<FunctionDeclarationNode>();
 						}
 					}
 

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -545,7 +545,7 @@ ParseResult Parser::parse_template_declaration() {
 					QualifiedIdentifier::fromQualifiedName(
 						nested_qualified_class_name,
 						gSymbolTable.get_current_namespace_handle()),
-					out_of_line_member);
+					std::move(out_of_line_member));
 
 				FLASH_LOG(Templates, Debug, "Registered nested template out-of-line member: ",
 						  nested_qualified_class_name, "::", nested_func_name_token.value(),

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -316,91 +316,119 @@ ParseResult Parser::parse_template_declaration() {
 			// We take the LAST such match before '(' to avoid misidentifying qualified
 			// return types (e.g. typename Container<T>::value_type) as the class::function pattern.
 			{
-				Token last_ident;
+				auto appendQualifiedComponent = [](std::string& qualified_name, std::string_view component) {
+					if (!qualified_name.empty()) {
+						qualified_name += "::";
+					}
+					qualified_name += component;
+				};
+
+				std::string qualified_prefix;
 				while (!peek().is_eof()) {
 					if (peek().is_identifier()) {
-						last_ident = peek_info();
+						Token current_ident = peek_info();
 						advance();
+
+						if (peek() == "::"_tok) {
+							appendQualifiedComponent(qualified_prefix, current_ident.value());
+							advance(); // consume '::'
+							continue;
+						}
+
 						if (peek() == "<"_tok) {
-							// This might be ClassName<T>
-							Token class_token = last_ident;
+							Token class_token = current_ident;
 							skip_template_arguments();
 							if (peek() == "::"_tok) {
+								std::string owner_name = qualified_prefix;
+								appendQualifiedComponent(owner_name, class_token.value());
 								advance(); // consume '::'
-								if (peek().is_identifier()) {
-									// Tentatively record this match
-									nested_class_name = class_token.value();
-									nested_qualified_class_name = std::string(class_token.value());
-									nested_func_name_token = peek_info();
-									advance(); // consume function name
-									// Handle nested :: for deeper nesting
-									while (peek() == "::"_tok) {
-										advance();
-										if (peek().is_identifier()) {
-											nested_qualified_class_name += "::";
-											nested_qualified_class_name += nested_func_name_token.value();
-											nested_class_name = nested_func_name_token.value();
-											nested_func_name_token = peek_info();
-											advance();
-										} else
-											break;
-									}
-									found_nested_def = true;
-									// If '(' follows, this is the actual definition - stop
-									if (peek() == "("_tok) {
-										break;
-									}
-									// Otherwise, this was a qualified return type - keep scanning
-								} else if (peek_info().value() == "operator") {
-									// Handle operator overloads: Class<T>::operator()(...)
-									nested_class_name = class_token.value();
-									nested_qualified_class_name = std::string(class_token.value());
-									Token operator_keyword = peek_info();
-									advance(); // consume 'operator'
-									// Consume the operator symbol(s) and build the full name
-									std::string_view full_op_name;
-									if (peek() == "("_tok) {
-										advance(); // consume '('
-										if (peek() == ")"_tok) {
-											advance(); // consume ')' -> operator()
+
+								while (!peek().is_eof()) {
+									if (peek_info().value() == "operator") {
+										nested_class_name = class_token.value();
+										nested_qualified_class_name = owner_name;
+										Token operator_keyword = peek_info();
+										advance(); // consume 'operator'
+										// Consume the operator symbol(s) and build the full name
+										std::string_view full_op_name;
+										if (peek() == "("_tok) {
+											advance(); // consume '('
+											if (peek() == ")"_tok) {
+												advance(); // consume ')' -> operator()
+											}
+											static const std::string op_call = "operator()";
+											full_op_name = op_call;
+										} else if (peek() == "["_tok) {
+											advance(); // consume '['
+											if (peek() == "]"_tok) {
+												advance(); // consume ']' -> operator[]
+											}
+											static const std::string op_subscript = "operator[]";
+											full_op_name = op_subscript;
+										} else if (peek().is_operator() || peek().is_punctuator()) {
+											// Build "operator+" etc.
+											static std::unordered_map<std::string_view, std::string> op_names;
+											auto sym = peek_info().value();
+											auto it = op_names.find(sym);
+											if (it == op_names.end()) {
+												it = op_names.emplace(sym, "operator" + std::string(sym)).first;
+											}
+											full_op_name = it->second;
+											advance(); // consume single-char operator
+										} else {
+											static const std::string op_default = "operator";
+											full_op_name = op_default;
 										}
-										static const std::string op_call = "operator()";
-										full_op_name = op_call;
-									} else if (peek() == "["_tok) {
-										advance(); // consume '['
-										if (peek() == "]"_tok) {
-											advance(); // consume ']' -> operator[]
-										}
-										static const std::string op_subscript = "operator[]";
-										full_op_name = op_subscript;
-									} else if (peek().is_operator() || peek().is_punctuator()) {
-										// Build "operator+" etc.
-										static std::unordered_map<std::string_view, std::string> op_names;
-										auto sym = peek_info().value();
-										auto it = op_names.find(sym);
-										if (it == op_names.end()) {
-											it = op_names.emplace(sym, "operator" + std::string(sym)).first;
-										}
-										full_op_name = it->second;
-										advance(); // consume single-char operator
-									} else {
-										static const std::string op_default = "operator";
-										full_op_name = op_default;
-									}
-									// Create a token with the full operator name
-									nested_func_name_token = Token(Token::Type::Identifier, full_op_name,
+										// Create a token with the full operator name
+										nested_func_name_token = Token(Token::Type::Identifier, full_op_name,
 																   operator_keyword.line(), operator_keyword.column(),
 																   operator_keyword.file_index());
-									found_nested_def = true;
-									if (peek() == "("_tok) {
+										found_nested_def = true;
 										break;
 									}
+
+									if (!peek().is_identifier()) {
+										break;
+									}
+
+									Token candidate_token = peek_info();
+									advance();
+									if (peek() == "<"_tok) {
+										skip_template_arguments();
+									}
+
+									if (peek() == "::"_tok) {
+										appendQualifiedComponent(owner_name, candidate_token.value());
+										nested_class_name = candidate_token.value();
+										advance(); // consume '::'
+										continue;
+									}
+
+									nested_class_name = class_token.value();
+									nested_qualified_class_name = owner_name;
+									nested_func_name_token = candidate_token;
+									found_nested_def = true;
+									break;
 								}
+
+								// If '(' follows, this is the actual definition - stop
+								if (found_nested_def && peek() == "("_tok) {
+									break;
+								}
+
+								// Otherwise, this was a qualified return type - keep scanning
+								qualified_prefix.clear();
+								continue;
 							}
 						}
+
+						qualified_prefix.clear();
 					} else if (peek() == "("_tok || peek() == "{"_tok || peek() == ";"_tok) {
 						break;
 					} else {
+						if (peek() != "::"_tok) {
+							qualified_prefix.clear();
+						}
 						advance();
 					}
 				}
@@ -513,7 +541,11 @@ ParseResult Parser::parse_template_declaration() {
 				out_of_line_member.inner_template_param_names = inner_template_param_names;
 				out_of_line_member.has_initializer_list = has_initializer_list;
 
-				gTemplateRegistry.registerOutOfLineMember(nested_qualified_class_name, std::move(out_of_line_member));
+				gTemplateRegistry.registerOutOfLineMember(
+					QualifiedIdentifier::fromQualifiedName(
+						nested_qualified_class_name,
+						gSymbolTable.get_current_namespace_handle()),
+					out_of_line_member);
 
 				FLASH_LOG(Templates, Debug, "Registered nested template out-of-line member: ",
 						  nested_qualified_class_name, "::", nested_func_name_token.value(),
@@ -4632,6 +4664,84 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		return param_list_result;
 	}
 
+	auto skipMemberStructTemplateConstructor = [&]() {
+		if (peek() == "("_tok) {
+			skip_balanced_parens();
+		}
+
+		int angle_depth = 0;
+		while (!peek().is_eof()) {
+			auto tk = peek();
+			if (angle_depth == 0 &&
+				(tk == ":"_tok || tk == "{"_tok || tk == "try"_tok || tk == ";"_tok || tk == "="_tok || tk == "requires"_tok)) {
+				break;
+			}
+			if (tk == "("_tok) {
+				skip_balanced_parens();
+			} else if (tk == "<"_tok || tk == ">"_tok || tk == ">>"_tok) {
+				update_angle_depth(tk, angle_depth);
+				advance();
+			} else {
+				advance();
+			}
+		}
+
+		if (peek() == "requires"_tok) {
+			skip_trailing_requires_clause();
+		}
+
+		if (peek() == ":"_tok) {
+			advance(); // consume ':'
+			while (!peek().is_eof()) {
+				if (peek() == "typename"_tok) {
+					advance();
+				}
+				while (!peek().is_eof() && peek() != "("_tok && peek() != "{"_tok && peek() != ";"_tok) {
+					if (peek() == "<"_tok) {
+						skip_template_arguments();
+					} else if (peek() == "::"_tok) {
+						advance();
+					} else {
+						advance();
+					}
+				}
+				if (peek() == "("_tok) {
+					skip_balanced_parens();
+				} else if (peek() == "{"_tok) {
+					auto check_save = save_token_position();
+					skip_balanced_braces();
+					if (peek() == ","_tok) {
+						discard_saved_token(check_save);
+					} else {
+						restore_token_position(check_save);
+						break;
+					}
+				} else {
+					break;
+				}
+				if (peek() == ","_tok) {
+					advance();
+				} else {
+					break;
+				}
+			}
+		}
+
+		if (peek() == "try"_tok) {
+			skip_function_body();
+		} else if (peek() == "{"_tok) {
+			skip_balanced_braces();
+		} else if (peek() == "="_tok) {
+			advance();
+			if (peek() == "default"_tok || peek() == "delete"_tok) {
+				advance();
+			}
+			consume(";"_tok);
+		} else if (peek() == ";"_tok) {
+			advance();
+		}
+	};
+
 	// Extract parameter names for later lookup
 	for (const auto& param : template_params) {
 		if (param.is<TemplateParameterNode>()) {
@@ -4857,6 +4967,14 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				continue;
 			}
 
+			if (peek() == "template"_tok) {
+				auto template_result = parse_member_template_or_function(member_struct_ref, current_access);
+				if (template_result.is_error()) {
+					return template_result;
+				}
+				continue;
+			}
+
 			// Check for access specifiers
 			if (peek().is_keyword()) {
 				std::string_view keyword = peek_info().value();
@@ -5018,14 +5136,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					}
 					continue;
 				}
-				// Handle nested template declarations (member function templates, member struct templates, etc.)
-				if (keyword == "template") {
-					auto template_result = parse_member_template_or_function(member_struct_ref, current_access);
-					if (template_result.is_error()) {
-						return template_result;
-					}
-					continue;
-				}
 			}
 			// This ensures specifiers like constexpr, inline, static aren't lost for non-constructor members
 			SaveHandle member_saved_pos = save_token_position();
@@ -5060,7 +5170,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					discard_saved_token(ctor_lookahead_pos);
 					discard_saved_token(member_saved_pos);
 					FLASH_LOG_FORMAT(Parser, Debug, "parse_member_struct_template: Skipping constructor for {}", struct_name);
-					skip_member_declaration_to_semicolon();
+					skipMemberStructTemplateConstructor();
 					continue;
 				} else {
 					// Not a constructor, restore position to BEFORE specifiers so they get re-parsed
@@ -5425,7 +5535,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				discard_saved_token(ctor_lookahead_pos2);
 				discard_saved_token(member_saved_pos2);
 				FLASH_LOG_FORMAT(Parser, Debug, "parse_member_struct_template (primary): Skipping constructor for {}", struct_name);
-				skip_member_declaration_to_semicolon();
+				skipMemberStructTemplateConstructor();
 				continue;
 			} else {
 				// Not a constructor, restore position to BEFORE specifiers so they get re-parsed

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -354,6 +354,7 @@ ParseResult Parser::parse_template_declaration() {
 								} else if (peek_info().value() == "operator") {
 									// Handle operator overloads: Class<T>::operator()(...)
 									nested_class_name = class_token.value();
+									nested_qualified_class_name = std::string(class_token.value());
 									Token operator_keyword = peek_info();
 									advance(); // consume 'operator'
 									// Consume the operator symbol(s) and build the full name

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5428,11 +5428,14 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				}
 				continue;
 			}
-			// Handle member function templates - skip them for now
-			// They will be properly instantiated when the member template struct is used
+			// Handle member templates inside the member struct template body.
+			// These declarations must be recorded now so out-of-line definitions can
+			// bind to the instantiated member later.
 			if (keyword == "template") {
-				advance(); // consume 'template'
-				skip_member_declaration_to_semicolon();
+				auto template_result = parse_member_template_or_function(member_struct_ref, current_access);
+				if (template_result.is_error()) {
+					return template_result;
+				}
 				continue;
 			}
 			// Handle static members (including static constexpr with initializers)

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -4,6 +4,30 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
+StringHandle Parser::getStructQualifiedNameForRegistration(const StructDeclarationNode& struct_node) const {
+	if (struct_parsing_context_stack_.empty()) {
+		return struct_node.qualified_name();
+	}
+
+	StringBuilder chain_builder;
+	bool found_struct = false;
+	for (const auto& ctx : struct_parsing_context_stack_) {
+		chain_builder.append(ctx.struct_name);
+		if (ctx.struct_node == &struct_node) {
+			found_struct = true;
+			break;
+		}
+		chain_builder.append("::"sv);
+	}
+
+	if (found_struct) {
+		return StringTable::getOrInternStringHandle(chain_builder.commit());
+	}
+
+	chain_builder.reset();
+	return struct_node.qualified_name();
+}
+
 ParseResult Parser::parse_template_function_declaration_body(
 	InlineVector<ASTNode, 4>& template_params,
 	std::optional<ASTNode> requires_clause,
@@ -219,28 +243,6 @@ ParseResult Parser::parse_template_function_declaration_body(
 // Pattern: template<typename U> ReturnType functionName(U param) { ... }
 ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct_node, AccessSpecifier access) {
 	ScopedTokenPosition saved_position(*this);
-	auto get_current_struct_qualified_name = [&]() -> StringHandle {
-		if (struct_parsing_context_stack_.empty()) {
-			return struct_node.qualified_name();
-		}
-
-		StringBuilder chain_builder;
-		for (const auto& ctx : struct_parsing_context_stack_) {
-			chain_builder.append(ctx.struct_name).append("::"sv);
-			if (ctx.struct_node == &struct_node) {
-				break;
-			}
-		}
-
-		std::string_view chain = chain_builder.commit();
-		if (!chain.empty() && chain.ends_with("::"sv)) {
-			chain.remove_suffix(2);
-		}
-		return chain.empty()
-			? struct_node.qualified_name()
-			: StringTable::getOrInternStringHandle(chain);
-	};
-
 	// Consume 'template' keyword
 	if (!consume("template"_tok)) {
 		return ParseResult::error("Expected 'template' keyword", peek_info());
@@ -737,7 +739,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 														false, false, false, false,
 														member_quals.cv_qualifier);
 
-						StringHandle owner_qualified_name = get_current_struct_qualified_name();
+						StringHandle owner_qualified_name = getStructQualifiedNameForRegistration(struct_node);
 						auto qualified_name = StringTable::getOrInternStringHandle(
 							StringBuilder().append(owner_qualified_name).append("::"sv).append(operator_name));
 						gTemplateRegistry.registerTemplate(qualified_name, template_func_node);
@@ -780,7 +782,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	}
 
 	// Register the template in the global registry with qualified name (ClassName::functionName)
-	StringHandle owner_qualified_name = get_current_struct_qualified_name();
+	StringHandle owner_qualified_name = getStructQualifiedNameForRegistration(struct_node);
 	auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(owner_qualified_name).append("::"sv).append(decl_node.identifier_token().value()));
 	gTemplateRegistry.registerTemplate(qualified_name, template_func_node);
 
@@ -796,28 +798,6 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 ParseResult Parser::parse_member_template_or_function(StructDeclarationNode& struct_node, AccessSpecifier access) {
 	// Look ahead to determine if this is a template alias, struct/class template, friend, or function template
 	SaveHandle lookahead_pos = save_token_position();
-	auto get_current_struct_qualified_name = [&]() -> StringHandle {
-		if (struct_parsing_context_stack_.empty()) {
-			return struct_node.qualified_name();
-		}
-
-		StringBuilder chain_builder;
-		for (const auto& ctx : struct_parsing_context_stack_) {
-			chain_builder.append(ctx.struct_name).append("::"sv);
-			if (ctx.struct_node == &struct_node) {
-				break;
-			}
-		}
-
-		std::string_view chain = chain_builder.commit();
-		if (!chain.empty() && chain.ends_with("::"sv)) {
-			chain.remove_suffix(2);
-		}
-		return chain.empty()
-			? struct_node.qualified_name()
-			: StringTable::getOrInternStringHandle(chain);
-	};
-
 	advance(); // consume 'template'
 
 	// Skip template parameter list to find what comes after

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -219,6 +219,27 @@ ParseResult Parser::parse_template_function_declaration_body(
 // Pattern: template<typename U> ReturnType functionName(U param) { ... }
 ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct_node, AccessSpecifier access) {
 	ScopedTokenPosition saved_position(*this);
+	auto get_current_struct_qualified_name = [&]() -> StringHandle {
+		if (struct_parsing_context_stack_.empty()) {
+			return struct_node.qualified_name();
+		}
+
+		StringBuilder chain_builder;
+		for (const auto& ctx : struct_parsing_context_stack_) {
+			chain_builder.append(ctx.struct_name).append("::"sv);
+			if (ctx.struct_node == &struct_node) {
+				break;
+			}
+		}
+
+		std::string_view chain = chain_builder.commit();
+		if (!chain.empty() && chain.ends_with("::"sv)) {
+			chain.remove_suffix(2);
+		}
+		return chain.empty()
+			? struct_node.qualified_name()
+			: StringTable::getOrInternStringHandle(chain);
+	};
 
 	// Consume 'template' keyword
 	if (!consume("template"_tok)) {
@@ -716,8 +737,9 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 														false, false, false, false,
 														member_quals.cv_qualifier);
 
+						StringHandle owner_qualified_name = get_current_struct_qualified_name();
 						auto qualified_name = StringTable::getOrInternStringHandle(
-							StringBuilder().append(struct_node.name()).append("::"sv).append(operator_name));
+							StringBuilder().append(owner_qualified_name).append("::"sv).append(operator_name));
 						gTemplateRegistry.registerTemplate(qualified_name, template_func_node);
 						gTemplateRegistry.registerTemplate(StringTable::getOrInternStringHandle(operator_name), template_func_node);
 
@@ -750,10 +772,16 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 
 	// Add to struct as a member function template
 	// First, add to the struct's member functions list so it can be found for inheritance lookup
-	struct_node.add_member_function(template_func_node, access);
+	OverloadableOperator operator_kind = overloadableOperatorFromFunctionName(decl_node.identifier_token().value());
+	if (operator_kind != OverloadableOperator::None) {
+		struct_node.add_operator_overload(operator_kind, template_func_node, access);
+	} else {
+		struct_node.add_member_function(template_func_node, access);
+	}
 
 	// Register the template in the global registry with qualified name (ClassName::functionName)
-	auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(struct_node.name()).append("::"sv).append(decl_node.identifier_token().value()));
+	StringHandle owner_qualified_name = get_current_struct_qualified_name();
+	auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(owner_qualified_name).append("::"sv).append(decl_node.identifier_token().value()));
 	gTemplateRegistry.registerTemplate(qualified_name, template_func_node);
 
 	// Also register with simple name for unqualified lookups (needed for inherited member template function calls)
@@ -768,6 +796,27 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 ParseResult Parser::parse_member_template_or_function(StructDeclarationNode& struct_node, AccessSpecifier access) {
 	// Look ahead to determine if this is a template alias, struct/class template, friend, or function template
 	SaveHandle lookahead_pos = save_token_position();
+	auto get_current_struct_qualified_name = [&]() -> StringHandle {
+		if (struct_parsing_context_stack_.empty()) {
+			return struct_node.qualified_name();
+		}
+
+		StringBuilder chain_builder;
+		for (const auto& ctx : struct_parsing_context_stack_) {
+			chain_builder.append(ctx.struct_name).append("::"sv);
+			if (ctx.struct_node == &struct_node) {
+				break;
+			}
+		}
+
+		std::string_view chain = chain_builder.commit();
+		if (!chain.empty() && chain.ends_with("::"sv)) {
+			chain.remove_suffix(2);
+		}
+		return chain.empty()
+			? struct_node.qualified_name()
+			: StringTable::getOrInternStringHandle(chain);
+	};
 
 	advance(); // consume 'template'
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7658,7 +7658,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_func_node,
 					template_func.requires_clause());
 
-				instantiated_struct_ref.add_member_function(new_template_func, mem_func.access);
+				if (mem_func.operator_kind != OverloadableOperator::None) {
+					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_template_func, mem_func.access);
+					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_template_func, mem_func.access,
+														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
+				} else {
+					instantiated_struct_ref.add_member_function(new_template_func, mem_func.access);
+					struct_info_ptr->addMemberFunction(
+						decl_node.identifier_token().handle(),
+						new_template_func,
+						mem_func.access,
+						mem_func.is_virtual,
+						mem_func.is_pure_virtual,
+						mem_func.is_override,
+						mem_func.is_final);
+				}
 
 				// Register with qualified name
 				StringBuilder qualified_name_builder;
@@ -7679,9 +7693,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 			} else {
 				// No substitution needed - copy as-is
-				instantiated_struct_ref.add_member_function(
-					mem_func.function_declaration,
-					mem_func.access);
+				if (mem_func.operator_kind != OverloadableOperator::None) {
+					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, mem_func.function_declaration, mem_func.access);
+					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, mem_func.function_declaration, mem_func.access,
+														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
+				} else {
+					instantiated_struct_ref.add_member_function(
+						mem_func.function_declaration,
+						mem_func.access);
+					struct_info_ptr->addMemberFunction(
+						decl_node.identifier_token().handle(),
+						mem_func.function_declaration,
+						mem_func.access,
+						mem_func.is_virtual,
+						mem_func.is_pure_virtual,
+						mem_func.is_override,
+						mem_func.is_final);
+				}
 
 				// Register with qualified name
 				StringBuilder qualified_name_builder;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -6026,7 +6026,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 
 			for (const auto& out_of_line_member : nested_out_of_line_members) {
-				for (const auto& mem_func : nested_struct.member_functions()) {
+				for (auto& mem_func : nested_struct.member_functions()) {
 					const bool out_of_line_ctor_stub =
 						out_of_line_member.function_node.is<FunctionDeclarationNode>() &&
 						out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node().identifier_token().value() ==
@@ -6058,6 +6058,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							if (out_of_line_member.has_initializer_list) {
 								ctor_decl.set_template_initializer_list_position(out_of_line_member.initializer_list_start);
 							}
+						}
+					} else if (!out_of_line_member.inner_template_params.empty() &&
+							   mem_func.function_declaration.is<TemplateFunctionDeclarationNode>() &&
+							   out_of_line_member.function_node.is<FunctionDeclarationNode>()) {
+						ASTNode nested_func_node = mem_func.function_declaration;
+						auto& nested_template_func = nested_func_node.as<TemplateFunctionDeclarationNode>();
+						auto* nested_func_decl = get_function_decl_node_mut(nested_func_node);
+						const auto& out_of_line_decl = out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node();
+						if (nested_func_decl != nullptr &&
+							!nested_func_decl->get_definition().has_value() &&
+							!nested_func_decl->has_template_body_position() &&
+							nested_template_func.template_parameters().size() == out_of_line_member.inner_template_params.size() &&
+							nested_func_decl->decl_node().identifier_token().value() == out_of_line_decl.identifier_token().value()) {
+							nested_func_decl->set_template_body_position(out_of_line_member.body_start);
 						}
 					}
 				}
@@ -7758,23 +7772,66 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			bool found = false;
 			for (auto& mem_func : instantiated_struct_ref.member_functions()) {
-				if (mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
-					auto& inst_template_func = mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
-					auto& inst_func_decl = inst_template_func.function_decl_node();
-					if (inst_func_decl.decl_node().identifier_token().value() == ool_func_name) {
-						// Set the body position from the out-of-line definition
-						inst_func_decl.set_template_body_position(out_of_line_member.body_start);
-						FLASH_LOG(Templates, Debug, "Set body position on nested template member: ", ool_func_name);
+				FunctionDeclarationNode* inst_func_decl = get_function_decl_node_mut(mem_func.function_declaration);
+				if (!inst_func_decl) {
+					continue;
+				}
+				if (inst_func_decl->decl_node().identifier_token().value() == ool_func_name) {
+					// Set the body position from the out-of-line definition
+					inst_func_decl->set_template_body_position(out_of_line_member.body_start);
+					FLASH_LOG(Templates, Debug, "Set body position on nested template member: ", ool_func_name);
+					found = true;
+					break;
+				}
+			}
+
+			if (!found) {
+				auto original_type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(template_name));
+				if (original_type_it != getTypesByNameMap().end() && original_type_it->second->getStructInfo()) {
+					for (const auto& original_member : original_type_it->second->getStructInfo()->member_functions) {
+						ASTNode recovered_member = original_member.function_decl;
+						FunctionDeclarationNode* recovered_func_decl = get_function_decl_node_mut(recovered_member);
+						if (!recovered_func_decl) {
+							continue;
+						}
+						if (recovered_func_decl->decl_node().identifier_token().value() != ool_func_name) {
+							continue;
+						}
+
+						recovered_func_decl->set_template_body_position(out_of_line_member.body_start);
+						OverloadableOperator recovered_operator_kind = original_member.operator_kind;
+						if (recovered_operator_kind == OverloadableOperator::None) {
+							recovered_operator_kind = overloadableOperatorFromFunctionName(ool_func_name);
+						}
+
+						if (recovered_operator_kind != OverloadableOperator::None) {
+							instantiated_struct_ref.add_operator_overload(recovered_operator_kind, recovered_member, original_member.access);
+							struct_info_ptr->addOperatorOverload(
+								recovered_operator_kind,
+								recovered_member,
+								original_member.access,
+								original_member.is_virtual,
+								original_member.is_pure_virtual,
+								original_member.is_override,
+								original_member.is_final);
+						} else {
+							instantiated_struct_ref.add_member_function(recovered_member, original_member.access);
+							struct_info_ptr->addMemberFunction(
+								recovered_func_decl->decl_node().identifier_token().handle(),
+								recovered_member,
+								original_member.access,
+								original_member.is_virtual,
+								original_member.is_pure_virtual,
+								original_member.is_override,
+								original_member.is_final);
+						}
+
 						found = true;
 						break;
 					}
 				}
 			}
 
-			if (!found) {
-				FLASH_LOG(Templates, Warning, "Nested template out-of-line member '", ool_func_name,
-						  "' not found in instantiated struct");
-			}
 			continue;
 		}
 

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -4,6 +4,61 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
+namespace {
+std::string_view unqualifiedTypeComponent(std::string_view type_name) {
+	size_t scope_pos = type_name.rfind("::");
+	return scope_pos == std::string_view::npos ? type_name : type_name.substr(scope_pos + 2);
+}
+
+std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_name) {
+	auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(struct_name));
+	if (type_it == getTypesByNameMap().end()) {
+		return std::nullopt;
+	}
+
+	const TypeInfo* type_info = type_it->second;
+	if (!type_info->struct_info_) {
+		if (type_info->isTemplateInstantiation()) {
+			return type_info->baseTemplateName();
+		}
+		return std::nullopt;
+	}
+
+	StringBuilder owner_name_builder;
+	bool has_owner_component = false;
+	auto append_lookup_owner = [&](const auto& self, const StructTypeInfo* current_struct) -> void {
+		if (current_struct == nullptr) {
+			return;
+		}
+
+		if (const StructTypeInfo* enclosing = current_struct->getEnclosingClass()) {
+			self(self, enclosing);
+			if (has_owner_component) {
+				owner_name_builder.append("::"sv);
+			}
+			owner_name_builder.append(unqualifiedTypeComponent(StringTable::getStringView(current_struct->getName())));
+			has_owner_component = true;
+			return;
+		}
+
+		std::string_view current_name = StringTable::getStringView(current_struct->getName());
+		auto current_type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(current_name));
+		if (current_type_it != getTypesByNameMap().end() && current_type_it->second->isTemplateInstantiation()) {
+			owner_name_builder.append(StringTable::getStringView(current_type_it->second->baseTemplateName()));
+		} else {
+			owner_name_builder.append(current_name);
+		}
+		has_owner_component = true;
+	};
+
+	append_lookup_owner(append_lookup_owner, type_info->struct_info_.get());
+	if (!has_owner_component) {
+		return std::nullopt;
+	}
+	return StringTable::getOrInternStringHandle(owner_name_builder.commit());
+}
+}
+
 bool Parser::tryAppendMemberDefaultTemplateArg(
 	const TemplateParameterNode& param,
 	const std::vector<ASTNode>& template_params,
@@ -90,15 +145,19 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	// Look up the template in the registry
 	auto template_opt = gTemplateRegistry.lookupTemplate(qualified_name);
 
-	// If not found and struct_name looks like an instantiated template (e.g., has_foo$a1b2c3),
-	// try the base template class name (e.g., has_foo::method)
+	// If not found, recover the source owner name for instantiated/nested owners
+	// (e.g. Outer$hash::Inner -> Outer::Inner, math::Adder$hash -> math::Adder).
 	if (!template_opt.has_value()) {
-		std::string_view base_name = extractBaseTemplateName(struct_name);
-		if (!base_name.empty()) {
+		if (auto lookup_owner = getTemplateLookupOwnerName(struct_name)) {
 			StringBuilder base_qualified_name_sb;
-			base_qualified_name_sb.append(base_name).append("::").append(member_name);
+			base_qualified_name_sb.append(StringTable::getStringView(*lookup_owner)).append("::").append(member_name);
 			StringHandle base_qualified_name = StringTable::getOrInternStringHandle(base_qualified_name_sb);
-			template_opt = gTemplateRegistry.lookupTemplate(base_qualified_name);
+			if (base_qualified_name != qualified_name) {
+				template_opt = gTemplateRegistry.lookupTemplate(base_qualified_name);
+				if (template_opt.has_value()) {
+					qualified_name = base_qualified_name;
+				}
+			}
 		}
 	}
 

--- a/tests/test_template_member_struct_out_of_line_operator_call_ret0.cpp
+++ b/tests/test_template_member_struct_out_of_line_operator_call_ret0.cpp
@@ -1,0 +1,23 @@
+// Regression test: member struct templates must carry out-of-line operator()
+// member templates through instantiation.
+
+template<typename T>
+struct Outer {
+	template<typename U>
+	struct Inner {
+		template<typename V>
+		U operator()(V value) const;
+	};
+};
+
+template<typename T>
+template<typename U>
+template<typename V>
+U Outer<T>::Inner<U>::operator()(V value) const {
+	return static_cast<U>(value) + 40;
+}
+
+int main() {
+	Outer<int>::Inner<int> add;
+	return add(2) - 42;
+}

--- a/tests/test_template_namespace_out_of_line_operator_call_ret0.cpp
+++ b/tests/test_template_namespace_out_of_line_operator_call_ret0.cpp
@@ -1,0 +1,27 @@
+// Regression test: namespaced out-of-line operator() on a class-template member
+// function template must still instantiate from calls on the concrete type.
+
+namespace math {
+	template<typename T>
+	struct Adder {
+		T base;
+
+		Adder(T value) : base(value) {}
+
+		template<typename U>
+		T operator()(U value) const;
+	};
+
+	template<typename T>
+	template<typename U>
+	T Adder<T>::operator()(U value) const {
+		return base + static_cast<T>(value);
+	}
+}
+
+int main() {
+	math::Adder<int> add(40);
+	if (add(2) != 42)
+		return 1;
+	return 0;
+}

--- a/tests/test_template_nested_out_of_line_operator_call_ret0.cpp
+++ b/tests/test_template_nested_out_of_line_operator_call_ret0.cpp
@@ -1,0 +1,22 @@
+// Regression test: nested class-template out-of-line operator() definitions must
+// register under the full owner name rather than only the innermost class.
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		template<typename U>
+		T operator()(U value) const;
+	};
+};
+
+template<typename T>
+template<typename U>
+T Outer<T>::Inner::operator()(U value) const {
+	return static_cast<T>(value) + 40;
+}
+
+int main() {
+	Outer<int>::Inner add;
+	int result = add(2);
+	return result - 42;
+}

--- a/tests/test_template_out_of_line_operator_call_ret0.cpp
+++ b/tests/test_template_out_of_line_operator_call_ret0.cpp
@@ -19,5 +19,7 @@ T Adder<T>::operator()(U value) const {
 
 int main() {
 	Adder<int> add(40);
-	return add(2);
+	if (add(2) != 42)
+		return 1;
+	return 0;
 }

--- a/tests/test_template_out_of_line_operator_call_ret42.cpp
+++ b/tests/test_template_out_of_line_operator_call_ret42.cpp
@@ -1,0 +1,23 @@
+// Regression test: out-of-line operator() on a class-template member function
+// template must register under the owning class name rather than an empty key.
+
+template<typename T>
+struct Adder {
+	T base;
+
+	Adder(T value) : base(value) {}
+
+	template<typename U>
+	T operator()(U value) const;
+};
+
+template<typename T>
+template<typename U>
+T Adder<T>::operator()(U value) const {
+	return base + static_cast<T>(value);
+}
+
+int main() {
+	Adder<int> add(40);
+	return add(2);
+}


### PR DESCRIPTION
 - src\Parser_Templates_Class.cpp to register Class<T>::operator... under the correct qualified owner name instead of an empty key.
 - src\Parser_Templates_Inst_ClassTemplate.cpp to preserve operator-overload metadata when copying member function templates into instantiated classes.
 - src\Parser_Expr_PrimaryExpr.cpp to instantiate member-function-template operator() candidates when resolving obj(args...).
 - Added tests\test_template_out_of_line_operator_call_ret42.cpp as the regression
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
