### PR TITLE
Fix variable-template NTTP in deferred base class instantiation

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,40 +1,5 @@
 # Known Issues
 
-## Variable-template values can evaluate incorrectly when used as base-class non-type arguments
-
-**Repro:**
-```cpp
-template <class, class>
-constexpr bool is_same_v = false;
-
-template <class T>
-constexpr bool is_same_v<T, T> = true;
-
-template <class Ty>
-constexpr bool is_integral_v = is_same_v<Ty, int>;
-
-template <bool Value>
-struct bool_constant {
-	static constexpr bool value = Value;
-};
-
-template <class Ty>
-struct is_integral : bool_constant<is_integral_v<Ty>> {};
-
-static_assert(is_integral<int>::value);
-```
-**Symptom:** The `static_assert` fails even though `is_same_v<int, int>`
-should select the partial specialization and evaluate to `true`.
-**Impact:** MSVC `<type_traits>` parses, but `std::is_integral<int>::value`
-evaluates incorrectly. This also causes recoverable `is_integral_v`
-instantiation warnings while compiling headers such as `<concepts>`.
-**Root cause:** Variable-template partial-specialization results are not
-reliably propagated when one variable template feeds another and the final value
-is used as a non-type template argument in a base class.
-**Fix approach:** Ensure variable-template instantiation/evaluation resolves
-the selected partial specialization before substituting the value into
-base-specifier template arguments such as `bool_constant<is_integral_v<T>>`.
-
 ## Function-template forward-declaration + definition instantiation picks wrong overload
 
 **Status:** Partially resolved. The `hasLaterUsableTemplateDefinitionWithMatchingShape` check

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4613,6 +4613,32 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							}
 						}
 
+						// Fallback: try as variable template before giving up on constexpr evaluation.
+						// For references like `is_integral_v<T>` where is_integral_v is a variable template,
+						// try_instantiate_template_explicit (function-template path) returns nullopt, and the
+						// generic try_evaluate_constant_expression fallback below would re-evaluate the
+						// ORIGINAL node whose template args still reference the unsubstituted template
+						// parameter (e.g., Ty), leading to inconsistent concrete_args during partial-spec
+						// lookup. Instantiate the variable template directly with the already-substituted
+						// function template args so the initializer is evaluated in a fully concrete context.
+						if (!has_dependent_template_args && !substituted_func_template_args.empty()) {
+							std::string_view func_name = func_call.called_from().value();
+							auto var_template_node = try_instantiate_variable_template(func_name, substituted_func_template_args);
+							if (var_template_node.has_value() && var_template_node->is<VariableDeclarationNode>()) {
+								const VariableDeclarationNode& var_decl = var_template_node->as<VariableDeclarationNode>();
+								if (var_decl.initializer().has_value()) {
+									if (auto value = try_evaluate_constant_expression(*var_decl.initializer())) {
+										FLASH_LOG_FORMAT(Templates, Debug, "Evaluated variable template '{}' to value {}",
+														 func_name, value->value);
+										TemplateTypeArg val_arg(value->value, value->type);
+										val_arg.is_pack = arg_info.is_pack;
+										resolved_args.push_back(val_arg);
+										continue;
+									}
+								}
+							}
+						}
+
 						// Fallback: try to evaluate the expression directly
 						if (auto value = try_evaluate_constant_expression(arg_info.node)) {
 							TemplateTypeArg val_arg(value->value, value->type);

--- a/tests/test_variable_template_nttp_base_class_ret0.cpp
+++ b/tests/test_variable_template_nttp_base_class_ret0.cpp
@@ -1,0 +1,58 @@
+// Regression test for variable-template values used as base-class non-type arguments.
+// Covers the chain: partial-spec variable template -> variable template alias -> NTTP
+// base class. Mixes native scalar types and a user struct for coverage.
+//
+// Previously, inside a deferred base like `bool_constant<is_integral_v<Ty>>`, the
+// inner variable template (`is_integral_v`) was evaluated with un-substituted
+// template arguments, so `is_same_v<Ty, int>` would reach partial-spec lookup as
+// `is_same_v<Ty, int>` (one arg still bound to the template parameter name,
+// category=UserDefined), failing the consistency check in the partial spec
+// `is_same_v<T, T>` and returning `false` for `is_integral_v<int>`.
+
+template <class, class>
+constexpr bool is_same_v = false;
+
+template <class T>
+constexpr bool is_same_v<T, T> = true;
+
+template <class Ty>
+constexpr bool is_integral_v = is_same_v<Ty, int>;
+
+template <class Ty>
+constexpr bool is_short_v = is_same_v<Ty, short>;
+
+template <class Ty>
+constexpr bool is_float_v = is_same_v<Ty, float>;
+
+template <bool Value>
+struct bool_constant {
+	static constexpr bool value = Value;
+};
+
+template <class Ty>
+struct is_integral : bool_constant<is_integral_v<Ty>> {};
+
+template <class Ty>
+struct is_short : bool_constant<is_short_v<Ty>> {};
+
+template <class Ty>
+struct is_float : bool_constant<is_float_v<Ty>> {};
+
+struct MyStruct {};
+
+int main() {
+	// Positive cases: partial specialization must fire.
+	if (!is_integral<int>::value) return 1;
+	if (!is_short<short>::value) return 2;
+	if (!is_float<float>::value) return 3;
+
+	// Negative cases: primary (false) template must be chosen.
+	if (is_integral<short>::value) return 4;
+	if (is_integral<float>::value) return 5;
+	if (is_integral<MyStruct>::value) return 6;
+	if (is_short<int>::value) return 7;
+	if (is_float<double>::value) return 8;
+	if (is_float<MyStruct>::value) return 9;
+
+	return 0;
+}


### PR DESCRIPTION
Fixes KNOWN_ISSUES #2 (variable-template values evaluating incorrectly when used as base-class non-type arguments).

## Root cause

When resolving a deferred base class like ` bool_constant<is_integral_v<Ty>> `, the CallExprNode arg-resolution path in `Parser_Templates_Inst_ClassTemplate.cpp` tried `try_instantiate_template_explicit` (function-template lookup) for `is_integral_v` and, on failure, fell back to evaluating the **original** node whose template args still referenced the unsubstituted parameter `Ty`.

Partial-spec lookup for `is_same_v<Ty, int>` then saw one arg as the formal parameter (category=UserDefined, name='Ty') and the other as concrete `int`, causing the `is_same_v<T, T>` consistency check to reject the match and the whole chain to evaluate as `false`.

## Fix

Before the generic constexpr-evaluation fallback, try `try_instantiate_variable_template` with the already-substituted function template args and evaluate the returned variable's initializer. This ensures the inner variable template is instantiated in a fully concrete context so its partial specialization is selected correctly.

## Test coverage

New regression test `tests/test_variable_template_nttp_base_class_ret0.cpp` mixes `int`/`short`/`float`/user-struct against a minimal `is_integral_v` / `is_short_v` / `is_float_v` / `bool_constant` chain, covering both positive (partial spec fires) and negative (primary false template) cases.

Removes the now-fixed entry from `docs/KNOWN_ISSUES.md`.

## Validation

- `.\build_flashcpp.bat`: Build succeeded, 0 errors
- `tests/run_all_tests.ps1`: **2204 pass / 149 expected-fail / 0 mismatches** (baseline was 2203/149, +1 for new regression test)
- No regressions, including the SFINAE-sensitive `test_namespaced_pair_swap_sfinae_ret0.cpp`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
