### PR TITLE
Phase 5 Slice G cleanup: probes, shared walker, and typed lazy-member keys

### DIFF
--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -452,6 +452,7 @@
     <ClInclude Include="src\ObjectFileCommon.h" />
     <ClInclude Include="src\OverloadResolution.h" />
     <ClInclude Include="src\Parser.h" />
+    <ClInclude Include="src\ReachableStructWalker.h" />
     <ClInclude Include="src\ParserInternal.h" />
     <ClInclude Include="src\ParserScopeGuards.h" />
     <ClInclude Include="src\ParserTemplateClassShared.h" />

--- a/FlashCppMSVC.vcxproj.filters
+++ b/FlashCppMSVC.vcxproj.filters
@@ -371,6 +371,9 @@
     <ClInclude Include="src\Parser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\ReachableStructWalker.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\ParserInternal.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -22,6 +22,10 @@ The core architectural recommendation from this document has largely landed alre
  - Slices I+J (`53327120`) deleted the last live `AstToIr::materializeLazyMemberIfNeeded` forwarder and simplified the codegen struct visitor into a pure consumer.
  - Item #8 below was finished afterwards on this branch (`bd49098c`): `registerLateMaterializedTopLevelNode*` now dedups by `raw_pointer()` identity instead of relying on callers not to double-push.
  - The stale post-forwarder comments called out below have also been cleaned up (`da472bdc`).
+ - Item #9 below is now finished on this branch as well: `ReachableStructWalker.h` provides the shared reachable-struct traversal used by both `SemanticAnalysis::drainLazyMemberRegistry`
+   and codegen's AST walk.
+ - Item #6 below is now finished on this branch too: `Log.h` exposes `FLASH_INVARIANT_PROBE` / `FLASH_INVARIANT_PROBE_FORMAT` with off/log/fail modes, and codegen uses a
+   `Phase5StructDrain` probe to catch any future regression where a still-lazy member or constructor reaches the struct visitor.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -163,7 +167,7 @@ the stale bridge-era comments in SemanticAnalysis.cpp / SemanticAnalysis.h have 
 
 ## Medium-impact changes
 
-### 6. Reusable invariant-probe infrastructure   [TODO]
+### 6. Reusable invariant-probe infrastructure   [DONE]
 
 The audit guard in materializeLazyMemberIfNeeded (writing to audit_phase5f.log, later turned into a hard-fail guard) was the single most effective tool in this whole slice. It
 told us empirically which tests still violated the invariant we were trying to establish.
@@ -182,8 +186,15 @@ With a few modes:
 Every slice that tightens an invariant would benefit. Right now each slice reinvents the instrumentation, and we remove it before commit — meaning we have zero regression
 coverage that the invariant holds going forward.
 
-Current state (TODO): No FLASH_INVARIANT_PROBE macro exists. Log.h has FLASH_LOG / FLASH_LOG_FORMAT / IS_FLASH_LOG_ENABLED, which cover the "log" mode informally, but there
-is no structured invariant concept with off/log/fail modes.
+Current state (DONE): `src/Log.h` now provides `FLASH_INVARIANT_PROBE(name, ...)` and `FLASH_INVARIANT_PROBE_FORMAT(name, fmt, ...)` backed by a compile-time
+`FLASHCPP_INVARIANT_PROBE_MODE` switch:
+
+ - `0` = off (compiled out)
+ - `1` = log (append to `audit_<probe>.log` and emit a warning)
+ - `2` = fail (throw `InternalError`)
+
+The first concrete use is `Phase5StructDrain` in `IrGenerator_Visitors_Decl.cpp`, which trips if codegen ever reaches a still-lazy member function or constructor that should
+have been drained by sema already. Current baseline remains green at 2204 pass / 149 expected-fail.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -211,7 +222,7 @@ double-pushed into the top-level list nor double-enqueued for sema normalization
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-### 9. Centralize the "what is a top-level struct for codegen purposes?" walker   [TODO]
+### 9. Centralize the "what is a top-level struct for codegen purposes?" walker   [DONE]
 
 Today both drainLazyMemberRegistry and the codegen struct-visitor implement their own "recurse namespaces + nested classes + structs" traversal. They have to match exactly or
 else sema drains something codegen won't emit (under-draining: harmless) or codegen emits something sema didn't drain (over-emitting: LNK errors).
@@ -219,8 +230,10 @@ else sema drains something codegen won't emit (under-draining: harmless) or code
 A shared forEachReachableStructDecl(parser, callback) utility would eliminate the drift risk. This is a very small refactor that prevents a whole class of "sema and codegen
 disagree about what's reachable" bugs.
 
-Current state (TODO): drainLazyMemberRegistry (SemanticAnalysis.cpp ~5554-5570) and visitStructDeclarationNode / IrGenerator_Visitors_Decl.cpp each have independent
-namespace-and-nested-class recursive walkers. They currently agree in practice (all tests pass), but there is no structural guarantee.
+Current state (DONE): `src/ReachableStructWalker.h` now owns the shared recursion over namespaces + structs + nested classes. `SemanticAnalysis::drainLazyMemberRegistry`
+uses `FlashCpp::forEachReachableStructDecl(top_node, drainOneStruct)`, and codegen's top-level `AstToIr::visit` uses `FlashCpp::walkReachableStructDecls(...)` with namespace
+enter/exit hooks plus struct enter/exit hooks (`beginStructDeclarationCodegen` / `endStructDeclarationCodegen`). This preserves codegen's context-sensitive behavior while removing the
+separate hand-rolled walkers. The refactor was validated against the full Windows baseline: 2204 pass / 149 expected-fail.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -259,10 +272,10 @@ exists.
 | 3 | InstantiationContext threading             | TODO     |
 | 4 | Separate instantiated-struct list          | PARTIAL  |
 | 5 | Sema owns ODR-use; codegen pure consumer   | DONE     |
-| 6 | FLASH_INVARIANT_PROBE infrastructure       | TODO     |
+| 6 | FLASH_INVARIANT_PROBE infrastructure       | DONE     |
 | 7 | Stable ASTNodeId                           | TODO     |
 | 8 | registerLateMaterializedTopLevelNode dedup | DONE     |
-| 9 | Shared forEachReachableStructDecl walker   | TODO     |
+| 9 | Shared forEachReachableStructDecl walker   | DONE     |
 |10 | Typed LazyMemberKey predicates             | TODO     |
 |11 | Explicit instantiation lifecycle hooks     | TODO     |
 
@@ -270,7 +283,7 @@ exists.
 
 ## What this buys us, in order
 
-Items #1, #5, and #8 are done. Together they deliver the core Slice G promise: sema marks every needed member, drains it, and codegen is a pure consumer. The
+Items #1, #5, #8, and #9 are done. Together they deliver the core Slice G promise: sema marks every needed member, drains it, and codegen is a pure consumer. The
 materializeLazyMemberIfNeeded forwarder no longer exists as live code.
 
 Item #4 is partially done — the parallel tracking vector is there, the clean consumption split is not. Completing it (making codegen apply different emission rules for user
@@ -279,10 +292,9 @@ nodes vs. instantiated nodes) would make "what should be emitted for this instan
 Items #2 and #3 remain the principled long-term fix for the SFINAE corner cases still listed in KNOWN_ISSUES. The workarounds in place (= delete tie-breaking heuristic,
 hasLaterUsableTemplateDefinitionWithMatchingShape check) paper over real gaps in the data model. Phase 6 work on deduction-rule cleanup will benefit from both of these.
 
-Item #6 (invariant probes) is the force-multiplier: it turns every future architectural tightening from "write audit, run tests, remove audit, repeat" into "flip the probe
-mode, trust the CI".
+Item #6 (invariant probes) is now in place: future architectural tightening can keep its guardrails checked in instead of re-inventing one-off audit files for each slice.
 
-Items #9, #10, and #11 are refactoring quality-of-life items that reduce future maintenance risk with low implementation cost.
+Items #10 and #11 are refactoring quality-of-life items that reduce future maintenance risk with low implementation cost.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -291,14 +303,11 @@ Items #9, #10, and #11 are refactoring quality-of-life items that reduce future 
 1. Complete item #4 (separate instantiated-struct list, consumption side): make codegen's top-level node iterator apply different emission rules for instantiated nodes
    (emit only odr_used members) vs. user-written nodes (emit every member). This is the last structural piece the original Slice G recommendation called for.
 
-2. Item #9 (shared forEachReachableStructDecl walker) is small and eliminates a concrete drift risk between sema drain and codegen traversal. A good candidate for the next
-   incremental PR before starting Phase 6.
+2. Item #10 (typed LazyMemberKey predicates) is now the best small cleanup. The registry API still exposes a pile of near-duplicate `StringHandle + bool` queries, and item #6
+   means future refactors can guard the migration with checked-in probes instead of temporary audits.
 
-3. Item #6 (FLASH_INVARIANT_PROBE) is now the best small cross-cutting follow-up after item #9. The Slice F/G audits proved their value; formalizing them would make future
-   invariant tightening CI-enforceable instead of a one-off local debugging exercise.
-
-4. Items #2 and #3 are Phase 6 prerequisites for principled SFINAE handling. They are medium-sized architectural changes. The existing KNOWN_ISSUES workarounds are stable
+3. Items #2 and #3 are Phase 6 prerequisites for principled SFINAE handling. They are medium-sized architectural changes. The existing KNOWN_ISSUES workarounds are stable
    enough to defer until Phase 6 begins.
 
-5. Item #7 (stable ASTNodeId) is still optional for correctness, but it becomes much more attractive if item #4 proceeds. Once there are multiple long-lived dedup/tracking sets,
+4. Item #7 (stable ASTNodeId) is still optional for correctness, but it becomes much more attractive if item #4 proceeds. Once there are multiple long-lived dedup/tracking sets,
    raw_pointer()-identity becomes more of a liability.

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -247,6 +247,14 @@ on a typed LazyMemberKey value that captures struct+member+const-ness. The const
 Current state (TODO): All four free-standing overloads plus the new markOdrUsed / isOdrUsed family still use the raw StringHandle pair + bool pattern. The makeKey static
 helper in LazyMemberInstantiationRegistry is an internal step toward a typed key, but it's private and not exposed to callers.
 
+Important lesson from the 2026-04-21 in-progress refactor attempt: the mechanical part is easy; the hidden risk is StringBuilder lifetime discipline inside the "any-const"
+lookup path. A representative regression (`flashcpp_crash_20260421_174831.log`) shows `StringBuilder::~StringBuilder` asserting from
+`LazyMemberInstantiationRegistry::needsInstantiation` (`src/TemplateRegistry_Lazy.h:102`) during `Parser::parse_member_postfix`, i.e. a typed-key wrapper reused the old
+`preview()`-based key construction without preserving the required `commit()/reset()` discipline. Future work on item #10 should either:
+
+ - eliminate the `StringBuilder::preview()`-driven two-variant lookup pattern entirely, or
+ - centralize it behind a helper that cannot return with a dirty builder state.
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ### 11. Explicit lifecycle hooks for instantiations   [TODO]

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -26,6 +26,9 @@ The core architectural recommendation from this document has largely landed alre
    and codegen's AST walk.
  - Item #6 below is now finished on this branch too: `Log.h` exposes `FLASH_INVARIANT_PROBE` / `FLASH_INVARIANT_PROBE_FORMAT` with off/log/fail modes, and codegen uses a
    `Phase5StructDrain` probe to catch any future regression where a still-lazy member or constructor reaches the struct visitor.
+ - Item #4 below is now finished on this branch (2026-04-21 follow-up): `drainLazyMemberRegistry` pass 1 now skips `isInstantiatedNode(i)` roots;
+   instantiated-struct members materialise only via the ODR-use snapshot pass 2. Closing the six coverage gaps (binary operator overloads, CV-aware conversion operators, struct→enum UDC,
+   `markOdrUsedAllInClass`, receiver-aware `tryMaterializeLazyCallTarget`, range-for begin/end, `member_context_stack_` fallback for `this->member()`) was what unlocked it.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -112,7 +115,7 @@ first match instead of most-specific" KNOWN_ISSUES entry would also benefit from
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-### 4. Give late-materialized instantiations their own first-class list, separate from ast_nodes_   [PARTIAL]
+### 4. Give late-materialized instantiations their own first-class list, separate from ast_nodes_   [DONE]
 
 The ast_nodes_ vector is currently doing double duty:
 
@@ -255,6 +258,61 @@ aware helper, it is a correct and independent ODR-use closure. Commit
 the improvement and leave item #4 at PARTIAL. The next session should
 target the three failures above — each has a concrete fix pointer in
 the list above.
+
+#### 2026-04-21 follow-up: item #4 LANDED
+
+All three blockers above closed; pass-1 skip of `isInstantiatedNode(i)`
+in `drainLazyMemberRegistry` is now ENABLED and the full suite stays
+green at 2204 pass / 149 expected-fail.
+
+Fixes landed:
+
+ 1. **Range-for begin/end ODR-use** (`SemanticAnalysis.cpp`
+    `normalizeRangedForLoopDecl`, after `set_resolved_member_begin_function`).
+    When `range_type_info->isTemplateInstantiation()`, mark both
+    `begin` and `end` lazy members ODR-used on the concrete owner,
+    trying the selected const variant first and falling back to the
+    opposite to defend against resolver-const-qualification drift.
+    Mirrors the receiver-aware helper's const-variant strategy.
+ 2. **`member_context_stack_` fallback in receiver-aware helper**
+    (`SemanticAnalysis.cpp` `tryMaterializeLazyCallTarget(func_decl,
+    call_info)`). When `inferExpressionType(call_info.receiver)`
+    returns an invalid id — which is what happens for `this->member()`
+    inside a late-materialised dependent body where the `this`
+    expression is not yet type-resolved — fall back to
+    `tryGetTypeInfo(member_context_stack_.back())`. That stack already
+    carries the innermost struct whose body we are annotating, which
+    is the correct receiver type for implicit- and explicit-`this`
+    calls. Covers both `test_dependent_base_this_lookup_ret0.cpp`
+    (Derived<T>::f calling Base<T>::get) and
+    `test_deferred_base_placeholder_codegen_ret0.cpp`
+    (optional<T>::has_value calling optional_payload<T>::_M_is_engaged
+    via a sub-object receiver that also resolves through the fallback).
+
+The drain-pass-1 `if (parser_.isInstantiatedNode(i)) continue;` is now
+permanent. Codegen and drainLazyMemberRegistry now have different
+consumption rules for user-written roots vs. instantiated roots:
+
+ - User-written roots (`!isInstantiatedNode(i)`): drained wholesale in
+   pass 1 — every member is materialised because the user wrote them.
+ - Instantiated roots: drained only through pass 2
+   (`snapshotOdrUsedLazyEntries`) — only members that sema-side sites
+   have explicitly marked ODR-used materialise. SFINAE probes never
+   reach the markers, so their candidate instantiations stay dormant.
+
+Lessons (updated):
+
+ - The six ODR-use gaps that the prototype surfaced were all real
+   bugs, not artefacts of the skip. Closing them individually was the
+   correct path.
+ - `member_context_stack_` is an under-used oracle. It already holds
+   the currently-normalised struct context and is trivial to consult
+   as a fallback when expression-typing fails. Any future ODR-use
+   site that needs "which struct am I inside right now?" should use
+   it directly.
+ - `isTemplateInstantiation()` is the right guard for distinguishing
+   an instantiated owner from a user-written struct. Gating
+   `markOdrUsed` on that bit keeps SFINAE-safe.
 
 Lessons:
 
@@ -411,7 +469,7 @@ exists.
 | 1 | Explicit ODR-use bit on lazy registry      | DONE     |
 | 2 | Shape / body phase split + variant state   | TODO     |
 | 3 | InstantiationContext threading             | TODO     |
-| 4 | Separate instantiated-struct list          | PARTIAL  |
+| 4 | Separate instantiated-struct list          | DONE     |
 | 5 | Sema owns ODR-use; codegen pure consumer   | DONE     |
 | 6 | FLASH_INVARIANT_PROBE infrastructure       | DONE     |
 | 7 | Stable ASTNodeId                           | TODO     |
@@ -427,8 +485,13 @@ exists.
 Items #1, #5, #8, and #9 are done. Together they deliver the core Slice G promise: sema marks every needed member, drains it, and codegen is a pure consumer. The
 materializeLazyMemberIfNeeded forwarder no longer exists as live code.
 
-Item #4 is partially done — the parallel tracking vector is there, the clean consumption split is not. Completing it (making codegen apply different emission rules for user
-nodes vs. instantiated nodes) would make "what should be emitted for this instantiation?" an answerable data-structure question rather than an inference from AST reachability.
+Item #4 is now done (2026-04-21 follow-up): the drain-pass-1 loop skips
+instantiated roots, and pass-2 ODR-use snapshot drives their member
+materialisation. Codegen can now treat user-written and instantiated
+roots under fundamentally different rules — user-written roots emit
+everything they declared, instantiated roots emit only what sema
+marked ODR-used. This closes the "what should be emitted for this
+instantiation?" question at the data-structure level.
 
 Items #2 and #3 remain the principled long-term fix for the SFINAE corner cases still listed in KNOWN_ISSUES. The workarounds in place (= delete tie-breaking heuristic,
 hasLaterUsableTemplateDefinitionWithMatchingShape check) paper over real gaps in the data model. Phase 6 work on deduction-rule cleanup will benefit from both of these.

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -207,6 +207,55 @@ required again when the final split lands. The pass-1 loop now carries a
 comment pointing at blockers (5) and (6) so the next attempt has a
 concrete starting list.
 
+#### 2026-04-22 follow-up: receiver-aware ODR-use
+
+Added `tryMaterializeLazyCallTarget(func_decl, call_info)` in
+`SemanticAnalysis.cpp` (overload of the existing pattern-parent helper).
+When the resolver returns a member-function decl with either (a) an empty
+`parent_struct_name` (using-decl pack / free-function-view resolution) or
+(b) a parent that names a template pattern, the new overload derives the
+concrete instantiated owner from the call's receiver type, walks the
+receiver's inheritance chain, and marks the matching lazy member
+ODR-used. It also defends against the resolver having lost const-
+qualification by trying both `is_const` variants. Wired through
+`tryAnnotateCallArgConversionsImpl`. Declaration in `SemanticAnalysis.h`.
+
+Gained coverage (re-enabling the pass-1 skip prototype with this helper):
+
+ - `test_late_member_body_class_template_paths_ret42.cpp`
+ - `test_late_member_body_class_template_functional_style_ret42.cpp`
+ - `test_late_member_signature_qualified_dependent_type_ret42.cpp`
+ - `test_using_decl_pack_expansion_ret1.cpp`
+
+All four tests now link cleanly under the pass-1 skip prototype.
+
+Still missing with the skip enabled (observed link errors, net −3 vs.
+baseline):
+
+ - `test_constexpr_range_begin_end_ret0.cpp` — range-based-for over an
+   instantiated struct. `normalizeRangedForLoopDecl` in
+   `SemanticAnalysis.cpp` resolves `begin`/`end` member functions but
+   never calls `markOdrUsed` on the concrete instantiation. Fix: after
+   `set_resolved_member_begin_function` / `_end_function`, mark both
+   members ODR-used on `range_type_info->name()` when it is a template
+   instantiation.
+ - `test_deferred_base_placeholder_codegen_ret0.cpp` — `optional<T>::has_value`
+   body calls `_M_payload._M_is_engaged()`. The late-materialised
+   member body's `this->member` / `sub_obj.member` calls do not pass
+   through `tryAnnotateCallArgConversionsImpl` for the inner receiver,
+   so the receiver-aware helper is never invoked.
+ - `test_dependent_base_this_lookup_ret0.cpp` — `Derived<T>::f` calls
+   `this->get()` on `Base<T>`. Same gap as above — the call annotation
+   pass simply does not run on the late-materialised body under the
+   skip prototype. Need to investigate where / whether sema is re-
+   running on the cloned body.
+
+Decision (unchanged): keep the pass-1 skip disabled; keep the receiver-
+aware helper, it is a correct and independent ODR-use closure. Commit
+the improvement and leave item #4 at PARTIAL. The next session should
+target the three failures above — each has a concrete fix pointer in
+the list above.
+
 Lessons:
 
  - Wholesale-draining instantiated roots was masking at least six distinct

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -8,9 +8,20 @@ It has been updated in place with the current implementation status of each item
 
 ## Status legend
 
-  [DONE]    Fully implemented and tested (2173/2173 tests green).
+  [DONE]    Fully implemented and verified on the current Windows baseline (2204 pass / 149 expected-fail).
   [PARTIAL] Structurally present but the clean-split described below is not yet realised.
   [TODO]    Not yet started.
+
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+## Progress since the original write-up
+
+The core architectural recommendation from this document has largely landed already:
+
+ - Slice G-H (`79790edd`) introduced explicit lazy-member ODR-use tracking plus the sema-side remap for intra-instantiation member calls.
+ - Slices I+J (`53327120`) deleted the last live `AstToIr::materializeLazyMemberIfNeeded` forwarder and simplified the codegen struct visitor into a pure consumer.
+ - Item #8 below was finished afterwards on this branch (`bd49098c`): `registerLateMaterializedTopLevelNode*` now dedups by `raw_pointer()` identity instead of relying on callers not to double-push.
+ - The stale post-forwarder comments called out below have also been cleaned up (`da472bdc`).
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -124,9 +135,9 @@ registerLateMaterializedTopLevelNode unnecessary as an ad-hoc hook.
 
 Current state (PARTIAL): A parallel ast_node_is_instantiated_ vector (std::vector<uint8_t>) exists in Parser.h, maintained in lockstep with ast_nodes_ by
 appendUserNode / registerLateMaterializedTopLevelNode* / eraseTopLevelNodeAt. The queries isInstantiatedNode(i), userNodeCount(), and instantiatedNodeCount() work. Dedup is
-handled via enqueuePendingSemanticRoot / pending_semantic_root_keys_ (so item 8 below is also done as a side-effect). However, ast_nodes_ is still a single vector; codegen
-and drainLazyMemberRegistry both iterate get_nodes() uniformly without filtering by isInstantiatedNode(). The full clean split (separate user_source_nodes_ /
-instantiated_struct_nodes_ with different emission rules at codegen) has not been done. The tracking infrastructure is there; the consumption side is not.
+now handled directly by registerLateMaterializedTopLevelNode* via instantiated_node_keys_ (an unordered_set<const void*> keyed by ASTNode::raw_pointer()), so duplicate
+late-materialized roots are rejected even before pending-semantic-root enqueue. However, ast_nodes_ is still a single vector; codegen and drainLazyMemberRegistry both iterate
+get_nodes() uniformly without a real split into user_source_nodes_ vs. instantiated_struct_nodes_. The tracking infrastructure is there; the consumption/data-model split is not.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -145,11 +156,8 @@ With ODR-use explicit (change #1), sema drain is the single materialization site
 Current state (DONE): The struct-visitor in IrGenerator_Visitors_Decl.cpp no longer contains any materializeLazyMemberIfNeeded fallback — its comments explicitly state "No
 defensive materialization fallback needed here" (lines ~1253-1264). generateDeferredMemberFunctions in IrGenerator_Visitors_TypeInit.cpp still exists and is called from
 FlashCppMain.cpp, but its comments confirm the old materialization fallback is dead ("the function-shaped materializeLazyMemberIfNeeded fallback that used to live here is now
-dead"). AstToIr::materializeLazyMemberIfNeeded no longer exists as a declared or defined function — remaining references to it in comments are historical notes about its past
-role. Multiple SemanticAnalysis.cpp sema annotation sites call markOdrUsed. All 2173 tests pass.
-
-Note: stale comment noise ("materialization are handled by AstToIr::materializeLazyMemberIfNeeded" etc.) remains in SemanticAnalysis.cpp and SemanticAnalysis.h. It does not
-affect correctness but should be cleaned up to avoid confusing future readers.
+dead"). AstToIr::materializeLazyMemberIfNeeded no longer exists as a declared or defined function. Multiple SemanticAnalysis.cpp sema annotation sites call markOdrUsed, and
+the stale bridge-era comments in SemanticAnalysis.cpp / SemanticAnalysis.h have been cleaned up. Current baseline remains green at 2204 pass / 149 expected-fail.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -188,7 +196,7 @@ typed concept. A real ASTNodeId (monotonically assigned at node creation, stored
  - Survive hypothetical future refactors of the underlying storage.
  - Allow persistent caches (e.g., "already-materialized" sets) that are not tied to raw addresses.
 
-Current state (TODO): Dedup in Parser.h still uses const void* raw pointers (pending_semantic_root_keys_). No typed ASTNodeId concept exists.
+Current state (TODO): Dedup in Parser.h still uses const void* raw pointers (both pending_semantic_root_keys_ and instantiated_node_keys_). No typed ASTNodeId concept exists.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -197,8 +205,9 @@ Current state (TODO): Dedup in Parser.h still uses const void* raw pointers (pen
 Even without #7, the helper should always dedup. Multiple instantiation paths (partial-spec success, primary-template success, base-class helper recursion) can all reach the
 same freshly-created struct. Silently double-pushing causes LNK2005s that are painful to diagnose. Dedup should be the contract, not the caller's responsibility.
 
-Current state (DONE): registerLateMaterializedTopLevelNode calls enqueuePendingSemanticRoot, which guards with pending_semantic_root_keys_ (an unordered_set<const void*>)
-so the same node is never enqueued twice. The contract is the function's, not the caller's.
+Current state (DONE): registerLateMaterializedTopLevelNode and registerLateMaterializedTopLevelNodeFront now both dedup directly through Parser.h's
+instantiated_node_keys_ set before mutating ast_nodes_. Duplicate calls still forward to enqueuePendingSemanticRoot(node) (itself dedup'd), so the same node is neither
+double-pushed into the top-level list nor double-enqueued for sema normalization. The contract is the helper's, not the caller's.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -282,13 +291,14 @@ Items #9, #10, and #11 are refactoring quality-of-life items that reduce future 
 1. Complete item #4 (separate instantiated-struct list, consumption side): make codegen's top-level node iterator apply different emission rules for instantiated nodes
    (emit only odr_used members) vs. user-written nodes (emit every member). This is the last structural piece the original Slice G recommendation called for.
 
-2. Clean up stale comments referencing AstToIr::materializeLazyMemberIfNeeded in SemanticAnalysis.cpp and SemanticAnalysis.h. The function is gone; the comments are
-   misleading noise.
-
-3. Item #9 (shared forEachReachableStructDecl walker) is small and eliminates a concrete drift risk between sema drain and codegen traversal. A good candidate for the next
+2. Item #9 (shared forEachReachableStructDecl walker) is small and eliminates a concrete drift risk between sema drain and codegen traversal. A good candidate for the next
    incremental PR before starting Phase 6.
+
+3. Item #6 (FLASH_INVARIANT_PROBE) is now the best small cross-cutting follow-up after item #9. The Slice F/G audits proved their value; formalizing them would make future
+   invariant tightening CI-enforceable instead of a one-off local debugging exercise.
 
 4. Items #2 and #3 are Phase 6 prerequisites for principled SFINAE handling. They are medium-sized architectural changes. The existing KNOWN_ISSUES workarounds are stable
    enough to defer until Phase 6 begins.
 
-5. Item #6 (FLASH_INVARIANT_PROBE) should be done at the start of any Phase 6 slice, not at the end, so invariant tightening is CI-enforceable from day one.
+5. Item #7 (stable ASTNodeId) is still optional for correctness, but it becomes much more attractive if item #4 proceeds. Once there are multiple long-lived dedup/tracking sets,
+   raw_pointer()-identity becomes more of a liability.

--- a/docs/2026-04-21-phase5-slice-g-analysis.md
+++ b/docs/2026-04-21-phase5-slice-g-analysis.md
@@ -143,6 +143,91 @@ now handled directly by registerLateMaterializedTopLevelNode* via instantiated_n
 late-materialized roots are rejected even before pending-semantic-root enqueue. However, ast_nodes_ is still a single vector; codegen and drainLazyMemberRegistry both iterate
 get_nodes() uniformly without a real split into user_source_nodes_ vs. instantiated_struct_nodes_. The tracking infrastructure is there; the consumption/data-model split is not.
 
+#### 2026-04-21 audit attempt (this session)
+
+A prototype that simply skipped `isInstantiatedNode(i)` roots in
+`drainLazyMemberRegistry` pass 1 was built and tested end-to-end against the
+full suite. It surfaced five previously-hidden ODR-use coverage gaps:
+
+ 1. Binary operator member-overloads (`operator==`, `operator+`, ...) not
+    marked ODR-used from the `normalizeExpression` BinaryOperatorNode branch.
+    → Fixed in this session via a new `markResolvedOperatorOverloadOdrUsed`
+    helper that pulls `{parent_struct_name, member_name, is_const}` out of
+    `resolved_member_operator_overload()` and calls `markOdrUsed`.
+ 2. Conversion-operator overload resolution skipped CV-aware pairing with
+    codegen's `findConversionOperator`. `structHasConversionOperatorTo` marked
+    only the first match; codegen later picked a different CV qualifier and
+    hit a lazy stub.
+    → Fixed by iterating all `mf.conversion_target_type`-matching overloads
+    and marking each (both const and non-const) ODR-used.
+ 3. `tryAnnotateConversion` bailed out early on `to_desc.category() == Enum`
+    before reaching the UserDefined-rank path, so struct→enum UDCs bypassed
+    `structHasConversionOperatorTo` entirely and relied on pass 1 draining
+    the instantiated root wholesale.
+    → Fixed by narrowing the early-return to `from != Struct`.
+ 4. `computeInstantiatedLookupName` canonicalises enum template arguments as
+    `TypeCategory::UserDefined` rather than `Enum`, so conversion-operator
+    stubs with enum template args register under an un-canonicalised name
+    (e.g. `operator value_type`). Sema can't round-trip the lookup.
+    → Worked around via a conservative
+    `LazyMemberInstantiationRegistry::markOdrUsedAllInClass(StringHandle)`
+    helper, invoked as a fallback after `structHasConversionOperatorTo`
+    finishes; it only fires for instantiated classes sema is already
+    annotating, so SFINAE-probed instantiations remain untouched.
+ 5. **Blocker** — using-decl pack expansion that imports static members from
+    a concrete base instantiation. For
+    `struct Combined : Bases... { using Bases::call...; }` with
+    `Combined<Fun<1>>`, sema resolves `c.call()` to the *pattern's*
+    `Fun::call`. The resolved FunctionDeclarationNode reports
+    `parent_struct_name().empty() == true` and `is_member_function() == false`
+    (verified via ad-hoc logging at `tryMaterializeLazyCallTarget`). No
+    existing ODR-use site knows which instantiated owner
+    (`Fun<1>` / `Fun$hash`) to mark, so skipping instantiated roots leaves
+    `Fun$hash::call` unmaterialized and a link error reaches the test.
+ 6. **Blocker** — late-materialised out-of-line member bodies (the
+    `test_late_member_body_class_template_*_ret42.cpp` and
+    `test_late_member_signature_qualified_dependent_type_ret42.cpp` cluster).
+    Once cross-instantiation substitution has run for
+    `Holder$hash::run`, the body references a sibling
+    `Box$hash::get` that still carries no ODR-use mark. The reference site
+    that chooses `Box$hash::get` is currently inside the instantiation-time
+    substitution walk (not a sema annotation pass), so the ODR-use signal
+    never reaches the drain.
+
+With fixes (1)–(4) in place and the pass-1 skip prototype active, gaps (5)
+and (6) each block exactly one (or a small cluster of) tests. Because
+item #4's whole purpose is to flip consumption rules for every
+instantiated root, partial coverage is unsafe: either every instantiated
+root honours the ODR-use protocol or none of them can be skipped.
+
+Decision: revert the pass-1 skip to preserve the 2204 / 149 baseline and
+land fixes (1)–(4) + `markOdrUsedAllInClass` as independent improvements.
+They are all correct-on-their-own-merit ODR-use closures and will be
+required again when the final split lands. The pass-1 loop now carries a
+comment pointing at blockers (5) and (6) so the next attempt has a
+concrete starting list.
+
+Lessons:
+
+ - Wholesale-draining instantiated roots was masking at least six distinct
+   ODR-use gaps. An audit-first approach (prototype the skip, observe what
+   breaks, close the gap) is the correct methodology; blanket skipping is
+   not.
+ - Sema annotation sites must be the single source of truth for ODR-use.
+   Anything that resolves a call, conversion, or member access against a
+   concrete instantiation must translate the resolved target into a
+   `(struct, member, is_const)` triple and call `markOdrUsed`. Helpers
+   that can't recover the struct/member (see blockers 5 and 6) indicate a
+   sema-side resolution bug, not a drain-side bug.
+ - `computeInstantiatedLookupName` has a latent enum-template-argument
+   canonicalisation bug. The `markOdrUsedAllInClass` helper is a pragmatic
+   gate, but the lookup name should be fixed at the registration site in
+   `Parser_Templates_Inst_ClassTemplate.cpp:201`.
+ - CV-aware conversion-operator selection is duplicated between sema's
+   `structHasConversionOperatorTo` and codegen's `findConversionOperator`.
+   The two must stay aligned (or share a helper) for ODR-use marking to
+   match codegen's actual selection.
+
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ### 5. Push ODR-use marking fully into sema; reduce codegen to a pure consumer   [DONE]
@@ -239,21 +324,20 @@ separate hand-rolled walkers. The refactor was validated against the full Window
 
 ## Lower-impact, still useful
 
-### 10. Promote needsInstantiation-style queries into typed predicates   [TODO]
+### 10. Promote needsInstantiation-style queries into typed predicates   [DONE]
 
 Free-standing needsInstantiation, needsInstantiationAny, getLazyMemberInfo, getLazyMemberInfoAny are strictly-similar string-handle-keyed queries. They'd read better as methods
 on a typed LazyMemberKey value that captures struct+member+const-ness. The const-ness std::optional<bool> juggling at every call site is a minor papercut that adds up.
 
-Current state (TODO): All four free-standing overloads plus the new markOdrUsed / isOdrUsed family still use the raw StringHandle pair + bool pattern. The makeKey static
-helper in LazyMemberInstantiationRegistry is an internal step toward a typed key, but it's private and not exposed to callers.
+Current state (DONE): `TemplateRegistry_Lazy.h` now exposes a typed `LazyMemberKey` value with exact/any-const helpers, and the registry implements typed overloads for
+`needsInstantiation`, `getLazyMemberInfo`, `markInstantiated`, `markOdrUsed`, and `isOdrUsed`. The old raw `StringHandle + bool` call shape still exists only as thin wrappers
+around the typed API so call sites can migrate incrementally.
 
-Important lesson from the 2026-04-21 in-progress refactor attempt: the mechanical part is easy; the hidden risk is StringBuilder lifetime discipline inside the "any-const"
-lookup path. A representative regression (`flashcpp_crash_20260421_174831.log`) shows `StringBuilder::~StringBuilder` asserting from
-`LazyMemberInstantiationRegistry::needsInstantiation` (`src/TemplateRegistry_Lazy.h:102`) during `Parser::parse_member_postfix`, i.e. a typed-key wrapper reused the old
-`preview()`-based key construction without preserving the required `commit()/reset()` discipline. Future work on item #10 should either:
-
- - eliminate the `StringBuilder::preview()`-driven two-variant lookup pattern entirely, or
- - centralize it behind a helper that cannot return with a dirty builder state.
+Important lesson from the 2026-04-21 implementation: the mechanical API refactor was easy; the hidden risk was `StringBuilder` lifetime discipline inside the "any-const"
+lookup path. A representative regression (`flashcpp_crash_20260421_174831.log`) showed `StringBuilder::~StringBuilder` asserting from
+`LazyMemberInstantiationRegistry::needsInstantiation` during `Parser::parse_member_postfix`, i.e. a typed-key wrapper reused the old `preview()`-based two-variant lookup
+without preserving the required `commit()/reset()` discipline. The shipped fix was to eliminate that pattern in the typed any-const helpers and build committed non-const /
+const keys directly.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -284,7 +368,7 @@ exists.
 | 7 | Stable ASTNodeId                           | TODO     |
 | 8 | registerLateMaterializedTopLevelNode dedup | DONE     |
 | 9 | Shared forEachReachableStructDecl walker   | DONE     |
-|10 | Typed LazyMemberKey predicates             | TODO     |
+|10 | Typed LazyMemberKey predicates             | DONE     |
 |11 | Explicit instantiation lifecycle hooks     | TODO     |
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -302,20 +386,20 @@ hasLaterUsableTemplateDefinitionWithMatchingShape check) paper over real gaps in
 
 Item #6 (invariant probes) is now in place: future architectural tightening can keep its guardrails checked in instead of re-inventing one-off audit files for each slice.
 
-Items #10 and #11 are refactoring quality-of-life items that reduce future maintenance risk with low implementation cost.
+Item #11 remains a refactoring quality-of-life item that could reduce future maintenance risk, but item #10 is now done and already removed a fair amount of duplicated
+const-ness plumbing from the lazy-member registry API.
 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 ## Recommended next steps
 
-1. Complete item #4 (separate instantiated-struct list, consumption side): make codegen's top-level node iterator apply different emission rules for instantiated nodes
-   (emit only odr_used members) vs. user-written nodes (emit every member). This is the last structural piece the original Slice G recommendation called for.
+1. Items #2 and #3 are now the highest-value remaining architectural follow-ups. They are the Phase 6 prerequisites for principled SFINAE handling, and the existing
+   KNOWN_ISSUES workarounds are stable enough that this can be tackled deliberately instead of as an emergency cleanup.
 
-2. Item #10 (typed LazyMemberKey predicates) is now the best small cleanup. The registry API still exposes a pile of near-duplicate `StringHandle + bool` queries, and item #6
-   means future refactors can guard the migration with checked-in probes instead of temporary audits.
+2. Item #4 is still the main unfinished Slice G structural split, but it should only be retried behind a focused ODR-use coverage audit. The earlier regressions showed that the
+   data model is close, not that blind top-level filtering is safe.
 
-3. Items #2 and #3 are Phase 6 prerequisites for principled SFINAE handling. They are medium-sized architectural changes. The existing KNOWN_ISSUES workarounds are stable
-   enough to defer until Phase 6 begins.
+3. Item #7 (stable ASTNodeId) is still optional for correctness, but it becomes more attractive if the project grows more long-lived dedup/tracking sets beyond the current
+   raw_pointer()-keyed helpers.
 
-4. Item #7 (stable ASTNodeId) is still optional for correctness, but it becomes much more attractive if item #4 proceeds. Once there are multiple long-lived dedup/tracking sets,
-   raw_pointer()-identity becomes more of a liability.
+4. Item #11 (explicit instantiation lifecycle hooks) remains a smaller cleanup that can wait until there is a clearer consumer for those phases.

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -99,6 +99,12 @@ private:
 		TypeCategory bindingType() const { return type_index.category(); }
 	};
 
+	struct StructCodegenFrame {
+		StringHandle saved_enclosing_function;
+		StringHandle saved_enclosing_function_mangled;
+		StringHandle saved_struct_name;
+	};
+
 	// Generate aggregate initialization of a struct from an InitializerListNode as a default argument.
 	// Emits ConstructorCallOp + MemberStoreOps for the struct, returns a TypedValue for the temporary.
 	std::optional<TypedValue> generateDefaultStructArg(const InitializerListNode& init_list, const TypeSpecifierNode& param_type);
@@ -152,6 +158,7 @@ private:
 		std::string_view error_context);
 
 	std::vector<std::vector<ScopeVariableInfo>> scope_stack_;
+	InlineVector<StructCodegenFrame, 8> struct_codegen_frame_stack_;
 
 	void enterScope() {
 		scope_stack_.push_back({});
@@ -228,7 +235,10 @@ private:
 	bool function_has_typed_catch_ = false;
 
 	void visitFunctionDeclarationNode(const FunctionDeclarationNode& node);
+	bool beginStructDeclarationCodegen(const StructDeclarationNode& node);
+	void endStructDeclarationCodegen(const StructDeclarationNode& node);
 	void visitStructDeclarationNode(const StructDeclarationNode& node);
+	void visitNonStructOrNamespaceNode(const ASTNode& node);
 	void visitEnumDeclarationNode([[maybe_unused]] const EnumDeclarationNode& node);
 	void visitConstructorDeclarationNode(const ConstructorDeclarationNode& node);
 	void visitDestructorDeclarationNode(const DestructorDeclarationNode& node);

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1677,15 +1677,22 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 	if (context.sema) {
 		(void)context.sema->ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
-	} else if (context.parser && LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(
-									 context.struct_info->name, function_name_handle)) {
-		auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfoAny(
-			context.struct_info->name, function_name_handle);
+	} else if (context.parser && LazyMemberInstantiationRegistry::getInstance().needsInstantiation(
+									 LazyMemberKey::anyConst(
+										 context.struct_info->name,
+										 function_name_handle))) {
+		auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(
+			LazyMemberKey::anyConst(
+				context.struct_info->name,
+				function_name_handle));
 		if (lazy_info_opt.has_value()) {
 			context.parser->instantiateLazyMemberFunction(*lazy_info_opt);
 			context.normalizePendingSemanticRoots();
 			LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-				context.struct_info->name, function_name_handle, lazy_info_opt->identity.is_const_method);
+				LazyMemberKey::exact(
+					context.struct_info->name,
+					function_name_handle,
+					lazy_info_opt->identity.is_const_method));
 		}
 	}
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -966,8 +966,9 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
 			StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
 			auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
-			if (lazy_registry.needsInstantiationAny(inst_name_handle, member_handle)) {
-				auto lazy_info = lazy_registry.getLazyMemberInfoAny(inst_name_handle, member_handle);
+			LazyMemberKey member_key = LazyMemberKey::anyConst(inst_name_handle, member_handle);
+			if (lazy_registry.needsInstantiation(member_key)) {
+				auto lazy_info = lazy_registry.getLazyMemberInfo(member_key);
 				if (lazy_info.has_value()) {
 					parser_.instantiateLazyMemberFunction(*lazy_info);
 					normalizePendingSemanticRoots();

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1256,7 +1256,10 @@ bool AstToIr::beginStructDeclarationCodegen(const StructDeclarationNode& node) {
 						if (!fn.get_definition().has_value() && !fn.is_implicit() &&
 							current_struct_name_.isValid() && member_name.isValid() &&
 							LazyMemberInstantiationRegistry::getInstance().needsInstantiation(
-								current_struct_name_, member_name, fn.is_const_member_function())) {
+								LazyMemberKey::exact(
+									current_struct_name_,
+									member_name,
+									fn.is_const_member_function()))) {
 							FLASH_INVARIANT_PROBE(
 								Phase5StructDrain,
 								"codegen reached a still-lazy member function",
@@ -1297,8 +1300,10 @@ bool AstToIr::beginStructDeclarationCodegen(const StructDeclarationNode& node) {
 					if (!ctor_has_auto) {
 						if (!ctor.get_definition().has_value() &&
 							current_struct_name_.isValid() && member_name.isValid() &&
-							LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(
-								current_struct_name_, member_name)) {
+							LazyMemberInstantiationRegistry::getInstance().needsInstantiation(
+								LazyMemberKey::anyConst(
+									current_struct_name_,
+									member_name))) {
 							FLASH_INVARIANT_PROBE(
 								Phase5StructDrain,
 								"codegen reached a still-lazy constructor",

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1146,13 +1146,13 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 		// This allows nested contexts (like local struct member functions) to work properly
 }
 
-void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
+bool AstToIr::beginStructDeclarationCodegen(const StructDeclarationNode& node) {
 		// Struct declarations themselves don't generate IR - they just define types
 		// The type information is already registered in the global type system
 
 		// Skip pattern structs - they're templates and shouldn't generate code
 	if (gTemplateRegistry.isPatternStructName(node.name())) {
-		return;
+		return false;
 	}
 
 		// Skip structs with incomplete instantiation - they have unresolved template params
@@ -1160,19 +1160,21 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 		auto incomplete_it = getTypesByNameMap().find(node.name());
 		if (incomplete_it != getTypesByNameMap().end() && incomplete_it->second->is_incomplete_instantiation_) {
 			FLASH_LOG(Codegen, Debug, "Skipping struct '", StringTable::getStringView(node.name()), "' (incomplete instantiation)");
-			return;
+			return false;
 		}
 	}
+
+	StructCodegenFrame frame;
+	frame.saved_enclosing_function = current_function_name_;
+	frame.saved_enclosing_function_mangled = current_function_mangled_name_;
+	frame.saved_struct_name = current_struct_name_;
+	struct_codegen_frame_stack_.push_back(frame);
 
 	std::string_view struct_name = StringTable::getStringView(node.name());
 
 		// Generate member functions for both global and local structs
 		// Save the enclosing function context so member function visits don't clobber it
-	StringHandle saved_enclosing_function = current_function_name_;
-	StringHandle saved_struct_name = current_struct_name_;
-
-		// Check if this is a local struct (declared inside a function)
-	bool is_local_struct = current_function_name_.isValid();
+	bool is_local_struct = frame.saved_enclosing_function.isValid();
 
 		// Set struct context so member functions know which struct they belong to
 		// NOTE: We don't clear this until the next struct - the string must persist
@@ -1180,10 +1182,10 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 		// For nested classes, we need to use the fully qualified name from TypeInfo
 		// If current_struct_name_ is valid, this is a nested class, so construct fully qualified name
 	StringHandle lookup_name;
-	if (current_struct_name_.isValid()) {
+	if (frame.saved_struct_name.isValid()) {
 			// This is a nested class - construct fully qualified name like "Outer::Inner"
 		StringBuilder qualified_name_builder;
-		qualified_name_builder.append(StringTable::getStringView(current_struct_name_))
+		qualified_name_builder.append(StringTable::getStringView(frame.saved_struct_name))
 			.append("::")
 			.append(struct_name);
 		lookup_name = StringTable::getOrInternStringHandle(qualified_name_builder.commit());
@@ -1223,13 +1225,14 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 		for (const auto& member_func : node.member_functions()) {
 			LocalStructMemberInfo info;
 			info.struct_name = current_struct_name_;
-			info.enclosing_function_name = saved_enclosing_function;
+			info.enclosing_function_name = frame.saved_enclosing_function;
 			info.member_function_node = member_func.function_declaration;
 			collected_local_struct_members_.push_back(std::move(info));
 		}
 	} else {
 		FLASH_LOG(Codegen, Debug, "[STRUCT] ", struct_name, " - visiting members immediately, count=", node.member_functions().size());
 		for (const auto& member_func : node.member_functions()) {
+			const StringHandle member_name = member_func.getName();
 				// Each member function can be a FunctionDeclarationNode, ConstructorDeclarationNode, or DestructorDeclarationNode
 			FLASH_LOG(Codegen, Debug, "[STRUCT] ", struct_name, " - processing member function, is_constructor=", member_func.is_constructor);
 			try {
@@ -1250,6 +1253,17 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 						}
 					}
 					if (!fn_has_auto) {
+						if (!fn.get_definition().has_value() && !fn.is_implicit() &&
+							current_struct_name_.isValid() && member_name.isValid() &&
+							LazyMemberInstantiationRegistry::getInstance().needsInstantiation(
+								current_struct_name_, member_name, fn.is_const_member_function())) {
+							FLASH_INVARIANT_PROBE(
+								Phase5StructDrain,
+								"codegen reached a still-lazy member function",
+								"struct=", StringTable::getStringView(current_struct_name_),
+								" member=", StringTable::getStringView(member_name),
+								" const=", fn.is_const_member_function());
+						}
 							// Phase 5 Slices F-L: sema's end-of-normalization drain
 							// (AST-walk pass + ODR-use fixpoint pass) materializes every
 							// lazy member reachable from the top-level AST plus every
@@ -1281,6 +1295,16 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 						}
 					}
 					if (!ctor_has_auto) {
+						if (!ctor.get_definition().has_value() &&
+							current_struct_name_.isValid() && member_name.isValid() &&
+							LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(
+								current_struct_name_, member_name)) {
+							FLASH_INVARIANT_PROBE(
+								Phase5StructDrain,
+								"codegen reached a still-lazy constructor",
+								"struct=", StringTable::getStringView(current_struct_name_),
+								" ctor=", StringTable::getStringView(member_name));
+						}
 						// Phase 5 Slices F-L: sema's drain materializes every reachable
 						// lazy constructor before codegen. If ctor still has no body
 						// here it is either implicit (handled by visitConstructorDeclarationNode)
@@ -1333,26 +1357,15 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 		}
 	}  // End of if-else for local vs global struct
 
-		// Clear current_function_name_ before visiting nested classes
-		// Nested classes should not be treated as local structs even if we're inside
-		// a member function context (e.g., after visiting constructors which set current_function_name_)
-		// Nested classes are always at class scope, not function scope
+		// Nested classes are always at class scope, not function scope. Clear
+		// function context before the shared reachable-struct walker descends.
 	current_function_name_ = StringHandle();
 	current_function_mangled_name_ = StringHandle();
+	return true;
+}
 
-		// Save current_struct_name_ before visiting nested classes so each nested class
-		// gets the correct parent context (important when there are multiple nested classes)
-	StringHandle parent_struct_name = current_struct_name_;
-
-			// Visit nested classes recursively
-	for (const auto& nested_class_node : node.nested_classes()) {
-		if (nested_class_node.is<StructDeclarationNode>()) {
-			FLASH_LOG(Codegen, Debug, "  Visiting nested class");
-					// Restore parent context before each nested class visit
-			current_struct_name_ = parent_struct_name;
-			visitStructDeclarationNode(nested_class_node.as<StructDeclarationNode>());
-		}
-	}
+void AstToIr::endStructDeclarationCodegen(const StructDeclarationNode& node) {
+	assert(!struct_codegen_frame_stack_.empty() && "unbalanced struct codegen frame stack");
 
 			// Generate global storage for static members
 	StringHandle static_member_lookup_name = current_struct_name_.isValid()
@@ -1416,17 +1429,26 @@ void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
 			}
 		}
 	}
-			// Clear current_struct_name_ for top-level structs
 
-	if (current_struct_name_.isValid()) {
-		std::string_view current_name = StringTable::getStringView(current_struct_name_);
-		if (current_name.find("::") == std::string_view::npos) {
-			current_struct_name_ = StringHandle();
-		}
+	const StructCodegenFrame frame = struct_codegen_frame_stack_.back();
+	struct_codegen_frame_stack_.pop_back();
+	current_function_name_ = frame.saved_enclosing_function;
+	current_function_mangled_name_ = frame.saved_enclosing_function_mangled;
+	current_struct_name_ = frame.saved_struct_name;
+}
+
+void AstToIr::visitStructDeclarationNode(const StructDeclarationNode& node) {
+	if (!beginStructDeclarationCodegen(node)) {
+		return;
 	}
-		// Restore the enclosing function and struct context
-	current_function_name_ = saved_enclosing_function;
-	current_struct_name_ = saved_struct_name;
+	for (const auto& nested_class_node : node.nested_classes()) {
+		if (!nested_class_node.is<StructDeclarationNode>()) {
+			continue;
+		}
+		FLASH_LOG(Codegen, Debug, "  Visiting nested class");
+		visitStructDeclarationNode(nested_class_node.as<StructDeclarationNode>());
+	}
+	endStructDeclarationCodegen(node);
 }
 
 void AstToIr::visitEnumDeclarationNode(const EnumDeclarationNode& node) {

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -1,6 +1,7 @@
 #include "Parser.h"
 #include "IrGenerator.h"
 #include "CallNodeHelpers.h"
+#include "ReachableStructWalker.h"
 #include "RebindStaticMemberAst.h"
 
 AstToIr::AstToIr(SymbolTable& global_symbol_table, CompileContext& context, Parser& parser)
@@ -20,6 +21,36 @@ void AstToIr::visit(const ASTNode& node) {
 		return;
 	}
 
+	if (node.is<StructDeclarationNode>() || node.is<NamespaceDeclarationNode>()) {
+		// Top-level/file-scope structs and namespace-contained structs should never
+		// inherit a stale enclosing-struct context from a previously visited node.
+		// The shared reachable-struct walker handles true nested-class context via
+		// beginStructDeclarationCodegen/endStructDeclarationCodegen; clear only the
+		// ambient root-level context here.
+		current_struct_name_ = StringHandle();
+	}
+
+	FlashCpp::walkReachableStructDecls(
+		node,
+		[this](const StructDeclarationNode& struct_node) {
+			return beginStructDeclarationCodegen(struct_node);
+		},
+		[this](const StructDeclarationNode& struct_node) {
+			endStructDeclarationCodegen(struct_node);
+		},
+		[this](const NamespaceDeclarationNode& ns) {
+			current_namespace_stack_.push_back(std::string(ns.name()));
+			return true;
+		},
+		[this](const NamespaceDeclarationNode&) {
+			current_namespace_stack_.pop_back();
+		},
+		[this](const ASTNode& other_node) {
+			visitNonStructOrNamespaceNode(other_node);
+		});
+}
+
+void AstToIr::visitNonStructOrNamespaceNode(const ASTNode& node) {
 	if (node.is<FunctionDeclarationNode>()) {
 		visitFunctionDeclarationNode(node.as<FunctionDeclarationNode>());
 		// Clear function context after completing a top-level function
@@ -65,15 +96,8 @@ void AstToIr::visit(const ASTNode& node) {
 	} else if (node.is<ExpressionNode>()) {
 		visitExpressionNode(node.as<ExpressionNode>());
 		emitAndClearFullExpressionTempDestructors();
-	} else if (node.is<StructDeclarationNode>()) {
-		// Clear struct context for top-level structs to prevent them from being
-		// mistakenly treated as nested classes of the previous struct
-		current_struct_name_ = StringHandle();
-		visitStructDeclarationNode(node.as<StructDeclarationNode>());
 	} else if (node.is<EnumDeclarationNode>()) {
 		visitEnumDeclarationNode(node.as<EnumDeclarationNode>());
-	} else if (node.is<NamespaceDeclarationNode>()) {
-		visitNamespaceDeclarationNode(node.as<NamespaceDeclarationNode>());
 	} else if (node.is<UsingDirectiveNode>()) {
 		visitUsingDirectiveNode(node.as<UsingDirectiveNode>());
 	} else if (node.is<UsingDeclarationNode>()) {

--- a/src/Log.h
+++ b/src/Log.h
@@ -1,11 +1,16 @@
 // ===== src/Log.h (header-only) =====
 
 #pragma once
+#include "CompileError.h"
 #include <iostream>
 #include <string_view>
+#include <string>
 #include <cstdint>
 #include <array>
+#include <cctype>
+#include <fstream>
 #include <format>
+#include <sstream>
 
 namespace FlashCpp {
 
@@ -59,6 +64,14 @@ enum class LogLevel : uint8_t {
 // Set this via compiler flag: -DFLASHCPP_DEFAULT_RUNTIME_LEVEL=2
 #ifndef FLASHCPP_DEFAULT_RUNTIME_LEVEL
 #define FLASHCPP_DEFAULT_RUNTIME_LEVEL 2	 // Both Debug and Release default to Info level (General category always enabled regardless of level)
+#endif
+
+// Invariant probe mode:
+//   0 = off  (compiled out)
+//   1 = log  (append to audit_<probe>.log and emit a warning)
+//   2 = fail (throw InternalError)
+#ifndef FLASHCPP_INVARIANT_PROBE_MODE
+#define FLASHCPP_INVARIANT_PROBE_MODE 0
 #endif
 
 // ANSI color codes for terminal output
@@ -328,6 +341,89 @@ constexpr bool isLogEnabled() {
 template <typename... Args>
 inline void flash_log_unused(Args&&...) {}
 
+inline std::string sanitizeInvariantProbeName(std::string_view probe_name) {
+	std::string sanitized;
+	sanitized.reserve(probe_name.size());
+	for (char ch : probe_name) {
+		unsigned char uch = static_cast<unsigned char>(ch);
+		if (std::isalnum(uch) || ch == '_' || ch == '-') {
+			sanitized.push_back(ch);
+		} else {
+			sanitized.push_back('_');
+		}
+	}
+	if (sanitized.empty()) {
+		sanitized = "unnamed";
+	}
+	return sanitized;
+}
+
+template <typename... Args>
+inline std::string buildInvariantProbeMessage(
+	std::string_view probe_name,
+	std::string_view message,
+	Args&&... args) {
+	std::ostringstream out;
+	out << "[INVARIANT][" << probe_name << "] " << message;
+	((out << " " << std::forward<Args>(args)), ...);
+	return out.str();
+}
+
+inline void appendInvariantProbeLog(std::string_view probe_name, const std::string& text) {
+	std::string filename = "audit_" + sanitizeInvariantProbeName(probe_name) + ".log";
+	std::ofstream file(filename, std::ios::app);
+	if (!file) {
+		Logger<LogLevel::Warning, LogCategory::General>::log(
+			"[INVARIANT][", probe_name, "] failed to open log file ", filename);
+		return;
+	}
+	file << text << "\n";
+}
+
+template <typename... Args>
+inline void logInvariantProbe(
+	std::string_view probe_name,
+	std::string_view message,
+	Args&&... args) {
+	std::string text = buildInvariantProbeMessage(
+		probe_name,
+		message,
+		std::forward<Args>(args)...);
+	appendInvariantProbeLog(probe_name, text);
+	Logger<LogLevel::Warning, LogCategory::General>::log(text);
+}
+
+template <typename... Args>
+[[noreturn]] inline void failInvariantProbe(
+	std::string_view probe_name,
+	std::string_view message,
+	Args&&... args) {
+	throw InternalError(buildInvariantProbeMessage(
+		probe_name,
+		message,
+		std::forward<Args>(args)...));
+}
+
+template <typename... Args>
+inline void logInvariantProbeFormatted(
+	std::string_view probe_name,
+	std::string_view fmt,
+	Args&&... args) {
+	logInvariantProbe(
+		probe_name,
+		std::vformat(fmt, std::make_format_args(args...)));
+}
+
+template <typename... Args>
+[[noreturn]] inline void failInvariantProbeFormatted(
+	std::string_view probe_name,
+	std::string_view fmt,
+	Args&&... args) {
+	throw InternalError(buildInvariantProbeMessage(
+		probe_name,
+		std::vformat(fmt, std::make_format_args(args...))));
+}
+
 // FLASH_LOG macro - completely eliminated at preprocessing when level is disabled
 // Now with runtime check BEFORE evaluating arguments to avoid expensive string construction
 #if FLASHCPP_LOG_LEVEL >= 4	// Trace
@@ -509,5 +605,28 @@ inline void flash_log_unused(Args&&...) {}
 
 // Main FLASH_LOG_FORMAT macro that dispatches based on level
 #define FLASH_LOG_FORMAT(cat, level, fmt, ...) FLASH_LOG_FORMAT_##level##_IMPL(cat, fmt, __VA_ARGS__)
+
+#if FLASHCPP_INVARIANT_PROBE_MODE == 0
+#define FLASH_INVARIANT_PROBE(name, ...) ::FlashCpp::flash_log_unused(__VA_ARGS__)
+#define FLASH_INVARIANT_PROBE_FORMAT(name, ...) ::FlashCpp::flash_log_unused(__VA_ARGS__)
+#elif FLASHCPP_INVARIANT_PROBE_MODE == 1
+#define FLASH_INVARIANT_PROBE(name, message, ...) \
+	do { \
+		::FlashCpp::logInvariantProbe(#name, message, __VA_ARGS__); \
+	} while (0)
+#define FLASH_INVARIANT_PROBE_FORMAT(name, fmt, ...) \
+	do { \
+		::FlashCpp::logInvariantProbeFormatted(#name, fmt, __VA_ARGS__); \
+	} while (0)
+#else
+#define FLASH_INVARIANT_PROBE(name, message, ...) \
+	do { \
+		::FlashCpp::failInvariantProbe(#name, message, __VA_ARGS__); \
+	} while (0)
+#define FLASH_INVARIANT_PROBE_FORMAT(name, fmt, ...) \
+	do { \
+		::FlashCpp::failInvariantProbeFormatted(#name, fmt, __VA_ARGS__); \
+	} while (0)
+#endif
 
 } // namespace FlashCpp

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -497,6 +497,13 @@ private:
 	// Maintained in lockstep with ast_nodes_ via the appendUserNode /
 	// registerLateMaterializedTopLevelNode* / eraseTopLevelNodeAt helpers.
 	std::vector<uint8_t> ast_node_is_instantiated_;
+	// Dedup set for late-materialized (instantiated) top-level nodes.
+	// Keyed by ASTNode::raw_pointer() which is stable for the node's lifetime
+	// (ChunkedAnyVector storage). Prevents duplicate pushes of the same
+	// instantiated struct/function, which would cause LNK2005 "symbol defined
+	// multiple times" at link time when codegen iterates the list. See
+	// docs/2026-04-21-phase5-slice-g-analysis.md item #8.
+	std::unordered_set<const void*> instantiated_node_keys_;
 	std::vector<ASTNode> pending_semantic_roots_;
 	std::unordered_set<const void*> pending_semantic_root_keys_;
 	SemanticAnalysis* active_sema_ = nullptr;
@@ -1712,6 +1719,9 @@ public:
 		if (index >= ast_nodes_.size()) {
 			return;
 		}
+		if (const void* key = ast_nodes_[index].raw_pointer()) {
+			instantiated_node_keys_.erase(key);
+		}
 		ast_nodes_.erase(ast_nodes_.begin() + static_cast<std::ptrdiff_t>(index));
 		if (index < ast_node_is_instantiated_.size()) {
 			ast_node_is_instantiated_.erase(
@@ -1722,7 +1732,22 @@ public:
 	/// Register a late-materialized AST node for codegen and sema processing.
 	/// Does NOT normalize immediately - use for batched registration.
 	/// After batched registration, call normalizePendingSemanticRootsIfAvailable().
+	///
+	/// Idempotent: if `node` has already been registered as a late-materialized
+	/// top-level node (same ASTNode::raw_pointer()), this is a no-op. Multiple
+	/// instantiation paths (partial-spec success, primary-template success,
+	/// base-class helper recursion) may reach the same freshly-created struct;
+	/// silently double-pushing would produce LNK2005 at codegen time.
 	void registerLateMaterializedTopLevelNode(const ASTNode& node) {
+		if (const void* key = node.raw_pointer()) {
+			auto [_, inserted] = instantiated_node_keys_.insert(key);
+			if (!inserted) {
+				// Still make sure sema sees it (enqueuePendingSemanticRoot is
+				// itself dedup'd, so this is safe).
+				enqueuePendingSemanticRoot(node);
+				return;
+			}
+		}
 		ast_nodes_.push_back(node);
 		ast_node_is_instantiated_.push_back(1);
 		enqueuePendingSemanticRoot(node);
@@ -1730,7 +1755,15 @@ public:
 
 	/// Register a late-materialized AST node at the front of the node list.
 	/// Does NOT normalize immediately - use for dependencies that must be processed first.
+	/// Idempotent by raw_pointer() identity (see registerLateMaterializedTopLevelNode).
 	void registerLateMaterializedTopLevelNodeFront(const ASTNode& node) {
+		if (const void* key = node.raw_pointer()) {
+			auto [_, inserted] = instantiated_node_keys_.insert(key);
+			if (!inserted) {
+				enqueuePendingSemanticRoot(node);
+				return;
+			}
+		}
 		ast_nodes_.insert(ast_nodes_.begin(), node);
 		ast_node_is_instantiated_.insert(ast_node_is_instantiated_.begin(), 1);
 		enqueuePendingSemanticRoot(node);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -413,6 +413,16 @@ public:
 			&& ast_node_is_instantiated_[index] != 0;
 	}
 
+	// Returns true when the node at `index` is a late-materialized top-level
+	// struct root. These are tracked separately from user-written source nodes
+	// for codegen/drain consumption even though they still live in ast_nodes_
+	// for parser/sema lifecycle purposes.
+	bool isInstantiatedStructNode(size_t index) const {
+		return isInstantiatedNode(index)
+			&& index < ast_nodes_.size()
+			&& ast_nodes_[index].is<StructDeclarationNode>();
+	}
+
 	// Number of user-written top-level nodes (added during initial parsing).
 	size_t userNodeCount() const {
 		size_t n = 0;

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -298,15 +298,20 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 			if (!func_name.empty()) {
 				StringHandle class_name_handle = StringTable::getOrInternStringHandle(*object_struct_name);
 				StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
-				if (LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(class_name_handle, func_name_handle)) {
+				LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, func_name_handle);
+				if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 					FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for: ", *object_struct_name, "::", func_name);
-					auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfoAny(class_name_handle, func_name_handle);
+					auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
 					if (lazy_info_opt.has_value()) {
 						const LazyMemberFunctionInfo& lazy_info = *lazy_info_opt;
 						instantiating_lazy_member_ = true;
 						instantiated_func = instantiateLazyMemberFunction(lazy_info);
 						instantiating_lazy_member_ = false;
-						LazyMemberInstantiationRegistry::getInstance().markInstantiated(class_name_handle, func_name_handle, lazy_info.identity.is_const_method);
+						LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+							LazyMemberKey::exact(
+								class_name_handle,
+								func_name_handle,
+								lazy_info.identity.is_const_method));
 						FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
 					}
 				}
@@ -929,14 +934,19 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						auto class_type_it = getTypesByNameMap().find(class_name_handle);
 						if (class_type_it != getTypesByNameMap().end() && class_type_it->second->isTemplateInstantiation()) {
 							StringHandle member_name_handle = final_identifier.handle();
-							if (LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(class_name_handle, member_name_handle)) {
-								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfoAny(class_name_handle, member_name_handle);
+							LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
+							if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
 								if (lazy_info_opt.has_value()) {
 									auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
 									if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
 										qualified_symbol = instantiated_func;
 										decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
-										LazyMemberInstantiationRegistry::getInstance().markInstantiated(class_name_handle, member_name_handle, lazy_info_opt->identity.is_const_method);
+										LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+											LazyMemberKey::exact(
+												class_name_handle,
+												member_name_handle,
+												lazy_info_opt->identity.is_const_method));
 									}
 								}
 							}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2608,15 +2608,23 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								if (!func_decl.get_definition().has_value() && inst_type_it != getTypesByNameMap().end() && inst_type_it->second->isTemplateInstantiation()) {
 									StringHandle member_name_handle = member_token.handle();
 									const bool member_is_const = func_decl.is_const_member_function();
+									LazyMemberKey member_key = LazyMemberKey::exact(
+										class_name_handle,
+										member_name_handle,
+										member_is_const);
 									if (!in_sfinae_context_ &&
-										LazyMemberInstantiationRegistry::getInstance().needsInstantiation(class_name_handle, member_name_handle, member_is_const)) {
-										auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(class_name_handle, member_name_handle, member_is_const);
+										LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+										auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
 										if (lazy_info_opt.has_value()) {
 											auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
 											if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
 												member_lookup = instantiated_func;
 												decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
-												LazyMemberInstantiationRegistry::getInstance().markInstantiated(class_name_handle, member_name_handle, lazy_info_opt->identity.is_const_method);
+												LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+													LazyMemberKey::exact(
+														class_name_handle,
+														member_name_handle,
+														lazy_info_opt->identity.is_const_method));
 											}
 										}
 									}
@@ -3564,14 +3572,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (scope_type_it != getTypesByNameMap().end() && scope_type_it->second->isTemplateInstantiation()) {
 							StringHandle member_name_handle = qual_id.identifier_token().handle();
 							const bool member_is_const = identifierType->as<FunctionDeclarationNode>().is_const_member_function();
+							LazyMemberKey member_key = LazyMemberKey::exact(
+								class_name_handle,
+								member_name_handle,
+								member_is_const);
 							if (!in_sfinae_context_ &&
-								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(class_name_handle, member_name_handle, member_is_const)) {
-								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(class_name_handle, member_name_handle, member_is_const);
+								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
 								if (lazy_info_opt.has_value()) {
 									auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
 									if (instantiated_func.has_value()) {
 										identifierType = *instantiated_func;
-										LazyMemberInstantiationRegistry::getInstance().markInstantiated(class_name_handle, member_name_handle, lazy_info_opt->identity.is_const_method);
+										LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+											LazyMemberKey::exact(
+												class_name_handle,
+												member_name_handle,
+												lazy_info_opt->identity.is_const_method));
 									}
 								}
 							}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -246,13 +246,18 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	if (!instantiated_func.has_value() && !in_sfinae_context_) {
 		StringHandle class_name_handle = StringTable::getOrInternStringHandle(instantiated_class_name);
 		StringHandle member_name_handle = StringTable::getOrInternStringHandle(member_name);
+		LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
 		FLASH_LOG(Templates, Debug, "Checking lazy instantiation for: ", instantiated_class_name, "::", member_name);
-		if (LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(class_name_handle, member_name_handle)) {
+		if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 			FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for qualified call: ", instantiated_class_name, "::", member_name);
-			auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfoAny(class_name_handle, member_name_handle);
+			auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
 			if (lazy_info_opt.has_value()) {
 				instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
-				LazyMemberInstantiationRegistry::getInstance().markInstantiated(class_name_handle, member_name_handle, lazy_info_opt->identity.is_const_method);
+				LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+					LazyMemberKey::exact(
+						class_name_handle,
+						member_name_handle,
+						lazy_info_opt->identity.is_const_method));
 			}
 		}
 		// If the hash-based name didn't match (dependent vs concrete hash mismatch),
@@ -267,13 +272,18 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 						StringTable::getStringView(type_info_ptr->baseTemplateName()) == base_tmpl &&
 						StringTable::getStringView(name_handle) != instantiated_class_name) {
 						StringHandle alt_class_handle = name_handle;
-						if (LazyMemberInstantiationRegistry::getInstance().needsInstantiationAny(alt_class_handle, member_name_handle)) {
+						LazyMemberKey alt_member_key = LazyMemberKey::anyConst(alt_class_handle, member_name_handle);
+						if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(alt_member_key)) {
 							FLASH_LOG(Templates, Debug, "Lazy instantiation triggered via base template match: ",
 									  StringTable::getStringView(alt_class_handle), "::", member_name);
-							auto lazy_info_opt2 = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfoAny(alt_class_handle, member_name_handle);
+							auto lazy_info_opt2 = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(alt_member_key);
 							if (lazy_info_opt2.has_value()) {
 								instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt2);
-								LazyMemberInstantiationRegistry::getInstance().markInstantiated(alt_class_handle, member_name_handle, lazy_info_opt2->identity.is_const_method);
+								LazyMemberInstantiationRegistry::getInstance().markInstantiated(
+									LazyMemberKey::exact(
+										alt_class_handle,
+										member_name_handle,
+										lazy_info_opt2->identity.is_const_method));
 								// Update instantiated_class_name to the correct one for mangling
 								instantiated_class_name = StringTable::getStringView(alt_class_handle);
 								break;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -581,17 +581,22 @@ static void instantiateDeferredStaticInitializerCalls(
 			}
 		}
 
-		if (!needs_instantiation || !lazy_registry.needsInstantiationAny(owner_name, member_name)) {
+		LazyMemberKey member_key = LazyMemberKey::anyConst(owner_name, member_name);
+		if (!needs_instantiation || !lazy_registry.needsInstantiation(member_key)) {
 			return;
 		}
 
-		auto lazy_info = lazy_registry.getLazyMemberInfoAny(owner_name, member_name);
+		auto lazy_info = lazy_registry.getLazyMemberInfo(member_key);
 		if (!lazy_info.has_value()) {
 			return;
 		}
 
 		parser->instantiateLazyMemberFunction(*lazy_info);
-		lazy_registry.markInstantiated(owner_name, member_name, lazy_info->identity.is_const_method);
+		lazy_registry.markInstantiated(
+			LazyMemberKey::exact(
+				owner_name,
+				member_name,
+				lazy_info->identity.is_const_method));
 	});
 }
 

--- a/src/ReachableStructWalker.h
+++ b/src/ReachableStructWalker.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "AstNodeTypes_Core.h"
+#include "AstNodeTypes_Expr.h"
+#include "AstNodeTypes_Template.h"
+
+namespace FlashCpp {
+
+template <typename OnStructEnter,
+		  typename OnStructExit,
+		  typename OnNamespaceEnter,
+		  typename OnNamespaceExit,
+		  typename OnOtherNode>
+void walkReachableStructDecls(
+	const ASTNode& root,
+	OnStructEnter&& on_struct_enter,
+	OnStructExit&& on_struct_exit,
+	OnNamespaceEnter&& on_namespace_enter,
+	OnNamespaceExit&& on_namespace_exit,
+	OnOtherNode&& on_other_node) {
+	const auto walk = [&](auto&& self, const ASTNode& node) -> void {
+		if (!node.has_value()) {
+			return;
+		}
+
+		if (node.is<NamespaceDeclarationNode>()) {
+			const auto& ns = node.as<NamespaceDeclarationNode>();
+			if (!on_namespace_enter(ns)) {
+				return;
+			}
+			for (const auto& child : ns.declarations()) {
+				self(self, child);
+			}
+			on_namespace_exit(ns);
+			return;
+		}
+
+		if (node.is<StructDeclarationNode>()) {
+			const auto& decl = node.as<StructDeclarationNode>();
+			if (!on_struct_enter(decl)) {
+				return;
+			}
+			for (const auto& nested : decl.nested_classes()) {
+				self(self, nested);
+			}
+			on_struct_exit(decl);
+			return;
+		}
+
+		on_other_node(node);
+	};
+
+	walk(walk, root);
+}
+
+template <typename OnStruct>
+void forEachReachableStructDecl(const ASTNode& root, OnStruct&& on_struct) {
+	walkReachableStructDecls(
+		root,
+		[&](const StructDeclarationNode& decl) {
+			on_struct(decl);
+			return true;
+		},
+		[](const StructDeclarationNode&) {},
+		[](const NamespaceDeclarationNode&) { return true; },
+		[](const NamespaceDeclarationNode&) {},
+		[](const ASTNode&) {});
+}
+
+} // namespace FlashCpp

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5204,9 +5204,10 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	//
 	// But codegen must emit a call to the *instantiation's* member
 	// (`Box$hash::helper`), whose body has `T` substituted. If we leave this
-	// unhandled here, the codegen-side `materializeLazyMemberIfNeeded`
-	// forwarder ends up being the first materializer for that instantiation
-	// member.
+	// unmarked here, no ODR-use signal reaches the end-of-sema drain and the
+	// instantiation's body never gets materialized. (Slices I+J removed the
+	// codegen-side `materializeLazyMemberIfNeeded` forwarder that used to be
+	// the fallback first-materializer; ODR-use marking is now the only path.)
 	//
 	// We remap here: if `member_context_stack_` shows we're currently
 	// normalizing a member of some instantiation `I`, and the lazy registry
@@ -5536,12 +5537,14 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 					// Phase 5 Slice G: annotate the freshly-substituted body so
 					// its internal call expressions run through the sema sites
 					// that call `markOdrUsed` on their resolved targets. Without
-					// this, inner calls would only be resolved at codegen time
-					// (via the `materializeLazyMemberIfNeeded` forwarder), which
-					// is exactly the residual we want to eliminate. The
-					// normalize helpers are idempotent via `normalized_bodies_`
-					// dedup, so re-normalizing an already-processed node is a
-					// safe no-op.
+					// this, inner calls would never reach the drain's ODR-use
+					// second pass and the corresponding instantiation members
+					// would stay unmaterialized. (Slices I+J deleted the
+					// codegen-side `materializeLazyMemberIfNeeded` forwarder
+					// that used to pick up these stragglers at lowering time.)
+					// The normalize helpers are idempotent via
+					// `normalized_bodies_` dedup, so re-normalizing an
+					// already-processed node is a safe no-op.
 					normalizeTopLevelNode(*result);
 				}
 			}
@@ -5573,19 +5576,21 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 	// registrations (e.g., a template instantiation used inside the body we
 	// just substituted). Keep walking until no more work happens.
 	//
-	// We intentionally only walk structs reachable from `parser_.get_nodes()`:
-	// they are exactly the structs whose members the codegen struct-visitor
-	// iterates. Extending the walk to the set of *all* instantiated class
-	// templates (e.g., via a side list populated by
+	// We intentionally only walk structs reachable from `parser_.get_nodes()`
+	// in this first pass: they are exactly the structs whose members the
+	// codegen struct-visitor iterates. Extending this walk to the set of *all*
+	// instantiated class templates (e.g., via a side list populated by
 	// `try_instantiate_class_template`) would over-materialize members of
 	// structs that only ever appear as template arguments in SFINAE-probed
 	// positions — their member bodies may be ill-formed by design (see
 	// `tests/test_namespaced_pair_swap_sfinae_ret0.cpp` where
 	// `pair<const int, int>::swap` references a deleted overload and is only
-	// valid to instantiate lazily via ODR-use, which never happens). The
-	// residual cases where a codegen call site still needs lazy
-	// materialization are handled by `AstToIr::materializeLazyMemberIfNeeded`,
-	// which forwards to `ensureMemberFunctionMaterialized` on demand.
+	// valid to instantiate lazily via ODR-use, which never happens).
+	//
+	// Non-reachable instantiations whose members *are* ODR-used are caught by
+	// the second pass below (`snapshotOdrUsedLazyEntries`). Slices I+J deleted
+	// the codegen-side `materializeLazyMemberIfNeeded` forwarder so every
+	// lazy-member materialization now flows through this drain.
 	while (true) {
 		size_t before = total_materialized;
 		for (const auto& top_node : parser_.get_nodes()) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1418,6 +1418,32 @@ ASTNode SemanticAnalysis::normalizeRangedForLoopDecl(const RangedForStatementNod
 	mutable_stmt.set_resolved_member_begin_function(&begin_func_decl);
 	mutable_stmt.set_resolved_member_end_function(&end_func_decl);
 	mutable_stmt.set_resolved_begin_is_const(begin_func->is_const());
+
+	// Phase 5 Slice G item #4 prep: range-for member begin/end calls are
+	// lowered by codegen without flowing through
+	// tryAnnotateCallArgConversionsImpl, so no sema site marks these lazy
+	// members ODR-used. When the range is a concrete template instantiation,
+	// pass-1 drain over the instantiated root is what currently materialises
+	// them; once that pass-1 skip lands, we must emit the ODR-use marker
+	// here. Mark both the selected const variant and the opposite variant
+	// the registry actually holds (resolver may return pattern-const info).
+	if (range_type_info->isTemplateInstantiation()) {
+		auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
+		StringHandle owner_name = range_type_info->name();
+		StringHandle begin_handle = begin_func_decl.decl_node().identifier_token().handle();
+		StringHandle end_handle = end_func_decl.decl_node().identifier_token().handle();
+		for (StringHandle member : {begin_handle, end_handle}) {
+			for (bool is_const : {begin_func->is_const(), !begin_func->is_const()}) {
+				if (lazy_registry.needsInstantiation(
+						LazyMemberKey::exact(owner_name, member, is_const))) {
+					lazy_registry.markOdrUsed(
+						LazyMemberKey::exact(owner_name, member, is_const));
+					break;
+				}
+			}
+		}
+	}
+
 	const TypeSpecifierNode& begin_return_type = begin_func_decl.decl_node().type_node().as<TypeSpecifierNode>();
 	const FunctionDeclarationNode* dereference_func = nullptr;
 	if (begin_return_type.pointer_depth() == 0) {
@@ -5334,20 +5360,27 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	// non-member-view of the decl (e.g. using-decl pack statics, certain
 	// static-member / free-function overload candidates). In that case we
 	// derive the instantiated owner purely from the receiver type below.
-
 	const CanonicalTypeId receiver_type_id = inferExpressionType(call_info.receiver);
-	if (!receiver_type_id) {
-		return result;
+	const TypeInfo* receiver_type_info = nullptr;
+	if (receiver_type_id) {
+		const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
+		if (receiver_desc.category() == TypeCategory::Struct ||
+			receiver_desc.category() == TypeCategory::UserDefined) {
+			receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
+			if (!receiver_type_info && receiver_desc.category() == TypeCategory::UserDefined) {
+				const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(receiver_desc.type_index);
+				receiver_type_info = resolved_alias.terminal_type_info;
+			}
+		}
 	}
-	const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
-	if (receiver_desc.category() != TypeCategory::Struct &&
-		receiver_desc.category() != TypeCategory::UserDefined) {
-		return result;
-	}
-	const TypeInfo* receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
-	if (!receiver_type_info && receiver_desc.category() == TypeCategory::UserDefined) {
-		const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(receiver_desc.type_index);
-		receiver_type_info = resolved_alias.terminal_type_info;
+	// Fallback: if receiver type inference failed (e.g. unresolved `this`
+	// in a late-materialised dependent member body), use the innermost
+	// member-context. That is the struct whose body we are currently
+	// annotating, which for `this->member()` calls is the correct
+	// receiver type.
+	if ((!receiver_type_info || !receiver_type_info->isStruct()) &&
+		!member_context_stack_.empty()) {
+		receiver_type_info = tryGetTypeInfo(member_context_stack_.back());
 	}
 	if (!receiver_type_info || !receiver_type_info->isStruct()) {
 		return result;
@@ -5769,6 +5802,9 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 		size_t before = total_materialized;
 		const auto& top_nodes = parser_.get_nodes();
 		for (size_t i = 0; i < top_nodes.size(); ++i) {
+			if (parser_.isInstantiatedNode(i)) {
+				continue;
+			}
 			FlashCpp::forEachReachableStructDecl(top_nodes[i], drainOneStruct);
 		}
 		if (total_materialized == before) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -9,6 +9,7 @@
 #include "OverloadResolution.h"
 #include "Log.h"
 #include "IrGenerator.h"
+#include "ReachableStructWalker.h"
 
 namespace {
 constexpr std::string_view kTemplatePatternStructSuffix = "$pattern__";
@@ -5551,27 +5552,6 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 		}
 	};
 
-	// Recursive walker over every top-level AST node. Struct declarations can
-	// appear at the top level, nested inside namespaces, or nested inside
-	// other structs; mirror the codegen struct-visitor's reachability.
-	auto walkNode = [&](auto& self, const ASTNode& node) -> void {
-		if (!node.has_value()) {
-			return;
-		}
-		if (node.is<StructDeclarationNode>()) {
-			const auto& struct_decl = node.as<StructDeclarationNode>();
-			drainOneStruct(struct_decl);
-			for (const auto& nested : struct_decl.nested_classes()) {
-				self(self, nested);
-			}
-		} else if (node.is<NamespaceDeclarationNode>()) {
-			const auto& ns = node.as<NamespaceDeclarationNode>();
-			for (const auto& child : ns.declarations()) {
-				self(self, child);
-			}
-		}
-	};
-
 	// Loop because materializing one body may trigger further lazy
 	// registrations (e.g., a template instantiation used inside the body we
 	// just substituted). Keep walking until no more work happens.
@@ -5594,7 +5574,7 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 	while (true) {
 		size_t before = total_materialized;
 		for (const auto& top_node : parser_.get_nodes()) {
-			walkNode(walkNode, top_node);
+			FlashCpp::forEachReachableStructDecl(top_node, drainOneStruct);
 		}
 		if (total_materialized == before) {
 			break;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5310,6 +5310,120 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	return func_decl;
 }
 
+const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
+	const FunctionDeclarationNode* func_decl,
+	const CallInfo& call_info) {
+	// First run the base marker (intra-instantiation remap + pattern-parent
+	// lazy materialization).
+	const FunctionDeclarationNode* result = tryMaterializeLazyCallTarget(func_decl);
+	if (!func_decl) {
+		return result;
+	}
+	// Phase 5 Slice G item #4 blockers (5)/(6): when the resolver returns a
+	// member-function decl whose parent_struct_name is empty (using-decl pack
+	// or static-like overload pick) or points at a template pattern (pattern
+	// member reached via an instantiation receiver), derive the concrete
+	// instantiated owner from the call's receiver type and mark that lazy
+	// member ODR-used so drain pass-2 materialises it.
+	if (!call_info.has_receiver || !call_info.receiver.has_value()) {
+		return result;
+	}
+
+	const std::string_view parent_sv = func_decl->parent_struct_name();
+	// Note: parent_sv may be empty for member calls whose resolver picked a
+	// non-member-view of the decl (e.g. using-decl pack statics, certain
+	// static-member / free-function overload candidates). In that case we
+	// derive the instantiated owner purely from the receiver type below.
+
+	const CanonicalTypeId receiver_type_id = inferExpressionType(call_info.receiver);
+	if (!receiver_type_id) {
+		return result;
+	}
+	const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
+	if (receiver_desc.category() != TypeCategory::Struct &&
+		receiver_desc.category() != TypeCategory::UserDefined) {
+		return result;
+	}
+	const TypeInfo* receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
+	if (!receiver_type_info && receiver_desc.category() == TypeCategory::UserDefined) {
+		const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(receiver_desc.type_index);
+		receiver_type_info = resolved_alias.terminal_type_info;
+	}
+	if (!receiver_type_info || !receiver_type_info->isStruct()) {
+		return result;
+	}
+
+	// Walk up the inheritance chain searching for an instantiated struct
+	// whose template pattern matches `parent_sv`. This handles both the
+	// direct case (receiver IS an instantiation of the owning template)
+	// and the using-decl pack case (receiver is a derived aggregate whose
+	// base is the relevant instantiation).
+	auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
+	StringHandle member_handle = func_decl->decl_node().identifier_token().handle();
+	const bool is_const = func_decl->is_const_member_function();
+	StringHandle parent_handle = parent_sv.empty()
+		? StringHandle()
+		: StringTable::getOrInternStringHandle(parent_sv);
+
+	auto try_mark = [&](const TypeInfo* type_info) -> bool {
+		if (!type_info || !type_info->isStruct()) {
+			return false;
+		}
+		StringHandle candidate_name = type_info->name();
+		if (!candidate_name.isValid() || (parent_handle.isValid() && candidate_name == parent_handle)) {
+			return false;
+		}
+		if (parent_handle.isValid()) {
+			auto pattern_opt = gTemplateRegistry.get_instantiation_pattern(candidate_name);
+			if (!pattern_opt.has_value() || pattern_opt.value() != parent_handle) {
+				return false;
+			}
+		} else {
+			if (!type_info->isTemplateInstantiation()) {
+				return false;
+			}
+		}
+		// Resolver may have lost const-qualification info when it resolves a
+		// member call through a pack/using-decl/instantiated path; try both
+		// const variants and mark whichever the lazy registry actually knows.
+		bool marked = false;
+		for (bool const_variant : {is_const, !is_const}) {
+			if (lazy_registry.needsInstantiation(
+					LazyMemberKey::exact(candidate_name, member_handle, const_variant))) {
+				lazy_registry.markOdrUsed(
+					LazyMemberKey::exact(candidate_name, member_handle, const_variant));
+				marked = true;
+				break;
+			}
+		}
+		return marked;
+	};
+
+	if (try_mark(receiver_type_info)) {
+		return result;
+	}
+
+	// Search base classes transitively.
+	auto searchBases = [&](auto&& self, const TypeInfo* ti) -> bool {
+		const StructTypeInfo* si = ti ? ti->getStructInfo() : nullptr;
+		if (!si) {
+			return false;
+		}
+		for (const auto& base_spec : si->base_classes) {
+			const TypeInfo* base_ti = tryGetTypeInfo(base_spec.type_index);
+			if (try_mark(base_ti)) {
+				return true;
+			}
+			if (self(self, base_ti)) {
+				return true;
+			}
+		}
+		return false;
+	};
+	searchBases(searchBases, receiver_type_info);
+	return result;
+}
+
 void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const CallInfo& call_info,
 														 const void* call_key,
 														 const char* context_description) {
@@ -5326,7 +5440,7 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const CallInfo& call_in
 	// template member stub, materialize it here in sema so codegen's normal
 	// struct visitor emits IR for the real body instead of relying on
 	// codegen-side fallbacks. See `tryMaterializeLazyCallTarget` for details.
-	func_decl = tryMaterializeLazyCallTarget(func_decl);
+	func_decl = tryMaterializeLazyCallTarget(func_decl, call_info);
 
 	const FunctionDeclarationNode* resolved_op_call = getResolvedOpCall(call_key);
 	const bool cache_as_direct_call =
@@ -5653,8 +5767,9 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 	// (`snapshotOdrUsedLazyEntries`).
 	while (true) {
 		size_t before = total_materialized;
-		for (const auto& top_node : parser_.get_nodes()) {
-			FlashCpp::forEachReachableStructDecl(top_node, drainOneStruct);
+		const auto& top_nodes = parser_.get_nodes();
+		for (size_t i = 0; i < top_nodes.size(); ++i) {
+			FlashCpp::forEachReachableStructDecl(top_nodes[i], drainOneStruct);
 		}
 		if (total_materialized == before) {
 			break;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5228,7 +5228,11 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 			StringHandle member_handle = func_decl->decl_node().identifier_token().handle();
 			const bool is_const = func_decl->is_const_member_function();
 			auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
-			if (lazy_registry.needsInstantiation(current_struct_name, member_handle, is_const)) {
+			if (lazy_registry.needsInstantiation(
+					LazyMemberKey::exact(
+						current_struct_name,
+						member_handle,
+						is_const))) {
 				// Mark only; the drain pass in SemanticAnalysis (running
 				// after normalizePendingSemanticRoots) picks up ODR-used
 				// residuals via its fixpoint loop over
@@ -5237,7 +5241,11 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 				// re-entrant cycle: materialization reparses and
 				// normalizes the body, which hits another call that lands
 				// back in this helper, ad infinitum.
-				lazy_registry.markOdrUsed(current_struct_name, member_handle, is_const);
+				lazy_registry.markOdrUsed(
+					LazyMemberKey::exact(
+						current_struct_name,
+						member_handle,
+						is_const));
 			}
 		}
 	}
@@ -5256,7 +5264,11 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	// been resolved by overload resolution in sema, so the member is ODR-used.
 	// Record it before materialization so the signal persists past the
 	// erase-on-instantiate in the lazy registry.
-	LazyMemberInstantiationRegistry::getInstance().markOdrUsed(parent_handle, member_handle, is_const);
+	LazyMemberInstantiationRegistry::getInstance().markOdrUsed(
+		LazyMemberKey::exact(
+			parent_handle,
+			member_handle,
+			is_const));
 	auto materialized = ensureMemberFunctionMaterialized(parent_handle, member_handle, is_const);
 	if (materialized.has_value() && materialized->is<FunctionDeclarationNode>()) {
 		return &materialized->as<FunctionDeclarationNode>();
@@ -5441,7 +5453,10 @@ const ConstructorDeclarationNode* SemanticAnalysis::ensureSelectedConstructorMat
 	// ODR-used. Ctors have no const/non-const variants, so the precise
 	// `is_const=false` marker captures the full overload set.
 	LazyMemberInstantiationRegistry::getInstance().markOdrUsed(
-		struct_info.getName(), ctor->name(), /*is_const=*/false);
+		LazyMemberKey::exact(
+			struct_info.getName(),
+			ctor->name(),
+			/*is_const=*/false));
 	// Constructors are never const-qualified members; use is_const = false.
 	auto instantiated = ensureMemberFunctionMaterialized(
 		struct_info.getName(), ctor->name(), /*is_const_member=*/false);
@@ -5467,9 +5482,10 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	// candidates are considered. getLazyMemberInfo / getLazyMemberInfoAny already
 	// return nullopt when nothing is registered or the entry was already marked
 	// instantiated, so no separate needsInstantiation pre-check is needed.
-	auto lazy_info_opt = is_const_member.has_value()
-		? lazy_registry.getLazyMemberInfo(struct_name, member_name, *is_const_member)
-		: lazy_registry.getLazyMemberInfoAny(struct_name, member_name);
+	LazyMemberKey query_key = is_const_member.has_value()
+		? LazyMemberKey::exact(struct_name, member_name, *is_const_member)
+		: LazyMemberKey::anyConst(struct_name, member_name);
+	auto lazy_info_opt = lazy_registry.getLazyMemberInfo(query_key);
 	if (!lazy_info_opt.has_value()) {
 		return std::nullopt;
 	}
@@ -5479,7 +5495,11 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	// Mark using the const-ness of the actual lazy entry we resolved, so the
 	// specific-const and any-const call patterns stay consistent with what
 	// parser_.instantiateLazyMemberFunction() just materialized.
-	lazy_registry.markInstantiated(struct_name, member_name, lazy_info_opt->identity.is_const_method);
+	lazy_registry.markInstantiated(
+		LazyMemberKey::exact(
+			struct_name,
+			member_name,
+			lazy_info_opt->identity.is_const_method));
 	return instantiated;
 }
 
@@ -5529,9 +5549,10 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 				const auto& fn = member_func.function_declaration.as<FunctionDeclarationNode>();
 				is_const_query = fn.is_const_member_function();
 			}
-			if (is_const_query.has_value()
-					? lazy_registry.needsInstantiation(struct_name, member_handle, *is_const_query)
-					: lazy_registry.needsInstantiationAny(struct_name, member_handle)) {
+			LazyMemberKey member_key = is_const_query.has_value()
+				? LazyMemberKey::exact(struct_name, member_handle, *is_const_query)
+				: LazyMemberKey::anyConst(struct_name, member_handle);
+			if (lazy_registry.needsInstantiation(member_key)) {
 				auto result = ensureMemberFunctionMaterialized(struct_name, member_handle, is_const_query);
 				if (result.has_value()) {
 					++total_materialized;
@@ -5605,8 +5626,11 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 			// Re-check needsInstantiation because a prior iteration may
 			// have already materialized this key (e.g., transitively via
 			// another member's body).
-			if (!lazy_registry.needsInstantiation(entry.instantiated_owner_name,
-					entry.member_name, entry.is_const_method)) {
+			if (!lazy_registry.needsInstantiation(
+					LazyMemberKey::exact(
+						entry.instantiated_owner_name,
+						entry.member_name,
+						entry.is_const_method))) {
 				continue;
 			}
 			auto result = ensureMemberFunctionMaterialized(

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2241,6 +2241,17 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(const ASTNode& node, cons
 													 " in assignment", rhs_id);
 					}
 				}
+				// Phase 5 Slice G item #4: mark resolved operator overloads
+				// as ODR-used so instantiated-struct member operator bodies
+				// are materialized by the end-of-sema drain's ODR-use pass.
+				// Free-function operator overloads are top-level (not lazy
+				// members of an instantiation) so they need no marking here.
+				if (e.has_resolved_member_operator_overload()) {
+					if (const StructMemberFunction* member_overload =
+							e.resolved_member_operator_overload()) {
+						markResolvedOperatorOverloadOdrUsed(*member_overload);
+					}
+				}
 				normalizeExpression(e.get_lhs(), ctx);
 				normalizeExpression(e.get_rhs(), ctx);
 			} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
@@ -3811,6 +3822,14 @@ static bool structHasConversionOperatorTo(
 		return false;
 
 	// Scan direct member functions for an exact conversion target match.
+	// Iterate all matching overloads so that both const and non-const
+	// conversion operators with the same target type are marked ODR-used.
+	// Codegen's `findConversionOperator` honors the cv-aware lookup (const
+	// source may call const op; non-const source prefers non-const op but
+	// falls back to const), so we cannot predict here which overload codegen
+	// will select without replicating that logic. Marking both is safe —
+	// the registry dedups and non-existent overloads are no-ops.
+	bool found = false;
 	for (const auto& mf : struct_info->member_functions) {
 		if (mf.conversion_target_type != canonical_target_type)
 			continue;
@@ -3829,6 +3848,15 @@ static bool structHasConversionOperatorTo(
 			// signal persists even after the lazy entry is erased.
 			LazyMemberInstantiationRegistry::getInstance().markOdrUsed(
 				struct_info->name, mf.getName(), /*is_const=*/mf.is_const());
+			// Phase 5 Slice G item #4: conversion-operator stubs may be
+			// registered under an un-canonicalized name (e.g.
+			// "operator value_type" when computeInstantiatedLookupName
+			// fails to resolve an enum template argument). Mark all lazy
+			// members of this instantiated class as ODR-used to ensure
+			// the matching stub is drained regardless of its stored name.
+			// This only fires for classes the user's code actually reaches.
+			LazyMemberInstantiationRegistry::getInstance().markOdrUsedAllInClass(
+				struct_info->name);
 			const bool needs_materialization =
 				mf.function_decl.is<FunctionDeclarationNode>() &&
 				!mf.function_decl.as<FunctionDeclarationNode>().get_definition().has_value();
@@ -3837,8 +3865,10 @@ static bool structHasConversionOperatorTo(
 					struct_info->name, mf.getName(), /*is_const_member=*/mf.is_const());
 			}
 		}
-		return true;
+		found = true;
 	}
+	if (found)
+		return true;
 
 	// Recurse into non-deferred base classes (inherited conversion operators).
 	for (const auto& base : struct_info->base_classes) {
@@ -3903,8 +3933,12 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 		return false;
 	if (is_non_primitive_target(to_desc.category()))
 		return false;
-	if (to_desc.category() == TypeCategory::Enum)
-		return false; // no implicit conversion TO enum
+	// Primitive->enum is forbidden (C++11+), but struct->enum IS allowed
+	// via a user-defined conversion operator (e.g. `operator Color() const`).
+	// Fall through to the UserDefined rank check below in that case.
+	if (to_desc.category() == TypeCategory::Enum &&
+		from_desc.category() != TypeCategory::Struct)
+		return false; // no implicit conversion TO enum from non-struct
 	// C++11+: scoped enums (enum class) do not allow implicit conversion to other types.
 	// Silently reject here; callers that need a diagnostic (variable init, return, assignment)
 	// check isScopedEnum() and throw CompileError themselves.
@@ -5467,6 +5501,22 @@ const ConstructorDeclarationNode* SemanticAnalysis::ensureSelectedConstructorMat
 	return &instantiated->as<ConstructorDeclarationNode>();
 }
 
+void SemanticAnalysis::markResolvedOperatorOverloadOdrUsed(
+	const StructMemberFunction& member_overload) {
+	if (!member_overload.function_decl.is<FunctionDeclarationNode>())
+		return;
+	const auto& fdecl = member_overload.function_decl.as<FunctionDeclarationNode>();
+	const std::string_view parent_sv = fdecl.parent_struct_name();
+	if (parent_sv.empty())
+		return;
+	StringHandle struct_name = StringTable::getOrInternStringHandle(parent_sv);
+	StringHandle member_name = member_overload.getName();
+	if (!struct_name.isValid() || !member_name.isValid())
+		return;
+	LazyMemberInstantiationRegistry::getInstance().markOdrUsed(
+		struct_name, member_name, member_overload.is_const());
+}
+
 std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	StringHandle struct_name,
 	StringHandle member_name,
@@ -5573,25 +5623,34 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 		}
 	};
 
-	// Loop because materializing one body may trigger further lazy
-	// registrations (e.g., a template instantiation used inside the body we
-	// just substituted). Keep walking until no more work happens.
+	// Phase 5 Slice G item #4: intended to be a data-model split where pass 1
+	// only walks user-written top-level nodes and instantiated roots are
+	// handled entirely by the ODR-use fixpoint pass below.
+	//
+	// Audit (2026-04-21): the split is architecturally correct but blocked on
+	// residual ODR-use coverage. The following code paths do not currently
+	// reach a `markOdrUsed(...)` site for members of instantiated roots:
+	//
+	//   * using-decl pack expansion that imports static members from a
+	//     concrete base instantiation (`tests/test_using_decl_pack_expansion_ret1.cpp`).
+	//     The receiver-based call resolves to the *pattern's* `Fun::call`
+	//     (with empty `parent_struct_name()`), so `tryMaterializeLazyCallTarget`
+	//     never identifies the instantiated owner.
+	//   * Late-bound out-of-line member bodies that reference sibling lazy
+	//     stubs only once cross-instantiation substitution has run
+	//     (see the `test_late_member_body_class_template_*_ret42.cpp` group
+	//     and `test_late_member_signature_qualified_dependent_type_ret42.cpp`).
+	//
+	// Until those resolution sites carry a proper ODR-use signal, pass 1 must
+	// drain every instantiated root that's reachable from `get_nodes()`.
+	// Reverting the split here preserves the documented 2204 / 149 baseline.
+	// See `docs/2026-04-21-phase5-slice-g-analysis.md` for the audit trail.
 	//
 	// We intentionally only walk structs reachable from `parser_.get_nodes()`
 	// in this first pass: they are exactly the structs whose members the
-	// codegen struct-visitor iterates. Extending this walk to the set of *all*
-	// instantiated class templates (e.g., via a side list populated by
-	// `try_instantiate_class_template`) would over-materialize members of
-	// structs that only ever appear as template arguments in SFINAE-probed
-	// positions — their member bodies may be ill-formed by design (see
-	// `tests/test_namespaced_pair_swap_sfinae_ret0.cpp` where
-	// `pair<const int, int>::swap` references a deleted overload and is only
-	// valid to instantiate lazily via ODR-use, which never happens).
-	//
-	// Non-reachable instantiations whose members *are* ODR-used are caught by
-	// the second pass below (`snapshotOdrUsedLazyEntries`). Slices I+J deleted
-	// the codegen-side `materializeLazyMemberIfNeeded` forwarder so every
-	// lazy-member materialization now flows through this drain.
+	// codegen struct-visitor iterates. Non-reachable instantiations whose
+	// members are ODR-used are caught by the second pass below
+	// (`snapshotOdrUsedLazyEntries`).
 	while (true) {
 		size_t before = total_materialized;
 		for (const auto& top_node : parser_.get_nodes()) {

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -354,6 +354,17 @@ private:
 	const FunctionDeclarationNode* tryMaterializeLazyCallTarget(
 		const FunctionDeclarationNode* func_decl);
 
+	// Phase 5 Slice G item #4: receiver-aware variant. When the resolved
+	// `func_decl` carries a template-pattern parent_struct_name (e.g.
+	// `Box` rather than `Box$hash`), the receiver's TypeInfo gives us the
+	// concrete instantiation. This marks the instantiated owner's lazy
+	// member ODR-used so the drain's pass 2 can materialize it — closing
+	// the coverage gap around late-materialized cross-struct member calls
+	// inside substituted instantiation bodies.
+	const FunctionDeclarationNode* tryMaterializeLazyCallTarget(
+		const FunctionDeclarationNode* func_decl,
+		const struct CallInfo& call_info);
+
 	// Annotate InitializerListNode elements used as constructor arguments
 	// with their parameter-type conversions (for direct-init syntax like `Type obj(args...)`).
 	void tryAnnotateInitListConstructorArgs(const InitializerListNode& init_list, const StructTypeInfo& struct_info);

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -185,6 +185,14 @@ public:
 		StringHandle member_name,
 		std::optional<bool> is_const_member);
 
+	// Phase 5 Slice G item #4: mark a resolved operator overload (member
+	// function) as ODR-used in the lazy-member registry so the end-of-sema
+	// drain materializes it. Safe no-op if the overload isn't a lazy-member
+	// entry. Used from binary/unary/subscript/arrow/call operator
+	// annotation sites after the parser resolved the overload.
+	void markResolvedOperatorOverloadOdrUsed(
+		const StructMemberFunction& member_overload);
+
 	// Phase 5 Slice F: Drain any remaining lazy-member registry entries by
 	// materializing them before codegen's struct-visitor runs. This preempts
 	// the last codegen-first materialization path (`IrGenerator_Visitors_Decl`'s

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -176,8 +176,10 @@ public:
 	//
 	// Returns the materialized ASTNode (FunctionDeclarationNode or
 	// ConstructorDeclarationNode) on success, or std::nullopt when no matching
-	// lazy entry needs instantiation. Codegen consumers forward here through
-	// the thin `AstToIr::materializeLazyMemberIfNeeded` bridge.
+	// lazy entry needs instantiation. After Phase 5 Slices I+J there is no
+	// codegen-side forwarder; all lazy-member materialization goes through
+	// either sema annotation sites (see `markOdrUsed`) or the end-of-sema
+	// drain in `drainLazyMemberRegistry`.
 	std::optional<ASTNode> ensureMemberFunctionMaterialized(
 		StringHandle struct_name,
 		StringHandle member_name,

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -23,6 +23,29 @@ struct LazyMemberFunctionInfo {
 	bool is_final = false;					   // Final flag
 };
 
+struct LazyMemberKey {
+	StringHandle instantiated_class_name;
+	StringHandle member_function_name;
+	std::optional<bool> is_const_method;
+
+	static LazyMemberKey exact(
+		StringHandle instantiated_class_name,
+		StringHandle member_function_name,
+		bool is_const_method) {
+		return {instantiated_class_name, member_function_name, is_const_method};
+	}
+
+	static LazyMemberKey anyConst(
+		StringHandle instantiated_class_name,
+		StringHandle member_function_name) {
+		return {instantiated_class_name, member_function_name, std::nullopt};
+	}
+
+	bool hasExactConstness() const {
+		return is_const_method.has_value();
+	}
+};
+
 // Registry for tracking uninstantiated template member functions
 // Allows lazy (on-demand) instantiation for better compilation performance
 class LazyMemberInstantiationRegistry {
@@ -33,8 +56,7 @@ public:
 	}
 
 	// Append the shared "instantiated_class_name::member_function_name" prefix.
-	// Callers that also need the const-qualified variant can inspect preview()
-	// before appending "$const".
+	// Prefer makeKey(...) for finished lookup keys.
 	static StringBuilder& appendMemberKeyPrefix(StringBuilder& key_builder, StringHandle class_name, StringHandle member_name) {
 		class_name = normalizeClassName(class_name);
 		return key_builder.append(class_name).append("::").append(member_name);
@@ -60,50 +82,73 @@ public:
 	}
 
 	// Check if a member function needs lazy instantiation
+	bool needsInstantiation(const LazyMemberKey& key) const {
+		if (key.is_const_method.has_value()) {
+			auto handle = makeKey(
+				key.instantiated_class_name,
+				key.member_function_name,
+				*key.is_const_method);
+			return lazy_members_.find(handle) != lazy_members_.end();
+		}
+
+		auto non_const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			false);
+		if (lazy_members_.find(non_const_handle) != lazy_members_.end()) {
+			return true;
+		}
+
+		auto const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			true);
+		return lazy_members_.find(const_handle) != lazy_members_.end();
+	}
+
 	bool needsInstantiation(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) const {
-		auto handle = makeKey(instantiated_class_name, member_function_name, is_const);
-		return lazy_members_.find(handle) != lazy_members_.end();
+		return needsInstantiation(
+			LazyMemberKey::exact(
+				instantiated_class_name,
+				member_function_name,
+				is_const));
 	}
 
 	// Check either the non-const or const variant — for call sites that don't yet know is_const.
 	bool needsInstantiationAny(StringHandle instantiated_class_name, StringHandle member_function_name) const {
-		StringBuilder key_builder;
-		appendMemberKeyPrefix(key_builder, instantiated_class_name, member_function_name);
-		auto non_const_handle = StringTable::getOrInternStringHandle(key_builder.preview());
-		if (lazy_members_.find(non_const_handle) != lazy_members_.end()) {
-			key_builder.reset();
-			return true;
-		}
-
-		key_builder.append("$const");
-		auto const_handle = StringTable::getOrInternStringHandle(key_builder);
-		return lazy_members_.find(const_handle) != lazy_members_.end();
+		return needsInstantiation(
+			LazyMemberKey::anyConst(
+				instantiated_class_name,
+				member_function_name));
 	}
 
 	// Get lazy member info for instantiation
-	std::optional<LazyMemberFunctionInfo> getLazyMemberInfo(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) {
-		auto handle = makeKey(instantiated_class_name, member_function_name, is_const);
-		auto it = lazy_members_.find(handle);
-		if (it != lazy_members_.end()) {
-			return it->second;
+	std::optional<LazyMemberFunctionInfo> getLazyMemberInfo(const LazyMemberKey& key) {
+		if (key.is_const_method.has_value()) {
+			auto handle = makeKey(
+				key.instantiated_class_name,
+				key.member_function_name,
+				*key.is_const_method);
+			auto it = lazy_members_.find(handle);
+			if (it != lazy_members_.end()) {
+				return it->second;
+			}
+			return std::nullopt;
 		}
-		return std::nullopt;
-	}
 
-	// Get lazy member info without knowing is_const — tries non-const first, then const.
-	// For call sites that haven't yet determined which overload they need.
-	std::optional<LazyMemberFunctionInfo> getLazyMemberInfoAny(StringHandle instantiated_class_name, StringHandle member_function_name) {
-		StringBuilder key_builder;
-		appendMemberKeyPrefix(key_builder, instantiated_class_name, member_function_name);
-		auto non_const_handle = StringTable::getOrInternStringHandle(key_builder.preview());
+		auto non_const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			false);
 		auto it = lazy_members_.find(non_const_handle);
 		if (it != lazy_members_.end()) {
-			key_builder.reset();
 			return it->second;
 		}
 
-		key_builder.append("$const");
-		auto const_handle = StringTable::getOrInternStringHandle(key_builder);
+		auto const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			true);
 		it = lazy_members_.find(const_handle);
 		if (it != lazy_members_.end()) {
 			return it->second;
@@ -111,10 +156,41 @@ public:
 		return std::nullopt;
 	}
 
+	std::optional<LazyMemberFunctionInfo> getLazyMemberInfo(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) {
+		return getLazyMemberInfo(
+			LazyMemberKey::exact(
+				instantiated_class_name,
+				member_function_name,
+				is_const));
+	}
+
+	// Get lazy member info without knowing is_const — tries non-const first, then const.
+	// For call sites that haven't yet determined which overload they need.
+	std::optional<LazyMemberFunctionInfo> getLazyMemberInfoAny(StringHandle instantiated_class_name, StringHandle member_function_name) {
+		return getLazyMemberInfo(
+			LazyMemberKey::anyConst(
+				instantiated_class_name,
+				member_function_name));
+	}
+
 	// Mark a member function as instantiated (remove from lazy registry)
-	void markInstantiated(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) {
-		auto handle = makeKey(instantiated_class_name, member_function_name, is_const);
+	void markInstantiated(const LazyMemberKey& key) {
+		if (!key.is_const_method.has_value()) {
+			return;
+		}
+		auto handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			*key.is_const_method);
 		lazy_members_.erase(handle);
+	}
+
+	void markInstantiated(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) {
+		markInstantiated(
+			LazyMemberKey::exact(
+				instantiated_class_name,
+				member_function_name,
+				is_const));
 	}
 
 	// ------------------------------------------------------------------
@@ -146,8 +222,31 @@ public:
 	// variant. Callers that truly don't know const-ness (ctor/dtor, or
 	// early lookup before overload resolution) may use the `...Any` helpers
 	// which record/query both variants.
+	void markOdrUsed(const LazyMemberKey& key) {
+		if (key.is_const_method.has_value()) {
+			odr_used_.insert(makeKey(
+				key.instantiated_class_name,
+				key.member_function_name,
+				*key.is_const_method));
+			return;
+		}
+
+		odr_used_.insert(makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			false));
+		odr_used_.insert(makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			true));
+	}
+
 	void markOdrUsed(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) {
-		odr_used_.insert(makeKey(instantiated_class_name, member_function_name, is_const));
+		markOdrUsed(
+			LazyMemberKey::exact(
+				instantiated_class_name,
+				member_function_name,
+				is_const));
 	}
 
 	// Mark both const and non-const variants as ODR-used. Prefer the precise
@@ -155,30 +254,49 @@ public:
 	// const-agnostic (ctor/dtor) or when the call site has not yet
 	// determined const-ness.
 	void markOdrUsedAny(StringHandle instantiated_class_name, StringHandle member_function_name) {
-		StringBuilder key_builder;
-		appendMemberKeyPrefix(key_builder, instantiated_class_name, member_function_name);
-		odr_used_.insert(StringTable::getOrInternStringHandle(key_builder.preview()));
-		key_builder.append("$const");
-		odr_used_.insert(StringTable::getOrInternStringHandle(key_builder));
+		markOdrUsed(
+			LazyMemberKey::anyConst(
+				instantiated_class_name,
+				member_function_name));
 	}
 
 
-	bool isOdrUsed(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) const {
-		return odr_used_.find(makeKey(instantiated_class_name, member_function_name, is_const)) != odr_used_.end();
-	}
+	bool isOdrUsed(const LazyMemberKey& key) const {
+		if (key.is_const_method.has_value()) {
+			return odr_used_.find(makeKey(
+				key.instantiated_class_name,
+				key.member_function_name,
+				*key.is_const_method)) != odr_used_.end();
+		}
 
-	bool isOdrUsedAny(StringHandle instantiated_class_name, StringHandle member_function_name) const {
-		StringBuilder key_builder;
-		appendMemberKeyPrefix(key_builder, instantiated_class_name, member_function_name);
-		auto non_const_handle = StringTable::getOrInternStringHandle(key_builder.preview());
+		auto non_const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			false);
 		if (odr_used_.find(non_const_handle) != odr_used_.end()) {
-			key_builder.reset();
 			return true;
 		}
 
-		key_builder.append("$const");
-		auto const_handle = StringTable::getOrInternStringHandle(key_builder);
+		auto const_handle = makeKey(
+			key.instantiated_class_name,
+			key.member_function_name,
+			true);
 		return odr_used_.find(const_handle) != odr_used_.end();
+	}
+
+	bool isOdrUsed(StringHandle instantiated_class_name, StringHandle member_function_name, bool is_const) const {
+		return isOdrUsed(
+			LazyMemberKey::exact(
+				instantiated_class_name,
+				member_function_name,
+				is_const));
+	}
+
+	bool isOdrUsedAny(StringHandle instantiated_class_name, StringHandle member_function_name) const {
+		return isOdrUsed(
+			LazyMemberKey::anyConst(
+				instantiated_class_name,
+				member_function_name));
 	}
 
 	// Clear all lazy members (for testing)

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -260,6 +260,28 @@ public:
 				member_function_name));
 	}
 
+	// Phase 5 Slice G item #4: mark every registered lazy member whose
+	// `identity.instantiated_owner_name` matches `instantiated_class_name`
+	// as ODR-used. This is a conservative escape hatch for call sites that
+	// have determined the instantiated class is ODR-reached but cannot
+	// reliably reproduce the stub's internal member-name key (notably
+	// conversion operators where `computeInstantiatedLookupName` may fail
+	// to canonicalize enum template arguments, leaving the stub registered
+	// under a template-parameter-dependent name like "operator value_type"
+	// instead of "operator Color"). See
+	// `tests/test_lazy_conv_op_enum_type_ret0.cpp` for the motivating case.
+	//
+	// Semantically this is a superset of the old pass-1 wholesale drain for
+	// the given struct only. Structs that are never ODR-reached (e.g.,
+	// SFINAE-probed instantiations) stay untouched.
+	void markOdrUsedAllInClass(StringHandle instantiated_class_name) {
+		for (const auto& [key_handle, info] : lazy_members_) {
+			if (info.identity.instantiated_owner_name == instantiated_class_name) {
+				odr_used_.insert(key_handle);
+			}
+		}
+	}
+
 
 	bool isOdrUsed(const LazyMemberKey& key) const {
 		if (key.is_const_method.has_value()) {


### PR DESCRIPTION
## Summary

This branch continues Phase 5 Slice G cleanup around lazy-member materialization and struct traversal.

- add `FLASH_INVARIANT_PROBE` / `FLASH_INVARIANT_PROBE_FORMAT` and wire a `Phase5StructDrain` probe into codegen
- deduplicate `registerLateMaterializedTopLevelNode*` by `raw_pointer()` identity
- introduce `ReachableStructWalker.h` so sema drain and codegen share the same reachable-struct traversal
- promote lazy-member lookup / ODR-use queries onto a typed `LazyMemberKey`
- fix the any-const typed-key path by building committed keys directly instead of relying on dirty `StringBuilder::preview()` state
- sync `src\\ReachableStructWalker.h` into the MSVC project files
- update the Slice G analysis doc with progress notes and follow-up guidance

## Validation

- `.\build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1335" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
