### PR TITLE
Add raw string literal support

### DIFF
--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -3,6 +3,7 @@
 #include "BuiltinListInitNarrowing.h"
 #include "CallNodeHelpers.h"
 #include "SemanticAnalysis.h"
+#include "StringLiteralTokenUtils.h"
 
 namespace ConstExpr {
 
@@ -751,11 +752,11 @@ EvalResult Evaluator::evaluate(const ASTNode& expr_node, EvaluationContext& cont
 	// operations on constexpr const char* variables and string-literal arguments work correctly
 	// (e.g. constexpr const char* s = "Hi"; static_assert(s[0] == 'H');).
 	if (const auto* str_literal = std::get_if<StringLiteralNode>(&expr)) {
-		std::string_view raw = str_literal->value();
-		// Strip surrounding double-quotes that the lexer keeps in the token value.
-		std::string_view str_content = (raw.size() >= 2 && raw.front() == '"' && raw.back() == '"')
-										   ? std::string_view(raw.data() + 1, raw.size() - 2)
-										   : raw;
+		auto parsed_literal = FlashCpp::parseStringLiteralToken(str_literal->value());
+		std::string_view str_content =
+			parsed_literal.is_raw && !parsed_literal.has_delimited_content
+			? str_literal->value()
+			: parsed_literal.content;
 		// Build an is_array result whose elements are the individual characters.
 		// The null terminator is appended so that str[n] == '\0' comparisons work.
 		const TypeSpecifierNode char_type(TypeCategory::Char, TypeQualifier::None, 8, Token{}, CVQualifier::None);

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -753,9 +753,10 @@ EvalResult Evaluator::evaluate(const ASTNode& expr_node, EvaluationContext& cont
 	// (e.g. constexpr const char* s = "Hi"; static_assert(s[0] == 'H');).
 	if (const auto* str_literal = std::get_if<StringLiteralNode>(&expr)) {
 		auto parsed_literal = FlashCpp::parseStringLiteralToken(str_literal->value());
+		const bool process_escapes = !parsed_literal.is_raw;
 		std::string_view str_content =
 			parsed_literal.is_raw && !parsed_literal.has_delimited_content
-			? str_literal->value()
+			? parsed_literal.normalized_token
 			: parsed_literal.content;
 		// Build an is_array result whose elements are the individual characters.
 		// The null terminator is appended so that str[n] == '\0' comparisons work.
@@ -764,7 +765,7 @@ EvalResult Evaluator::evaluate(const ASTNode& expr_node, EvaluationContext& cont
 		result.is_array = true;
 		for (size_t si = 0; si < str_content.size(); ++si) {
 			char c = str_content[si];
-			if (c == '\\' && si + 1 < str_content.size()) {
+			if (process_escapes && c == '\\' && si + 1 < str_content.size()) {
 				// Match the same escape-handling logic as IrGenerator_Stmt_Decl.cpp.
 				switch (str_content[si + 1]) {
 				case 'n':

--- a/src/ElfFileWriter_EH.cpp
+++ b/src/ElfFileWriter_EH.cpp
@@ -1,5 +1,6 @@
 #include "ObjFileWriter.h"
 #include "ElfFileWriter.h"
+#include "StringLiteralTokenUtils.h"
 
 // ElfFileWriter_EH.cpp - Out-of-line method definitions for ElfFileWriter
 // Part of ElfFileWriter class (unity build)
@@ -1145,9 +1146,16 @@ size_t ElfFileWriter::getSymbolCount() const {
 std::string ElfFileWriter::processStringLiteral(std::string_view str_content) {
 	std::string result;
 
-	if (str_content.size() >= 2 && str_content.front() == '"' && str_content.back() == '"') {
+	const auto parsed_literal = FlashCpp::parseStringLiteralToken(str_content);
+	if (parsed_literal.is_raw) {
+		if (parsed_literal.has_delimited_content) {
+			result.append(parsed_literal.content);
+		} else {
+			result = std::string(str_content);
+		}
+	} else if (parsed_literal.has_delimited_content) {
 		// Remove quotes
-		std::string_view content(str_content.data() + 1, str_content.size() - 2);
+		std::string_view content = parsed_literal.content;
 
 		// Process escape sequences
 		for (size_t i = 0; i < content.size(); ++i) {

--- a/src/ElfFileWriter_EH.cpp
+++ b/src/ElfFileWriter_EH.cpp
@@ -1151,7 +1151,7 @@ std::string ElfFileWriter::processStringLiteral(std::string_view str_content) {
 		if (parsed_literal.has_delimited_content) {
 			result.append(parsed_literal.content);
 		} else {
-			result = std::string(str_content);
+			result = std::string(parsed_literal.normalized_token);
 		}
 	} else if (parsed_literal.has_delimited_content) {
 		// Remove quotes

--- a/src/Lexer.h
+++ b/src/Lexer.h
@@ -91,6 +91,8 @@ public:
 					// Handle division operator
 					return consume_operator();
 				}
+			} else if (c == 'R' && cursor_ + 1 < source_size_ && source_[cursor_ + 1] == '"') {
+				return consume_raw_string_literal(cursor_);
 			} else if (c == 'L' && cursor_ + 1 < source_size_ && (source_[cursor_ + 1] == '\"' || source_[cursor_ + 1] == '\'')) {
 				// Wide string/character literals (L"..." or L'...')
 				size_t start = cursor_;
@@ -101,6 +103,10 @@ public:
 				} else {
 					return consume_prefixed_character_literal(start);
 				}
+			} else if (is_raw_string_prefix_at_cursor()) {
+				size_t start = cursor_;
+				consume_raw_string_prefix();
+				return consume_raw_string_literal(start);
 			} else if (std::isalpha(c) || c == '_') {
 				return consume_identifier_or_keyword();
 			} else if (std::isdigit(c)) {
@@ -556,6 +562,85 @@ private:
 		if (cursor_ < source_size_ && source_[cursor_] == '\"') {
 			++cursor_;
 			++column_;
+		}
+
+		std::string_view value = source_.substr(start, cursor_ - start);
+		return Token(Token::Type::StringLiteral, value, line_, column_,
+					 current_file_index_);
+	}
+
+	bool is_raw_string_prefix_at_cursor() const {
+		if (cursor_ >= source_size_) {
+			return false;
+		}
+		if ((source_[cursor_] == 'u' || source_[cursor_] == 'U' || source_[cursor_] == 'L') &&
+			cursor_ + 2 < source_size_ &&
+			source_[cursor_ + 1] == 'R' &&
+			source_[cursor_ + 2] == '"') {
+			return true;
+		}
+		return source_[cursor_] == 'u' &&
+			cursor_ + 3 < source_size_ &&
+			source_[cursor_ + 1] == '8' &&
+			source_[cursor_ + 2] == 'R' &&
+			source_[cursor_ + 3] == '"';
+	}
+
+	void consume_raw_string_prefix() {
+		if (source_[cursor_] == 'u' && cursor_ + 1 < source_size_ && source_[cursor_ + 1] == '8') {
+			cursor_ += 2;
+			column_ += 2;
+		} else {
+			++cursor_;
+			++column_;
+		}
+	}
+
+	Token consume_raw_string_literal(size_t start) {
+		// Assumes current cursor_ is at R in R"delim(content)delim".
+		++cursor_;
+		++column_;
+		if (cursor_ >= source_size_ || source_[cursor_] != '"') {
+			std::string_view value = source_.substr(start, cursor_ - start);
+			return Token(Token::Type::Identifier, value, line_, column_, current_file_index_);
+		}
+
+		++cursor_;
+		++column_;
+		size_t delimiter_start = cursor_;
+		while (cursor_ < source_size_ && source_[cursor_] != '(') {
+			++cursor_;
+			++column_;
+		}
+
+		if (cursor_ >= source_size_) {
+			std::string_view value = source_.substr(start, cursor_ - start);
+			return Token(Token::Type::StringLiteral, value, line_, column_, current_file_index_);
+		}
+
+		std::string_view delimiter = source_.substr(delimiter_start, cursor_ - delimiter_start);
+		++cursor_;
+		++column_;
+
+		while (cursor_ < source_size_) {
+			if (source_[cursor_] == ')' &&
+				cursor_ + delimiter.size() + 1 < source_size_ &&
+				source_.substr(cursor_ + 1, delimiter.size()) == delimiter &&
+				source_[cursor_ + 1 + delimiter.size()] == '"') {
+				cursor_ += delimiter.size() + 2;
+				column_ += delimiter.size() + 2;
+				break;
+			}
+
+			if (source_[cursor_] == '\n') {
+				++cursor_;
+				++line_;
+				column_ = 1;
+				update_file_index_from_line();
+			} else {
+				++cursor_;
+				++column_;
+			}
 		}
 
 		std::string_view value = source_.substr(start, cursor_ - start);

--- a/src/ObjFileWriter_RTTI.cpp
+++ b/src/ObjFileWriter_RTTI.cpp
@@ -272,7 +272,7 @@ std::string_view ObjectFileWriter::add_string_literal(std::string_view str_conte
 		if (parsed_literal.has_delimited_content) {
 			string_literal_buffer_.append(parsed_literal.content);
 		} else {
-			string_literal_buffer_.append(str_content);
+			string_literal_buffer_.append(parsed_literal.normalized_token);
 		}
 	} else if (parsed_literal.has_delimited_content) {
 		// Remove quotes

--- a/src/ObjFileWriter_RTTI.cpp
+++ b/src/ObjFileWriter_RTTI.cpp
@@ -1,5 +1,6 @@
 #include "ObjFileWriter.h"
 #include "Log.h"
+#include "StringLiteralTokenUtils.h"
 
 // ObjFileWriter_RTTI.cpp - Out-of-line method definitions for ObjectFileWriter
 // Part of ObjectFileWriter class (unity build)
@@ -266,9 +267,16 @@ std::string_view ObjectFileWriter::add_string_literal(std::string_view str_conte
 	string_literal_buffer_.clear();
 	string_literal_buffer_.reserve(str_content.size() + 1);
 
-	if (str_content.size() >= 2 && str_content.front() == '"' && str_content.back() == '"') {
+	const auto parsed_literal = FlashCpp::parseStringLiteralToken(str_content);
+	if (parsed_literal.is_raw) {
+		if (parsed_literal.has_delimited_content) {
+			string_literal_buffer_.append(parsed_literal.content);
+		} else {
+			string_literal_buffer_.append(str_content);
+		}
+	} else if (parsed_literal.has_delimited_content) {
 		// Remove quotes
-		std::string_view content(str_content.data() + 1, str_content.size() - 2);
+		std::string_view content = parsed_literal.content;
 
 		// Process escape sequences
 		for (size_t i = 0; i < content.size(); ++i) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -11,6 +11,7 @@
 #include "IrGenerator.h"
 #include "ConstExprEvaluator.h"
 #include "ReachableStructWalker.h"
+#include "StringLiteralTokenUtils.h"
 
 namespace {
 constexpr std::string_view kTemplatePatternStructSuffix = "$pattern__";
@@ -50,52 +51,16 @@ void applyDeclarationArrayBoundsToTypeSpec(const DeclarationNode& decl, TypeSpec
 //   \UNNNNNNNN — exactly 8 hex digits
 //   all other named escapes (\n, \t, \\, etc.) — one source char after backslash
 static size_t computeStringContentLength(std::string_view token_raw) {
-	std::string_view content = token_raw;
-	// Strip optional encoding prefix (L, u8, u, U) before the quote or R.
-	if (!content.empty() && content.front() != '"' && content.front() != 'R') {
-		size_t q = content.find('"');
-		size_t r = content.find('R');
-		// Find the first occurrence of either " or R (after stripping prefix).
-		size_t pos = std::string_view::npos;
-		if (q != std::string_view::npos && r != std::string_view::npos)
-			pos = std::min(q, r);
-		else if (q != std::string_view::npos)
-			pos = q;
-		else if (r != std::string_view::npos)
-			pos = r;
-		if (pos == std::string_view::npos)
-			return 0; // malformed token
-		content = content.substr(pos);
+	const auto parsed_literal = FlashCpp::parseStringLiteralToken(token_raw);
+	if (parsed_literal.is_raw) {
+		return parsed_literal.has_delimited_content ? parsed_literal.content.size() : 0;
 	}
 
-	// Check if this is a raw string literal (starts with R).
-	if (!content.empty() && content.front() == 'R') {
-		// Raw string: R"delim(content)delim"
-		content = content.substr(1); // Skip 'R'
-
-		// Strip enclosing double-quotes.
-		if (content.size() >= 2 && content.front() == '"' && content.back() == '"')
-			content = content.substr(1, content.size() - 2);
-
-		// Find opening ( and closing )
-		size_t open_paren = content.find('(');
-		if (open_paren == std::string_view::npos)
-			return 0; // malformed raw string
-
-		// The delimiter is between " and (, or empty if ( is immediately after "
-		size_t close_paren = content.rfind(')');
-		if (close_paren == std::string_view::npos || close_paren <= open_paren)
-			return 0; // malformed raw string
-
-		// Extract content between ( and )
-		std::string_view raw_content = content.substr(open_paren + 1, close_paren - open_paren - 1);
-		// For raw strings, no escape processing; return length as-is
-		return raw_content.size();
+	if (!parsed_literal.has_delimited_content) {
+		return 0;
 	}
 
-	// Regular string: strip enclosing double-quotes.
-	if (content.size() >= 2 && content.front() == '"' && content.back() == '"')
-		content = content.substr(1, content.size() - 2);
+	std::string_view content = parsed_literal.content;
 
 	size_t len = 0;
 	for (size_t i = 0; i < content.size(); ++i) {

--- a/src/StringLiteralTokenUtils.h
+++ b/src/StringLiteralTokenUtils.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string_view>
+
+namespace FlashCpp {
+
+struct ParsedStringLiteralToken {
+	std::string_view normalized_token;
+	std::string_view content;
+	bool is_raw = false;
+	bool has_delimited_content = false;
+};
+
+inline ParsedStringLiteralToken parseStringLiteralToken(std::string_view token_raw) {
+	ParsedStringLiteralToken result{
+		.normalized_token = token_raw,
+		.content = token_raw,
+	};
+	if (token_raw.empty()) {
+		return result;
+	}
+
+	std::string_view token = token_raw;
+	if (token.front() != '"' && token.front() != 'R') {
+		const size_t quote = token.find('"');
+		const size_t raw_marker = token.find('R');
+		if (raw_marker != std::string_view::npos &&
+			(quote == std::string_view::npos || raw_marker < quote)) {
+			token = token.substr(raw_marker);
+		} else if (quote != std::string_view::npos) {
+			token = token.substr(quote);
+		} else {
+			return result;
+		}
+	}
+
+	result.normalized_token = token;
+	result.content = token;
+	if (token.empty()) {
+		return result;
+	}
+
+	if (token.front() == 'R') {
+		result.is_raw = true;
+		token.remove_prefix(1);
+		if (token.size() < 2 || token.front() != '"' || token.back() != '"') {
+			return result;
+		}
+
+		token = token.substr(1, token.size() - 2);
+		const size_t open_paren = token.find('(');
+		const size_t close_paren = token.rfind(')');
+		if (open_paren == std::string_view::npos ||
+			close_paren == std::string_view::npos ||
+			close_paren <= open_paren) {
+			return result;
+		}
+
+		result.content = token.substr(open_paren + 1, close_paren - open_paren - 1);
+		result.has_delimited_content = true;
+		return result;
+	}
+
+	if (token.size() >= 2 && token.front() == '"' && token.back() == '"') {
+		result.content = token.substr(1, token.size() - 2);
+		result.has_delimited_content = true;
+	}
+
+	return result;
+}
+
+}

--- a/src/StringLiteralTokenUtils.h
+++ b/src/StringLiteralTokenUtils.h
@@ -42,17 +42,24 @@ inline ParsedStringLiteralToken parseStringLiteralToken(std::string_view token_r
 
 	if (token.front() == 'R') {
 		result.is_raw = true;
-		token.remove_prefix(1);
-		if (token.size() < 2 || token.front() != '"' || token.back() != '"') {
+		if (token.size() < 3 || token[1] != '"') {
 			return result;
 		}
 
-		token = token.substr(1, token.size() - 2);
-		const size_t open_paren = token.find('(');
-		const size_t close_paren = token.rfind(')');
-		if (open_paren == std::string_view::npos ||
-			close_paren == std::string_view::npos ||
-			close_paren <= open_paren) {
+		const size_t open_paren = token.find('(', 2);
+		if (open_paren == std::string_view::npos || token.back() != '"') {
+			return result;
+		}
+
+		const std::string_view delimiter = token.substr(2, open_paren - 2);
+		const size_t closing_marker_size = delimiter.size() + 2; // )delim"
+		if (token.size() < open_paren + 1 + closing_marker_size) {
+			return result;
+		}
+
+		const size_t close_paren = token.size() - closing_marker_size;
+		if (token[close_paren] != ')' ||
+			token.substr(close_paren + 1, delimiter.size()) != delimiter) {
 			return result;
 		}
 

--- a/tests/test_raw_string_literals_ret42.cpp
+++ b/tests/test_raw_string_literals_ret42.cpp
@@ -1,0 +1,22 @@
+int main() {
+	const char (&plain_size)[6] = R"(hello)";
+	const char (&delimited_size)[6] = R"tag(hello)tag";
+	const char (&escape_text_size)[13] = R"(hello\nworld)";
+	const char* plain = R"(hello)";
+	const char* delimited = R"tag(hello)tag";
+	const char* escape_text = R"(hello\nworld)";
+	const char* p = R"delim(a\nb)delim";
+	if (plain[0] != 'h' || plain[4] != 'o' || plain[5] != 0) {
+		return 1;
+	}
+	if (delimited[0] != 'h' || delimited[5] != 0) {
+		return 2;
+	}
+	if (escape_text[5] != '\\' || escape_text[6] != 'n' || escape_text[12] != 0) {
+		return 3;
+	}
+	if (p[0] != 'a' || p[1] != '\\' || p[2] != 'n' || p[3] != 'b' || p[4] != 0) {
+		return 4;
+	}
+	return 42;
+}

--- a/tests/test_raw_string_literals_ret42.cpp
+++ b/tests/test_raw_string_literals_ret42.cpp
@@ -1,3 +1,10 @@
+constexpr const char* raw_constexpr = R"(a\nb)";
+static_assert(raw_constexpr[0] == 'a');
+static_assert(raw_constexpr[1] == '\\');
+static_assert(raw_constexpr[2] == 'n');
+static_assert(raw_constexpr[3] == 'b');
+static_assert(raw_constexpr[4] == '\0');
+
 int main() {
 	const char (&plain_size)[6] = R"(hello)";
 	const char (&delimited_size)[6] = R"tag(hello)tag";


### PR DESCRIPTION
## Summary
- add lexer support for raw string literals, including delimited and prefixed raw forms
- unify raw string token parsing through a shared helper used by semantic analysis, constexpr evaluation, and COFF/ELF string emission
- add a regression test covering raw string sizing and runtime byte content

## Testing
- `./build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1 "test_raw_string_literals_ret42.cpp"`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1 "test_string_escape_sequences_ret0.cpp"`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1376" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
