### PR TITLE
[codex] Narrow dependent placeholder classification

### DIFF
--- a/docs/2026-04-08-template-instantiation-materialization-plan.md
+++ b/docs/2026-04-08-template-instantiation-materialization-plan.md
@@ -110,8 +110,11 @@ Active fallback evidence from the 2026-04-27 audit:
   `TypeSpecifierNode`s for deferred-base and dependent-member cases;
 - unresolved template defaults still need catch-all handling for template
   template defaults and some NTTP defaults;
-- `type_index == 0` is still used as a dependent-placeholder signal in several
-  parser/template paths;
+- `type_index == 0` dependent-placeholder handling has been narrowed in
+  template-argument classification: ordinary comparison speculation now fails
+  the tentative template-argument parse, known current template parameters are
+  materialized with canonical placeholder indices, and any remaining invalid
+  placeholder in an active template context is an invariant failure;
 - fold substitution for non-type parameter packs still reconstructs values from
   `template_params` / `template_args`;
 - `sizeof...` still depends on preserved per-pack size metadata plus broader

--- a/docs/2026-04-27-fallback-comments-audit.md
+++ b/docs/2026-04-27-fallback-comments-audit.md
@@ -76,7 +76,7 @@ Representative sites:
 - `src\ExpressionSubstitutor.cpp:1537` - recovers template arguments from type names when TypeInfo has no stored args.
 - `src\Parser_Templates_Inst_ClassTemplate.cpp:4049`, `src\Parser_Templates_Inst_ClassTemplate.cpp:4589`, `src\Parser_Templates_Inst_ClassTemplate.cpp:4787`, `src\Parser_Templates_Inst_ClassTemplate.cpp:4813`, `src\Parser_Templates_Inst_ClassTemplate.cpp:5246`, `src\Parser_Templates_Inst_ClassTemplate.cpp:5844`, `src\Parser_Templates_Inst_ClassTemplate.cpp:5904` - non-type defaults, variable templates, array dimensions, initializers, and static members use catch-all substitution or AST fallback passes.
 - `src\Parser_Templates_Substitution.cpp:692`, `src\Parser_Templates_Substitution.cpp:762`, `src\Parser_Templates_Substitution.cpp:848`, `src\Parser_Templates_Substitution.cpp:1633` - pack and template parameter lookup fallbacks after primary scope information is unavailable.
-- `src\Parser_Templates_Params.cpp:1826` - invalid `type_index` is still treated as an unresolved dependent placeholder signal.
+- `src\Parser_Templates_Params.cpp:1826` - invalid `type_index` is no longer a catch-all unresolved dependent-placeholder signal; classification now either materializes a canonical placeholder for a known current template parameter, rejects non-template speculative parses such as comparisons, or hard-fails active template contexts that still produce an invalid placeholder.
 
 Missing feature:
 
@@ -236,10 +236,11 @@ The initial audit above was architectural. Several template-instantiation fallba
    - Probe result: replacing this with a hard error broke deferred-base and pack-expansion cases including `tests\test_nttp_base_class_substitution_ret0.cpp`, `tests\test_pack_expansion_base_class_ret0.cpp`, `tests\test_ratio_negative_lazy_member_ret0.cpp`, and `tests\test_type_traits_dependent_member_nttp_ret42.cpp`.
    - Conclusion: this fallback is active and currently carries real class-template substitution traffic, especially around deferred base resolution and dependent member/type-trait cases.
 
-3. `src\Parser_Templates_Params.cpp` — `type_index == 0` dependent-placeholder path
-    - Probe result: replacing the dependent-marking path with a hard error broke comparison/operator template cases including `comparison_operators_ret1.cpp`, `float_comparisons_ret1.cpp`, `test_const_member_with_param_ret255.cpp`, `test_decltype_function_template_base_ret42.cpp`, and multiple spaceship tests.
-    - Probe result: wiring `parse_member_function_template(...)` in `src\Parser_Templates_Function.cpp` to preserve `registered_type_index()` on type template parameters was safe, but did not change that failing cluster, so member-function-template parameter registration is not the only remaining producer of invalid placeholder type indices.
-    - Conclusion: invalid/placeholder `TypeIndex` is still an active dependency signal in the current parser/template pipeline and cannot be removed before the placeholder metadata path is finished.
+3. `src\Parser_Templates_Params.cpp` — narrowed invalid `type_index` dependent-placeholder path
+    - Previous probe result: replacing the dependent-marking path with a hard error broke comparison/operator template cases including `comparison_operators_ret1.cpp`, `float_comparisons_ret1.cpp`, `test_const_member_with_param_ret255.cpp`, `test_decltype_function_template_base_ret42.cpp`, and multiple spaceship tests.
+    - Follow-up fix: friend-template and member-struct-template parameter registration now use canonical template-parameter TypeInfo entries and preserve `registered_type_index()`. Template-argument classification now rejects invalid non-template speculation by returning `std::nullopt` instead of treating the token as dependent, materializes a canonical placeholder for known current template parameters that reached the classifier without an index, and hard-fails any remaining active-template invalid placeholder.
+    - Validation: the comparison/operator cluster, `test_operator_overload_template_ret40.cpp`, all `*spaceship*.cpp` tests, and the full Windows suite passed after the narrowing.
+    - Conclusion: the broad invalid-`TypeIndex` dependency signal is removed from this site. Remaining producers, if any, should now surface as invariant failures rather than being silently accepted as dependent.
 
 4. `src\Parser_Templates_Inst_ClassTemplate.cpp` — non-type default evaluation fallback via `tryAppendEvaluatedTemplateValue(...)`
    - Probe result: replacing it with a hard error broke `tests\test_expr_subst_noexcept_wrap_ret0.cpp`, `tests\test_template_spec_outofline_default_arg_ret42.cpp`, and `tests\test_template_spec_outofline_default_arg_namespaced_ret42.cpp`.
@@ -321,4 +322,5 @@ The audit is now backed by direct suite evidence for several representative temp
 - the unknown-member-function copy fallback in `Parser_Templates_Inst_ClassTemplate.cpp` was dead in the current corpus and has now been removed;
 - the `Parser_Templates_Substitution.cpp` direct unqualified type-lookup step is required ordinary lookup, so the misleading fallback wording has been removed even though the behavior stays;
 - multiple dependent-type/deduction fallback paths are definitely active;
-- the larger ExpressionSubstitutor/static-initializer/pack-size/dependent-placeholder fallback classes should still be assumed active until probed or root-fixed individually.
+- the `Parser_Templates_Params.cpp` invalid-placeholder dependency branch has been narrowed to explicit speculative-parse rejection, canonical current-template-parameter materialization, and invariant failure for any remaining active-template producer;
+- the larger ExpressionSubstitutor/static-initializer/pack-size fallback classes should still be assumed active until probed or root-fixed individually.

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1135,6 +1135,9 @@ private:
 		ASTNode& out_template_node);
 	ParseResult parse_template_parameter_list(InlineVector<ASTNode, 4>& out_params);	 // NEW: Parse template parameter list
 	ParseResult parse_template_parameter();	// NEW: Parse a single template parameter
+	void registerTemplateTypeParametersInScope(
+		InlineVector<ASTNode, 4>& template_params,
+		FlashCpp::TemplateParameterScope& template_scope);
 	bool parseDeferredAliasTargetTemplateId(
 		StringHandle& out_target_template_name,
 		std::vector<ASTNode>& out_target_template_arg_nodes,

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -4455,15 +4455,10 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	// visible when parsing the friend function declaration (e.g. return type T, param type T).
 	FlashCpp::TemplateParameterScope template_scope;
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
+	registerTemplateTypeParametersInScope(template_params, template_scope);
 	for (auto& param : template_params) {
 		if (param.is<TemplateParameterNode>()) {
 			auto& tparam = param.as<TemplateParameterNode>();
-			if (tparam.kind() == TemplateParameterKind::Type) {
-				TypeInfo& type_info = add_template_param_type(tparam.nameHandle(), TypeCategory::UserDefined, 0);
-				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
-				tparam.set_registered_type_index(type_info.type_index_);
-				template_scope.addParameter(&type_info);
-			}
 			pushCurrentTemplateParamName(tparam.nameHandle());
 		}
 	}

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -4455,13 +4455,13 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	// visible when parsing the friend function declaration (e.g. return type T, param type T).
 	FlashCpp::TemplateParameterScope template_scope;
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
-	for (const auto& param : template_params) {
+	for (auto& param : template_params) {
 		if (param.is<TemplateParameterNode>()) {
-			const auto& tparam = param.as<TemplateParameterNode>();
+			auto& tparam = param.as<TemplateParameterNode>();
 			if (tparam.kind() == TemplateParameterKind::Type) {
-				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0);
+				TypeInfo& type_info = add_template_param_type(tparam.nameHandle(), TypeCategory::UserDefined, 0);
 				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
-				getTypesByNameMap().emplace(type_info.name(), &type_info);
+				tparam.set_registered_type_index(type_info.type_index_);
 				template_scope.addParameter(&type_info);
 			}
 			pushCurrentTemplateParamName(tparam.nameHandle());

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -4822,17 +4822,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 	// Temporarily add template parameters to type system using RAII scope guard
 	FlashCpp::TemplateParameterScope template_scope;
-	for (auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-			if (tparam.kind() == TemplateParameterKind::Type) {
-				TypeInfo& type_info = add_template_param_type(tparam.nameHandle(), TypeCategory::UserDefined, 0);
-				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
-				tparam.set_registered_type_index(type_info.type_index_);
-				template_scope.addParameter(&type_info);
-			}
-		}
-	}
+	registerTemplateTypeParametersInScope(template_params, template_scope);
 
 	// Skip requires clause if present (for partial specializations with constraints)
 	// e.g., template<typename T> requires Constraint<T> struct Name<T> { ... };

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -4822,12 +4822,13 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 	// Temporarily add template parameters to type system using RAII scope guard
 	FlashCpp::TemplateParameterScope template_scope;
-	for (const auto& param : template_params) {
+	for (auto& param : template_params) {
 		if (param.is<TemplateParameterNode>()) {
-			const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
+			TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
 			if (tparam.kind() == TemplateParameterKind::Type) {
-				TypeInfo& type_info = add_user_type(tparam.nameHandle(), 0); // Do we need a correct size here?
+				TypeInfo& type_info = add_template_param_type(tparam.nameHandle(), TypeCategory::UserDefined, 0);
 				type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
+				tparam.set_registered_type_index(type_info.type_index_);
 				template_scope.addParameter(&type_info);
 			}
 		}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -83,6 +83,24 @@ ParseResult Parser::parse_template_parameter_list(InlineVector<ASTNode, 4>& out_
 	return ParseResult::success();
 }
 
+void Parser::registerTemplateTypeParametersInScope(
+	InlineVector<ASTNode, 4>& template_params,
+	FlashCpp::TemplateParameterScope& template_scope) {
+	for (ASTNode& param : template_params) {
+		if (!param.is<TemplateParameterNode>()) {
+			continue;
+		}
+		TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
+		if (tparam.kind() != TemplateParameterKind::Type) {
+			continue;
+		}
+		TypeInfo& type_info = add_template_param_type(tparam.nameHandle(), TypeCategory::UserDefined, 0);
+		type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
+		tparam.set_registered_type_index(type_info.type_index_);
+		template_scope.addParameter(&type_info);
+	}
+}
+
 // Parse a single template parameter: typename T, class T, int N, etc.
 ParseResult Parser::parse_template_parameter() {
 	ScopedTokenPosition saved_position(*this);
@@ -1824,14 +1842,14 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 			// Dependent placeholders must be registered with a canonical TypeIndex by
 			// their template-parameter owner before they reach argument classification.
 			if (!arg.is_dependent && !type_node.type_index().is_valid()) {
-				const StringHandle token_name = StringTable::getOrInternStringHandle(type_node.token().value());
-				bool is_current_template_param = false;
-				for (StringHandle param_name : currentTemplateParamNames()) {
-					if (param_name == token_name) {
-						is_current_template_param = true;
-						break;
-					}
-				}
+				const StringHandle token_name = type_node.token().handle();
+				const auto& current_param_names = currentTemplateParamNames();
+				bool is_current_template_param = std::any_of(
+					current_param_names.begin(),
+					current_param_names.end(),
+					[token_name](StringHandle param_name) {
+						return param_name == token_name;
+					});
 				if (is_current_template_param) {
 					TypeInfo& type_info = add_template_param_type(token_name, TypeCategory::UserDefined, 0);
 					type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1821,10 +1821,34 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 				}
 			}
 
-			// An invalid type_index still marks an unresolved dependent placeholder type.
+			// Dependent placeholders must be registered with a canonical TypeIndex by
+			// their template-parameter owner before they reach argument classification.
 			if (!arg.is_dependent && !type_node.type_index().is_valid()) {
-				arg.is_dependent = true;
-				FLASH_LOG(Templates, Debug, "Template argument is dependent (placeholder with type_index=0)");
+				const StringHandle token_name = StringTable::getOrInternStringHandle(type_node.token().value());
+				bool is_current_template_param = false;
+				for (StringHandle param_name : currentTemplateParamNames()) {
+					if (param_name == token_name) {
+						is_current_template_param = true;
+						break;
+					}
+				}
+				if (is_current_template_param) {
+					TypeInfo& type_info = add_template_param_type(token_name, TypeCategory::UserDefined, 0);
+					type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
+					type_node.set_type_index(type_info.type_index_.withCategory(TypeCategory::UserDefined));
+					arg.type_index = type_node.type_index();
+					arg.is_dependent = true;
+					arg.dependent_name = token_name;
+					FLASH_LOG(Templates, Debug, "Registered missing dependent placeholder TypeIndex for template argument");
+				}
+				else if (full_type_name.empty()) {
+					restore_token_position(saved_pos);
+					last_failed_template_arg_parse_handle_ = saved_pos;
+					return std::nullopt;
+				}
+				else {
+					throw InternalError("Unregistered dependent placeholder type reached template argument classification");
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

- canonicalize remaining template-parameter placeholder registration paths for friend templates and member struct templates
- narrow template-argument invalid `TypeIndex` handling so comparison speculation fails cleanly instead of becoming dependent
- document the narrowed fallback state in the template materialization plan and fallback audit

## Validation

- `./build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1`
  - 2268 regular tests passed
  - 154 expected-fail tests failed as expected