### PR TITLE
Refactor template parameter list parsing

### DIFF
--- a/src/AstNodeTypes_Stmt.h
+++ b/src/AstNodeTypes_Stmt.h
@@ -618,7 +618,7 @@ class ConceptDeclarationNode {
 public:
 	explicit ConceptDeclarationNode(
 		Token name,
-		std::vector<TemplateParameterNode> template_params,
+		InlineVector<TemplateParameterNode, 4> template_params,
 		ASTNode constraint_expr,
 		Token concept_token = Token())
 		: name_(name),
@@ -628,13 +628,13 @@ public:
 
 	std::string_view name() const { return name_.value(); }
 	const Token& name_token() const { return name_; }
-	const std::vector<TemplateParameterNode>& template_params() const { return template_params_; }
+	const InlineVector<TemplateParameterNode, 4>& template_params() const { return template_params_; }
 	const ASTNode& constraint_expr() const { return constraint_expr_; }
 	const Token& concept_token() const { return concept_token_; }
 
 private:
 	Token name_;									 // Concept name
-	std::vector<TemplateParameterNode> template_params_;	 // Template parameters for the concept
+	InlineVector<TemplateParameterNode, 4> template_params_;	 // Template parameters for the concept
 	ASTNode constraint_expr_;						  // The constraint expression
 	Token concept_token_;							// For error reporting
 };

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -80,13 +80,24 @@ private:
 class TemplateFunctionDeclarationNode {
 public:
 	TemplateFunctionDeclarationNode() = delete;
-	TemplateFunctionDeclarationNode(InlineVector<ASTNode, 4> template_params, ASTNode function_decl,
+	TemplateFunctionDeclarationNode(std::vector<TemplateParameterNode> template_params, ASTNode function_decl,
 									std::optional<ASTNode> requires_clause = std::nullopt)
 		: template_parameters_(std::move(template_params)),
 		  function_declaration_(function_decl),
 		  requires_clause_(requires_clause) {}
+	TemplateFunctionDeclarationNode(std::vector<ASTNode> template_params, ASTNode function_decl,
+									std::optional<ASTNode> requires_clause = std::nullopt)
+		: function_declaration_(function_decl),
+		  requires_clause_(requires_clause) {
+		template_parameters_.reserve(template_params.size());
+		for (const ASTNode& template_param : template_params) {
+			if (template_param.is<TemplateParameterNode>()) {
+				template_parameters_.push_back(template_param.as<TemplateParameterNode>());
+			}
+		}
+	}
 
-	const InlineVector<ASTNode, 4>& template_parameters() const { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
 	ASTNode function_declaration() const { return function_declaration_; }
 	const std::optional<ASTNode>& requires_clause() const { return requires_clause_; }
 	bool has_requires_clause() const { return requires_clause_.has_value(); }
@@ -100,7 +111,7 @@ public:
 	}
 
 private:
-	InlineVector<ASTNode, 4> template_parameters_;  // TemplateParameterNode instances
+	std::vector<TemplateParameterNode> template_parameters_;
 	ASTNode function_declaration_;  // FunctionDeclarationNode
 	std::optional<ASTNode> requires_clause_;	 // Optional RequiresClauseNode
 };
@@ -140,26 +151,26 @@ inline FunctionDeclarationNode* get_function_decl_node_mut(ASTNode& node) {
 class TemplateAliasNode {
 public:
 	TemplateAliasNode() = delete;
-	TemplateAliasNode(InlineVector<ASTNode, 4> template_params,
+	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  const TypeSpecifierNode& target_type)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), alias_name_(alias_name), target_type_(target_type), is_deferred_(false) {}
-	TemplateAliasNode(InlineVector<ASTNode, 4> template_params,
+	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  ASTNode target_type)
 		: TemplateAliasNode(std::move(template_params), std::move(param_names), alias_name, target_type.as<TypeSpecifierNode>()) {}
 
 	// Constructor for deferred template instantiation (Option 1)
-	TemplateAliasNode(InlineVector<ASTNode, 4> template_params,
+	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  const TypeSpecifierNode& target_type,
 					  StringHandle target_template_name,
 					  std::vector<ASTNode> target_template_args)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), alias_name_(alias_name), target_type_(target_type), is_deferred_(true), target_template_name_(target_template_name), target_template_args_(std::move(target_template_args)) {}
-	TemplateAliasNode(InlineVector<ASTNode, 4> template_params,
+	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  ASTNode target_type,
@@ -167,7 +178,7 @@ public:
 					  std::vector<ASTNode> target_template_args)
 		: TemplateAliasNode(std::move(template_params), std::move(param_names), alias_name, target_type.as<TypeSpecifierNode>(), target_template_name, std::move(target_template_args)) {}
 
-	const InlineVector<ASTNode, 4>& template_parameters() const { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
 	const InlineVector<StringHandle, 4>& template_param_names() const { return template_param_names_; }
 	std::string_view alias_name() const { return alias_name_.view(); }
 	const TypeSpecifierNode& target_type() const { return target_type_; }
@@ -182,7 +193,7 @@ public:
 	const TypeSpecifierNode& target_type_node() const { return target_type_; }
 
 private:
-	InlineVector<ASTNode, 4> template_parameters_;  // TemplateParameterNode instances
+	std::vector<TemplateParameterNode> template_parameters_;
 	InlineVector<StringHandle, 4> template_param_names_;	 // Parameter names for lookup
 	StringHandle alias_name_;  // The name of the alias (e.g., "Ptr")
 	TypeSpecifierNode target_type_;  // The target type (e.g., T*)
@@ -198,19 +209,19 @@ private:
 class DeductionGuideNode {
 public:
 	DeductionGuideNode() = delete;
-	DeductionGuideNode(std::vector<ASTNode> template_params,
+	DeductionGuideNode(std::vector<TemplateParameterNode> template_params,
 					   std::string_view class_name,
 					   std::vector<ASTNode> guide_params,
 					   std::vector<ASTNode> deduced_template_args)
 		: template_parameters_(std::move(template_params)), class_name_(class_name), guide_parameters_(std::move(guide_params)), deduced_template_args_(std::move(deduced_template_args)) {}
 
-	const std::vector<ASTNode>& template_parameters() const { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
 	std::string_view class_name() const { return class_name_; }
 	const std::vector<ASTNode>& guide_parameters() const { return guide_parameters_; }
 	const std::vector<ASTNode>& deduced_template_args_nodes() const { return deduced_template_args_; }
 
 private:
-	std::vector<ASTNode> template_parameters_;  // TemplateParameterNode instances for the guide's template params
+	std::vector<TemplateParameterNode> template_parameters_;
 	std::string_view class_name_;  // Name of the class template
 	std::vector<ASTNode> guide_parameters_;	// Parameters of the guide (like constructor params)
 	std::vector<ASTNode> deduced_template_args_;	 // RHS nodes for template arguments (TypeSpecifierNode instances)
@@ -224,10 +235,10 @@ class VariableDeclarationNode;
 class TemplateVariableDeclarationNode {
 public:
 	TemplateVariableDeclarationNode() = delete;
-	TemplateVariableDeclarationNode(InlineVector<ASTNode, 4> template_params, ASTNode variable_decl)
+	TemplateVariableDeclarationNode(std::vector<TemplateParameterNode> template_params, ASTNode variable_decl)
 		: template_parameters_(std::move(template_params)), variable_declaration_(variable_decl) {}
 
-	const InlineVector<ASTNode, 4>& template_parameters() const { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
 	ASTNode variable_declaration() const { return variable_declaration_; }
 
 	// Get the underlying VariableDeclarationNode
@@ -239,7 +250,7 @@ public:
 	}
 
 private:
-	InlineVector<ASTNode, 4> template_parameters_;  // TemplateParameterNode instances
+	std::vector<TemplateParameterNode> template_parameters_;
 	ASTNode variable_declaration_;  // VariableDeclarationNode
 };
 
@@ -510,13 +521,13 @@ public:
 	const std::optional<ASTNode>& requires_clause() const { return requires_clause_; }
 	bool has_requires_clause() const { return requires_clause_.has_value(); }
 
-	void set_template_parameters(const std::vector<ASTNode>& template_parameters) {
+	void set_template_parameters(const std::vector<TemplateParameterNode>& template_parameters) {
 		template_parameters_ = template_parameters;
 	}
-	void add_template_parameter(ASTNode template_parameter) {
+	void add_template_parameter(const TemplateParameterNode& template_parameter) {
 		template_parameters_.push_back(template_parameter);
 	}
-	const std::vector<ASTNode>& template_parameters() const { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
 	bool has_template_parameters() const { return !template_parameters_.empty(); }
 
 	// Template body position: for member function template constructors whose bodies
@@ -586,7 +597,7 @@ private:
 	bool is_constexpr_ = false;	// constexpr specifier
 	std::string_view mangled_name_;	// Pre-computed mangled name (points to ChunkedStringAllocator storage)
 	std::optional<ASTNode> requires_clause_;	 // C++20 trailing requires clause
-	std::vector<ASTNode> template_parameters_;
+	std::vector<TemplateParameterNode> template_parameters_;
 	bool has_template_body_ = false;
 	bool has_template_initializer_list_ = false;
 	SaveHandle template_body_position_handle_;  // Handle to saved position for template body
@@ -1274,13 +1285,24 @@ private:
 class TemplateClassDeclarationNode {
 public:
 	TemplateClassDeclarationNode() = delete;
-	TemplateClassDeclarationNode(InlineVector<ASTNode, 4> template_params,
+	TemplateClassDeclarationNode(std::vector<TemplateParameterNode> template_params,
 								 InlineVector<std::string_view, 4> param_names,
 								 ASTNode class_decl)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), class_declaration_(class_decl) {}
+	TemplateClassDeclarationNode(InlineVector<ASTNode, 4> template_params,
+								 InlineVector<std::string_view, 4> param_names,
+								 ASTNode class_decl)
+		: template_param_names_(std::move(param_names)), class_declaration_(class_decl) {
+		template_parameters_.reserve(template_params.size());
+		for (const ASTNode& template_param : template_params) {
+			if (template_param.is<TemplateParameterNode>()) {
+				template_parameters_.push_back(template_param.as<TemplateParameterNode>());
+			}
+		}
+	}
 
-	const InlineVector<ASTNode, 4>& template_parameters() const { return template_parameters_; }
-	InlineVector<ASTNode, 4>& template_parameters() { return template_parameters_; }
+	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	std::vector<TemplateParameterNode>& template_parameters() { return template_parameters_; }
 	const InlineVector<std::string_view, 4>& template_param_names() const { return template_param_names_; }
 	ASTNode class_declaration() const { return class_declaration_; }
 
@@ -1304,7 +1326,7 @@ public:
 	}
 
 private:
-	InlineVector<ASTNode, 4> template_parameters_;  // TemplateParameterNode instances
+	std::vector<TemplateParameterNode> template_parameters_;
 	InlineVector<std::string_view, 4> template_param_names_;	 // Parameter names for lookup
 	ASTNode class_declaration_;	// StructDeclarationNode
 	std::vector<DeferredTemplateMemberBody> deferred_bodies_;  // Member function bodies to parse at instantiation

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -214,20 +214,20 @@ public:
 	DeductionGuideNode() = delete;
 	DeductionGuideNode(InlineVector<TemplateParameterNode, 4> template_params,
 					   std::string_view class_name,
-					   std::vector<ASTNode> guide_params,
+					   InlineVector<TypeSpecifierNode, 4> guide_params,
 					   std::vector<ASTNode> deduced_template_args)
 		: template_parameters_(std::move(template_params)), class_name_(class_name), guide_parameters_(std::move(guide_params)), deduced_template_args_(std::move(deduced_template_args)) {}
 
 	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	std::string_view class_name() const { return class_name_; }
-	const std::vector<ASTNode>& guide_parameters() const { return guide_parameters_; }
-	const std::vector<ASTNode>& deduced_template_args_nodes() const { return deduced_template_args_; }
+	const InlineVector<TypeSpecifierNode, 4>& guide_parameters() const { return guide_parameters_; }
+	const std::vector<ASTNode>& deduced_template_args() const { return deduced_template_args_; }
 
 private:
 	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	std::string_view class_name_;  // Name of the class template
-	std::vector<ASTNode> guide_parameters_;	// Parameters of the guide (like constructor params)
-	std::vector<ASTNode> deduced_template_args_;	 // RHS nodes for template arguments (TypeSpecifierNode instances)
+	InlineVector<TypeSpecifierNode, 4> guide_parameters_;
+	std::vector<ASTNode> deduced_template_args_;
 };
 
 // Forward declarations
@@ -242,15 +242,12 @@ public:
 		: template_parameters_(std::move(template_params)), variable_declaration_(variable_decl) {}
 
 	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
-	ASTNode variable_declaration() const { return variable_declaration_; }
+	VariableDeclarationNode& variable_declaration() { return variable_declaration_.as<VariableDeclarationNode>(); }
+	const VariableDeclarationNode& variable_declaration() const { return variable_declaration_.as<VariableDeclarationNode>(); }
 
 	// Get the underlying VariableDeclarationNode
-	VariableDeclarationNode& variable_decl_node() {
-		return variable_declaration_.as<VariableDeclarationNode>();
-	}
-	const VariableDeclarationNode& variable_decl_node() const {
-		return variable_declaration_.as<VariableDeclarationNode>();
-	}
+	VariableDeclarationNode& variable_decl_node() { return variable_declaration_.as<VariableDeclarationNode>(); }
+	const VariableDeclarationNode& variable_decl_node() const { return variable_declaration_.as<VariableDeclarationNode>(); }
 
 private:
 	InlineVector<TemplateParameterNode, 4> template_parameters_;

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -11,6 +11,9 @@ enum class TemplateParameterKind {
 // Template parameter node - represents a single template parameter
 class TemplateParameterNode {
 public:
+	TemplateParameterNode()
+		: kind_(TemplateParameterKind::Type) {}
+
 	// Type parameter: template<typename T> or template<class T>
 	TemplateParameterNode(StringHandle name, Token token)
 		: kind_(TemplateParameterKind::Type), name_(name), token_(token) {}
@@ -80,13 +83,13 @@ private:
 class TemplateFunctionDeclarationNode {
 public:
 	TemplateFunctionDeclarationNode() = delete;
-	TemplateFunctionDeclarationNode(std::vector<TemplateParameterNode> template_params, ASTNode function_decl,
-									std::optional<ASTNode> requires_clause = std::nullopt)
+	TemplateFunctionDeclarationNode(InlineVector<TemplateParameterNode, 4> template_params, ASTNode function_decl,
+									std::optional<ASTNode> requires_clause)
 		: template_parameters_(std::move(template_params)),
 		  function_declaration_(function_decl),
 		  requires_clause_(requires_clause) {}
-	TemplateFunctionDeclarationNode(std::vector<ASTNode> template_params, ASTNode function_decl,
-									std::optional<ASTNode> requires_clause = std::nullopt)
+	TemplateFunctionDeclarationNode(InlineVector<ASTNode, 4> template_params, ASTNode function_decl,
+									std::optional<ASTNode> requires_clause)
 		: function_declaration_(function_decl),
 		  requires_clause_(requires_clause) {
 		template_parameters_.reserve(template_params.size());
@@ -97,7 +100,7 @@ public:
 		}
 	}
 
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	ASTNode function_declaration() const { return function_declaration_; }
 	const std::optional<ASTNode>& requires_clause() const { return requires_clause_; }
 	bool has_requires_clause() const { return requires_clause_.has_value(); }
@@ -111,7 +114,7 @@ public:
 	}
 
 private:
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	ASTNode function_declaration_;  // FunctionDeclarationNode
 	std::optional<ASTNode> requires_clause_;	 // Optional RequiresClauseNode
 };
@@ -151,26 +154,26 @@ inline FunctionDeclarationNode* get_function_decl_node_mut(ASTNode& node) {
 class TemplateAliasNode {
 public:
 	TemplateAliasNode() = delete;
-	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
+	TemplateAliasNode(InlineVector<TemplateParameterNode, 4> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  const TypeSpecifierNode& target_type)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), alias_name_(alias_name), target_type_(target_type), is_deferred_(false) {}
-	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
+	TemplateAliasNode(InlineVector<TemplateParameterNode, 4> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  ASTNode target_type)
 		: TemplateAliasNode(std::move(template_params), std::move(param_names), alias_name, target_type.as<TypeSpecifierNode>()) {}
 
 	// Constructor for deferred template instantiation (Option 1)
-	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
+	TemplateAliasNode(InlineVector<TemplateParameterNode, 4> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  const TypeSpecifierNode& target_type,
 					  StringHandle target_template_name,
 					  std::vector<ASTNode> target_template_args)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), alias_name_(alias_name), target_type_(target_type), is_deferred_(true), target_template_name_(target_template_name), target_template_args_(std::move(target_template_args)) {}
-	TemplateAliasNode(std::vector<TemplateParameterNode> template_params,
+	TemplateAliasNode(InlineVector<TemplateParameterNode, 4> template_params,
 					  InlineVector<StringHandle, 4> param_names,
 					  StringHandle alias_name,
 					  ASTNode target_type,
@@ -178,7 +181,7 @@ public:
 					  std::vector<ASTNode> target_template_args)
 		: TemplateAliasNode(std::move(template_params), std::move(param_names), alias_name, target_type.as<TypeSpecifierNode>(), target_template_name, std::move(target_template_args)) {}
 
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	const InlineVector<StringHandle, 4>& template_param_names() const { return template_param_names_; }
 	std::string_view alias_name() const { return alias_name_.view(); }
 	const TypeSpecifierNode& target_type() const { return target_type_; }
@@ -193,7 +196,7 @@ public:
 	const TypeSpecifierNode& target_type_node() const { return target_type_; }
 
 private:
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	InlineVector<StringHandle, 4> template_param_names_;	 // Parameter names for lookup
 	StringHandle alias_name_;  // The name of the alias (e.g., "Ptr")
 	TypeSpecifierNode target_type_;  // The target type (e.g., T*)
@@ -209,19 +212,19 @@ private:
 class DeductionGuideNode {
 public:
 	DeductionGuideNode() = delete;
-	DeductionGuideNode(std::vector<TemplateParameterNode> template_params,
+	DeductionGuideNode(InlineVector<TemplateParameterNode, 4> template_params,
 					   std::string_view class_name,
 					   std::vector<ASTNode> guide_params,
 					   std::vector<ASTNode> deduced_template_args)
 		: template_parameters_(std::move(template_params)), class_name_(class_name), guide_parameters_(std::move(guide_params)), deduced_template_args_(std::move(deduced_template_args)) {}
 
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	std::string_view class_name() const { return class_name_; }
 	const std::vector<ASTNode>& guide_parameters() const { return guide_parameters_; }
 	const std::vector<ASTNode>& deduced_template_args_nodes() const { return deduced_template_args_; }
 
 private:
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	std::string_view class_name_;  // Name of the class template
 	std::vector<ASTNode> guide_parameters_;	// Parameters of the guide (like constructor params)
 	std::vector<ASTNode> deduced_template_args_;	 // RHS nodes for template arguments (TypeSpecifierNode instances)
@@ -235,10 +238,10 @@ class VariableDeclarationNode;
 class TemplateVariableDeclarationNode {
 public:
 	TemplateVariableDeclarationNode() = delete;
-	TemplateVariableDeclarationNode(std::vector<TemplateParameterNode> template_params, ASTNode variable_decl)
+	TemplateVariableDeclarationNode(InlineVector<TemplateParameterNode, 4> template_params, ASTNode variable_decl)
 		: template_parameters_(std::move(template_params)), variable_declaration_(variable_decl) {}
 
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	ASTNode variable_declaration() const { return variable_declaration_; }
 
 	// Get the underlying VariableDeclarationNode
@@ -250,7 +253,7 @@ public:
 	}
 
 private:
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	ASTNode variable_declaration_;  // VariableDeclarationNode
 };
 
@@ -521,13 +524,13 @@ public:
 	const std::optional<ASTNode>& requires_clause() const { return requires_clause_; }
 	bool has_requires_clause() const { return requires_clause_.has_value(); }
 
-	void set_template_parameters(const std::vector<TemplateParameterNode>& template_parameters) {
+	void set_template_parameters(const InlineVector<TemplateParameterNode, 4>& template_parameters) {
 		template_parameters_ = template_parameters;
 	}
 	void add_template_parameter(const TemplateParameterNode& template_parameter) {
 		template_parameters_.push_back(template_parameter);
 	}
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	bool has_template_parameters() const { return !template_parameters_.empty(); }
 
 	// Template body position: for member function template constructors whose bodies
@@ -597,7 +600,7 @@ private:
 	bool is_constexpr_ = false;	// constexpr specifier
 	std::string_view mangled_name_;	// Pre-computed mangled name (points to ChunkedStringAllocator storage)
 	std::optional<ASTNode> requires_clause_;	 // C++20 trailing requires clause
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	bool has_template_body_ = false;
 	bool has_template_initializer_list_ = false;
 	SaveHandle template_body_position_handle_;  // Handle to saved position for template body
@@ -1285,7 +1288,7 @@ private:
 class TemplateClassDeclarationNode {
 public:
 	TemplateClassDeclarationNode() = delete;
-	TemplateClassDeclarationNode(std::vector<TemplateParameterNode> template_params,
+	TemplateClassDeclarationNode(InlineVector<TemplateParameterNode, 4> template_params,
 								 InlineVector<std::string_view, 4> param_names,
 								 ASTNode class_decl)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), class_declaration_(class_decl) {}
@@ -1301,8 +1304,8 @@ public:
 		}
 	}
 
-	const std::vector<TemplateParameterNode>& template_parameters() const { return template_parameters_; }
-	std::vector<TemplateParameterNode>& template_parameters() { return template_parameters_; }
+	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
+	InlineVector<TemplateParameterNode, 4>& template_parameters() { return template_parameters_; }
 	const InlineVector<std::string_view, 4>& template_param_names() const { return template_param_names_; }
 	ASTNode class_declaration() const { return class_declaration_; }
 
@@ -1326,7 +1329,7 @@ public:
 	}
 
 private:
-	std::vector<TemplateParameterNode> template_parameters_;
+	InlineVector<TemplateParameterNode, 4> template_parameters_;
 	InlineVector<std::string_view, 4> template_param_names_;	 // Parameter names for lookup
 	ASTNode class_declaration_;	// StructDeclarationNode
 	std::vector<DeferredTemplateMemberBody> deferred_bodies_;  // Member function bodies to parse at instantiation

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1261,9 +1261,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 							// Get template parameter names for evaluation
 							InlineVector<std::string_view, 4> eval_param_names;
 							for (const auto& tparam_node : template_func.template_parameters()) {
-								if (tparam_node.is<TemplateParameterNode>()) {
-									eval_param_names.push_back(tparam_node.as<TemplateParameterNode>().name());
-								}
+								eval_param_names.push_back(tparam_node.name());
 							}
 
 							// Convert arg_types to TemplateTypeArg for evaluation
@@ -1309,9 +1307,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 						// Get template parameter names
 						InlineVector<std::string_view, 4> param_names;
 						for (const auto& tparam_node : template_func.template_parameters()) {
-							if (tparam_node.is<TemplateParameterNode>()) {
-								param_names.push_back(tparam_node.as<TemplateParameterNode>().name());
-							}
+							param_names.push_back(tparam_node.name());
 						}
 
 						// Generate the mangled name

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1131,22 +1131,21 @@ private:
 	// Parses: type_and_name + function_declaration + body handling (semicolon or skip braces)
 	// Returns the TemplateFunctionDeclarationNode in out_template_node
 	ParseResult parse_template_function_declaration_body(
-		std::vector<TemplateParameterNode>& template_params,
+		InlineVector<TemplateParameterNode, 4>& template_params,
 		std::optional<ASTNode> requires_clause,
 		ASTNode& out_template_node);
 	struct TemplateParameterMetadata {
 		InlineVector<StringHandle, 4> names;
-		InlineVector<std::string_view, 4> name_views;
 		InlineVector<TemplateParameterKind, 4> kinds;
 		bool has_packs = false;
 	};
-	ParseResult parse_template_parameter_list(std::vector<TemplateParameterNode>& out_params);	 // NEW: Parse template parameter list
+	ParseResult parse_template_parameter_list(InlineVector<TemplateParameterNode, 4>& out_params);	 // NEW: Parse template parameter list
 	ParseResult parse_template_parameter();	// NEW: Parse a single template parameter
 	TypeInfo& ensureTemplateParameterTypeRegistration(TemplateParameterNode& tparam);
 	TemplateParameterMetadata registerTemplateParametersInScope(
-		std::vector<TemplateParameterNode>& template_params,
+		InlineVector<TemplateParameterNode, 4>& template_params,
 		FlashCpp::TemplateParameterScope& template_scope);
-	InlineVector<ASTNode, 4> cloneTemplateParameterNodes(const std::vector<TemplateParameterNode>& template_params);
+	InlineVector<ASTNode, 4> cloneTemplateParameterNodes(const InlineVector<TemplateParameterNode, 4>& template_params);
 	bool parseDeferredAliasTargetTemplateId(
 		StringHandle& out_target_template_name,
 		std::vector<ASTNode>& out_target_template_arg_nodes,
@@ -1280,7 +1279,7 @@ private:
 		int recursion_depth);
 	bool tryAppendDefaultTemplateArg(
 		const TemplateParameterNode& param,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
 	bool tryAppendDefaultTemplateArg(
@@ -1290,7 +1289,7 @@ private:
 		NamespaceHandle source_namespace);
 	bool tryAppendMemberDefaultTemplateArg(
 		const TemplateParameterNode& param,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const OuterTemplateBinding* outer_binding,
 		InlineVector<TemplateTypeArg, 4>& template_args);
 	void appendOuterBindingSubstitutionInputs(
@@ -1303,7 +1302,7 @@ private:
 		std::span<const TemplateTypeArg> template_args);
 	ASTNode substituteNonTypeDefaultExpression(
 		const ASTNode& default_node,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args);
 	ASTNode substituteNonTypeDefaultExpression(
 		const ASTNode& default_node,
@@ -1316,7 +1315,7 @@ private:
 		std::span<const std::string_view> template_param_names);
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
 		const ASTNode& default_node,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args,
 		std::span<const std::string_view> template_param_names);
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
@@ -1332,7 +1331,7 @@ private:
 		int recursion_depth,
 		NamespaceHandle source_namespace);
 	std::optional<InlineVector<TemplateTypeArg, 4>> deduceTemplateArgsFromCall(
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const std::vector<TypeSpecifierNode>& arg_types,
 		const CallArgDeductionInfo& deduction_info,
 		size_t function_pack_arg_start,
@@ -1342,12 +1341,12 @@ private:
 	// types. The returned metadata also carries the canonical function-param → call-arg
 	// mapping so deduction sites can reuse one pack-aware view of the call shape.
 	std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const std::vector<ASTNode>& func_params,
 		const std::vector<TypeSpecifierNode>& arg_types,
 		int recursion_depth);
 	std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const FunctionDeclarationNode& func_decl,
 		const std::vector<TypeSpecifierNode>& arg_types,
 		int recursion_depth);
@@ -1371,7 +1370,7 @@ private:
 	void reparse_template_function_body(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		bool preserve_ref_qualifier);
 	// Populate template_param_substitutions_ from parallel (name, arg) pairs for
@@ -1776,7 +1775,7 @@ private:
 		const std::vector<TemplateTypeArg>& template_args);
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
-		const std::vector<TemplateParameterNode>& template_parameters,
+		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
 		const std::vector<TemplateTypeArg>& template_args);
 	std::optional<std::vector<TemplateTypeArg>> materializeDeferredAliasTemplateArgs(
@@ -2157,7 +2156,7 @@ private:
 		const std::vector<TemplateTypeArg>& template_args);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	AliasTemplateMaterializationResult materializeAliasTemplateInstantiation(
 		std::string_view alias_template_name,
@@ -2166,7 +2165,7 @@ private:
 		const InlineVector<ASTNode, 4>& template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	void normalizeDependentNonTypeTemplateArgs(
-		const std::vector<TemplateParameterNode>& template_parameters,
+		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	bool resolveAliasTemplateInstantiation(
 		TypeSpecifierNode& type_spec,
@@ -2199,7 +2198,7 @@ private:
 		const std::vector<TemplateTypeArg>& args,
 		const std::vector<ASTNode>& params);	 // Substitute non-type template parameter in initializer
 
-	std::optional<bool> try_parse_out_of_line_template_member(const std::vector<TemplateParameterNode>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const std::vector<TemplateParameterNode>& inner_template_params = {}, const InlineVector<StringHandle, 4>& inner_template_param_names = {});	 // NEW: Parse out-of-line template member function
+	std::optional<bool> try_parse_out_of_line_template_member(const InlineVector<TemplateParameterNode, 4>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const InlineVector<TemplateParameterNode, 4>& inner_template_params, const InlineVector<StringHandle, 4>& inner_template_param_names);	 // NEW: Parse out-of-line template member function
 	bool try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const InitializerListNode& init_list);
 	bool deduce_template_arguments_from_guide(const DeductionGuideNode& guide,
 											  const std::vector<TypeSpecifierNode>& argument_types,
@@ -2232,7 +2231,7 @@ public:	// Public methods for template instantiation
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 
 	// Helper to extract type from an expression for overload resolution.
@@ -2356,7 +2355,7 @@ private:	 // Resume private methods
 		ChunkedVector<ASTNode>& out_args);
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		ChunkedVector<ASTNode>& out_args);
 
@@ -2588,7 +2587,7 @@ private:	 // Resume private methods
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
-		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 
 	// Lookup symbol with template parameter checking

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1298,38 +1298,13 @@ private:
 		InlineVector<TemplateTypeArg, 4>& out_args);
 	ASTNode substituteNonTypeDefaultExpression(
 		const ASTNode& default_node,
-		const std::vector<ASTNode>& template_params,
-		std::span<const TemplateTypeArg> template_args);
-	ASTNode substituteNonTypeDefaultExpression(
-		const ASTNode& default_node,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args);
-	ASTNode substituteNonTypeDefaultExpression(
-		const ASTNode& default_node,
-		const InlineVector<ASTNode, 4>& template_params,
-		std::span<const TemplateTypeArg> template_args);
-	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
-		const ASTNode& default_node,
-		const std::vector<ASTNode>& template_params,
-		std::span<const TemplateTypeArg> template_args,
-		std::span<const std::string_view> template_param_names);
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
 		const ASTNode& default_node,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args,
 		std::span<const std::string_view> template_param_names);
-	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
-		const ASTNode& default_node,
-		const InlineVector<ASTNode, 4>& template_params,
-		std::span<const TemplateTypeArg> template_args,
-		std::span<const std::string_view> template_param_names);
-	std::optional<InlineVector<TemplateTypeArg, 4>> deduceTemplateArgsFromCall(
-		const std::vector<ASTNode>& template_params,
-		const std::vector<TypeSpecifierNode>& arg_types,
-		const CallArgDeductionInfo& deduction_info,
-		size_t function_pack_arg_start,
-		int recursion_depth,
-		NamespaceHandle source_namespace);
 	std::optional<InlineVector<TemplateTypeArg, 4>> deduceTemplateArgsFromCall(
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const std::vector<TypeSpecifierNode>& arg_types,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -321,13 +321,13 @@ inline SubstitutionParamMap buildSubstitutionParamMap(
 	SubstitutionParamMap result;
 	result.param_order.reserve(std::min(template_params.size(), template_args.size()));
 	for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-		if (!template_params[i].template is<TemplateParameterNode>()) {
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr) {
 			continue;
 		}
-		const TemplateParameterNode& param = template_params[i].template as<TemplateParameterNode>();
-		TemplateTypeArg arg_to_insert = enrichTemplateArgForParameter(param, template_args[i]);
-		result.param_map[param.name()] = arg_to_insert;
-		result.param_order.push_back(param.name());
+		TemplateTypeArg arg_to_insert = enrichTemplateArgForParameter(*param, template_args[i]);
+		result.param_map[param->name()] = arg_to_insert;
+		result.param_order.push_back(param->name());
 	}
 	return result;
 }
@@ -338,11 +338,12 @@ inline std::vector<std::string_view> buildTemplateParamNames(
 	std::vector<std::string_view> param_names;
 	param_names.reserve(template_params.size());
 	for (const auto& template_param_node : template_params) {
-		if (!template_param_node.template is<TemplateParameterNode>()) {
+		const TemplateParameterNode* template_param =
+			tryGetTemplateParameterNode(template_param_node);
+		if (template_param == nullptr) {
 			continue;
 		}
-		param_names.push_back(
-			template_param_node.template as<TemplateParameterNode>().name());
+		param_names.push_back(template_param->name());
 	}
 	return param_names;
 }
@@ -1145,7 +1146,7 @@ private:
 	TemplateParameterMetadata registerTemplateParametersInScope(
 		std::vector<TemplateParameterNode>& template_params,
 		FlashCpp::TemplateParameterScope& template_scope);
-	InlineVector<ASTNode, 4> createTemplateParameterAstNodes(const std::vector<TemplateParameterNode>& template_params);
+	InlineVector<ASTNode, 4> cloneTemplateParameterNodes(const std::vector<TemplateParameterNode>& template_params);
 	bool parseDeferredAliasTargetTemplateId(
 		StringHandle& out_target_template_name,
 		std::vector<ASTNode>& out_target_template_arg_nodes,
@@ -1279,12 +1280,17 @@ private:
 		int recursion_depth);
 	bool tryAppendDefaultTemplateArg(
 		const TemplateParameterNode& param,
+		const std::vector<TemplateParameterNode>& template_params,
+		InlineVector<TemplateTypeArg, 4>& template_args,
+		NamespaceHandle source_namespace);
+	bool tryAppendDefaultTemplateArg(
+		const TemplateParameterNode& param,
 		const std::vector<ASTNode>& template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
 	bool tryAppendMemberDefaultTemplateArg(
 		const TemplateParameterNode& param,
-		const std::vector<ASTNode>& template_params,
+		const std::vector<TemplateParameterNode>& template_params,
 		const OuterTemplateBinding* outer_binding,
 		InlineVector<TemplateTypeArg, 4>& template_args);
 	void appendOuterBindingSubstitutionInputs(
@@ -1297,11 +1303,20 @@ private:
 		std::span<const TemplateTypeArg> template_args);
 	ASTNode substituteNonTypeDefaultExpression(
 		const ASTNode& default_node,
+		const std::vector<TemplateParameterNode>& template_params,
+		std::span<const TemplateTypeArg> template_args);
+	ASTNode substituteNonTypeDefaultExpression(
+		const ASTNode& default_node,
 		const InlineVector<ASTNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args);
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
 		const ASTNode& default_node,
 		const std::vector<ASTNode>& template_params,
+		std::span<const TemplateTypeArg> template_args,
+		std::span<const std::string_view> template_param_names);
+	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
+		const ASTNode& default_node,
+		const std::vector<TemplateParameterNode>& template_params,
 		std::span<const TemplateTypeArg> template_args,
 		std::span<const std::string_view> template_param_names);
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefault(
@@ -1316,16 +1331,23 @@ private:
 		size_t function_pack_arg_start,
 		int recursion_depth,
 		NamespaceHandle source_namespace);
+	std::optional<InlineVector<TemplateTypeArg, 4>> deduceTemplateArgsFromCall(
+		const std::vector<TemplateParameterNode>& template_params,
+		const std::vector<TypeSpecifierNode>& arg_types,
+		const CallArgDeductionInfo& deduction_info,
+		size_t function_pack_arg_start,
+		int recursion_depth,
+		NamespaceHandle source_namespace);
 	// Shared pre-deduction helper for matching function-parameter slots to call-argument
 	// types. The returned metadata also carries the canonical function-param → call-arg
 	// mapping so deduction sites can reuse one pack-aware view of the call shape.
 	std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
-		const std::vector<ASTNode>& template_params,
+		const std::vector<TemplateParameterNode>& template_params,
 		const std::vector<ASTNode>& func_params,
 		const std::vector<TypeSpecifierNode>& arg_types,
 		int recursion_depth);
 	std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
-		const std::vector<ASTNode>& template_params,
+		const std::vector<TemplateParameterNode>& template_params,
 		const FunctionDeclarationNode& func_decl,
 		const std::vector<TypeSpecifierNode>& arg_types,
 		int recursion_depth);
@@ -1346,6 +1368,12 @@ private:
 		const InlineVector<ASTNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		bool preserve_ref_qualifier = false);
+	void reparse_template_function_body(
+		FunctionDeclarationNode& new_func_ref,
+		const FunctionDeclarationNode& func_decl,
+		const std::vector<TemplateParameterNode>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		bool preserve_ref_qualifier);
 	// Populate template_param_substitutions_ from parallel (name, arg) pairs for
 	// body-reparse paths so non-type params (e.g. int N → 4) are resolved in parse_block().
 	// Overload 1: TemplateTypeArg source (lazy body-reparse path).
@@ -1361,9 +1389,9 @@ private:
 	// Build outer-template binding data from the AST template parameter list so
 	// parameter names and args stay index-aligned even if the parameter list
 	// ever stops being a pure TemplateParameterNode sequence.
-	template <typename ArgContainer, typename OutArgContainer>
+	template <typename ParamContainer, typename ArgContainer, typename OutArgContainer>
 	void collectOuterTemplateBindings(
-		const InlineVector<ASTNode, 4>& template_params,
+		const ParamContainer& template_params,
 		const ArgContainer& template_args,
 		InlineVector<StringHandle, 4>& out_param_names,
 		OutArgContainer& out_args) const {
@@ -1374,17 +1402,17 @@ private:
 		out_args.reserve(pair_count);
 
 		for (size_t i = 0; i < pair_count; ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			if (param == nullptr) {
 				continue;
 			}
-
-			out_param_names.push_back(template_params[i].as<TemplateParameterNode>().nameHandle());
+			out_param_names.push_back(param->nameHandle());
 			out_args.push_back(template_args[i]);
 		}
 	}
-	template <typename ArgContainer>
+	template <typename ParamContainer, typename ArgContainer>
 	void collectOuterTemplateBinding(
-		const InlineVector<ASTNode, 4>& template_params,
+		const ParamContainer& template_params,
 		const ArgContainer& template_args,
 		OuterTemplateBinding& out_binding) const {
 		out_binding.param_names.clear();
@@ -1398,21 +1426,22 @@ private:
 
 		size_t arg_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
+			const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+			if (tparam == nullptr) {
 				continue;
 			}
+			out_binding.param_names.push_back(tparam->nameHandle());
+			if constexpr (std::is_same_v<std::decay_t<decltype(template_params[i])>, ASTNode>) {
+				out_binding.params.push_back(template_params[i]);
+			} else {
+				out_binding.params.push_back(ASTNode::emplace_node<TemplateParameterNode>(*tparam));
+			}
 
-			const auto& tparam = template_params[i].as<TemplateParameterNode>();
-			out_binding.param_names.push_back(tparam.nameHandle());
-			out_binding.params.push_back(template_params[i]);
-
-			if (tparam.is_variadic()) {
+			if (tparam->is_variadic()) {
 				size_t remaining_args = arg_index < template_args.size()
 										 ? template_args.size() - arg_index
 										 : 0;
-				size_t required_after = countRequiredTemplateArgsAfter<
-					InlineVector<ASTNode, 4>,
-					ArgContainer>(template_params, i + 1);
+				size_t required_after = countRequiredTemplateArgsAfter(template_params, i + 1);
 				size_t pack_size = remaining_args > required_after
 									 ? remaining_args - required_after
 									 : 0;
@@ -1443,10 +1472,10 @@ private:
 			++arg_index;
 		}
 	}
-	template <typename NodeT, typename ArgContainer>
+	template <typename NodeT, typename ParamContainer, typename ArgContainer>
 	void setOuterTemplateBindingsFromParams(
 		NodeT& node,
-		const InlineVector<ASTNode, 4>& template_params,
+		const ParamContainer& template_params,
 		const ArgContainer& template_args) {
 		InlineVector<StringHandle, 4> outer_template_param_names;
 		std::vector<std::decay_t<decltype(template_args[0])>> filtered_template_args;
@@ -1462,12 +1491,12 @@ private:
 		const TemplateParamsContainer& template_params,
 		const TemplateArgsContainer& template_args) {
 		for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-			if (!template_params[i].template is<TemplateParameterNode>()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			if (param == nullptr) {
 				continue;
 			}
 
-			const TemplateParameterNode& param = template_params[i].template as<TemplateParameterNode>();
-			if (param.kind() != TemplateParameterKind::Type || param.nameHandle() != base_name) {
+			if (param->kind() != TemplateParameterKind::Type || param->nameHandle() != base_name) {
 				continue;
 			}
 
@@ -1521,13 +1550,12 @@ private:
 
 			size_t arg_index = 0;
 			for (size_t i = 0; i < template_params.size(); ++i) {
-				if (!template_params[i].template is<TemplateParameterNode>()) {
+				const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+				if (param == nullptr) {
 					continue;
 				}
 
-				const auto& param =
-					template_params[i].template as<TemplateParameterNode>();
-				if (param.is_variadic()) {
+				if (param->is_variadic()) {
 					size_t remaining_args = arg_index < template_args.size()
 						? template_args.size() - arg_index
 						: 0;
@@ -1539,7 +1567,7 @@ private:
 						? remaining_args - required_after
 						: 0;
 
-					if (param.nameHandle() == arg_info.dependent_name) {
+					if (param->nameHandle() == arg_info.dependent_name) {
 						for (size_t pack_index = 0;
 							 pack_index < pack_size &&
 							 (arg_index + pack_index) < template_args.size();
@@ -1744,6 +1772,11 @@ private:
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
 		const InlineVector<ASTNode, 4>& template_parameters,
+		const InlineVector<StringHandle, 4>& param_names,
+		const std::vector<TemplateTypeArg>& template_args);
+	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
+		const ASTNode& arg_node,
+		const std::vector<TemplateParameterNode>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
 		const std::vector<TemplateTypeArg>& template_args);
 	std::optional<std::vector<TemplateTypeArg>> materializeDeferredAliasTemplateArgs(
@@ -2122,11 +2155,18 @@ private:
 		const TypeSpecifierNode& alias_type_spec,
 		const InlineVector<ASTNode, 4>& template_params,
 		const std::vector<TemplateTypeArg>& template_args);
+	const TypeInfo* materializeInstantiatedMemberAliasTarget(
+		const TypeSpecifierNode& alias_type_spec,
+		const std::vector<TemplateParameterNode>& template_params,
+		const std::vector<TemplateTypeArg>& template_args);
 	AliasTemplateMaterializationResult materializeAliasTemplateInstantiation(
 		std::string_view alias_template_name,
 		const std::vector<TemplateTypeArg>& template_args);
 	void normalizeDependentNonTypeTemplateArgs(
 		const InlineVector<ASTNode, 4>& template_parameters,
+		std::vector<TemplateTypeArg>& template_args);
+	void normalizeDependentNonTypeTemplateArgs(
+		const std::vector<TemplateParameterNode>& template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	bool resolveAliasTemplateInstantiation(
 		TypeSpecifierNode& type_spec,
@@ -2159,7 +2199,7 @@ private:
 		const std::vector<TemplateTypeArg>& args,
 		const std::vector<ASTNode>& params);	 // Substitute non-type template parameter in initializer
 
-	std::optional<bool> try_parse_out_of_line_template_member(const InlineVector<ASTNode, 4>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const InlineVector<ASTNode, 4>& inner_template_params = {}, const InlineVector<StringHandle, 4>& inner_template_param_names = {});	 // NEW: Parse out-of-line template member function
+	std::optional<bool> try_parse_out_of_line_template_member(const std::vector<TemplateParameterNode>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const std::vector<TemplateParameterNode>& inner_template_params = {}, const InlineVector<StringHandle, 4>& inner_template_param_names = {});	 // NEW: Parse out-of-line template member function
 	bool try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const InitializerListNode& init_list);
 	bool deduce_template_arguments_from_guide(const DeductionGuideNode& guide,
 											  const std::vector<TypeSpecifierNode>& argument_types,
@@ -2189,6 +2229,10 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		const InlineVector<ASTNode, 4>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args);
+	ASTNode substituteTemplateParameters(
+		const ASTNode& node,
+		const std::vector<TemplateParameterNode>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 
 	// Helper to extract type from an expression for overload resolution.
@@ -2308,6 +2352,11 @@ private:	 // Resume private methods
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
 		const InlineVector<ASTNode, 4>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		ChunkedVector<ASTNode>& out_args);
+	bool expandPackExpansionArgs(
+		const PackExpansionExprNode& pack_expansion,
+		const std::vector<TemplateParameterNode>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		ChunkedVector<ASTNode>& out_args);
 
@@ -2536,6 +2585,10 @@ private:	 // Resume private methods
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
 		const InlineVector<ASTNode, 4>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args);
+	TypeIndex substitute_template_parameter(
+		const TypeSpecifierNode& original_type,
+		const std::vector<TemplateParameterNode>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 
 	// Lookup symbol with template parameter checking

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1130,15 +1130,22 @@ private:
 	// Parses: type_and_name + function_declaration + body handling (semicolon or skip braces)
 	// Returns the TemplateFunctionDeclarationNode in out_template_node
 	ParseResult parse_template_function_declaration_body(
-		InlineVector<ASTNode, 4>& template_params,
+		std::vector<TemplateParameterNode>& template_params,
 		std::optional<ASTNode> requires_clause,
 		ASTNode& out_template_node);
-	ParseResult parse_template_parameter_list(InlineVector<ASTNode, 4>& out_params);	 // NEW: Parse template parameter list
+	struct TemplateParameterMetadata {
+		InlineVector<StringHandle, 4> names;
+		InlineVector<std::string_view, 4> name_views;
+		InlineVector<TemplateParameterKind, 4> kinds;
+		bool has_packs = false;
+	};
+	ParseResult parse_template_parameter_list(std::vector<TemplateParameterNode>& out_params);	 // NEW: Parse template parameter list
 	ParseResult parse_template_parameter();	// NEW: Parse a single template parameter
 	TypeInfo& ensureTemplateParameterTypeRegistration(TemplateParameterNode& tparam);
-	void registerTemplateTypeParametersInScope(
-		InlineVector<ASTNode, 4>& template_params,
+	TemplateParameterMetadata registerTemplateParametersInScope(
+		std::vector<TemplateParameterNode>& template_params,
 		FlashCpp::TemplateParameterScope& template_scope);
+	InlineVector<ASTNode, 4> createTemplateParameterAstNodes(const std::vector<TemplateParameterNode>& template_params);
 	bool parseDeferredAliasTargetTemplateId(
 		StringHandle& out_target_template_name,
 		std::vector<ASTNode>& out_target_template_arg_nodes,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1360,6 +1360,10 @@ private:
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		const std::vector<ASTNode>& template_params,
 		const std::vector<TemplateTypeArg>& template_args);
+	void populateTemplateParamSubstitutions(
+		InlineVector<TemplateParamSubstitution, 4>& subs,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
+		const std::vector<TemplateTypeArg>& template_args);
 	// Build outer-template binding data from the AST template parameter list so
 	// parameter names and args stay index-aligned even if the parameter list
 	// ever stops being a pure TemplateParameterNode sequence.

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -51,10 +51,10 @@ void registerTypeParamsInScope(
 	const InlineVector<StringHandle, 4>& param_names,
 	const InlineVector<TemplateTypeArg, 4>& type_args,
 	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier = false);
+	bool preserve_ref_qualifier);
 
 void registerTypeParamsInScope(
-	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier);
@@ -66,21 +66,21 @@ void registerTypeParamsInScope(
 	bool preserve_ref_qualifier);
 
 void registerTypeParamsInScope(
-	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
-	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map = nullptr);
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
-	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map = nullptr);
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
 
 void registerOuterBindingInScope(
 	const OuterTemplateBinding& outer_binding,
 	FlashCpp::TemplateParameterScope& scope,
-	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map = nullptr);
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
 
 bool is_known_type_trait_name(std::string_view name);
 

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -54,13 +54,25 @@ void registerTypeParamsInScope(
 	bool preserve_ref_qualifier = false);
 
 void registerTypeParamsInScope(
-	const std::vector<ASTNode>& template_param_nodes,
+	const std::vector<TemplateParameterNode>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier);
 
 void registerTypeParamsInScope(
-	const std::vector<ASTNode>& template_param_nodes,
+	const InlineVector<ASTNode, 4>& template_param_nodes,
+	const std::vector<TemplateTypeArg>& template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	bool preserve_ref_qualifier);
+
+void registerTypeParamsInScope(
+	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const std::vector<TemplateTypeArg>& template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map = nullptr);
+
+void registerTypeParamsInScope(
+	const InlineVector<ASTNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map = nullptr);

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -77,7 +77,7 @@ void appendLazyTemplateSequence(TDest& destination, const TSource& source) {
 
 inline void appendLazyTemplateSequence(
 	InlineVector<ASTNode, 4>& destination,
-	const std::vector<TemplateParameterNode>& source) {
+	const InlineVector<TemplateParameterNode, 4>& source) {
 	for (const auto& value : source) {
 		destination.push_back(ASTNode::emplace_node<TemplateParameterNode>(value));
 	}

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -75,6 +75,14 @@ void appendLazyTemplateSequence(TDest& destination, const TSource& source) {
 	}
 }
 
+inline void appendLazyTemplateSequence(
+	InlineVector<ASTNode, 4>& destination,
+	const std::vector<TemplateParameterNode>& source) {
+	for (const auto& value : source) {
+		destination.push_back(ASTNode::emplace_node<TemplateParameterNode>(value));
+	}
+}
+
 template <typename TParams, typename TArgs>
 LazyMemberFunctionInfo buildLazyNestedMemberFunctionInfo(
 	const StructMemberFunctionDecl& mem_func,

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -4429,7 +4429,7 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	advance(); // consume '<'
 
 	// Parse template parameters so type names like T are visible when parsing the function declaration.
-	std::vector<TemplateParameterNode> template_params;
+	InlineVector<TemplateParameterNode, 4> template_params;
 	auto param_list_result = parse_template_parameter_list(template_params);
 	// On error: fall back to raw skip of this declaration
 	if (param_list_result.is_error()) {

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -4429,7 +4429,7 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	advance(); // consume '<'
 
 	// Parse template parameters so type names like T are visible when parsing the function declaration.
-	InlineVector<ASTNode, 4> template_params;
+	std::vector<TemplateParameterNode> template_params;
 	auto param_list_result = parse_template_parameter_list(template_params);
 	// On error: fall back to raw skip of this declaration
 	if (param_list_result.is_error()) {
@@ -4457,12 +4457,9 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	// visible when parsing the friend function declaration (e.g. return type T, param type T).
 	FlashCpp::TemplateParameterScope template_scope;
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
-	registerTemplateTypeParametersInScope(template_params, template_scope);
-	for (auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			auto& tparam = param.as<TemplateParameterNode>();
-			pushCurrentTemplateParamName(tparam.nameHandle());
-		}
+	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
+	for (StringHandle param_name : template_param_metadata.names) {
+		pushCurrentTemplateParamName(param_name);
 	}
 
 	// Parse optional requires clause between template parameters and 'friend'

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -10,9 +10,7 @@ namespace {
 static int computeFunctionTemplateSpecificity(const TemplateFunctionDeclarationNode& template_func) {
 	std::unordered_set<StringHandle, StringHandleHash> param_name_handles;
 	for (const auto& tp : template_func.template_parameters()) {
-		if (tp.is<TemplateParameterNode>()) {
-			param_name_handles.insert(tp.as<TemplateParameterNode>().nameHandle());
-		}
+		param_name_handles.insert(tp.nameHandle());
 	}
 
 	int score = 0;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1095,11 +1095,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializePrimaryTemplateOwn
 		const std::vector<std::string_view> template_param_names =
 			buildTemplateParamNames(template_params);
 		for (size_t param_idx = completed_args.size(); param_idx < template_params.size(); ++param_idx) {
-			if (!template_params[param_idx].is<TemplateParameterNode>()) {
-				continue;
-			}
-			const TemplateParameterNode& param =
-				template_params[param_idx].as<TemplateParameterNode>();
+			const TemplateParameterNode& param = template_params[param_idx];
 			if (param.is_variadic()) {
 				continue;
 			}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1460,6 +1460,16 @@ TypeIndex Parser::substitute_template_parameter(
 	return current_type_index.withCategory(current_type);
 }
 
+TypeIndex Parser::substitute_template_parameter(
+	const TypeSpecifierNode& original_type,
+	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	return substitute_template_parameter(
+		original_type,
+		cloneTemplateParameterNodes(template_params),
+		template_args);
+}
+
 // Lookup symbol with template parameter checking
 std::optional<ASTNode> Parser::lookup_symbol_with_template_check(StringHandle identifier) {
 	// First check if it's a template parameter using the new method

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1462,7 +1462,7 @@ TypeIndex Parser::substitute_template_parameter(
 
 TypeIndex Parser::substitute_template_parameter(
 	const TypeSpecifierNode& original_type,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	return substitute_template_parameter(
 		original_type,

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -2453,40 +2453,17 @@ bool Parser::deduce_template_arguments_from_guide(const DeductionGuideNode& guid
 		}
 	}
 
-	auto tryGetTypeSpecifierFromGuideParameter = [](const ASTNode& param_node) -> const TypeSpecifierNode* {
-		if (param_node.is<TypeSpecifierNode>()) {
-			return &param_node.as<TypeSpecifierNode>();
-		}
-		if (param_node.is<DeclarationNode>()) {
-			const auto& decl = param_node.as<DeclarationNode>();
-			{
-				return &decl.type_specifier_node();
-			}
-		}
-		if (param_node.is<VariableDeclarationNode>()) {
-			const auto& var_decl = param_node.as<VariableDeclarationNode>();
-			{
-				return &var_decl.declaration().type_specifier_node();
-			}
-		}
-		return nullptr;
-	};
-
 	std::unordered_map<std::string_view, TypeSpecifierNode> bindings;
 	for (size_t i = 0; i < guide.guide_parameters().size(); ++i) {
-		const TypeSpecifierNode* param_type = tryGetTypeSpecifierFromGuideParameter(guide.guide_parameters()[i]);
-		if (!param_type) {
-			return false;
-		}
 		const auto& arg_type = argument_types[i];
-		if (!match_template_parameter_type(*param_type, arg_type, template_params, bindings)) {
+		if (!match_template_parameter_type(guide.guide_parameters()[i], arg_type, template_params, bindings)) {
 			return false;
 		}
 	}
 
 	out_template_args.clear();
-	out_template_args.reserve(guide.deduced_template_args_nodes().size());
-	for (const auto& rhs_node : guide.deduced_template_args_nodes()) {
+	out_template_args.reserve(guide.deduced_template_args().size());
+	for (const ASTNode& rhs_node : guide.deduced_template_args()) {
 		if (!rhs_node.is<TypeSpecifierNode>()) {
 			return false;
 		}

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -2361,11 +2361,9 @@ bool Parser::try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const
 	// Build template parameter name set for matching
 	std::unordered_map<std::string_view, size_t> tparam_name_to_index;
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		if (template_params[i].is<TemplateParameterNode>()) {
-			const auto& tparam = template_params[i].as<TemplateParameterNode>();
-			if (tparam.kind() == TemplateParameterKind::Type) {
-				tparam_name_to_index[tparam.name()] = i;
-			}
+		if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+			tparam != nullptr && tparam->kind() == TemplateParameterKind::Type) {
+			tparam_name_to_index[tparam->name()] = i;
 		}
 	}
 
@@ -2419,13 +2417,13 @@ bool Parser::try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const
 			continue;
 
 		// Check all template type params were deduced
-		bool all_deduced = true;
-		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (tparam_name_to_index.count(template_params[i].is<TemplateParameterNode>()
-											   ? template_params[i].as<TemplateParameterNode>().name()
-											   : "") > 0 &&
-				!deduced[i]) {
-				all_deduced = false;
+	bool all_deduced = true;
+	for (size_t i = 0; i < template_params.size(); ++i) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+		if (tparam != nullptr &&
+			tparam_name_to_index.count(tparam->name()) > 0 &&
+			!deduced[i]) {
+			all_deduced = false;
 				break;
 			}
 		}
@@ -2449,10 +2447,7 @@ bool Parser::deduce_template_arguments_from_guide(const DeductionGuideNode& guid
 
 	std::unordered_map<std::string_view, const TemplateParameterNode*> template_params;
 	for (const auto& param_node : guide.template_parameters()) {
-		if (!param_node.is<TemplateParameterNode>()) {
-			continue;
-		}
-		const auto& tparam = param_node.as<TemplateParameterNode>();
+		const auto& tparam = param_node;
 		if (tparam.kind() == TemplateParameterKind::Type) {
 			template_params.emplace(tparam.name(), &tparam);
 		}

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -2417,13 +2417,13 @@ bool Parser::try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const
 			continue;
 
 		// Check all template type params were deduced
-	bool all_deduced = true;
-	for (size_t i = 0; i < template_params.size(); ++i) {
-		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
-		if (tparam != nullptr &&
-			tparam_name_to_index.count(tparam->name()) > 0 &&
-			!deduced[i]) {
-			all_deduced = false;
+		bool all_deduced = true;
+		for (size_t i = 0; i < template_params.size(); ++i) {
+			const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+			if (tparam != nullptr &&
+				tparam_name_to_index.count(tparam->name()) > 0 &&
+				!deduced[i]) {
+				all_deduced = false;
 				break;
 			}
 		}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -150,7 +150,7 @@ ParseResult Parser::parse_template_declaration() {
 	}
 
 	// Parse template parameter list (unless it's a specialization)
-	std::vector<TemplateParameterNode> template_param_nodes;
+	InlineVector<TemplateParameterNode, 4> template_param_nodes;
 	TemplateParameterMetadata template_param_metadata;
 	InlineVector<ASTNode, 4> template_params;
 	if (!is_specialization) {
@@ -193,7 +193,7 @@ ParseResult Parser::parse_template_declaration() {
 	for (const auto& param : template_param_nodes) {
 		template_params.push_back(emplace_node<TemplateParameterNode>(param));
 	}
-	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
+	const InlineVector<StringHandle, 4>& template_param_names = template_param_metadata.names;
 
 	// Set the flag to enable fold expression parsing if we have parameter packs
 	bool saved_has_packs = has_parameter_packs_;
@@ -223,7 +223,7 @@ ParseResult Parser::parse_template_declaration() {
 			advance(); // consume '<'
 
 			// Parse inner template parameters
-			std::vector<TemplateParameterNode> inner_template_params;
+			InlineVector<TemplateParameterNode, 4> inner_template_params;
 			auto inner_param_result = parse_template_parameter_list(inner_template_params);
 			if (inner_param_result.is_error()) {
 				// Fallback: skip the rest (for standard headers that use unsupported features)
@@ -277,7 +277,7 @@ ParseResult Parser::parse_template_declaration() {
 			// Extract inner template parameter names
 			FlashCpp::TemplateParameterScope inner_template_scope;
 			TemplateParameterMetadata inner_template_param_metadata = registerTemplateParametersInScope(inner_template_params, inner_template_scope);
-			InlineVector<StringHandle, 4> inner_template_param_names = inner_template_param_metadata.names;
+			const InlineVector<StringHandle, 4>& inner_template_param_names = inner_template_param_metadata.names;
 
 			discard_saved_token(inner_saved);
 
@@ -747,17 +747,17 @@ ParseResult Parser::parse_template_declaration() {
 		}
 
 		// Convert template_params (ASTNode vector) to TemplateParameterNode vector
-		std::vector<TemplateParameterNode> template_param_nodes;
+		InlineVector<TemplateParameterNode, 4> concept_template_param_nodes;
 		for (const auto& param : template_params) {
 			if (param.is<TemplateParameterNode>()) {
-				template_param_nodes.push_back(param.as<TemplateParameterNode>());
+				concept_template_param_nodes.push_back(param.as<TemplateParameterNode>());
 			}
 		}
 
 		// Create the ConceptDeclarationNode with template parameters
 		auto concept_node = emplace_node<ConceptDeclarationNode>(
 			concept_name_token,
-			std::move(template_param_nodes),
+			std::move(concept_template_param_nodes),
 			*constraint_result.node(),
 			concept_token);
 
@@ -3975,8 +3975,8 @@ ParseResult Parser::parse_template_declaration() {
 		// This will prevent delayed function bodies from being parsed immediately
 		parsing_template_class_ = true;
 		template_param_names_.clear();
-		for (std::string_view param_name : template_param_metadata.name_views) {
-			template_param_names_.push_back(param_name);
+		for (StringHandle param_name : template_param_metadata.names) {
+			template_param_names_.push_back(StringTable::getStringView(param_name));
 		}
 
 		// Set template parameter context for current_template_param_names_
@@ -4266,7 +4266,13 @@ ParseResult Parser::parse_template_declaration() {
 
 		// Try to detect out-of-line member function definition
 		// Pattern: ReturnType ClassName<TemplateArgs>::FunctionName(...)
-		auto out_of_line_result = try_parse_out_of_line_template_member(template_param_nodes, template_param_names);
+		InlineVector<TemplateParameterNode, 4> inner_template_param_nodes;
+		InlineVector<StringHandle, 4> inner_template_param_names;
+		auto out_of_line_result = try_parse_out_of_line_template_member(
+			template_param_nodes,
+			template_param_names,
+			inner_template_param_nodes,
+			inner_template_param_names);
 		if (out_of_line_result.has_value()) {
 			return saved_position.success();	 // Successfully parsed out-of-line definition
 		}
@@ -4505,9 +4511,9 @@ ParseResult Parser::parse_template_declaration() {
 	// Note: Function templates are now handled above via parse_template_function_declaration_body() (Phase 6)
 	if (decl_node.is<StructDeclarationNode>()) {
 		// Create a TemplateClassDeclarationNode with parameter names for lookup
-		std::vector<std::string_view> param_names;
-		for (std::string_view param_name : template_param_metadata.name_views) {
-			param_names.push_back(param_name);
+		InlineVector<std::string_view, 4> param_names;
+		for (StringHandle param_name : template_param_metadata.names) {
+			param_names.push_back(StringTable::getStringView(param_name));
 		}
 
 		auto template_class_node = emplace_node<TemplateClassDeclarationNode>(
@@ -4643,7 +4649,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	advance(); // consume '<'
 
 	// Parse template parameter list
-	std::vector<TemplateParameterNode> template_param_nodes;
+	InlineVector<TemplateParameterNode, 4> template_param_nodes;
 	InlineVector<ASTNode, 4> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_param_nodes);
@@ -4790,7 +4796,11 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	// Temporarily add template parameters to type system using RAII scope guard
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
-	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
+	InlineVector<std::string_view, 4> template_param_names;
+	template_param_names.reserve(template_param_metadata.names.size());
+	for (StringHandle param_name : template_param_metadata.names) {
+		template_param_names.push_back(StringTable::getStringView(param_name));
+	}
 	template_params.clear();
 	for (const auto& param : template_param_nodes) {
 		template_params.push_back(emplace_node<TemplateParameterNode>(param));

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -189,7 +189,10 @@ ParseResult Parser::parse_template_declaration() {
 	// This allows them to be used in the function body or class members
 	FlashCpp::TemplateParameterScope template_scope;
 	template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
-	template_params = createTemplateParameterAstNodes(template_param_nodes);
+	template_params.clear();
+	for (const auto& param : template_param_nodes) {
+		template_params.push_back(emplace_node<TemplateParameterNode>(param));
+	}
 	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
 
 	// Set the flag to enable fold expression parsing if we have parameter packs
@@ -275,7 +278,6 @@ ParseResult Parser::parse_template_declaration() {
 			FlashCpp::TemplateParameterScope inner_template_scope;
 			TemplateParameterMetadata inner_template_param_metadata = registerTemplateParametersInScope(inner_template_params, inner_template_scope);
 			InlineVector<StringHandle, 4> inner_template_param_names = inner_template_param_metadata.names;
-			InlineVector<ASTNode, 4> inner_template_param_ast_nodes = createTemplateParameterAstNodes(inner_template_params);
 
 			discard_saved_token(inner_saved);
 
@@ -510,12 +512,12 @@ ParseResult Parser::parse_template_declaration() {
 
 				// Register as out-of-line member with inner template params
 				OutOfLineMemberFunction out_of_line_member;
-				out_of_line_member.template_params = template_params;
+				out_of_line_member.template_params = template_param_nodes;
 				out_of_line_member.function_node = func_node;
 				out_of_line_member.body_start = body_start;
 				out_of_line_member.initializer_list_start = initializer_list_start;
 				out_of_line_member.template_param_names = template_param_names;
-				out_of_line_member.inner_template_params = inner_template_param_ast_nodes;
+				out_of_line_member.inner_template_params = inner_template_params;
 				out_of_line_member.inner_template_param_names = inner_template_param_names;
 				out_of_line_member.has_initializer_list = has_initializer_list;
 
@@ -938,7 +940,7 @@ ParseResult Parser::parse_template_declaration() {
 		if (has_unresolved_params && target_template_name.isValid()) {
 			FLASH_LOG(Parser, Debug, "Creating deferred TemplateAliasNode for '", alias_name, "' -> '", target_template_name.view(), "'");
 			alias_node = emplace_node<TemplateAliasNode>(
-				std::move(template_params),
+				template_param_nodes,
 				std::move(template_param_names),
 				StringTable::getOrInternStringHandle(alias_name),
 				type_result.node().value(),
@@ -947,7 +949,7 @@ ParseResult Parser::parse_template_declaration() {
 		} else {
 			// Regular (non-deferred) alias
 			alias_node = emplace_node<TemplateAliasNode>(
-				std::move(template_params),
+				template_param_nodes,
 				std::move(template_param_names),
 				StringTable::getOrInternStringHandle(alias_name),
 				type_result.node().value());
@@ -1154,7 +1156,7 @@ ParseResult Parser::parse_template_declaration() {
 
 		// Create TemplateVariableDeclarationNode
 		auto template_var_node = emplace_node<TemplateVariableDeclarationNode>(
-			std::move(template_params),
+			template_param_nodes,
 			var_decl_node);
 
 		// Register in template registry
@@ -4251,7 +4253,7 @@ ParseResult Parser::parse_template_declaration() {
 
 			// Create DeductionGuideNode
 			auto guide_node = emplace_node<DeductionGuideNode>(
-				std::move(template_params),
+				template_param_nodes,
 				class_name,
 				std::move(guide_params),
 				std::move(deduced_type_nodes));
@@ -4264,7 +4266,7 @@ ParseResult Parser::parse_template_declaration() {
 
 		// Try to detect out-of-line member function definition
 		// Pattern: ReturnType ClassName<TemplateArgs>::FunctionName(...)
-		auto out_of_line_result = try_parse_out_of_line_template_member(template_params, template_param_names);
+		auto out_of_line_result = try_parse_out_of_line_template_member(template_param_nodes, template_param_names);
 		if (out_of_line_result.has_value()) {
 			return saved_position.success();	 // Successfully parsed out-of-line definition
 		}
@@ -4504,14 +4506,12 @@ ParseResult Parser::parse_template_declaration() {
 	if (decl_node.is<StructDeclarationNode>()) {
 		// Create a TemplateClassDeclarationNode with parameter names for lookup
 		std::vector<std::string_view> param_names;
-		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				param_names.push_back(param.as<TemplateParameterNode>().name());
-			}
+		for (std::string_view param_name : template_param_metadata.name_views) {
+			param_names.push_back(param_name);
 		}
 
 		auto template_class_node = emplace_node<TemplateClassDeclarationNode>(
-			std::move(template_params),
+			template_param_nodes,
 			std::move(param_names),
 			decl_node);
 
@@ -4791,7 +4791,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
 	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
-	template_params = createTemplateParameterAstNodes(template_param_nodes);
+	template_params.clear();
+	for (const auto& param : template_param_nodes) {
+		template_params.push_back(emplace_node<TemplateParameterNode>(param));
+	}
 
 	// Skip requires clause if present (for partial specializations with constraints)
 	// e.g., template<typename T> requires Constraint<T> struct Name<T> { ... };
@@ -4850,7 +4853,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 		// Create template struct node for the forward declaration
 		auto template_struct_node = emplace_node<TemplateClassDeclarationNode>(
-			std::move(template_params),
+			template_param_nodes,
 			std::move(template_param_names),
 			forward_struct_node);
 
@@ -5374,7 +5377,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 		// Create template struct node for the partial specialization
 		auto template_struct_node = emplace_node<TemplateClassDeclarationNode>(
-			template_params,	 // Copy, don't move yet
+			template_param_nodes,	 // Copy, don't move yet
 			template_param_names,  // Copy, don't move yet
 			member_struct_node);
 
@@ -5731,7 +5734,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 	// Create template struct node (using TemplateClassDeclarationNode which handles both struct and class)
 	auto template_struct_node = emplace_node<TemplateClassDeclarationNode>(
-		std::move(template_params),
+		template_param_nodes,
 		std::move(template_param_names),
 		member_struct_node);
 

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -4069,7 +4069,7 @@ ParseResult Parser::parse_template_declaration() {
 			}
 			advance(); // consume '('
 
-			std::vector<ASTNode> guide_params;
+			InlineVector<TypeSpecifierNode, 4> guide_params;
 			if (peek() != ")"_tok) {
 				// Parse parameters
 				while (true) {
@@ -4077,11 +4077,14 @@ ParseResult Parser::parse_template_declaration() {
 					if (param_type_result.is_error()) {
 						return param_type_result;
 					}
-					guide_params.push_back(*param_type_result.node());
+					if (!param_type_result.node()->is<TypeSpecifierNode>()) {
+						return ParseResult::error("Expected type specifier in deduction guide parameter", current_token_);
+					}
+					guide_params.push_back(param_type_result.node()->as<TypeSpecifierNode>());
 
 					// Allow pointer/reference declarators directly in guide parameters (e.g., T*, const T&, etc.)
-					if (!guide_params.empty() && guide_params.back().is<TypeSpecifierNode>()) {
-						TypeSpecifierNode& param_type = guide_params.back().as<TypeSpecifierNode>();
+					if (!guide_params.empty()) {
+						TypeSpecifierNode& param_type = guide_params.back();
 
 						// Handle array reference pattern: _Type(&)[_ArrayExtent] or _Type(&&)[_ArrayExtent]
 						// Also handle function pointer pattern: _Type(*)(Args...)

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -150,9 +150,11 @@ ParseResult Parser::parse_template_declaration() {
 	}
 
 	// Parse template parameter list (unless it's a specialization)
+	std::vector<TemplateParameterNode> template_param_nodes;
+	TemplateParameterMetadata template_param_metadata;
 	InlineVector<ASTNode, 4> template_params;
 	if (!is_specialization) {
-		auto param_list_result = parse_template_parameter_list(template_params);
+		auto param_list_result = parse_template_parameter_list(template_param_nodes);
 		if (param_list_result.is_error()) {
 			return param_list_result;
 		}
@@ -186,31 +188,18 @@ ParseResult Parser::parse_template_declaration() {
 	// Add template parameters to the type system temporarily using RAII scope guard (Phase 6)
 	// This allows them to be used in the function body or class members
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
-	InlineVector<StringHandle, 4> template_param_names;
-	InlineVector<TemplateParameterKind, 4> template_param_kinds;
-	bool has_packs = false;	// Track if any parameter is a pack
-	for (auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-			// Add ALL template parameters to the name list (Type, NonType, and Template)
-			// This allows them to be recognized when referenced in the template body
-			template_param_names.push_back(tparam.nameHandle());	 // string_view from Token
-			template_param_kinds.push_back(tparam.kind());
-
-			// Check if this is a parameter pack
-			has_packs |= tparam.is_variadic();
-		}
-	}
+	template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
+	template_params = createTemplateParameterAstNodes(template_param_nodes);
+	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
 
 	// Set the flag to enable fold expression parsing if we have parameter packs
 	bool saved_has_packs = has_parameter_packs_;
-	has_parameter_packs_ = has_packs;
+	has_parameter_packs_ = template_param_metadata.has_packs;
 
 	// Set template parameter context EARLY, before any code that might call parse_type_specifier()
 	// This includes variable template detection below which needs to recognize template params
 	// like _Int in return types: typename tuple_element<_Int, pair<_Tp1, _Tp2>>::type&
-	setCurrentTemplateParameters(template_param_names, template_param_kinds);
+	setCurrentTemplateParameters(template_param_metadata.names, template_param_metadata.kinds);
 	FlashCpp::TemplateDepthGuard guard_template_depth(parsing_template_depth_);
 
 	// Check if this is a nested template (member function template of a class template)
@@ -231,7 +220,7 @@ ParseResult Parser::parse_template_declaration() {
 			advance(); // consume '<'
 
 			// Parse inner template parameters
-			InlineVector<ASTNode, 4> inner_template_params;
+			std::vector<TemplateParameterNode> inner_template_params;
 			auto inner_param_result = parse_template_parameter_list(inner_template_params);
 			if (inner_param_result.is_error()) {
 				// Fallback: skip the rest (for standard headers that use unsupported features)
@@ -283,12 +272,10 @@ ParseResult Parser::parse_template_declaration() {
 			advance(); // consume '>'
 
 			// Extract inner template parameter names
-			InlineVector<StringHandle, 4> inner_template_param_names;
-			for (const auto& param : inner_template_params) {
-				if (param.is<TemplateParameterNode>()) {
-					inner_template_param_names.push_back(param.as<TemplateParameterNode>().nameHandle());
-				}
-			}
+			FlashCpp::TemplateParameterScope inner_template_scope;
+			TemplateParameterMetadata inner_template_param_metadata = registerTemplateParametersInScope(inner_template_params, inner_template_scope);
+			InlineVector<StringHandle, 4> inner_template_param_names = inner_template_param_metadata.names;
+			InlineVector<ASTNode, 4> inner_template_param_ast_nodes = createTemplateParameterAstNodes(inner_template_params);
 
 			discard_saved_token(inner_saved);
 
@@ -528,7 +515,7 @@ ParseResult Parser::parse_template_declaration() {
 				out_of_line_member.body_start = body_start;
 				out_of_line_member.initializer_list_start = initializer_list_start;
 				out_of_line_member.template_param_names = template_param_names;
-				out_of_line_member.inner_template_params = inner_template_params;
+				out_of_line_member.inner_template_params = inner_template_param_ast_nodes;
 				out_of_line_member.inner_template_param_names = inner_template_param_names;
 				out_of_line_member.has_initializer_list = has_initializer_list;
 
@@ -3986,24 +3973,12 @@ ParseResult Parser::parse_template_declaration() {
 		// This will prevent delayed function bodies from being parsed immediately
 		parsing_template_class_ = true;
 		template_param_names_.clear();
-		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-				template_param_names_.push_back(tparam.name());
-			}
+		for (std::string_view param_name : template_param_metadata.name_views) {
+			template_param_names_.push_back(param_name);
 		}
 
 		// Set template parameter context for current_template_param_names_
-		InlineVector<StringHandle, 4> template_param_names_for_body;
-		InlineVector<TemplateParameterKind, 4> template_param_kinds_for_body;
-		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-				template_param_names_for_body.push_back(tparam.nameHandle());
-				template_param_kinds_for_body.push_back(tparam.kind());
-			}
-		}
-		setCurrentTemplateParameters(std::move(template_param_names_for_body), std::move(template_param_kinds_for_body));
+		setCurrentTemplateParameters(template_param_metadata.names, template_param_metadata.kinds);
 
 		// Parse class template
 		// Save scope/stack state before try block so we can restore on exception
@@ -4478,7 +4453,7 @@ ParseResult Parser::parse_template_declaration() {
 		// parsing, so template parameters are recognized when parsing the return type.
 
 		ASTNode template_func_node;
-		auto body_result = parse_template_function_declaration_body(template_params, requires_clause, template_func_node);
+		auto body_result = parse_template_function_declaration_body(template_param_nodes, requires_clause, template_func_node);
 
 		// Clean up template parameter context
 		clearCurrentTemplateParameters();
@@ -4668,10 +4643,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	advance(); // consume '<'
 
 	// Parse template parameter list
+	std::vector<TemplateParameterNode> template_param_nodes;
 	InlineVector<ASTNode, 4> template_params;
-	std::vector<std::string_view> template_param_names;
 
-	auto param_list_result = parse_template_parameter_list(template_params);
+	auto param_list_result = parse_template_parameter_list(template_param_nodes);
 	if (param_list_result.is_error()) {
 		return param_list_result;
 	}
@@ -4806,13 +4781,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		skipMemberTemplateFunctionTail();
 	};
 
-	// Extract parameter names for later lookup
-	for (const auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			template_param_names.push_back(param.as<TemplateParameterNode>().name());
-		}
-	}
-
 	// Expect '>' to close template parameter list
 	if (peek() != ">"_tok) {
 		return ParseResult::error("Expected '>' after template parameter list", current_token_);
@@ -4821,7 +4789,9 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 	// Temporarily add template parameters to type system using RAII scope guard
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
+	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
+	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
+	template_params = createTemplateParameterAstNodes(template_param_nodes);
 
 	// Skip requires clause if present (for partial specializations with constraints)
 	// e.g., template<typename T> requires Constraint<T> struct Name<T> { ... };

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -46,7 +46,7 @@ ParseResult Parser::parse_concept_declaration() {
 
 	// Create the ConceptDeclarationNode
 	// For simplified concepts (without template<>), we use an empty template parameter list
-	std::vector<TemplateParameterNode> template_params;
+	InlineVector<TemplateParameterNode, 4> template_params;
 
 	auto concept_node = emplace_node<ConceptDeclarationNode>(
 		concept_name_token,

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -29,7 +29,7 @@ StringHandle Parser::getStructQualifiedNameForRegistration(const StructDeclarati
 }
 
 ParseResult Parser::parse_template_function_declaration_body(
-	std::vector<TemplateParameterNode>& template_params,
+	InlineVector<TemplateParameterNode, 4>& template_params,
 	std::optional<ASTNode> requires_clause,
 	ASTNode& out_template_node) {
 	// Save position for template declaration re-parsing (needed for SFINAE)
@@ -249,7 +249,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	advance(); // consume '<'
 
 	// Parse template parameter list
-	std::vector<TemplateParameterNode> template_params;
+	InlineVector<TemplateParameterNode, 4> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -29,7 +29,7 @@ StringHandle Parser::getStructQualifiedNameForRegistration(const StructDeclarati
 }
 
 ParseResult Parser::parse_template_function_declaration_body(
-	InlineVector<ASTNode, 4>& template_params,
+	std::vector<TemplateParameterNode>& template_params,
 	std::optional<ASTNode> requires_clause,
 	ASTNode& out_template_node) {
 	// Save position for template declaration re-parsing (needed for SFINAE)
@@ -37,7 +37,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	SaveHandle declaration_start = save_token_position();
 
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
+	registerTemplateParametersInScope(template_params, template_scope);
 
 	// Parse storage class specifiers (constexpr, inline, static, etc.)
 	// This must be done BEFORE parse_type_and_name() to capture constexpr for template functions
@@ -185,7 +185,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	// Create a template function declaration node
 	func_decl.set_is_template_pattern(true);
 	auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
-		std::move(template_params),
+		createTemplateParameterAstNodes(template_params),
 		*func_result_node,
 		final_requires_clause);
 
@@ -249,7 +249,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	advance(); // consume '<'
 
 	// Parse template parameter list
-	InlineVector<ASTNode, 4> template_params;
+	std::vector<TemplateParameterNode> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {
@@ -264,16 +264,13 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 
 	// Temporarily add template parameters to type system using RAII scope guard (Phase 3)
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
+	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
 
 	// Set up template parameter names for the body parsing phase
 	// This is needed for decltype expressions and other template-dependent constructs
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
-	for (const auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-			pushCurrentTemplateParamName(tparam.nameHandle());
-		}
+	for (StringHandle param_name : template_param_metadata.names) {
+		pushCurrentTemplateParamName(param_name);
 	}
 
 	// Check for requires clause after template parameters
@@ -422,7 +419,8 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 				for (const auto& param : header.params.parameters) {
 					ctor_ref.add_parameter_node(param);
 				}
-				for (const auto& template_param : template_params) {
+				InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
+				for (const auto& template_param : template_param_ast_nodes) {
 					ctor_ref.add_template_parameter(template_param);
 				}
 
@@ -595,10 +593,8 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 
 					// Extract template parameter names for use during delayed body parsing
 					InlineVector<StringHandle, 4> template_param_name_handles;
-					for (const auto& param : template_params) {
-						if (param.is<TemplateParameterNode>()) {
-							template_param_name_handles.push_back(param.as<TemplateParameterNode>().nameHandle());
-						}
+					for (StringHandle param_name : template_param_metadata.names) {
+						template_param_name_handles.push_back(param_name);
 					}
 
 					FLASH_LOG_FORMAT(Parser, Debug, "Deferring template constructor body parsing for struct='{}', param_count={}",
@@ -711,7 +707,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 						// Create template function declaration node
 						func_ref.set_is_template_pattern(true);
 						auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
-							std::move(template_params),
+							createTemplateParameterAstNodes(template_params),
 							func_node,
 							requires_clause);
 

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -185,7 +185,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	// Create a template function declaration node
 	func_decl.set_is_template_pattern(true);
 	auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
-		createTemplateParameterAstNodes(template_params),
+		template_params,
 		*func_result_node,
 		final_requires_clause);
 
@@ -419,8 +419,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 				for (const auto& param : header.params.parameters) {
 					ctor_ref.add_parameter_node(param);
 				}
-				InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
-				for (const auto& template_param : template_param_ast_nodes) {
+				for (const auto& template_param : template_params) {
 					ctor_ref.add_template_parameter(template_param);
 				}
 
@@ -707,7 +706,7 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 						// Create template function declaration node
 						func_ref.set_is_template_pattern(true);
 						auto template_func_node = emplace_node<TemplateFunctionDeclarationNode>(
-							createTemplateParameterAstNodes(template_params),
+							template_params,
 							func_node,
 							requires_clause);
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -297,13 +297,15 @@ static int getTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {
 // Extract template parameter names (as StringHandles) from a list of
 // TemplateParameterNode AST nodes.  Only collects names for the first
 // `max_count` parameters to stay in sync with the argument vector.
+template <typename ParamContainer>
 static InlineVector<StringHandle, 4> collectParamNameHandles(
-	const InlineVector<ASTNode, 4>& template_params,
+	const ParamContainer& template_params,
 	size_t max_count) {
 	InlineVector<StringHandle, 4> names;
 	for (size_t i = 0; i < template_params.size() && i < max_count; ++i) {
-		if (template_params[i].is<TemplateParameterNode>()) {
-			names.push_back(template_params[i].as<TemplateParameterNode>().nameHandle());
+		if (const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			param != nullptr) {
+			names.push_back(param->nameHandle());
 		}
 	}
 	return names;
@@ -1058,7 +1060,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	auto substitute_default_initializer = [&](
 											  const std::optional<ASTNode>& default_init,
 											  const std::vector<TemplateTypeArg>& args,
-											  const std::vector<ASTNode>& params) -> std::optional<ASTNode> {
+											  const auto& params) -> std::optional<ASTNode> {
 		if (!default_init.has_value()) {
 			return std::nullopt;
 		}
@@ -1074,8 +1076,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		eval_ctx.template_args = args;
 		eval_ctx.template_param_names.reserve(params.size());
 		for (const auto& param : params) {
-			if (param.is<TemplateParameterNode>()) {
-				eval_ctx.template_param_names.push_back(param.as<TemplateParameterNode>().name());
+			if (const TemplateParameterNode* template_param = tryGetTemplateParameterNode(param);
+				template_param != nullptr) {
+				eval_ctx.template_param_names.push_back(template_param->name());
 			}
 		}
 
@@ -1202,14 +1205,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				size_t pack_size = 0;
 				bool found_pack = false;
 				for (size_t i = 0; i < tmpl_params.size(); ++i) {
-					if (!tmpl_params[i].template is<TemplateParameterNode>())
+					const TemplateParameterNode* tparam = tryGetTemplateParameterNode(tmpl_params[i]);
+					if (tparam == nullptr)
 						continue;
-					const TemplateParameterNode& tparam = tmpl_params[i].template as<TemplateParameterNode>();
-					if (!tparam.is_variadic()) {
+					if (!tparam->is_variadic()) {
 						non_variadic++;
 						continue;
 					}
-					if (tparam.name() == type_name) {
+					if (tparam->name() == type_name) {
 						pack_size = tmpl_args.size() > non_variadic ? tmpl_args.size() - non_variadic : 0;
 						found_pack = true;
 						break;
@@ -1440,7 +1443,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	};
 
 	auto substituteDefaultTemplateArg = [&](const ASTNode& default_node,
-											const InlineVector<ASTNode, 4>& params,
+											const auto& params,
 											const std::vector<TemplateTypeArg>& current_args) -> ASTNode {
 		if (current_args.empty()) {
 			return default_node;
@@ -1452,10 +1455,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		std::vector<std::string_view> names;
 		names.reserve(params.size());
 		for (const auto& param_node : params) {
-			if (!param_node.template is<TemplateParameterNode>()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(param_node);
+			if (param == nullptr) {
 				continue;
 			}
-			names.push_back(param_node.template as<TemplateParameterNode>().name());
+			names.push_back(param->name());
 		}
 		return names;
 	};
@@ -1482,7 +1486,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Helper lambda to resolve a deferred bitfield width from non-type template parameters
 	auto resolve_bitfield_width = [&](
 									  const StructMemberDecl& member_decl,
-									  const std::vector<ASTNode>& params,
+									  const auto& params,
 									  const std::vector<TemplateTypeArg>& args) -> std::optional<size_t> {
 		if (member_decl.bitfield_width.has_value())
 			return member_decl.bitfield_width;
@@ -1491,11 +1495,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
 		std::unordered_map<std::string_view, int64_t> nontype_sub_map;
 		for (size_t pi = 0; pi < params.size() && pi < args.size(); ++pi) {
-			if (!params[pi].template is<TemplateParameterNode>())
+			const TemplateParameterNode* tparam = tryGetTemplateParameterNode(params[pi]);
+			if (tparam == nullptr)
 				continue;
-			const auto& tparam = params[pi].template as<TemplateParameterNode>();
-			if (tparam.kind() == TemplateParameterKind::NonType && args[pi].is_value)
-				nontype_sub_map[tparam.name()] = args[pi].value;
+			if (tparam->kind() == TemplateParameterKind::NonType && args[pi].is_value)
+				nontype_sub_map[tparam->name()] = args[pi].value;
 		}
 		ASTNode substituted = substitute_template_params_in_expression(
 			*member_decl.bitfield_width_expr, type_sub_map, nontype_sub_map, StringHandle{});
@@ -1508,7 +1512,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	auto resolve_array_dimensions = [&](
 										const DeclarationNode& decl,
-										const std::vector<ASTNode>& params,
+										const auto& params,
 										const std::vector<TemplateTypeArg>& args) -> std::vector<size_t> {
 		std::vector<size_t> resolved_dims;
 		if (!decl.is_array()) {
@@ -1517,11 +1521,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
 		std::unordered_map<std::string_view, int64_t> nontype_sub_map;
 		for (size_t pi = 0; pi < params.size() && pi < args.size(); ++pi) {
-			if (!params[pi].template is<TemplateParameterNode>())
+			const TemplateParameterNode* tparam = tryGetTemplateParameterNode(params[pi]);
+			if (tparam == nullptr)
 				continue;
-			const auto& tparam = params[pi].template as<TemplateParameterNode>();
-			if (tparam.kind() == TemplateParameterKind::NonType && args[pi].is_value) {
-				nontype_sub_map[tparam.name()] = args[pi].value;
+			if (tparam->kind() == TemplateParameterKind::NonType && args[pi].is_value) {
+				nontype_sub_map[tparam->name()] = args[pi].value;
 			}
 		}
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
@@ -1723,23 +1727,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			// Fill in defaults for missing arguments
 			for (size_t i = filled_args_for_pattern_match.size(); i < primary_params.size(); ++i) {
-				if (!primary_params[i].is<TemplateParameterNode>())
+				const TemplateParameterNode* param = tryGetTemplateParameterNode(primary_params[i]);
+				if (param == nullptr)
 					continue;
 
-				const TemplateParameterNode& param = primary_params[i].as<TemplateParameterNode>();
-
 				// Skip variadic parameters
-				if (param.is_variadic())
+				if (param->is_variadic())
 					continue;
 
 				// Check if parameter has a default
-				if (!param.has_default())
+				if (!param->has_default())
 					break; // No default = can't fill in
 
 				// Get the default value
-				const ASTNode& default_node = param.default_value();
+				const ASTNode& default_node = param->default_value();
 
-				if (param.kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
+				if (param->kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
 					const TypeSpecifierNode& default_type = default_node.as<TypeSpecifierNode>();
 					bool handled_type_default = false;
 
@@ -1806,7 +1809,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						filled_args_for_pattern_match.push_back(TemplateTypeArg(default_type));
 						FLASH_LOG(Templates, Debug, "Filled in default type argument for param ", i);
 					}
-				} else if (param.kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
+				} else if (param->kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
 					// Handle non-type template parameter defaults like is_arithmetic<T>::value
 					size_t size_before = filled_args_for_pattern_match.size();
 					ASTNode substituted_default_node = substituteNonTypeDefaultExpression(
@@ -1907,9 +1910,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								if (!type_name.empty()) {
 									// Check if this is one of the template parameters we've already filled
 									for (size_t j = 0; j < primary_params.size() && j < filled_args_for_pattern_match.size(); ++j) {
-										if (primary_params[j].is<TemplateParameterNode>()) {
-											const TemplateParameterNode& prev_param = primary_params[j].as<TemplateParameterNode>();
-											if (prev_param.name() == type_name) {
+										if (const TemplateParameterNode* prev_param = tryGetTemplateParameterNode(primary_params[j]);
+											prev_param != nullptr) {
+											if (prev_param->name() == type_name) {
 												// Found the matching template parameter - use its filled value
 												const TemplateTypeArg& filled_arg = filled_args_for_pattern_match[j];
 												if (filled_arg.category() != TypeCategory::Invalid) {
@@ -2066,11 +2069,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								bool current_has_anon = false;
 								bool best_has_anon = false;
 								for (const auto& param : tmpl_class.template_parameters()) {
-									if (param.is<TemplateParameterNode>() && param.as<TemplateParameterNode>().name().starts_with("__anon_type_"))
+									if (param.name().starts_with("__anon_type_"))
 										current_has_anon = true;
 								}
 								for (const auto& param : best->template_parameters()) {
-									if (param.is<TemplateParameterNode>() && param.as<TemplateParameterNode>().name().starts_with("__anon_type_"))
+									if (param.name().starts_with("__anon_type_"))
 										best_has_anon = true;
 								}
 								if (best_has_anon && !current_has_anon)
@@ -2079,8 +2082,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 					if (best) {
-						pattern_template_params = std::vector<ASTNode>(best->template_parameters().begin(),
-																	   best->template_parameters().end());
+						const InlineVector<ASTNode, 4> best_template_params_ast =
+							cloneTemplateParameterNodes(best->template_parameters());
+						pattern_template_params.assign(
+							best_template_params_ast.begin(),
+							best_template_params_ast.end());
 					}
 				}
 			}
@@ -3751,6 +3757,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	const TemplateClassDeclarationNode& template_class = template_node.as<TemplateClassDeclarationNode>();
 	const auto& template_params = template_class.template_parameters();
+	const InlineVector<ASTNode, 4> template_params_inline_ast = cloneTemplateParameterNodes(template_params);
+	const std::vector<ASTNode> template_params_ast(
+		template_params_inline_ast.begin(),
+		template_params_inline_ast.end());
 	const StructDeclarationNode& class_decl = template_class.class_decl_node();
 
 	// Count non-variadic parameters
@@ -3758,8 +3768,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	bool has_parameter_pack = false;
 
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-		if (param.is_variadic()) {
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr) {
+			continue;
+		}
+		if (param->is_variadic()) {
 			has_parameter_pack = true;
 		} else {
 			non_variadic_param_count++;
@@ -3772,13 +3785,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	if (has_parameter_pack) {
 		std::vector<ClassTemplatePackInfo> pack_infos;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-			if (param.is_variadic()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			if (param != nullptr && param->is_variadic()) {
 				size_t pack_size = template_args.size() >= non_variadic_param_count
 									   ? template_args.size() - non_variadic_param_count
 									   : 0;
-				pack_infos.push_back({param.name(), pack_size});
-				FLASH_LOG(Templates, Debug, "Registered class template pack '", param.name(), "' with size ", pack_size);
+				pack_infos.push_back({param->name(), pack_size});
+				FLASH_LOG(Templates, Debug, "Registered class template pack '", param->name(), "' with size ", pack_size);
 			}
 		}
 		if (!pack_infos.empty()) {
@@ -3809,13 +3822,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Fill in default arguments for missing parameters
 	for (size_t i = filled_template_args.size(); i < template_params.size(); ++i) {
-		const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr) {
+			continue;
+		}
 		// Skip variadic parameters - they're allowed to be empty
-		if (param.is_variadic()) {
+		if (param->is_variadic()) {
 			continue;
 		}
 
-		if (!param.has_default()) {
+		if (!param->has_default()) {
 			FLASH_LOG(Templates, Error, "Template '", template_name, "': Param ", i, " has no default (got ",
 					  template_args.size(), " args, need ", template_params.size(), "), returning nullopt");
 			return std::nullopt; // Missing required template argument
@@ -3827,9 +3843,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		size_t size_before = filled_template_args.size();
 
 		// Use the default value
-		if (param.kind() == TemplateParameterKind::Type) {
+		if (param->kind() == TemplateParameterKind::Type) {
 			// For type parameters with defaults, extract the type
-			const ASTNode& default_node = param.default_value();
+			const ASTNode& default_node = param->default_value();
 			if (default_node.is<TypeSpecifierNode>()) {
 				const TypeSpecifierNode& default_type = default_node.as<TypeSpecifierNode>();
 
@@ -3864,9 +3880,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					filled_template_args.push_back(TemplateTypeArg(default_type));
 				}
 			}
-		} else if (param.kind() == TemplateParameterKind::NonType) {
+		} else if (param->kind() == TemplateParameterKind::NonType) {
 			// For non-type parameters with defaults, evaluate the expression
-			const ASTNode& default_node = param.default_value();
+			const ASTNode& default_node = param->default_value();
 			FLASH_LOG(Templates, Debug, "Processing non-type param default, is_expression=", default_node.is<ExpressionNode>());
 
 			// Substitute template parameters in the default expression
@@ -4044,9 +4060,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							if (!sizeof_type_name.empty()) {
 								// Check if this is one of the template parameters we've already filled
 								for (size_t j = 0; j < template_params.size() && j < filled_template_args.size(); ++j) {
-									if (template_params[j].is<TemplateParameterNode>()) {
-										const TemplateParameterNode& prev_param = template_params[j].as<TemplateParameterNode>();
-										if (prev_param.name() == sizeof_type_name) {
+									if (const TemplateParameterNode* prev_param = tryGetTemplateParameterNode(template_params[j]);
+										prev_param != nullptr) {
+										if (prev_param->name() == sizeof_type_name) {
 											// Found the matching template parameter - use its filled value
 											const TemplateTypeArg& filled_arg = filled_template_args[j];
 											if (filled_arg.category() != TypeCategory::Invalid) {
@@ -4093,8 +4109,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					filled_template_args.push_back(*evaluated_default);
 				}
 			}
-		} else if (param.kind() == TemplateParameterKind::Template && param.has_default()) {
-			const ASTNode& default_node = param.default_value();
+		} else if (param->kind() == TemplateParameterKind::Template && param->has_default()) {
+			const ASTNode& default_node = param->default_value();
 			if (default_node.is<TypeSpecifierNode>()) {
 				const TypeSpecifierNode& default_type = default_node.as<TypeSpecifierNode>();
 				StringHandle tpl_name_handle = StringTable::getOrInternStringHandle(default_type.token().value());
@@ -4110,14 +4126,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// This covers: Type defaults whose node isn't TypeSpecifierNode, NonType defaults
 		// that no handler could evaluate, and any other unhandled parameter kind.
 		if (filled_template_args.size() == size_before) {
-			if (param.kind() == TemplateParameterKind::Type) {
+			if (param->kind() == TemplateParameterKind::Type) {
 				// Push a void-like placeholder type
 				TemplateTypeArg placeholder;
 				placeholder.setType(TypeCategory::Void);
 				filled_template_args.push_back(placeholder);
 				FLASH_LOG(Templates, Warning, "Could not resolve type default for param ", i,
 						  " of '", template_name, "', using placeholder");
-			} else if (param.kind() == TemplateParameterKind::Template) {
+			} else if (param->kind() == TemplateParameterKind::Template) {
 				throw InternalError(
 					std::string("Could not resolve template-template default for param ") +
 					std::to_string(i) + " of '" + std::string(template_name) + "'");
@@ -4152,16 +4168,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		size_t arg_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>())
+			const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+			if (tparam == nullptr)
 				continue;
 
-			const auto& tparam = template_params[i].as<TemplateParameterNode>();
-
-			std::string_view param_name = tparam.name();
+			std::string_view param_name = tparam->name();
 			template_param_order.push_back(param_name);
 
 			// Check if this is a variadic pack parameter
-			if (tparam.is_variadic()) {
+			if (tparam->is_variadic()) {
 				// Collect remaining arguments as a pack
 				std::vector<TemplateTypeArg> pack_args;
 				for (size_t j = arg_index; j < template_args_to_use.size(); ++j) {
@@ -4177,7 +4192,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Regular scalar parameter (type or non-type)
 				if (arg_index < template_args_to_use.size()) {
 					TemplateTypeArg arg_to_insert =
-						enrichTemplateArgForParameter(tparam, template_args_to_use[arg_index]);
+						enrichTemplateArgForParameter(*tparam, template_args_to_use[arg_index]);
 					name_substitution_map[param_name] = arg_to_insert;
 					FLASH_LOG(Templates, Debug, "Added substitution: ", param_name, " -> base_type=", static_cast<int>(arg_to_insert.typeEnum()), " type_index=", arg_to_insert.type_index, " is_value=", arg_to_insert.is_value, " is_ttp=", arg_to_insert.is_template_template_arg);
 					arg_index++;
@@ -4309,12 +4324,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	if (has_parameter_pack) {
 		std::vector<ClassTemplatePackInfo> pack_infos;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-			if (param.is_variadic()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			if (param != nullptr && param->is_variadic()) {
 				size_t pack_size = template_args_to_use.size() >= non_variadic_param_count
 									   ? template_args_to_use.size() - non_variadic_param_count
 									   : 0;
-				pack_infos.push_back({param.name(), pack_size});
+				pack_infos.push_back({param->name(), pack_size});
 			}
 		}
 		if (!pack_infos.empty()) {
@@ -5294,8 +5309,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (identifier_name.has_value()) {
 					// Try to find which non-type template parameter this is
 					for (size_t i = 0; i < template_params.size(); ++i) {
-						const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
-						if (tparam.kind() == TemplateParameterKind::NonType && tparam.name() == *identifier_name) {
+						const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+						if (tparam != nullptr &&
+							tparam->kind() == TemplateParameterKind::NonType &&
+							tparam->name() == *identifier_name) {
 							// Found the non-type parameter - substitute with the actual value
 							if (i < template_args_to_use.size() && template_args_to_use[i].is_value) {
 								// Create a numeric literal node with the substituted value
@@ -5625,7 +5642,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				lazy_info.is_array = static_member.is_array;
 				lazy_info.array_dimensions = static_member.array_dimensions;
 				lazy_info.pointer_depth = static_member.pointer_depth;
-				lazy_info.template_params = template_params;
+				lazy_info.template_params = template_params_ast;
 				lazy_info.template_args = template_args_to_use;
 				lazy_info.needs_substitution = true;
 
@@ -5659,7 +5676,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::optional<ASTNode> substituted_initializer = static_member.initializer.has_value()
 				? std::optional<ASTNode>(substituteTemplateParameters(
 					*static_member.initializer,
-					template_params,
+					template_params_inline_ast,
 					template_args_to_use))
 				: std::nullopt;
 
@@ -5671,7 +5688,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					gSymbolTable,
 					this,
 					struct_info.get(),
-					template_params,
+					template_params_inline_ast,
 					template_args_to_use,
 					substituted_type_index,
 					substituted_size,
@@ -6497,7 +6514,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					id.cv_qualifier = mem_func.cv_qualifier;
 					id.kind = DeferredMemberIdentity::Kind::Function;
 				}
-				lazy_info.template_params = template_params;
+				lazy_info.template_params = template_params_inline_ast;
 				lazy_info.template_args = template_args_to_use;
 				lazy_info.access = mem_func.access;
 				lazy_info.is_virtual = mem_func.is_virtual;
@@ -6922,8 +6939,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					InlineVector<StringHandle, 4> param_names;
 					param_names.reserve(template_params.size());
 					for (const auto& tparam_node : template_params) {
-						if (tparam_node.is<TemplateParameterNode>()) {
-							param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
+						if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(tparam_node);
+							tparam != nullptr) {
+							param_names.push_back(tparam->nameHandle());
 						}
 					}
 
@@ -7258,8 +7276,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Ensure template_param_order is populated (used by ExpressionSubstitutor later)
 					if (template_param_order.empty()) {
 						for (size_t i = 0; i < template_params.size() && i < template_args_to_use.size(); ++i) {
-							if (template_params[i].is<TemplateParameterNode>()) {
-								template_param_order.push_back(template_params[i].as<TemplateParameterNode>().name());
+							if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+								tparam != nullptr) {
+								template_param_order.push_back(tparam->name());
 							}
 						}
 					}
@@ -7327,8 +7346,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Ensure template_param_order is populated (used by ExpressionSubstitutor)
 					if (template_param_order.empty()) {
 						for (size_t i = 0; i < template_params.size() && i < template_args_to_use.size(); ++i) {
-							if (template_params[i].is<TemplateParameterNode>()) {
-								template_param_order.push_back(template_params[i].as<TemplateParameterNode>().name());
+							if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+								tparam != nullptr) {
+								template_param_order.push_back(tparam->name());
 							}
 						}
 					}
@@ -7564,18 +7584,18 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
 							std::unordered_map<std::string_view, int64_t> nontype_sub_map;
 							for (size_t i = 0; i < template_params.size() && i < template_args_to_use.size(); ++i) {
-								if (!template_params[i].is<TemplateParameterNode>())
+								const TemplateParameterNode* template_param = tryGetTemplateParameterNode(template_params[i]);
+								if (template_param == nullptr)
 									continue;
-								const auto& template_param = template_params[i].as<TemplateParameterNode>();
-								if (template_param.kind() == TemplateParameterKind::Type && !template_args_to_use[i].is_value) {
-									auto type_it = getTypesByNameMap().find(template_param.nameHandle());
+								if (template_param->kind() == TemplateParameterKind::Type && !template_args_to_use[i].is_value) {
+									auto type_it = getTypesByNameMap().find(template_param->nameHandle());
 									if (type_it != getTypesByNameMap().end()) {
 										type_sub_map[type_it->second->type_index_] = template_args_to_use[i];
 									} else {
 										type_sub_map[TypeIndex{getTypeInfoCount() + type_sub_map.size() + 1}] = template_args_to_use[i];
 									}
-								} else if (template_param.kind() == TemplateParameterKind::NonType && template_args_to_use[i].is_value) {
-									nontype_sub_map[template_param.name()] = template_args_to_use[i].value;
+								} else if (template_param->kind() == TemplateParameterKind::NonType && template_args_to_use[i].is_value) {
+									nontype_sub_map[template_param->name()] = template_args_to_use[i].value;
 								}
 							}
 							ASTNode substituted_default = substitute_template_params_in_expression(
@@ -8003,11 +8023,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Calculate pack size for substitution
 					auto calculate_pack_size = [&](std::string_view pack_name) -> std::optional<size_t> {
 						for (size_t i = 0; i < template_params.size(); ++i) {
-							const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
-							if (tparam.name() == pack_name && tparam.is_variadic()) {
+							const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+							if (tparam != nullptr && tparam->name() == pack_name && tparam->is_variadic()) {
 								size_t non_variadic_count = 0;
 								for (const auto& param : template_params) {
-									if (!param.as<TemplateParameterNode>().is_variadic()) {
+									const TemplateParameterNode* inner_param = tryGetTemplateParameterNode(param);
+									if (inner_param != nullptr && !inner_param->is_variadic()) {
 										non_variadic_count++;
 									}
 								}
@@ -8139,7 +8160,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 
 						// Use shared helper lambda defined at function scope
-						if (auto subst = substitute_template_param_in_initializer(param_name, template_args_to_use, template_params)) {
+						if (auto subst = substitute_template_param_in_initializer(param_name, template_args_to_use, template_params_ast)) {
 							substituted_initializer = subst;
 							FLASH_LOG(Templates, Debug, "Substituted static member initializer template parameter '", param_name, "'");
 						}
@@ -8160,8 +8181,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 								// Look up the parameter value
 								for (size_t p = 0; p < template_params.size(); ++p) {
-									const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
-									if (tparam.name() == tparam_ref.param_name() && tparam.kind() == TemplateParameterKind::NonType) {
+									const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[p]);
+									if (tparam != nullptr &&
+										tparam->name() == tparam_ref.param_name() &&
+										tparam->kind() == TemplateParameterKind::NonType) {
 										if (p < template_args_to_use.size() && template_args_to_use[p].is_value) {
 											cond_value = template_args_to_use[p].value;
 											FLASH_LOG(Templates, Debug, "Found template param value: ", *cond_value);
@@ -8176,8 +8199,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 								// Look up the identifier as a template parameter
 								for (size_t p = 0; p < template_params.size(); ++p) {
-									const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
-									if (tparam.name() == id_name && tparam.kind() == TemplateParameterKind::NonType) {
+									const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[p]);
+									if (tparam != nullptr &&
+										tparam->name() == id_name &&
+										tparam->kind() == TemplateParameterKind::NonType) {
 										if (p < template_args_to_use.size() && template_args_to_use[p].is_value) {
 											cond_value = template_args_to_use[p].value;
 											FLASH_LOG(Templates, Debug, "Found template param value: ", *cond_value);
@@ -8335,7 +8360,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// and type parameters like '_R1' in '__is_ratio_v<_R1>' to be substituted with actual types
 			template_param_substitutions_.clear();
 			for (size_t i = 0; i < template_params.size() && i < template_args_to_use.size(); ++i) {
-				const auto& param = template_params[i].as<TemplateParameterNode>();
+				const TemplateParameterNode& param = template_params[i];
 				const auto& arg = template_args_to_use[i];
 
 				if (param.kind() == TemplateParameterKind::NonType && arg.is_value) {
@@ -8404,7 +8429,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 		struct_info_ptr,
 		this,
-		template_params,
+		template_params_inline_ast,
 		template_args_to_use);
 
 	FLASH_LOG(Templates, Debug, "About to return instantiated_struct for ", instantiated_name);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -834,6 +834,37 @@ void Parser::populateTemplateParamSubstitutions(
 			subs.push_back(subst);
 		});
 }
+
+void Parser::populateTemplateParamSubstitutions(
+	InlineVector<TemplateParamSubstitution, 4>& subs,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
+	const std::vector<TemplateTypeArg>& template_args) {
+	forEachNonPackTemplateParamArgBinding(
+		template_params,
+		template_args,
+		[&](const TemplateParameterNode& template_param, const TemplateTypeArg& arg, size_t) {
+			if (arg.is_template_template_arg) {
+				TemplateParamSubstitution subst;
+				subst.param_name = template_param.nameHandle();
+				subst.is_template_template_param = true;
+				subst.concrete_template_name = arg.template_name_handle;
+				subs.push_back(subst);
+				return;
+			}
+			TemplateParamSubstitution subst;
+			subst.param_name = template_param.nameHandle();
+			if (arg.is_value) {
+				subst.is_value_param = true;
+				subst.value = arg.value;
+				subst.value_type = arg.typeEnum();
+			} else {
+				subst.is_value_param = false;
+				subst.is_type_param = true;
+				subst.substituted_type = arg;
+			}
+			subs.push_back(subst);
+		});
+}
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helper: re-parse a template function body with concrete argument
 // substitution and set the result as new_func_ref's definition.

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -219,12 +219,13 @@ static bool templateParameterListsHaveMatchingShape(const LeftParamContainer& lh
 			return false;
 		}
 		for (size_t i = 0; i < lhs_params.size(); ++i) {
-			if (!lhs_params[i].template is<TemplateParameterNode>() ||
-				!rhs_params[i].template is<TemplateParameterNode>()) {
+			const TemplateParameterNode* lhs_param_ptr = tryGetTemplateParameterNode(lhs_params[i]);
+			const TemplateParameterNode* rhs_param_ptr = tryGetTemplateParameterNode(rhs_params[i]);
+			if (lhs_param_ptr == nullptr || rhs_param_ptr == nullptr) {
 				return false;
 			}
-			const TemplateParameterNode& lhs_param = lhs_params[i].template as<TemplateParameterNode>();
-			const TemplateParameterNode& rhs_param = rhs_params[i].template as<TemplateParameterNode>();
+			const TemplateParameterNode& lhs_param = *lhs_param_ptr;
+			const TemplateParameterNode& rhs_param = *rhs_param_ptr;
 			if (lhs_param.kind() != rhs_param.kind() ||
 				lhs_param.is_variadic() != rhs_param.is_variadic() ||
 				lhs_param.has_concept_constraint() != rhs_param.has_concept_constraint()) {
@@ -327,9 +328,7 @@ static int computeTemplateFunctionSpecificity(const TemplateFunctionDeclarationN
 	// Build set of template parameter name handles for quick lookup.
 	std::unordered_set<StringHandle, StringHandleHash> param_name_handles;
 	for (const auto& tp : template_func.template_parameters()) {
-		if (tp.is<TemplateParameterNode>()) {
-			param_name_handles.insert(tp.as<TemplateParameterNode>().nameHandle());
-		}
+		param_name_handles.insert(tp.nameHandle());
 	}
 
 	int score = 0;
@@ -371,7 +370,7 @@ static int computeTemplateFunctionSpecificity(const TemplateFunctionDeclarationN
 
 bool Parser::tryAppendDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const std::vector<ASTNode>& template_params,
+	const std::vector<TemplateParameterNode>& template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
 	FLASH_LOG_FORMAT(Templates, Debug,
@@ -387,10 +386,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 		std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
 		std::unordered_map<std::string_view, int64_t> nontype_sub_map;
 		for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				continue;
-			}
-			const auto& template_param = template_params[i].as<TemplateParameterNode>();
+			const auto& template_param = template_params[i];
 			if (template_param.kind() == TemplateParameterKind::Type && !template_args[i].is_value) {
 				if (template_param.registered_type_index().is_valid()) {
 					type_sub_map[template_param.registered_type_index()] = template_args[i];
@@ -565,6 +561,22 @@ bool Parser::tryAppendDefaultTemplateArg(
 	return false;
 }
 
+bool Parser::tryAppendDefaultTemplateArg(
+	const TemplateParameterNode& param,
+	const std::vector<ASTNode>& template_params,
+	InlineVector<TemplateTypeArg, 4>& template_args,
+	NamespaceHandle source_namespace) {
+	std::vector<TemplateParameterNode> typed_template_params;
+	typed_template_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_template_params.push_back(*typed_param);
+		}
+	}
+	return tryAppendDefaultTemplateArg(param, typed_template_params, template_args, source_namespace);
+}
+
 template <typename ParamContainer, typename ArgContainer>
 static void applyTemplateArgIndirection(
 	TypeSpecifierNode& substituted_type,
@@ -640,7 +652,7 @@ void registerTypeParamsInScope(
 // so the caller avoids index-alignment issues.
 // ─────────────────────────────────────────────────────────────────────────────
 void registerTypeParamsInScope(
-	const std::vector<ASTNode>& template_param_nodes,
+	const std::vector<TemplateParameterNode>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
@@ -657,7 +669,43 @@ void registerTypeParamsInScope(
 }
 
 void registerTypeParamsInScope(
-	const std::vector<ASTNode>& template_param_nodes,
+	const InlineVector<ASTNode, 4>& template_param_nodes,
+	const std::vector<TemplateTypeArg>& template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	bool preserve_ref_qualifier) {
+	forEachNonPackTemplateParamArgBinding(
+		template_param_nodes,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (arg.is_value || arg.is_template_template_arg)
+				return;
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
+			scope.addParameter(&type_info);
+		});
+}
+
+void registerTypeParamsInScope(
+	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const std::vector<TemplateTypeArg>& template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
+	forEachNonPackTemplateParamArgBinding(
+		template_param_nodes,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (arg.is_value || arg.is_template_template_arg)
+				return;
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, true);
+			scope.addParameter(&type_info);
+			if (sfinae_map)
+				(*sfinae_map)[type_info.name()] = arg.type_index;
+		});
+}
+
+void registerTypeParamsInScope(
+	const InlineVector<ASTNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
@@ -839,9 +887,11 @@ void Parser::reparse_template_function_body(
 	InlineVector<StringHandle, 4> param_names;
 	param_names.reserve(template_params.size());
 	for (const auto& tparam_node : template_params) {
-		if (tparam_node.is<TemplateParameterNode>()) {
-			param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
+		const TemplateParameterNode* template_param = tryGetTemplateParameterNode(tparam_node);
+		if (template_param == nullptr) {
+			continue;
 		}
+		param_names.push_back(template_param->nameHandle());
 	}
 	// preserve_ref_qualifier=true for the explicit path (user-written T=int& must be
 	// reflected in TypeInfo); false for the deduced path.
@@ -912,6 +962,20 @@ void Parser::reparse_template_function_body(
 			std::string("non-dependent name '").append(tok.value()).append("' was not declared before the template definition (C++20 [temp.res]/9)"));
 	}
 	// template_scope RAII guard removes TypeInfo entries automatically.
+}
+
+void Parser::reparse_template_function_body(
+	FunctionDeclarationNode& new_func_ref,
+	const FunctionDeclarationNode& func_decl,
+	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	bool preserve_ref_qualifier) {
+	reparse_template_function_body(
+		new_func_ref,
+		func_decl,
+		cloneTemplateParameterNodes(template_params),
+		template_args,
+		preserve_ref_qualifier);
 }
 
 // Synthesize a TypeSpecifierNode from a TypeInfo::TemplateArgInfo entry.
@@ -1153,7 +1217,7 @@ std::optional<bool> Parser::preDeduceTemplateArgsFromMatchingTypes(
 }
 
 std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArgs(
-	const std::vector<ASTNode>& template_params,
+	const std::vector<TemplateParameterNode>& template_params,
 	const std::vector<ASTNode>& func_params,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	int recursion_depth) {
@@ -1167,10 +1231,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 	// types correspond to template type parameters.
 	std::unordered_map<StringHandle, const TemplateParameterNode*, StringHash, StringEqual> tparam_nodes_by_name;
 	for (const auto& tparam_node : template_params) {
-		if (tparam_node.is<TemplateParameterNode>()) {
-			const auto& tparam = tparam_node.as<TemplateParameterNode>();
-			tparam_nodes_by_name.emplace(tparam.nameHandle(), &tparam);
-		}
+		tparam_nodes_by_name.emplace(tparam_node.nameHandle(), &tparam_node);
 	}
 
 	auto getNonTypeTemplateParamCategoryOrInt = [&](StringHandle param_name) -> TypeCategory {
@@ -1490,7 +1551,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 }
 
 std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArgs(
-	const std::vector<ASTNode>& template_params,
+	const std::vector<TemplateParameterNode>& template_params,
 	const FunctionDeclarationNode& func_decl,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	int recursion_depth) {
@@ -1531,7 +1592,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		}
 
 		const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
-		const std::vector<ASTNode>& template_params = template_func.template_parameters();
+		const auto& template_params = template_func.template_parameters();
 		const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 		FLASH_LOG_FORMAT(Templates, Debug, "[explicit] func_decl name='{}' ns={}",
 			func_decl.decl_node().identifier_token().value(),
@@ -1559,25 +1620,16 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		// Check if template has a variadic parameter pack
 		bool has_variadic_pack = false;
 		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				const TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-				if (tparam.is_variadic()) {
-					has_variadic_pack = true;
-					break;
-				}
+			if (param.is_variadic()) {
+				has_variadic_pack = true;
+				break;
 			}
 		}
 
 		// Verify we have the right number of template arguments.
-		size_t required_template_args = countRequiredTemplateArgsAfter<
-			decltype(template_params),
-			decltype(explicit_types)>(template_params, 0);
-		size_t max_template_args = 0;
-		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				++max_template_args;
-			}
-		}
+		size_t required_template_args = countRequiredTemplateArgsAfter(
+			template_params, 0);
+		size_t max_template_args = template_params.size();
 		const bool can_deduce_remaining_explicit_args = current_explicit_call_arg_types_ != nullptr;
 		if (!has_variadic_pack) {
 			if ((!can_deduce_remaining_explicit_args && explicit_types.size() < required_template_args) ||
@@ -1613,11 +1665,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		}
 		bool overload_mismatch = false;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				FLASH_LOG_FORMAT(Templates, Error, "Template parameter {} is not a TemplateParameterNode (type: {})", i, template_params[i].type_name());
-				continue;
-			}
-			const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
+			const TemplateParameterNode& param = template_params[i];
 			size_t arg_start_index = template_args.size();
 			if (param.kind() == TemplateParameterKind::Template) {
 				if (explicit_idx < explicit_types.size()) {
@@ -1643,9 +1691,8 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 										   : 0;
 				size_t pack_size = remaining_args;
 				if (current_explicit_call_arg_types_ == nullptr) {
-					size_t required_after = countRequiredTemplateArgsAfter<
-						decltype(template_params),
-						decltype(explicit_types)>(template_params, i + 1);
+					size_t required_after = countRequiredTemplateArgsAfter(
+						template_params, i + 1);
 					pack_size = remaining_args > required_after
 									 ? remaining_args - required_after
 									 : 0;
@@ -1748,9 +1795,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 			// Get template parameter names for evaluation
 			InlineVector<std::string_view, 4> eval_param_names;
 			for (const auto& tparam_node : template_params) {
-				if (tparam_node.is<TemplateParameterNode>()) {
-					eval_param_names.push_back(tparam_node.as<TemplateParameterNode>().name());
-				}
+				eval_param_names.push_back(tparam_node.name());
 			}
 
 			// Create a copy of explicit_types with template template arg flags properly set
@@ -2157,10 +2202,11 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		};
 		auto getTemplateParamPackBinding = [&](std::string_view pack_param_name) -> std::optional<PackBinding> {
 			for (size_t template_param_index = 0; template_param_index < template_params.size(); ++template_param_index) {
-				if (!template_params[template_param_index].is<TemplateParameterNode>()) {
+				const TemplateParameterNode* template_param_ptr = tryGetTemplateParameterNode(template_params[template_param_index]);
+				if (template_param_ptr == nullptr) {
 					continue;
 				}
-				const auto& template_param = template_params[template_param_index].as<TemplateParameterNode>();
+				const auto& template_param = *template_param_ptr;
 				if (template_param.is_variadic() && template_param.name() == pack_param_name) {
 					return PackBinding{
 						template_param_arg_starts[template_param_index],
@@ -2186,10 +2232,11 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 				}
 				size_t template_arg_index = 0;
 				for (size_t template_param_index = 0; template_param_index < template_params.size(); ++template_param_index) {
-					if (!template_params[template_param_index].is<TemplateParameterNode>()) {
+					const TemplateParameterNode* template_param_ptr = tryGetTemplateParameterNode(template_params[template_param_index]);
+					if (template_param_ptr == nullptr) {
 						continue;
 					}
-					const auto& template_param = template_params[template_param_index].as<TemplateParameterNode>();
+					const auto& template_param = *template_param_ptr;
 					if (template_param.is_variadic()) {
 						// Substitute at position i when this is the primary pack (pack_param_name)
 						// OR a co-pack in a multi-dependent element type (e.g. the "Us" in
@@ -2213,7 +2260,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 					if (template_arg_index >= template_args.size()) {
 						break;
 					}
-					subst_params.push_back(template_params[template_param_index]);
+					subst_params.push_back(emplace_node<TemplateParameterNode>(template_param));
 					subst_args.push_back(template_args[template_arg_index]);
 					++template_arg_index;
 				}
@@ -2353,8 +2400,9 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		});
 		template_param_pack_sizes_.clear();
 		for (size_t pi = 0; pi < template_params.size(); ++pi) {
-			if (!template_params[pi].is<TemplateParameterNode>()) continue;
-			const auto& tparam = template_params[pi].as<TemplateParameterNode>();
+			const TemplateParameterNode* tparam_ptr = tryGetTemplateParameterNode(template_params[pi]);
+			if (tparam_ptr == nullptr) continue;
+			const auto& tparam = *tparam_ptr;
 			if (tparam.is_variadic() && template_param_arg_starts[pi] != SIZE_MAX) {
 				template_param_pack_sizes_.emplace_back(tparam.nameHandle(), template_param_arg_counts[pi]);
 			}
@@ -2677,7 +2725,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 	};
 
 	for (const auto& template_param_node : template_params) {
-		const TemplateParameterNode& param = template_param_node.as<TemplateParameterNode>();
+		const TemplateParameterNode* param_ptr = tryGetTemplateParameterNode(template_param_node);
+		if (param_ptr == nullptr) {
+			continue;
+		}
+		const TemplateParameterNode& param = *param_ptr;
 
 		if (param.kind() == TemplateParameterKind::Template) {
 			skipPreDeducedArgs();
@@ -2812,6 +2864,23 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 	return template_args;
 }
 
+std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCall(
+	const std::vector<TemplateParameterNode>& template_params,
+	const std::vector<TypeSpecifierNode>& arg_types,
+	const CallArgDeductionInfo& deduction_info,
+	size_t function_pack_arg_start,
+	int recursion_depth,
+	NamespaceHandle source_namespace) {
+	const InlineVector<ASTNode, 4> ast_template_params = cloneTemplateParameterNodes(template_params);
+	return deduceTemplateArgsFromCall(
+		std::vector<ASTNode>(ast_template_params.begin(), ast_template_params.end()),
+		arg_types,
+		deduction_info,
+		function_pack_arg_start,
+		recursion_depth,
+		source_namespace);
+}
+
 // Helper function: Try to instantiate a specific template node
 // This contains the core instantiation logic extracted from try_instantiate_template
 // Returns nullopt if instantiation fails (for SFINAE)
@@ -2821,7 +2890,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	const std::vector<TypeSpecifierNode>& arg_types,
 	int& recursion_depth) {
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
-	const std::vector<ASTNode>& template_params = template_func.template_parameters();
+	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 
 	// Step 1: Deduce template arguments from function call arguments.
@@ -2835,7 +2904,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	// Check if we have only variadic parameters - they can be empty
 	bool all_variadic = true;
 	for (const auto& template_param_node : template_params) {
-		const TemplateParameterNode& param = template_param_node.as<TemplateParameterNode>();
+		const TemplateParameterNode& param = template_param_node;
 		if (!param.is_variadic()) {
 			all_variadic = false;
 		}
@@ -2995,9 +3064,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 		// Get template parameter names for evaluation
 		std::vector<std::string_view> eval_param_names;
 		for (const auto& tparam_node : template_params) {
-			if (tparam_node.is<TemplateParameterNode>()) {
-				eval_param_names.push_back(tparam_node.as<TemplateParameterNode>().name());
-			}
+			eval_param_names.push_back(tparam_node.name());
 		}
 
 		FLASH_LOG(Templates, Debug, "  Evaluating constraint with ", template_args.size(), " template args and ", eval_param_names.size(), " param names");
@@ -3139,9 +3206,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 		FlashCpp::TemplateParameterScope template_scope;
 		InlineVector<StringHandle, 4> param_names;
 		for (const auto& tparam_node : template_params) {
-			if (tparam_node.is<TemplateParameterNode>()) {
-				param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
-			}
+			param_names.push_back(tparam_node.nameHandle());
 		}
 
 		registerTypeParamsInScope(template_params, template_args, template_scope, false);
@@ -3850,8 +3915,9 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 				? (deduction_info->function_pack_call_arg_end - deduction_info->function_pack_call_arg_start)
 				: 0;
 		for (const auto& tpnode : template_params) {
-			if (!tpnode.is<TemplateParameterNode>()) continue;
-			const auto& tparam = tpnode.as<TemplateParameterNode>();
+			const TemplateParameterNode* tparam_ptr = tryGetTemplateParameterNode(tpnode);
+			if (tparam_ptr == nullptr) continue;
+			const auto& tparam = *tparam_ptr;
 			if (!tparam.is_variadic()) continue;
 			const size_t pack_count =
 				deduction_info->function_pack_dependent_param_names.count(tparam.nameHandle())
@@ -3903,7 +3969,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 		// Re-parse body, register types, substitute parameters — shared with explicit path.
 		// preserve_ref_qualifier=false: deduced args carry call-site lvalue-ness which must
 		// NOT be propagated to TypeInfo (see registerTypeParamsInScope comment).
-		const std::vector<ASTNode>& func_template_params = template_func.template_parameters();
+		const auto& func_template_params = template_func.template_parameters();
 		reparse_template_function_body(new_func_ref, func_decl, func_template_params, template_args,
 									   /*preserve_ref_qualifier=*/false);
 		if (!new_func_ref.is_materialized()) {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -370,7 +370,7 @@ static int computeTemplateFunctionSpecificity(const TemplateFunctionDeclarationN
 
 bool Parser::tryAppendDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
 	FLASH_LOG_FORMAT(Templates, Debug,
@@ -566,7 +566,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 	const std::vector<ASTNode>& template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
-	std::vector<TemplateParameterNode> typed_template_params;
+	InlineVector<TemplateParameterNode, 4> typed_template_params;
 	typed_template_params.reserve(template_params.size());
 	for (const ASTNode& template_param : template_params) {
 		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
@@ -652,7 +652,7 @@ void registerTypeParamsInScope(
 // so the caller avoids index-alignment issues.
 // ─────────────────────────────────────────────────────────────────────────────
 void registerTypeParamsInScope(
-	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
@@ -686,7 +686,7 @@ void registerTypeParamsInScope(
 }
 
 void registerTypeParamsInScope(
-	const std::vector<TemplateParameterNode>& template_param_nodes,
+	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	const std::vector<TemplateTypeArg>& template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
@@ -967,7 +967,7 @@ void Parser::reparse_template_function_body(
 void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	bool preserve_ref_qualifier) {
 	reparse_template_function_body(
@@ -1217,7 +1217,7 @@ std::optional<bool> Parser::preDeduceTemplateArgsFromMatchingTypes(
 }
 
 std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArgs(
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<ASTNode>& func_params,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	int recursion_depth) {
@@ -1551,7 +1551,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 }
 
 std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArgs(
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const FunctionDeclarationNode& func_decl,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	int recursion_depth) {
@@ -2865,7 +2865,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 }
 
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCall(
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	const CallArgDeductionInfo& deduction_info,
 	size_t function_pack_arg_start,

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -2702,7 +2702,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 }
 
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCall(
-	const std::vector<ASTNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TypeSpecifierNode>& arg_types,
 	const CallArgDeductionInfo& deduction_info,
 	size_t function_pack_arg_start,
@@ -2724,13 +2724,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 		}
 	};
 
-	for (const auto& template_param_node : template_params) {
-		const TemplateParameterNode* param_ptr = tryGetTemplateParameterNode(template_param_node);
-		if (param_ptr == nullptr) {
-			continue;
-		}
-		const TemplateParameterNode& param = *param_ptr;
-
+	for (const TemplateParameterNode& param : template_params) {
 		if (param.kind() == TemplateParameterKind::Template) {
 			skipPreDeducedArgs();
 			if (arg_index >= arg_types.size()) {
@@ -2862,23 +2856,6 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 	}
 
 	return template_args;
-}
-
-std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCall(
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const std::vector<TypeSpecifierNode>& arg_types,
-	const CallArgDeductionInfo& deduction_info,
-	size_t function_pack_arg_start,
-	int recursion_depth,
-	NamespaceHandle source_namespace) {
-	const InlineVector<ASTNode, 4> ast_template_params = cloneTemplateParameterNodes(template_params);
-	return deduceTemplateArgsFromCall(
-		std::vector<ASTNode>(ast_template_params.begin(), ast_template_params.end()),
-		arg_types,
-		deduction_info,
-		function_pack_arg_start,
-		recursion_depth,
-		source_namespace);
 }
 
 // Helper function: Try to instantiate a specific template node

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1542,7 +1542,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	// try_instantiate_template_explicit for free function templates.
 	{
 		FlashCpp::ScopedState guard_subs(template_param_substitutions_);
-		populateTemplateParamSubstitutions(template_param_substitutions_, param_names, template_args);
+		populateTemplateParamSubstitutions(template_param_substitutions_, template_params, template_args);
 
 		// Parse the function body
 		{

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -61,7 +61,7 @@ std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_n
 
 bool Parser::tryAppendMemberDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const OuterTemplateBinding* outer_binding,
 	InlineVector<TemplateTypeArg, 4>& current_template_args) {
 	// Member templates don't have a separate namespace context - use invalid handle
@@ -1461,7 +1461,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 	// Also add outer template parameter bindings (e.g., T→int from class template)
 	if (outer_binding) {
-		registerOuterBindingInScope(*outer_binding, template_scope);
+		registerOuterBindingInScope(*outer_binding, template_scope, nullptr);
 		FLASH_LOG(Templates, Debug, "Added ", outer_binding->param_names.size(), " outer template param bindings for body parsing");
 	}
 

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -61,7 +61,7 @@ std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_n
 
 bool Parser::tryAppendMemberDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const std::vector<ASTNode>& template_params,
+	const std::vector<TemplateParameterNode>& template_params,
 	const OuterTemplateBinding* outer_binding,
 	InlineVector<TemplateTypeArg, 4>& current_template_args) {
 	// Member templates don't have a separate namespace context - use invalid handle
@@ -80,7 +80,7 @@ bool Parser::tryAppendMemberDefaultTemplateArg(
 	appendOuterBindingSubstitutionInputs(*outer_binding, combined_template_params, combined_template_args);
 
 	for (const auto& template_param_node : template_params) {
-		combined_template_params.push_back(template_param_node);
+		combined_template_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param_node));
 	}
 	for (const auto& current_arg : current_template_args) {
 		combined_template_args.push_back(current_arg);
@@ -167,7 +167,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 
 	size_t arg_index = 0;
 	for (const auto& template_param_node : template_params) {
-		const TemplateParameterNode& param = template_param_node.as<TemplateParameterNode>();
+		const TemplateParameterNode& param = template_param_node;
 
 		if (param.kind() == TemplateParameterKind::Template) {
 			return std::nullopt;
@@ -273,10 +273,7 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 	InlineVector<TemplateTypeArg, 4> ctor_template_args;
 	size_t arg_index = 0;
 	for (const auto& template_param_node : template_params) {
-		if (!template_param_node.is<TemplateParameterNode>()) {
-			return std::nullopt;
-		}
-		const auto& param = template_param_node.as<TemplateParameterNode>();
+		const auto& param = template_param_node;
 		auto deduced_it = deduction_info->param_name_to_arg.find(param.nameHandle());
 		if (deduced_it != deduction_info->param_name_to_arg.end()) {
 			ctor_template_args.push_back(deduced_it->second);
@@ -323,7 +320,7 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 			nullptr));
 	}
 	for (const auto& template_param : template_params) {
-		lazy_info.template_params.push_back(template_param);
+		lazy_info.template_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
 	}
 	for (const auto& template_arg : ctor_template_args) {
 		lazy_info.template_args.push_back(template_arg);
@@ -689,11 +686,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 		}
 		bool has_all_template_args = true;
 		for (size_t i = completed_template_args.size(); i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				has_all_template_args = false;
-				break;
-			}
-			const auto& template_param = template_params[i].as<TemplateParameterNode>();
+			const auto& template_param = template_params[i];
 			if (!tryAppendMemberDefaultTemplateArg(template_param, template_params, outer_binding, completed_template_args)) {
 				has_all_template_args = false;
 				break;
@@ -846,11 +839,11 @@ bool Parser::buildSubstitutionForPackElement(
 	InlineVector<TemplateTypeArg, 4>& subst_args) {
 	std::optional<std::pair<size_t, size_t>> pack_binding;
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		if (!template_params[i].is<TemplateParameterNode>()) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+		if (tparam == nullptr) {
 			continue;
 		}
-		const auto& tparam = template_params[i].as<TemplateParameterNode>();
-		if (tparam.is_variadic() && tparam.nameHandle() == pack_param_name) {
+		if (tparam->is_variadic() && tparam->nameHandle() == pack_param_name) {
 			pack_binding = std::pair<size_t, size_t>{
 				template_param_arg_starts[i],
 				template_param_arg_counts[i]};
@@ -861,19 +854,19 @@ bool Parser::buildSubstitutionForPackElement(
 		return false;
 	}
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		if (!template_params[i].is<TemplateParameterNode>()) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+		if (tparam == nullptr) {
 			continue;
 		}
-		const auto& tparam = template_params[i].as<TemplateParameterNode>();
-		if (tparam.is_variadic()) {
-			const bool is_primary = (tparam.nameHandle() == pack_param_name);
+		if (tparam->is_variadic()) {
+			const bool is_primary = (tparam->nameHandle() == pack_param_name);
 			const bool is_co_pack = !is_primary &&
-				dependent_pack_names.count(tparam.nameHandle());
+				dependent_pack_names.count(tparam->nameHandle());
 			if (is_primary || is_co_pack) {
 				size_t pack_index = template_param_arg_starts[i] + pack_element_offset;
 				if (pack_index < template_args.size()) {
 					subst_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(
-						cloneNonVariadicTemplateParam(tparam)));
+						cloneNonVariadicTemplateParam(*tparam)));
 					subst_args.push_back(template_args[pack_index]);
 				}
 			}
@@ -958,6 +951,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const auto& template_params = template_func.template_parameters();
+	const InlineVector<ASTNode, 4> template_params_ast = cloneTemplateParameterNodes(template_params);
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 	const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
 	auto deduction_info = buildDeductionMapFromCallArgs(
@@ -1004,7 +998,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 			// Check inner template params first
 			for (size_t i = 0; i < template_params.size(); ++i) {
-				const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
+				const TemplateParameterNode& tparam = template_params[i];
 				if (tparam.name() == tn && i < template_args.size()) {
 					return {template_args[i].type_index.withCategory(template_args[i].typeEnum()), &template_args[i]};
 				}
@@ -1167,9 +1161,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		}
 	}
 	for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-		if (!template_params[i].is<TemplateParameterNode>())
-			continue;
-		const auto& template_param = template_params[i].as<TemplateParameterNode>();
+		const auto& template_param = template_params[i];
 		default_param_order.push_back(template_param.name());
 		default_param_map[template_param.name()] = template_args[i];
 		if (template_param.kind() == TemplateParameterKind::Type && !template_args[i].is_value) {
@@ -1208,10 +1200,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	};
 	std::unordered_map<StringHandle, const TemplateParameterNode*, StringHash, StringEqual> tparam_nodes_by_name;
 	for (const auto& template_param_node : template_params) {
-		if (!template_param_node.is<TemplateParameterNode>()) {
-			continue;
-		}
-		const auto& template_param = template_param_node.as<TemplateParameterNode>();
+		const auto& template_param = template_param_node;
 		tparam_nodes_by_name.emplace(template_param.nameHandle(), &template_param);
 	}
 	std::vector<size_t> template_param_arg_starts(template_params.size(), SIZE_MAX);
@@ -1219,10 +1208,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	{
 		size_t template_arg_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				continue;
-			}
-			const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
+			const TemplateParameterNode& tparam = template_params[i];
 			if (tparam.is_variadic()) {
 				size_t pack_count = 0;
 				if (deduction_info.has_value()) {
@@ -1242,9 +1228,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					size_t remaining_args = template_arg_index < template_args.size()
 											 ? template_args.size() - template_arg_index
 											 : 0;
-					size_t required_after =
-						countRequiredTemplateArgsAfter<InlineVector<ASTNode, 4>, InlineVector<TemplateTypeArg, 4>>(
-							template_params, i + 1);
+					size_t required_after = countRequiredTemplateArgsAfter(
+						template_params, i + 1);
 					pack_count = remaining_args > required_after
 								 ? remaining_args - required_after
 								 : 0;
@@ -1273,10 +1258,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	});
 	template_param_pack_sizes_.clear();
 	for (size_t pi = 0; pi < template_params.size(); ++pi) {
-		if (!template_params[pi].is<TemplateParameterNode>()) {
-			continue;
-		}
-		const auto& tparam = template_params[pi].as<TemplateParameterNode>();
+		const auto& tparam = template_params[pi];
 		if (tparam.is_variadic() && template_param_arg_starts[pi] != SIZE_MAX) {
 			template_param_pack_sizes_.emplace_back(tparam.nameHandle(), template_param_arg_counts[pi]);
 		}
@@ -1315,10 +1297,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	};
 	auto getTemplateParamPackBinding = [&](StringHandle pack_param_name) -> std::optional<std::pair<size_t, size_t>> {
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				continue;
-			}
-			const auto& tparam = template_params[i].as<TemplateParameterNode>();
+			const auto& tparam = template_params[i];
 			if (tparam.is_variadic() && tparam.nameHandle() == pack_param_name) {
 				return std::pair<size_t, size_t>{
 					template_param_arg_starts[i],
@@ -1344,9 +1323,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			StringHandle type_name_handle = getTypeName(param_type_spec);
 			if (!is_pack_param && type_name_handle.isValid()) {
 				for (size_t i = 0; i < template_params.size(); ++i) {
-					if (!template_params[i].is<TemplateParameterNode>())
-						continue;
-					const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
+					const TemplateParameterNode& tparam = template_params[i];
 					if (tparam.is_variadic() && tparam.nameHandle() == type_name_handle) {
 						is_pack_param = true;
 						break;
@@ -1387,7 +1364,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 								primary_pack_name,
 								pi,
 								dependent_pack_names,
-								template_params,
+								template_params_ast,
 								template_param_arg_starts,
 								template_param_arg_counts,
 								template_args,
@@ -1475,9 +1452,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	FlashCpp::TemplateParameterScope template_scope;
 	InlineVector<StringHandle, 4> param_names;
 	for (const auto& tparam_node : template_params) {
-		if (tparam_node.is<TemplateParameterNode>()) {
-			param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
-		}
+		param_names.push_back(tparam_node.nameHandle());
 	}
 
 	// Kind::Value and Kind::Template entries are intentionally skipped by registerTypeParamsInScope:
@@ -1567,7 +1542,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	// try_instantiate_template_explicit for free function templates.
 	{
 		FlashCpp::ScopedState guard_subs(template_param_substitutions_);
-		populateTemplateParamSubstitutions(template_param_substitutions_, template_params, template_args);
+		populateTemplateParamSubstitutions(template_param_substitutions_, param_names, template_args);
 
 		// Parse the function body
 		{

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -90,7 +90,7 @@ ASTNode Parser::substituteNonTypeDefaultExpression(
 
 ASTNode Parser::substituteNonTypeDefaultExpression(
 	const ASTNode& default_node,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args) {
 	return substituteNonTypeDefaultExpressionImpl(
 		*this,
@@ -125,7 +125,7 @@ std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
 
 std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
 	const ASTNode& default_node,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args,
 	std::span<const std::string_view> template_param_names) {
 	return substituteAndEvaluateNonTypeDefaultImpl(
@@ -256,7 +256,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 
 std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
-	const std::vector<TemplateParameterNode>& template_parameters,
+	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
 	const std::vector<TemplateTypeArg>& template_args) {
 	return materializeDeferredAliasTemplateArg(
@@ -368,7 +368,7 @@ void Parser::normalizeDependentNonTypeTemplateArgs(
 }
 
 void Parser::normalizeDependentNonTypeTemplateArgs(
-	const std::vector<TemplateParameterNode>& template_parameters,
+	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	std::vector<TemplateTypeArg>& template_args) {
 	normalizeDependentNonTypeTemplateArgs(
 		cloneTemplateParameterNodes(template_parameters),
@@ -539,7 +539,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	return materializeInstantiatedMemberAliasTarget(
 		alias_type_spec,

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -24,12 +24,11 @@ TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_
 
 namespace {
 
-template <typename ParamContainer>
-ASTNode substituteNonTypeDefaultExpressionImpl(
-	Parser& parser,
-	const ASTNode& default_node,
-	const ParamContainer& template_params,
-	std::span<const TemplateTypeArg> template_args) {
+	ASTNode substituteNonTypeDefaultExpressionImpl(
+		Parser& parser,
+		const ASTNode& default_node,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
+		std::span<const TemplateTypeArg> template_args) {
 	if (!default_node.is<ExpressionNode>() || template_args.empty()) {
 		return default_node;
 	}
@@ -43,13 +42,12 @@ ASTNode substituteNonTypeDefaultExpressionImpl(
 	return substitutor.substitute(default_node);
 }
 
-template <typename ParamContainer>
-std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefaultImpl(
-	Parser& parser,
-	const ASTNode& default_node,
-	const ParamContainer& template_params,
-	std::span<const TemplateTypeArg> template_args,
-	std::span<const std::string_view> template_param_names) {
+	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefaultImpl(
+		Parser& parser,
+		const ASTNode& default_node,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
+		std::span<const TemplateTypeArg> template_args,
+		std::span<const std::string_view> template_param_names) {
 	ASTNode substituted_default_node = substituteNonTypeDefaultExpressionImpl(
 		parser,
 		default_node,
@@ -79,17 +77,6 @@ std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefaultImpl(
 
 ASTNode Parser::substituteNonTypeDefaultExpression(
 	const ASTNode& default_node,
-	const std::vector<ASTNode>& template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	return substituteNonTypeDefaultExpressionImpl(
-		*this,
-		default_node,
-		template_params,
-		template_args);
-}
-
-ASTNode Parser::substituteNonTypeDefaultExpression(
-	const ASTNode& default_node,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args) {
 	return substituteNonTypeDefaultExpressionImpl(
@@ -99,46 +86,9 @@ ASTNode Parser::substituteNonTypeDefaultExpression(
 		template_args);
 }
 
-ASTNode Parser::substituteNonTypeDefaultExpression(
-	const ASTNode& default_node,
-	const InlineVector<ASTNode, 4>& template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	return substituteNonTypeDefaultExpressionImpl(
-		*this,
-		default_node,
-		template_params,
-		template_args);
-}
-
-std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
-	const ASTNode& default_node,
-	const std::vector<ASTNode>& template_params,
-	std::span<const TemplateTypeArg> template_args,
-	std::span<const std::string_view> template_param_names) {
-	return substituteAndEvaluateNonTypeDefaultImpl(
-		*this,
-		default_node,
-		template_params,
-		template_args,
-		template_param_names);
-}
-
 std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
 	const ASTNode& default_node,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
-	std::span<const TemplateTypeArg> template_args,
-	std::span<const std::string_view> template_param_names) {
-	return substituteAndEvaluateNonTypeDefaultImpl(
-		*this,
-		default_node,
-		template_params,
-		template_args,
-		template_param_names);
-}
-
-std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
-	const ASTNode& default_node,
-	const InlineVector<ASTNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args,
 	std::span<const std::string_view> template_param_names) {
 	return substituteAndEvaluateNonTypeDefaultImpl(
@@ -237,9 +187,19 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 		template_param_names_sv.push_back(StringTable::getStringView(param_name));
 	}
 
+	InlineVector<TemplateParameterNode, 4> typed_template_parameters;
+	typed_template_parameters.reserve(template_parameters.size());
+	for (const ASTNode& template_param : template_parameters) {
+		const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+		if (typed_param == nullptr) {
+			return std::nullopt;
+		}
+		typed_template_parameters.push_back(*typed_param);
+	}
+
 	if (auto substituted_eval = substituteAndEvaluateNonTypeDefault(
 			arg_node,
-			template_parameters,
+			typed_template_parameters,
 			std::span<const TemplateTypeArg>(template_args.data(), template_args.size()),
 			std::span<const std::string_view>(template_param_names_sv.data(), template_param_names_sv.size()))) {
 		return *substituted_eval;

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -90,6 +90,17 @@ ASTNode Parser::substituteNonTypeDefaultExpression(
 
 ASTNode Parser::substituteNonTypeDefaultExpression(
 	const ASTNode& default_node,
+	const std::vector<TemplateParameterNode>& template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	return substituteNonTypeDefaultExpressionImpl(
+		*this,
+		default_node,
+		template_params,
+		template_args);
+}
+
+ASTNode Parser::substituteNonTypeDefaultExpression(
+	const ASTNode& default_node,
 	const InlineVector<ASTNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args) {
 	return substituteNonTypeDefaultExpressionImpl(
@@ -102,6 +113,19 @@ ASTNode Parser::substituteNonTypeDefaultExpression(
 std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
 	const ASTNode& default_node,
 	const std::vector<ASTNode>& template_params,
+	std::span<const TemplateTypeArg> template_args,
+	std::span<const std::string_view> template_param_names) {
+	return substituteAndEvaluateNonTypeDefaultImpl(
+		*this,
+		default_node,
+		template_params,
+		template_args,
+		template_param_names);
+}
+
+std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
+	const ASTNode& default_node,
+	const std::vector<TemplateParameterNode>& template_params,
 	std::span<const TemplateTypeArg> template_args,
 	std::span<const std::string_view> template_param_names) {
 	return substituteAndEvaluateNonTypeDefaultImpl(
@@ -148,14 +172,13 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	};
 	const auto normalize_alias_param_arg = [&](size_t alias_param_idx, const TemplateTypeArg& source_arg) {
 		TemplateTypeArg normalized = source_arg;
-		if (alias_param_idx < template_parameters.size() &&
-			template_parameters[alias_param_idx].is<TemplateParameterNode>()) {
-			const auto& alias_param = template_parameters[alias_param_idx].as<TemplateParameterNode>();
-			if (alias_param.kind() == TemplateParameterKind::NonType && !normalized.is_value) {
+		if (alias_param_idx < template_parameters.size()) {
+			const TemplateParameterNode* alias_param = tryGetTemplateParameterNode(template_parameters[alias_param_idx]);
+			if (alias_param != nullptr && alias_param->kind() == TemplateParameterKind::NonType && !normalized.is_value) {
 				normalized.is_value = true;
 				normalized.is_dependent = normalized.is_dependent || normalized.dependent_name.isValid();
-				if (alias_param.has_type()) {
-					const auto& param_type = alias_param.type_specifier_node();
+				if (alias_param->has_type()) {
+					const auto& param_type = alias_param->type_specifier_node();
 					normalized.type_index = param_type.type_index();
 					normalized.setCategory(param_type.type());
 				} else if (!normalized.type_index.is_valid()) {
@@ -229,6 +252,18 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	}
 
 	return std::nullopt;
+}
+
+std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
+	const ASTNode& arg_node,
+	const std::vector<TemplateParameterNode>& template_parameters,
+	const InlineVector<StringHandle, 4>& param_names,
+	const std::vector<TemplateTypeArg>& template_args) {
+	return materializeDeferredAliasTemplateArg(
+		arg_node,
+		cloneTemplateParameterNodes(template_parameters),
+		param_names,
+		template_args);
 }
 
 std::optional<std::vector<TemplateTypeArg>> Parser::materializeDeferredAliasTemplateArgs(
@@ -330,6 +365,14 @@ void Parser::normalizeDependentNonTypeTemplateArgs(
 
 		++arg_index;
 	}
+}
+
+void Parser::normalizeDependentNonTypeTemplateArgs(
+	const std::vector<TemplateParameterNode>& template_parameters,
+	std::vector<TemplateTypeArg>& template_args) {
+	normalizeDependentNonTypeTemplateArgs(
+		cloneTemplateParameterNodes(template_parameters),
+		template_args);
 }
 
 Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInstantiation(
@@ -494,6 +537,16 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	return nullptr;
 }
 
+const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
+	const TypeSpecifierNode& alias_type_spec,
+	const std::vector<TemplateParameterNode>& template_params,
+	const std::vector<TemplateTypeArg>& template_args) {
+	return materializeInstantiatedMemberAliasTarget(
+		alias_type_spec,
+		cloneTemplateParameterNodes(template_params),
+		template_args);
+}
+
 bool Parser::resolveAliasTemplateInstantiation(
 	TypeSpecifierNode& type_spec,
 	std::string_view alias_template_name,
@@ -594,17 +647,16 @@ std::string_view Parser::instantiate_and_register_base_template(
 			// Fill in defaults for missing arguments
 			std::vector<TemplateTypeArg> filled_args = template_args;
 			for (size_t i = filled_args.size(); i < primary_params.size(); ++i) {
-				if (!primary_params[i].is<TemplateParameterNode>())
+				const TemplateParameterNode* param = tryGetTemplateParameterNode(primary_params[i]);
+				if (param == nullptr)
 					continue;
-
-				const TemplateParameterNode& param = primary_params[i].as<TemplateParameterNode>();
-				if (param.is_variadic())
+				if (param->is_variadic())
 					continue;
-				if (!param.has_default())
+				if (!param->has_default())
 					break;
 
-				const ASTNode& default_node = param.default_value();
-				if (param.kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
+				const ASTNode& default_node = param->default_value();
+				if (param->kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
 					InlineVector<TemplateTypeArg, 4> filled_args_inline =
 						toInlineTemplateArgs(filled_args);
 					ASTNode substituted_default_node = substituteTemplateParameters(
@@ -618,7 +670,7 @@ std::string_view Parser::instantiate_and_register_base_template(
 						filled_args.emplace_back(default_type);
 					}
 					FLASH_LOG(Templates, Debug, "Filled in default type argument for param ", i);
-				} else if (param.kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
+				} else if (param->kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
 					if (auto evaluated_default = substituteAndEvaluateNonTypeDefault(
 							default_node,
 							primary_params,
@@ -1040,12 +1092,11 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		bool has_parameter_pack = false;
 		size_t non_variadic_param_count = 0;
 		for (const auto& param_node : template_params) {
-			if (!param_node.is<TemplateParameterNode>()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(param_node);
+			if (param == nullptr) {
 				continue;
 			}
-
-			const auto& param = param_node.as<TemplateParameterNode>();
-			if (param.is_variadic()) {
+			if (param->is_variadic()) {
 				has_parameter_pack = true;
 				continue;
 			}
@@ -1055,12 +1106,11 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		if (has_parameter_pack) {
 			size_t minimum_required_args = 0;
 			for (const auto& param_node : template_params) {
-				if (!param_node.is<TemplateParameterNode>()) {
+				const TemplateParameterNode* param = tryGetTemplateParameterNode(param_node);
+				if (param == nullptr) {
 					continue;
 				}
-
-				const auto& param = param_node.as<TemplateParameterNode>();
-				if (param.is_variadic() || param.has_default()) {
+				if (param->is_variadic() || param->has_default()) {
 					continue;
 				}
 				++minimum_required_args;
@@ -1124,16 +1174,15 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 		size_t arg_index = 0;
 
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
+			const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+			if (param == nullptr) {
 				continue;
 			}
-
-			const auto& param = template_params[i].as<TemplateParameterNode>();
-			if (param.is_variadic()) {
+			if (param->is_variadic()) {
 				size_t remaining_args = arg_index < input_args.size()
 					? input_args.size() - arg_index
 					: 0;
-				size_t required_after = countRequiredTemplateArgsAfter<InlineVector<ASTNode, 4>, std::vector<TemplateTypeArg>>(
+				size_t required_after = countRequiredTemplateArgsAfter(
 					template_params, i + 1);
 				size_t pack_size = remaining_args > required_after
 					? remaining_args - required_after
@@ -1151,10 +1200,10 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 				continue;
 			}
 
-			auto default_arg = materialize_default_arg(param, filled_args);
+			auto default_arg = materialize_default_arg(*param, filled_args);
 			if (!default_arg.has_value()) {
 				FLASH_LOG(Templates, Error, "Variable template '", template_name,
-						  "': missing argument for parameter '", param.name(), "'");
+						  "': missing argument for parameter '", param->name(), "'");
 				return std::nullopt;
 			}
 
@@ -1207,15 +1256,15 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 			// pattern qualifiers, so we use those substitutions directly.
 			converted_args.reserve(spec_params.size());
 			for (const auto& param : spec_params) {
-				if (param.is<TemplateParameterNode>()) {
-					const TemplateParameterNode& tp = param.as<TemplateParameterNode>();
-					auto it = structural_match->substitutions.find(tp.nameHandle());
+				if (const TemplateParameterNode* tp = tryGetTemplateParameterNode(param);
+					tp != nullptr) {
+					auto it = structural_match->substitutions.find(tp->nameHandle());
 					if (it != structural_match->substitutions.end()) {
 						converted_args.push_back(it->second);
 					} else {
 						throw InternalError(
 							"TemplatePattern::matches() did not produce a substitution for variable-template specialization parameter '" +
-							std::string(tp.name()) + "'");
+							std::string(tp->name()) + "'");
 					}
 				}
 			}
@@ -1887,8 +1936,11 @@ std::optional<ASTNode> Parser::substitute_nontype_template_param(
 	const std::vector<TemplateTypeArg>& args,
 	const std::vector<ASTNode>& params) {
 	for (size_t i = 0; i < params.size(); ++i) {
-		const TemplateParameterNode& tparam = params[i].as<TemplateParameterNode>();
-		if (tparam.name() == param_name && tparam.kind() == TemplateParameterKind::NonType) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(params[i]);
+		if (tparam == nullptr) {
+			continue;
+		}
+		if (tparam->name() == param_name && tparam->kind() == TemplateParameterKind::NonType) {
 			if (i < args.size() && args[i].is_value) {
 				int64_t val = args[i].value;
 				TypeCategory val_type = args[i].typeEnum();
@@ -1925,25 +1977,25 @@ std::optional<int64_t> Parser::evaluateDependentNTTPExpression(
 	// Build non-type substitution map for value parameters
 	std::unordered_map<std::string_view, int64_t> nontype_substitution_map;
 	for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-		if (!template_params[i].is<TemplateParameterNode>()) {
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr) {
 			continue;
 		}
-		const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-		if (param.kind() == TemplateParameterKind::Type) {
+		if (param->kind() == TemplateParameterKind::Type) {
 			// For typename/class parameters, registered_type_index() is the TypeIndex assigned
 			// when the template was parsed (via add_user_type in Parser_Templates_Function.cpp).
 			// This is the same TypeIndex that sizeof(T) will carry in its TypeSpecifierNode.
-			if (param.registered_type_index().is_valid()) {
-				type_substitution_map[param.registered_type_index()] = template_args[i];
+			if (param->registered_type_index().is_valid()) {
+				type_substitution_map[param->registered_type_index()] = template_args[i];
 			}
 			// For non-type parameters that have an explicit type node (e.g., template<int N>
 			// where someone uses sizeof(N)), also map by the param's type specifier index.
-			if (param.has_type()) {
-				const TypeSpecifierNode& param_type = param.type_specifier_node();
+			if (param->has_type()) {
+				const TypeSpecifierNode& param_type = param->type_specifier_node();
 				type_substitution_map[param_type.type_index()] = template_args[i];
 			}
-		} else if (param.kind() == TemplateParameterKind::NonType && template_args[i].is_value) {
-			nontype_substitution_map[param.name()] = template_args[i].value;
+		} else if (param->kind() == TemplateParameterKind::NonType && template_args[i].is_value) {
+			nontype_substitution_map[param->name()] = template_args[i].value;
 		}
 	}
 

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -5,9 +5,9 @@
 #include "TypeTraitEvaluator.h"
 
 std::optional<bool> Parser::try_parse_out_of_line_template_member(
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<StringHandle, 4>& template_param_names,
-	const std::vector<TemplateParameterNode>& inner_template_params,
+	const InlineVector<TemplateParameterNode, 4>& inner_template_params,
 	const InlineVector<StringHandle, 4>& inner_template_param_names) {
 	auto makeQualifiedClassIdentifier = [&](std::string_view class_name) {
 		return QualifiedIdentifier::fromQualifiedName(

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -5,9 +5,9 @@
 #include "TypeTraitEvaluator.h"
 
 std::optional<bool> Parser::try_parse_out_of_line_template_member(
-	const InlineVector<ASTNode, 4>& template_params,
+	const std::vector<TemplateParameterNode>& template_params,
 	const InlineVector<StringHandle, 4>& template_param_names,
-	const InlineVector<ASTNode, 4>& inner_template_params,
+	const std::vector<TemplateParameterNode>& inner_template_params,
 	const InlineVector<StringHandle, 4>& inner_template_param_names) {
 	auto makeQualifiedClassIdentifier = [&](std::string_view class_name) {
 		return QualifiedIdentifier::fromQualifiedName(
@@ -607,7 +607,7 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 
 		// Register the static member variable definition
 		OutOfLineMemberVariable out_of_line_var;
-		out_of_line_var.template_params = template_params;
+		out_of_line_var.template_params = cloneTemplateParameterNodes(template_params);
 		out_of_line_var.member_name = function_name_token.handle();	// Actually the variable name
 		out_of_line_var.type_node = return_type_node;				  // Actually the variable type
 		out_of_line_var.initializer = *init_result.node();
@@ -631,7 +631,7 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 		// Register the static member variable definition without initializer
 		// This is used for providing storage for static constexpr members declared in the class
 		OutOfLineMemberVariable out_of_line_var;
-		out_of_line_var.template_params = template_params;
+		out_of_line_var.template_params = cloneTemplateParameterNodes(template_params);
 		out_of_line_var.member_name = function_name_token.handle();	// Actually the variable name
 		out_of_line_var.type_node = return_type_node;				  // Actually the variable type
 		// No initializer for this case

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -123,12 +123,13 @@ Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
 	return metadata;
 }
 
-InlineVector<ASTNode, 4> Parser::createTemplateParameterAstNodes(const std::vector<TemplateParameterNode>& template_params) {
-	InlineVector<ASTNode, 4> ast_params;
-	for (const TemplateParameterNode& tparam : template_params) {
-		ast_params.push_back(emplace_node<TemplateParameterNode>(tparam));
+InlineVector<ASTNode, 4> Parser::cloneTemplateParameterNodes(const std::vector<TemplateParameterNode>& template_params) {
+	InlineVector<ASTNode, 4> ast_nodes;
+	ast_nodes.reserve(template_params.size());
+	for (const TemplateParameterNode& template_param : template_params) {
+		ast_nodes.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
 	}
-	return ast_params;
+	return ast_nodes;
 }
 
 // Parse a single template parameter: typename T, class T, int N, etc.

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -32,7 +32,7 @@ bool Parser::parse_noexcept_value() {
 	return true; // dependent — assume true
 }
 
-ParseResult Parser::parse_template_parameter_list(std::vector<TemplateParameterNode>& out_params) {
+ParseResult Parser::parse_template_parameter_list(InlineVector<TemplateParameterNode, 4>& out_params) {
 	// Save and restore the current template parameter state that existed before
 	// parsing this list so names added here do not persist after the parse.
 	// ScopedStateCopy keeps the field populated so that outer template parameter
@@ -106,12 +106,11 @@ TypeInfo& Parser::ensureTemplateParameterTypeRegistration(TemplateParameterNode&
 }
 
 Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
-	std::vector<TemplateParameterNode>& template_params,
+	InlineVector<TemplateParameterNode, 4>& template_params,
 	FlashCpp::TemplateParameterScope& template_scope) {
 	TemplateParameterMetadata metadata;
 	for (TemplateParameterNode& tparam : template_params) {
 		metadata.names.push_back(tparam.nameHandle());
-		metadata.name_views.push_back(tparam.name());
 		metadata.kinds.push_back(tparam.kind());
 		metadata.has_packs |= tparam.is_variadic();
 		if (tparam.kind() == TemplateParameterKind::Type ||
@@ -123,7 +122,7 @@ Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
 	return metadata;
 }
 
-InlineVector<ASTNode, 4> Parser::cloneTemplateParameterNodes(const std::vector<TemplateParameterNode>& template_params) {
+InlineVector<ASTNode, 4> Parser::cloneTemplateParameterNodes(const InlineVector<TemplateParameterNode, 4>& template_params) {
 	InlineVector<ASTNode, 4> ast_nodes;
 	ast_nodes.reserve(template_params.size());
 	for (const TemplateParameterNode& template_param : template_params) {

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -32,7 +32,7 @@ bool Parser::parse_noexcept_value() {
 	return true; // dependent — assume true
 }
 
-ParseResult Parser::parse_template_parameter_list(InlineVector<ASTNode, 4>& out_params) {
+ParseResult Parser::parse_template_parameter_list(std::vector<TemplateParameterNode>& out_params) {
 	// Save and restore the current template parameter state that existed before
 	// parsing this list so names added here do not persist after the parse.
 	// ScopedStateCopy keeps the field populated so that outer template parameter
@@ -53,19 +53,20 @@ ParseResult Parser::parse_template_parameter_list(InlineVector<ASTNode, 4>& out_
 		}
 
 		if (param_result.node().has_value()) {
-			out_params.push_back(*param_result.node());
+			if (!param_result.node()->is<TemplateParameterNode>()) {
+				return ParseResult::error("Expected template parameter node", current_token_);
+			}
+			out_params.push_back(param_result.node()->as<TemplateParameterNode>());
 			// Add this parameter's name so subsequent parameters can reference it in
 			// their default values, e.g. template<typename T, bool = is_arithmetic<T>::value>.
-			if (param_result.node()->is<TemplateParameterNode>()) {
-				auto& tparam = out_params.back().as<TemplateParameterNode>();
-				pushCurrentTemplateParamName(tparam.nameHandle());
-				if (tparam.kind() == TemplateParameterKind::Type ||
-					tparam.kind() == TemplateParameterKind::Template) {
-					ensureTemplateParameterTypeRegistration(tparam);
-				}
-				FLASH_LOG(Templates, Debug, "Added template parameter '", tparam.name(),
-						  "' to current_template_param_names_ (now has ", currentTemplateParamCount(), " params)");
+			auto& tparam = out_params.back();
+			pushCurrentTemplateParamName(tparam.nameHandle());
+			if (tparam.kind() == TemplateParameterKind::Type ||
+				tparam.kind() == TemplateParameterKind::Template) {
+				ensureTemplateParameterTypeRegistration(tparam);
 			}
+			FLASH_LOG(Templates, Debug, "Added template parameter '", tparam.name(),
+					  "' to current_template_param_names_ (now has ", currentTemplateParamCount(), " params)");
 		}
 	}
 
@@ -104,21 +105,30 @@ TypeInfo& Parser::ensureTemplateParameterTypeRegistration(TemplateParameterNode&
 	return *type_info;
 }
 
-void Parser::registerTemplateTypeParametersInScope(
-	InlineVector<ASTNode, 4>& template_params,
+Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
+	std::vector<TemplateParameterNode>& template_params,
 	FlashCpp::TemplateParameterScope& template_scope) {
-	for (ASTNode& param : template_params) {
-		if (!param.is<TemplateParameterNode>()) {
-			continue;
+	TemplateParameterMetadata metadata;
+	for (TemplateParameterNode& tparam : template_params) {
+		metadata.names.push_back(tparam.nameHandle());
+		metadata.name_views.push_back(tparam.name());
+		metadata.kinds.push_back(tparam.kind());
+		metadata.has_packs |= tparam.is_variadic();
+		if (tparam.kind() == TemplateParameterKind::Type ||
+			tparam.kind() == TemplateParameterKind::Template) {
+			TypeInfo& type_info = ensureTemplateParameterTypeRegistration(tparam);
+			template_scope.addParameter(&type_info);
 		}
-		TemplateParameterNode& tparam = param.as<TemplateParameterNode>();
-		if (tparam.kind() != TemplateParameterKind::Type &&
-			tparam.kind() != TemplateParameterKind::Template) {
-			continue;
-		}
-		TypeInfo& type_info = ensureTemplateParameterTypeRegistration(tparam);
-		template_scope.addParameter(&type_info);
 	}
+	return metadata;
+}
+
+InlineVector<ASTNode, 4> Parser::createTemplateParameterAstNodes(const std::vector<TemplateParameterNode>& template_params) {
+	InlineVector<ASTNode, 4> ast_params;
+	for (const TemplateParameterNode& tparam : template_params) {
+		ast_params.push_back(emplace_node<TemplateParameterNode>(tparam));
+	}
+	return ast_params;
 }
 
 // Parse a single template parameter: typename T, class T, int N, etc.

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1616,7 +1616,7 @@ ASTNode Parser::substituteTemplateParameters(
 
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	return substituteTemplateParameters(
 		node,
@@ -1853,7 +1853,7 @@ bool Parser::expandPackExpansionArgs(
 
 bool Parser::expandPackExpansionArgs(
 	const PackExpansionExprNode& pack_expansion,
-	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	ChunkedVector<ASTNode>& out_args) {
 	return expandPackExpansionArgs(

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -56,11 +56,11 @@ std::optional<std::vector<TemplateTypeArg>> extractNamedTemplateArgumentPack(
 	size_t total_non_variadic = 0;
 	size_t total_variadic = 0;
 	for (const auto& param_node : template_params) {
-		if (!param_node.template is<TemplateParameterNode>()) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(param_node);
+		if (tparam == nullptr) {
 			continue;
 		}
-		const auto& tparam = param_node.template as<TemplateParameterNode>();
-		if (tparam.is_variadic()) {
+		if (tparam->is_variadic()) {
 			++total_variadic;
 		} else {
 			++total_non_variadic;
@@ -69,11 +69,11 @@ std::optional<std::vector<TemplateTypeArg>> extractNamedTemplateArgumentPack(
 
 	size_t arg_index = 0;
 	for (const auto& param_node : template_params) {
-		if (!param_node.template is<TemplateParameterNode>()) {
+		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(param_node);
+		if (tparam == nullptr) {
 			continue;
 		}
-		const auto& tparam = param_node.template as<TemplateParameterNode>();
-		if (!tparam.is_variadic()) {
+		if (!tparam->is_variadic()) {
 			if (arg_index >= template_args.size()) {
 				return std::nullopt;
 			}
@@ -82,7 +82,7 @@ std::optional<std::vector<TemplateTypeArg>> extractNamedTemplateArgumentPack(
 		}
 
 		size_t pack_size = 0;
-		if (auto exact_size = exact_pack_size_lookup(tparam.name())) {
+		if (auto exact_size = exact_pack_size_lookup(tparam->name())) {
 			pack_size = *exact_size;
 		} else if (total_variadic == 1 && template_args.size() >= total_non_variadic) {
 			pack_size = template_args.size() - total_non_variadic;
@@ -90,7 +90,7 @@ std::optional<std::vector<TemplateTypeArg>> extractNamedTemplateArgumentPack(
 			return std::nullopt;
 		}
 
-		if (tparam.name() == pack_name) {
+		if (tparam->name() == pack_name) {
 			if (arg_index + pack_size > template_args.size()) {
 				return std::nullopt;
 			}
@@ -383,7 +383,7 @@ ASTNode Parser::substituteTemplateParameters(
 				size_t remaining_args = arg_index < template_args.size()
 											? template_args.size() - arg_index
 											: 0;
-				size_t required_after = countRequiredTemplateArgsAfter<InlineVector<ASTNode, 4>, InlineVector<TemplateTypeArg, 4>>(
+				size_t required_after = countRequiredTemplateArgsAfter(
 					template_params, i + 1);
 				size_t pack_size = remaining_args > required_after
 									   ? remaining_args - required_after
@@ -1049,15 +1049,12 @@ ASTNode Parser::substituteTemplateParameters(
 									if (tmpl_node.is<TemplateClassDeclarationNode>()) {
 										const auto& tmpl_class = tmpl_node.as<TemplateClassDeclarationNode>();
 										for (const auto& param : tmpl_class.template_parameters()) {
-											if (param.is<TemplateParameterNode>()) {
-												const auto& tparam = param.as<TemplateParameterNode>();
-												if (tparam.is_variadic()) {
-													// Match by name, or match if the stored name is anonymous
-													// (from forward declarations like `template<typename...> class tuple;`)
-													if (tparam.name() == pack_name || tparam.name().starts_with("__anon_type_")) {
-														is_known_template_param = true;
-														break;
-													}
+											if (param.is_variadic()) {
+												// Match by name, or match if the stored name is anonymous
+												// (from forward declarations like `template<typename...> class tuple;`)
+												if (param.name() == pack_name || param.name().starts_with("__anon_type_")) {
+													is_known_template_param = true;
+													break;
 												}
 											}
 										}
@@ -1617,6 +1614,16 @@ ASTNode Parser::substituteTemplateParameters(
 	return node;
 }
 
+ASTNode Parser::substituteTemplateParameters(
+	const ASTNode& node,
+	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	return substituteTemplateParameters(
+		node,
+		cloneTemplateParameterNodes(template_params),
+		template_args);
+}
+
 // Extract base template name from a mangled template instantiation name
 // Supports underscore-based naming: "enable_if_void_int" -> "enable_if"
 // Future: Will support hash-based naming: "enable_if$abc123" -> "enable_if"
@@ -1842,6 +1849,18 @@ bool Parser::expandPackExpansionArgs(
 		out_args.push_back(substituted);
 	}
 	return true;
+}
+
+bool Parser::expandPackExpansionArgs(
+	const PackExpansionExprNode& pack_expansion,
+	const std::vector<TemplateParameterNode>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	ChunkedVector<ASTNode>& out_args) {
+	return expandPackExpansionArgs(
+		pack_expansion,
+		cloneTemplateParameterNodes(template_params),
+		template_args,
+		out_args);
 }
 
 // Substitute a single argument, expanding PackExpansionExprNode when present.

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -98,7 +98,6 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
 	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
-	InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
 
 	// Set template parameter context for parsing the requires clause
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
@@ -190,7 +189,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	ASTNode alias_node;
 	if (has_deferred_target && target_template_name.isValid()) {
 		alias_node = emplace_node<TemplateAliasNode>(
-			std::move(template_param_ast_nodes),
+			template_params,
 			std::move(template_param_names),
 			alias_name_handle,
 			type_result.node().value(),
@@ -198,7 +197,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 			std::move(target_template_arg_nodes));
 	} else {
 		alias_node = emplace_node<TemplateAliasNode>(
-			std::move(template_param_ast_nodes),
+			template_params,
 			std::move(template_param_names),
 			alias_name_handle,
 			type_result.node().value());
@@ -243,7 +242,6 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
 	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
-	InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
 
 	// Expect '>'
 	if (peek() != ">"_tok) {
@@ -331,7 +329,7 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 
 	// Create TemplateVariableDeclarationNode
 	auto template_var_node = emplace_node<TemplateVariableDeclarationNode>(
-		std::move(template_param_ast_nodes),
+		template_params,
 		var_decl_node);
 
 	// Build qualified name for registration

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -81,7 +81,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	advance(); // consume '<'
 
 	// Parse template parameter list
-	std::vector<TemplateParameterNode> template_params;
+	InlineVector<TemplateParameterNode, 4> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {
@@ -97,7 +97,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	// Extract parameter names and register type parameters in one pass
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
-	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
+	const InlineVector<StringHandle, 4>& template_param_names = template_param_metadata.names;
 
 	// Set template parameter context for parsing the requires clause
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
@@ -231,7 +231,7 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 	}
 	advance(); // consume '<'
 
-	std::vector<TemplateParameterNode> template_params;
+	InlineVector<TemplateParameterNode, 4> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {
@@ -241,7 +241,11 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 	// Extract parameter names and register type parameters in one pass
 	FlashCpp::TemplateParameterScope template_scope;
 	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
-	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
+	InlineVector<std::string_view, 4> template_param_names;
+	template_param_names.reserve(template_param_metadata.names.size());
+	for (StringHandle param_name : template_param_metadata.names) {
+		template_param_names.push_back(StringTable::getStringView(param_name));
+	}
 
 	// Expect '>'
 	if (peek() != ">"_tok) {

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -81,8 +81,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	advance(); // consume '<'
 
 	// Parse template parameter list
-	InlineVector<ASTNode, 4> template_params;
-	InlineVector<StringHandle, 4> template_param_names;
+	std::vector<TemplateParameterNode> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {
@@ -97,12 +96,9 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 
 	// Extract parameter names and register type parameters in one pass
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
-	for (auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			template_param_names.push_back(param.as<TemplateParameterNode>().nameHandle());
-		}
-	}
+	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
+	InlineVector<StringHandle, 4> template_param_names = template_param_metadata.names;
+	InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
 
 	// Set template parameter context for parsing the requires clause
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
@@ -194,7 +190,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 	ASTNode alias_node;
 	if (has_deferred_target && target_template_name.isValid()) {
 		alias_node = emplace_node<TemplateAliasNode>(
-			std::move(template_params),
+			std::move(template_param_ast_nodes),
 			std::move(template_param_names),
 			alias_name_handle,
 			type_result.node().value(),
@@ -202,7 +198,7 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 			std::move(target_template_arg_nodes));
 	} else {
 		alias_node = emplace_node<TemplateAliasNode>(
-			std::move(template_params),
+			std::move(template_param_ast_nodes),
 			std::move(template_param_names),
 			alias_name_handle,
 			type_result.node().value());
@@ -236,8 +232,7 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 	}
 	advance(); // consume '<'
 
-	InlineVector<ASTNode, 4> template_params;
-	InlineVector<std::string_view, 4> template_param_names;
+	std::vector<TemplateParameterNode> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_params);
 	if (param_list_result.is_error()) {
@@ -246,12 +241,9 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 
 	// Extract parameter names and register type parameters in one pass
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTemplateTypeParametersInScope(template_params, template_scope);
-	for (auto& param : template_params) {
-		if (param.is<TemplateParameterNode>()) {
-			template_param_names.push_back(param.as<TemplateParameterNode>().name());
-		}
-	}
+	TemplateParameterMetadata template_param_metadata = registerTemplateParametersInScope(template_params, template_scope);
+	InlineVector<std::string_view, 4> template_param_names = template_param_metadata.name_views;
+	InlineVector<ASTNode, 4> template_param_ast_nodes = createTemplateParameterAstNodes(template_params);
 
 	// Expect '>'
 	if (peek() != ">"_tok) {
@@ -339,7 +331,7 @@ ParseResult Parser::parse_member_variable_template(StructDeclarationNode& struct
 
 	// Create TemplateVariableDeclarationNode
 	auto template_var_node = emplace_node<TemplateVariableDeclarationNode>(
-		std::move(template_params),
+		std::move(template_param_ast_nodes),
 		var_decl_node);
 
 	// Build qualified name for registration

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1378,8 +1378,9 @@ ParseResult Parser::parse_type_specifier() {
 							size_t count = std::min(placeholder_params.size(), template_args->size());
 							placeholder_param_names.reserve(count);
 							for (size_t i = 0; i < count; ++i) {
-								if (placeholder_params[i].is<TemplateParameterNode>()) {
-									placeholder_param_names.push_back(placeholder_params[i].as<TemplateParameterNode>().nameHandle());
+								if (const TemplateParameterNode* placeholder_param = tryGetTemplateParameterNode(placeholder_params[i]);
+									placeholder_param != nullptr) {
+									placeholder_param_names.push_back(placeholder_param->nameHandle());
 								}
 							}
 						}
@@ -1473,17 +1474,17 @@ ParseResult Parser::parse_type_specifier() {
 
 					// Fill in defaults for missing parameters
 					for (size_t i = filled_template_args.size(); i < template_params.size(); ++i) {
-						if (!template_params[i].is<TemplateParameterNode>()) {
+						const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+						if (param == nullptr) {
 							FLASH_LOG_FORMAT(Templates, Error, "Template parameter {} is not a TemplateParameterNode", i);
 							continue;
 						}
-						const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-						if (!param.has_default()) {
+						if (!param->has_default()) {
 							continue;
 						}
-						const ASTNode& default_node = param.default_value();
+						const ASTNode& default_node = param->default_value();
 						InlineVector<TemplateTypeArg, 4> inline_filled_args = toInlineTemplateArgs(filled_template_args);
-						if (param.kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
+						if (param->kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
 							ASTNode substituted_default_node = default_node;
 							if (!inline_filled_args.empty()) {
 								substituted_default_node = substituteTemplateParameters(default_node, template_params, inline_filled_args);
@@ -1491,7 +1492,7 @@ ParseResult Parser::parse_type_specifier() {
 							if (substituted_default_node.is<TypeSpecifierNode>()) {
 								filled_template_args.push_back(TemplateTypeArg(substituted_default_node.as<TypeSpecifierNode>()));
 							}
-						} else if (param.kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
+						} else if (param->kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
 							if (auto evaluated_default = substituteAndEvaluateNonTypeDefault(
 									default_node,
 									template_params,
@@ -2077,8 +2078,9 @@ ParseResult Parser::parse_type_specifier() {
 						size_t count = std::min(placeholder_params.size(), template_args->size());
 						placeholder_param_names.reserve(count);
 						for (size_t i = 0; i < count; ++i) {
-							if (placeholder_params[i].is<TemplateParameterNode>()) {
-								placeholder_param_names.push_back(placeholder_params[i].as<TemplateParameterNode>().nameHandle());
+							if (const TemplateParameterNode* placeholder_param = tryGetTemplateParameterNode(placeholder_params[i]);
+								placeholder_param != nullptr) {
+								placeholder_param_names.push_back(placeholder_param->nameHandle());
 							}
 						}
 					}
@@ -2106,12 +2108,10 @@ ParseResult Parser::parse_type_specifier() {
 			// Check if all parameters have defaults
 			bool all_have_defaults = true;
 			for (const auto& param_node : template_params) {
-				if (param_node.is<TemplateParameterNode>()) {
-					const auto& param = param_node.as<TemplateParameterNode>();
-					if (!param.has_default()) {
-						all_have_defaults = false;
-						break;
-					}
+				const TemplateParameterNode* param = tryGetTemplateParameterNode(param_node);
+				if (param != nullptr && !param->has_default()) {
+					all_have_defaults = false;
+					break;
 				}
 			}
 
@@ -2126,17 +2126,17 @@ ParseResult Parser::parse_type_specifier() {
 				const std::vector<std::string_view> template_param_names =
 					buildTemplateParamNames(template_params);
 				for (size_t i = 0; i < template_params.size(); ++i) {
-					if (!template_params[i].is<TemplateParameterNode>()) {
+					const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+					if (param == nullptr) {
 						FLASH_LOG_FORMAT(Templates, Error, "Template parameter {} is not a TemplateParameterNode", i);
 						continue;
 					}
-					const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-					if (!param.has_default()) {
+					if (!param->has_default()) {
 						continue;
 					}
-					const ASTNode& default_node = param.default_value();
+					const ASTNode& default_node = param->default_value();
 					InlineVector<TemplateTypeArg, 4> inline_filled_args = toInlineTemplateArgs(filled_template_args);
-					if (param.kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
+					if (param->kind() == TemplateParameterKind::Type && default_node.is<TypeSpecifierNode>()) {
 						ASTNode substituted_default_node = default_node;
 						if (!inline_filled_args.empty()) {
 							substituted_default_node = substituteTemplateParameters(default_node, template_params, inline_filled_args);
@@ -2144,7 +2144,7 @@ ParseResult Parser::parse_type_specifier() {
 						if (substituted_default_node.is<TypeSpecifierNode>()) {
 							filled_template_args.push_back(TemplateTypeArg(substituted_default_node.as<TypeSpecifierNode>()));
 						}
-					} else if (param.kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
+					} else if (param->kind() == TemplateParameterKind::NonType && default_node.is<ExpressionNode>()) {
 						if (auto evaluated_default = substituteAndEvaluateNonTypeDefault(
 								default_node,
 								template_params,

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -1311,7 +1311,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 
 					std::optional<long long> resolveAliasTypeSpecSize(
 						const TypeSpecifierNode& alias_type_spec,
-						std::span<const ASTNode> primary_params,
+						std::span<const TemplateParameterNode> primary_params,
 						std::span<const TemplateTypeArg> concrete_member_args) {
 						if (depth_ >= kMaxDepth) return std::nullopt;
 						DepthGuard guard{depth_};
@@ -1321,11 +1321,7 @@ inline std::optional<long long> evaluateConstraintExpression(
 							for (size_t i = 0; i < primary_params.size() &&
 									i < concrete_member_args.size();
 								 ++i) {
-								if (!primary_params[i].is<TemplateParameterNode>()) {
-									continue;
-								}
-								const auto& param =
-									primary_params[i].as<TemplateParameterNode>();
+								const auto& param = primary_params[i];
 								if (param.name() == param_name) {
 									return &concrete_member_args[i];
 								}
@@ -1980,9 +1976,7 @@ inline ConstraintEvaluationResult evaluateConstraint(
 									// and map outer template args to them via positional matching
 									std::vector<std::string_view> callee_param_names;
 									for (const auto& param_node : tfdn.template_parameters()) {
-										if (param_node.is<TemplateParameterNode>()) {
-											callee_param_names.push_back(param_node.as<TemplateParameterNode>().name());
-										}
+										callee_param_names.push_back(param_node.name());
 									}
 									// Evaluate using the callee's param names with the outer args
 									// (positional: concept's T maps to callee's T by position)

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -44,7 +44,7 @@ inline bool patternPointerDepthMatches(
 
 // Out-of-line template member function definition
 struct OutOfLineMemberFunction {
-	InlineVector<ASTNode, 4> template_params; // Template parameters (e.g., <typename T>)
+	std::vector<TemplateParameterNode> template_params; // Template parameters (e.g., <typename T>)
 	ASTNode function_node; // FunctionDeclarationNode
 	SaveHandle body_start; // Handle to saved position of function body for re-parsing
 	SaveHandle initializer_list_start{}; // Handle to saved position at ':' for ctor initializer re-parse
@@ -52,7 +52,7 @@ struct OutOfLineMemberFunction {
 	// For nested templates (member function templates of class templates):
 	// template<typename T> template<typename U> T Container<T>::convert(U u) { ... }
 	// inner_template_params stores the inner template params (U), while template_params stores the outer (T)
-	InlineVector<ASTNode, 4> inner_template_params;
+	std::vector<TemplateParameterNode> inner_template_params;
 	InlineVector<StringHandle, 4> inner_template_param_names;
 	// Function specifiers from out-of-line definition (= default, = delete)
 	bool has_initializer_list = false;

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -44,7 +44,7 @@ inline bool patternPointerDepthMatches(
 
 // Out-of-line template member function definition
 struct OutOfLineMemberFunction {
-	std::vector<TemplateParameterNode> template_params; // Template parameters (e.g., <typename T>)
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters (e.g., <typename T>)
 	ASTNode function_node; // FunctionDeclarationNode
 	SaveHandle body_start; // Handle to saved position of function body for re-parsing
 	SaveHandle initializer_list_start{}; // Handle to saved position at ':' for ctor initializer re-parse
@@ -52,7 +52,7 @@ struct OutOfLineMemberFunction {
 	// For nested templates (member function templates of class templates):
 	// template<typename T> template<typename U> T Container<T>::convert(U u) { ... }
 	// inner_template_params stores the inner template params (U), while template_params stores the outer (T)
-	std::vector<TemplateParameterNode> inner_template_params;
+	InlineVector<TemplateParameterNode, 4> inner_template_params;
 	InlineVector<StringHandle, 4> inner_template_param_names;
 	// Function specifiers from out-of-line definition (= default, = delete)
 	bool has_initializer_list = false;

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -53,10 +53,8 @@ public:
 		auto& def_params = full_def.as<TemplateClassDeclarationNode>().template_parameters();
 		size_t count = std::min(fwd_params.size(), def_params.size());
 		for (size_t i = 0; i < count; ++i) {
-			if (!fwd_params[i].is<TemplateParameterNode>() || !def_params[i].is<TemplateParameterNode>())
-				continue;
-			const auto& fwd_p = fwd_params[i].as<TemplateParameterNode>();
-			auto& def_p = def_params[i].as<TemplateParameterNode>();
+			const auto& fwd_p = fwd_params[i];
+			auto& def_p = def_params[i];
 			if (fwd_p.has_default() && !def_p.has_default()) {
 				def_p.set_default_value(fwd_p.default_value());
 			}
@@ -142,6 +140,16 @@ public:
 		StringHandle key = StringTable::getOrInternStringHandle(base_name);
 		variable_template_specializations_[key].push_back(
 			TemplatePattern{template_params, pattern_args, specialized_node, std::nullopt});
+	}
+	void registerVariableTemplateSpecialization(std::string_view base_name,
+												const std::vector<TemplateParameterNode>& template_params,
+												const std::vector<TemplateTypeArg>& pattern_args,
+												ASTNode specialized_node) {
+		InlineVector<ASTNode, 4> ast_params;
+		for (const auto& param : template_params) {
+			ast_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
+		}
+		registerVariableTemplateSpecialization(base_name, std::vector<ASTNode>(ast_params.begin(), ast_params.end()), pattern_args, specialized_node);
 	}
 
 	// Find the best matching variable template partial specialization for concrete args.

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -142,7 +142,7 @@ public:
 			TemplatePattern{template_params, pattern_args, specialized_node, std::nullopt});
 	}
 	void registerVariableTemplateSpecialization(std::string_view base_name,
-												const std::vector<TemplateParameterNode>& template_params,
+												const InlineVector<TemplateParameterNode, 4>& template_params,
 												const std::vector<TemplateTypeArg>& pattern_args,
 												ASTNode specialized_node) {
 		InlineVector<ASTNode, 4> ast_params;

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -15,6 +15,7 @@
 #include <iterator>
 #include <limits>
 #include <span>
+#include <type_traits>
 
 // SaveHandle type for parser save/restore operations
 // Matches Parser::SaveHandle typedef in Parser.h
@@ -592,20 +593,43 @@ inline TemplateTypeArg deduceArgFromPattern(const TemplateTypeArg& concrete_arg,
 // substitute_template_parameter does not return through its TypeIndex result.
 // Templated on container types to avoid InlineVector -> std::vector conversion,
 // which would create temporaries and make the returned pointer dangle.
-template <typename ParamContainer, typename ArgContainer>
+inline const TemplateParameterNode* tryGetTemplateParameterNode(const ASTNode& node) {
+	return node.is<TemplateParameterNode>() ? &node.as<TemplateParameterNode>() : nullptr;
+}
+
+inline TemplateParameterNode* tryGetTemplateParameterNode(ASTNode& node) {
+	return node.is<TemplateParameterNode>() ? &node.as<TemplateParameterNode>() : nullptr;
+}
+
+inline const TemplateParameterNode* tryGetTemplateParameterNode(const TemplateParameterNode& node) {
+	return &node;
+}
+
+inline TemplateParameterNode* tryGetTemplateParameterNode(TemplateParameterNode& node) {
+	return &node;
+}
+
+template <typename ParamContainer>
 inline size_t countRequiredTemplateArgsAfter(
 	const ParamContainer& template_params,
 	size_t start_index) {
 	size_t required_args = 0;
 	for (size_t i = start_index; i < template_params.size(); ++i) {
-		if (!template_params[i].template is<TemplateParameterNode>())
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr)
 			continue;
-		const auto& param = template_params[i].template as<TemplateParameterNode>();
-		if (param.is_variadic() || param.has_default())
+		if (param->is_variadic() || param->has_default())
 			continue;
 		++required_args;
 	}
 	return required_args;
+}
+
+template <typename ParamContainer, typename ArgContainer>
+inline size_t countRequiredTemplateArgsAfter(
+	const ParamContainer& template_params,
+	size_t start_index) {
+	return countRequiredTemplateArgsAfter<ParamContainer>(template_params, start_index);
 }
 
 template <typename ParamContainer, typename ArgContainer, typename Callback>
@@ -615,10 +639,10 @@ inline void forEachNonPackTemplateParamArgBinding(
 	Callback&& callback) {
 	size_t arg_index = 0;
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		if (!template_params[i].template is<TemplateParameterNode>())
+		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+		if (param == nullptr)
 			continue;
-		const auto& param = template_params[i].template as<TemplateParameterNode>();
-		if (param.is_variadic()) {
+		if (param->is_variadic()) {
 			size_t remaining_args = arg_index < template_args.size()
 										? template_args.size() - arg_index
 										: 0;
@@ -632,7 +656,7 @@ inline void forEachNonPackTemplateParamArgBinding(
 		}
 		if (arg_index >= template_args.size())
 			break;
-		callback(param, template_args[arg_index], arg_index);
+		callback(*param, template_args[arg_index], arg_index);
 		++arg_index;
 	}
 }
@@ -910,9 +934,11 @@ inline TemplateTypeArg materializeTemplateArg(
 	if (arg_info.dependent_name.isValid()) {
 		std::string_view dep_name = StringTable::getStringView(arg_info.dependent_name);
 		for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-			if (!template_params[i].template is<TemplateParameterNode>())
+			const TemplateParameterNode* template_param =
+				tryGetTemplateParameterNode(template_params[i]);
+			if (template_param == nullptr)
 				continue;
-			if (template_params[i].template as<TemplateParameterNode>().name() == dep_name) {
+			if (template_param->name() == dep_name) {
 				const TemplateTypeArg& substituted_arg = template_args[i];
 				if (!arg_info.is_value && !substituted_arg.is_value) {
 					concrete_arg = rebindDependentTemplateTypeArg(substituted_arg, arg_info);
@@ -926,13 +952,36 @@ inline TemplateTypeArg materializeTemplateArg(
 		// For dependent NTTP expressions (e.g., sizeof(T)), evaluate with concrete args.
 		// Only attempted when a non-null evaluator callback is provided.
 		if constexpr (!std::is_null_pointer_v<std::decay_t<EvalFn>>) {
-			if (auto evaluated = eval_dependent_expr(
-					*arg_info.dependent_expr,
-					std::span<const ASTNode>(std::data(template_params), std::size(template_params)),
-					std::span<const TemplateTypeArg>(std::data(template_args), std::size(template_args)))) {
-				concrete_arg.value = *evaluated;
-				concrete_arg.is_dependent = false;
-				concrete_arg.dependent_expr = std::nullopt;
+			using TemplateParamNodeType =
+				std::remove_cvref_t<decltype(*std::begin(template_params))>;
+			if constexpr (std::is_same_v<TemplateParamNodeType, ASTNode>) {
+				if (auto evaluated = eval_dependent_expr(
+						*arg_info.dependent_expr,
+						std::span<const ASTNode>(std::data(template_params), std::size(template_params)),
+						std::span<const TemplateTypeArg>(std::data(template_args), std::size(template_args)))) {
+					concrete_arg.value = *evaluated;
+					concrete_arg.is_dependent = false;
+					concrete_arg.dependent_expr = std::nullopt;
+				}
+			} else {
+				InlineVector<ASTNode, 4> ast_template_params;
+				ast_template_params.reserve(template_params.size());
+				for (const auto& template_param_node : template_params) {
+					if (const TemplateParameterNode* template_param =
+							tryGetTemplateParameterNode(template_param_node);
+						template_param != nullptr) {
+						ast_template_params.push_back(
+							ASTNode::emplace_node<TemplateParameterNode>(*template_param));
+					}
+				}
+				if (auto evaluated = eval_dependent_expr(
+						*arg_info.dependent_expr,
+						std::span<const ASTNode>(ast_template_params.data(), ast_template_params.size()),
+						std::span<const TemplateTypeArg>(std::data(template_args), std::size(template_args)))) {
+					concrete_arg.value = *evaluated;
+					concrete_arg.is_dependent = false;
+					concrete_arg.dependent_expr = std::nullopt;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- parse template parameter lists into strongly typed TemplateParameterNode vectors instead of generic ASTNode vectors
- collect template parameter names, kinds, and pack metadata while registering scoped template parameter types
- convert back to ASTNode vectors only at AST storage boundaries

Closes #1379

## Testing
- .\\build_flashcpp.bat
- pwsh -NoProfile -ExecutionPolicy Bypass -File .\\tests\\run_all_tests.ps1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/gregorgullwi/flashcpp/pull/1390" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
