### PR TITLE
[codex] Fix sema-owned ternary function pointer typing

### DIFF
--- a/docs/2026-04-27-fallback-comments-audit.md
+++ b/docs/2026-04-27-fallback-comments-audit.md
@@ -62,9 +62,10 @@ Usual arithmetic conversions, contextual conversions, user-defined conversions, 
 
 Removal direction:
 
-- Require sema to annotate every implicit conversion, including ternary branch conversions, assignment RHS conversions, binary arithmetic conversions, contextual `bool`, and user-defined conversions.
+- Require sema to own the exact result type for every ternary expression and annotate every implicit conversion, including ternary branch conversions, assignment RHS conversions, binary arithmetic conversions, contextual `bool`, and user-defined conversions.
 - Extend sema coverage to template-instantiated, catch-block, lambda, and delayed member bodies so parser expression typing is never needed by codegen.
 - Replace codegen fallbacks with assertions once all normalized body contexts are covered.
+- TODO: remove the remaining non-normalized ternary category/size fallback once template-instantiated, catch-block, lambda, and delayed member bodies all carry sema-owned exact ternary result types.
 - Keep codegen conversion helpers only as emitters for an already-selected conversion, not as selectors.
 
 ### 3. Template instantiation and substitution recovery
@@ -445,5 +446,8 @@ The audit is now backed by direct suite evidence for several representative temp
   targets in place before ternary common-type lowering consults them. The
   focused ternary/callable cluster including
   `tests/test_nested_funcptr_direct_invoke_ternary_ret0.cpp` and
-  `tests/test_ternary_sema_consumption_ret0.cpp` passed after this root fix;
+  `tests/test_ternary_sema_consumption_ret0.cpp` passed after this root fix.
+  A 2026-04-30 follow-up made normalized ternary lowering require sema's exact
+  result `TypeSpecifierNode`; the remaining category/size fallback is now
+  limited to non-normalized bodies and tracked above as future cleanup;
 - the larger ExpressionSubstitutor/static-initializer/pack-size fallback classes should still be assumed active until probed or root-fixed individually.

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -728,42 +728,7 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		}
 		return nativeTypeIndex(merged_type);
 	};
-	auto sameFunctionSignature = [](const FunctionSignature& lhs, const FunctionSignature& rhs) {
-		return lhs.return_type_index == rhs.return_type_index &&
-			   lhs.return_pointer_depth == rhs.return_pointer_depth &&
-			   lhs.return_reference_qualifier == rhs.return_reference_qualifier &&
-			   lhs.parameter_type_indices == rhs.parameter_type_indices &&
-			   lhs.linkage == rhs.linkage &&
-			   lhs.class_name == rhs.class_name &&
-			   lhs.calling_convention == rhs.calling_convention &&
-			   lhs.is_const == rhs.is_const &&
-			   lhs.function_reference_qualifier == rhs.function_reference_qualifier &&
-			   lhs.is_noexcept == rhs.is_noexcept;
-	};
-	auto sameTypeSpec = [&](const TypeSpecifierNode& lhs, const TypeSpecifierNode& rhs) {
-		if (lhs.type() != rhs.type() ||
-			lhs.type_index() != rhs.type_index() ||
-			lhs.pointer_depth() != rhs.pointer_depth() ||
-			lhs.reference_qualifier() != rhs.reference_qualifier() ||
-			lhs.cv_qualifier() != rhs.cv_qualifier() ||
-			lhs.has_function_signature() != rhs.has_function_signature()) {
-			return false;
-		}
-		return !lhs.has_function_signature() || sameFunctionSignature(lhs.function_signature(), rhs.function_signature());
-	};
 	std::optional<TypeSpecifierNode> exact_ternary_result_type;
-	std::optional<TypeSpecifierNode> fallback_pointer_like_branch_type;
-	auto captureFallbackPointerLikeBranchType = [&](const std::optional<TypeSpecifierNode>& true_ts,
-												   const std::optional<TypeSpecifierNode>& false_ts) {
-		if (!true_ts.has_value() || !false_ts.has_value() || !sameTypeSpec(*true_ts, *false_ts)) {
-			return;
-		}
-		if (true_ts->pointer_depth() > 0 &&
-			!true_ts->is_reference() &&
-			!true_ts->is_rvalue_reference()) {
-			fallback_pointer_like_branch_type = *true_ts;
-		}
-	};
 
 	// True branch label
 	ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = true_label}, ternaryNode.get_token()));
@@ -798,7 +763,6 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && sema_) {
 		auto true_ts = sema_->getExpressionType(ternaryNode.true_expr());
 		auto false_ts = sema_->getExpressionType(ternaryNode.false_expr());
-		captureFallbackPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -807,7 +771,6 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && parser_) {
 		auto true_ts = parser_->get_expression_type(ternaryNode.true_expr());
 		auto false_ts = parser_->get_expression_type(ternaryNode.false_expr());
-		captureFallbackPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -832,9 +795,7 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		: common_cat;
 	PointerDepth result_pointer_depth = exact_ternary_result_type.has_value()
 		? PointerDepth{static_cast<int>(exact_ternary_result_type->pointer_depth())}
-		: (fallback_pointer_like_branch_type.has_value()
-			? PointerDepth{static_cast<int>(fallback_pointer_like_branch_type->pointer_depth())}
-			: PointerDepth{});
+		: PointerDepth{};
 
 	// Convert true result to common type if needed.
 	// NOTE: sema annotations were already consumed above when determining common_type

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -728,31 +728,7 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		}
 		return nativeTypeIndex(merged_type);
 	};
-	auto sameFunctionSignature = [](const FunctionSignature& lhs, const FunctionSignature& rhs) {
-		return lhs.return_type_index == rhs.return_type_index &&
-			   lhs.return_pointer_depth == rhs.return_pointer_depth &&
-			   lhs.return_reference_qualifier == rhs.return_reference_qualifier &&
-			   lhs.parameter_type_indices == rhs.parameter_type_indices &&
-			   lhs.linkage == rhs.linkage &&
-			   lhs.class_name == rhs.class_name &&
-			   lhs.calling_convention == rhs.calling_convention &&
-			   lhs.is_const == rhs.is_const &&
-			   lhs.is_volatile == rhs.is_volatile &&
-			   lhs.function_reference_qualifier == rhs.function_reference_qualifier &&
-			   lhs.is_noexcept == rhs.is_noexcept;
-	};
-	auto sameTypeSpec = [&](const TypeSpecifierNode& lhs, const TypeSpecifierNode& rhs) {
-		if (lhs.type() != rhs.type() ||
-			lhs.type_index() != rhs.type_index() ||
-			lhs.pointer_depth() != rhs.pointer_depth() ||
-			lhs.reference_qualifier() != rhs.reference_qualifier() ||
-			lhs.cv_qualifier() != rhs.cv_qualifier() ||
-			lhs.has_function_signature() != rhs.has_function_signature()) {
-			return false;
-		}
-		return !lhs.has_function_signature() || sameFunctionSignature(lhs.function_signature(), rhs.function_signature());
-	};
-	std::optional<TypeSpecifierNode> exact_pointer_like_branch_type;
+	std::optional<TypeSpecifierNode> exact_ternary_result_type;
 
 	// True branch label
 	ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = true_label}, ternaryNode.get_token()));
@@ -762,20 +738,15 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	// The sema pass annotates each branch with a conversion to the common type.
 	// We also try parser type inference as a fallback.
 	TypeCategory common_cat = TypeCategory::Invalid;
-	auto captureExactPointerLikeBranchType = [&](const std::optional<TypeSpecifierNode>& true_ts,
-												 const std::optional<TypeSpecifierNode>& false_ts) {
-		if (!true_ts.has_value() || !false_ts.has_value() || !sameTypeSpec(*true_ts, *false_ts)) {
-			return;
+	if (context != ExpressionContext::LValueAddress && sema_) {
+		exact_ternary_result_type = sema_->getTernaryResultType(ternaryNode);
+		if (exact_ternary_result_type.has_value()) {
+			common_cat = exact_ternary_result_type->category();
 		}
-		if (true_ts->pointer_depth() > 0 &&
-			!true_ts->is_reference() &&
-			!true_ts->is_rvalue_reference()) {
-			exact_pointer_like_branch_type = *true_ts;
-		}
-	};
+	}
 	// Check sema annotations: if either branch has a conversion annotation, that
 	// tells us the target (common) type.
-	if (sema_) {
+	if (common_cat == TypeCategory::Invalid && sema_) {
 		TypeCategory true_cat = getSemaAnnotatedTargetType(ternaryNode.true_expr());
 		TypeCategory false_cat = getSemaAnnotatedTargetType(ternaryNode.false_expr());
 		if (true_cat != TypeCategory::Invalid)
@@ -788,7 +759,6 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && sema_) {
 		auto true_ts = sema_->getExpressionType(ternaryNode.true_expr());
 		auto false_ts = sema_->getExpressionType(ternaryNode.false_expr());
-		captureExactPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -797,7 +767,6 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && parser_) {
 		auto true_ts = parser_->get_expression_type(ternaryNode.true_expr());
 		auto false_ts = parser_->get_expression_type(ternaryNode.false_expr());
-		captureExactPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -817,14 +786,13 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	// NOTE: sema does not yet cover all contexts (e.g. catch-block bodies), so we
 	// cannot treat a miss here as an InternalError even in normalized bodies.
 	if (context != ExpressionContext::LValueAddress &&
-		!exact_pointer_like_branch_type.has_value() &&
 		common_cat == TypeCategory::Invalid)
 		common_cat = true_result.category();
 	TypeCategory common_type = context == ExpressionContext::LValueAddress
 		? true_result.category()
-		: (exact_pointer_like_branch_type.has_value() ? exact_pointer_like_branch_type->type() : common_cat);
-	PointerDepth result_pointer_depth = exact_pointer_like_branch_type.has_value()
-		? PointerDepth{static_cast<int>(exact_pointer_like_branch_type->pointer_depth())}
+		: common_cat;
+	PointerDepth result_pointer_depth = exact_ternary_result_type.has_value()
+		? PointerDepth{static_cast<int>(exact_ternary_result_type->pointer_depth())}
 		: PointerDepth{};
 
 	// Convert true result to common type if needed.
@@ -836,8 +804,8 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		true_result.typeEnum() != common_type)
 		true_result = generateTypeConversion(true_result, true_result.category(), common_type, ternaryNode.get_token());
 
-	int result_size = exact_pointer_like_branch_type.has_value()
-		? getTypeSpecSizeBits(*exact_pointer_like_branch_type)
+	int result_size = exact_ternary_result_type.has_value()
+		? getTypeSpecSizeBits(*exact_ternary_result_type)
 		: get_type_size_bits(common_type);
 	if (context == ExpressionContext::LValueAddress || result_size == 0)
 		result_size = true_result.size_in_bits.value;

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -735,14 +735,19 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 
 	// C++20 [expr.cond]/7: if the second and third operands have different
 	// arithmetic types, the usual arithmetic conversions determine the common type.
-	// The sema pass annotates each branch with a conversion to the common type.
-	// We also try parser type inference as a fallback.
+	// Sema owns the full ternary result type for normalized bodies. The fallbacks
+	// below are only for legacy non-normalized bodies that can still reach codegen.
 	TypeCategory common_cat = TypeCategory::Invalid;
 	if (context != ExpressionContext::LValueAddress && sema_) {
 		exact_ternary_result_type = sema_->getTernaryResultType(ternaryNode);
 		if (exact_ternary_result_type.has_value()) {
 			common_cat = exact_ternary_result_type->category();
 		}
+	}
+	if (context != ExpressionContext::LValueAddress &&
+		sema_normalized_current_function_ &&
+		!exact_ternary_result_type.has_value()) {
+		throw InternalError("Sema-normalized ternary expression missing exact result type");
 	}
 	// Check sema annotations: if either branch has a conversion annotation, that
 	// tells us the target (common) type.
@@ -780,11 +785,9 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 			ternaryNode.get_token());
 	}
 
-	// Finalize common_cat: if both sema and parser inference failed, fall back to
-	// true branch type.  This is correct for same-type ternaries; for mixed-type
-	// ternaries the sema or parser paths above should have resolved the common type.
-	// NOTE: sema does not yet cover all contexts (e.g. catch-block bodies), so we
-	// cannot treat a miss here as an InternalError even in normalized bodies.
+	// Finalize common_cat for legacy non-normalized bodies if sema and parser
+	// inference both failed. Normalized ternaries must already have sema's exact
+	// result type above.
 	if (context != ExpressionContext::LValueAddress &&
 		common_cat == TypeCategory::Invalid)
 		common_cat = true_result.category();
@@ -804,11 +807,16 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		true_result.typeEnum() != common_type)
 		true_result = generateTypeConversion(true_result, true_result.category(), common_type, ternaryNode.get_token());
 
-	int result_size = exact_ternary_result_type.has_value()
-		? getTypeSpecSizeBits(*exact_ternary_result_type)
-		: get_type_size_bits(common_type);
-	if (context == ExpressionContext::LValueAddress || result_size == 0)
+	int result_size = 0;
+	if (context == ExpressionContext::LValueAddress) {
 		result_size = true_result.size_in_bits.value;
+	} else if (exact_ternary_result_type.has_value()) {
+		result_size = getTypeSpecSizeBits(*exact_ternary_result_type);
+	} else {
+		result_size = get_type_size_bits(common_type);
+		if (result_size == 0)
+			result_size = true_result.size_in_bits.value;
+	}
 
 	// Build the LHS (destination slot) TypedValue for a branch assignment.
 	// For LValueAddress context, the slot is always a pointer-sized unsigned integer.

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -728,7 +728,42 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		}
 		return nativeTypeIndex(merged_type);
 	};
+	auto sameFunctionSignature = [](const FunctionSignature& lhs, const FunctionSignature& rhs) {
+		return lhs.return_type_index == rhs.return_type_index &&
+			   lhs.return_pointer_depth == rhs.return_pointer_depth &&
+			   lhs.return_reference_qualifier == rhs.return_reference_qualifier &&
+			   lhs.parameter_type_indices == rhs.parameter_type_indices &&
+			   lhs.linkage == rhs.linkage &&
+			   lhs.class_name == rhs.class_name &&
+			   lhs.calling_convention == rhs.calling_convention &&
+			   lhs.is_const == rhs.is_const &&
+			   lhs.function_reference_qualifier == rhs.function_reference_qualifier &&
+			   lhs.is_noexcept == rhs.is_noexcept;
+	};
+	auto sameTypeSpec = [&](const TypeSpecifierNode& lhs, const TypeSpecifierNode& rhs) {
+		if (lhs.type() != rhs.type() ||
+			lhs.type_index() != rhs.type_index() ||
+			lhs.pointer_depth() != rhs.pointer_depth() ||
+			lhs.reference_qualifier() != rhs.reference_qualifier() ||
+			lhs.cv_qualifier() != rhs.cv_qualifier() ||
+			lhs.has_function_signature() != rhs.has_function_signature()) {
+			return false;
+		}
+		return !lhs.has_function_signature() || sameFunctionSignature(lhs.function_signature(), rhs.function_signature());
+	};
 	std::optional<TypeSpecifierNode> exact_ternary_result_type;
+	std::optional<TypeSpecifierNode> fallback_pointer_like_branch_type;
+	auto captureFallbackPointerLikeBranchType = [&](const std::optional<TypeSpecifierNode>& true_ts,
+												   const std::optional<TypeSpecifierNode>& false_ts) {
+		if (!true_ts.has_value() || !false_ts.has_value() || !sameTypeSpec(*true_ts, *false_ts)) {
+			return;
+		}
+		if (true_ts->pointer_depth() > 0 &&
+			!true_ts->is_reference() &&
+			!true_ts->is_rvalue_reference()) {
+			fallback_pointer_like_branch_type = *true_ts;
+		}
+	};
 
 	// True branch label
 	ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = true_label}, ternaryNode.get_token()));
@@ -738,14 +773,13 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	// Sema owns the full ternary result type for normalized bodies. The fallbacks
 	// below are only for legacy non-normalized bodies that can still reach codegen.
 	TypeCategory common_cat = TypeCategory::Invalid;
-	if (context != ExpressionContext::LValueAddress && sema_) {
+	if (sema_) {
 		exact_ternary_result_type = sema_->getTernaryResultType(ternaryNode);
-		if (exact_ternary_result_type.has_value()) {
+		if (context != ExpressionContext::LValueAddress && exact_ternary_result_type.has_value()) {
 			common_cat = exact_ternary_result_type->category();
 		}
 	}
-	if (context != ExpressionContext::LValueAddress &&
-		sema_normalized_current_function_ &&
+	if (sema_normalized_current_function_ &&
 		!exact_ternary_result_type.has_value()) {
 		throw InternalError("Sema-normalized ternary expression missing exact result type");
 	}
@@ -764,6 +798,7 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && sema_) {
 		auto true_ts = sema_->getExpressionType(ternaryNode.true_expr());
 		auto false_ts = sema_->getExpressionType(ternaryNode.false_expr());
+		captureFallbackPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -772,6 +807,7 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	if (common_cat == TypeCategory::Invalid && parser_) {
 		auto true_ts = parser_->get_expression_type(ternaryNode.true_expr());
 		auto false_ts = parser_->get_expression_type(ternaryNode.false_expr());
+		captureFallbackPointerLikeBranchType(true_ts, false_ts);
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}
@@ -796,7 +832,9 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 		: common_cat;
 	PointerDepth result_pointer_depth = exact_ternary_result_type.has_value()
 		? PointerDepth{static_cast<int>(exact_ternary_result_type->pointer_depth())}
-		: PointerDepth{};
+		: (fallback_pointer_like_branch_type.has_value()
+			? PointerDepth{static_cast<int>(fallback_pointer_like_branch_type->pointer_depth())}
+			: PointerDepth{});
 
 	// Convert true result to common type if needed.
 	// NOTE: sema annotations were already consumed above when determining common_type

--- a/src/Parser_FunctionTypeHelpers.h
+++ b/src/Parser_FunctionTypeHelpers.h
@@ -36,7 +36,10 @@ inline const FunctionDeclarationNode* findFunctionDeclarationForSymbol(const AST
 
 inline TypeSpecifierNode buildFunctionPointerTypeFromFunctionDeclaration(const FunctionDeclarationNode& func_decl) {
 	FunctionSignature sig;
-	sig.return_type_index = func_decl.decl_node().type_specifier_node().type_index();
+	const TypeSpecifierNode& return_type = func_decl.decl_node().type_specifier_node();
+	sig.return_type_index = return_type.type_index();
+	sig.return_pointer_depth = static_cast<int>(return_type.pointer_depth());
+	sig.return_reference_qualifier = return_type.reference_qualifier();
 	for (const auto& param_node : func_decl.parameter_nodes()) {
 		if (!param_node.is<DeclarationNode>()) {
 			continue;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2624,6 +2624,10 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				// Normalize the branches first so sema-owned child slots/call targets
 				// exist before we compute and annotate the common-type conversions.
 				tryAnnotateTernaryBranchConversions(e);
+				if (const CanonicalTypeId result_type_id = inferExpressionType(node)) {
+					ternary_result_types_[&e] = result_type_id;
+					annotateExpressionTypeSlot(node, result_type_id, inferExpressionValueCategory(node));
+				}
 			} else if constexpr (std::is_same_v<T, ConstructorCallNode>) {
 				tryAnnotateConstructorCallArgConversions(e);
 				for (const auto& arg : e.arguments()) {
@@ -2925,6 +2929,14 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNo
 			throw InternalError("Unexpected semantic value category");
 	}
 	return type;
+}
+
+std::optional<TypeSpecifierNode> SemanticAnalysis::getTernaryResultType(const TernaryOperatorNode& ternary_node) const {
+	auto it = ternary_result_types_.find(&ternary_node);
+	if (it == ternary_result_types_.end()) {
+		return std::nullopt;
+	}
+	return materializeTypeSpecifier(type_context_.get(it->second));
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::getOverloadResolutionArgType(const ASTNode& arg) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -12,6 +12,7 @@
 #include "ConstExprEvaluator.h"
 #include "ReachableStructWalker.h"
 #include "StringLiteralTokenUtils.h"
+#include "Parser_FunctionTypeHelpers.h"
 
 namespace {
 constexpr std::string_view kTemplatePatternStructSuffix = "$pattern__";
@@ -3482,10 +3483,7 @@ CanonicalTypeId SemanticAnalysis::inferResolvedSymbolType(const ASTNode& symbol)
 
 	if (symbol.is<FunctionDeclarationNode>()) {
 		const auto& func = symbol.as<FunctionDeclarationNode>();
-		const ASTNode ret_type_node = func.decl_node().type_node();
-		if (ret_type_node.has_value() && ret_type_node.is<TypeSpecifierNode>()) {
-			return canonicalizeType(ret_type_node.as<TypeSpecifierNode>());
-		}
+		return canonicalizeType(FlashCpp::ParserFunctionTypeHelpers::buildFunctionPointerTypeFromFunctionDeclaration(func));
 	}
 
 	return {};

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2439,7 +2439,21 @@ void SemanticAnalysis::normalizeStatement(const ASTNode& node, const SemanticCon
 		normalizeStatement(stmt.try_block(), ctx);
 		for (const auto& handler : stmt.catch_clauses()) {
 			if (handler.is<CatchClauseNode>()) {
-				normalizeStatement(handler.as<CatchClauseNode>().body(), ctx);
+				pushScope();
+				auto guard = ScopeGuard([this]() { popScope(); });
+				const auto& catch_clause = handler.as<CatchClauseNode>();
+				if (catch_clause.exception_declaration().has_value() &&
+					catch_clause.exception_declaration()->is<DeclarationNode>()) {
+					const auto& catch_decl = catch_clause.exception_declaration()->as<DeclarationNode>();
+					TypeSpecifierNode catch_type = catch_decl.type_specifier_node();
+					applyDeclarationArrayBoundsToTypeSpec(catch_decl, catch_type);
+					const CanonicalTypeId tid = canonicalizeType(catch_type);
+					const StringHandle name = catch_decl.identifier_token().handle();
+					if (name.isValid()) {
+						addLocalType(name, tid);
+					}
+				}
+				normalizeStatement(catch_clause.body(), ctx);
 			}
 		}
 	} else if (node.is<SehTryExceptStatementNode>()) {

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -73,6 +73,7 @@ public:
 	// Key is the raw pointer to the ExpressionNode (stable, from gChunkedAnyStorage).
 	std::optional<SemanticSlot> getSlot(const void* key) const;
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
+	std::optional<TypeSpecifierNode> getTernaryResultType(const TernaryOperatorNode& ternary_node) const;
 	// Public bridge for codegen/helper paths that need the same canonical type
 	// identity as sema while keeping the primary canonicalizeType helper private.
 	CanonicalTypeId canonicalizeTypeForImplicitConversion(const TypeSpecifierNode& type);
@@ -456,6 +457,7 @@ private:
 	std::unordered_map<const QualifiedIdentifierNode*, ResolvedQualifiedIdentifierInfo> resolved_qualified_identifier_table_;
 	std::unordered_map<const void*, TypeSpecifierNode> overload_resolution_arg_types_;
 	std::unordered_map<const void*, std::vector<CallArgReferenceBindingInfo>> call_ref_bindings_;
+	std::unordered_map<const TernaryOperatorNode*, CanonicalTypeId> ternary_result_types_;
 
 	// Side table: ArraySubscriptNode pointer → resolved operator[] declaration.
 	// Populated by tryResolveSubscriptOperator when the subscript object is a struct type.

--- a/tests/test_nested_funcptr_direct_invoke_ternary_swapped_ret0.cpp
+++ b/tests/test_nested_funcptr_direct_invoke_ternary_swapped_ret0.cpp
@@ -1,0 +1,23 @@
+int plus1(int x) {
+	return x + 1;
+}
+
+int plus2(int x) {
+	return x + 2;
+}
+
+using Fn = int (*)(int);
+
+Fn choose(bool pick_first) {
+	return pick_first ? plus1 : plus2;
+}
+
+Fn forward(Fn fn) {
+	return fn;
+}
+
+int main() {
+	int nested_direct = forward(choose(true))(41);
+	int ternary_direct = false ? forward(choose(false))(40) : forward(choose(true))(41);
+	return (nested_direct == 42 && ternary_direct == 42) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Fix sema typing for bare function designators so function names carry function-pointer type information instead of collapsing to the return type.
- Move ternary result typing ownership into sema and make normalized ternary codegen require sema's exact result type.
- Add catch-handler scope normalization so catch-body expressions also receive sema-owned ternary result metadata.
- Document the remaining non-normalized ternary fallback cleanup in the fallback audit.

## Root Cause
Ternary-selected function pointer expressions could be typed from parser/codegen fallbacks instead of sema-owned exact result types. Bare function names were previously inferred as their return type, which let codegen truncate function pointers through integer-sized ternary slots. A stricter invariant exposed a catch-body normalization gap where the catch declaration was not in sema scope.

## Validation
- `./build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1 test_eh_copy_ctor_ret0.cpp test_eh_move_ctor_ret0.cpp test_nested_funcptr_direct_invoke_ternary_ret0.cpp test_nested_funcptr_direct_invoke_ternary_swapped_ret0.cpp test_ternary_funcptr_prvalue_direct_invoke_ret0.cpp test_ternary_sema_consumption_ret0.cpp`
- `pwsh tests/run_all_tests.ps1` (2276 regular passed, 154 expected failures)