### PR TITLE
[codex] Improve MSVC std header template parsing

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2403,6 +2403,15 @@ private:	 // Resume private methods
 	const FunctionDeclarationNode* tryResolveConcreteMemberFunction(const std::optional<ASTNode>& object_expr, std::string_view member_name);
 	std::optional<ASTNode> tryResolveMemberFunctionTemplate(const std::optional<ASTNode>& object_expr, std::string_view member_name,
 															const std::optional<std::vector<TemplateTypeArg>>& explicit_template_args, const std::vector<TypeSpecifierNode>& arg_types);
+	// Shared member-template call dispatch once the caller knows whether arguments were
+	// syntactically present and whether any of them stayed dependent while collecting types.
+	std::optional<ASTNode> tryInstantiateMemberFunctionTemplateCall(
+		std::string_view struct_name,
+		std::string_view member_name,
+		const std::optional<std::vector<TemplateTypeArg>>& explicit_template_args,
+		const std::vector<TypeSpecifierNode>& call_arg_types,
+		bool has_call_args,
+		bool has_dependent_call_args);
 	ParseResult parse_member_postfix(std::optional<ASTNode>& result, const Token& operator_start_token);
 	ParseResult parse_unary_expression(ExpressionContext context);
 	ParseResult parse_qualified_operator_call(const Token& context_token, const std::vector<StringType<32>>& namespaces);  // Parse operator symbol + call after 'operator' keyword consumed

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -246,16 +246,15 @@ ParseResult Parser::parse_top_level_node() {
 			}
 
 			ParseResult decl_result;
+			Linkage saved_linkage = current_linkage_;
+			current_linkage_ = linkage;
 			if (peek() == "template"_tok) {
 				decl_result = parse_template_declaration();
 			} else {
 				// Single declaration form: extern "C" int func();
-				// Set the current linkage and parse the declaration/function
-				Linkage saved_linkage = current_linkage_;
-				current_linkage_ = linkage;
 				decl_result = parse_declaration_or_function_definition();
-				current_linkage_ = saved_linkage;
 			}
+			current_linkage_ = saved_linkage;
 
 			if (decl_result.is_error()) {
 				return decl_result;
@@ -716,13 +715,15 @@ ParseResult Parser::parse_namespace() {
 				// Check for block form: extern "C" { ... }
 				if (peek() == "{"_tok) {
 					decl_result = parse_extern_block(linkage);
-				} else if (peek() == "template"_tok) {
-					decl_result = parse_template_declaration();
 				} else {
-					// Single declaration form: extern "C++" int func();
 					Linkage saved_linkage = current_linkage_;
 					current_linkage_ = linkage;
-					decl_result = parse_declaration_or_function_definition();
+					if (peek() == "template"_tok) {
+						decl_result = parse_template_declaration();
+					} else {
+						// Single declaration form: extern "C++" int func();
+						decl_result = parse_declaration_or_function_definition();
+					}
 					current_linkage_ = saved_linkage;
 				}
 			} else if (peek() == "template"_tok) {

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -245,15 +245,17 @@ ParseResult Parser::parse_top_level_node() {
 				return saved_position.propagate(std::move(result));
 			}
 
-			// Single declaration form: extern "C" int func();
-			// Set the current linkage and parse the declaration/function
-			Linkage saved_linkage = current_linkage_;
-			current_linkage_ = linkage;
-
-			ParseResult decl_result = parse_declaration_or_function_definition();
-
-			// Restore the previous linkage
-			current_linkage_ = saved_linkage;
+			ParseResult decl_result;
+			if (peek() == "template"_tok) {
+				decl_result = parse_template_declaration();
+			} else {
+				// Single declaration form: extern "C" int func();
+				// Set the current linkage and parse the declaration/function
+				Linkage saved_linkage = current_linkage_;
+				current_linkage_ = linkage;
+				decl_result = parse_declaration_or_function_definition();
+				current_linkage_ = saved_linkage;
+			}
 
 			if (decl_result.is_error()) {
 				return decl_result;
@@ -714,6 +716,8 @@ ParseResult Parser::parse_namespace() {
 				// Check for block form: extern "C" { ... }
 				if (peek() == "{"_tok) {
 					decl_result = parse_extern_block(linkage);
+				} else if (peek() == "template"_tok) {
+					decl_result = parse_template_declaration();
 				} else {
 					// Single declaration form: extern "C++" int func();
 					Linkage saved_linkage = current_linkage_;

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -85,6 +85,41 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 	return match;
 }
 
+std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
+	std::string_view struct_name,
+	std::string_view member_name,
+	const std::optional<std::vector<TemplateTypeArg>>& explicit_template_args,
+	const std::vector<TypeSpecifierNode>& call_arg_types,
+	bool has_call_args,
+	bool has_dependent_call_args) {
+	// `has_call_args` tracks whether the parser saw any call arguments syntactically,
+	// while `call_arg_types` tracks only the arguments whose types are already known
+	// at this parse point and may therefore be only a partial subset.  If a
+	// syntactically non-empty call still has no collected types here, preserving the
+	// old behavior by deferring deduction is safer than forcing a hard failure.
+	if (explicit_template_args.has_value()) {
+		return try_instantiate_member_function_template_explicit(
+			struct_name,
+			member_name,
+			*explicit_template_args);
+	}
+	if (!has_call_args) {
+		return try_instantiate_member_function_template_explicit(
+			struct_name,
+			member_name,
+			{});
+	}
+	// Reaching this point means the call was syntactically non-empty, so an empty
+	// collected-type list means deduction still has to wait for instantiation-time typing.
+	if (has_dependent_call_args || call_arg_types.empty()) {
+		return std::nullopt;
+	}
+	return try_instantiate_member_function_template(
+		struct_name,
+		member_name,
+		call_arg_types);
+}
+
 ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const Token& operator_start_token) {
 	// Expect an identifier (member name) OR ~ for pseudo-destructor call
 	// Pseudo-destructor pattern: obj.~Type() or ptr->~Type()
@@ -277,21 +312,20 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		}
 
 		std::optional<ASTNode> instantiated_func;
-		if (object_struct_name.has_value() && explicit_template_args) {
-			instantiated_func = try_instantiate_member_function_template_explicit(
+		if (object_struct_name.has_value()) {
+			std::optional<std::vector<TemplateTypeArg>> member_template_args;
+			if (explicit_template_args) {
+				member_template_args = explicit_template_args.read_template_type_args();
+			}
+			instantiated_func = tryInstantiateMemberFunctionTemplateCall(
 				*object_struct_name,
 				member_name_token.value(),
-				explicit_template_args.read_template_type_args());
-		} else if (object_struct_name.has_value() && arg_types.empty()) {
-			instantiated_func = try_instantiate_member_function_template_explicit(
-				*object_struct_name,
-				member_name_token.value(),
-				{});
-		} else if (object_struct_name.has_value() && !arg_types.empty()) {
-			instantiated_func = try_instantiate_member_function_template(
-				*object_struct_name,
-				member_name_token.value(),
-				arg_types);
+				member_template_args,
+				arg_types,
+				!args.empty(),
+				// parse_function_arguments already produced the concrete arg-type list used
+				// by this postfix path; keep the existing "no extra dependent deferral" behavior.
+				false);
 		}
 
 		if (object_struct_name.has_value() && !instantiating_lazy_member_ &&

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -235,43 +235,30 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	// 2. No call args and no explicit args — try zero-arg explicit instantiation.
 	// 3. Call args but no explicit args (e.g. Type::member(args)) — deduce from args.
 	//    This covers static member function templates like `S<T1,T2>::f(a, b)` where
-	//    `try_parse_member_template_function_call` is the only path and the lazy
-	//    fallback below only handles non-template members.
-	std::optional<ASTNode> instantiated_func;
-	if (member_template_args.has_value()) {
-		instantiated_func = try_instantiate_member_function_template_explicit(
-			instantiated_class_name,
-			member_name,
-			*member_template_args);
-	} else if (args.empty()) {
-		instantiated_func = try_instantiate_member_function_template_explicit(
-			instantiated_class_name,
-			member_name,
-			{});
-	} else {
-		// Collect argument types from the already-parsed call args, then attempt
-		// deduction-based member function template instantiation.  This is the
-		// same mechanism used for regular (non-static) member template calls in
-		// Parser_Expr_PostfixCalls.cpp.
-		std::vector<TypeSpecifierNode> deduced_arg_types;
-		deduced_arg_types.reserve(args.size());
-		bool has_dependent_call_arg = false;
-		for (const auto& arg : args) {
-			auto type_opt = get_expression_type(arg);
-			if (!type_opt.has_value()) {
-				if (!currentTemplateParamNames().empty()) {
-					has_dependent_call_arg = true;
-					continue;
-				}
-				throw InternalError("Could not determine type of call argument during qualified static member template deduction");
+	//    `try_parse_member_template_function_call` is the only path that reaches
+	//    these qualified static member template calls, so this path still has to
+	//    collect call-arg types before delegating to the shared helper below.
+	std::vector<TypeSpecifierNode> deduced_arg_types;
+	deduced_arg_types.reserve(args.size());
+	bool has_dependent_call_arg = false;
+	for (const auto& arg : args) {
+		auto type_opt = get_expression_type(arg);
+		if (!type_opt.has_value()) {
+			if (!currentTemplateParamNames().empty()) {
+				has_dependent_call_arg = true;
+				continue;
 			}
-			deduced_arg_types.push_back(*type_opt);
+			throw InternalError("Could not determine type of call argument during qualified static member template deduction");
 		}
-		if (!has_dependent_call_arg && !deduced_arg_types.empty()) {
-			instantiated_func = try_instantiate_member_function_template(
-				instantiated_class_name, member_name, deduced_arg_types);
-		}
+		deduced_arg_types.push_back(*type_opt);
 	}
+	std::optional<ASTNode> instantiated_func = tryInstantiateMemberFunctionTemplateCall(
+		instantiated_class_name,
+		member_name,
+		member_template_args,
+		deduced_arg_types,
+		!args.empty(),
+		has_dependent_call_arg);
 
 	// Trigger lazy member function instantiation if needed
 	if (!instantiated_func.has_value() &&

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -255,14 +255,19 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		// Parser_Expr_PostfixCalls.cpp.
 		std::vector<TypeSpecifierNode> deduced_arg_types;
 		deduced_arg_types.reserve(args.size());
+		bool has_dependent_call_arg = false;
 		for (const auto& arg : args) {
 			auto type_opt = get_expression_type(arg);
 			if (!type_opt.has_value()) {
+				if (!currentTemplateParamNames().empty()) {
+					has_dependent_call_arg = true;
+					continue;
+				}
 				throw InternalError("Could not determine type of call argument during qualified static member template deduction");
 			}
 			deduced_arg_types.push_back(*type_opt);
 		}
-		if (!deduced_arg_types.empty()) {
+		if (!has_dependent_call_arg && !deduced_arg_types.empty()) {
 			instantiated_func = try_instantiate_member_function_template(
 				instantiated_class_name, member_name, deduced_arg_types);
 		}

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -101,7 +101,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
 
-#### 2026-05-05 Windows/MSVC std-header parser/sema follow-up
+### 2026-05-05 Windows/MSVC std-header parser/sema follow-up
 
 This pass rebuilt `x64/Sharded/FlashCppMSVC.exe` with MSBuild and retested
 selected `tests/std/test_std_*.cpp` files against MSVC 14.44.35207 headers.

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -101,6 +101,37 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
 
+#### 2026-05-05 Windows/MSVC std-header parser/sema follow-up
+
+This pass rebuilt `x64/Sharded/FlashCppMSVC.exe` with MSBuild and retested
+selected `tests/std/test_std_*.cpp` files against MSVC 14.44.35207 headers.
+
+Fixes landed:
+
+- **Single-declaration linkage specifications now accept template declarations.**
+  MSVC writes forward declarations such as
+  `extern "C++" template <class _Elem, class _Traits = char_traits<_Elem>> class basic_ios;`
+  in `iosfwd`; the top-level and namespace parsers now route `extern "C++" template ...`
+  through the existing template declaration path instead of ordinary type parsing.
+- **Qualified static member function template calls no longer hard-error when a
+  call argument type is unavailable in an active template context.**  The parser
+  skips immediate deduction for those dependent calls and lets the existing lazy
+  member/fallback call path preserve the expression for later instantiation.
+
+Regression tests:
+
+- `tests/test_extern_cxx_template_forward_ret0.cpp`
+- `tests/test_qualified_static_member_template_dependent_arg_ret0.cpp`
+
+Validation snapshot (`x64/Sharded/FlashCppMSVC.exe`, Windows/MSVC 14.44.35207):
+
+| Header | Status | Time | First-order stop / note |
+|--------|--------|------|-------------------------|
+| `<string_view>` | ❌ Compile Error | parse stopped after ~3032ms | The previous `iosfwd:166` `extern "C++" template` parser stop and the qualified static member template deduction fatal are fixed. Current first hard error is MSVC `<utility>:458` `Call to deleted function 'swap'`; recoverable deferred static_assert / `std::invoke` failures still precede the final diagnostic. |
+| `<optional>` | ❌ Compile Error | parse stopped after ~1304ms | The qualified static member template deduction fatal is fixed. Current first hard error is MSVC `<utility>:458` `Call to deleted function 'swap'`. |
+| `<atomic>` | ❌ Parse Error | parse stopped after ~933ms | The qualified static member template deduction fatal is fixed. Current first hard error is MSVC `xatomic_wait.h:50` `Expected ';' after type alias` for `using _Atomic_wait_indirect_equal_callback_t = bool(__stdcall*)(...) noexcept;`. |
+| `<latch>` | ❌ Parse Error | parse stopped after ~911ms | Same `xatomic_wait.h:50` function-pointer type-alias parser blocker as `<atomic>`. |
+
 
 
 #### 2026-05-05 Copy-init array-to-pointer constructor conversion for `<string_view>` (Linux/libstdc++-14)

--- a/tests/test_extern_cxx_template_forward_ret0.cpp
+++ b/tests/test_extern_cxx_template_forward_ret0.cpp
@@ -1,0 +1,16 @@
+template <class _Elem>
+struct char_traits {};
+
+extern "C++" template <class _Elem, class _Traits = char_traits<_Elem>>
+class basic_ios;
+
+template <class _Elem, class _Traits>
+class basic_ios {
+public:
+	_Elem value;
+};
+
+int main() {
+	basic_ios<int> io{0};
+	return io.value;
+}

--- a/tests/test_qualified_static_member_template_dependent_arg_ret0.cpp
+++ b/tests/test_qualified_static_member_template_dependent_arg_ret0.cpp
@@ -1,0 +1,23 @@
+template <class T>
+struct Source {
+	static T make() {
+		return T{};
+	}
+};
+
+template <class T>
+struct Sink {
+	template <class U>
+	static int accept(U value) {
+		(void)value;
+		return 0;
+	}
+
+	static int run() {
+		return Sink::accept(Source<T>::make());
+	}
+};
+
+int main() {
+	return Sink<int>::run();
+}

--- a/tests/test_qualified_static_member_template_partial_deduction_ret0.cpp
+++ b/tests/test_qualified_static_member_template_partial_deduction_ret0.cpp
@@ -1,0 +1,29 @@
+template <class T>
+struct Source {
+	static T make() {
+		return T{};
+	}
+};
+
+struct Known {
+	int value;
+};
+
+template <class T>
+struct Sink {
+	template <class KnownType, class DependentType>
+	static KnownType select(KnownType known, DependentType dependent) {
+		(void)dependent;
+		return known;
+	}
+
+	static constexpr int parsed_while_dependent = static_cast<int>(sizeof(Sink::select(Known{0}, Source<T>::make()).value));
+
+	static int run() {
+		return parsed_while_dependent - 4;
+	}
+};
+
+int main() {
+	return Sink<int>::run();
+}


### PR DESCRIPTION
## Summary
- parse single-declaration `extern "C++" template ...` forms through the existing template declaration path
- defer qualified static member function template deduction when call argument types are still dependent in an active template context
- add focused regressions for the MSVC `iosfwd` forward declaration form and dependent qualified static member template calls
- update `tests/std/README_STANDARD_HEADERS.md` with the current Windows/MSVC header findings and next blockers

## Root Cause
MSVC standard headers expose two front-end gaps. `iosfwd` uses `extern "C++" template <...> class basic_ios;`, but the linkage parser only routed ordinary declarations through the single-declaration path. Separately, qualified static member function template calls tried to deduce from every parsed argument immediately, which made dependent arguments with unavailable first-phase types fatal instead of deferring them.

## Validation
- `./build_flashcpp.bat`
- `./tests/run_all_tests.ps1`
- targeted std-header retests for `test_std_string_view.cpp`, `test_std_optional.cpp`, `test_std_atomic.cpp`, and `test_std_latch.cpp` to document the next blockers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better support for template declarations following extern "C"/extern "C++" linkage.
  * Qualified static/member template calls no longer hard-error when argument types are undeducible; parsing now defers deduction instead of forcing an empty explicit instantiation.

* **Tests**
  * Added multiple regression tests covering extern linkage with templates and dependent-template member calls.

* **Documentation**
  * Updated test README with Windows/MSVC parser/sema notes and validation snapshot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->