### PR TITLE
[codex] Harden is_complete_or_unbounded fallback

### DIFF
--- a/docs/2026-04-08-template-instantiation-materialization-plan.md
+++ b/docs/2026-04-08-template-instantiation-materialization-plan.md
@@ -355,6 +355,11 @@ Recent historical baselines recorded for this work:
   `materializeDeferredBasePlaceholderIfNeeded(...)` before the residual
   `TypeSpecifierNode` passthrough. Added
   `tests/test_deferred_base_member_alias_type_arg_ret0.cpp`.
+- 2026-05-05 Windows constexpr/type-trait fallback follow-up: the
+  `__is_complete_or_unbounded` constexpr evaluator now errors when the argument
+  cannot be extracted as a type-shaped expression instead of returning true as a
+  missing-metadata fallback. Added
+  `tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp`.
 
 Refresh this section only after a new full validation run. Do not treat the
 older pass counts as today's baseline without rerunning the suite.

--- a/docs/2026-04-27-fallback-comments-audit.md
+++ b/docs/2026-04-27-fallback-comments-audit.md
@@ -176,7 +176,7 @@ Representative sites:
 
 - `src\IrGenerator_MemberAccess.cpp:1996` - `sizeof(member_access)` searches instantiated types by string prefix when direct lookup finds unsubstituted template members.
 - `src\IrGenerator_MemberAccess.cpp:2081`, `src\IrGenerator_MemberAccess.cpp:2110`, `src\IrGenerator_MemberAccess.cpp:2131`, `src\IrGenerator_MemberAccess.cpp:2151` - `sizeof(arr[index])` and general `sizeof(expr)` fall through to IR generation and can return zero with only a warning.
-- `src\ConstExprEvaluator_Core.cpp:4002` - `__is_complete_or_unbounded` returns true if it cannot extract the type.
+- `src\ConstExprEvaluator_Core.cpp:4002` - `__is_complete_or_unbounded` previously returned true if it could not extract the type; this now reports a constexpr evaluation error instead of treating missing type metadata as success.
 - `src\ConstExprEvaluator_Members.cpp:4194` - struct initializer evaluation falls back to evaluating the initializer expression directly.
 - `src\IrGenerator_Visitors_TypeInit.cpp:1175`, `src\IrGenerator_Visitors_TypeInit.cpp:1420` - type initialization tries full constexpr eval or emits bytes from fallback zero-initialization.
 
@@ -538,3 +538,4 @@ The audit is now backed by direct suite evidence for several representative temp
   the current member context. The focused regression and the full 2254-test
   Linux suite passed with the hard-fail probe enabled after this change;
 - the larger ExpressionSubstitutor/static-initializer/pack-size fallback classes should still be assumed active until probed or root-fixed individually.
+- the `ConstExprEvaluator_Core.cpp` `__is_complete_or_unbounded` missing-type fallback now hard-fails instead of returning true. Added `tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp`; the existing `tests/test_stdlib_features_ret0.cpp` still covers valid type-shaped use.

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4151,9 +4151,7 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 			}
 		}
 
-		// If we can't extract the type, return true as a fallback
-		FLASH_LOG(Templates, Debug, "__is_complete_or_unbounded: couldn't extract type, returning true as fallback");
-		return EvalResult::from_bool(true);
+		return EvalResult::error("__is_complete_or_unbounded requires a type argument");
 	}
 
 	// Prefer the parser-stored exact call target before falling back to raw name lookup.

--- a/tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp
+++ b/tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp
@@ -1,0 +1,4 @@
+int main() {
+	static_assert(__is_complete_or_unbounded(0), "non-type argument must be rejected");
+	return 0;
+}


### PR DESCRIPTION
## Summary

Hardens `__is_complete_or_unbounded` constexpr evaluation so invalid non-type-shaped arguments no longer silently return `true` when type extraction fails.

## Details

- Replaces the permissive missing-type fallback with a constexpr evaluation error.
- Adds an expected-fail regression for `__is_complete_or_unbounded(0)`.
- Updates the fallback audit and template materialization plan notes with the closed fallback class.

## Validation

- `./build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1 test_is_complete_or_unbounded_invalid_arg_fail.cpp`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1 test_stdlib_features_ret0.cpp`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1` passed: 2312 regular tests, 157 expected-fail tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type completeness evaluator now properly rejects invalid type arguments with an error instead of defaulting to success.

* **Documentation**
  * Updated validation baseline records and audit documentation to reflect the corrected evaluator behavior.

* **Tests**
  * Added regression test for type argument validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->