### PR TITLE
[codex] Fix template pseudo-dtor noexcept materialization

### DIFF
--- a/docs/2026-04-08-template-instantiation-materialization-plan.md
+++ b/docs/2026-04-08-template-instantiation-materialization-plan.md
@@ -360,6 +360,12 @@ Recent historical baselines recorded for this work:
   cannot be extracted as a type-shaped expression instead of returning true as a
   missing-metadata fallback. Added
   `tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp`.
+- 2026-05-05 Windows pseudo-destructor noexcept follow-up: template destructor
+  instantiation now substitutes and re-evaluates explicit `noexcept(expr)` in
+  the concrete template context, and pseudo-destructor `noexcept` checks resolve
+  constructor/list-init temporary object types before falling back to the
+  destructor-name token. Added
+  `tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp`.
 
 Refresh this section only after a new full validation run. Do not treat the
 older pass counts as today's baseline without rerunning the suite.

--- a/docs/2026-04-27-fallback-comments-audit.md
+++ b/docs/2026-04-27-fallback-comments-audit.md
@@ -539,3 +539,9 @@ The audit is now backed by direct suite evidence for several representative temp
   Linux suite passed with the hard-fail probe enabled after this change;
 - the larger ExpressionSubstitutor/static-initializer/pack-size fallback classes should still be assumed active until probed or root-fixed individually.
 - the `ConstExprEvaluator_Core.cpp` `__is_complete_or_unbounded` missing-type fallback now hard-fails instead of returning true. Added `tests/test_is_complete_or_unbounded_invalid_arg_fail.cpp`; the existing `tests/test_stdlib_features_ret0.cpp` still covers valid type-shaped use.
+- pseudo-destructor `noexcept(expr)` evaluation no longer depends on the
+  destructor-name token for template temporaries. `TypeTraitEvaluator.cpp`
+  resolves constructor/list-init temporary object types before the legacy token
+  lookup, and class-template destructor instantiation now substitutes and
+  re-evaluates explicit `noexcept(expr)` specifiers in the concrete template
+  context. Added `tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp`.

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7824,6 +7824,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_dtor_ref.set_noexcept_expression(substituted_noexcept);
 						ConstExpr::EvaluationContext ctx(gSymbolTable);
 						ctx.parser = this;
+						ctx.sema = getActiveSemanticAnalysis();
+						ctx.struct_info = struct_info_ptr;
+						ctx.struct_type_index =
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct);
 						auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
 						if (eval.success()) {
 							new_dtor_ref.set_noexcept(eval.as_bool());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7810,11 +7810,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						specialized_dtor_name);
 					setOuterTemplateBindingsFromParams(new_dtor_ref, template_params, template_args_to_use);
 
-					// Copy noexcept properties from the original destructor declaration.
-					// DestructorDeclarationNode defaults to noexcept(true) per C++11, so we
-					// must propagate the original's evaluated flag (and expression, if any)
-					// to handle explicit noexcept(false) correctly.
-					new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 					new_dtor_ref.set_has_noexcept_specifier(dtor_decl.has_noexcept_specifier());
 					if (dtor_decl.has_noexcept_expression()) {
 						ASTNode substituted_noexcept = substituteTemplateParameters(
@@ -7828,10 +7823,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						ctx.struct_info = struct_info_ptr;
 						ctx.struct_type_index =
 							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct);
-						auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
-						if (eval.success()) {
-							new_dtor_ref.set_noexcept(eval.as_bool());
+						ctx.template_args = template_args_to_use;
+						for (const TemplateParameterNode& template_param : template_params) {
+							ctx.template_param_names.push_back(template_param.name());
 						}
+						auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
+						if (!eval.success()) {
+							throw CompileError("Failed to evaluate instantiated destructor noexcept-expression");
+						}
+						new_dtor_ref.set_noexcept(eval.as_bool());
+					} else {
+						new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 					}
 
 					new_dtor_ref.set_definition(substituted_body);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7817,7 +7817,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 					new_dtor_ref.set_has_noexcept_specifier(dtor_decl.has_noexcept_specifier());
 					if (dtor_decl.has_noexcept_expression()) {
-						new_dtor_ref.set_noexcept_expression(*dtor_decl.noexcept_expression());
+						ASTNode substituted_noexcept = substituteTemplateParameters(
+							*dtor_decl.noexcept_expression(),
+							template_params,
+							template_args_to_use);
+						new_dtor_ref.set_noexcept_expression(substituted_noexcept);
+						ConstExpr::EvaluationContext ctx(gSymbolTable);
+						ctx.parser = this;
+						auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
+						if (eval.success()) {
+							new_dtor_ref.set_noexcept(eval.as_bool());
+						}
 					}
 
 					new_dtor_ref.set_definition(substituted_body);

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -382,15 +382,26 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			lazy_info.identity.instantiated_owner_name, dtor_name_handle);
 		new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 		new_dtor_ref.set_has_noexcept_specifier(dtor_decl.has_noexcept_specifier());
-		if (dtor_decl.has_noexcept_expression()) {
-			new_dtor_ref.set_noexcept_expression(*dtor_decl.noexcept_expression());
-		}
 
 		std::vector<TemplateTypeArg> converted_template_args;
 		converted_template_args.reserve(lazy_info.template_args.size());
 		for (const auto& ttype_arg : lazy_info.template_args) {
 
 			converted_template_args.push_back(ttype_arg);
+		}
+
+		if (dtor_decl.has_noexcept_expression()) {
+			ASTNode substituted_noexcept = substituteTemplateParameters(
+				*dtor_decl.noexcept_expression(),
+				lazy_info.template_params,
+				converted_template_args);
+			new_dtor_ref.set_noexcept_expression(substituted_noexcept);
+			ConstExpr::EvaluationContext ctx(gSymbolTable);
+			ctx.parser = this;
+			auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
+			if (eval.success()) {
+				new_dtor_ref.set_noexcept(eval.as_bool());
+			}
 		}
 
 		ASTNode substituted_body = substituteTemplateParameters(

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -398,6 +398,12 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			new_dtor_ref.set_noexcept_expression(substituted_noexcept);
 			ConstExpr::EvaluationContext ctx(gSymbolTable);
 			ctx.parser = this;
+			ctx.sema = getActiveSemanticAnalysis();
+			auto owner_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
+			if (owner_it != getTypesByNameMap().end() && owner_it->second) {
+				ctx.struct_info = owner_it->second->getStructInfo();
+				ctx.struct_type_index = owner_it->second->registeredTypeIndex().withCategory(TypeCategory::Struct);
+			}
 			auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
 			if (eval.success()) {
 				new_dtor_ref.set_noexcept(eval.as_bool());

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -380,7 +380,6 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 
 		auto [new_dtor_node, new_dtor_ref] = emplace_node_ref<DestructorDeclarationNode>(
 			lazy_info.identity.instantiated_owner_name, dtor_name_handle);
-		new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 		new_dtor_ref.set_has_noexcept_specifier(dtor_decl.has_noexcept_specifier());
 
 		std::vector<TemplateTypeArg> converted_template_args;
@@ -399,15 +398,25 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			ConstExpr::EvaluationContext ctx(gSymbolTable);
 			ctx.parser = this;
 			ctx.sema = getActiveSemanticAnalysis();
+			ctx.template_args = converted_template_args;
+			for (const ASTNode& template_param : lazy_info.template_params) {
+				if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_param);
+					tparam != nullptr) {
+					ctx.template_param_names.push_back(tparam->name());
+				}
+			}
 			auto owner_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
 			if (owner_it != getTypesByNameMap().end() && owner_it->second) {
 				ctx.struct_info = owner_it->second->getStructInfo();
 				ctx.struct_type_index = owner_it->second->registeredTypeIndex().withCategory(TypeCategory::Struct);
 			}
 			auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, ctx);
-			if (eval.success()) {
-				new_dtor_ref.set_noexcept(eval.as_bool());
+			if (!eval.success()) {
+				throw CompileError("Failed to evaluate lazy instantiated destructor noexcept-expression");
 			}
+			new_dtor_ref.set_noexcept(eval.as_bool());
+		} else {
+			new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 		}
 
 		ASTNode substituted_body = substituteTemplateParameters(

--- a/src/TypeTraitEvaluator.cpp
+++ b/src/TypeTraitEvaluator.cpp
@@ -105,6 +105,9 @@ std::optional<TypeIndex> resolvePseudoDestructorExpressionTypeIndex(const Expres
 	if (const auto* subscript = std::get_if<ArraySubscriptNode>(&expr)) {
 		return resolvePseudoDestructorObjectTypeIndex(subscript->array_expr(), symbols);
 	}
+	if (const auto* call_expr = std::get_if<CallExprNode>(&expr)) {
+		return call_expr->callee().declaration().type_specifier_node().type_index();
+	}
 	return std::nullopt;
 }
 

--- a/src/TypeTraitEvaluator.cpp
+++ b/src/TypeTraitEvaluator.cpp
@@ -62,38 +62,80 @@ const StructTypeInfo* structInfoFromTypeSpecifier(const TypeSpecifierNode& type_
 	return nullptr;
 }
 
-const StructTypeInfo* resolvePseudoDestructorObjectStruct(const ASTNode& object, const SymbolTable& symbols) {
-	if (object.is<ConstructorCallNode>()) {
-		return structInfoFromTypeSpecifier(object.as<ConstructorCallNode>().type_node());
+const StructTypeInfo* structInfoFromTypeIndex(TypeIndex type_index) {
+	if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
+		return type_info->getStructInfo();
 	}
-	if (object.is<InitializerListConstructionNode>()) {
-		const ASTNode& target_type = object.as<InitializerListConstructionNode>().target_type();
-		if (target_type.is<TypeSpecifierNode>()) {
-			return structInfoFromTypeSpecifier(target_type.as<TypeSpecifierNode>());
-		}
-	}
-	if (!object.is<ExpressionNode>()) {
-		return nullptr;
-	}
+	return nullptr;
+}
 
-	const ExpressionNode& obj_expr = object.as<ExpressionNode>();
-	if (const auto* ctor_call = std::get_if<ConstructorCallNode>(&obj_expr)) {
-		return structInfoFromTypeSpecifier(ctor_call->type_node());
+std::optional<TypeIndex> resolvePseudoDestructorObjectTypeIndex(const ASTNode& object, const SymbolTable& symbols);
+
+std::optional<TypeIndex> resolvePseudoDestructorExpressionTypeIndex(const ExpressionNode& expr, const SymbolTable& symbols) {
+	if (const auto* ctor_call = std::get_if<ConstructorCallNode>(&expr)) {
+		return ctor_call->type_node().type_index();
 	}
-	if (const auto* init_list = std::get_if<InitializerListConstructionNode>(&obj_expr)) {
+	if (const auto* init_list = std::get_if<InitializerListConstructionNode>(&expr)) {
 		const ASTNode& target_type = init_list->target_type();
 		if (target_type.is<TypeSpecifierNode>()) {
-			return structInfoFromTypeSpecifier(target_type.as<TypeSpecifierNode>());
+			return target_type.as<TypeSpecifierNode>().type_index();
 		}
+		return std::nullopt;
 	}
-	if (const auto* obj_id = std::get_if<IdentifierNode>(&obj_expr)) {
+	if (const auto* obj_id = std::get_if<IdentifierNode>(&expr)) {
 		auto symbol = symbols.lookup(obj_id->name());
 		if (symbol.has_value()) {
 			const DeclarationNode* decl = get_decl_from_symbol(*symbol);
 			if (decl) {
-				return structInfoFromTypeSpecifier(decl->type_specifier_node());
+				return decl->type_specifier_node().type_index();
 			}
 		}
+		return std::nullopt;
+	}
+	if (const auto* member_access = std::get_if<MemberAccessNode>(&expr)) {
+		std::optional<TypeIndex> object_type_index =
+			resolvePseudoDestructorObjectTypeIndex(member_access->object(), symbols);
+		if (!object_type_index.has_value()) {
+			return std::nullopt;
+		}
+		const StructTypeInfo* object_struct = structInfoFromTypeIndex(*object_type_index);
+		if (!object_struct) {
+			return std::nullopt;
+		}
+		std::optional<StructMember> member =
+			object_struct->findMemberRecursive(member_access->member_token().handle());
+		if (member.has_value()) {
+			return member->type_index;
+		}
+		return std::nullopt;
+	}
+	if (const auto* subscript = std::get_if<ArraySubscriptNode>(&expr)) {
+		return resolvePseudoDestructorObjectTypeIndex(subscript->array_expr(), symbols);
+	}
+	return std::nullopt;
+}
+
+std::optional<TypeIndex> resolvePseudoDestructorObjectTypeIndex(const ASTNode& object, const SymbolTable& symbols) {
+	if (object.is<ConstructorCallNode>()) {
+		return object.as<ConstructorCallNode>().type_node().type_index();
+	}
+	if (object.is<InitializerListConstructionNode>()) {
+		const ASTNode& target_type = object.as<InitializerListConstructionNode>().target_type();
+		if (target_type.is<TypeSpecifierNode>()) {
+			return target_type.as<TypeSpecifierNode>().type_index();
+		}
+		return std::nullopt;
+	}
+	if (object.is<ExpressionNode>()) {
+		return resolvePseudoDestructorExpressionTypeIndex(object.as<ExpressionNode>(), symbols);
+	}
+	return std::nullopt;
+}
+
+const StructTypeInfo* resolvePseudoDestructorObjectStruct(const ASTNode& object, const SymbolTable& symbols) {
+	std::optional<TypeIndex> type_index = resolvePseudoDestructorObjectTypeIndex(object, symbols);
+	if (type_index.has_value()) {
+		return structInfoFromTypeIndex(*type_index);
 	}
 	return nullptr;
 }

--- a/src/TypeTraitEvaluator.cpp
+++ b/src/TypeTraitEvaluator.cpp
@@ -53,6 +53,53 @@ inline bool isUnsigned(TypeCategory cat) {
 
 } // namespace TypeTraitEval
 
+namespace {
+
+const StructTypeInfo* structInfoFromTypeSpecifier(const TypeSpecifierNode& type_spec) {
+	if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
+		return type_info->getStructInfo();
+	}
+	return nullptr;
+}
+
+const StructTypeInfo* resolvePseudoDestructorObjectStruct(const ASTNode& object, const SymbolTable& symbols) {
+	if (object.is<ConstructorCallNode>()) {
+		return structInfoFromTypeSpecifier(object.as<ConstructorCallNode>().type_node());
+	}
+	if (object.is<InitializerListConstructionNode>()) {
+		const ASTNode& target_type = object.as<InitializerListConstructionNode>().target_type();
+		if (target_type.is<TypeSpecifierNode>()) {
+			return structInfoFromTypeSpecifier(target_type.as<TypeSpecifierNode>());
+		}
+	}
+	if (!object.is<ExpressionNode>()) {
+		return nullptr;
+	}
+
+	const ExpressionNode& obj_expr = object.as<ExpressionNode>();
+	if (const auto* ctor_call = std::get_if<ConstructorCallNode>(&obj_expr)) {
+		return structInfoFromTypeSpecifier(ctor_call->type_node());
+	}
+	if (const auto* init_list = std::get_if<InitializerListConstructionNode>(&obj_expr)) {
+		const ASTNode& target_type = init_list->target_type();
+		if (target_type.is<TypeSpecifierNode>()) {
+			return structInfoFromTypeSpecifier(target_type.as<TypeSpecifierNode>());
+		}
+	}
+	if (const auto* obj_id = std::get_if<IdentifierNode>(&obj_expr)) {
+		auto symbol = symbols.lookup(obj_id->name());
+		if (symbol.has_value()) {
+			const DeclarationNode* decl = get_decl_from_symbol(*symbol);
+			if (decl) {
+				return structInfoFromTypeSpecifier(decl->type_specifier_node());
+			}
+		}
+	}
+	return nullptr;
+}
+
+} // namespace
+
 bool isStructNothrowDestructible(const StructTypeInfo* struct_info) {
 	if (!struct_info)
 		return true;
@@ -96,28 +143,14 @@ bool isStructNothrowDestructible(const StructTypeInfo* struct_info) {
 }
 
 bool isPseudoDestructorCallNoexcept(const PseudoDestructorCallNode& pseudo_dtor, const SymbolTable& symbols) {
-	// Try to resolve the actual type from the object expression's declaration
-	// (not the type_name() token) so that template specializations like
-	// Wrapper<int> resolve to the correct instantiated type.
-	if (pseudo_dtor.object().is<ExpressionNode>()) {
-		const ExpressionNode& obj_expr = pseudo_dtor.object().as<ExpressionNode>();
-		if (const auto* obj_id = std::get_if<IdentifierNode>(&obj_expr)) {
-			auto symbol = symbols.lookup(obj_id->name());
-			if (symbol.has_value()) {
-				const DeclarationNode* decl = get_decl_from_symbol(*symbol);
-				if (decl) {
-					const TypeSpecifierNode& type_spec = decl->type_specifier_node();
-					if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
-						const StructTypeInfo* struct_info = type_info->getStructInfo();
-						if (struct_info) {
-							return isStructNothrowDestructible(struct_info);
-						}
-					}
-				}
-			}
-		}
+	// Resolve the actual object type first so template specializations and
+	// temporary objects do not depend on the destructor-name token.
+	if (const StructTypeInfo* struct_info = resolvePseudoDestructorObjectStruct(pseudo_dtor.object(), symbols)) {
+		return isStructNothrowDestructible(struct_info);
 	}
-	// Fallback: look up by type name token (works for non-template types)
+
+	// Compatibility path for scalar pseudo-destructors and legacy non-template
+	// object shapes where only the destructor type token is available.
 	std::string_view type_name = pseudo_dtor.type_name();
 	auto it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(type_name));
 	if (it != getTypesByNameMap().end()) {

--- a/src/TypeTraitEvaluator.cpp
+++ b/src/TypeTraitEvaluator.cpp
@@ -55,13 +55,6 @@ inline bool isUnsigned(TypeCategory cat) {
 
 namespace {
 
-const StructTypeInfo* structInfoFromTypeSpecifier(const TypeSpecifierNode& type_spec) {
-	if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
-		return type_info->getStructInfo();
-	}
-	return nullptr;
-}
-
 const StructTypeInfo* structInfoFromTypeIndex(TypeIndex type_index) {
 	if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
 		return type_info->getStructInfo();

--- a/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
+++ b/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
@@ -9,6 +9,14 @@ struct Holder {
 	DtorFlag<NoThrow> member;
 };
 
+DtorFlag<false> make_false() {
+	return DtorFlag<false>{};
+}
+
+DtorFlag<true> make_true() {
+	return DtorFlag<true>{};
+}
+
 int main() {
 	int result = 0;
 
@@ -37,6 +45,12 @@ int main() {
 	DtorFlag<true> arr_true[1]{};
 	if (!noexcept(arr_true[0].~DtorFlag<true>()))
 		result |= 64;
+
+	if (noexcept(make_false().~DtorFlag<false>()))
+		result |= 128;
+
+	if (!noexcept(make_true().~DtorFlag<true>()))
+		result |= 256;
 
 	return result;
 }

--- a/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
+++ b/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
@@ -4,6 +4,11 @@ struct DtorFlag {
 	~DtorFlag() noexcept(NoThrow) {}
 };
 
+template <bool NoThrow>
+struct Holder {
+	DtorFlag<NoThrow> member;
+};
+
 int main() {
 	int result = 0;
 
@@ -16,6 +21,22 @@ int main() {
 	DtorFlag<false> local_false{};
 	if (noexcept(local_false.~DtorFlag<false>()))
 		result |= 4;
+
+	Holder<false> holder_false{};
+	if (noexcept(holder_false.member.~DtorFlag<false>()))
+		result |= 8;
+
+	DtorFlag<false> arr_false[1]{};
+	if (noexcept(arr_false[0].~DtorFlag<false>()))
+		result |= 16;
+
+	Holder<true> holder_true{};
+	if (!noexcept(holder_true.member.~DtorFlag<true>()))
+		result |= 32;
+
+	DtorFlag<true> arr_true[1]{};
+	if (!noexcept(arr_true[0].~DtorFlag<true>()))
+		result |= 64;
 
 	return result;
 }

--- a/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
+++ b/tests/test_pseudo_dtor_noexcept_template_temp_ret0.cpp
@@ -1,0 +1,21 @@
+template <bool NoThrow>
+struct DtorFlag {
+	int value;
+	~DtorFlag() noexcept(NoThrow) {}
+};
+
+int main() {
+	int result = 0;
+
+	if (noexcept(DtorFlag<false>{}.~DtorFlag<false>()))
+		result |= 1;
+
+	if (!noexcept(DtorFlag<true>{}.~DtorFlag<true>()))
+		result |= 2;
+
+	DtorFlag<false> local_false{};
+	if (noexcept(local_false.~DtorFlag<false>()))
+		result |= 4;
+
+	return result;
+}


### PR DESCRIPTION
## What changed

- Re-evaluate explicit template destructor `noexcept(expr)` after substituting concrete template arguments.
- Resolve pseudo-destructor `noexcept` checks from constructor/list-init temporary object types before using the legacy destructor-name token lookup.
- Add a regression for `DtorFlag<false>{}.~DtorFlag<false>()` and `DtorFlag<true>{}.~DtorFlag<true>()`.
- Update the template materialization and fallback audit docs with the closed fallback class.

## Why

The previous path copied the pattern destructor's already-evaluated `is_noexcept` flag into each class-template instantiation. For dependent specifiers such as `noexcept(NoThrow)`, that made `DtorFlag<false>` appear nothrow-destructible and kept pseudo-destructor checks dependent on token fallback behavior.

## Validation

- `./build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1 test_pseudo_dtor_noexcept_template_temp_ret0.cpp`
- Focused noexcept/destructor/type-trait cluster
- `pwsh -NoProfile -ExecutionPolicy Bypass -File ./tests/run_all_tests.ps1` (2313 regular tests, 157 expected-fail tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `noexcept` in template destructors now substitutes template parameters and is re-evaluated in the concrete template context.
  * Pseudo-destructor `noexcept` evaluation now resolves object types from temporaries, constructor/list-init forms, member and subscript expressions before falling back to legacy lookup.

* **Tests**
  * Added a regression test covering template-temporary and member destruction `noexcept` cases.

* **Documentation**
  * Added validation/audit entries describing the new `noexcept` evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->