### PR TITLE
[codex] Share call argument lowering helpers

### DIFF
--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1194,6 +1194,7 @@ private:
 	std::unordered_map<StringHandle, std::vector<CachedParamInfo>> function_param_cache_;
 	void applyTypeNodeMetadata(TypedValue& value, const TypeSpecifierNode& type_node);
 	void applyCallParameterBindingMetadata(TypedValue& value, const TypeSpecifierNode& param_type);
+	std::optional<TypedValue> tryBuildSemaBoundCallArgument(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode& param_type, const CallArgReferenceBindingInfo* sema_ref_binding, const Token& token);
 	ExprResult applyCallArgumentConversions(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode* param_type, const Token& token);
 	TypedValue buildOrdinaryCallArgument(const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
 	TypedValue buildReferenceCallArgumentFromDeclaration(const DeclarationNode& decl_node, StringHandle identifier_name);

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1198,6 +1198,7 @@ private:
 	void appendOrdinaryCallArgument(CallOp& call_op, const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
 	void appendReferenceCallArgument(std::vector<TypedValue>& args, const DeclarationNode& decl_node, StringHandle identifier_name);
 	TypedValue buildReferenceCallArgumentFromResult(const ExprResult& argument_result, const Token& token, bool reuse_address_valued_temp);
+	void appendDirectIdentifierCallArgument(std::vector<TypedValue>& args, const DeclarationNode& arg_decl_node, StringHandle identifier_name, CVReferenceQualifier param_ref_qualifier, const ASTNode& argument, const Token& token);
 	TypedValue buildConstructorArgumentValue(const ExprResult& argument_result,
 											 const ASTNode& argument,
 											 const TypeSpecifierNode* param_type,

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1197,6 +1197,7 @@ private:
 	ExprResult applyCallArgumentConversions(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode* param_type, const Token& token);
 	void appendOrdinaryCallArgument(CallOp& call_op, const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
 	void appendReferenceCallArgument(std::vector<TypedValue>& args, const DeclarationNode& decl_node, StringHandle identifier_name);
+	TypedValue buildReferenceCallArgumentFromResult(const ExprResult& argument_result, const Token& token, bool reuse_address_valued_temp);
 	TypedValue buildConstructorArgumentValue(const ExprResult& argument_result,
 											 const ASTNode& argument,
 											 const TypeSpecifierNode* param_type,

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1195,10 +1195,10 @@ private:
 	void applyTypeNodeMetadata(TypedValue& value, const TypeSpecifierNode& type_node);
 	void applyCallParameterBindingMetadata(TypedValue& value, const TypeSpecifierNode& param_type);
 	ExprResult applyCallArgumentConversions(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode* param_type, const Token& token);
-	void appendOrdinaryCallArgument(CallOp& call_op, const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
-	void appendReferenceCallArgument(std::vector<TypedValue>& args, const DeclarationNode& decl_node, StringHandle identifier_name);
+	TypedValue buildOrdinaryCallArgument(const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
+	TypedValue buildReferenceCallArgumentFromDeclaration(const DeclarationNode& decl_node, StringHandle identifier_name);
 	TypedValue buildReferenceCallArgumentFromResult(const ExprResult& argument_result, const Token& token, bool reuse_address_valued_temp);
-	void appendDirectIdentifierCallArgument(std::vector<TypedValue>& args, const DeclarationNode& arg_decl_node, StringHandle identifier_name, CVReferenceQualifier param_ref_qualifier, const ASTNode& argument, const Token& token);
+	TypedValue buildDirectIdentifierCallArgument(const DeclarationNode& arg_decl_node, StringHandle identifier_name, CVReferenceQualifier param_ref_qualifier, const ASTNode& argument, const Token& token);
 	TypedValue buildConstructorArgumentValue(const ExprResult& argument_result,
 											 const ASTNode& argument,
 											 const TypeSpecifierNode* param_type,

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1359,7 +1359,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 					// Argument is a reference variable being passed to a reference parameter
 					// Pass the identifier name directly - the IRConverter will use MOV to
 					// load the address stored in the reference variable
-					appendReferenceCallArgument(call_arguments, *decl_ptr, identifier_name);
+					call_arguments.push_back(buildReferenceCallArgumentFromDeclaration(*decl_ptr, identifier_name));
 					arg_index++;
 					return;	// Skip the rest of the processing
 				}
@@ -1595,13 +1595,12 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			}
 
 			const auto& arg_decl_node = *decl_ptr;
-			appendDirectIdentifierCallArgument(
-				call_arguments,
+			call_arguments.push_back(buildDirectIdentifierCallArgument(
 				arg_decl_node,
 				identifier_name,
 				param_ref_qualifier,
 				argument,
-				callExprNode.called_from());
+				callExprNode.called_from()));
 			return;
 		} else {
 			// Not an identifier - could be a literal, expression result, etc.

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1691,93 +1691,10 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			if (param_ref_qualifier != CVReferenceQualifier::None) {
 				// Parameter expects a reference, but argument is not an identifier
 				// We need to materialize the value into a temporary and pass its address
-
-				// Check if this is a literal value (has unsigned long long or double in value)
-				bool is_literal = (std::holds_alternative<unsigned long long>(argumentIrOperands.value) ||
-								   std::holds_alternative<double>(argumentIrOperands.value));
-
-				if (is_literal) {
-					// Materialize the literal into a temporary variable
-					TypeCategory literal_type = argumentIrOperands.typeEnum();
-					int literal_size = argumentIrOperands.size_in_bits.value;
-
-					// Create a temporary variable to hold the literal value
-					TempVar temp_var = var_counter.next();
-
-					// Generate an assignment IR to store the literal using typed payload
-					AssignmentOp assign_op;
-					assign_op.result = temp_var;	 // unused but required
-
-					// Convert IrOperand to IrValue for the literal
-					IrValue rhs_value;
-					if (const auto* ull_val = std::get_if<unsigned long long>(&argumentIrOperands.value)) {
-						rhs_value = *ull_val;
-					} else if (const auto* d_val = std::get_if<double>(&argumentIrOperands.value)) {
-						rhs_value = *d_val;
-					}
-
-					// Create TypedValue for lhs and rhs
-					assign_op.lhs = makeTypedValue(literal_type, SizeInBits{static_cast<int>(literal_size)}, temp_var);
-					assign_op.rhs = makeTypedValue(literal_type, SizeInBits{static_cast<int>(literal_size)}, rhs_value);
-
-					ir_.addInstruction(IrInstruction(IrOpcode::Assignment, std::move(assign_op), Token()));
-
-					// Now take the address of the temporary
-					TempVar addr_var = emitAddressOf(literal_type, literal_size, IrValue(temp_var));
-
-					// Pass the address
-					appendArgumentValueWithReference(
-						argumentIrOperands.type_index.withCategory(literal_type),
-						SizeInBits{POINTER_SIZE_BITS},
-						IrValue(addr_var),
-						ReferenceQualifier::LValueReference);
-				} else {
-						// Not a literal (expression result in a TempVar) - check if it needs address taken
-					if (std::holds_alternative<TempVar>(argumentIrOperands.value)) {
-						TypeCategory expr_type = argumentIrOperands.typeEnum();
-						int expr_size = argumentIrOperands.size_in_bits.value;
-						TempVar expr_var = std::get<TempVar>(argumentIrOperands.value);
-
-						// Check if the TempVar already holds an address
-						// This can happen when:
-						// 1. It's the result of a cast to reference (xvalue/lvalue)
-						// 2. It's a 64-bit struct (pointer to struct)
-						// 3. It has lvalue/xvalue metadata indicating it's already an address
-						bool is_already_address = false;
-
-						// Check for xvalue/lvalue metadata (from reference casts)
-						auto& metadata_storage = GlobalTempVarMetadataStorage::instance();
-						if (metadata_storage.hasMetadata(expr_var)) {
-							TempVarMetadata metadata = metadata_storage.getMetadata(expr_var);
-							if (metadata.category == ValueCategory::LValue ||
-								metadata.category == ValueCategory::XValue) {
-								is_already_address = true;
-							}
-						}
-
-						// Fallback heuristic: 64-bit struct type likely holds an address
-						if (!is_already_address && expr_size == 64 && expr_type == TypeCategory::Struct) {
-							is_already_address = true;
-						}
-
-						if (is_already_address) {
-							// Already an address - pass through directly
-							appendArgumentIrResult(argumentIrOperands);
-						} else {
-								// Need to take address of the value
-							TempVar addr_var = emitAddressOf(expr_type, expr_size, IrValue(expr_var));
-
-							appendArgumentValueWithReference(
-								argumentIrOperands.type_index.withCategory(expr_type),
-								SizeInBits{POINTER_SIZE_BITS},
-								IrValue(addr_var),
-								ReferenceQualifier::LValueReference);
-						}
-					} else {
-						// Fallback - just pass through directly
-						appendArgumentIrResult(argumentIrOperands);
-					}
-				}
+				call_arguments.push_back(buildReferenceCallArgumentFromResult(
+					argumentIrOperands,
+					callExprNode.called_from(),
+					true));
 			} else {
 				// Parameter doesn't expect a reference - pass through as-is
 				appendArgumentIrResult(argumentIrOperands);

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1461,12 +1461,9 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 				}
 			}
 
-			// sema should annotate all standard primitive argument conversions.
-			// Non-arithmetic types (struct, user_defined, enum, auto, function_pointer)
-			// are outside sema's current scope — keep fallback unconditionally.
-			// For arithmetic types, assert when sema missed the annotation.
+			// sema should annotate all resolved standard argument conversions.
 			// Exception: hasUnresolvedCallArgs means sema tried but couldn't resolve the callee
-			// (e.g. template specialization) — Phase 16+ work item.
+			// (e.g. template specialization), so keep conversion recovery for that path.
 			if (!sema_applied_arg_conversion &&
 				param_ref_qualifier == CVReferenceQualifier::None &&
 				param_type->pointer_depth() == 0 &&
@@ -1474,9 +1471,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 				TypeConversionResult standard_conversion = can_convert_type(arg_type, param_base_type);
 				if (standard_conversion.is_valid &&
 					standard_conversion.rank != ConversionRank::UserDefined) {
-					if (sema_normalized_current_function_ &&
-						is_standard_arithmetic_type(arg_type) && is_standard_arithmetic_type(param_base_type) &&
-						!sema_->hasUnresolvedCallArgs(sema_call_key)) {
+					if (sema_normalized_current_function_ && !sema_->hasUnresolvedCallArgs(sema_call_key)) {
 						throw InternalError(std::string("Phase 15: sema missed function call argument conversion (") + std::string(getTypeName(arg_type)) + " -> " + std::string(getTypeName(param_base_type)) + ")");
 					}
 					argumentIrOperands = generateTypeConversion(argumentIrOperands, arg_type, param_base_type, callExprNode.called_from());

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -399,23 +399,6 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	auto appendArgumentIrResult = [&](const ExprResult& result) {
 		call_arguments.push_back(toTypedValue(result));
 	};
-	auto appendArgumentValue = [&](TypeIndex type_index, SizeInBits size_in_bits, IrValue value) {
-		if (!type_index.is_valid()) {
-			type_index = nativeTypeIndex(type_index.category());
-		}
-		call_arguments.push_back(makeTypedValue(type_index, size_in_bits, std::move(value)));
-	};
-	auto appendArgumentValueWithReference = [&](TypeIndex type_index, SizeInBits size_in_bits, IrValue value, ReferenceQualifier ref_qualifier) {
-		call_arguments.push_back(makeTypedValue(type_index, size_in_bits, std::move(value), ref_qualifier));
-	};
-	auto appendPointerArgumentValue = [&](TypeIndex type_index, IrValue value) {
-		if (!type_index.is_valid()) {
-			type_index = nativeTypeIndex(type_index.category());
-		}
-		TypedValue arg = makeTypedValue(type_index, SizeInBits{POINTER_SIZE_BITS}, std::move(value));
-		arg.pointer_depth = PointerDepth{1};
-		call_arguments.push_back(std::move(arg));
-	};
 
 	const auto& decl_node = callExprNode.callee().declaration();
 	StringHandle func_name = decl_node.identifier_token().handle();
@@ -1617,74 +1600,14 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			}
 
 			const auto& arg_decl_node = *decl_ptr;
-			const auto& type_node = arg_decl_node.type_specifier_node();
-
-				// Enumerator constants should be passed as immediate values, not variable references.
-			if (std::optional<ExprResult> enumerator_constant = tryMakeEnumeratorConstantExpr(
-					type_node,
-					identifier_name)) {
-				appendArgumentIrResult(*enumerator_constant);
-				return;
-			}
-
-			// C++20 [conv.array]: Arrays decay to pointers when passed to functions.
-			// Primary path: sema annotates the argument expression with
-			// StandardConversionKind::ArrayToPointer when it visits a sema-normalised
-			// function body.  Fallback: when sema did not normalise the current body
-			// (e.g. template instantiation codegen) fall back to inspecting
-			// DeclarationNode::is_array() directly.
-			bool needs_array_decay = false;
-			if (argument.is<ExpressionNode>()) {
-				const void* arg_key = &argument.as<ExpressionNode>();
-				const auto arg_slot = sema_->getSlot(arg_key);
-				if (arg_slot.has_value() && arg_slot->has_cast()) {
-					const ImplicitCastInfo& ci =
-						sema_->castInfoTable()[arg_slot->cast_info_index.value - 1];
-					needs_array_decay =
-						(ci.cast_kind == StandardConversionKind::ArrayToPointer);
-				}
-			}
-			// Fallback only for non-sema-normalized bodies (e.g. template-instantiation
-			// codegen); sema-normalized functions must carry the ArrayToPointer cast.
-			if (!needs_array_decay && !sema_normalized_current_function_) {
-				needs_array_decay = arg_decl_node.is_array();
-			}
-
-			if (needs_array_decay) {
-				// Emit AddressOf to get the address of the array's first element.
-				TempVar addr_var = emitAddressOf(type_node.category(), static_cast<int>(type_node.size_in_bits()), IrValue(identifier_name));
-
-				appendPointerArgumentValue(
-					type_node.type_index().withCategory(type_node.type()),
-					IrValue(addr_var));
-			} else if (param_ref_qualifier != CVReferenceQualifier::None) {
-				// Parameter expects a reference - pass the address of the argument
-				appendReferenceCallArgument(call_arguments, arg_decl_node, identifier_name);
-			} else if (type_node.is_reference() || type_node.is_rvalue_reference()) {
-				// Argument is a reference but parameter expects a value - dereference
-				TempVar deref_var = emitDereference(type_node.category(), 64, 1,
-													identifier_name);
-
-				// Pass the dereferenced value
-				appendArgumentValue(
-					type_node.type_index().withCategory(type_node.type()),
-					SizeInBits{static_cast<int>(type_node.size_in_bits())},
-					IrValue(deref_var));
-			} else {
-				// Regular variable - pass by value
-				// For pointer types, size is always 64 bits regardless of pointee type
-				int arg_size = (type_node.pointer_depth() > 0) ? 64 : static_cast<int>(type_node.size_in_bits());
-				if (type_node.pointer_depth() > 0) {
-					appendPointerArgumentValue(
-						type_node.type_index().withCategory(type_node.type()),
-						IrValue(identifier_name));
-				} else {
-					appendArgumentValue(
-						type_node.type_index().withCategory(type_node.type()),
-						SizeInBits{arg_size},
-						IrValue(identifier_name));
-				}
-			}
+			appendDirectIdentifierCallArgument(
+				call_arguments,
+				arg_decl_node,
+				identifier_name,
+				param_ref_qualifier,
+				argument,
+				callExprNode.called_from());
+			return;
 		} else {
 			// Not an identifier - could be a literal, expression result, etc.
 			// Check if parameter expects a reference and argument is a literal

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1380,10 +1380,10 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		ExprResult argumentIrOperands = visitExpressionNode(argument.as<ExpressionNode>(), arg_context);
 		arg_index++;
 
-		if (param_type && sema_ref_binding && sema_ref_binding->is_valid()) {
-			if (auto sema_bound_arg = tryApplySemaCallArgReferenceBinding(
+		if (param_type) {
+			if (auto sema_bound_arg = tryBuildSemaBoundCallArgument(
 					argumentIrOperands, argument, *param_type, sema_ref_binding, callExprNode.called_from())) {
-				appendArgumentIrResult(*sema_bound_arg);
+				call_arguments.push_back(std::move(*sema_bound_arg));
 				return;
 			}
 		}

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1906,9 +1906,9 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					// Check if parameter expects a reference
 					if (!sema_ref_binding_applied &&
 						param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
-						appendReferenceCallArgument(call_op.args, decl_node, identifier_name);
+						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(decl_node, identifier_name));
 					} else {
-						appendOrdinaryCallArgument(call_op, argument, param_type, sema_evaluated_arg, callExprNode.called_from());
+						call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
 					}
 				} else if (symbol.has_value() && symbol->is<VariableDeclarationNode>()) {
 					// Handle VariableDeclarationNode (local variables)
@@ -1918,12 +1918,12 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					// Check if parameter expects a reference
 					if (!sema_ref_binding_applied &&
 						param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
-						appendReferenceCallArgument(call_op.args, decl_node, identifier_name);
+						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(decl_node, identifier_name));
 					} else {
-						appendOrdinaryCallArgument(call_op, argument, param_type, sema_evaluated_arg, callExprNode.called_from());
+						call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
 					}
 				} else {
-					appendOrdinaryCallArgument(call_op, argument, param_type, sema_evaluated_arg, callExprNode.called_from());
+					call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
 				}
 			} else {
 				// Not an identifier - reuse the already-evaluated result when sema
@@ -1943,7 +1943,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 						true));
 				} else {
 					// Parameter doesn't expect a reference - pass through as-is
-					appendOrdinaryCallArgument(call_op, argument, param_type, argument_result, callExprNode.called_from());
+					call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, argument_result, callExprNode.called_from()));
 				}
 			}
 

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1896,8 +1896,23 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 
 				// Check if this is a function being passed as a function pointer argument
 				if (symbol.has_value() && symbol->is<FunctionDeclarationNode>()) {
-					// Function being passed as function pointer - just pass its name
-					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(identifier_name)));
+					// Function being passed as function pointer — emit a FunctionAddress
+					// instruction to load the global function's address into a TempVar,
+					// then pass the TempVar.  Passing the raw StringHandle directly would
+					// make the codegen look the name up in the local variables map (where
+					// it is not present), causing a code-generation error.
+					const auto& fp_func_decl = symbol->as<FunctionDeclarationNode>();
+					std::string_view fp_mangled = generateMangledNameForCall(fp_func_decl, StringHandle{}, {});
+					TempVar func_addr_var = var_counter.next();
+					FunctionAddressOp fa_op;
+					fa_op.result.setType(TypeCategory::FunctionPointer);
+					fa_op.result.ir_type = IrType::FunctionPointer;
+					fa_op.result.size_in_bits = SizeInBits{64};
+					fa_op.result.value = func_addr_var;
+					fa_op.function_name = identifier_name;
+					fa_op.mangled_name = StringTable::getOrInternStringHandle(fp_mangled);
+					ir_.addInstruction(IrInstruction(IrOpcode::FunctionAddress, std::move(fa_op), callExprNode.called_from()));
+					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(func_addr_var)));
 				} else if (symbol.has_value()) {
 					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
 					// Check if parameter expects a reference

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1937,66 +1937,10 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
 					// Parameter expects a reference, but argument is not an identifier
 					// We need to materialize the value into a temporary and pass its address
-
-					// Check if this is a literal value
-					bool is_literal =
-						std::holds_alternative<unsigned long long>(argument_result.value) ||
-						std::holds_alternative<double>(argument_result.value);
-
-					if (is_literal) {
-						// Materialize the literal into a temporary variable
-						TypeCategory literal_type = argument_result.typeEnum();
-						int literal_size = argument_result.size_in_bits.value;
-
-						// Create a temporary variable to hold the literal value
-						TempVar temp_var = var_counter.next();
-
-						// Generate an assignment IR to store the literal using typed payload
-						AssignmentOp assign_op;
-						assign_op.result = temp_var; // unused but required
-
-						// Convert IrOperand to IrValue for the literal
-						IrValue rhs_value;
-						if (const auto* ull_val = std::get_if<unsigned long long>(&argument_result.value)) {
-							rhs_value = *ull_val;
-						} else if (const auto* d_val = std::get_if<double>(&argument_result.value)) {
-							rhs_value = *d_val;
-						}
-
-						// Create TypedValue for lhs and rhs
-						assign_op.lhs = makeTypedValue(literal_type, SizeInBits{static_cast<int>(literal_size)}, temp_var);
-						assign_op.rhs = makeTypedValue(literal_type, SizeInBits{static_cast<int>(literal_size)}, rhs_value);
-
-						ir_.addInstruction(IrInstruction(IrOpcode::Assignment, std::move(assign_op), Token()));
-
-						// Now take the address of the temporary
-						TempVar addr_var = emitAddressOf(literal_type, literal_size, IrValue(temp_var));
-
-						// Pass the address
-						call_op.args.push_back(makeTypedValue(
-							argument_result.type_index.withCategory(literal_type),
-							SizeInBits{POINTER_SIZE_BITS},
-							IrValue(addr_var),
-							ReferenceQualifier::LValueReference));
-					} else {
-						// Not a literal (expression result in a TempVar) - take its address
-						if (std::holds_alternative<TempVar>(argument_result.value)) {
-							TypeCategory expr_type = argument_result.typeEnum();
-							int expr_size = argument_result.size_in_bits.value;
-							TempVar expr_var = std::get<TempVar>(argument_result.value);
-
-							TempVar addr_var = emitAddressOf(expr_type, expr_size, IrValue(expr_var));
-
-							call_op.args.push_back(makeTypedValue(
-								argument_result.type_index.withCategory(expr_type),
-								SizeInBits{POINTER_SIZE_BITS},
-								IrValue(addr_var),
-								ReferenceQualifier::LValueReference));
-						} else {
-							// Fallback - just pass through
-							call_op.args.push_back(toTypedValue(argument_result));
-						}
-					}
+					call_op.args.push_back(buildReferenceCallArgumentFromResult(
+						argument_result,
+						callExprNode.called_from(),
+						true));
 				} else {
 					// Parameter doesn't expect a reference - pass through as-is
 					appendOrdinaryCallArgument(call_op, argument, param_type, argument_result, callExprNode.called_from());

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1894,31 +1894,18 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 			if (std::holds_alternative<IdentifierNode>(argument.as<ExpressionNode>())) {
 				const auto& identifier = std::get<IdentifierNode>(argument.as<ExpressionNode>());
 				StringHandle identifier_name = identifier.nameHandle();
-				const std::optional<ASTNode> symbol = symbol_table.lookup(identifier.name());
+				const std::optional<ASTNode> symbol = lookupSymbol(identifier_name);
 
 				// Check if this is a function being passed as a function pointer argument
 				if (symbol.has_value() && symbol->is<FunctionDeclarationNode>()) {
 					// Function being passed as function pointer - just pass its name
 					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(identifier_name)));
-				} else if (symbol.has_value() && symbol->is<DeclarationNode>()) {
-					const auto& decl_node = symbol->as<DeclarationNode>();
-
+				} else if (symbol.has_value()) {
+					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
 					// Check if parameter expects a reference
-					if (!sema_ref_binding_applied &&
+					if (decl_node && !sema_ref_binding_applied &&
 						param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
-						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(decl_node, identifier_name));
-					} else {
-						call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
-					}
-				} else if (symbol.has_value() && symbol->is<VariableDeclarationNode>()) {
-					// Handle VariableDeclarationNode (local variables)
-					const auto& var_decl = symbol->as<VariableDeclarationNode>();
-					const auto& decl_node = var_decl.declaration();
-
-					// Check if parameter expects a reference
-					if (!sema_ref_binding_applied &&
-						param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
-						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(decl_node, identifier_name));
+						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(*decl_node, identifier_name));
 					} else {
 						call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
 					}

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1878,11 +1878,9 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 													? ExpressionContext::LValueAddress
 													: ExpressionContext::Load;
 				sema_evaluated_arg = visitExpressionNode(argument.as<ExpressionNode>(), arg_context);
-				if (auto sema_bound_arg = tryApplySemaCallArgReferenceBinding(
+				if (auto sema_bound_arg = tryBuildSemaBoundCallArgument(
 						*sema_evaluated_arg, argument, *param_type, sema_ref_binding, callExprNode.called_from())) {
-					TypedValue typed_arg = toTypedValue(*sema_bound_arg);
-					applyCallParameterBindingMetadata(typed_arg, *param_type);
-					call_op.args.push_back(std::move(typed_arg));
+					call_op.args.push_back(std::move(*sema_bound_arg));
 					arg_index++;
 					sema_ref_binding_applied = true;
 					return;

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -484,6 +484,86 @@ TypedValue AstToIr::buildReferenceCallArgumentFromResult(
 	return toTypedValue(argument_result);
 }
 
+void AstToIr::appendDirectIdentifierCallArgument(
+	std::vector<TypedValue>& args,
+	const DeclarationNode& arg_decl_node,
+	StringHandle identifier_name,
+	CVReferenceQualifier param_ref_qualifier,
+	const ASTNode& argument,
+	const Token& token) {
+	const TypeSpecifierNode& type_node = arg_decl_node.type_specifier_node();
+
+	if (std::optional<ExprResult> enumerator_constant = tryMakeEnumeratorConstantExpr(
+			type_node,
+			identifier_name)) {
+		args.push_back(toTypedValue(*enumerator_constant));
+		return;
+	}
+
+	bool needs_array_decay = false;
+	if (argument.is<ExpressionNode>()) {
+		const void* arg_key = &argument.as<ExpressionNode>();
+		const auto arg_slot = sema_->getSlot(arg_key);
+		if (arg_slot.has_value() && arg_slot->has_cast()) {
+			const ImplicitCastInfo& ci =
+				sema_->castInfoTable()[arg_slot->cast_info_index.value - 1];
+			needs_array_decay =
+				(ci.cast_kind == StandardConversionKind::ArrayToPointer);
+		}
+	}
+	if (!needs_array_decay && !sema_normalized_current_function_) {
+		needs_array_decay = arg_decl_node.is_array();
+	}
+
+	if (needs_array_decay) {
+		TempVar addr_var = emitAddressOf(
+			type_node.category(),
+			static_cast<int>(type_node.size_in_bits()),
+			IrValue(identifier_name),
+			token);
+		TypedValue arg = makeTypedValue(
+			type_node.type_index().withCategory(type_node.type()),
+			SizeInBits{POINTER_SIZE_BITS},
+			IrValue(addr_var));
+		arg.pointer_depth = PointerDepth{1};
+		args.push_back(std::move(arg));
+		return;
+	}
+
+	if (param_ref_qualifier != CVReferenceQualifier::None) {
+		appendReferenceCallArgument(args, arg_decl_node, identifier_name);
+		return;
+	}
+
+	if (type_node.is_reference() || type_node.is_rvalue_reference()) {
+		TempVar deref_var = emitDereference(
+			type_node.category(),
+			POINTER_SIZE_BITS,
+			1,
+			identifier_name);
+		args.push_back(makeTypedValue(
+			type_node.type_index().withCategory(type_node.type()),
+			SizeInBits{static_cast<int>(type_node.size_in_bits())},
+			IrValue(deref_var)));
+		return;
+	}
+
+	if (type_node.pointer_depth() > 0) {
+		TypedValue arg = makeTypedValue(
+			type_node.type_index().withCategory(type_node.type()),
+			SizeInBits{POINTER_SIZE_BITS},
+			IrValue(identifier_name));
+		arg.pointer_depth = PointerDepth{static_cast<int>(type_node.pointer_depth())};
+		args.push_back(std::move(arg));
+		return;
+	}
+
+	args.push_back(makeTypedValue(
+		type_node.type_index().withCategory(type_node.type()),
+		SizeInBits{static_cast<int>(type_node.size_in_bits())},
+		IrValue(identifier_name)));
+}
+
 TypedValue AstToIr::buildConstructorArgumentValue(
 	const ExprResult& argument_result,
 	const ASTNode& argument,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -465,9 +465,6 @@ TypedValue AstToIr::buildReferenceCallArgumentFromResult(
 					metadata.category == ValueCategory::LValue ||
 					metadata.category == ValueCategory::XValue;
 			}
-			if (!is_already_address && expr_size == POINTER_SIZE_BITS && expr_type == TypeCategory::Struct) {
-				is_already_address = true;
-			}
 		}
 		if (is_already_address) {
 			return toTypedValue(argument_result);
@@ -511,10 +508,6 @@ void AstToIr::appendDirectIdentifierCallArgument(
 				(ci.cast_kind == StandardConversionKind::ArrayToPointer);
 		}
 	}
-	if (!needs_array_decay && !sema_normalized_current_function_) {
-		needs_array_decay = arg_decl_node.is_array();
-	}
-
 	if (needs_array_decay) {
 		TempVar addr_var = emitAddressOf(
 			type_node.category(),

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -418,6 +418,72 @@ void AstToIr::appendReferenceCallArgument(
 		ReferenceQualifier::LValueReference));
 }
 
+TypedValue AstToIr::buildReferenceCallArgumentFromResult(
+	const ExprResult& argument_result,
+	const Token& token,
+	bool reuse_address_valued_temp) {
+	bool is_literal =
+		std::holds_alternative<unsigned long long>(argument_result.value) ||
+		std::holds_alternative<double>(argument_result.value);
+	if (is_literal) {
+		TypeCategory literal_type = argument_result.typeEnum();
+		int literal_size = argument_result.size_in_bits.value;
+		TempVar temp_var = var_counter.next();
+
+		AssignmentOp assign_op;
+		assign_op.result = temp_var;
+		assign_op.lhs = makeTypedValue(literal_type, SizeInBits{literal_size}, temp_var);
+
+		IrValue rhs_value;
+		if (const auto* ull_val = std::get_if<unsigned long long>(&argument_result.value)) {
+			rhs_value = *ull_val;
+		} else if (const auto* d_val = std::get_if<double>(&argument_result.value)) {
+			rhs_value = *d_val;
+		}
+		assign_op.rhs = makeTypedValue(literal_type, SizeInBits{literal_size}, rhs_value);
+		ir_.addInstruction(IrInstruction(IrOpcode::Assignment, std::move(assign_op), token));
+
+		TempVar addr_var = emitAddressOf(literal_type, literal_size, IrValue(temp_var), token);
+		return makeTypedValue(
+			argument_result.type_index.withCategory(literal_type),
+			SizeInBits{POINTER_SIZE_BITS},
+			IrValue(addr_var),
+			ReferenceQualifier::LValueReference);
+	}
+
+	if (std::holds_alternative<TempVar>(argument_result.value)) {
+		TypeCategory expr_type = argument_result.typeEnum();
+		int expr_size = argument_result.size_in_bits.value;
+		TempVar expr_var = std::get<TempVar>(argument_result.value);
+
+		bool is_already_address = false;
+		if (reuse_address_valued_temp) {
+			auto& metadata_storage = GlobalTempVarMetadataStorage::instance();
+			if (metadata_storage.hasMetadata(expr_var)) {
+				TempVarMetadata metadata = metadata_storage.getMetadata(expr_var);
+				is_already_address =
+					metadata.category == ValueCategory::LValue ||
+					metadata.category == ValueCategory::XValue;
+			}
+			if (!is_already_address && expr_size == POINTER_SIZE_BITS && expr_type == TypeCategory::Struct) {
+				is_already_address = true;
+			}
+		}
+		if (is_already_address) {
+			return toTypedValue(argument_result);
+		}
+
+		TempVar addr_var = emitAddressOf(expr_type, expr_size, IrValue(expr_var), token);
+		return makeTypedValue(
+			argument_result.type_index.withCategory(expr_type),
+			SizeInBits{POINTER_SIZE_BITS},
+			IrValue(addr_var),
+			ReferenceQualifier::LValueReference);
+	}
+
+	return toTypedValue(argument_result);
+}
+
 TypedValue AstToIr::buildConstructorArgumentValue(
 	const ExprResult& argument_result,
 	const ASTNode& argument,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -380,8 +380,7 @@ ExprResult AstToIr::applyCallArgumentConversions(
 	return applyConstructorArgConversion(argument_result, argument, *param_type, token);
 }
 
-void AstToIr::appendOrdinaryCallArgument(
-	CallOp& call_op,
+TypedValue AstToIr::buildOrdinaryCallArgument(
 	const ASTNode& argument,
 	const TypeSpecifierNode* param_type,
 	const std::optional<ExprResult>& evaluated_arg,
@@ -390,32 +389,30 @@ void AstToIr::appendOrdinaryCallArgument(
 									 ? *evaluated_arg
 									 : visitExpressionNode(argument.as<ExpressionNode>());
 	argument_result = applyCallArgumentConversions(argument_result, argument, param_type, token);
-	call_op.args.push_back(toTypedValue(argument_result));
+	return toTypedValue(argument_result);
 }
 
-void AstToIr::appendReferenceCallArgument(
-	std::vector<TypedValue>& args,
+TypedValue AstToIr::buildReferenceCallArgumentFromDeclaration(
 	const DeclarationNode& decl_node,
 	StringHandle identifier_name) {
 	const TypeSpecifierNode& type_node = decl_node.type_specifier_node();
 	if (type_node.is_reference() || type_node.is_rvalue_reference()) {
-		args.push_back(makeTypedValue(
+		return makeTypedValue(
 			type_node.type_index().withCategory(type_node.type()),
 			SizeInBits{POINTER_SIZE_BITS},
 			IrValue(identifier_name),
-			ReferenceQualifier::LValueReference));
-		return;
+			ReferenceQualifier::LValueReference);
 	}
 
 	TempVar addr_var = emitAddressOf(
 		type_node.category(),
 		static_cast<int>(type_node.size_in_bits()),
 		IrValue(identifier_name));
-	args.push_back(makeTypedValue(
+	return makeTypedValue(
 		type_node.type_index().withCategory(type_node.type()),
 		SizeInBits{POINTER_SIZE_BITS},
 		IrValue(addr_var),
-		ReferenceQualifier::LValueReference));
+		ReferenceQualifier::LValueReference);
 }
 
 TypedValue AstToIr::buildReferenceCallArgumentFromResult(
@@ -481,8 +478,7 @@ TypedValue AstToIr::buildReferenceCallArgumentFromResult(
 	return toTypedValue(argument_result);
 }
 
-void AstToIr::appendDirectIdentifierCallArgument(
-	std::vector<TypedValue>& args,
+TypedValue AstToIr::buildDirectIdentifierCallArgument(
 	const DeclarationNode& arg_decl_node,
 	StringHandle identifier_name,
 	CVReferenceQualifier param_ref_qualifier,
@@ -493,8 +489,7 @@ void AstToIr::appendDirectIdentifierCallArgument(
 	if (std::optional<ExprResult> enumerator_constant = tryMakeEnumeratorConstantExpr(
 			type_node,
 			identifier_name)) {
-		args.push_back(toTypedValue(*enumerator_constant));
-		return;
+		return toTypedValue(*enumerator_constant);
 	}
 
 	bool needs_array_decay = false;
@@ -519,13 +514,11 @@ void AstToIr::appendDirectIdentifierCallArgument(
 			SizeInBits{POINTER_SIZE_BITS},
 			IrValue(addr_var));
 		arg.pointer_depth = PointerDepth{1};
-		args.push_back(std::move(arg));
-		return;
+		return arg;
 	}
 
 	if (param_ref_qualifier != CVReferenceQualifier::None) {
-		appendReferenceCallArgument(args, arg_decl_node, identifier_name);
-		return;
+		return buildReferenceCallArgumentFromDeclaration(arg_decl_node, identifier_name);
 	}
 
 	if (type_node.is_reference() || type_node.is_rvalue_reference()) {
@@ -534,11 +527,10 @@ void AstToIr::appendDirectIdentifierCallArgument(
 			POINTER_SIZE_BITS,
 			1,
 			identifier_name);
-		args.push_back(makeTypedValue(
+		return makeTypedValue(
 			type_node.type_index().withCategory(type_node.type()),
 			SizeInBits{static_cast<int>(type_node.size_in_bits())},
-			IrValue(deref_var)));
-		return;
+			IrValue(deref_var));
 	}
 
 	if (type_node.pointer_depth() > 0) {
@@ -547,14 +539,13 @@ void AstToIr::appendDirectIdentifierCallArgument(
 			SizeInBits{POINTER_SIZE_BITS},
 			IrValue(identifier_name));
 		arg.pointer_depth = PointerDepth{static_cast<int>(type_node.pointer_depth())};
-		args.push_back(std::move(arg));
-		return;
+		return arg;
 	}
 
-	args.push_back(makeTypedValue(
+	return makeTypedValue(
 		type_node.type_index().withCategory(type_node.type()),
 		SizeInBits{static_cast<int>(type_node.size_in_bits())},
-		IrValue(identifier_name)));
+		IrValue(identifier_name));
 }
 
 TypedValue AstToIr::buildConstructorArgumentValue(

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -362,6 +362,31 @@ void AstToIr::applyCallParameterBindingMetadata(TypedValue& value, const TypeSpe
 	}
 }
 
+std::optional<TypedValue> AstToIr::tryBuildSemaBoundCallArgument(
+	ExprResult argument_result,
+	const ASTNode& argument,
+	const TypeSpecifierNode& param_type,
+	const CallArgReferenceBindingInfo* sema_ref_binding,
+	const Token& token) {
+	if (!sema_ref_binding || !sema_ref_binding->is_valid()) {
+		return std::nullopt;
+	}
+
+	std::optional<ExprResult> sema_bound_arg = tryApplySemaCallArgReferenceBinding(
+		argument_result,
+		argument,
+		param_type,
+		sema_ref_binding,
+		token);
+	if (!sema_bound_arg) {
+		return std::nullopt;
+	}
+
+	TypedValue typed_arg = toTypedValue(*sema_bound_arg);
+	applyCallParameterBindingMetadata(typed_arg, param_type);
+	return typed_arg;
+}
+
 ExprResult AstToIr::applyCallArgumentConversions(
 	ExprResult argument_result,
 	const ASTNode& argument,


### PR DESCRIPTION
## Summary

- Share direct and member call argument lowering through common `TypedValue` builders.
- Move identifier, declaration-reference, result-reference, and sema-bound reference argument typing into helper paths.
- Remove redundant IRGen fallbacks now covered by sema metadata for array decay and address-valued temporaries, and tighten standard conversion recovery for normalized resolved calls.

## Validation

- `./build_flashcpp.bat`
- Focused direct/member call reference, array decay, enum conversion, member function, and type-index tests
- `pwsh tests/run_all_tests.ps1` passed: 2257 regular tests, 164 expected failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal function call argument handling to improve type binding, reference argument processing, and argument conversion logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->