### PR TITLE
Harden template instantiation fallbacks

### DIFF
--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1771,22 +1771,12 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 	if (context.sema) {
 		(void)context.sema->ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
-	} else if (context.parser && LazyMemberInstantiationRegistry::getInstance().needsInstantiation(
-									 LazyMemberKey::anyConst(
-										 context.struct_info->name,
-										 function_name_handle))) {
-		auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(
-			LazyMemberKey::anyConst(
-				context.struct_info->name,
-				function_name_handle));
-		if (lazy_info_opt.has_value()) {
-			context.parser->instantiateLazyMemberFunction(*lazy_info_opt);
+	} else if (context.parser) {
+		LazyMemberKey member_key = LazyMemberKey::anyConst(
+			context.struct_info->name,
+			function_name_handle);
+		if (context.parser->instantiateLazyMemberIfNeeded(member_key).has_value()) {
 			context.normalizePendingSemanticRoots();
-			LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-				LazyMemberKey::exact(
-					context.struct_info->name,
-					function_name_handle,
-					lazy_info_opt->identity.is_const_method));
 		}
 	}
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1025,14 +1025,10 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			// Try to trigger lazy member function instantiation for the target
 			StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
 			StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
-			auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
 			LazyMemberKey member_key = LazyMemberKey::anyConst(inst_name_handle, member_handle);
-			if (lazy_registry.needsInstantiation(member_key)) {
-				auto lazy_info = lazy_registry.getLazyMemberInfo(member_key);
-				if (lazy_info.has_value()) {
-					parser_.instantiateLazyMemberFunction(*lazy_info);
+			if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+				if (parser_.instantiateLazyMemberIfNeeded(member_key).has_value()) {
 					normalizePendingSemanticRoots();
-					lazy_registry.markInstantiated(inst_name_handle, member_handle, lazy_info->identity.is_const_method);
 				}
 			}
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1671,41 +1671,11 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 			const TemplateTypeArg& subst = it->second;
 			FLASH_LOG(Templates, Debug, "  Substituting template parameter: ", type_name,
 					  " -> base_type=", (int)subst.typeEnum(), ", type_index=", subst.type_index);
-
-			// Create a TypeSpecifierNode from the substitution
-			// Determine the correct size_in_bits based on the type
-			int size_in_bits = get_type_size_bits(subst.category());
-			if (size_in_bits == 0) {
-				switch (subst.category()) {
-				case TypeCategory::Struct:
-				case TypeCategory::UserDefined:
-				case TypeCategory::TypeAlias:
-						// For struct types, we need to look up the size from TypeInfo
-					if (const TypeInfo* ti = tryGetTypeInfo(subst.type_index)) {
-						if (ti->isStruct()) {
-							const StructTypeInfo* si = ti->getStructInfo();
-							if (si) {
-								size_in_bits = si->sizeInBits().value;
-							}
-						}
-					}
-					break;
-				default:
-					size_in_bits = 64; // Default to 64 bits if unknown
-					break;
-				}
+			if (subst.is_value) {
+				throw InternalError("ExpressionSubstitutor attempted to substitute a value template argument as a type");
 			}
 
-			TypeSpecifierNode substituted_type(
-				subst.type_index.withCategory(subst.typeEnum()),
-				size_in_bits,
-				Token{},
-				subst.cv_qualifier,
-				subst.reference_qualifier());
-
-			substituted_type.add_pointer_levels(subst.pointer_depth);
-
-			return substituted_type;
+			return makeTypeSpecifierFromTemplateTypeArg(subst, Token{});
 		}
 
 		if (!type_name.empty()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1672,10 +1672,10 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 			FLASH_LOG(Templates, Debug, "  Substituting template parameter: ", type_name,
 					  " -> base_type=", (int)subst.typeEnum(), ", type_index=", subst.type_index);
 			if (subst.is_value) {
-				throw InternalError("ExpressionSubstitutor attempted to substitute a value template argument as a type");
+				throw CompileError("Template argument used in a type position did not resolve to a type");
 			}
 
-			return makeTypeSpecifierFromTemplateTypeArg(subst, Token{});
+			return makeTypeSpecifierFromTemplateTypeArg(subst, type.token());
 		}
 
 		if (!type_name.empty()) {

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -47,11 +47,44 @@ namespace {
 }
 
 bool typeSpecStillNeedsTemplateMaterialization(const TypeSpecifierNode& type_spec) {
+	if (isPlaceholderAutoType(type_spec.type())) {
+		return true;
+	}
 	if (type_spec.type_index().is_valid() &&
 		typeIndexContainsDependentPlaceholder(type_spec.type_index(), AstToIr::kMaxPlaceholderRecursionDepth)) {
 		return true;
 	}
 	return false;
+}
+
+[[noreturn]] void reportUnresolvedFunctionTypeForCodegen(
+	std::string_view function_name,
+	std::string_view type_role,
+	const TypeSpecifierNode& type_spec,
+	std::string_view reason) {
+	throw InternalError(std::string(StringBuilder()
+		.append("Function '")
+		.append(function_name)
+		.append("' reached IR generation with unresolved ")
+		.append(type_role)
+		.append(" type (category=")
+		.append(static_cast<int64_t>(type_spec.type()))
+		.append(", type_index=")
+		.append(static_cast<uint64_t>(type_spec.type_index().index()))
+		.append("): ")
+		.append(reason)
+		.commit()));
+}
+
+void requireFunctionTypeReadyForCodegen(
+	std::string_view function_name,
+	std::string_view type_role,
+	const TypeSpecifierNode& type_spec,
+	int resolved_size_bits) {
+	(void)resolved_size_bits;
+	if (isPlaceholderAutoType(type_spec.type())) {
+		reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "placeholder return/parameter type was not resolved by parser/sema");
+	}
 }
 
 bool functionSignatureStillNeedsTemplateMaterialization(const FunctionDeclarationNode& func_decl) {
@@ -190,6 +223,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 	// emitReturn calls in the function body use the correct size.  Previously this
 	// used the unresolved ret_type_spec, which could be 0 for self-referential types.
 	int actual_ret_size = getTypeSpecSizeBits(resolved_ret_type);
+	requireFunctionTypeReadyForCodegen(func_name_view, "return", resolved_ret_type, actual_ret_size);
 	current_function_return_size_ = (resolved_ret_type.pointer_depth() > 0 || resolved_ret_type.is_reference() || currentFunctionReturnsFunctionPointer())
 										? 64
 										: actual_ret_size;

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -81,20 +81,22 @@ void requireFunctionTypeReadyForCodegen(
 	std::string_view type_role,
 	const TypeSpecifierNode& type_spec,
 	int resolved_size_bits) {
+
 	if (isPlaceholderAutoType(type_spec.type())) {
 		reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "placeholder return/parameter type was not resolved by parser/sema");
 	}
 
-	const bool size_required =
-		type_spec.type() != TypeCategory::Void &&
-		type_spec.pointer_depth() == 0 &&
-		!type_spec.is_reference() &&
-		!type_spec.is_function_pointer() &&
-		!type_spec.has_function_signature();
-	if (size_required &&
-		resolved_size_bits <= 0 &&
-		!type_spec.type_index().is_valid()) {
-		reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "type did not resolve to a concrete runtime size");
+	if (resolved_size_bits <= 0) {
+		const bool size_required =
+			type_spec.type() != TypeCategory::Void &&
+			type_spec.pointer_depth() == 0 &&
+			!type_spec.is_reference() &&
+			!type_spec.is_function_pointer() &&
+			!type_spec.has_function_signature();
+		if (size_required &&
+			!type_spec.type_index().is_valid()) {
+			reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "type did not resolve to a concrete runtime size");
+		}
 	}
 }
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -81,9 +81,20 @@ void requireFunctionTypeReadyForCodegen(
 	std::string_view type_role,
 	const TypeSpecifierNode& type_spec,
 	int resolved_size_bits) {
-	(void)resolved_size_bits;
 	if (isPlaceholderAutoType(type_spec.type())) {
 		reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "placeholder return/parameter type was not resolved by parser/sema");
+	}
+
+	const bool size_required =
+		type_spec.type() != TypeCategory::Void &&
+		type_spec.pointer_depth() == 0 &&
+		!type_spec.is_reference() &&
+		!type_spec.is_function_pointer() &&
+		!type_spec.has_function_signature();
+	if (size_required &&
+		resolved_size_bits <= 0 &&
+		!type_spec.type_index().is_valid()) {
+		reportUnresolvedFunctionTypeForCodegen(function_name, type_role, type_spec, "type did not resolve to a concrete runtime size");
 	}
 }
 

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2730,7 +2730,11 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 			}
 		}
 	} else {
-		std::cerr << "Warning: Template body does NOT have value!\n";
+		throw InternalError(std::string(StringBuilder()
+			.append("Template instantiation for '")
+			.append(StringTable::getStringView(inst_info.qualified_template_name))
+			.append("' reached legacy IR generation without a parsed template body")
+			.commit()));
 	}
 
 	// Add implicit return for void functions
@@ -2747,11 +2751,9 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 }
 
 ExprResult AstToIr::generateTemplateParameterReferenceIr(const TemplateParameterReferenceNode& templateParamRefNode) {
-	// This should not happen during normal code generation - template parameters should be substituted
-	// during template instantiation. If we get here, it means template instantiation failed.
-	std::string param_name = std::string(templateParamRefNode.param_name().view());
-	std::cerr << "Error: Template parameter '" << param_name << "' was not substituted during template instantiation\n";
-	std::cerr << "This indicates a bug in template instantiation - template parameters should be replaced with concrete types/values\n";
-	assert(false && "Template parameter reference found during code generation - should have been substituted");
-	return ExprResult{};
+	throw InternalError(std::string(StringBuilder()
+		.append("Template parameter '")
+		.append(templateParamRefNode.param_name().view())
+		.append("' reached IR generation without being substituted")
+		.commit()));
 }

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2709,6 +2709,12 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 		}
 	}
 
+	auto restore_template_instantiation_state = ScopeGuard([&]() {
+		symbol_table.exit_scope();
+		current_struct_name_ = saved_struct_name;
+		current_namespace_stack_ = saved_namespace_stack;
+	});
+
 	// Parse the template body with concrete types
 	// Pass the struct name and type index so the parser can set up member function context
 	auto body_node_opt = parser_->parseTemplateBody(
@@ -2743,11 +2749,6 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 		ReturnOp ret_op; // No return value for void
 		ir_.addInstruction(IrInstruction(IrOpcode::Return, std::move(ret_op), mangled_token));
 	}
-
-	// Exit function scope
-	symbol_table.exit_scope();
-	current_struct_name_ = saved_struct_name;
-	current_namespace_stack_ = saved_namespace_stack;
 }
 
 ExprResult AstToIr::generateTemplateParameterReferenceIr(const TemplateParameterReferenceNode& templateParamRefNode) {

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2649,6 +2649,11 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 
 	// Enter function scope
 	symbol_table.enter_scope(ScopeType::Function);
+	auto restore_template_instantiation_state = ScopeGuard([&]() {
+		symbol_table.exit_scope();
+		current_struct_name_ = saved_struct_name;
+		current_namespace_stack_ = saved_namespace_stack;
+	});
 
 	// Get struct type info for member functions
 	const TypeInfo* struct_type_info = nullptr;
@@ -2708,12 +2713,6 @@ void AstToIr::generateTemplateInstantiation(const TemplateInstantiationInfo& ins
 			}
 		}
 	}
-
-	auto restore_template_instantiation_state = ScopeGuard([&]() {
-		symbol_table.exit_scope();
-		current_struct_name_ = saved_struct_name;
-		current_namespace_stack_ = saved_namespace_stack;
-	});
 
 	// Parse the template body with concrete types
 	// Pass the struct name and type index so the parser can set up member function context

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1876,12 +1876,14 @@ private:
 		const ASTNode& arg_node,
 		const InlineVector<ASTNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
-		const std::vector<TemplateTypeArg>& template_args);
+		const std::vector<TemplateTypeArg>& template_args,
+		const TemplateParameterNode* target_template_param);
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
 		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
-		const std::vector<TemplateTypeArg>& template_args);
+		const std::vector<TemplateTypeArg>& template_args,
+		const TemplateParameterNode* target_template_param);
 	std::optional<std::vector<TemplateTypeArg>> materializeDeferredAliasTemplateArgs(
 		const TemplateAliasNode& alias_node,
 		const std::vector<TemplateTypeArg>& template_args);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2221,6 +2221,7 @@ public:
 		}
 	}
 	std::optional<ASTNode> instantiateLazyMemberFunction(const LazyMemberFunctionInfo& lazy_info);  // NEW: Instantiate lazy member function on-demand
+	std::optional<ASTNode> instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key);
 	std::optional<ASTNode> try_instantiate_constructor_template(StringHandle instantiated_struct_name, const ConstructorDeclarationNode& ctor_decl, const std::vector<TypeSpecifierNode>& arg_types);
 	const ConstructorDeclarationNode* materializeMatchingConstructorTemplate(
 		StringHandle instantiated_struct_name,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -684,6 +684,7 @@ private:
 	struct ActiveTemplateParameterState {
 		InlineVector<StringHandle, 4> names;	 // Names of current template parameters - from Token storage
 		InlineVector<TemplateParameterKind, 4> kinds;
+		InlineVector<TypeCategory, 4> non_type_categories;
 
 		bool empty() const { return names.empty(); }
 		size_t size() const { return names.size(); }
@@ -691,32 +692,64 @@ private:
 		void clear() {
 			names.clear();
 			kinds.clear();
+			non_type_categories.clear();
 		}
 
 		void setNames(const InlineVector<StringHandle, 4>& param_names) {
 			names = param_names;
 			kinds.clear();
+			non_type_categories.clear();
 		}
 
 		void setNames(InlineVector<StringHandle, 4>&& param_names) {
 			names = std::move(param_names);
 			kinds.clear();
+			non_type_categories.clear();
 		}
 
 		void setNamesAndKinds(const InlineVector<StringHandle, 4>& param_names,
 							  const InlineVector<TemplateParameterKind, 4>& param_kinds) {
 			names = param_names;
 			kinds = param_kinds;
+			non_type_categories.clear();
 		}
 
 		void setNamesAndKinds(InlineVector<StringHandle, 4>&& param_names,
 							  InlineVector<TemplateParameterKind, 4>&& param_kinds) {
 			names = std::move(param_names);
 			kinds = std::move(param_kinds);
+			non_type_categories.clear();
+		}
+
+		void setNamesKindsAndCategories(
+			const InlineVector<StringHandle, 4>& param_names,
+			const InlineVector<TemplateParameterKind, 4>& param_kinds,
+			const InlineVector<TypeCategory, 4>& param_categories) {
+			names = param_names;
+			kinds = param_kinds;
+			non_type_categories = param_categories;
+		}
+
+		void setNamesKindsAndCategories(
+			InlineVector<StringHandle, 4>&& param_names,
+			InlineVector<TemplateParameterKind, 4>&& param_kinds,
+			InlineVector<TypeCategory, 4>&& param_categories) {
+			names = std::move(param_names);
+			kinds = std::move(param_kinds);
+			non_type_categories = std::move(param_categories);
 		}
 
 		void pushName(StringHandle param_name) {
 			names.push_back(param_name);
+		}
+
+		void pushParameter(
+			StringHandle param_name,
+			TemplateParameterKind param_kind,
+			TypeCategory non_type_category) {
+			names.push_back(param_name);
+			kinds.push_back(param_kind);
+			non_type_categories.push_back(non_type_category);
 		}
 
 		std::optional<TemplateParameterKind> kindOf(StringHandle param_name) const {
@@ -726,6 +759,22 @@ private:
 				}
 				if (i < kinds.size()) {
 					return kinds[i];
+				}
+				break;
+			}
+			return std::nullopt;
+		}
+
+		std::optional<TypeCategory> nonTypeCategoryOf(StringHandle param_name) const {
+			for (size_t i = 0; i < names.size(); ++i) {
+				if (names[i] != param_name) {
+					continue;
+				}
+				if (i < kinds.size() &&
+					kinds[i] == TemplateParameterKind::NonType &&
+					i < non_type_categories.size() &&
+					non_type_categories[i] != TypeCategory::Invalid) {
+					return non_type_categories[i];
 				}
 				break;
 			}
@@ -1202,6 +1251,7 @@ private:
 	struct TemplateParameterMetadata {
 		InlineVector<StringHandle, 4> names;
 		InlineVector<TemplateParameterKind, 4> kinds;
+		InlineVector<TypeCategory, 4> non_type_categories;
 		bool has_packs = false;
 	};
 	ParseResult parse_template_parameter_list(InlineVector<TemplateParameterNode, 4>& out_params);	 // NEW: Parse template parameter list
@@ -2778,6 +2828,10 @@ private:	 // Resume private methods
 		return current_template_params_.kindOf(param_name);
 	}
 
+	std::optional<TypeCategory> currentTemplateParamNonTypeCategory(StringHandle param_name) const {
+		return current_template_params_.nonTypeCategoryOf(param_name);
+	}
+
 	void setCurrentTemplateParamNames(const InlineVector<StringHandle, 4>& param_names) {
 		current_template_params_.setNames(param_names);
 	}
@@ -2796,12 +2850,36 @@ private:	 // Resume private methods
 		current_template_params_.setNamesAndKinds(std::move(param_names), std::move(param_kinds));
 	}
 
+	void setCurrentTemplateParameters(
+		const InlineVector<StringHandle, 4>& param_names,
+		const InlineVector<TemplateParameterKind, 4>& param_kinds,
+		const InlineVector<TypeCategory, 4>& non_type_categories) {
+		current_template_params_.setNamesKindsAndCategories(param_names, param_kinds, non_type_categories);
+	}
+
+	void setCurrentTemplateParameters(
+		InlineVector<StringHandle, 4>&& param_names,
+		InlineVector<TemplateParameterKind, 4>&& param_kinds,
+		InlineVector<TypeCategory, 4>&& non_type_categories) {
+		current_template_params_.setNamesKindsAndCategories(
+			std::move(param_names),
+			std::move(param_kinds),
+			std::move(non_type_categories));
+	}
+
 	void clearCurrentTemplateParameters() {
 		current_template_params_.clear();
 	}
 
 	void pushCurrentTemplateParamName(StringHandle param_name) {
 		current_template_params_.pushName(param_name);
+	}
+
+	void pushCurrentTemplateParameter(
+		StringHandle param_name,
+		TemplateParameterKind param_kind,
+		TypeCategory non_type_category) {
+		current_template_params_.pushParameter(param_name, param_kind, non_type_category);
 	}
 
 	ActiveTemplateParameterState& currentTemplateParamState() {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -704,11 +704,11 @@ private:
 		}
 
 		void padNonTypeCategoriesToNameCount() {
+			if (non_type_categories.size() > names.size()) {
+				throw InternalError("ActiveTemplateParameterState category slots out of sync");
+			}
 			while (non_type_categories.size() < names.size()) {
 				non_type_categories.push_back(TypeCategory::Invalid);
-			}
-			while (non_type_categories.size() > names.size()) {
-				non_type_categories.pop_back();
 			}
 		}
 
@@ -759,6 +759,10 @@ private:
 		}
 
 		void pushName(StringHandle param_name) {
+			if (!kinds.empty() && kinds.size() != names.size()) {
+				throw InternalError("ActiveTemplateParameterState kind slots out of sync");
+			}
+			padNonTypeCategoriesToNameCount();
 			names.push_back(param_name);
 			non_type_categories.push_back(TypeCategory::Invalid);
 		}
@@ -767,6 +771,15 @@ private:
 			StringHandle param_name,
 			TemplateParameterKind param_kind,
 			TypeCategory non_type_category) {
+			if (kinds.empty() && !names.empty()) {
+				kinds.reserve(names.size() + 1);
+				for (size_t i = 0; i < names.size(); ++i) {
+					kinds.push_back(TemplateParameterKind::Type);
+				}
+			}
+			if (!kinds.empty() && kinds.size() != names.size()) {
+				throw InternalError("ActiveTemplateParameterState kind slots out of sync");
+			}
 			padNonTypeCategoriesToNameCount();
 			names.push_back(param_name);
 			kinds.push_back(param_kind);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -695,30 +695,47 @@ private:
 			non_type_categories.clear();
 		}
 
+		void resetNonTypeCategories(size_t count) {
+			non_type_categories.clear();
+			non_type_categories.reserve(count);
+			for (size_t i = 0; i < count; ++i) {
+				non_type_categories.push_back(TypeCategory::Invalid);
+			}
+		}
+
+		void padNonTypeCategoriesToNameCount() {
+			while (non_type_categories.size() < names.size()) {
+				non_type_categories.push_back(TypeCategory::Invalid);
+			}
+			while (non_type_categories.size() > names.size()) {
+				non_type_categories.pop_back();
+			}
+		}
+
 		void setNames(const InlineVector<StringHandle, 4>& param_names) {
 			names = param_names;
 			kinds.clear();
-			non_type_categories.clear();
+			resetNonTypeCategories(names.size());
 		}
 
 		void setNames(InlineVector<StringHandle, 4>&& param_names) {
 			names = std::move(param_names);
 			kinds.clear();
-			non_type_categories.clear();
+			resetNonTypeCategories(names.size());
 		}
 
 		void setNamesAndKinds(const InlineVector<StringHandle, 4>& param_names,
 							  const InlineVector<TemplateParameterKind, 4>& param_kinds) {
 			names = param_names;
 			kinds = param_kinds;
-			non_type_categories.clear();
+			resetNonTypeCategories(names.size());
 		}
 
 		void setNamesAndKinds(InlineVector<StringHandle, 4>&& param_names,
 							  InlineVector<TemplateParameterKind, 4>&& param_kinds) {
 			names = std::move(param_names);
 			kinds = std::move(param_kinds);
-			non_type_categories.clear();
+			resetNonTypeCategories(names.size());
 		}
 
 		void setNamesKindsAndCategories(
@@ -728,6 +745,7 @@ private:
 			names = param_names;
 			kinds = param_kinds;
 			non_type_categories = param_categories;
+			padNonTypeCategoriesToNameCount();
 		}
 
 		void setNamesKindsAndCategories(
@@ -737,16 +755,19 @@ private:
 			names = std::move(param_names);
 			kinds = std::move(param_kinds);
 			non_type_categories = std::move(param_categories);
+			padNonTypeCategoriesToNameCount();
 		}
 
 		void pushName(StringHandle param_name) {
 			names.push_back(param_name);
+			non_type_categories.push_back(TypeCategory::Invalid);
 		}
 
 		void pushParameter(
 			StringHandle param_name,
 			TemplateParameterKind param_kind,
 			TypeCategory non_type_category) {
+			padNonTypeCategoriesToNameCount();
 			names.push_back(param_name);
 			kinds.push_back(param_kind);
 			non_type_categories.push_back(non_type_category);

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -109,10 +109,17 @@ std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
 			member_name,
 			{});
 	}
-	// Reaching this point means the call was syntactically non-empty, so an empty
-	// collected-type list means deduction still has to wait for instantiation-time typing.
-	if (has_dependent_call_args || call_arg_types.empty()) {
+	if (has_dependent_call_args) {
 		return std::nullopt;
+	}
+	if (call_arg_types.empty()) {
+		throw InternalError(std::string(StringBuilder()
+			.append("Non-dependent member template call '")
+			.append(struct_name)
+			.append("::")
+			.append(member_name)
+			.append("' has call arguments but no collected argument types")
+			.commit()));
 	}
 	return try_instantiate_member_function_template(
 		struct_name,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -337,17 +337,18 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 				LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, func_name_handle);
 				if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 					FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for: ", *object_struct_name, "::", func_name);
-					auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
-					if (lazy_info_opt.has_value()) {
-						const LazyMemberFunctionInfo& lazy_info = *lazy_info_opt;
-						instantiating_lazy_member_ = true;
-						instantiated_func = instantiateLazyMemberFunction(lazy_info);
-						instantiating_lazy_member_ = false;
-						LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-							LazyMemberKey::exact(
-								class_name_handle,
-								func_name_handle,
-								lazy_info.identity.is_const_method));
+					struct ScopedLazyMemberInstantiationFlag {
+						bool& flag;
+						explicit ScopedLazyMemberInstantiationFlag(bool& target)
+							: flag(target) {
+							flag = true;
+						}
+						~ScopedLazyMemberInstantiationFlag() {
+							flag = false;
+						}
+					} scoped_lazy_instantiation(instantiating_lazy_member_);
+					instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+					if (instantiated_func.has_value()) {
 						FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
 					}
 				}
@@ -973,18 +974,10 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							StringHandle member_name_handle = final_identifier.handle();
 							LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
 							if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
-								if (lazy_info_opt.has_value()) {
-									auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
-									if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-										qualified_symbol = instantiated_func;
-										decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
-										LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-											LazyMemberKey::exact(
-												class_name_handle,
-												member_name_handle,
-												lazy_info_opt->identity.is_const_method));
-									}
+								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+								if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
+									qualified_symbol = instantiated_func;
+									decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
 								}
 							}
 						}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -113,13 +113,10 @@ std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
 		return std::nullopt;
 	}
 	if (call_arg_types.empty()) {
-		throw InternalError(std::string(StringBuilder()
-			.append("Non-dependent member template call '")
-			.append(struct_name)
-			.append("::")
-			.append(member_name)
-			.append("' has call arguments but no collected argument types")
-			.commit()));
+		FLASH_LOG(Templates, Debug,
+			"Deferring member template instantiation for ", struct_name, "::", member_name,
+			" because no concrete argument types were collected at this parse point");
+		return std::nullopt;
 	}
 	return try_instantiate_member_function_template(
 		struct_name,
@@ -344,17 +341,13 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 				LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, func_name_handle);
 				if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 					FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for: ", *object_struct_name, "::", func_name);
-					struct ScopedLazyMemberInstantiationFlag {
-						bool& flag;
-						explicit ScopedLazyMemberInstantiationFlag(bool& target)
-							: flag(target) {
-							flag = true;
-						}
-						~ScopedLazyMemberInstantiationFlag() {
-							flag = false;
-						}
-					} scoped_lazy_instantiation(instantiating_lazy_member_);
-					instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+					if (!instantiated_func.has_value()) {
+						instantiating_lazy_member_ = true;
+						auto restore_lazy_instantiation = ScopeGuard([&]() {
+							instantiating_lazy_member_ = false;
+						});
+						instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+					}
 					if (instantiated_func.has_value()) {
 						FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
 					}
@@ -980,7 +973,12 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						if (class_type_it != getTypesByNameMap().end() && class_type_it->second->isTemplateInstantiation()) {
 							StringHandle member_name_handle = final_identifier.handle();
 							LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
-							if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+							if (!instantiating_lazy_member_ &&
+								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+								instantiating_lazy_member_ = true;
+								auto restore_lazy_instantiation = ScopeGuard([&]() {
+									instantiating_lazy_member_ = false;
+								});
 								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
 								if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
 									qualified_symbol = instantiated_func;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4804,6 +4804,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return ParseResult::error("Expected ')' after function call arguments", current_token_);
 					}
 
+					const bool has_dependent_call_args =
+						argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+						argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
+					const bool allow_undeclared_decltype_call_recovery =
+						context != ExpressionContext::Decltype || has_dependent_call_args;
+
 					// Try to instantiate the template function (skip in extern "C" contexts - C has no templates)
 					if (current_linkage_ != Linkage::C) {
 						template_func_inst = try_instantiate_template(identifier_token.value(), arg_types);
@@ -4824,6 +4830,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 						if (!found_member_function_in_context && !identifierType.has_value() &&
 							!lookupTypeInCurrentContext(identifier_token.handle())) {
+							if (!allow_undeclared_decltype_call_recovery) {
+								return ParseResult::error("Missing identifier", identifier_token);
+							}
 							auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
 							auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 							gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
@@ -4842,14 +4851,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// bogus forward declaration that would confuse Phase 1 two-phase lookup.
 				if (!found_member_function_in_context && !identifierType.has_value() &&
 					!lookupTypeInCurrentContext(identifier_token.handle())) {
-					// We'll assume it returns int for now (this is a simplification)
-					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-					auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-
-					// Add to GLOBAL symbol table as a forward declaration
-					// Using insertGlobal ensures it persists after scope exits
-					gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
-					identifierType = forward_decl;
 				}
 
 				if (peek().is_eof())
@@ -4878,6 +4879,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				if (!consume(")"_tok)) {
 					return ParseResult::error("Expected ')' after function call arguments", current_token_);
+				}
+
+				if (!found_member_function_in_context && !identifierType.has_value() &&
+					!lookupTypeInCurrentContext(identifier_token.handle())) {
+					if (context == ExpressionContext::Decltype &&
+						!argsHaveDeferredTemplateDependency(args, currentTemplateParamNames())) {
+						return ParseResult::error("Missing identifier", identifier_token);
+					}
+					// We'll assume it returns int for now (this is a simplification)
+					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
+					auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+
+					// Add to GLOBAL symbol table as a forward declaration
+					// Using insertGlobal ensures it persists after scope exits
+					gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
+					identifierType = forward_decl;
 				}
 
 				// Unified resolution: collect candidates, augment with ADL, resolve overload.

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4813,8 +4813,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					const bool has_dependent_call_args =
 						argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 						argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
-					const bool allow_undeclared_decltype_call_recovery =
-						context != ExpressionContext::Decltype || has_dependent_call_args;
 
 					// Try to instantiate the template function (skip in extern "C" contexts - C has no templates)
 					if (current_linkage_ != Linkage::C) {
@@ -4836,7 +4834,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 						if (!found_member_function_in_context && !identifierType.has_value() &&
 							!lookupTypeInCurrentContext(identifier_token.handle())) {
-							if (!allow_undeclared_decltype_call_recovery) {
+							if (context == ExpressionContext::Decltype) {
+								if (has_dependent_call_args) {
+									FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
+									auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+									auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+									result = emplace_node<ExpressionNode>(
+										makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
+									return ParseResult::success(*result);
+								}
 								return ParseResult::error("Missing identifier", identifier_token);
 							}
 							auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
@@ -4863,13 +4869,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					return ParseResult::error(ParserError::NotImplemented, identifier_token);
 
 				ChunkedVector<ASTNode> args;
+				std::vector<TypeSpecifierNode> arg_types;
 				while (current_token_.type() != Token::Type::Punctuator || current_token_.value() != ")") {
 					ParseResult argResult = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 					if (argResult.is_error()) {
 						return argResult;
 					}
 
-					if (auto append_error = append_function_call_argument(argResult, args, nullptr); append_error.has_value()) {
+					if (auto append_error = append_function_call_argument(argResult, args, &arg_types); append_error.has_value()) {
 						return *append_error;
 					}
 
@@ -4889,8 +4896,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				if (!found_member_function_in_context && !identifierType.has_value() &&
 					!lookupTypeInCurrentContext(identifier_token.handle())) {
-					if (context == ExpressionContext::Decltype &&
-						!argsHaveDeferredTemplateDependency(args, currentTemplateParamNames())) {
+					if (context == ExpressionContext::Decltype) {
+						const bool has_dependent_call_args =
+							argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+							argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
+						if (has_dependent_call_args) {
+							FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
+							auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+							auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+							result = emplace_node<ExpressionNode>(
+								makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
+							return ParseResult::success(*result);
+						}
 						return ParseResult::error("Missing identifier", identifier_token);
 					}
 					// We'll assume it returns int for now (this is a simplification)

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4778,6 +4778,42 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// Skip template lookup if we already found this as a member function in the class context
 				// to avoid namespace-scope template functions shadowing class member function overloads
 				std::optional<ASTNode> template_func_inst;
+				auto make_dependent_decltype_call = [&](ChunkedVector<ASTNode>&& call_args) -> ParseResult {
+					FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
+					auto type_node = emplace_node<TypeSpecifierNode>(
+						TypeCategory::Bool,
+						TypeQualifier::None,
+						get_type_size_bits(TypeCategory::Bool),
+						identifier_token,
+						CVQualifier::None);
+					auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+					result = emplace_node<ExpressionNode>(
+						makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(call_args), identifier_token));
+					return ParseResult::success(*result);
+				};
+				auto create_unresolved_call_decl_if_deferred = [&]() {
+					const bool should_defer_unresolved_call =
+						parsing_template_depth_ > 0 ||
+						hasActiveTemplateParameters() ||
+						!struct_parsing_context_stack_.empty() ||
+						template_instantiation_mode_ != TemplateInstantiationMode::HardUse ||
+						context == ExpressionContext::TemplateTypeArg ||
+						context == ExpressionContext::RequiresClause ||
+						context == ExpressionContext::ConceptDefinition;
+					if (!should_defer_unresolved_call) {
+						return;
+					}
+
+					auto unresolved_type = emplace_node<TypeSpecifierNode>(
+						TypeIndex{}.withCategory(TypeCategory::Auto),
+						0,
+						identifier_token,
+						CVQualifier::None,
+						ReferenceQualifier::None);
+					auto unresolved_decl = emplace_node<DeclarationNode>(unresolved_type, identifier_token);
+					(void)gSymbolTable.insert(identifier_token.value(), unresolved_decl);
+					identifierType = unresolved_decl;
+				};
 				if (!found_member_function_in_context && gTemplateRegistry.lookupTemplate(identifier_token.value()).has_value()) {
 					// Parse arguments to deduce template parameters
 					if (peek().is_eof())
@@ -4836,18 +4872,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							!lookupTypeInCurrentContext(identifier_token.handle())) {
 							if (context == ExpressionContext::Decltype) {
 								if (has_dependent_call_args) {
-									FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
-									auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
-									auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-									result = emplace_node<ExpressionNode>(
-										makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
-									return ParseResult::success(*result);
+									return make_dependent_decltype_call(std::move(args));
 								}
 							} else {
-								auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-								auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-								gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
-								identifierType = forward_decl;
+								create_unresolved_call_decl_if_deferred();
 							}
 						}
 
@@ -4901,22 +4929,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 							argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 						if (has_dependent_call_args) {
-							FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
-							auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
-							auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-							result = emplace_node<ExpressionNode>(
-								makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
-							return ParseResult::success(*result);
+							return make_dependent_decltype_call(std::move(args));
 						}
 					} else {
-						// We'll assume it returns int for now (this is a simplification)
-						auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-						auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-
-						// Add to GLOBAL symbol table as a forward declaration
-						// Using insertGlobal ensures it persists after scope exits
-						gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
-						identifierType = forward_decl;
+						create_unresolved_call_decl_if_deferred();
 					}
 				}
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2763,18 +2763,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										member_is_const);
 									if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
 										LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-										auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
-										if (lazy_info_opt.has_value()) {
-											auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
-											if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-												member_lookup = instantiated_func;
-												decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
-												LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-													LazyMemberKey::exact(
-														class_name_handle,
-														member_name_handle,
-														lazy_info_opt->identity.is_const_method));
-											}
+										auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+										if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
+											member_lookup = instantiated_func;
+											decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
 										}
 									}
 								}
@@ -3727,17 +3719,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								member_is_const);
 							if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
 								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-								auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
-								if (lazy_info_opt.has_value()) {
-									auto instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
-									if (instantiated_func.has_value()) {
-										identifierType = *instantiated_func;
-										LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-											LazyMemberKey::exact(
-												class_name_handle,
-												member_name_handle,
-												lazy_info_opt->identity.is_const_method));
-									}
+								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+								if (instantiated_func.has_value()) {
+									identifierType = *instantiated_func;
 								}
 							}
 						}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4843,12 +4843,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
 									return ParseResult::success(*result);
 								}
-								return ParseResult::error("Missing identifier", identifier_token);
+							} else {
+								auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
+								auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+								gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
+								identifierType = forward_decl;
 							}
-							auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-							auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
-							gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
-							identifierType = forward_decl;
 						}
 
 						return unified_resolve_function_call(args);
@@ -4908,16 +4908,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
 							return ParseResult::success(*result);
 						}
-						return ParseResult::error("Missing identifier", identifier_token);
-					}
-					// We'll assume it returns int for now (this is a simplification)
-					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-					auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
+					} else {
+						// We'll assume it returns int for now (this is a simplification)
+						auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
+						auto forward_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 
-					// Add to GLOBAL symbol table as a forward declaration
-					// Using insertGlobal ensures it persists after scope exits
-					gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
-					identifierType = forward_decl;
+						// Add to GLOBAL symbol table as a forward declaration
+						// Using insertGlobal ensures it persists after scope exits
+						gSymbolTable.insertGlobal(identifier_token.value(), forward_decl);
+						identifierType = forward_decl;
+					}
 				}
 
 				// Unified resolution: collect candidates, augment with ADL, resolve overload.

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2764,10 +2764,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
 										LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 										auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
-										if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-											member_lookup = instantiated_func;
-											decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
+										if (!instantiated_func.has_value() || !instantiated_func->is<FunctionDeclarationNode>()) {
+											return ParseResult::error(
+												"Failed to materialize lazy member function '" + std::string(member_token.value()) + "'",
+												member_token);
 										}
+										member_lookup = instantiated_func;
+										decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
 									}
 								}
 							}
@@ -3720,9 +3723,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
 								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
-								if (instantiated_func.has_value()) {
-									identifierType = *instantiated_func;
+								if (!instantiated_func.has_value() || !instantiated_func->is<FunctionDeclarationNode>()) {
+									return ParseResult::error(
+										"Failed to materialize lazy member function '" + std::string(final_identifier.value()) + "'",
+										final_identifier);
 								}
+								identifierType = *instantiated_func;
 							}
 						}
 					}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -317,15 +317,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		FLASH_LOG(Templates, Debug, "Checking lazy instantiation for: ", instantiated_class_name, "::", member_name);
 		if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 			FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for qualified call: ", instantiated_class_name, "::", member_name);
-			auto lazy_info_opt = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(member_key);
-			if (lazy_info_opt.has_value()) {
-				instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt);
-				LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-					LazyMemberKey::exact(
-						class_name_handle,
-						member_name_handle,
-						lazy_info_opt->identity.is_const_method));
-			}
+			instantiated_func = instantiateLazyMemberIfNeeded(member_key);
 		}
 		// If the hash-based name didn't match (dependent vs concrete hash mismatch),
 		// try to find the correct instantiation by looking up getTypesByNameMap() for a matching
@@ -343,14 +335,8 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 						if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(alt_member_key)) {
 							FLASH_LOG(Templates, Debug, "Lazy instantiation triggered via base template match: ",
 									  StringTable::getStringView(alt_class_handle), "::", member_name);
-							auto lazy_info_opt2 = LazyMemberInstantiationRegistry::getInstance().getLazyMemberInfo(alt_member_key);
-							if (lazy_info_opt2.has_value()) {
-								instantiated_func = instantiateLazyMemberFunction(*lazy_info_opt2);
-								LazyMemberInstantiationRegistry::getInstance().markInstantiated(
-									LazyMemberKey::exact(
-										alt_class_handle,
-										member_name_handle,
-										lazy_info_opt2->identity.is_const_method));
+							instantiated_func = instantiateLazyMemberIfNeeded(alt_member_key);
+							if (instantiated_func.has_value()) {
 								// Update instantiated_class_name to the correct one for mangling
 								instantiated_class_name = StringTable::getStringView(alt_class_handle);
 								break;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -205,7 +205,10 @@ ParseResult Parser::parse_template_declaration() {
 	// Set template parameter context EARLY, before any code that might call parse_type_specifier()
 	// This includes variable template detection below which needs to recognize template params
 	// like _Int in return types: typename tuple_element<_Int, pair<_Tp1, _Tp2>>::type&
-	setCurrentTemplateParameters(template_param_metadata.names, template_param_metadata.kinds);
+	setCurrentTemplateParameters(
+		template_param_metadata.names,
+		template_param_metadata.kinds,
+		template_param_metadata.non_type_categories);
 	FlashCpp::TemplateDepthGuard guard_template_depth(parsing_template_depth_);
 
 	// Check if this is a nested template (member function template of a class template)
@@ -3982,7 +3985,10 @@ ParseResult Parser::parse_template_declaration() {
 		}
 
 		// Set template parameter context for current_template_param_names_
-		setCurrentTemplateParameters(template_param_metadata.names, template_param_metadata.kinds);
+		setCurrentTemplateParameters(
+			template_param_metadata.names,
+			template_param_metadata.kinds,
+			template_param_metadata.non_type_categories);
 
 		// Parse class template
 		// Save scope/stack state before try block so we can restore on exception

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -114,8 +114,11 @@ ParseResult Parser::parse_template_declaration() {
 					registerAndNormalizeLateMaterializedTopLevelNode(*instantiated);
 					FLASH_LOG(Templates, Debug, "Successfully explicitly instantiated: ", name_token.value());
 				} else {
-					// Template not found or instantiation failed
-					FLASH_LOG(Templates, Warning, "Could not explicitly instantiate template: ", name_token.value());
+					throw CompileError(std::string(StringBuilder()
+						.append("Could not explicitly instantiate template '")
+						.append(name_token.value())
+						.append("'")
+						.commit()));
 				}
 			} else if (is_extern) {
 				// extern template - suppresses implicit instantiation

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -269,8 +269,15 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	// Set up template parameter names for the body parsing phase
 	// This is needed for decltype expressions and other template-dependent constructs
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
-	for (StringHandle param_name : template_param_metadata.names) {
-		pushCurrentTemplateParamName(param_name);
+	for (size_t i = 0; i < template_param_metadata.names.size(); ++i) {
+		pushCurrentTemplateParameter(
+			template_param_metadata.names[i],
+			i < template_param_metadata.kinds.size()
+				? template_param_metadata.kinds[i]
+				: TemplateParameterKind::Type,
+			i < template_param_metadata.non_type_categories.size()
+				? template_param_metadata.non_type_categories[i]
+				: TypeCategory::Invalid);
 	}
 
 	// Check for requires clause after template parameters

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -85,6 +85,23 @@ static void buildTemplateArgSubstitutionMaps(
 	}
 }
 
+static std::string buildDeferredStaticAssertInstantiationError(
+	std::string_view evaluation_error,
+	StringHandle message_handle,
+	bool include_evaluation_error) {
+	std::string error_msg = "static_assert failed during template instantiation";
+	if (include_evaluation_error) {
+		error_msg += ": ";
+		error_msg += std::string(evaluation_error);
+	}
+	std::string_view message_view = StringTable::getStringView(message_handle);
+	if (!message_view.empty()) {
+		error_msg += include_evaluation_error ? " - " : ": ";
+		error_msg += std::string(message_view);
+	}
+	return error_msg;
+}
+
 // Collect pack bindings referenced by a deferred base specifier and verify that
 // every participating pack expands to the same number of elements.
 static DeferredBasePackExpansionBindingInfo collectDeferredBasePackExpansionBindings(
@@ -780,17 +797,7 @@ static void instantiateDeferredStaticInitializerCalls(
 			return;
 		}
 
-		auto lazy_info = lazy_registry.getLazyMemberInfo(member_key);
-		if (!lazy_info.has_value()) {
-			return;
-		}
-
-		parser->instantiateLazyMemberFunction(*lazy_info);
-		lazy_registry.markInstantiated(
-			LazyMemberKey::exact(
-				owner_name,
-				member_name,
-				lazy_info->identity.is_const_method));
+		(void)parser->instantiateLazyMemberIfNeeded(member_key);
 	});
 }
 
@@ -4136,27 +4143,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				auto eval_result = ConstExpr::Evaluator::evaluate(substituted_expr, eval_ctx);
 
 				if (!eval_result.success()) {
-					std::string error_msg = "static_assert failed during template instantiation: " +
-											eval_result.error_message;
-					std::string_view message_view = StringTable::getStringView(deferred_assert.message);
-					if (!message_view.empty()) {
-						error_msg += " - " + std::string(message_view);
+					std::string error_msg = buildDeferredStaticAssertInstantiationError(
+						eval_result.error_message, deferred_assert.message, true);
+					if (!is_implicit_instantiation) {
+						throw CompileError(error_msg);
 					}
 					FLASH_LOG(Templates, Error, error_msg);
-					// Don't return error - continue with other static_asserts
-					// This matches the behavior of most compilers which report all failures
 					continue;
 				}
 
 				// Check if the assertion failed
 				if (!eval_result.as_bool()) {
-					std::string error_msg = "static_assert failed during template instantiation";
-					std::string_view message_view = StringTable::getStringView(deferred_assert.message);
-					if (!message_view.empty()) {
-						error_msg += ": " + std::string(message_view);
+					std::string error_msg = buildDeferredStaticAssertInstantiationError(
+						std::string_view(), deferred_assert.message, false);
+					if (!is_implicit_instantiation) {
+						throw CompileError(error_msg);
 					}
 					FLASH_LOG(Templates, Error, error_msg);
-					// Don't return error - continue with other static_asserts
 					continue;
 				}
 
@@ -8919,27 +8922,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		auto eval_result = ConstExpr::Evaluator::evaluate(substituted_expr, eval_ctx);
 
 		if (!eval_result.success()) {
-			std::string error_msg = "static_assert failed during template instantiation: " +
-									eval_result.error_message;
-			std::string_view message_view = StringTable::getStringView(deferred_assert.message);
-			if (!message_view.empty()) {
-				error_msg += " - " + std::string(message_view);
+			std::string error_msg = buildDeferredStaticAssertInstantiationError(
+				eval_result.error_message, deferred_assert.message, true);
+			if (force_eager) {
+				throw CompileError(error_msg);
 			}
 			FLASH_LOG(Templates, Error, error_msg);
-			// Don't return error - continue with other static_asserts
-			// This matches the behavior of most compilers which report all failures
 			continue;
 		}
 
 		// Check if the assertion failed
 		if (!eval_result.as_bool()) {
-			std::string error_msg = "static_assert failed during template instantiation";
-			std::string_view message_view = StringTable::getStringView(deferred_assert.message);
-			if (!message_view.empty()) {
-				error_msg += ": " + std::string(message_view);
+			std::string error_msg = buildDeferredStaticAssertInstantiationError(
+				std::string_view(), deferred_assert.message, false);
+			if (force_eager) {
+				throw CompileError(error_msg);
 			}
 			FLASH_LOG(Templates, Error, error_msg);
-			// Don't return error - continue with other static_asserts
 			continue;
 		}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4149,7 +4149,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						throw CompileError(error_msg);
 					}
 					FLASH_LOG(Templates, Error, error_msg);
-					continue;
+					return std::nullopt;
 				}
 
 				// Check if the assertion failed
@@ -4160,7 +4160,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						throw CompileError(error_msg);
 					}
 					FLASH_LOG(Templates, Error, error_msg);
-					continue;
+					return std::nullopt;
 				}
 
 				FLASH_LOG(Templates, Debug, "Deferred static_assert passed during template instantiation");
@@ -8928,7 +8928,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				throw CompileError(error_msg);
 			}
 			FLASH_LOG(Templates, Error, error_msg);
-			continue;
+			return std::nullopt;
 		}
 
 		// Check if the assertion failed
@@ -8939,7 +8939,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				throw CompileError(error_msg);
 			}
 			FLASH_LOG(Templates, Error, error_msg);
-			continue;
+			return std::nullopt;
 		}
 
 		FLASH_LOG(Templates, Debug, "Deferred static_assert passed during template instantiation");

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3,6 +3,7 @@
 #include "ConstExprEvaluator.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
+#include "ParserTemplateClassShared.h"
 #include "TemplateRegistry_Pattern.h"
 #include "TypeTraitEvaluator.h"
 
@@ -2316,32 +2317,24 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 			}
 			return_type = emplace_node<TypeSpecifierNode>(reparsed_return_type);
 		} else {
-			TypeIndex substituted_return_type_index = substitute_template_parameter(
-				orig_return_type, template_params, template_args);
-
-			// Create return type with substituted type, preserving qualifiers
-			return_type = emplace_node<TypeSpecifierNode>(
-				substituted_return_type_index,
-				get_type_size_bits(substituted_return_type_index.category()),
-				orig_return_type.token(),
-				orig_return_type.cv_qualifier(),
-				ReferenceQualifier::None);
-
-			// Apply pointer levels and references from original type
-			TypeSpecifierNode& return_type_ref = return_type.as<TypeSpecifierNode>();
-			return_type_ref.set_reference_qualifier(orig_return_type.reference_qualifier());
-			applyTemplateArgIndirection(return_type_ref, orig_return_type, template_params, template_args,
-										/*propagate_reference_qualifier=*/true);
-			for (const auto& ptr_level : orig_return_type.pointer_levels()) {
-				return_type_ref.add_pointer_level(ptr_level.cv_qualifier);
-			}
-			propagateFunctionSignatureFromTemplateArg(
-				return_type_ref,
+			TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
 				orig_return_type,
-				substituted_return_type_index,
+				orig_decl.type_node(),
+				orig_decl.identifier_token(),
 				template_params,
-				template_args);
-			apply_resolved_alias_metadata_local(return_type_ref);
+				template_args,
+				[this](const ASTNode& node, const auto& params, const auto& args) {
+					return substituteTemplateParameters(node, params, args);
+				},
+				[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+					return substitute_template_parameter(type_spec, params, args);
+				},
+				nullptr,
+				TypeIndex{},
+				TypeIndex{},
+				false,
+				true);
+			return_type = emplace_node<TypeSpecifierNode>(substituted_return_type);
 		}
 
 		auto new_decl = emplace_node<DeclarationNode>(return_type, mangled_token);
@@ -2467,41 +2460,30 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 				return true;
 			};
 		auto buildMaterializedParamType =
-			[&](const TypeSpecifierNode& original_param_type,
+			[&](const DeclarationNode& original_param_decl,
 				const InlineVector<ASTNode, 4>& materialized_template_params,
 				const InlineVector<TemplateTypeArg, 4>& materialized_template_args) {
-				TypeIndex substituted_type_index = substitute_template_parameter(
-					original_param_type, materialized_template_params, materialized_template_args);
-				ASTNode param_type = emplace_node<TypeSpecifierNode>(
-					substituted_type_index,
-					get_type_size_bits(substituted_type_index.category()),
-					original_param_type.token(),
-					original_param_type.cv_qualifier(),
-					ReferenceQualifier::None);
-				resolveDependentMemberAlias(param_type, materialized_template_params, materialized_template_args);
-
-				TypeSpecifierNode& param_type_ref = param_type.as<TypeSpecifierNode>();
-				int resolved_param_size_bits = getTypeSpecSizeBits(param_type_ref);
-				if (resolved_param_size_bits > 0) {
-					param_type_ref.set_size_in_bits(resolved_param_size_bits);
-				}
-				param_type_ref.set_reference_qualifier(original_param_type.reference_qualifier());
-				applyTemplateArgIndirection(
-					param_type_ref,
+				const TypeSpecifierNode& original_param_type = original_param_decl.type_specifier_node();
+				TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
 					original_param_type,
+					original_param_decl.type_node(),
+					original_param_decl.identifier_token(),
 					materialized_template_params,
 					materialized_template_args,
-					/*propagate_reference_qualifier=*/true);
-				for (const auto& ptr_level : original_param_type.pointer_levels()) {
-					param_type_ref.add_pointer_level(ptr_level.cv_qualifier);
-				}
-				propagateFunctionSignatureFromTemplateArg(
-					param_type_ref,
-					original_param_type,
-					substituted_type_index,
-					materialized_template_params,
-					materialized_template_args);
-				apply_resolved_alias_metadata_local(param_type_ref);
+					[this](const ASTNode& node, const auto& params, const auto& args) {
+						return substituteTemplateParameters(node, params, args);
+					},
+					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+						return substitute_template_parameter(type_spec, params, args);
+					},
+					nullptr,
+					TypeIndex{},
+					TypeIndex{},
+					false,
+					true);
+				ASTNode param_type = emplace_node<TypeSpecifierNode>(substituted_param_type);
+				resolveDependentMemberAlias(param_type, materialized_template_params, materialized_template_args);
+				normalizeSubstitutedTypeSpec(param_type.as<TypeSpecifierNode>());
 				return param_type;
 			};
 
@@ -2525,7 +2507,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 								continue;
 							}
 
-							ASTNode param_type = buildMaterializedParamType(orig_param_type, subst_params, subst_args);
+							ASTNode param_type = buildMaterializedParamType(param_decl, subst_params, subst_args);
 
 							std::string_view param_name = buildPackElementParamName(param_decl, pack_element_offset);
 
@@ -2546,37 +2528,26 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 				}
 
 				// Substitute template parameters in the type
-				TypeIndex substituted_type_index = substitute_template_parameter(
-					orig_param_type, template_params, template_args);
-
-				// Create new type specifier with substituted type
-				ASTNode param_type = emplace_node<TypeSpecifierNode>(
-					substituted_type_index,
-					get_type_size_bits(substituted_type_index.category()),
-					orig_param_type.token(),
-					orig_param_type.cv_qualifier(),
-					ReferenceQualifier::None);
-				resolveDependentMemberAlias(param_type, template_params, template_args);
-
-				// Apply pointer levels and references from original type
-				TypeSpecifierNode& param_type_ref = param_type.as<TypeSpecifierNode>();
-				int resolved_param_size_bits = getTypeSpecSizeBits(param_type_ref);
-				if (resolved_param_size_bits > 0) {
-					param_type_ref.set_size_in_bits(resolved_param_size_bits);
-				}
-				param_type_ref.set_reference_qualifier(orig_param_type.reference_qualifier());
-				applyTemplateArgIndirection(param_type_ref, orig_param_type, template_params, template_args,
-											/*propagate_reference_qualifier=*/true);
-				for (const auto& ptr_level : orig_param_type.pointer_levels()) {
-					param_type_ref.add_pointer_level(ptr_level.cv_qualifier);
-				}
-				propagateFunctionSignatureFromTemplateArg(
-					param_type_ref,
+				TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
 					orig_param_type,
-					substituted_type_index,
+					param_decl.type_node(),
+					param_decl.identifier_token(),
 					template_params,
-					template_args);
-				apply_resolved_alias_metadata_local(param_type_ref);
+					template_args,
+					[this](const ASTNode& node, const auto& params, const auto& args) {
+						return substituteTemplateParameters(node, params, args);
+					},
+					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+						return substitute_template_parameter(type_spec, params, args);
+					},
+					nullptr,
+					TypeIndex{},
+					TypeIndex{},
+					false,
+					true);
+				ASTNode param_type = emplace_node<TypeSpecifierNode>(substituted_param_type);
+				resolveDependentMemberAlias(param_type, template_params, template_args);
+				normalizeSubstitutedTypeSpec(param_type.as<TypeSpecifierNode>());
 
 				auto new_param_decl = emplace_node<DeclarationNode>(param_type, param_decl.identifier_token());
 				// Preserve default argument value from the original template declaration

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -306,9 +306,18 @@ std::optional<std::vector<TemplateTypeArg>> Parser::materializeDeferredAliasTemp
 		getTargetTemplateParameters(StringTable::getOrInternStringHandle(alias_node.target_template_name()));
 	substituted_args.reserve(target_template_args.size());
 
+	auto getTargetTemplateParam = [&](size_t index) -> const TemplateParameterNode* {
+		if (index < target_template_params.size()) {
+			return &target_template_params[index];
+		}
+		if (!target_template_params.empty() && target_template_params.back().is_variadic()) {
+			return &target_template_params.back();
+		}
+		return nullptr;
+	};
+
 	for (size_t i = 0; i < target_template_args.size(); ++i) {
-		const TemplateParameterNode* target_template_param =
-			i < target_template_params.size() ? &target_template_params[i] : nullptr;
+		const TemplateParameterNode* target_template_param = getTargetTemplateParam(i);
 		auto materialized_arg = materializeDeferredAliasTemplateArg(
 			target_template_args[i],
 			alias_node.template_parameters(),

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -24,6 +24,60 @@ TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_
 
 namespace {
 
+	InlineVector<TemplateParameterNode, 4> getTargetTemplateParameters(StringHandle target_template_name) {
+		if (!target_template_name.isValid()) {
+			return {};
+		}
+		if (auto alias_template_opt = gTemplateRegistry.lookup_alias_template(target_template_name);
+			alias_template_opt.has_value()) {
+			return alias_template_opt->as<TemplateAliasNode>().template_parameters();
+		}
+		if (auto class_or_function_template_opt = gTemplateRegistry.lookupTemplate(target_template_name);
+			class_or_function_template_opt.has_value()) {
+			if (class_or_function_template_opt->is<TemplateClassDeclarationNode>()) {
+				return class_or_function_template_opt->as<TemplateClassDeclarationNode>().template_parameters();
+			}
+			if (class_or_function_template_opt->is<TemplateFunctionDeclarationNode>()) {
+				return class_or_function_template_opt->as<TemplateFunctionDeclarationNode>().template_parameters();
+			}
+		}
+		if (auto variable_template_opt = gTemplateRegistry.lookupVariableTemplate(target_template_name);
+			variable_template_opt.has_value()) {
+			return variable_template_opt->as<TemplateVariableDeclarationNode>().template_parameters();
+		}
+		return {};
+	}
+
+	StringHandle getQualifiedIdentifierHandle(const QualifiedIdentifierNode& qual_id) {
+		if (!qual_id.namespace_handle().isValid() || qual_id.namespace_handle().isGlobal()) {
+			return qual_id.nameHandle();
+		}
+		return gNamespaceRegistry.buildQualifiedIdentifier(qual_id.namespace_handle(), qual_id.nameHandle());
+	}
+
+	std::optional<TemplateTypeArg> classifyDeferredQualifiedIdentifier(
+		const QualifiedIdentifierNode& qual_id,
+		const TemplateParameterNode* target_template_param) {
+		if (target_template_param == nullptr) {
+			return std::nullopt;
+		}
+		const StringHandle qualified_name = getQualifiedIdentifierHandle(qual_id);
+		switch (target_template_param->kind()) {
+		case TemplateParameterKind::NonType:
+			if (!target_template_param->has_type()) {
+				throw InternalError("Non-type target template parameter is missing a declared type");
+			}
+			return TemplateTypeArg::makeDependentValue(
+				qualified_name,
+				target_template_param->type_specifier_node().type());
+		case TemplateParameterKind::Template:
+			return TemplateTypeArg::makeTemplate(qualified_name);
+		case TemplateParameterKind::Type:
+			return std::nullopt;
+		}
+		return std::nullopt;
+	}
+
 	ASTNode substituteNonTypeDefaultExpressionImpl(
 		Parser& parser,
 		const ASTNode& default_node,
@@ -111,7 +165,8 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
 	const InlineVector<ASTNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
-	const std::vector<TemplateTypeArg>& template_args) {
+	const std::vector<TemplateTypeArg>& template_args,
+	const TemplateParameterNode* target_template_param) {
 	const auto find_param_index = [&](StringHandle param_name) -> std::optional<size_t> {
 		for (size_t i = 0; i < param_names.size(); ++i) {
 			if (param_names[i] == param_name) {
@@ -221,9 +276,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	}
 
 	if (const auto* qual_id = std::get_if<QualifiedIdentifierNode>(&arg_expr)) {
-		return TemplateTypeArg::makeDependentValue(
-			StringTable::getOrInternStringHandle(qual_id->full_name()),
-			TypeCategory::Bool);
+		return classifyDeferredQualifiedIdentifier(*qual_id, target_template_param);
 	}
 
 	return std::nullopt;
@@ -233,12 +286,14 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
 	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
-	const std::vector<TemplateTypeArg>& template_args) {
+	const std::vector<TemplateTypeArg>& template_args,
+	const TemplateParameterNode* target_template_param) {
 	return materializeDeferredAliasTemplateArg(
 		arg_node,
 		cloneTemplateParameterNodes(template_parameters),
 		param_names,
-		template_args);
+		template_args,
+		target_template_param);
 }
 
 std::optional<std::vector<TemplateTypeArg>> Parser::materializeDeferredAliasTemplateArgs(
@@ -247,14 +302,19 @@ std::optional<std::vector<TemplateTypeArg>> Parser::materializeDeferredAliasTemp
 	std::vector<TemplateTypeArg> substituted_args;
 	const auto& param_names = alias_node.template_param_names();
 	const auto& target_template_args = alias_node.target_template_args();
+	const auto target_template_params =
+		getTargetTemplateParameters(StringTable::getOrInternStringHandle(alias_node.target_template_name()));
 	substituted_args.reserve(target_template_args.size());
 
-	for (const auto& arg_node : target_template_args) {
+	for (size_t i = 0; i < target_template_args.size(); ++i) {
+		const TemplateParameterNode* target_template_param =
+			i < target_template_params.size() ? &target_template_params[i] : nullptr;
 		auto materialized_arg = materializeDeferredAliasTemplateArg(
-			arg_node,
+			target_template_args[i],
 			alias_node.template_parameters(),
 			param_names,
-			template_args);
+			template_args,
+			target_template_param);
 		if (!materialized_arg.has_value()) {
 			return std::nullopt;
 		}

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -7,6 +7,26 @@
 #include "ParserTemplateClassShared.h"
 #include "RebindStaticMemberAst.h"
 
+namespace {
+
+[[noreturn]] void throwLazyMemberDefinitionCompileError(
+	const LazyMemberFunctionInfo& lazy_info,
+	std::string_view member_kind,
+	std::string_view detail) {
+	throw CompileError(std::string(StringBuilder()
+		.append("Lazy ")
+		.append(member_kind)
+		.append(" '")
+		.append(StringTable::getStringView(effectiveLookupName(lazy_info.identity)))
+		.append("' for '")
+		.append(StringTable::getStringView(lazy_info.identity.instantiated_owner_name))
+		.append("' ")
+		.append(detail)
+		.commit()));
+}
+
+} // namespace
+
 std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key) {
 	auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
 	auto lazy_info_opt = lazy_registry.getLazyMemberInfo(member_key);
@@ -35,8 +55,10 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	if (lazy_info.identity.kind == DeferredMemberIdentity::Kind::Constructor && lazy_info.identity.original_member_node.is<ConstructorDeclarationNode>()) {
 		const ConstructorDeclarationNode& ctor_decl = lazy_info.identity.original_member_node.as<ConstructorDeclarationNode>();
 		if (!ctor_decl.has_any_body_source()) {
-			FLASH_LOG(Templates, Error, "Lazy constructor has no definition and no deferred body position");
-			return std::nullopt;
+			throwLazyMemberDefinitionCompileError(
+				lazy_info,
+				"constructor",
+				"has no definition or deferred body position");
 		}
 
 		StringHandle ctor_name_handle = effectiveLookupName(lazy_info.identity);
@@ -374,8 +396,10 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	if (lazy_info.identity.kind == DeferredMemberIdentity::Kind::Destructor && lazy_info.identity.original_member_node.is<DestructorDeclarationNode>()) {
 		const DestructorDeclarationNode& dtor_decl = lazy_info.identity.original_member_node.as<DestructorDeclarationNode>();
 		if (!dtor_decl.is_materialized()) {
-			FLASH_LOG(Templates, Error, "Lazy destructor has no definition");
-			return std::nullopt;
+			throwLazyMemberDefinitionCompileError(
+				lazy_info,
+				"destructor",
+				"has no materialized definition");
 		}
 
 		StringHandle dtor_name_handle = effectiveLookupName(lazy_info.identity);
@@ -447,16 +471,17 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 
 	// Get the original function declaration
 	if (!lazy_info.identity.original_member_node.is<FunctionDeclarationNode>()) {
-		FLASH_LOG(Templates, Error, "Lazy member function node is not a FunctionDeclarationNode");
-		return std::nullopt;
+		throw InternalError("Lazy member function node is not a FunctionDeclarationNode");
 	}
 
 	const FunctionDeclarationNode& func_decl = lazy_info.identity.original_member_node.as<FunctionDeclarationNode>();
 	const DeclarationNode& decl = func_decl.decl_node();
 
 	if (!func_decl.has_any_body_source()) {
-		FLASH_LOG(Templates, Error, "Lazy member function has no definition and no deferred body position");
-		return std::nullopt;
+		throwLazyMemberDefinitionCompileError(
+			lazy_info,
+			"member function",
+			"has no definition or deferred body position");
 	}
 
 	// Look up the owner struct once for use in both return type and parameter alias resolution.

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -35,6 +35,9 @@ std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey
 	}
 
 	auto instantiated = instantiateLazyMemberFunction(*lazy_info_opt);
+	if (!instantiated.has_value()) {
+		return std::nullopt;
+	}
 	lazy_registry.markInstantiated(
 		LazyMemberKey::exact(
 			lazy_info_opt->identity.instantiated_owner_name,

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -7,6 +7,22 @@
 #include "ParserTemplateClassShared.h"
 #include "RebindStaticMemberAst.h"
 
+std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key) {
+	auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
+	auto lazy_info_opt = lazy_registry.getLazyMemberInfo(member_key);
+	if (!lazy_info_opt.has_value()) {
+		return std::nullopt;
+	}
+
+	auto instantiated = instantiateLazyMemberFunction(*lazy_info_opt);
+	lazy_registry.markInstantiated(
+		LazyMemberKey::exact(
+			lazy_info_opt->identity.instantiated_owner_name,
+			effectiveLookupName(lazy_info_opt->identity),
+			lazy_info_opt->identity.is_const_method));
+	return instantiated;
+}
+
 std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFunctionInfo& lazy_info) {
 	FLASH_LOG(Templates, Debug, "instantiateLazyMemberFunction: ",
 			  lazy_info.identity.instantiated_owner_name, "::", effectiveLookupName(lazy_info.identity));

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -60,7 +60,11 @@ ParseResult Parser::parse_template_parameter_list(InlineVector<TemplateParameter
 			// Add this parameter's name so subsequent parameters can reference it in
 			// their default values, e.g. template<typename T, bool = is_arithmetic<T>::value>.
 			auto& tparam = out_params.back();
-			pushCurrentTemplateParamName(tparam.nameHandle());
+			const TypeCategory non_type_category =
+				tparam.kind() == TemplateParameterKind::NonType && tparam.has_type()
+				? tparam.type_specifier_node().type()
+				: TypeCategory::Invalid;
+			pushCurrentTemplateParameter(tparam.nameHandle(), tparam.kind(), non_type_category);
 			if (tparam.kind() == TemplateParameterKind::Type ||
 				tparam.kind() == TemplateParameterKind::Template) {
 				ensureTemplateParameterTypeRegistration(tparam);
@@ -112,6 +116,10 @@ Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
 	for (TemplateParameterNode& tparam : template_params) {
 		metadata.names.push_back(tparam.nameHandle());
 		metadata.kinds.push_back(tparam.kind());
+		metadata.non_type_categories.push_back(
+			tparam.kind() == TemplateParameterKind::NonType && tparam.has_type()
+			? tparam.type_specifier_node().type()
+			: TypeCategory::Invalid);
 		metadata.has_packs |= tparam.is_variadic();
 		if (tparam.kind() == TemplateParameterKind::Type ||
 			tparam.kind() == TemplateParameterKind::Template) {
@@ -845,6 +853,83 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 		return SimpleTemplateArgKind::NotSimple;
 	};
 
+	auto dependentIdentifierValueCategory = [&](StringHandle name_handle) -> std::optional<TypeCategory> {
+		for (const auto& subst : template_param_substitutions_) {
+			if (subst.param_name == name_handle && subst.is_value_param) {
+				return subst.value_type;
+			}
+		}
+
+		if (auto current_param_category = currentTemplateParamNonTypeCategory(name_handle);
+			current_param_category.has_value()) {
+			return current_param_category;
+		}
+
+		if (auto symbol_lookup = lookup_symbol_with_template_check(name_handle);
+			symbol_lookup.has_value()) {
+			if (symbol_lookup->is<VariableDeclarationNode>()) {
+				return symbol_lookup->as<VariableDeclarationNode>().declaration().type_specifier_node().type();
+			}
+			if (symbol_lookup->is<ExpressionNode>()) {
+				const ExpressionNode& lookup_expr = symbol_lookup->as<ExpressionNode>();
+				if (const auto* tparam_ref = std::get_if<TemplateParameterReferenceNode>(&lookup_expr)) {
+					return currentTemplateParamNonTypeCategory(tparam_ref->param_name());
+				}
+			}
+		}
+
+		return std::nullopt;
+	};
+
+	auto dependentExpressionValueCategory =
+		[&](const ExpressionNode& expr, std::optional<StringHandle> dependent_name = std::nullopt) {
+			if (dependent_name.has_value()) {
+				if (auto category = dependentIdentifierValueCategory(*dependent_name);
+					category.has_value()) {
+					return *category;
+				}
+			}
+
+			if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
+				const auto& tparam_ref = std::get<TemplateParameterReferenceNode>(expr);
+				if (auto category = dependentIdentifierValueCategory(tparam_ref.param_name());
+					category.has_value()) {
+					return *category;
+				}
+			}
+
+			if (std::holds_alternative<IdentifierNode>(expr)) {
+				const auto& id = std::get<IdentifierNode>(expr);
+				if (auto category = dependentIdentifierValueCategory(
+						StringTable::getOrInternStringHandle(id.name()));
+					category.has_value()) {
+					return *category;
+				}
+			}
+
+			if (std::holds_alternative<SizeofExprNode>(expr) ||
+				std::holds_alternative<AlignofExprNode>(expr)) {
+				return TypeCategory::UnsignedLongLong;
+			}
+
+			if (std::holds_alternative<NoexceptExprNode>(expr) ||
+				std::holds_alternative<TypeTraitExprNode>(expr)) {
+				return TypeCategory::Bool;
+			}
+
+			if (std::holds_alternative<BinaryOperatorNode>(expr)) {
+				const auto& binary = std::get<BinaryOperatorNode>(expr);
+				if (binary.op() == "==" || binary.op() == "!=" ||
+					binary.op() == "<" || binary.op() == "<=" ||
+					binary.op() == ">" || binary.op() == ">=" ||
+					binary.op() == "&&" || binary.op() == "||") {
+					return TypeCategory::Bool;
+				}
+			}
+
+			return TypeCategory::Int;
+		};
+
 	while (true) {
 		// Save position in case type parsing fails
 		SaveHandle arg_saved_pos = save_token_position();
@@ -877,12 +962,9 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 					TemplateTypeArg simple_arg = prebuilt_arg.value_or(
 						TemplateTypeArg::makeDependentValue(
 							identifier_handle,
-							// Deferred bare identifier NTTPs do not yet carry an authoritative
-							// value type here. Use Int as the same neutral placeholder category
-							// already used elsewhere for dependent NTTP identities; template
-							// instantiation later re-evaluates the stored expression and replaces
-							// this placeholder with the concrete value/category.
-							TypeCategory::Int,
+							dependentExpressionValueCategory(
+								ExpressionNode(IdentifierNode(identifier_token)),
+								identifier_handle),
 							0,
 							ASTNode::emplace_node<ExpressionNode>(IdentifierNode(identifier_token))));
 
@@ -1131,12 +1213,11 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 						FLASH_LOG(Templates, Debug, "Accepting dependent compile-time expression as template argument");
 						// Create a dependent template argument
 						auto makeDependentCompileTimeArg = [&](StringHandle dependent_name, std::optional<ASTNode> dep_expr) {
-							TypeCategory value_category = TypeCategory::Bool;
-							if (std::holds_alternative<SizeofExprNode>(expr) ||
-								std::holds_alternative<AlignofExprNode>(expr)) {
-								// sizeof/alignof have type size_t (modeled as UnsignedLongLong on 64-bit).
-								value_category = TypeCategory::UnsignedLongLong;
-							}
+							TypeCategory value_category = dependentExpressionValueCategory(
+								expr,
+								dependent_name.isValid()
+								? std::optional<StringHandle>(dependent_name)
+								: std::nullopt);
 							return TemplateTypeArg::makeDependentValue(dependent_name, value_category, 0, std::move(dep_expr));
 						};
 
@@ -1486,12 +1567,6 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 								std::holds_alternative<BinaryOperatorNode>(expr) ||
 								simple_identifier_kind == SimpleTemplateArgKind::ValueLike;
 							if (is_value_like_dependent_expr) {
-								// For sizeof/alignof expressions, use UnsignedLongLong (size_t) as the type
-								TypeCategory value_category = TypeCategory::Bool;
-								if (std::holds_alternative<SizeofExprNode>(expr) ||
-									std::holds_alternative<AlignofExprNode>(expr)) {
-									value_category = TypeCategory::UnsignedLongLong;
-								}
 								// Store the original AST expression for dependent NTTP expressions
 								// so it can be re-evaluated during template instantiation
 								std::optional<ASTNode> stored_expr = std::nullopt;
@@ -1507,7 +1582,11 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 									stored_expr = *expr_result.node();
 									FLASH_LOG(Templates, Debug, "Storing dependent NTTP expression (sizeof/alignof/etc) for re-evaluation");
 								}
-								dependent_arg = TemplateTypeArg::makeDependentValue(StringHandle{}, value_category, 0, std::move(stored_expr));
+								dependent_arg = TemplateTypeArg::makeDependentValue(
+									StringHandle{},
+									dependentExpressionValueCategory(expr),
+									0,
+									std::move(stored_expr));
 							} else {
 								dependent_arg.type_index = nativeTypeIndex(TypeCategory::UserDefined);  // Template parameter is a user-defined type placeholder; will try to look up
 								dependent_arg.is_value = false;	// This is a TYPE parameter, not a value

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -101,7 +101,10 @@ ParseResult Parser::parse_member_template_alias(StructDeclarationNode& struct_no
 
 	// Set template parameter context for parsing the requires clause
 	FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
-	setCurrentTemplateParameters(template_param_metadata.names, template_param_metadata.kinds);
+	setCurrentTemplateParameters(
+		template_param_metadata.names,
+		template_param_metadata.kinds,
+		template_param_metadata.non_type_categories);
 	FlashCpp::TemplateDepthGuard guard_parsing_body(parsing_template_depth_);
 
 	// Handle optional requires clause

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -389,11 +389,12 @@ ParseResult Parser::parse_type_specifier() {
 				underlying, TypeQualifier::None, underlying_size, underlying_token, CVQualifier::None));
 		}
 
-		// For non-enum types in template context, return a placeholder
-		// The actual type will be resolved when the template is instantiated
-		FLASH_LOG(Templates, Debug, "parse_type_specifier: __underlying_type of non-enum or deferred, returning int placeholder");
-		return ParseResult::success(emplace_node<TypeSpecifierNode>(
-			TypeCategory::Int, TypeQualifier::None, 32, underlying_token, CVQualifier::None));
+		if (type_info.is_incomplete_instantiation_ || type_info.isDependentMemberType()) {
+			FLASH_LOG(Templates, Debug, "parse_type_specifier: __underlying_type of incomplete dependent type, returning dependent placeholder");
+			return ParseResult::success(makeDependentUnderlyingType(arg_type));
+		}
+
+		return ParseResult::error("__underlying_type requires an enumeration type", underlying_token);
 	}
 
 	// Check for typename keyword (used in template-dependent contexts)

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2461,7 +2461,38 @@ ParseResult Parser::parse_decltype_specifier() {
 			CVQualifier::None,
 			ReferenceQualifier::None);
 	};
+	auto tokenRangeMentionsActiveTemplateParam = [&](SaveHandle scan_start) {
+		if (!isTemplateParameterTrackingActive()) {
+			return false;
+		}
 
+		SaveHandle resume_pos = save_token_position();
+		restore_token_position(scan_start);
+		int paren_depth = 1;
+		bool mentions_active_template_param = false;
+		while (!peek().is_eof() && paren_depth > 0) {
+			const Token token = peek_info();
+			if (token.type() == Token::Type::Identifier &&
+				std::find(
+					currentTemplateParamNames().begin(),
+					currentTemplateParamNames().end(),
+					token.handle()) != currentTemplateParamNames().end()) {
+				mentions_active_template_param = true;
+				break;
+			}
+			if (peek() == "("_tok) {
+				paren_depth++;
+			} else if (peek() == ")"_tok) {
+				paren_depth--;
+				if (paren_depth == 0) {
+					break;
+				}
+			}
+			advance();
+		}
+		restore_token_position(resume_pos);
+		return mentions_active_template_param;
+	};
 	// Expect '('
 	if (!consume("("_tok)) {
 		return ParseResult::error(std::string("Expected '(' after '") + std::string(keyword) + "'", current_token_);
@@ -2491,7 +2522,7 @@ ParseResult Parser::parse_decltype_specifier() {
 		// trailing return type) even in SFINAE context so the error doesn't cascade.
 		bool is_recursion_error = expr_result.error_message().find("recursion depth") != std::string::npos ||
 								  expr_result.error_message().find("recursion") != std::string::npos;
-		bool should_recover = isTemplateParameterTrackingActive() &&
+		bool should_recover = tokenRangeMentionsActiveTemplateParam(expr_start_pos) &&
 							  (template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe || is_recursion_error);
 		if (should_recover) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for failed decltype expression in template context");
@@ -2518,8 +2549,6 @@ ParseResult Parser::parse_decltype_specifier() {
 		discard_saved_token(expr_start_pos);
 		return expr_result;
 	}
-	discard_saved_token(expr_start_pos);
-
 	// Handle comma operator inside decltype: decltype(expr1, expr2, expr3)
 	// The comma here is the C++ comma operator, not an argument separator.
 	// The result type of decltype is the type of the last expression.
@@ -2531,7 +2560,7 @@ ParseResult Parser::parse_decltype_specifier() {
 			// In template context, create dependent type and skip to closing paren.
 			// Restore to position before the failed parse_expression to ensure
 			// reliable paren depth counting (mirrors the first-expression recovery above).
-			if (isTemplateParameterTrackingActive() &&
+			if (tokenRangeMentionsActiveTemplateParam(comma_expr_pos) &&
 				template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
 				restore_token_position(comma_expr_pos);
 				int paren_depth = 1;
@@ -2557,6 +2586,10 @@ ParseResult Parser::parse_decltype_specifier() {
 		expr_result = std::move(next_expr);
 	}
 
+	const bool decltype_source_mentions_active_template_param =
+		tokenRangeMentionsActiveTemplateParam(expr_start_pos);
+	discard_saved_token(expr_start_pos);
+
 	// Expect ')'
 	if (!consume(")"_tok)) {
 		return ParseResult::error("Expected ')' after decltype expression", current_token_);
@@ -2570,7 +2603,7 @@ ParseResult Parser::parse_decltype_specifier() {
 		// Check both parsing_template_depth_ > 0 and current_template_param_names_ since
 		// some template contexts (like member function templates in structs) might not
 		// set parsing_template_depth_ > 0 but will have template parameter names.
-		if (isTemplateParameterTrackingActive()) {
+		if (decltype_source_mentions_active_template_param) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for decltype expression in template context");
 			return saved_position.success(makeDependentDecltypeType(decltype_token));
 		}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -6768,21 +6768,11 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	LazyMemberKey query_key = is_const_member.has_value()
 		? LazyMemberKey::exact(struct_name, member_name, *is_const_member)
 		: LazyMemberKey::anyConst(struct_name, member_name);
-	auto lazy_info_opt = lazy_registry.getLazyMemberInfo(query_key);
-	if (!lazy_info_opt.has_value()) {
+	auto instantiated = parser_.instantiateLazyMemberIfNeeded(query_key);
+	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-
-	auto instantiated = parser_.instantiateLazyMemberFunction(*lazy_info_opt);
 	parser_.normalizePendingSemanticRootsIfAvailable();
-	// Mark using the const-ness of the actual lazy entry we resolved, so the
-	// specific-const and any-const call patterns stay consistent with what
-	// parser_.instantiateLazyMemberFunction() just materialized.
-	lazy_registry.markInstantiated(
-		LazyMemberKey::exact(
-			struct_name,
-			member_name,
-			lazy_info_opt->identity.is_const_method));
 	return instantiated;
 }
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -6758,8 +6758,6 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 		return std::nullopt;
 	}
 
-	auto& lazy_registry = LazyMemberInstantiationRegistry::getInstance();
-
 	// Resolve a matching lazy-member entry. When the caller is indifferent to
 	// const-ness, fall back to the "Any" variant so both const and non-const
 	// candidates are considered. getLazyMemberInfo / getLazyMemberInfoAny already

--- a/tests/decltype_nondependent_missing_call_in_template_fail.cpp
+++ b/tests/decltype_nondependent_missing_call_in_template_fail.cpp
@@ -1,0 +1,6 @@
+template<typename T>
+using broken_decltype = decltype(missing_function());
+
+int main() {
+	return 0;
+}

--- a/tests/explicit_instantiation_missing_template_fail.cpp
+++ b/tests/explicit_instantiation_missing_template_fail.cpp
@@ -1,0 +1,6 @@
+template class MissingTemplate<int>;
+
+int main() {
+	return 0;
+}
+

--- a/tests/explicit_instantiation_static_assert_fail.cpp
+++ b/tests/explicit_instantiation_static_assert_fail.cpp
@@ -1,0 +1,11 @@
+template<class T>
+struct StaticAssertOnInstantiation {
+	static_assert(sizeof(T) == 0, "explicit instantiation must evaluate static_assert");
+};
+
+template class StaticAssertOnInstantiation<int>;
+
+int main() {
+	return 0;
+}
+

--- a/tests/test_decltype_hidden_friend_adl_ret0.cpp
+++ b/tests/test_decltype_hidden_friend_adl_ret0.cpp
@@ -1,0 +1,13 @@
+namespace adl_decltype_hidden_friend {
+	struct Tag {
+		friend int hidden(Tag) {
+			return 17;
+		}
+	};
+}
+
+int main() {
+	using ReturnType = decltype(hidden(adl_decltype_hidden_friend::Tag{}));
+	ReturnType value = 17;
+	return value - 17;
+}

--- a/tests/underlying_type_non_enum_fail.cpp
+++ b/tests/underlying_type_non_enum_fail.cpp
@@ -1,0 +1,5 @@
+using InvalidUnderlying = __underlying_type(int);
+
+int main() {
+	return 0;
+}


### PR DESCRIPTION
## Summary

- harden template-instantiation diagnostics so unresolved placeholders and explicit instantiation failures surface as errors instead of permissive fallback behavior
- share more template substitution paths across function, alias, lazy-member, NTTP, and `decltype(...)` handling to reduce duplicated logic
- add regression coverage for explicit instantiation, `__underlying_type`, and non-dependent `decltype(...)` failure cases

## Testing

- `.\build_flashcpp.bat`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Faster, clearer failures for lazy member instantiation and earlier detection of unresolved/invalid function types; pending semantic work is normalized after instantiation.

* **Improvements**
  * Expanded template-parameter and non-type-parameter tracking; more robust template substitution, decltype and underlying-type handling; stricter error paths for template instantiation failures.

* **Tests**
  * Added tests for explicit instantiation, static_assert evaluation, decltype error cases, and invalid underlying-type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->