### PR TITLE
Share call parameter lookup

### DIFF
--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1192,6 +1192,19 @@ private:
 	};
 	// Cache parameter reference info by mangled function name to aid call-site lowering
 	std::unordered_map<StringHandle, std::vector<CachedParamInfo>> function_param_cache_;
+	struct CallParamView {
+		const DeclarationNode* declaration = nullptr;
+		const CachedParamInfo* cached = nullptr;
+		std::optional<TypeSpecifierNode> deduced_type;
+		CVReferenceQualifier ref_qualifier = CVReferenceQualifier::None;
+		bool is_parameter_pack = false;
+
+		const TypeSpecifierNode* type() const;
+	};
+	CallParamView resolveCallParamView(const std::vector<ASTNode>& param_nodes,
+									   size_t arg_index,
+									   const std::vector<TypeSpecifierNode>* deduced_param_types,
+									   const std::vector<CachedParamInfo>* cached_params) const;
 	CVReferenceQualifier callParameterRefQualifier(const TypeSpecifierNode* param_type) const;
 	void applyTypeNodeMetadata(TypedValue& value, const TypeSpecifierNode& type_node);
 	void applyCallParameterBindingMetadata(TypedValue& value, const TypeSpecifierNode& param_type);

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1192,6 +1192,7 @@ private:
 	};
 	// Cache parameter reference info by mangled function name to aid call-site lowering
 	std::unordered_map<StringHandle, std::vector<CachedParamInfo>> function_param_cache_;
+	CVReferenceQualifier callParameterRefQualifier(const TypeSpecifierNode* param_type) const;
 	void applyTypeNodeMetadata(TypedValue& value, const TypeSpecifierNode& type_node);
 	void applyCallParameterBindingMetadata(TypedValue& value, const TypeSpecifierNode& param_type);
 	std::optional<TypedValue> tryBuildSemaBoundCallArgument(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode& param_type, const CallArgReferenceBindingInfo* sema_ref_binding, const Token& token);

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1197,7 +1197,6 @@ private:
 		const CachedParamInfo* cached = nullptr;
 		std::optional<TypeSpecifierNode> deduced_type;
 		CVReferenceQualifier ref_qualifier = CVReferenceQualifier::None;
-		bool is_parameter_pack = false;
 
 		const TypeSpecifierNode* type() const;
 	};

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1305,7 +1305,6 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		CallParamView param_view = resolveCallParamView(param_nodes, arg_index, nullptr, cached_param_list);
 		const TypeSpecifierNode* param_type = param_view.type();
 		CVReferenceQualifier param_ref_qualifier = param_view.ref_qualifier;
-		[[maybe_unused]] bool param_is_pack = param_view.is_parameter_pack;
 		const CallArgReferenceBindingInfo* sema_ref_binding = nullptr;
 		if (param_type && sema_) {
 			sema_ref_binding = sema_->getCallRefBinding(

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1302,35 +1302,10 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	}
 
 	callExprNode.arguments().visit([&](ASTNode argument) {
-		// Get the parameter type for this argument (if it exists)
-		const TypeSpecifierNode* param_type = nullptr;
-		const DeclarationNode* param_decl = nullptr;
-		if (arg_index < param_nodes.size() && param_nodes[arg_index].is<DeclarationNode>()) {
-			param_decl = &param_nodes[arg_index].as<DeclarationNode>();
-		} else if (!param_nodes.empty() && param_nodes.back().is<DeclarationNode>()) {
-			const auto& last_param = param_nodes.back().as<DeclarationNode>();
-			if (last_param.is_parameter_pack()) {
-				param_decl = &last_param;
-			}
-		}
-		if (param_decl)
-			param_type = &param_decl->type_specifier_node();
-
-		const CachedParamInfo* cached_param = nullptr;
-		if (cached_param_list && !cached_param_list->empty()) {
-			if (arg_index < cached_param_list->size()) {
-				cached_param = &(*cached_param_list)[arg_index];
-			} else if (cached_param_list->back().is_parameter_pack) {
-				cached_param = &cached_param_list->back();
-			}
-		}
-
-		CVReferenceQualifier param_ref_qualifier = callParameterRefQualifier(param_type);
-		[[maybe_unused]] bool param_is_pack = param_decl && param_decl->is_parameter_pack();
-		if (!param_type && cached_param) {
-			param_ref_qualifier = cached_param->ref_qualifier;
-			param_is_pack = cached_param->is_parameter_pack;
-		}
+		CallParamView param_view = resolveCallParamView(param_nodes, arg_index, nullptr, cached_param_list);
+		const TypeSpecifierNode* param_type = param_view.type();
+		CVReferenceQualifier param_ref_qualifier = param_view.ref_qualifier;
+		[[maybe_unused]] bool param_is_pack = param_view.is_parameter_pack;
 		const CallArgReferenceBindingInfo* sema_ref_binding = nullptr;
 		if (param_type && sema_) {
 			sema_ref_binding = sema_->getCallRefBinding(

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1325,13 +1325,9 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			}
 		}
 
-		CVReferenceQualifier param_ref_qualifier = CVReferenceQualifier::None;
+		CVReferenceQualifier param_ref_qualifier = callParameterRefQualifier(param_type);
 		[[maybe_unused]] bool param_is_pack = param_decl && param_decl->is_parameter_pack();
-		if (param_type) {
-			param_ref_qualifier = param_type->is_rvalue_reference()
-									  ? CVReferenceQualifier::RValueReference
-									  : (param_type->is_reference() ? CVReferenceQualifier::LValueReference : CVReferenceQualifier::None);
-		} else if (cached_param) {
+		if (!param_type && cached_param) {
 			param_ref_qualifier = cached_param->ref_qualifier;
 			param_is_pack = cached_param->is_parameter_pack;
 		}

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1868,11 +1868,11 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					sema_call_key,
 					arg_index);
 			}
+			const CVReferenceQualifier param_ref_qualifier = callParameterRefQualifier(param_type);
 
 			// Evaluate the argument expression once when sema ref-binding is active so that
 			// the result can be reused in the fallback path without double evaluation.
 			std::optional<ExprResult> sema_evaluated_arg;
-			bool sema_ref_binding_applied = false;
 			if (param_type && sema_ref_binding && sema_ref_binding->is_valid()) {
 				ExpressionContext arg_context = sema_ref_binding->binds_directly()
 													? ExpressionContext::LValueAddress
@@ -1882,7 +1882,6 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 						*sema_evaluated_arg, argument, *param_type, sema_ref_binding, callExprNode.called_from())) {
 					call_op.args.push_back(std::move(*sema_bound_arg));
 					arg_index++;
-					sema_ref_binding_applied = true;
 					return;
 				}
 			}
@@ -1915,10 +1914,13 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(func_addr_var)));
 				} else if (symbol.has_value()) {
 					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
-					// Check if parameter expects a reference
-					if (decl_node && !sema_ref_binding_applied &&
-						param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
-						call_op.args.push_back(buildReferenceCallArgumentFromDeclaration(*decl_node, identifier_name));
+					if (decl_node) {
+						call_op.args.push_back(buildDirectIdentifierCallArgument(
+							*decl_node,
+							identifier_name,
+							param_ref_qualifier,
+							argument,
+							callExprNode.called_from()));
 					} else {
 						call_op.args.push_back(buildOrdinaryCallArgument(argument, param_type, sema_evaluated_arg, callExprNode.called_from()));
 					}
@@ -1933,8 +1935,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 												 : visitExpressionNode(argument.as<ExpressionNode>());
 
 				// Check if parameter expects a reference and argument is a literal
-				if (!sema_ref_binding_applied &&
-					param_type && (param_type->is_reference() || param_type->is_rvalue_reference())) {
+				if (param_ref_qualifier != CVReferenceQualifier::None) {
 					// Parameter expects a reference, but argument is not an identifier
 					// We need to materialize the value into a temporary and pass its address
 					call_op.args.push_back(buildReferenceCallArgumentFromResult(

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1901,7 +1901,11 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(func_addr_var)));
 				} else if (symbol.has_value()) {
 					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
-					if (decl_node && param_ref_qualifier != CVReferenceQualifier::None) {
+					const bool can_use_direct_identifier_arg =
+						decl_node &&
+						param_ref_qualifier != CVReferenceQualifier::None &&
+						(!sema_ref_binding || !sema_ref_binding->is_valid() || sema_ref_binding->binds_directly());
+					if (can_use_direct_identifier_arg) {
 						call_op.args.push_back(buildDirectIdentifierCallArgument(
 							*decl_node,
 							identifier_name,

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1843,32 +1843,19 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		}
 
 		callExprNode.arguments().visit([&](ASTNode argument) {
-			// Get the parameter type from the function declaration to check if it's a reference
-			// For generic lambdas, use the deduced types from param_types instead of the original auto types
-			const TypeSpecifierNode* param_type = nullptr;
-			std::optional<TypeSpecifierNode> deduced_param_type;
-			if (arg_index < param_types.size()) {
-				// Use deduced type from param_types (handles generic lambdas correctly)
-				deduced_param_type = param_types[arg_index];
-				param_type = &(*deduced_param_type);
-			} else if (arg_index < actual_func_decl->parameter_nodes().size()) {
-				const ASTNode& param_node = actual_func_decl->parameter_nodes()[arg_index];
-				if (param_node.is<DeclarationNode>()) {
-					const DeclarationNode& param_decl = param_node.as<DeclarationNode>();
-					param_type = &param_decl.type_specifier_node();
-				} else if (param_node.is<VariableDeclarationNode>()) {
-					const VariableDeclarationNode& var_decl = param_node.as<VariableDeclarationNode>();
-					const DeclarationNode& param_decl = var_decl.declaration();
-					param_type = &param_decl.type_specifier_node();
-				}
-			}
+			CallParamView param_view = resolveCallParamView(
+				actual_func_decl->parameter_nodes(),
+				arg_index,
+				&param_types,
+				nullptr);
+			const TypeSpecifierNode* param_type = param_view.type();
 			const CallArgReferenceBindingInfo* sema_ref_binding = nullptr;
 			if (param_type && sema_) {
 				sema_ref_binding = sema_->getCallRefBinding(
 					sema_call_key,
 					arg_index);
 			}
-			const CVReferenceQualifier param_ref_qualifier = callParameterRefQualifier(param_type);
+			const CVReferenceQualifier param_ref_qualifier = param_view.ref_qualifier;
 
 			// Evaluate the argument expression once when sema ref-binding is active so that
 			// the result can be reused in the fallback path without double evaluation.

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1901,7 +1901,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(func_addr_var)));
 				} else if (symbol.has_value()) {
 					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
-					if (decl_node) {
+					if (decl_node && param_ref_qualifier != CVReferenceQualifier::None) {
 						call_op.args.push_back(buildDirectIdentifierCallArgument(
 							*decl_node,
 							identifier_name,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -375,6 +375,70 @@ CVReferenceQualifier AstToIr::callParameterRefQualifier(const TypeSpecifierNode*
 	return CVReferenceQualifier::None;
 }
 
+const TypeSpecifierNode* AstToIr::CallParamView::type() const {
+	if (deduced_type.has_value()) {
+		return &*deduced_type;
+	}
+	if (declaration) {
+		return &declaration->type_specifier_node();
+	}
+	if (cached && cached->type_node.is<TypeSpecifierNode>()) {
+		return &cached->type_node.as<TypeSpecifierNode>();
+	}
+	return nullptr;
+}
+
+AstToIr::CallParamView AstToIr::resolveCallParamView(
+	const std::vector<ASTNode>& param_nodes,
+	size_t arg_index,
+	const std::vector<TypeSpecifierNode>* deduced_param_types,
+	const std::vector<CachedParamInfo>* cached_params) const {
+	CallParamView view;
+
+	if (deduced_param_types && arg_index < deduced_param_types->size()) {
+		view.deduced_type = (*deduced_param_types)[arg_index];
+		view.ref_qualifier = callParameterRefQualifier(view.type());
+		return view;
+	}
+
+	auto trySetDeclaration = [&](const ASTNode& param_node) {
+		if (param_node.is<DeclarationNode>()) {
+			view.declaration = &param_node.as<DeclarationNode>();
+		} else if (param_node.is<VariableDeclarationNode>()) {
+			view.declaration = &param_node.as<VariableDeclarationNode>().declaration();
+		}
+	};
+
+	if (arg_index < param_nodes.size()) {
+		trySetDeclaration(param_nodes[arg_index]);
+	} else if (!param_nodes.empty()) {
+		trySetDeclaration(param_nodes.back());
+		if (view.declaration && !view.declaration->is_parameter_pack()) {
+			view.declaration = nullptr;
+		}
+	}
+
+	if (view.declaration) {
+		view.is_parameter_pack = view.declaration->is_parameter_pack();
+		view.ref_qualifier = callParameterRefQualifier(view.type());
+		return view;
+	}
+
+	if (cached_params && !cached_params->empty()) {
+		if (arg_index < cached_params->size()) {
+			view.cached = &(*cached_params)[arg_index];
+		} else if (cached_params->back().is_parameter_pack) {
+			view.cached = &cached_params->back();
+		}
+	}
+	if (view.cached) {
+		view.is_parameter_pack = view.cached->is_parameter_pack;
+		view.ref_qualifier = view.cached->ref_qualifier;
+	}
+
+	return view;
+}
+
 std::optional<TypedValue> AstToIr::tryBuildSemaBoundCallArgument(
 	ExprResult argument_result,
 	const ASTNode& argument,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -419,7 +419,6 @@ AstToIr::CallParamView AstToIr::resolveCallParamView(
 	}
 
 	if (view.declaration) {
-		view.is_parameter_pack = view.declaration->is_parameter_pack();
 		view.ref_qualifier = callParameterRefQualifier(view.type());
 		return view;
 	}
@@ -432,7 +431,6 @@ AstToIr::CallParamView AstToIr::resolveCallParamView(
 		}
 	}
 	if (view.cached) {
-		view.is_parameter_pack = view.cached->is_parameter_pack;
 		view.ref_qualifier = view.cached->ref_qualifier;
 	}
 

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -362,6 +362,19 @@ void AstToIr::applyCallParameterBindingMetadata(TypedValue& value, const TypeSpe
 	}
 }
 
+CVReferenceQualifier AstToIr::callParameterRefQualifier(const TypeSpecifierNode* param_type) const {
+	if (!param_type) {
+		return CVReferenceQualifier::None;
+	}
+	if (param_type->is_rvalue_reference()) {
+		return CVReferenceQualifier::RValueReference;
+	}
+	if (param_type->is_reference()) {
+		return CVReferenceQualifier::LValueReference;
+	}
+	return CVReferenceQualifier::None;
+}
+
 std::optional<TypedValue> AstToIr::tryBuildSemaBoundCallArgument(
 	ExprResult argument_result,
 	const ASTNode& argument,
@@ -579,7 +592,7 @@ TypedValue AstToIr::buildConstructorArgumentValue(
 	const TypeSpecifierNode* param_type,
 	const Token& token) {
 	TypedValue value;
-	bool param_is_ref = param_type && (param_type->is_reference() || param_type->is_rvalue_reference());
+	bool param_is_ref = callParameterRefQualifier(param_type) != CVReferenceQualifier::None;
 
 	auto makeReferenceAddressValue = [&](TempVar address_temp) {
 		value.setType(argument_result.category());

--- a/tests/test_member_identifier_arg_conversion_ret0.cpp
+++ b/tests/test_member_identifier_arg_conversion_ret0.cpp
@@ -1,0 +1,29 @@
+struct Box {
+	int value;
+
+	Box(double input, int bias = 2) : value(static_cast<int>(input) + bias) {}
+};
+
+struct Sink {
+	int takeBox(Box box) {
+		return box.value;
+	}
+
+	int takeDouble(double value) {
+		return static_cast<int>(value * 2.0);
+	}
+};
+
+int main() {
+	Sink sink;
+
+	int int_source = 40;
+	if (sink.takeBox(int_source) != 42)
+		return 1;
+
+	float float_source = 1.5f;
+	if (sink.takeDouble(float_source) != 3)
+		return 2;
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Share indirect/member call identifier argument lowering through the direct identifier argument helper
- Add a shared call parameter view for parameter lookup, deduced generic-call params, cached params, and pack fallback
- Keep parameter-pack fallback internal to parameter lookup and remove unused locals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal handling of function/method call parameters and reference qualifiers; no change to external behavior.
* **Tests**
  * Added a new C++ test validating implicit argument conversions and call-site behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->