### PR TITLE
[codex] Share call assembly parameter lookup

### DIFF
--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1212,6 +1212,7 @@ private:
 	TypedValue buildOrdinaryCallArgument(const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);
 	TypedValue buildReferenceCallArgumentFromDeclaration(const DeclarationNode& decl_node, StringHandle identifier_name);
 	TypedValue buildReferenceCallArgumentFromResult(const ExprResult& argument_result, const Token& token, bool reuse_address_valued_temp);
+	bool canUseDirectIdentifierCallArgument(const DeclarationNode* decl_node, CVReferenceQualifier param_ref_qualifier, const CallArgReferenceBindingInfo* sema_ref_binding) const;
 	TypedValue buildDirectIdentifierCallArgument(const DeclarationNode& arg_decl_node, StringHandle identifier_name, CVReferenceQualifier param_ref_qualifier, const ASTNode& argument, const Token& token);
 	TypedValue buildConstructorArgumentValue(const ExprResult& argument_result,
 											 const ASTNode& argument,

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1669,22 +1669,8 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 
 	size_t arg_idx = 0;
 	for (TypedValue arg : call_arguments) {
-		const TypeSpecifierNode* param_type_spec = nullptr;
-		if (matched_func_decl && arg_idx < param_nodes.size() && param_nodes[arg_idx].is<DeclarationNode>()) {
-			param_type_spec = &param_nodes[arg_idx].as<DeclarationNode>().type_specifier_node();
-		} else if (cached_param_list && !cached_param_list->empty()) {
-			if (arg_idx < cached_param_list->size()) {
-				const auto& cached = (*cached_param_list)[arg_idx];
-				if (cached.type_node.is<TypeSpecifierNode>()) {
-					param_type_spec = &cached.type_node.as<TypeSpecifierNode>();
-				}
-			} else if (cached_param_list->back().is_parameter_pack) {
-				const auto& cached = cached_param_list->back();
-				if (cached.type_node.is<TypeSpecifierNode>()) {
-					param_type_spec = &cached.type_node.as<TypeSpecifierNode>();
-				}
-			}
-		}
+		CallParamView param_view = resolveCallParamView(param_nodes, arg_idx, nullptr, cached_param_list);
+		const TypeSpecifierNode* param_type_spec = param_view.type();
 		if (param_type_spec) {
 			// Preserve the lowered argument's type identity and pointer depth.
 			// They describe the runtime value being passed; copying them from the

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1901,11 +1901,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					call_op.args.push_back(makeTypedValue(TypeCategory::FunctionPointer, SizeInBits{64}, IrValue(func_addr_var)));
 				} else if (symbol.has_value()) {
 					const DeclarationNode* decl_node = get_decl_from_symbol(*symbol);
-					const bool can_use_direct_identifier_arg =
-						decl_node &&
-						param_ref_qualifier != CVReferenceQualifier::None &&
-						(!sema_ref_binding || !sema_ref_binding->is_valid() || sema_ref_binding->binds_directly());
-					if (can_use_direct_identifier_arg) {
+					if (canUseDirectIdentifierCallArgument(decl_node, param_ref_qualifier, sema_ref_binding)) {
 						call_op.args.push_back(buildDirectIdentifierCallArgument(
 							*decl_node,
 							identifier_name,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -578,6 +578,15 @@ TypedValue AstToIr::buildReferenceCallArgumentFromResult(
 	return toTypedValue(argument_result);
 }
 
+bool AstToIr::canUseDirectIdentifierCallArgument(
+	const DeclarationNode* decl_node,
+	CVReferenceQualifier param_ref_qualifier,
+	const CallArgReferenceBindingInfo* sema_ref_binding) const {
+	return decl_node &&
+		   param_ref_qualifier != CVReferenceQualifier::None &&
+		   (!sema_ref_binding || !sema_ref_binding->is_valid() || sema_ref_binding->binds_directly());
+}
+
 TypedValue AstToIr::buildDirectIdentifierCallArgument(
 	const DeclarationNode& arg_decl_node,
 	StringHandle identifier_name,


### PR DESCRIPTION
## Summary
- Reuse the shared CallParamView helper in direct call payload assembly
- Extract the member/indirect direct-identifier argument shortcut eligibility rule
- Keep sema reference-binding policy explicit at the call site while preserving ordinary conversion paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal argument-to-parameter binding logic to reduce code duplication and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->