### PR TITLE
[codex] Support constexpr pointer parameter writes

### DIFF
--- a/docs/CONSTEXPR_LIMITATIONS.md
+++ b/docs/CONSTEXPR_LIMITATIONS.md
@@ -947,10 +947,30 @@ constexpr int g() {
 static_assert(g() == 10);  // ✅ Works
 ```
 
-**Limitation:** Write-through-pointer in a *different* call frame (i.e., passing `&local`
-to a separate constexpr function that writes via the pointer parameter) is not yet
-supported.  This requires inter-frame binding mutation, which needs architectural changes
-to the evaluator.  Same-frame writes work fully.
+Write-through-pointer in a different constexpr call frame is now supported for
+straightforward local scalar and local struct-object targets. Passing `&local` to a
+separate constexpr function can update the caller's object through `*p = value`,
+compound assignments such as `*p += value`, and direct member writes such as
+`p->member = value`.
+
+```cpp
+struct Pair { int value; };
+
+constexpr void set_int(int* p, int value) { *p = value; }
+constexpr void set_pair(Pair* p, int value) { p->value = value; }
+
+constexpr int f() {
+	int x = 1;
+	Pair pair{2};
+	set_int(&x, 7);
+	set_pair(&pair, 11);
+	return x + pair.value;
+}
+
+static_assert(f() == 18);  // ✅ Works
+```
+
+This is covered by `tests/test_constexpr_pointer_param_write_ret0.cpp`.
 
 Covered by `tests/test_constexpr_deref_assign_local_ret5.cpp`.
 
@@ -1314,6 +1334,7 @@ Potential areas for enhancement (in order of complexity):
   - straightforward returned closure-object state transfer
   - straightforward returned `[*this]` member closures from local aggregate objects
   - straightforward nested lambdas over enclosing state
+- ✅ Straightforward write-through-pointer across constexpr function frames for local scalar and struct-object targets
 - ❌ `throw` expressions in constexpr evaluation
 - ❌ Complex member initialization chains
 

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -785,7 +785,8 @@ private:
 		const FunctionDeclarationNode& func_decl,
 		const ChunkedVector<ASTNode>& arguments,
 		const std::unordered_map<std::string_view, EvalResult>& outer_bindings,
-		EvaluationContext& context);
+		EvaluationContext& context,
+		std::unordered_map<std::string_view, EvalResult>* mutable_outer_bindings);
 	static EvalResult bind_evaluated_arguments(
 		const std::vector<ASTNode>& parameters,
 		const ChunkedVector<ASTNode>& arguments,

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -18,6 +18,8 @@ namespace {
 constexpr std::string_view kStatementExecutedWithoutReturn = "Statement executed (not a return)";
 constexpr std::string_view kBreakExecuted = "Break executed";
 constexpr std::string_view kContinueExecuted = "Continue executed";
+constexpr std::string_view kFunctionDidNotReturnValue = "Constexpr function did not return a value";
+constexpr std::string_view kReturnStatementNoExpression = "Constexpr function return statement has no expression";
 
 struct MemberPointerTarget {
 	StringHandle member_name;
@@ -4549,6 +4551,7 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 		return bind_result;
 	}
 	std::vector<std::string_view> pointer_target_writebacks;
+	std::vector<std::pair<std::string_view, EvalResult>> pointer_target_imports;
 	for (const auto& [param_name, param_value] : param_bindings) {
 		(void)param_name;
 		if (!param_value.pointer_to_var.isValid()) {
@@ -4562,8 +4565,11 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 		if (outer_it == outer_bindings.end()) {
 			continue;
 		}
-		param_bindings[target_name] = outer_it->second;
+		pointer_target_imports.push_back({target_name, outer_it->second});
 		pointer_target_writebacks.push_back(target_name);
+	}
+	for (const auto& [target_name, target_value] : pointer_target_imports) {
+		param_bindings[target_name] = target_value;
 	}
 
 	auto saved_template_param_names = context.template_param_names;
@@ -4607,13 +4613,13 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 		local_bindings,
 		context,
 		"Function body is not a block",
-		"Constexpr function did not return a value");
+		std::string(kFunctionDidNotReturnValue));
 
 	context.current_depth--;
 	context.return_type_info = saved_return_type_info;
 	restore_template_bindings();
-	if (!result.success() && (result.error_message == "Constexpr function did not return a value" ||
-							  result.error_message == "Constexpr function return statement has no expression")) {
+	if (!result.success() && (result.error_message == kFunctionDidNotReturnValue ||
+							  result.error_message == kReturnStatementNoExpression)) {
 		const TypeSpecifierNode& ret_spec = func_decl.decl_node().type_specifier_node();
 		if (ret_spec.category() == TypeCategory::Void) {
 			result = EvalResult::from_int(0LL);
@@ -4793,7 +4799,7 @@ EvalResult Evaluator::evaluate_statement_with_bindings(
 		const auto& return_expr = ret_stmt.expression();
 
 		if (!return_expr.has_value()) {
-			return EvalResult::error("Constexpr function return statement has no expression");
+			return EvalResult::error(std::string(kReturnStatementNoExpression));
 		}
 
 		// Handle brace-init return: return {x, y, ...} in a struct-returning function.

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -2007,7 +2007,7 @@ EvalResult Evaluator::evaluate_resolved_function_call(
 	}
 
 	if (outer_bindings) {
-		return evaluate_function_call_with_bindings(func_decl, arguments, *outer_bindings, context);
+		return evaluate_function_call_with_bindings(func_decl, arguments, *outer_bindings, context, nullptr);
 	}
 
 	std::unordered_map<std::string_view, EvalResult> empty_bindings;
@@ -4364,7 +4364,7 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 					arguments.size() <= parameter_count) {
 					// Found a potential match - try to evaluate it
 					std::unordered_map<std::string_view, EvalResult> empty_bindings;
-					return evaluate_function_call_with_bindings(candidate, arguments, empty_bindings, context);
+					return evaluate_function_call_with_bindings(candidate, arguments, empty_bindings, context, nullptr);
 				}
 			}
 		}
@@ -4496,7 +4496,7 @@ EvalResult Evaluator::evaluate_function_call_with_template_context(
 		load_template_bindings_from_type(fallback_template_type, context);
 	}
 
-	EvalResult result = evaluate_function_call_with_bindings(func_decl, arguments, outer_bindings, context);
+	EvalResult result = evaluate_function_call_with_bindings(func_decl, arguments, outer_bindings, context, nullptr);
 	restore_template_bindings();
 	return result;
 }
@@ -4505,11 +4505,19 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 	const FunctionDeclarationNode& func_decl,
 	const ChunkedVector<ASTNode>& arguments,
 	const std::unordered_map<std::string_view, EvalResult>& outer_bindings,
-	EvaluationContext& context) {
+	EvaluationContext& context,
+	std::unordered_map<std::string_view, EvalResult>* mutable_outer_bindings) {
 
 	// Check recursion depth
 	if (context.current_depth >= context.max_recursion_depth) {
 		return EvalResult::error("Constexpr recursion depth limit exceeded");
+	}
+	std::string_view func_name = func_decl.decl_node().identifier_token().value();
+	if (!func_decl.is_constexpr() && !func_decl.is_consteval() &&
+		context.storage_duration != ConstExpr::StorageDuration::Static) {
+		return EvalResult::error(
+			"Function in constant expression must be constexpr or consteval: " + std::string(func_name),
+			EvalErrorType::NotConstantExpression);
 	}
 
 	// Get the function body
@@ -4539,6 +4547,23 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 		&outer_bindings);
 	if (!bind_result.success()) {
 		return bind_result;
+	}
+	std::vector<std::string_view> pointer_target_writebacks;
+	for (const auto& [param_name, param_value] : param_bindings) {
+		(void)param_name;
+		if (!param_value.pointer_to_var.isValid()) {
+			continue;
+		}
+		std::string_view target_name = StringTable::getStringView(param_value.pointer_to_var);
+		if (param_bindings.find(target_name) != param_bindings.end()) {
+			continue;
+		}
+		auto outer_it = outer_bindings.find(target_name);
+		if (outer_it == outer_bindings.end()) {
+			continue;
+		}
+		param_bindings[target_name] = outer_it->second;
+		pointer_target_writebacks.push_back(target_name);
 	}
 
 	auto saved_template_param_names = context.template_param_names;
@@ -4587,6 +4612,22 @@ EvalResult Evaluator::evaluate_function_call_with_bindings(
 	context.current_depth--;
 	context.return_type_info = saved_return_type_info;
 	restore_template_bindings();
+	if (!result.success() && (result.error_message == "Constexpr function did not return a value" ||
+							  result.error_message == "Constexpr function return statement has no expression")) {
+		const TypeSpecifierNode& ret_spec = func_decl.decl_node().type_specifier_node();
+		if (ret_spec.category() == TypeCategory::Void) {
+			result = EvalResult::from_int(0LL);
+		}
+	}
+	if (result.success() && mutable_outer_bindings) {
+		for (std::string_view target_name : pointer_target_writebacks) {
+			auto local_it = local_bindings.find(target_name);
+			if (local_it == local_bindings.end()) {
+				continue;
+			}
+			(*mutable_outer_bindings)[target_name] = local_it->second;
+		}
+	}
 	// Per C++20 [expr.const]/p5, any allocation made with `new` during a
 	// constant expression must be freed before the constant expression ends.
 	// Check this at the outermost function call (depth returning to 0).

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -2143,12 +2143,19 @@ EvalResult Evaluator::evaluate_expression_with_bindings(
 							if (!object_binding) {
 								return EvalResult::error("Arrow assignment: pointer does not refer to a constexpr heap object or local binding");
 							}
-							if (ptr_result.pointer_offset != 0) {
+							EvalResult* object_slot = object_binding;
+							if (object_binding->is_array) {
+								if (ptr_result.pointer_offset < 0 ||
+									static_cast<size_t>(ptr_result.pointer_offset) >= object_binding->array_elements.size()) {
+									return EvalResult::error("Arrow assignment: pointer offset out of bounds for local struct array");
+								}
+								object_slot = &object_binding->array_elements[static_cast<size_t>(ptr_result.pointer_offset)];
+							} else if (ptr_result.pointer_offset != 0) {
 								return EvalResult::error(
 									"Arrow assignment: non-zero pointer offset on non-array local object in constexpr assignment");
 							}
-							auto member_it = object_binding->object_member_bindings.find(ma.member_name());
-							if (member_it == object_binding->object_member_bindings.end()) {
+							auto member_it = object_slot->object_member_bindings.find(ma.member_name());
+							if (member_it == object_slot->object_member_bindings.end()) {
 								return EvalResult::error("Arrow assignment: member not found in local struct: " + std::string(ma.member_name()));
 							}
 							auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -942,13 +942,19 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 				*current_struct_match.function,
 				call_expr.arguments(),
 				bindings,
-				context);
+				context,
+				mutable_bindings);
 		}
 	}
 
 	if (const FunctionDeclarationNode* resolved_function = call_expr.callee().function_declaration_or_null()) {
 		if (resolved_function->is_static() || !context.struct_info) {
-			return evaluate_resolved_function_call(*resolved_function, call_expr.arguments(), context, &bindings);
+			return evaluate_function_call_with_bindings(
+				*resolved_function,
+				call_expr.arguments(),
+				bindings,
+				context,
+				mutable_bindings);
 		}
 	}
 
@@ -1013,7 +1019,7 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		return evaluate_member_function_call(member_call, context);
 	}
 
-	return evaluate_function_call_with_bindings(func_decl, call_expr.arguments(), bindings, context);
+	return evaluate_function_call_with_bindings(func_decl, call_expr.arguments(), bindings, context, mutable_bindings);
 }
 
 std::optional<EvalResult> Evaluator::try_evaluate_bound_member_operator_call(
@@ -2132,7 +2138,27 @@ EvalResult Evaluator::evaluate_expression_with_bindings(
 						StringHandle heap_key = ptr_result.pointer_to_var;
 						auto heap_it = context.constexpr_heap.find(heap_key);
 						if (heap_it == context.constexpr_heap.end()) {
-							return EvalResult::error("Arrow assignment: pointer does not refer to a constexpr heap object");
+							std::string_view pointed_name = heap_key.view();
+							EvalResult* object_binding = findMutableBindingValue(pointed_name, bindings, context);
+							if (!object_binding) {
+								return EvalResult::error("Arrow assignment: pointer does not refer to a constexpr heap object or local binding");
+							}
+							if (ptr_result.pointer_offset != 0) {
+								return EvalResult::error(
+									"Arrow assignment: non-zero pointer offset on non-array local object in constexpr assignment");
+							}
+							auto member_it = object_binding->object_member_bindings.find(ma.member_name());
+							if (member_it == object_binding->object_member_bindings.end()) {
+								return EvalResult::error("Arrow assignment: member not found in local struct: " + std::string(ma.member_name()));
+							}
+							auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);
+							if (!rhs_result.success())
+								return rhs_result;
+							auto assign_result = apply_op_to(member_it->second, rhs_result);
+							if (assign_result.success()) {
+								refreshPointerSnapshotsForBinding(pointed_name, *object_binding, bindings, context);
+							}
+							return assign_result;
 						}
 						if (heap_it->second.freed) {
 							return EvalResult::error("Arrow assignment: use after free in constant expression");

--- a/tests/test_constexpr_for_init_constexpr_call_ret0.cpp
+++ b/tests/test_constexpr_for_init_constexpr_call_ret0.cpp
@@ -1,0 +1,15 @@
+constexpr int runtime_value() { return 1; }
+
+constexpr int for_init_constexpr_call() {
+	int sum = 0;
+	for (int i = runtime_value(); i < 3; i++) {
+		sum += i;
+	}
+	return sum;
+}
+
+static_assert(for_init_constexpr_call() == 3);
+
+int main() {
+	return for_init_constexpr_call() == 3 ? 0 : 1;
+}

--- a/tests/test_constexpr_for_init_error_fail.cpp
+++ b/tests/test_constexpr_for_init_error_fail.cpp
@@ -3,7 +3,7 @@
 // This is a _fail test — compilation should fail because the
 // for-loop init calls a non-constexpr function.
 
-int runtime_value() { return 0; }
+int runtime_value() { return 1; }
 
 constexpr int bad_for_init() {
 	int sum = 0;

--- a/tests/test_constexpr_pointer_param_write_ret0.cpp
+++ b/tests/test_constexpr_pointer_param_write_ret0.cpp
@@ -2,6 +2,11 @@ struct Pair {
 	int value;
 };
 
+template <typename T>
+struct PairT {
+	T value;
+};
+
 constexpr void writeScalar(int* p, int value) {
 	*p = value;
 }
@@ -10,11 +15,29 @@ constexpr void addScalar(int* p, int value) {
 	*p += value;
 }
 
+constexpr void writeScalar(long long* p, long long value) {
+	*p = value;
+}
+
+constexpr void addScalar(long long* p, long long value) {
+	*p += value;
+}
+
 constexpr void writeMember(Pair* p, int value) {
 	p->value = value;
 }
 
 constexpr void addMember(Pair* p, int value) {
+	p->value += value;
+}
+
+template <typename T>
+constexpr void writeMember(PairT<T>* p, T value) {
+	p->value = value;
+}
+
+template <typename T>
+constexpr void addMember(PairT<T>* p, T value) {
 	p->value += value;
 }
 
@@ -30,8 +53,36 @@ constexpr int evaluatePointerParameterWrites() {
 	return x + pair.value;
 }
 
+constexpr long long evaluatePointerParameterWritesMixedTypes() {
+	long long wide = 2;
+	writeScalar(&wide, 9);
+	addScalar(&wide, 3);
+
+	PairT<unsigned short> box{1};
+	writeMember(&box, static_cast<unsigned short>(5));
+	addMember(&box, static_cast<unsigned short>(4));
+
+	return wide + box.value;
+}
+
+constexpr int evaluatePointerParameterWritesArrayElement() {
+	PairT<int> pairs[2]{{1}, {2}};
+	writeMember(&pairs[1], 11);
+	addMember(&pairs[1], 3);
+
+	return pairs[0].value + pairs[1].value;
+}
+
 static_assert(evaluatePointerParameterWrites() == 25);
+static_assert(evaluatePointerParameterWritesMixedTypes() == 21);
+static_assert(evaluatePointerParameterWritesArrayElement() == 15);
+
+constexpr int pointer_parameter_writes = evaluatePointerParameterWrites();
+constexpr long long pointer_parameter_writes_mixed_types = evaluatePointerParameterWritesMixedTypes();
+constexpr int pointer_parameter_writes_array_element = evaluatePointerParameterWritesArrayElement();
 
 int main() {
-	return evaluatePointerParameterWrites() == 25 ? 0 : 1;
+	return pointer_parameter_writes == 25 &&
+		pointer_parameter_writes_mixed_types == 21 &&
+		pointer_parameter_writes_array_element == 15 ? 0 : 1;
 }

--- a/tests/test_constexpr_pointer_param_write_ret0.cpp
+++ b/tests/test_constexpr_pointer_param_write_ret0.cpp
@@ -1,0 +1,37 @@
+struct Pair {
+	int value;
+};
+
+constexpr void writeScalar(int* p, int value) {
+	*p = value;
+}
+
+constexpr void addScalar(int* p, int value) {
+	*p += value;
+}
+
+constexpr void writeMember(Pair* p, int value) {
+	p->value = value;
+}
+
+constexpr void addMember(Pair* p, int value) {
+	p->value += value;
+}
+
+constexpr int evaluatePointerParameterWrites() {
+	int x = 1;
+	writeScalar(&x, 7);
+	addScalar(&x, 5);
+
+	Pair pair{3};
+	writeMember(&pair, 11);
+	addMember(&pair, 2);
+
+	return x + pair.value;
+}
+
+static_assert(evaluatePointerParameterWrites() == 25);
+
+int main() {
+	return evaluatePointerParameterWrites() == 25 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Support straightforward write-through-pointer across constexpr function frames for local scalar and struct-object targets.
- Keep non-constexpr free-function calls rejected during constant evaluation through the shared bound function-call path.
- Document the constexpr pointer-parameter write support and add positive/negative regression coverage.

## Root Cause

Pointer arguments preserved the target name for reads, but callee frames did not materialize mutable caller-local targets or write updates back after the call. The new mutable function-call path also needed the same constexpr/consteval guard as the older resolved-call path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced constexpr evaluation to support write-through pointer mutation across nested constexpr calls for local scalar and struct-object targets.

* **Documentation**
  * Updated docs with a new example showing pointer-parameter writes in constexpr helper calls and clarified limitations.

* **Tests**
  * Added tests covering constexpr for-loop initialization behavior and comprehensive pointer-parameter write scenarios, with compile-time assertions and runtime checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->