### PR TITLE
[codex] Support constexpr constructor member helper calls

### DIFF
--- a/docs/CONSTEXPR_LIMITATIONS.md
+++ b/docs/CONSTEXPR_LIMITATIONS.md
@@ -413,13 +413,13 @@ constexpr helper calls that take the member address:
 
 ```cpp
 struct Pair { int value; };
-constexpr void set_pair(Pair* p, int v) { p->value = v; }
+constexpr void setPair(Pair* p, int v) { p->value = v; }
 
 struct Box {
     Pair pair;
     constexpr Box(int v) {
         pair.value = 0;
-        set_pair(&pair, v);
+        setPair(&pair, v);
     }
 };
 

--- a/docs/CONSTEXPR_LIMITATIONS.md
+++ b/docs/CONSTEXPR_LIMITATIONS.md
@@ -408,6 +408,27 @@ static_assert(r.lo == 2 && r.hi == 9);  // ✅ Works
 
 More complex constructor-body execution involving complex aliasing or non-trivial call chains is still a remaining limitation.
 
+Constructor bodies may now also mutate member subobjects through straightforward
+constexpr helper calls that take the member address:
+
+```cpp
+struct Pair { int value; };
+constexpr void set_pair(Pair* p, int v) { p->value = v; }
+
+struct Box {
+    Pair pair;
+    constexpr Box(int v) {
+        pair.value = 0;
+        set_pair(&pair, v);
+    }
+};
+
+constexpr Box b(42);
+static_assert(b.pair.value == 42);  // ✅ Works
+```
+
+This is covered by `tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp`.
+
 **Preferred style when practical:** Use member initializer lists:
 ```cpp
 constexpr Point(int x_val, int y_val) : x(x_val), y(y_val) {}  // ✅ Works
@@ -1321,7 +1342,7 @@ Potential areas for enhancement (in order of complexity):
   - ✅ **Global constexpr struct arrays now preserve constructor semantics in emitted runtime data** *(Implemented)* — The static-storage array path now tries full-array constexpr materialization before falling back to the older per-element packing logic, and the array packer now recognizes struct-valued `EvalResult` leaves instead of collapsing them through scalar conversion. In addition, global unsized-array declarations now keep the inferred outer bound on the registered declaration node, so later codegen/runtime uses the real array extent instead of the pre-inference `[]` form. This fixes cases like `constexpr Pair arr[2] = {{1, 2}, {3, 4}};` and `constexpr Pair arr[] = {{1, 2}, {3, 4}, {5, 6}};` when `Pair` has a user-declared constructor that reorders/transforms its arguments. Covered by `tests/test_constexpr_global_struct_array_ctor_runtime_ret0.cpp` and `tests/test_constexpr_global_unsized_struct_array_ctor_runtime_ret0.cpp`.
 
 ### Hard
-- ⚠️ Complex constructor body statement execution involving complex aliasing or non-trivial call chains (simple assignments, conditionals, loops, and switch now work)
+- ⚠️ Complex constructor body statement execution involving complex aliasing or non-trivial call chains (simple assignments, conditionals, loops, switch, and straightforward member-address helper calls now work)
 - ✅ **Short-circuit `&&` / `||` in top-level `evaluate_binary_operator`** *(Implemented)* — Both the top-level path (`static_assert`, constexpr variable initializers) and the bindings-aware path (constexpr function bodies) now short-circuit correctly. The `is_speculative` flag in `EvaluationContext` is set to `true` during template-argument disambiguation so that speculative evaluation does not change parse behavior.
   - ⚠️ **`is_speculative` disables short-circuit globally** — The flag is set on the `EvaluationContext` and applies to all sub-expressions (including nested function calls). This means expressions like `constexpr bool x = false && some_complex_call()` evaluated speculatively will eagerly evaluate `some_complex_call()`, potentially producing spurious errors. This is acceptable since speculative evaluation returns `nullopt` on failure anyway.
   - ⚠️ **`is_speculative` only affects the top-level path** — The bindings-aware paths (`evaluate_expression_with_bindings`, `evaluate_expression_with_bindings_dispatch`) always short-circuit regardless of the flag. This is correct because `try_evaluate_constant_expression` only uses the top-level evaluator for template-argument disambiguation.

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -25,7 +25,7 @@ std::optional<EvalResult> tryMaterializeMultidimArrayRow(
 	const InitializerListNode& init_list,
 	size_t index,
 	ConstExpr::EvaluationContext& context);
-EvalResult make_constructor_member_default_init(const StructMember& member, EvaluationContext& context);
+EvalResult makeConstructorMemberDefaultInit(const StructMember& member, EvaluationContext& context);
 
 struct ShiftEvaluationInfo {
 	int width_bits = kDefaultShiftWidthBits;
@@ -55,7 +55,7 @@ const StructMember* findMemberInfoRecursive(const StructTypeInfo* struct_info, S
 	return nullptr;
 }
 
-TypeSpecifierNode make_member_type_spec_for_default_init(const StructMember& member) {
+TypeSpecifierNode makeMemberTypeSpecForDefaultInit(const StructMember& member) {
 	TypeSpecifierNode type_spec(
 		member.type_index,
 		TypeQualifier::None,
@@ -71,7 +71,18 @@ TypeSpecifierNode make_member_type_spec_for_default_init(const StructMember& mem
 	return type_spec;
 }
 
-EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type_spec, EvaluationContext& context) {
+TypeSpecifierNode makeTypeSpecForDefaultInit(TypeIndex type_index) {
+	const TypeInfo* type_info = tryGetTypeInfo(type_index);
+	const SizeInBits size_in_bits = type_info ? type_info->sizeInBits() : SizeInBits{0};
+	return TypeSpecifierNode(
+		type_index,
+		TypeQualifier::None,
+		size_in_bits,
+		Token{},
+		CVQualifier::None);
+}
+
+EvalResult makeConstructorDefaultInitFromType(const TypeSpecifierNode& type_spec, EvaluationContext& context) {
 	if (type_spec.is_array()) {
 		const std::vector<size_t>& dims = type_spec.array_dimensions();
 		if (dims.empty()) {
@@ -93,7 +104,7 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 
 		array_result.array_elements.reserve(dims[0]);
 		for (size_t i = 0; i < dims[0]; ++i) {
-			EvalResult element_result = make_constructor_default_init_from_type(element_type, context);
+			EvalResult element_result = makeConstructorDefaultInitFromType(element_type, context);
 			if (!element_result.success()) {
 				return element_result;
 			}
@@ -129,16 +140,38 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 			return *ctor_result;
 		}
 
+		std::unordered_map<std::string_view, EvalResult> base_bindings;
+		bool base_is_indeterminate = false;
+		for (const auto& base : struct_info->base_classes) {
+			EvalResult base_result = makeConstructorDefaultInitFromType(makeTypeSpecForDefaultInit(base.type_index), context);
+			if (!base_result.success()) {
+				return base_result;
+			}
+			for (const auto& [base_member_name, base_member_value] : base_result.object_member_bindings) {
+				if (base_bindings.find(base_member_name) == base_bindings.end()) {
+					base_bindings[base_member_name] = base_member_value;
+				}
+			}
+			base_is_indeterminate = base_is_indeterminate || base_result.is_indeterminate;
+		}
+
 		InitializerListNode empty_init_list;
 		EvalResult object_result = Evaluator::materialize_aggregate_object_value(
 			struct_info,
 			type_spec.type_index(),
 			empty_init_list,
-			context);
+			context,
+			base_bindings.empty() ? nullptr : &base_bindings);
 		if (!object_result.success()) {
 			return object_result;
 		}
-		object_result.is_indeterminate = false;
+		object_result.is_indeterminate = base_is_indeterminate;
+
+		for (const auto& [base_member_name, base_member_value] : base_bindings) {
+			if (object_result.object_member_bindings.find(base_member_name) == object_result.object_member_bindings.end()) {
+				object_result.object_member_bindings[base_member_name] = base_member_value;
+			}
+		}
 
 		for (const auto& nested_member : struct_info->members) {
 			std::string_view nested_name = StringTable::getStringView(nested_member.getName());
@@ -147,7 +180,7 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 					object_result.is_indeterminate || object_result.object_member_bindings[nested_name].is_indeterminate;
 				continue;
 			}
-			EvalResult nested_result = make_constructor_member_default_init(nested_member, context);
+			EvalResult nested_result = makeConstructorMemberDefaultInit(nested_member, context);
 			if (!nested_result.success()) {
 				return nested_result;
 			}
@@ -162,8 +195,8 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 	return result;
 }
 
-EvalResult make_constructor_member_default_init(const StructMember& member, EvaluationContext& context) {
-	return make_constructor_default_init_from_type(make_member_type_spec_for_default_init(member), context);
+EvalResult makeConstructorMemberDefaultInit(const StructMember& member, EvaluationContext& context) {
+	return makeConstructorDefaultInitFromType(makeMemberTypeSpecForDefaultInit(member), context);
 }
 
 std::optional<TypeSpecifierNode> try_get_type_from_eval_result(const EvalResult& value) {
@@ -888,6 +921,23 @@ std::optional<BoundWriteTarget> resolveBoundWriteTarget(
 			if (object_id && object_id->name() == "this") {
 				if (EvalResult* binding = findMutableBindingValue(member_access->member_name(), bindings, context)) {
 					return BoundWriteTarget{binding, member_access->member_name()};
+				}
+			}
+
+			EvalResult pointer_result = evaluate_index_expression(member_access->object(), bindings, context);
+			if (!pointer_result.success()) {
+				resolve_error = pointer_result;
+				return std::nullopt;
+			}
+			if (!pointer_result.pointer_to_var.isValid() || pointer_result.pointer_offset != 0) {
+				return std::nullopt;
+			}
+
+			std::string_view pointed_name = StringTable::getStringView(pointer_result.pointer_to_var);
+			if (EvalResult* binding = findMutableBindingValue(pointed_name, bindings, context)) {
+				auto member_it = binding->object_member_bindings.find(member_access->member_name());
+				if (member_it != binding->object_member_bindings.end()) {
+					return BoundWriteTarget{&member_it->second, pointed_name};
 				}
 			}
 			return std::nullopt;
@@ -6357,12 +6407,13 @@ EvalResult materialize_member_initializer_value(
 	const StructMember& member_info,
 	const ASTNode& initializer,
 	EvaluationContext& context,
+	const std::unordered_map<std::string_view, EvalResult>* evaluation_bindings,
 	bool enforce_list_narrowing) {
 	if (initializer.is<InitializerListNode>()) {
 		const InitializerListNode& init_list = initializer.as<InitializerListNode>();
 
 		if (member_info.is_array) {
-			return Evaluator::materialize_array_value(member_info.type_index, init_list, context, nullptr);
+			return Evaluator::materialize_array_value(member_info.type_index, init_list, context, evaluation_bindings);
 		}
 
 		if (is_struct_type(member_info.type_index.category())) {
@@ -6378,7 +6429,7 @@ EvalResult materialize_member_initializer_value(
 						ctor_args,
 						context,
 						false,
-						nullptr,
+						evaluation_bindings,
 						nullptr,
 						false)) {
 					return std::move(*ctor_result);
@@ -6387,7 +6438,8 @@ EvalResult materialize_member_initializer_value(
 					member_struct_info,
 					member_info.type_index,
 					init_list,
-					context);
+					context,
+					evaluation_bindings);
 			}
 		}
 	}
@@ -6486,6 +6538,7 @@ EvalResult Evaluator::bind_members_from_initializer_list(
 					*member_info,
 					initializer,
 					context,
+					nullptr,
 					init_list.is_brace_init());
 			}
 			if (!val.success())
@@ -6513,20 +6566,21 @@ EvalResult Evaluator::bind_members_from_initializer_list(
 		if (bindings.find(mname) == bindings.end() && member.default_initializer.has_value()) {
 			EvalResult default_result;
 			const ASTNode& default_initializer = member.default_initializer.value();
+			std::unordered_map<std::string_view, EvalResult> default_bindings;
+			if (evaluation_bindings) {
+				default_bindings = *evaluation_bindings;
+			}
+			for (const auto& [name, value] : bindings) {
+				default_bindings[name] = value;
+			}
 			if (default_initializer.is<InitializerListNode>()) {
 				default_result = materialize_member_initializer_value(
 					member,
 					default_initializer,
 					context,
+					&default_bindings,
 					false);
 			} else {
-				std::unordered_map<std::string_view, EvalResult> default_bindings;
-				if (evaluation_bindings) {
-					default_bindings = *evaluation_bindings;
-				}
-				for (const auto& [name, value] : bindings) {
-					default_bindings[name] = value;
-				}
 				default_result = Evaluator::evaluate_expression_with_bindings_const(
 					default_initializer,
 					default_bindings,
@@ -6759,6 +6813,30 @@ EvalResult Evaluator::materialize_members_from_constructor(
 		return base_bind_result;
 	}
 
+	for (const auto& base : struct_info->base_classes) {
+		bool has_explicit_base_initializer = false;
+		StringHandle base_name = StringTable::getOrInternStringHandle(base.name);
+		for (const auto& base_init : ctor_decl.base_initializers()) {
+			if (base_name == base_init.getBaseClassName()) {
+				has_explicit_base_initializer = true;
+				break;
+			}
+		}
+		if (has_explicit_base_initializer) {
+			continue;
+		}
+
+		EvalResult base_result = makeConstructorDefaultInitFromType(makeTypeSpecForDefaultInit(base.type_index), context);
+		if (!base_result.success()) {
+			return base_result;
+		}
+		for (const auto& [base_member_name, base_member_value] : base_result.object_member_bindings) {
+			if (member_bindings.find(base_member_name) == member_bindings.end()) {
+				member_bindings[base_member_name] = base_member_value;
+			}
+		}
+	}
+
 	context.local_bindings = &ctor_param_bindings;
 	auto member_bind_result = bind_members_from_constructor_initializers(
 		struct_info,
@@ -6778,7 +6856,7 @@ EvalResult Evaluator::materialize_members_from_constructor(
 			continue;
 		}
 
-		EvalResult default_result = make_constructor_member_default_init(member, context);
+		EvalResult default_result = makeConstructorMemberDefaultInit(member, context);
 		if (!default_result.success()) {
 			return default_result;
 		}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -25,6 +25,7 @@ std::optional<EvalResult> tryMaterializeMultidimArrayRow(
 	const InitializerListNode& init_list,
 	size_t index,
 	ConstExpr::EvaluationContext& context);
+EvalResult make_constructor_member_default_init(const StructMember& member, EvaluationContext& context);
 
 struct ShiftEvaluationInfo {
 	int width_bits = kDefaultShiftWidthBits;
@@ -52,6 +53,111 @@ const StructMember* findMemberInfoRecursive(const StructTypeInfo* struct_info, S
 	}
 
 	return nullptr;
+}
+
+TypeSpecifierNode make_member_type_spec_for_default_init(const StructMember& member) {
+	TypeSpecifierNode type_spec(
+		member.type_index,
+		TypeQualifier::None,
+		SizeInBits{static_cast<int>(member.size * 8)},
+		Token{},
+		CVQualifier::None);
+	type_spec.set_reference_qualifier(member.reference_qualifier);
+	type_spec.add_pointer_levels(member.pointer_depth);
+	type_spec.set_array_dimensions(member.array_dimensions);
+	if (member.function_signature.has_value()) {
+		type_spec.set_function_signature(*member.function_signature);
+	}
+	return type_spec;
+}
+
+EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type_spec, EvaluationContext& context) {
+	if (type_spec.is_array()) {
+		const std::vector<size_t>& dims = type_spec.array_dimensions();
+		if (dims.empty()) {
+			return EvalResult::error("Default-initialized constructor member array is missing dimensions in constexpr evaluation");
+		}
+
+		EvalResult array_result = EvalResult::from_int(0LL);
+		array_result.is_array = true;
+		array_result.is_indeterminate = false;
+		array_result.set_exact_type(type_spec);
+
+		TypeSpecifierNode element_type = type_spec;
+		if (dims.size() <= 1) {
+			element_type.set_array_dimensions({});
+		} else {
+			element_type.set_array_dimensions(std::vector<size_t>(dims.begin() + 1, dims.end()));
+		}
+
+		array_result.array_elements.reserve(dims[0]);
+		for (size_t i = 0; i < dims[0]; ++i) {
+			EvalResult element_result = make_constructor_default_init_from_type(element_type, context);
+			if (!element_result.success()) {
+				return element_result;
+			}
+			array_result.is_indeterminate = array_result.is_indeterminate || element_result.is_indeterminate;
+			array_result.array_elements.push_back(std::move(element_result));
+		}
+		return array_result;
+	}
+
+	if (is_struct_type(type_spec.category())) {
+		const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
+		const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
+		if (!struct_info) {
+			return EvalResult::error("Struct type info not found for default-initialized constructor member");
+		}
+
+		if (struct_info->hasUserDefinedConstructor()) {
+			ChunkedVector<ASTNode> empty_args;
+			auto ctor_result = Evaluator::try_materialize_struct_from_ctor_args(
+				struct_info,
+				type_spec.type_index(),
+				empty_args,
+				context,
+				true,
+				nullptr,
+				nullptr,
+				false);
+			if (!ctor_result.has_value()) {
+				return EvalResult::error(
+					"No matching default constructor for '" +
+					std::string(StringTable::getStringView(struct_info->getName())) +
+					"' in constexpr constructor member initialization");
+			}
+			return *ctor_result;
+		}
+
+		EvalResult object_result = EvalResult::from_int(0LL);
+		object_result.object_type_index = type_spec.type_index();
+		object_result.is_indeterminate = false;
+		object_result.set_exact_type(type_spec);
+
+		for (const auto& nested_member : struct_info->members) {
+			std::string_view nested_name = StringTable::getStringView(nested_member.getName());
+			EvalResult nested_result;
+			if (nested_member.default_initializer.has_value()) {
+				nested_result = Evaluator::evaluate(*nested_member.default_initializer, context);
+			} else {
+				nested_result = make_constructor_member_default_init(nested_member, context);
+			}
+			if (!nested_result.success()) {
+				return nested_result;
+			}
+			object_result.is_indeterminate = object_result.is_indeterminate || nested_result.is_indeterminate;
+			object_result.object_member_bindings[nested_name] = std::move(nested_result);
+		}
+		return object_result;
+	}
+
+	EvalResult result = EvalResult::indeterminate();
+	result.set_exact_type(type_spec);
+	return result;
+}
+
+EvalResult make_constructor_member_default_init(const StructMember& member, EvaluationContext& context) {
+	return make_constructor_default_init_from_type(make_member_type_spec_for_default_init(member), context);
 }
 
 std::optional<TypeSpecifierNode> try_get_type_from_eval_result(const EvalResult& value) {
@@ -1998,6 +2104,30 @@ EvalResult Evaluator::evaluate_expression_with_bindings(
 			};
 			// Get the left-hand side variable name
 			const ASTNode& lhs = bin_op.get_lhs();
+			if (const auto* member_lhs = tryGetNode<MemberAccessNode>(lhs)) {
+				const IdentifierNode* direct_object_id = tryGetIdentifier(member_lhs->object());
+				if (!direct_object_id || direct_object_id->name() != "this") {
+					std::optional<EvalResult> resolve_error;
+					if (std::optional<BoundWriteTarget> target = resolveBoundWriteTarget(
+							lhs, bindings, context, evaluate_expression_with_bindings_const, resolve_error);
+						target.has_value() && target->slot != nullptr) {
+						auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);
+						if (!rhs_result.success()) {
+							return rhs_result;
+						}
+						auto assign_result = apply_op_to(*target->slot, rhs_result);
+						if (assign_result.success() && !target->root_name.empty()) {
+							if (EvalResult* root_binding = findMutableBindingValue(target->root_name, bindings, context)) {
+								refreshPointerSnapshotsForBinding(target->root_name, *root_binding, bindings, context);
+							}
+						}
+						return assign_result;
+					}
+					if (resolve_error.has_value()) {
+						return *resolve_error;
+					}
+				}
+			}
 			if (lhs.is<ExpressionNode>()) {
 				const ExpressionNode& lhs_expr = lhs.as<ExpressionNode>();
 
@@ -6612,6 +6742,19 @@ EvalResult Evaluator::materialize_members_from_constructor(
 	context.local_bindings = saved_local_bindings;
 	if (!member_bind_result.success()) {
 		return member_bind_result;
+	}
+
+	for (const auto& member : struct_info->members) {
+		std::string_view member_name = StringTable::getStringView(member.getName());
+		if (member_bindings.find(member_name) != member_bindings.end()) {
+			continue;
+		}
+
+		EvalResult default_result = make_constructor_member_default_init(member, context);
+		if (!default_result.success()) {
+			return default_result;
+		}
+		member_bindings[member_name] = std::move(default_result);
 	}
 
 	const auto& ctor_definition = ctor_decl.get_definition();

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -75,7 +75,7 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 	if (type_spec.is_array()) {
 		const std::vector<size_t>& dims = type_spec.array_dimensions();
 		if (dims.empty()) {
-			return EvalResult::error("Default-initialized constructor member array is missing dimensions in constexpr evaluation");
+			return EvalResult::error("Missing dimensions for default-initialized array member");
 		}
 
 		EvalResult array_result = EvalResult::from_int(0LL);
@@ -89,6 +89,7 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 		} else {
 			element_type.set_array_dimensions(std::vector<size_t>(dims.begin() + 1, dims.end()));
 		}
+		element_type.set_size_in_bits(getTypeSpecSizeBits(element_type));
 
 		array_result.array_elements.reserve(dims[0]);
 		for (size_t i = 0; i < dims[0]; ++i) {
@@ -106,7 +107,7 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 		const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
 		const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
 		if (!struct_info) {
-			return EvalResult::error("Struct type info not found for default-initialized constructor member");
+			return EvalResult::error("Struct type info not found for default-initialized member");
 		}
 
 		if (struct_info->hasUserDefinedConstructor()) {
@@ -123,25 +124,30 @@ EvalResult make_constructor_default_init_from_type(const TypeSpecifierNode& type
 			if (!ctor_result.has_value()) {
 				return EvalResult::error(
 					"No matching default constructor for '" +
-					std::string(StringTable::getStringView(struct_info->getName())) +
-					"' in constexpr constructor member initialization");
+					std::string(StringTable::getStringView(struct_info->getName())) + "'");
 			}
 			return *ctor_result;
 		}
 
-		EvalResult object_result = EvalResult::from_int(0LL);
-		object_result.object_type_index = type_spec.type_index();
+		InitializerListNode empty_init_list;
+		EvalResult object_result = Evaluator::materialize_aggregate_object_value(
+			struct_info,
+			type_spec.type_index(),
+			empty_init_list,
+			context);
+		if (!object_result.success()) {
+			return object_result;
+		}
 		object_result.is_indeterminate = false;
-		object_result.set_exact_type(type_spec);
 
 		for (const auto& nested_member : struct_info->members) {
 			std::string_view nested_name = StringTable::getStringView(nested_member.getName());
-			EvalResult nested_result;
-			if (nested_member.default_initializer.has_value()) {
-				nested_result = Evaluator::evaluate(*nested_member.default_initializer, context);
-			} else {
-				nested_result = make_constructor_member_default_init(nested_member, context);
+			if (object_result.object_member_bindings.find(nested_name) != object_result.object_member_bindings.end()) {
+				object_result.is_indeterminate =
+					object_result.is_indeterminate || object_result.object_member_bindings[nested_name].is_indeterminate;
+				continue;
 			}
+			EvalResult nested_result = make_constructor_member_default_init(nested_member, context);
 			if (!nested_result.success()) {
 				return nested_result;
 			}
@@ -6505,11 +6511,33 @@ EvalResult Evaluator::bind_members_from_initializer_list(
 		const auto& member = struct_info->members[mi];
 		std::string_view mname = StringTable::getStringView(member.getName());
 		if (bindings.find(mname) == bindings.end() && member.default_initializer.has_value()) {
-			auto default_result = materialize_member_initializer_value(
-				member,
-				member.default_initializer.value(),
-				context,
-				false);
+			EvalResult default_result;
+			const ASTNode& default_initializer = member.default_initializer.value();
+			if (default_initializer.is<InitializerListNode>()) {
+				default_result = materialize_member_initializer_value(
+					member,
+					default_initializer,
+					context,
+					false);
+			} else {
+				std::unordered_map<std::string_view, EvalResult> default_bindings;
+				if (evaluation_bindings) {
+					default_bindings = *evaluation_bindings;
+				}
+				for (const auto& [name, value] : bindings) {
+					default_bindings[name] = value;
+				}
+				default_result = Evaluator::evaluate_expression_with_bindings_const(
+					default_initializer,
+					default_bindings,
+					context);
+			}
+			if (default_result.success() && !default_initializer.is<InitializerListNode>()) {
+				default_result = applyAggregateMemberScalarInitialization(
+					member,
+					std::move(default_result),
+					false);
+			}
 			if (!default_result.success())
 				return default_result;
 			bindings[mname] = default_result;

--- a/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
+++ b/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
@@ -7,6 +7,19 @@ struct Defaults {
 	int second = first + 1;
 };
 
+struct BraceDefaults {
+	int first = 12;
+	Pair pair{first};
+};
+
+struct BaseDefaults {
+	int baseValue = 6;
+};
+
+struct DerivedDefaults : BaseDefaults {
+	int extra = baseValue + 1;
+};
+
 constexpr void setPair(Pair* p, int v) {
 	p->value = v;
 }
@@ -19,15 +32,28 @@ constexpr void addDefaults(Defaults* p, int v) {
 	p->second += v;
 }
 
+constexpr void addBraceDefaults(BraceDefaults* p, int v) {
+	p->pair.value += v;
+}
+
+constexpr void addDerivedDefaults(DerivedDefaults* p, int v) {
+	p->baseValue += v;
+	p->extra += p->baseValue;
+}
+
 struct Box {
 	Pair pair;
 	Defaults defaults;
+	BraceDefaults braceDefaults;
+	DerivedDefaults derivedDefaults;
 
 	constexpr Box(int v) {
 		pair.value = 0;
 		setPair(&pair, v);
 		addPair(&pair, 2);
 		addDefaults(&defaults, 1);
+		addBraceDefaults(&braceDefaults, 3);
+		addDerivedDefaults(&derivedDefaults, 2);
 	}
 };
 
@@ -36,9 +62,15 @@ constexpr Box box(40);
 static_assert(box.pair.value == 42);
 static_assert(box.defaults.first == 40);
 static_assert(box.defaults.second == 42);
+static_assert(box.braceDefaults.first == 12);
+static_assert(box.braceDefaults.pair.value == 15);
+static_assert(box.derivedDefaults.baseValue == 8);
+static_assert(box.derivedDefaults.extra == 15);
 
 int main() {
 	return box.pair.value == 42 &&
 		box.defaults.first == 40 &&
-		box.defaults.second == 42 ? 0 : 1;
+		box.defaults.second == 42 &&
+		box.braceDefaults.first == 12 &&
+		box.braceDefaults.pair.value == 15 ? 0 : 1;
 }

--- a/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
+++ b/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
@@ -2,28 +2,43 @@ struct Pair {
 	int value;
 };
 
-constexpr void set_pair(Pair* p, int v) {
+struct Defaults {
+	int first = 40;
+	int second = first + 1;
+};
+
+constexpr void setPair(Pair* p, int v) {
 	p->value = v;
 }
 
-constexpr void add_pair(Pair* p, int v) {
+constexpr void addPair(Pair* p, int v) {
 	p->value += v;
+}
+
+constexpr void addDefaults(Defaults* p, int v) {
+	p->second += v;
 }
 
 struct Box {
 	Pair pair;
+	Defaults defaults;
 
 	constexpr Box(int v) {
 		pair.value = 0;
-		set_pair(&pair, v);
-		add_pair(&pair, 2);
+		setPair(&pair, v);
+		addPair(&pair, 2);
+		addDefaults(&defaults, 1);
 	}
 };
 
 constexpr Box box(40);
 
 static_assert(box.pair.value == 42);
+static_assert(box.defaults.first == 40);
+static_assert(box.defaults.second == 42);
 
 int main() {
-	return box.pair.value == 42 ? 0 : 1;
+	return box.pair.value == 42 &&
+		box.defaults.first == 40 &&
+		box.defaults.second == 42 ? 0 : 1;
 }

--- a/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
+++ b/tests/test_constexpr_ctor_body_member_pointer_call_ret0.cpp
@@ -1,0 +1,29 @@
+struct Pair {
+	int value;
+};
+
+constexpr void set_pair(Pair* p, int v) {
+	p->value = v;
+}
+
+constexpr void add_pair(Pair* p, int v) {
+	p->value += v;
+}
+
+struct Box {
+	Pair pair;
+
+	constexpr Box(int v) {
+		pair.value = 0;
+		set_pair(&pair, v);
+		add_pair(&pair, 2);
+	}
+};
+
+constexpr Box box(40);
+
+static_assert(box.pair.value == 42);
+
+int main() {
+	return box.pair.value == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- support constexpr constructor bodies that pass member subobject addresses to constexpr helper functions
- default-materialize constructor members before body evaluation so member subobjects are available for write-through pointer calls
- document the newly supported constructor-body helper-call shape


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Constexpr constructors can now mutate member subobjects via pointer-based helper calls and have more robust default-member initialization during evaluation.

* **Documentation**
  * Expanded constexpr guidance with examples showing member-mutation patterns and constructor-body behaviors.

* **Tests**
  * Added test coverage validating constexpr constructor member updates performed through pointer-based helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->