### PR TITLE
Refactor: Unify template param/arg APIs to std::span and InlineVector

### DIFF
--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cassert>
+#include <span>
 #include "AstNodeTypes_TypeSystem.h"
 #include "SizeTypes.h"
 #include "VariantUtils.h"
@@ -1505,10 +1506,10 @@ public:
 		has_unsized_outer_array_dimension_ = false;
 		array_dimensions_.push_back(size);
 	}
-	void set_array_dimensions(const std::vector<size_t>& dims) {
+	void set_array_dimensions(std::span<const size_t> dims) {
 		is_array_ = !dims.empty();
 		has_unsized_outer_array_dimension_ = false;
-		array_dimensions_ = dims;
+		array_dimensions_.assign(dims.begin(), dims.end());
 	}
 	bool has_unsized_outer_array_dimension() const { return has_unsized_outer_array_dimension_; }
 	void set_unsized_outer_array_dimension(bool has_unsized_outer_array_dimension) {

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -23,8 +23,17 @@ public:
 		: kind_(TemplateParameterKind::NonType), name_(name), type_node_(type_node), token_(token) {}
 
 	// Template template parameter: template<template<typename> class Container>
-	TemplateParameterNode(StringHandle name, std::vector<ASTNode> nested_params, Token token)
+	TemplateParameterNode(StringHandle name, std::vector<TemplateParameterNode> nested_params, Token token)
 		: kind_(TemplateParameterKind::Template), name_(name), nested_params_(std::move(nested_params)), token_(token) {}
+	TemplateParameterNode(StringHandle name, std::vector<ASTNode> nested_params, Token token)
+		: kind_(TemplateParameterKind::Template), name_(name), token_(token) {
+		nested_params_.reserve(nested_params.size());
+		for (const ASTNode& nested_param : nested_params) {
+			if (nested_param.is<TemplateParameterNode>()) {
+				nested_params_.push_back(nested_param.as<TemplateParameterNode>());
+			}
+		}
+	}
 
 	TemplateParameterKind kind() const { return kind_; }
 	std::string_view name() const { return name_.view(); }
@@ -39,7 +48,7 @@ public:
 	const TypeSpecifierNode& type_specifier_node() const { return type_node_.value(); }
 
 	// For template template parameters
-	const std::vector<ASTNode>& nested_parameters() const { return nested_params_; }
+	const std::vector<TemplateParameterNode>& nested_parameters() const { return nested_params_; }
 
 	// For default arguments
 	bool has_default() const { return default_value_.has_value(); }
@@ -69,7 +78,7 @@ private:
 	TemplateParameterKind kind_;
 	StringHandle name_;	// Points directly into source text from lexer token
 	std::optional<TypeSpecifierNode> type_node_;  // For non-type parameters (e.g., int N)
-	std::vector<ASTNode> nested_params_;	 // For template template parameters (nested template parameters)
+	std::vector<TemplateParameterNode> nested_params_;	 // For template template parameters (nested template parameters)
 	std::optional<ASTNode> default_value_;  // Default argument (e.g., typename T = int)
 	std::optional<SaveHandle> default_value_position_;  // Lexer position for SFINAE re-parse of dependent defaults
 	Token token_;  // For error reporting
@@ -88,18 +97,6 @@ public:
 		: template_parameters_(std::move(template_params)),
 		  function_declaration_(function_decl),
 		  requires_clause_(requires_clause) {}
-	TemplateFunctionDeclarationNode(InlineVector<ASTNode, 4> template_params, ASTNode function_decl,
-									std::optional<ASTNode> requires_clause)
-		: function_declaration_(function_decl),
-		  requires_clause_(requires_clause) {
-		template_parameters_.reserve(template_params.size());
-		for (const ASTNode& template_param : template_params) {
-			if (template_param.is<TemplateParameterNode>()) {
-				template_parameters_.push_back(template_param.as<TemplateParameterNode>());
-			}
-		}
-	}
-
 	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	const ASTNode& function_declaration() const { return function_declaration_; }
 	const std::optional<ASTNode>& requires_clause() const { return requires_clause_; }
@@ -1289,18 +1286,6 @@ public:
 								 InlineVector<std::string_view, 4> param_names,
 								 ASTNode class_decl)
 		: template_parameters_(std::move(template_params)), template_param_names_(std::move(param_names)), class_declaration_(class_decl) {}
-	TemplateClassDeclarationNode(InlineVector<ASTNode, 4> template_params,
-								 InlineVector<std::string_view, 4> param_names,
-								 ASTNode class_decl)
-		: template_param_names_(std::move(param_names)), class_declaration_(class_decl) {
-		template_parameters_.reserve(template_params.size());
-		for (const ASTNode& template_param : template_params) {
-			if (template_param.is<TemplateParameterNode>()) {
-				template_parameters_.push_back(template_param.as<TemplateParameterNode>());
-			}
-		}
-	}
-
 	const InlineVector<TemplateParameterNode, 4>& template_parameters() const { return template_parameters_; }
 	InlineVector<TemplateParameterNode, 4>& template_parameters() { return template_parameters_; }
 	const InlineVector<std::string_view, 4>& template_param_names() const { return template_param_names_; }

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -23,6 +23,13 @@ public:
 		: kind_(TemplateParameterKind::NonType), name_(name), type_node_(type_node), token_(token) {}
 
 	// Template template parameter: template<template<typename> class Container>
+	TemplateParameterNode(StringHandle name, std::span<const TemplateParameterNode> nested_params, Token token)
+		: kind_(TemplateParameterKind::Template), name_(name), token_(token) {
+		nested_params_.reserve(nested_params.size());
+		for (const TemplateParameterNode& nested_param : nested_params) {
+			nested_params_.push_back(nested_param);
+		}
+	}
 	TemplateParameterNode(StringHandle name, std::vector<TemplateParameterNode> nested_params, Token token)
 		: kind_(TemplateParameterKind::Template), name_(name), nested_params_(std::move(nested_params)), token_(token) {}
 	TemplateParameterNode(StringHandle name, std::vector<ASTNode> nested_params, Token token)
@@ -48,7 +55,7 @@ public:
 	const TypeSpecifierNode& type_specifier_node() const { return type_node_.value(); }
 
 	// For template template parameters
-	const std::vector<TemplateParameterNode>& nested_parameters() const { return nested_params_; }
+	std::span<const TemplateParameterNode> nested_parameters() const { return nested_params_; }
 
 	// For default arguments
 	bool has_default() const { return default_value_.has_value(); }

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -432,8 +432,8 @@ struct EvaluationContext {
 
 	// Template parameter names and arguments for evaluating template-dependent expressions
 	// (e.g., sizeof(T) inside a template member function)
-	std::vector<std::string_view> template_param_names;
-	std::vector<TemplateTypeArg> template_args;
+	InlineVector<std::string_view, 4> template_param_names;
+	InlineVector<TemplateTypeArg, 4> template_args;
 
 	// Parser pointer for template instantiation (optional)
 	Parser* parser = nullptr;

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4457,9 +4457,7 @@ bool Evaluator::try_load_current_struct_template_bindings(EvaluationContext& con
 		context.template_args = lazy_class_info->template_args;
 		context.template_param_names.reserve(lazy_class_info->template_params.size());
 		for (const auto& template_param : lazy_class_info->template_params) {
-			if (template_param.is<TemplateParameterNode>()) {
-				context.template_param_names.push_back(template_param.as<TemplateParameterNode>().name());
-			}
+			context.template_param_names.push_back(template_param.name());
 		}
 		return true;
 	}

--- a/src/InlineVector.h
+++ b/src/InlineVector.h
@@ -168,6 +168,13 @@ public:
 		resetStorage();
 	}
 
+	template <typename InputIt>
+	void assign(InputIt first, InputIt last) {
+		clear();
+		for (InputIt it = first; it != last; ++it)
+			push_back(*it);
+	}
+
 	void reserve(size_t capacity) {
 		if (using_inline_storage_) {
 			if (capacity > N) {

--- a/src/InlineVector.h
+++ b/src/InlineVector.h
@@ -79,8 +79,7 @@ public:
 		return *this;
 	}
 
-	// Implicit conversion to std::vector (enables seamless migration)
-	operator std::vector<T>() const {
+	[[nodiscard]] std::vector<T> toVector() const {
 		if (!using_inline_storage_) {
 			return heap_data_;
 		}

--- a/src/InstantiationQueue.h
+++ b/src/InstantiationQueue.h
@@ -209,7 +209,7 @@ public:
 	// Build an InstantiationKey from template name and TemplateTypeArg vector
 	// This consolidates the conversion logic that was duplicated in call sites
 	static InstantiationKey makeKey(std::string_view template_name,
-									const std::vector<TemplateTypeArg>& template_args) {
+									std::span<const TemplateTypeArg> template_args) {
 		InstantiationKey key;
 		key.template_name = StringTable::getOrInternStringHandle(template_name);
 		key.arguments.reserve(template_args.size());

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -536,9 +536,7 @@ void AstToIr::generateStaticMemberDeclarations() {
 					ctx.template_args = lazy_class_info->template_args;
 					ctx.template_param_names.reserve(lazy_class_info->template_params.size());
 					for (const auto& template_param : lazy_class_info->template_params) {
-						if (template_param.is<TemplateParameterNode>()) {
-							ctx.template_param_names.push_back(template_param.as<TemplateParameterNode>().name());
-						}
+						ctx.template_param_names.push_back(template_param.name());
 					}
 				}
 			}

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1452,11 +1452,6 @@ private:
 		std::span<const TemplateParameterNode> template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
-	bool tryAppendDefaultTemplateArg(
-		const TemplateParameterNode& param,
-		std::span<const ASTNode> template_params,
-		InlineVector<TemplateTypeArg, 4>& template_args,
-		NamespaceHandle source_namespace);
 	bool tryAppendMemberDefaultTemplateArg(
 		const TemplateParameterNode& param,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
@@ -1522,12 +1517,6 @@ private:
 	void reparse_template_function_body(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
-		std::span<const ASTNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
-		bool preserve_ref_qualifier);
-	void reparse_template_function_body(
-		FunctionDeclarationNode& new_func_ref,
-		const FunctionDeclarationNode& func_decl,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		bool preserve_ref_qualifier);
@@ -1542,10 +1531,6 @@ private:
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args);
-	void populateTemplateParamSubstitutions(
-		InlineVector<TemplateParamSubstitution, 4>& subs,
-		std::span<const ASTNode> template_params,
 		std::span<const TemplateTypeArg> template_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
@@ -2452,10 +2437,6 @@ private:
 		const std::vector<TemplateTypeArg>& template_args);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
-		std::span<const ASTNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
-	const TypeInfo* materializeInstantiatedMemberAliasTarget(
-		const TypeSpecifierNode& alias_type_spec,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	AliasTemplateMaterializationResult materializeAliasTemplateInstantiation(
@@ -2528,11 +2509,6 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args);
-
-	ASTNode substituteTemplateParameters(
-		const ASTNode& node,
-		std::span<const ASTNode> template_params,
 		std::span<const TemplateTypeArg> template_args);
 
 	// Helper to extract type from an expression for overload resolution.
@@ -2670,24 +2646,9 @@ private:	 // Resume private methods
 		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out_args);
 
-	bool expandPackExpansionArgs(
-		const PackExpansionExprNode& pack_expansion,
-		std::span<const ASTNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
-		ChunkedVector<ASTNode>& out_args);
-
-		// Substitute a single argument, expanding PackExpansionExprNode into
-		// multiple arguments when present.  Falls back to substituteTemplateParameters
-		// for non-pack arguments.  Appends result(s) to `out`.
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
-		ChunkedVector<ASTNode>& out);
-
-	void substituteArgWithPackExpansion(
-		const ASTNode& arg,
-		std::span<const ASTNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out);
 
@@ -2920,11 +2881,6 @@ private:	 // Resume private methods
 
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
-		std::span<const ASTNode> template_params,
-		std::span<const TemplateTypeArg> template_args);
-
-	TypeIndex substitute_template_parameter(
-		const TypeSpecifierNode& original_type,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 
@@ -2940,14 +2896,6 @@ private:	 // Resume private methods
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
-	DependentAliasResolutionStatus resolveDependentMemberAlias(
-		ASTNode& type_node,
-		std::span<const ASTNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
-	DependentAliasResolutionStatus resolveDependentMemberAlias(
-		ASTNode& type_node,
-		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1645,8 +1645,8 @@ private:
 		const ASTNode& original_return_type_node,
 		const Token& fallback_return_token,
 		StringHandle parent_struct_name,
-		const InlineVector<ASTNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const ASTNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
 		const StructDeclarationNode* owner_decl,
 		TypeIndex instantiated_owner_type_index, // Rewrite self-references (e.g. W<T>& -> W<int>&)
 		TypeIndex override_return_type_index,	  // Force return TypeIndex when caller already resolved aliases
@@ -1658,8 +1658,8 @@ private:
 	void substituteAndCopyMemberFunctionParameters(
 		const std::vector<ASTNode>& original_params,
 		FunctionDeclarationNode& target_node,
-		const InlineVector<ASTNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const ASTNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
 		const StructDeclarationNode* owner_decl,
 		TypeIndex instantiated_owner_type_index, // Rewrite self-referential parameter type indices
 		TypeIndex self_type_from_index,		   // Optional explicit self-type rewrite source (invalid = disabled)

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1538,19 +1538,19 @@ private:
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		const InlineVector<StringHandle, 4>& param_names,
-		const std::vector<TemplateTypeArg>& type_args);
+		std::span<const TemplateTypeArg> type_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		std::span<const TemplateParameterNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		std::span<const ASTNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	// Build outer-template binding data from the AST template parameter list so
 	// parameter names and args stay index-aligned even if the parameter list
 	// ever stops being a pure TemplateParameterNode sequence.
@@ -2112,7 +2112,7 @@ private:
 		std::string_view struct_name, std::string_view member_name,
 		StringHandle qualified_name,
 		const ASTNode& template_node,
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		const FlashCpp::TemplateInstantiationKey& key,
 		const std::vector<TypeSpecifierNode>& call_arg_types);
 	bool buildSubstitutionForPackElement(
@@ -2122,7 +2122,7 @@ private:
 		std::span<const TemplateParameterNode> template_params,
 		const std::vector<size_t>& template_param_arg_starts,
 		const std::vector<size_t>& template_param_arg_counts,
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		InlineVector<ASTNode, 4>& subst_params,
 		InlineVector<TemplateTypeArg, 4>& subst_args);
 	ASTNode buildMaterializedParamType(
@@ -2528,15 +2528,12 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
+		std::span<const TemplateTypeArg> template_args);
+
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const ASTNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
-	ASTNode substituteTemplateParameters(
-		const ASTNode& node,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 
 	// Helper to extract type from an expression for overload resolution.
 	// Public so codegen/constexpr consumers can reuse the parser's type deduction.
@@ -2670,17 +2667,13 @@ private:	 // Resume private methods
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out_args);
+
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
 		std::span<const ASTNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
-		ChunkedVector<ASTNode>& out_args);
-	bool expandPackExpansionArgs(
-		const PackExpansionExprNode& pack_expansion,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out_args);
 
 		// Substitute a single argument, expanding PackExpansionExprNode into
@@ -2689,12 +2682,13 @@ private:	 // Resume private methods
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out);
+
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,
 		std::span<const ASTNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out);
 
 		// Phase 3: Expression context tracking for template disambiguation
@@ -2922,11 +2916,13 @@ private:	 // Resume private methods
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
+		std::span<const TemplateTypeArg> template_args);
+
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
 		std::span<const ASTNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
+		std::span<const TemplateTypeArg> template_args);
+
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
 		const InlineVector<TemplateParameterNode, 4>& template_params,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1450,7 +1450,7 @@ private:
 		NamespaceHandle source_namespace);
 	bool tryAppendDefaultTemplateArg(
 		const TemplateParameterNode& param,
-		const std::vector<ASTNode>& template_params,
+		std::span<const ASTNode> template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
 	bool tryAppendMemberDefaultTemplateArg(
@@ -1512,7 +1512,7 @@ private:
 	void reparse_template_function_body(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		bool preserve_ref_qualifier = false);
 	void reparse_template_function_body(
@@ -1531,7 +1531,7 @@ private:
 		const std::vector<TemplateTypeArg>& type_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
-		const std::vector<ASTNode>& template_params,
+		std::span<const ASTNode> template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
@@ -2061,7 +2061,7 @@ private:
 		StringHandle pack_param_name,
 		size_t pack_element_offset,
 		const std::unordered_set<StringHandle, StringHash, StringEqual>& dependent_pack_names,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const std::vector<size_t>& template_param_arg_starts,
 		const std::vector<size_t>& template_param_arg_counts,
 		const std::vector<TemplateTypeArg>& template_args,
@@ -2390,7 +2390,7 @@ private:
 		const Token& source_token);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
@@ -2465,7 +2465,7 @@ public:	// Public methods for template instantiation
 	// Substitute template parameters in an AST node with concrete types/values
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
@@ -2603,7 +2603,7 @@ private:	 // Resume private methods
 	// legitimately contribute zero arguments.
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		ChunkedVector<ASTNode>& out_args);
 	bool expandPackExpansionArgs(
@@ -2617,7 +2617,7 @@ private:	 // Resume private methods
 		// for non-pack arguments.  Appends result(s) to `out`.
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		ChunkedVector<ASTNode>& out);
 
@@ -2845,7 +2845,7 @@ private:	 // Resume private methods
 	// Handles complex transformations like const T& -> const int&, T* -> int*, etc.
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
@@ -2859,11 +2859,11 @@ private:	 // Resume private methods
 	};
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
-		const InlineVector<ASTNode, 4>& template_params,
+		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -119,6 +119,21 @@ enum class ParserError {
 	NotImplemented
 };
 
+enum class SubstitutedDefaultArgumentPolicy {
+	None,
+	SubstituteTemplateParameters,
+	ExpressionSubstitutor
+};
+
+struct SubstitutedMemberFunctionShell {
+	ASTNode declaration_node;
+	DeclarationNode* declaration;
+	ASTNode function_node;
+	FunctionDeclarationNode* function;
+	TypeSpecifierNode return_type;
+	StringHandle effective_name;
+};
+
 static std::string_view get_parser_error_string(ParserError e) {
 	switch (e) {
 	case ParserError::None:
@@ -1621,6 +1636,38 @@ private:
 			node.set_outer_template_bindings(outer_template_param_names, filtered_template_args);
 		}
 	}
+	static StringHandle computeInstantiatedLookupName(
+		StringHandle original_name,
+		OverloadableOperator op_kind,
+		const TypeSpecifierNode& substituted_return_type);
+	SubstitutedMemberFunctionShell createSubstitutedMemberFunctionShell(
+		const FunctionDeclarationNode& original_func,
+		const ASTNode& original_return_type_node,
+		const Token& fallback_return_token,
+		StringHandle parent_struct_name,
+		const InlineVector<ASTNode, 4>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		const StructDeclarationNode* owner_decl,
+		TypeIndex instantiated_owner_type_index, // Rewrite self-references (e.g. W<T>& -> W<int>&)
+		TypeIndex override_return_type_index,	  // Force return TypeIndex when caller already resolved aliases
+		OverloadableOperator operator_kind,
+		StringHandle effective_name_override,	   // Use precomputed lookup name instead of recomputing
+		StringHandle partial_pattern_owner_name,  // Enable partial-pattern pointer-depth clamp when valid
+		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
+		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
+	void substituteAndCopyMemberFunctionParameters(
+		const std::vector<ASTNode>& original_params,
+		FunctionDeclarationNode& target_node,
+		const InlineVector<ASTNode, 4>& template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		const StructDeclarationNode* owner_decl,
+		TypeIndex instantiated_owner_type_index, // Rewrite self-referential parameter type indices
+		TypeIndex self_type_from_index,		   // Optional explicit self-type rewrite source (invalid = disabled)
+		TypeIndex self_type_to_index,			   // Optional explicit self-type rewrite target
+		SubstitutedDefaultArgumentPolicy default_argument_policy, // Default-arg substitution strategy
+		bool preserve_parameter_cv_qualifier, // Keep declared cv qualifier; false reproduces decl-only legacy behavior
+		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
+		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
 	template <typename TemplateParamsContainer, typename TemplateArgsContainer>
 	StringHandle resolveBaseInitializerNameForTemplateArgs(
 		StringHandle base_name,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1450,6 +1450,11 @@ private:
 		NamespaceHandle source_namespace);
 	bool tryAppendDefaultTemplateArg(
 		const TemplateParameterNode& param,
+		std::span<const TemplateParameterNode> template_params,
+		InlineVector<TemplateTypeArg, 4>& template_args,
+		NamespaceHandle source_namespace);
+	bool tryAppendDefaultTemplateArg(
+		const TemplateParameterNode& param,
 		std::span<const ASTNode> template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
@@ -1512,9 +1517,15 @@ private:
 	void reparse_template_function_body(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
-		std::span<const ASTNode> template_params,
+		std::span<const TemplateParameterNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		bool preserve_ref_qualifier = false);
+	void reparse_template_function_body(
+		FunctionDeclarationNode& new_func_ref,
+		const FunctionDeclarationNode& func_decl,
+		std::span<const ASTNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		bool preserve_ref_qualifier);
 	void reparse_template_function_body(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
@@ -1529,6 +1540,10 @@ private:
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		const InlineVector<StringHandle, 4>& param_names,
 		const std::vector<TemplateTypeArg>& type_args);
+	void populateTemplateParamSubstitutions(
+		InlineVector<TemplateParamSubstitution, 4>& subs,
+		std::span<const TemplateParameterNode> template_params,
+		const std::vector<TemplateTypeArg>& template_args);
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		std::span<const ASTNode> template_params,
@@ -1645,7 +1660,7 @@ private:
 		const ASTNode& original_return_type_node,
 		const Token& fallback_return_token,
 		StringHandle parent_struct_name,
-		std::span<const ASTNode> template_params,
+		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
 		const StructDeclarationNode* owner_decl,
 		TypeIndex instantiated_owner_type_index, // Rewrite self-references (e.g. W<T>& -> W<int>&)
@@ -1655,10 +1670,25 @@ private:
 		StringHandle partial_pattern_owner_name,  // Enable partial-pattern pointer-depth clamp when valid
 		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
 		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
+	SubstitutedMemberFunctionShell createSubstitutedMemberFunctionShell(
+		const FunctionDeclarationNode& original_func,
+		const ASTNode& original_return_type_node,
+		const Token& fallback_return_token,
+		StringHandle parent_struct_name,
+		std::span<const ASTNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
+		const StructDeclarationNode* owner_decl,
+		TypeIndex instantiated_owner_type_index,
+		TypeIndex override_return_type_index,
+		OverloadableOperator operator_kind,
+		StringHandle effective_name_override,
+		StringHandle partial_pattern_owner_name,
+		bool apply_bound_metadata_to_full_substitution,
+		bool apply_resolved_index_to_full_substitution);
 	void substituteAndCopyMemberFunctionParameters(
 		const std::vector<ASTNode>& original_params,
 		FunctionDeclarationNode& target_node,
-		std::span<const ASTNode> template_params,
+		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
 		const StructDeclarationNode* owner_decl,
 		TypeIndex instantiated_owner_type_index, // Rewrite self-referential parameter type indices
@@ -1668,6 +1698,19 @@ private:
 		bool preserve_parameter_cv_qualifier, // Keep declared cv qualifier; false reproduces decl-only legacy behavior
 		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
 		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
+	void substituteAndCopyMemberFunctionParameters(
+		const std::vector<ASTNode>& original_params,
+		FunctionDeclarationNode& target_node,
+		std::span<const ASTNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
+		const StructDeclarationNode* owner_decl,
+		TypeIndex instantiated_owner_type_index,
+		TypeIndex self_type_from_index,
+		TypeIndex self_type_to_index,
+		SubstitutedDefaultArgumentPolicy default_argument_policy,
+		bool preserve_parameter_cv_qualifier,
+		bool apply_bound_metadata_to_full_substitution,
+		bool apply_resolved_index_to_full_substitution);
 	template <typename TemplateParamsContainer, typename TemplateArgsContainer>
 	StringHandle resolveBaseInitializerNameForTemplateArgs(
 		StringHandle base_name,
@@ -1699,7 +1742,18 @@ private:
 				std::vector<TemplateTypeArg> concrete_base_args =
 					materializeTemplateArgs(*base_type_info, template_params, template_args,
 						[this](const ASTNode& expr, std::span<const ASTNode> params, std::span<const TemplateTypeArg> args) {
-							return this->evaluateDependentNTTPExpression(expr, params, args);
+							InlineVector<TemplateParameterNode, 4> typed_params;
+							typed_params.reserve(params.size());
+							for (const ASTNode& param_node : params) {
+								if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+									typed_param != nullptr) {
+									typed_params.push_back(*typed_param);
+								}
+							}
+							return this->evaluateDependentNTTPExpression(
+								expr,
+								std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+								args);
 						});
 				auto instantiated_base = try_instantiate_class_template(base_template_name, concrete_base_args);
 				if (instantiated_base.has_value() && instantiated_base->is<StructDeclarationNode>()) {
@@ -1784,7 +1838,18 @@ private:
 			concrete_args.push_back(
 				materializeTemplateArg(arg_info, template_params, template_args,
 					[this](const ASTNode& expr, std::span<const ASTNode> params, std::span<const TemplateTypeArg> args) {
-						return this->evaluateDependentNTTPExpression(expr, params, args);
+						InlineVector<TemplateParameterNode, 4> typed_params;
+						typed_params.reserve(params.size());
+						for (const ASTNode& param_node : params) {
+							if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+								typed_param != nullptr) {
+								typed_params.push_back(*typed_param);
+							}
+						}
+						return this->evaluateDependentNTTPExpression(
+							expr,
+							std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+							args);
 					}));
 		}
 
@@ -1808,7 +1873,18 @@ private:
 			std::vector<TemplateTypeArg> nested_args =
 				materializeTemplateArgs(*base_info, template_params, template_args,
 					[this](const ASTNode& expr, std::span<const ASTNode> params, std::span<const TemplateTypeArg> args) {
-						return this->evaluateDependentNTTPExpression(expr, params, args);
+						InlineVector<TemplateParameterNode, 4> typed_params;
+						typed_params.reserve(params.size());
+						for (const ASTNode& param_node : params) {
+							if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+								typed_param != nullptr) {
+								typed_params.push_back(*typed_param);
+							}
+						}
+						return this->evaluateDependentNTTPExpression(
+							expr,
+							std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+							args);
 					});
 			try_instantiate_class_template(nested_template_name, nested_args);
 			std::string_view instantiated_nested_name =
@@ -1868,7 +1944,18 @@ private:
 					std::vector<TemplateTypeArg> exact_args =
 						materializeTemplateArgs(*concrete_type_info, template_params, template_args,
 							[this](const ASTNode& expr, std::span<const ASTNode> params, std::span<const TemplateTypeArg> args) {
-								return this->evaluateDependentNTTPExpression(expr, params, args);
+								InlineVector<TemplateParameterNode, 4> typed_params;
+								typed_params.reserve(params.size());
+								for (const ASTNode& param_node : params) {
+									if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+										typed_param != nullptr) {
+										typed_params.push_back(*typed_param);
+									}
+								}
+								return this->evaluateDependentNTTPExpression(
+									expr,
+									std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+									args);
 							});
 					auto specialization_ast =
 						gTemplateRegistry.lookupExactSpecialization(base_template_name, exact_args);
@@ -2043,7 +2130,7 @@ private:
 // Returns the evaluated value and its category, or nullopt if evaluation fails.
 	std::optional<TemplateTypeArg> evaluateDependentNTTPExpression(
 		const ASTNode& dependent_expr,
-		std::span<const ASTNode> template_params,
+		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args);
 	std::optional<ASTNode> try_instantiate_member_function_template(std::string_view struct_name, std::string_view member_name, const std::vector<TypeSpecifierNode>& arg_types);  // NEW: Instantiate member function template
 	std::optional<ASTNode> try_instantiate_member_function_template_explicit(std::string_view struct_name, std::string_view member_name, const std::vector<TemplateTypeArg>& template_type_args);  // NEW: Instantiate member function template with explicit args
@@ -2061,7 +2148,7 @@ private:
 		StringHandle pack_param_name,
 		size_t pack_element_offset,
 		const std::unordered_set<StringHandle, StringHash, StringEqual>& dependent_pack_names,
-		std::span<const ASTNode> template_params,
+		std::span<const TemplateParameterNode> template_params,
 		const std::vector<size_t>& template_param_arg_starts,
 		const std::vector<size_t>& template_param_arg_counts,
 		const std::vector<TemplateTypeArg>& template_args,
@@ -2390,6 +2477,10 @@ private:
 		const Token& source_token);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
+		std::span<const TemplateParameterNode> template_params,
+		const std::vector<TemplateTypeArg>& template_args);
+	const TypeInfo* materializeInstantiatedMemberAliasTarget(
+		const TypeSpecifierNode& alias_type_spec,
 		std::span<const ASTNode> template_params,
 		const std::vector<TemplateTypeArg>& template_args);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
@@ -2463,6 +2554,10 @@ public:	// Public methods for template instantiation
 	);
 
 	// Substitute template parameters in an AST node with concrete types/values
+	ASTNode substituteTemplateParameters(
+		const ASTNode& node,
+		std::span<const TemplateParameterNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args);
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const ASTNode> template_params,
@@ -2603,6 +2698,11 @@ private:	 // Resume private methods
 	// legitimately contribute zero arguments.
 	bool expandPackExpansionArgs(
 		const PackExpansionExprNode& pack_expansion,
+		std::span<const TemplateParameterNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		ChunkedVector<ASTNode>& out_args);
+	bool expandPackExpansionArgs(
+		const PackExpansionExprNode& pack_expansion,
 		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args,
 		ChunkedVector<ASTNode>& out_args);
@@ -2615,6 +2715,11 @@ private:	 // Resume private methods
 		// Substitute a single argument, expanding PackExpansionExprNode into
 		// multiple arguments when present.  Falls back to substituteTemplateParameters
 		// for non-pack arguments.  Appends result(s) to `out`.
+	void substituteArgWithPackExpansion(
+		const ASTNode& arg,
+		std::span<const TemplateParameterNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		ChunkedVector<ASTNode>& out);
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,
 		std::span<const ASTNode> template_params,
@@ -2845,6 +2950,10 @@ private:	 // Resume private methods
 	// Handles complex transformations like const T& -> const int&, T* -> int*, etc.
 	TypeIndex substitute_template_parameter(
 		const TypeSpecifierNode& original_type,
+		std::span<const TemplateParameterNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args);
+	TypeIndex substitute_template_parameter(
+		const TypeSpecifierNode& original_type,
 		std::span<const ASTNode> template_params,
 		const InlineVector<TemplateTypeArg, 4>& template_args);
 	TypeIndex substitute_template_parameter(
@@ -2857,6 +2966,14 @@ private:	 // Resume private methods
 		Resolved,
 		StillDependent
 	};
+	DependentAliasResolutionStatus resolveDependentMemberAlias(
+		ASTNode& type_node,
+		std::span<const TemplateParameterNode> template_params,
+		const std::vector<TemplateTypeArg>& template_args);
+	DependentAliasResolutionStatus resolveDependentMemberAlias(
+		ASTNode& type_node,
+		std::span<const TemplateParameterNode> template_params,
+		const InlineVector<TemplateTypeArg, 4>& template_args);
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
 		std::span<const ASTNode> template_params,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1228,7 +1228,7 @@ private:
 	// so this helper is intentionally non-const.
 	std::optional<AliasTemplateMaterializationResult> tryResolveCurrentInstantiationTemplateOwner(
 		std::string_view primary_template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 
 	// Helper function to parse cv-qualifiers (const/volatile) from token stream
 	// Returns combined CVQualifier flags (None, Const, Volatile, or ConstVolatile)
@@ -1444,11 +1444,6 @@ private:
 		int recursion_depth);
 	bool tryAppendDefaultTemplateArg(
 		const TemplateParameterNode& param,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		InlineVector<TemplateTypeArg, 4>& template_args,
-		NamespaceHandle source_namespace);
-	bool tryAppendDefaultTemplateArg(
-		const TemplateParameterNode& param,
 		std::span<const TemplateParameterNode> template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		NamespaceHandle source_namespace);
@@ -1512,13 +1507,7 @@ private:
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
 		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
-		bool preserve_ref_qualifier = false);
-	void reparse_template_function_body(
-		FunctionDeclarationNode& new_func_ref,
-		const FunctionDeclarationNode& func_decl,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		bool preserve_ref_qualifier);
 	// Populate template_param_substitutions_ from parallel (name, arg) pairs for
 	// body-reparse paths so non-type params (e.g. int N → 4) are resolved in parse_block().
@@ -1531,10 +1520,6 @@ private:
 	void populateTemplateParamSubstitutions(
 		InlineVector<TemplateParamSubstitution, 4>& subs,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args);
-	void populateTemplateParamSubstitutions(
-		InlineVector<TemplateParamSubstitution, 4>& subs,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
 		std::span<const TemplateTypeArg> template_args);
 	// Build outer-template binding data from the AST template parameter list so
 	// parameter names and args stay index-aligned even if the parameter list
@@ -2043,24 +2028,24 @@ private:
 		return substituted_arg;
 	}
 	bool isReachableVirtualBaseInitializer(const StructTypeInfo* struct_info, std::string_view candidate_name) const;
-	std::optional<ASTNode> try_instantiate_class_template(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args, bool force_eager = false);	// NEW: Instantiate class template
-	std::optional<ASTNode> instantiate_full_specialization(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args, ASTNode& spec_node);  // Instantiate full specialization
-	std::optional<ASTNode> try_instantiate_variable_template(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args);	 // NEW: Instantiate variable template
+	std::optional<ASTNode> try_instantiate_class_template(std::string_view template_name, std::span<const TemplateTypeArg> template_args, bool force_eager = false);	// NEW: Instantiate class template
+	std::optional<ASTNode> instantiate_full_specialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args, ASTNode& spec_node);  // Instantiate full specialization
+	std::optional<ASTNode> try_instantiate_variable_template(std::string_view template_name, std::span<const TemplateTypeArg> template_args);	 // NEW: Instantiate variable template
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
 		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		const TemplateParameterNode* target_template_param);
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
 		const InlineVector<ASTNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		const TemplateParameterNode* target_template_param);
 	std::optional<std::vector<TemplateTypeArg>> materializeDeferredAliasTemplateArgs(
 		const TemplateAliasNode& alias_node,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	StringHandle getAliasTargetNameHandle(const TypeSpecifierNode& alias_target) const;
 	std::optional<size_t> findAliasTargetTemplateParamIndex(
 		const TemplateAliasNode& alias_node,
@@ -2415,35 +2400,31 @@ private:
 		const TypeInfo* resolved_type_info = nullptr;
 		std::optional<ASTNode> instantiated_struct_node{};  // Set when try_instantiate_class_template returns a StructDeclarationNode
 	};
-	std::string_view get_instantiated_class_name(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args);	 // NEW: Get mangled name for instantiated class
-	std::string_view instantiate_and_register_base_template(std::string_view& base_class_name, const std::vector<TemplateTypeArg>& template_args);  // Helper: Instantiate base class template and add to AST
+	std::string_view get_instantiated_class_name(std::string_view template_name, std::span<const TemplateTypeArg> template_args);	 // NEW: Get mangled name for instantiated class
+	std::string_view instantiate_and_register_base_template(std::string_view& base_class_name, std::span<const TemplateTypeArg> template_args);  // Helper: Instantiate base class template and add to AST
 	AliasTemplateMaterializationResult materializeTemplateInstantiationForLookup(
 		std::string_view template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	AliasTemplateMaterializationResult materializePrimaryTemplateOwnerForLookup(
 		std::string_view primary_template_name,
 		std::string_view fallback_template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	AliasTemplateMaterializationResult materializePrimaryTemplateOwnerForConstructorLookup(
 		std::string_view primary_template_name,
 		std::string_view fallback_template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	ParseResult parseMaterializedTemplateFunctionalCast(
 		const AliasTemplateMaterializationResult& materialized_owner,
 		const Token& source_token);
 	const TypeInfo* materializeInstantiatedMemberAliasTarget(
 		const TypeSpecifierNode& alias_type_spec,
 		std::span<const TemplateParameterNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
-	const TypeInfo* materializeInstantiatedMemberAliasTarget(
-		const TypeSpecifierNode& alias_type_spec,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	AliasTemplateMaterializationResult materializeAliasTemplateInstantiation(
 		std::string_view alias_template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	void normalizeDependentNonTypeTemplateArgs(
-		const InlineVector<TemplateParameterNode, 4>& template_parameters,
+		std::span<const TemplateParameterNode> template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	void normalizeDependentNonTypeTemplateArgs(
 		const InlineVector<ASTNode, 4>& template_parameters,
@@ -2451,7 +2432,7 @@ private:
 	bool resolveAliasTemplateInstantiation(
 		TypeSpecifierNode& type_spec,
 		std::string_view alias_template_name,
-		const std::vector<TemplateTypeArg>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 	bool resolveAliasTemplateInstantiation(TypeSpecifierNode& type_spec);
 	// Shared alias-target capture helper: parses the template-id that forms the
 	// right-hand side of an alias declaration from the current token position.
@@ -2476,7 +2457,7 @@ private:
 		// Template instantiation helper methods (extracted from try_instantiate_class_template)
 	std::optional<ASTNode> substitute_nontype_template_param(
 		std::string_view param_name,
-		const std::vector<TemplateTypeArg>& args,
+		std::span<const TemplateTypeArg> args,
 		std::span<const TemplateParameterNode> params);	 // Substitute non-type template parameter in initializer
 
 	std::optional<bool> try_parse_out_of_line_template_member(const InlineVector<TemplateParameterNode, 4>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const InlineVector<TemplateParameterNode, 4>& inner_template_params, const InlineVector<StringHandle, 4>& inner_template_param_names);	 // NEW: Parse out-of-line template member function
@@ -2492,7 +2473,7 @@ private:
 																const std::unordered_map<std::string_view, const TemplateParameterNode*>& template_params) const;
 	bool types_equivalent(const TypeSpecifierNode& lhs, const TypeSpecifierNode& rhs) const;
 	bool instantiate_deduced_template(std::string_view class_name,
-									  const std::vector<TemplateTypeArg>& template_args,
+									  std::span<const TemplateTypeArg> template_args,
 									  TypeSpecifierNode& type_specifier);
 
 public:	// Public methods for template instantiation
@@ -2709,7 +2690,7 @@ private:	 // Resume private methods
 	// Helper to parse template brace initialization: Template<Args>{}
 	// Returns ParseResult with ConstructorCallNode on success
 	ParseResult parse_template_brace_initialization(
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		std::string_view template_name,
 		const Token& identifier_token);
 
@@ -2814,7 +2795,7 @@ private:	 // Resume private methods
 	// Helper: Build TemplateArgumentNodeInfo vector from parsed template args and AST nodes.
 	// Shared across all base class deferral sites.
 	static std::vector<TemplateArgumentNodeInfo> build_template_arg_infos(
-		const std::vector<TemplateTypeArg>& template_args,
+		std::span<const TemplateTypeArg> template_args,
 		const std::vector<ASTNode>& template_arg_nodes);
 
 	// Helper: Parse base class list for a member struct template (already consumed ':').
@@ -2879,11 +2860,6 @@ private:	 // Resume private methods
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args);
 
-	TypeIndex substitute_template_parameter(
-		const TypeSpecifierNode& original_type,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
-
 	enum class DependentAliasResolutionStatus {
 		NotApplicable,
 		Resolved,
@@ -2892,19 +2868,7 @@ private:	 // Resume private methods
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
 		std::span<const TemplateParameterNode> template_params,
-		const std::vector<TemplateTypeArg>& template_args);
-	DependentAliasResolutionStatus resolveDependentMemberAlias(
-		ASTNode& type_node,
-		std::span<const TemplateParameterNode> template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
-	DependentAliasResolutionStatus resolveDependentMemberAlias(
-		ASTNode& type_node,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const std::vector<TemplateTypeArg>& template_args);
-	DependentAliasResolutionStatus resolveDependentMemberAlias(
-		ASTNode& type_node,
-		const InlineVector<TemplateParameterNode, 4>& template_params,
-		const InlineVector<TemplateTypeArg, 4>& template_args);
+		std::span<const TemplateTypeArg> template_args);
 
 	// Lookup symbol with template parameter checking
 	std::optional<ASTNode> lookup_symbol_with_template_check(StringHandle identifier);
@@ -3021,7 +2985,7 @@ private:	 // Resume private methods
 	bool isTemplateTemplateParameter(StringHandle template_name_handle) const;
 
 	// Build an interned placeholder name for TTP instantiation.
-	StringHandle buildTTPPlaceholderName(std::string_view ttp_name, const std::vector<TemplateTypeArg>& template_args);
+	StringHandle buildTTPPlaceholderName(std::string_view ttp_name, std::span<const TemplateTypeArg> template_args);
 
 	// Create a QualifiedIdentifierNode for a TTP-qualified expression like W<int>::id
 	ParseResult buildTTPQualifiedIdentifier(StringHandle ttp_placeholder_name);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1670,21 +1670,6 @@ private:
 		StringHandle partial_pattern_owner_name,  // Enable partial-pattern pointer-depth clamp when valid
 		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
 		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
-	SubstitutedMemberFunctionShell createSubstitutedMemberFunctionShell(
-		const FunctionDeclarationNode& original_func,
-		const ASTNode& original_return_type_node,
-		const Token& fallback_return_token,
-		StringHandle parent_struct_name,
-		std::span<const ASTNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
-		const StructDeclarationNode* owner_decl,
-		TypeIndex instantiated_owner_type_index,
-		TypeIndex override_return_type_index,
-		OverloadableOperator operator_kind,
-		StringHandle effective_name_override,
-		StringHandle partial_pattern_owner_name,
-		bool apply_bound_metadata_to_full_substitution,
-		bool apply_resolved_index_to_full_substitution);
 	void substituteAndCopyMemberFunctionParameters(
 		const std::vector<ASTNode>& original_params,
 		FunctionDeclarationNode& target_node,
@@ -1698,19 +1683,6 @@ private:
 		bool preserve_parameter_cv_qualifier, // Keep declared cv qualifier; false reproduces decl-only legacy behavior
 		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
 		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
-	void substituteAndCopyMemberFunctionParameters(
-		const std::vector<ASTNode>& original_params,
-		FunctionDeclarationNode& target_node,
-		std::span<const ASTNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
-		const StructDeclarationNode* owner_decl,
-		TypeIndex instantiated_owner_type_index,
-		TypeIndex self_type_from_index,
-		TypeIndex self_type_to_index,
-		SubstitutedDefaultArgumentPolicy default_argument_policy,
-		bool preserve_parameter_cv_qualifier,
-		bool apply_bound_metadata_to_full_substitution,
-		bool apply_resolved_index_to_full_substitution);
 	template <typename TemplateParamsContainer, typename TemplateArgsContainer>
 	StringHandle resolveBaseInitializerNameForTemplateArgs(
 		StringHandle base_name,
@@ -2092,13 +2064,13 @@ private:
 	std::optional<ASTNode> try_instantiate_variable_template(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args);	 // NEW: Instantiate variable template
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
-		const InlineVector<ASTNode, 4>& template_parameters,
+		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
 		const std::vector<TemplateTypeArg>& template_args,
 		const TemplateParameterNode* target_template_param);
 	std::optional<TemplateTypeArg> materializeDeferredAliasTemplateArg(
 		const ASTNode& arg_node,
-		const InlineVector<TemplateParameterNode, 4>& template_parameters,
+		const InlineVector<ASTNode, 4>& template_parameters,
 		const InlineVector<StringHandle, 4>& param_names,
 		const std::vector<TemplateTypeArg>& template_args,
 		const TemplateParameterNode* target_template_param);
@@ -2491,10 +2463,10 @@ private:
 		std::string_view alias_template_name,
 		const std::vector<TemplateTypeArg>& template_args);
 	void normalizeDependentNonTypeTemplateArgs(
-		const InlineVector<ASTNode, 4>& template_parameters,
+		const InlineVector<TemplateParameterNode, 4>& template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	void normalizeDependentNonTypeTemplateArgs(
-		const InlineVector<TemplateParameterNode, 4>& template_parameters,
+		const InlineVector<ASTNode, 4>& template_parameters,
 		std::vector<TemplateTypeArg>& template_args);
 	bool resolveAliasTemplateInstantiation(
 		TypeSpecifierNode& type_spec,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1309,7 +1309,6 @@ private:
 	TemplateParameterMetadata registerTemplateParametersInScope(
 		InlineVector<TemplateParameterNode, 4>& template_params,
 		FlashCpp::TemplateParameterScope& template_scope);
-	InlineVector<ASTNode, 4> cloneTemplateParameterNodes(const InlineVector<TemplateParameterNode, 4>& template_params);
 	bool parseDeferredAliasTargetTemplateId(
 		StringHandle& out_target_template_name,
 		std::vector<ASTNode>& out_target_template_arg_nodes,
@@ -1384,7 +1383,7 @@ private:
 		}
 	};
 
-	ParseResult parse_template_template_parameter_forms(std::vector<ASTNode>& out_params);  // NEW: Parse template<template<typename> class T> forms
+	ParseResult parse_template_template_parameter_forms(InlineVector<TemplateParameterNode, 4>& out_params);  // NEW: Parse template<template<typename> class T> forms
 	ParseResult parse_template_template_parameter_form();  // NEW: Parse single template<template<typename> class T> form
 	std::optional<std::vector<TemplateTypeArg>> parse_explicit_template_arguments(std::vector<ASTNode>* out_type_nodes = nullptr);  // NEW: Parse explicit template arguments like <int, float>
 	TemplateTypeArgParsingResult parse_explicit_template_arguments_as_result(TokenDestroyPattern destroy_pattern);	// NEW: Lookahead to check if '<' starts template arguments (Phase 1 of C++20 disambiguation)
@@ -2497,7 +2496,7 @@ private:
 	std::optional<ASTNode> substitute_nontype_template_param(
 		std::string_view param_name,
 		const std::vector<TemplateTypeArg>& args,
-		const std::vector<ASTNode>& params);	 // Substitute non-type template parameter in initializer
+		std::span<const TemplateParameterNode> params);	 // Substitute non-type template parameter in initializer
 
 	std::optional<bool> try_parse_out_of_line_template_member(const InlineVector<TemplateParameterNode, 4>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const InlineVector<TemplateParameterNode, 4>& inner_template_params, const InlineVector<StringHandle, 4>& inner_template_param_names);	 // NEW: Parse out-of-line template member function
 	bool try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const InitializerListNode& init_list);

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -39,7 +39,7 @@ size_t getResolvedTypeSizeBytes(const TypeSpecifierNode& type_spec, TypeIndex re
 MemberSizeAndAlignment calculateResolvedMemberSizeAndAlignment(const TypeSpecifierNode& type_spec, TypeIndex resolved_type_index);
 int getTypeSizeFromTemplateArgument(const TemplateTypeArg& arg);
 InlineVector<TemplateTypeArg, 4> toInlineTemplateArgs(const std::vector<TemplateTypeArg>& template_args);
-InlineVector<TypeInfo::TemplateArgInfo, 4> convertToTemplateArgInfo(const std::vector<TemplateTypeArg>& template_args);
+InlineVector<TypeInfo::TemplateArgInfo, 4> convertToTemplateArgInfo(std::span<const TemplateTypeArg> template_args);
 std::pair<bool, std::string_view> isDependentTemplatePlaceholder(std::string_view type_name);
 std::vector<std::string_view> splitQualifiedNamespace(std::string_view qualified_namespace);
 void collectLambdaCaptureCandidates(
@@ -68,6 +68,18 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
+	std::span<const TemplateTypeArg> template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
+
+void registerTypeParamsInScope(
+	std::span<const TemplateParameterNode> template_param_nodes,
+	std::span<const TemplateTypeArg> template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	bool preserve_ref_qualifier);
+
+void registerTypeParamsInScope(
+	std::span<const TemplateParameterNode> template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -2,6 +2,7 @@
 
 #include <string_view>
 #include <optional>
+#include <span>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -55,25 +56,25 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier);
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier);
 
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map);
 

--- a/src/ParserTypes.h
+++ b/src/ParserTypes.h
@@ -201,7 +201,7 @@ struct ParsedFunctionHeader {
 	MemberQualifiers member_quals;
 	FunctionSpecifiers specifiers;
 	StorageSpecifiers storage;
-	std::vector<ASTNode> template_params;		  // If function template
+	InlineVector<TemplateParameterNode, 4> template_params;		  // If function template
 	std::optional<ASTNode> requires_clause;		// C++20 requires
 	std::optional<ASTNode> trailing_return_type;
 };

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -182,7 +182,7 @@ InlineVector<TemplateTypeArg, 4> toInlineTemplateArgs(const std::vector<Template
 
 // Helper to convert TemplateTypeArg vector to TypeInfo::TemplateArgInfo vector
 // This enables storing template instantiation metadata in TypeInfo for O(1) lookup
-InlineVector<TypeInfo::TemplateArgInfo, 4> convertToTemplateArgInfo(const std::vector<TemplateTypeArg>& template_args) {
+InlineVector<TypeInfo::TemplateArgInfo, 4> convertToTemplateArgInfo(std::span<const TemplateTypeArg> template_args) {
 	InlineVector<TypeInfo::TemplateArgInfo, 4> result;
 	for (const auto& arg : template_args) {
 		TypeInfo::TemplateArgInfo info;

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -766,7 +766,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 			if (!auto_params.empty()) {
 				// Create synthetic template parameters for each auto parameter
 				// Each auto becomes a unique template type parameter: _T0, _T1, etc.
-				std::vector<ASTNode> template_params;
+				InlineVector<TemplateParameterNode, 4> template_params;
 				InlineVector<StringHandle, 4> template_param_names;
 
 				for (size_t i = 0; i < auto_params.size(); ++i) {
@@ -786,7 +786,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 						param_node.as<TemplateParameterNode>().set_concept_constraint(auto_params[i].concept_name);
 					}
 
-					template_params.push_back(param_node);
+					template_params.push_back(param_node.as<TemplateParameterNode>());
 					template_param_names.push_back(param_name);
 				}
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -101,7 +101,7 @@ bool Parser::templateArgMatchesCurrentInstantiationSlot(
 
 std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveCurrentInstantiationTemplateOwner(
 	std::string_view primary_template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	if (member_function_context_stack_.empty()) {
 		return std::nullopt;
 	}
@@ -208,7 +208,7 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveCurr
 //   p<handle>       -> template-template template argument
 StringHandle Parser::buildTTPPlaceholderName(
 	std::string_view ttp_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	StringBuilder placeholder_name;
 	placeholder_name.append(ttp_name);
 	placeholder_name.append("$"sv);
@@ -1048,7 +1048,7 @@ ParseResult Parser::parse_qualified_operator_call(const Token& context_token, co
 Parser::AliasTemplateMaterializationResult Parser::materializePrimaryTemplateOwnerForLookup(
 	std::string_view primary_template_name,
 	std::string_view fallback_template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	if (auto current_instantiation =
 			tryResolveCurrentInstantiationTemplateOwner(primary_template_name, template_args);
 		current_instantiation.has_value()) {
@@ -1071,7 +1071,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializePrimaryTemplateOwn
 		}
 
 		AliasTemplateMaterializationResult result;
-		std::vector<TemplateTypeArg> completed_args = template_args;
+		std::vector<TemplateTypeArg> completed_args(template_args.begin(), template_args.end());
 		const auto& template_params =
 			template_entry->as<TemplateClassDeclarationNode>().template_parameters();
 		const std::vector<std::string_view> template_param_names =
@@ -1148,7 +1148,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializePrimaryTemplateOwn
 Parser::AliasTemplateMaterializationResult Parser::materializePrimaryTemplateOwnerForConstructorLookup(
 	std::string_view primary_template_name,
 	std::string_view fallback_template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	if (auto current_instantiation =
 			tryResolveCurrentInstantiationTemplateOwner(primary_template_name, template_args);
 		current_instantiation.has_value()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1021,7 +1021,7 @@ ParseResult Parser::validate_and_add_base_class(
 TypeIndex Parser::substitute_template_parameter(
 	const TypeSpecifierNode& original_type,
 	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	TypeCategory current_type = original_type.type();
 	TypeIndex current_type_index = original_type.type_index();
 
@@ -1526,13 +1526,13 @@ TypeIndex Parser::substitute_template_parameter(
 	return substitute_template_parameter(
 		original_type,
 		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args);
+		std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
 }
 
 TypeIndex Parser::substitute_template_parameter(
 	const TypeSpecifierNode& original_type,
 	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	InlineVector<TemplateParameterNode, 4> typed_params;
 	typed_params.reserve(template_params.size());
 	for (const ASTNode& template_param : template_params) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1020,7 +1020,7 @@ ParseResult Parser::validate_and_add_base_class(
 // Handles complex transformations like const T& -> const int&, T* -> int*, etc.
 TypeIndex Parser::substitute_template_parameter(
 	const TypeSpecifierNode& original_type,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	TypeCategory current_type = original_type.type();
 	TypeIndex current_type_index = original_type.type_index();

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1020,7 +1020,7 @@ ParseResult Parser::validate_and_add_base_class(
 // Handles complex transformations like const T& -> const int&, T* -> int*, etc.
 TypeIndex Parser::substitute_template_parameter(
 	const TypeSpecifierNode& original_type,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	TypeCategory current_type = original_type.type();
 	TypeIndex current_type_index = original_type.type_index();
@@ -1053,7 +1053,18 @@ TypeIndex Parser::substitute_template_parameter(
 	auto materializePlaceholderArgs = [&](const TypeInfo& placeholder_info) {
 		return materializeTemplateArgs(placeholder_info, template_params, template_args,
 			[this](const ASTNode& expr, std::span<const ASTNode> params, std::span<const TemplateTypeArg> args) {
-				return this->evaluateDependentNTTPExpression(expr, params, args);
+				InlineVector<TemplateParameterNode, 4> typed_params;
+				typed_params.reserve(params.size());
+				for (const ASTNode& param_node : params) {
+					if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+						typed_param != nullptr) {
+						typed_params.push_back(*typed_param);
+					}
+				}
+				return this->evaluateDependentNTTPExpression(
+					expr,
+					std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+					args);
 			});
 	};
 	auto rebindConcretePlaceholderArgsByTypeName = [&](std::vector<TemplateTypeArg>& concrete_args) {
@@ -1249,11 +1260,7 @@ TypeIndex Parser::substitute_template_parameter(
 		const std::string_view placeholder_name = StringTable::getStringView(placeholder_info->name());
 		const std::string_view base_template_name = buildQualifiedNameFromHandle(
 			placeholder_info->sourceNamespace(), StringTable::getStringView(placeholder_info->baseTemplateName()));
-		for (const ASTNode& template_param_node : template_params) {
-			if (!template_param_node.is<TemplateParameterNode>()) {
-				continue;
-			}
-			const TemplateParameterNode& template_param = template_param_node.as<TemplateParameterNode>();
+		for (const TemplateParameterNode& template_param : template_params) {
 			if (template_param.kind() == TemplateParameterKind::Template &&
 				template_param.name() == base_template_name) {
 				return false;
@@ -1454,10 +1461,7 @@ TypeIndex Parser::substitute_template_parameter(
 			if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_info->type_index_)) {
 				const std::string_view alias_target_name = StringTable::getStringView(alias_target_info->name());
 				for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-					if (!template_params[i].is<TemplateParameterNode>()) {
-						continue;
-					}
-					const TemplateParameterNode& template_param = template_params[i].as<TemplateParameterNode>();
+					const TemplateParameterNode& template_param = template_params[i];
 					if (template_param.name() == alias_target_name) {
 						const TemplateTypeArg& template_arg = template_args[i];
 						current_type = template_arg.typeEnum();
@@ -1478,11 +1482,7 @@ TypeIndex Parser::substitute_template_parameter(
 			const std::string_view base_template_name = buildQualifiedNameFromHandle(
 				placeholder_info->sourceNamespace(), StringTable::getStringView(placeholder_info->baseTemplateName()));
 			for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-				if (!template_params[i].is<TemplateParameterNode>()) {
-					continue;
-				}
-
-				const TemplateParameterNode& template_param = template_params[i].as<TemplateParameterNode>();
+				const TemplateParameterNode& template_param = template_params[i];
 				if (template_param.kind() != TemplateParameterKind::Template ||
 					template_param.name() != base_template_name) {
 					continue;
@@ -1525,7 +1525,25 @@ TypeIndex Parser::substitute_template_parameter(
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	return substitute_template_parameter(
 		original_type,
-		cloneTemplateParameterNodes(template_params),
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+		template_args);
+}
+
+TypeIndex Parser::substitute_template_parameter(
+	const TypeSpecifierNode& original_type,
+	std::span<const ASTNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return substitute_template_parameter(
+		original_type,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
 		template_args);
 }
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1529,24 +1529,6 @@ TypeIndex Parser::substitute_template_parameter(
 		std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
 }
 
-TypeIndex Parser::substitute_template_parameter(
-	const TypeSpecifierNode& original_type,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return substitute_template_parameter(
-		original_type,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
 // Lookup symbol with template parameter checking
 std::optional<ASTNode> Parser::lookup_symbol_with_template_check(StringHandle identifier) {
 	// First check if it's a template parameter using the new method

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -61,7 +61,7 @@ bool expressionTypeDeductionIsStillDependent(
 // Helper: Parse template brace initialization: Template<Args>{}
 // Parses the brace initializer, looks up the instantiated type, and creates a ConstructorCallNode
 ParseResult Parser::parse_template_brace_initialization(
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	std::string_view template_name,
 	const Token& identifier_token) {
 
@@ -856,7 +856,7 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 
 // Helper: Build TemplateArgumentNodeInfo vector from parsed template args and AST nodes.
 std::vector<TemplateArgumentNodeInfo> Parser::build_template_arg_infos(
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	const std::vector<ASTNode>& template_arg_nodes) {
 	std::vector<TemplateArgumentNodeInfo> arg_infos;
 	arg_infos.reserve(template_args.size());
@@ -1519,15 +1519,7 @@ TypeIndex Parser::substitute_template_parameter(
 	return current_type_index.withCategory(current_type);
 }
 
-TypeIndex Parser::substitute_template_parameter(
-	const TypeSpecifierNode& original_type,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	return substitute_template_parameter(
-		original_type,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
-}
+
 
 // Lookup symbol with template parameter checking
 std::optional<ASTNode> Parser::lookup_symbol_with_template_check(StringHandle identifier) {

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -2635,7 +2635,7 @@ bool Parser::types_equivalent(const TypeSpecifierNode& lhs, const TypeSpecifierN
 }
 
 bool Parser::instantiate_deduced_template(std::string_view class_name,
-										  const std::vector<TemplateTypeArg>& template_args,
+										  std::span<const TemplateTypeArg> template_args,
 										  TypeSpecifierNode& type_specifier) {
 	if (template_args.empty()) {
 		return false;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -1292,8 +1292,16 @@ ParseResult Parser::parse_template_declaration() {
 					// can re-parse "struct Wrapper<T>::Nested { ... }" during instantiation.
 					// For full specializations (template<>), store the concrete template_args so the
 					// nested class is only applied when instantiation arguments match.
+					InlineVector<TemplateParameterNode, 4> out_of_line_template_params;
+					out_of_line_template_params.reserve(template_params.size());
+					for (const ASTNode& template_param : template_params) {
+						if (!template_param.is<TemplateParameterNode>()) {
+							continue;
+						}
+						out_of_line_template_params.push_back(template_param.as<TemplateParameterNode>());
+					}
 					gTemplateRegistry.registerOutOfLineNestedClass(template_name, OutOfLineNestedClass{
-																					  template_params,
+																					  out_of_line_template_params,
 																					  StringTable::getOrInternStringHandle(member_class_name),
 																					  struct_keyword_pos, template_param_names, is_class,
 																					  context_.getCurrentPackAlignment(),
@@ -2703,8 +2711,16 @@ ParseResult Parser::parse_template_declaration() {
 					// struct_keyword_pos points at the struct/class keyword so parse_struct_declaration()
 					// can re-parse "struct Wrapper<T>::Nested { ... }" during instantiation.
 					// Partial specializations leave specialization_args empty — applies to all instantiations.
+					InlineVector<TemplateParameterNode, 4> out_of_line_template_params;
+					out_of_line_template_params.reserve(template_params.size());
+					for (const ASTNode& template_param : template_params) {
+						if (!template_param.is<TemplateParameterNode>()) {
+							continue;
+						}
+						out_of_line_template_params.push_back(template_param.as<TemplateParameterNode>());
+					}
 					gTemplateRegistry.registerOutOfLineNestedClass(template_name, OutOfLineNestedClass{
-																					  template_params,
+																					  out_of_line_template_params,
 																					  StringTable::getOrInternStringHandle(member_class_name),
 																					  struct_keyword_pos,
 																					  template_param_names,

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -155,7 +155,6 @@ ParseResult Parser::parse_template_declaration() {
 	// Parse template parameter list (unless it's a specialization)
 	InlineVector<TemplateParameterNode, 4> template_param_nodes;
 	TemplateParameterMetadata template_param_metadata;
-	InlineVector<ASTNode, 4> template_params;
 	if (!is_specialization) {
 		auto param_list_result = parse_template_parameter_list(template_param_nodes);
 		if (param_list_result.is_error()) {
@@ -192,10 +191,6 @@ ParseResult Parser::parse_template_declaration() {
 	// This allows them to be used in the function body or class members
 	FlashCpp::TemplateParameterScope template_scope;
 	template_param_metadata = registerTemplateParametersInScope(template_param_nodes, template_scope);
-	template_params.clear();
-	for (const auto& param : template_param_nodes) {
-		template_params.push_back(emplace_node<TemplateParameterNode>(param));
-	}
 	const InlineVector<StringHandle, 4>& template_param_names = template_param_metadata.names;
 
 	// Set the flag to enable fold expression parsing if we have parameter packs
@@ -535,7 +530,7 @@ ParseResult Parser::parse_template_declaration() {
 
 				FLASH_LOG(Templates, Debug, "Registered nested template out-of-line member: ",
 						  nested_qualified_class_name, "::", nested_func_name_token.value(),
-						  " (outer params: ", template_params.size(),
+						  " (outer params: ", template_param_nodes.size(),
 						  ", inner params: ", inner_template_params.size(), ")");
 
 				cleanup_template_state();
@@ -752,13 +747,7 @@ ParseResult Parser::parse_template_declaration() {
 			return ParseResult::error("Expected ';' after concept definition", current_token_);
 		}
 
-		// Convert template_params (ASTNode vector) to TemplateParameterNode vector
-		InlineVector<TemplateParameterNode, 4> concept_template_param_nodes;
-		for (const auto& param : template_params) {
-			if (param.is<TemplateParameterNode>()) {
-				concept_template_param_nodes.push_back(param.as<TemplateParameterNode>());
-			}
-		}
+		InlineVector<TemplateParameterNode, 4> concept_template_param_nodes = template_param_nodes;
 
 		// Create the ConceptDeclarationNode with template parameters
 		auto concept_node = emplace_node<ConceptDeclarationNode>(
@@ -1091,7 +1080,7 @@ ParseResult Parser::parse_template_declaration() {
 					arg.is_array = is_array;
 					// Mark as dependent only for partial specializations
 					// For full specializations (template<>), the types are concrete, not dependent
-					arg.is_dependent = !template_params.empty();
+					arg.is_dependent = !template_param_nodes.empty();
 
 					// Store the type name for pattern matching
 					// For template instantiations like ratio<_Num, _Den>, this will be "ratio"
@@ -1193,7 +1182,7 @@ ParseResult Parser::parse_template_declaration() {
 		// Pattern: template<typename T> struct Name<T&> { ... }
 		// After struct/class keyword and name, if we see '<', it's a specialization
 		bool is_partial_specialization = false;
-		if (!is_specialization && !template_params.empty()) {
+		if (!is_specialization && !template_param_nodes.empty()) {
 			// Save position to peek ahead
 			auto peek_pos = save_token_position();
 
@@ -1293,12 +1282,9 @@ ParseResult Parser::parse_template_declaration() {
 					// For full specializations (template<>), store the concrete template_args so the
 					// nested class is only applied when instantiation arguments match.
 					InlineVector<TemplateParameterNode, 4> out_of_line_template_params;
-					out_of_line_template_params.reserve(template_params.size());
-					for (const ASTNode& template_param : template_params) {
-						if (!template_param.is<TemplateParameterNode>()) {
-							continue;
-						}
-						out_of_line_template_params.push_back(template_param.as<TemplateParameterNode>());
+					out_of_line_template_params.reserve(template_param_nodes.size());
+					for (const TemplateParameterNode& template_param : template_param_nodes) {
+						out_of_line_template_params.push_back(template_param);
 					}
 					gTemplateRegistry.registerOutOfLineNestedClass(template_name, OutOfLineNestedClass{
 																					  out_of_line_template_params,
@@ -2627,12 +2613,12 @@ ParseResult Parser::parse_template_declaration() {
 			//     via registerSpecialization().
 			//   - Otherwise, treat as partial specialization pattern and register via
 			//     registerSpecializationPattern().
-			if (template_params.empty()) {
+			if (template_param_nodes.empty()) {
 				// Full specialization: exact match on concrete arguments
 				gTemplateRegistry.registerSpecialization(template_name, template_args, struct_node);
 			} else {
 				// Partial specialization: register as a pattern for matching
-				gTemplateRegistry.registerSpecializationPattern(template_name, template_params, template_args, struct_node);
+				gTemplateRegistry.registerSpecializationPattern(template_name, template_param_nodes, template_args, struct_node);
 			}
 
 			// Reset parsing context flags
@@ -2686,10 +2672,10 @@ ParseResult Parser::parse_template_declaration() {
 				advance(); // consume '::'
 				if (peek().is_identifier()) {
 					discard_saved_token(scope_check);
-					std::string_view member_class_name = peek_info().value();
+					StringHandle member_class_name_handle = peek_info().handle();
 					advance(); // consume member class name
 					FLASH_LOG_FORMAT(Templates, Debug, "Out-of-line member class definition: {}::{}",
-									 template_name, member_class_name);
+									 template_name, member_class_name_handle.view());
 
 					// Skip base class list if present
 					if (peek() == ":"_tok) {
@@ -2712,16 +2698,13 @@ ParseResult Parser::parse_template_declaration() {
 					// can re-parse "struct Wrapper<T>::Nested { ... }" during instantiation.
 					// Partial specializations leave specialization_args empty — applies to all instantiations.
 					InlineVector<TemplateParameterNode, 4> out_of_line_template_params;
-					out_of_line_template_params.reserve(template_params.size());
-					for (const ASTNode& template_param : template_params) {
-						if (!template_param.is<TemplateParameterNode>()) {
-							continue;
-						}
-						out_of_line_template_params.push_back(template_param.as<TemplateParameterNode>());
+					out_of_line_template_params.reserve(template_param_nodes.size());
+					for (const TemplateParameterNode& template_param : template_param_nodes) {
+						out_of_line_template_params.push_back(template_param);
 					}
 					gTemplateRegistry.registerOutOfLineNestedClass(template_name, OutOfLineNestedClass{
 																					  out_of_line_template_params,
-																					  StringTable::getOrInternStringHandle(member_class_name),
+																					  member_class_name_handle,
 																					  struct_keyword_pos,
 																					  template_param_names,
 																					  is_class,
@@ -2729,7 +2712,7 @@ ParseResult Parser::parse_template_declaration() {
 																					  {}	 // no specialization args — applies to all instantiations
 																				  });
 					FLASH_LOG_FORMAT(Templates, Debug, "Registered out-of-line nested class: {}::{}",
-									 template_name, member_class_name);
+									 template_name, member_class_name_handle.view());
 
 					// Clean up template parameter context
 					clearCurrentTemplateParameters();
@@ -2941,7 +2924,7 @@ ParseResult Parser::parse_template_declaration() {
 					param_names_view.push_back(StringTable::getStringView(name));
 				}
 				auto template_class_node = emplace_node<TemplateClassDeclarationNode>(
-					template_params,
+					template_param_nodes,
 					std::move(param_names_view),
 					struct_node);
 
@@ -2984,7 +2967,7 @@ ParseResult Parser::parse_template_declaration() {
 					param_names_view2.push_back(StringTable::getStringView(name));
 				}
 				auto template_class_node = emplace_node<TemplateClassDeclarationNode>(
-					template_params,
+					template_param_nodes,
 					std::move(param_names_view2),
 					struct_node);
 
@@ -3984,7 +3967,7 @@ ParseResult Parser::parse_template_declaration() {
 
 			// Register the specialization PATTERN (not exact match)
 			// This allows pattern matching during instantiation
-			gTemplateRegistry.registerSpecializationPattern(template_name, template_params, pattern_args, struct_node);
+			gTemplateRegistry.registerSpecializationPattern(template_name, template_param_nodes, pattern_args, struct_node);
 
 			// Clean up template parameter context before returning
 			clearCurrentTemplateParameters();
@@ -4675,7 +4658,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 	// Parse template parameter list
 	InlineVector<TemplateParameterNode, 4> template_param_nodes;
-	InlineVector<ASTNode, 4> template_params;
 
 	auto param_list_result = parse_template_parameter_list(template_param_nodes);
 	if (param_list_result.is_error()) {
@@ -4825,10 +4807,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	template_param_names.reserve(template_param_metadata.names.size());
 	for (StringHandle param_name : template_param_metadata.names) {
 		template_param_names.push_back(StringTable::getStringView(param_name));
-	}
-	template_params.clear();
-	for (const auto& param : template_param_nodes) {
-		template_params.push_back(emplace_node<TemplateParameterNode>(param));
 	}
 
 	// Skip requires clause if present (for partial specializations with constraints)
@@ -5419,7 +5397,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		// Register pattern under qualified name (MakeUnsigned::List)
 		gTemplateRegistry.registerSpecializationPattern(
 			StringTable::getStringView(qualified_simple_name),
-			template_params,
+			template_param_nodes,
 			pattern_args,
 			template_struct_node);
 
@@ -5427,7 +5405,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		// This ensures patterns are found regardless of whether qualified or simple name is used
 		gTemplateRegistry.registerSpecializationPattern(
 			struct_name,
-			template_params,
+			template_param_nodes,
 			pattern_args,
 			template_struct_node);
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -608,46 +608,6 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 		effective_name};
 }
 
-SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
-	const FunctionDeclarationNode& original_func,
-	const ASTNode& original_return_type_node,
-	const Token& fallback_return_token,
-	StringHandle parent_struct_name,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	const StructDeclarationNode* owner_decl,
-	TypeIndex instantiated_owner_type_index,
-	TypeIndex override_return_type_index,
-	OverloadableOperator operator_kind,
-	StringHandle effective_name_override,
-	StringHandle partial_pattern_owner_name,
-	bool apply_bound_metadata_to_full_substitution,
-	bool apply_resolved_index_to_full_substitution) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return createSubstitutedMemberFunctionShell(
-		original_func,
-		original_return_type_node,
-		fallback_return_token,
-		parent_struct_name,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		owner_decl,
-		instantiated_owner_type_index,
-		override_return_type_index,
-		operator_kind,
-		effective_name_override,
-		partial_pattern_owner_name,
-		apply_bound_metadata_to_full_substitution,
-		apply_resolved_index_to_full_substitution);
-}
-
 void Parser::substituteAndCopyMemberFunctionParameters(
 	const std::vector<ASTNode>& original_params,
 	FunctionDeclarationNode& target_node,
@@ -824,42 +784,6 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 	}
 }
 
-void Parser::substituteAndCopyMemberFunctionParameters(
-	const std::vector<ASTNode>& original_params,
-	FunctionDeclarationNode& target_node,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	const StructDeclarationNode* owner_decl,
-	TypeIndex instantiated_owner_type_index,
-	TypeIndex self_type_from_index,
-	TypeIndex self_type_to_index,
-	SubstitutedDefaultArgumentPolicy default_argument_policy,
-	bool preserve_parameter_cv_qualifier,
-	bool apply_bound_metadata_to_full_substitution,
-	bool apply_resolved_index_to_full_substitution) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	substituteAndCopyMemberFunctionParameters(
-		original_params,
-		target_node,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		owner_decl,
-		instantiated_owner_type_index,
-		self_type_from_index,
-		self_type_to_index,
-		default_argument_policy,
-		preserve_parameter_cv_qualifier,
-		apply_bound_metadata_to_full_substitution,
-		apply_resolved_index_to_full_substitution);
-}
-
 static int getTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {
 	int size_in_bytes = get_type_size_bits(arg.category()) / 8;
 	if (size_in_bytes > 0) {
@@ -1024,11 +948,12 @@ static bool staticMemberInitializerContainsFunctionCall(const ASTNode& node) {
 	});
 }
 
+template <typename TemplateParamsContainer>
 static ConstExpr::EvaluationContext makeStaticMemberInitializerEvaluationContext(
 	const SymbolTable& symbol_table,
 	Parser* parser,
 	const StructTypeInfo* struct_info,
-	const InlineVector<ASTNode, 4>& template_params,
+	const TemplateParamsContainer& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	ConstExpr::EvaluationContext eval_ctx(symbol_table);
 	eval_ctx.storage_duration = ConstExpr::StorageDuration::Static;
@@ -1041,9 +966,9 @@ static ConstExpr::EvaluationContext makeStaticMemberInitializerEvaluationContext
 	eval_ctx.template_args = template_args;
 	eval_ctx.template_param_names.reserve(template_params.size());
 	for (const auto& template_param : template_params) {
-		if (template_param.is<TemplateParameterNode>()) {
-			eval_ctx.template_param_names.push_back(
-				template_param.as<TemplateParameterNode>().name());
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			eval_ctx.template_param_names.push_back(typed_param->name());
 		}
 	}
 	return eval_ctx;
@@ -1157,12 +1082,13 @@ static void instantiateDeferredStaticInitializerCalls(
 	});
 }
 
+template <typename TemplateParamsContainer>
 static std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMemberInitializer(
 	std::optional<ASTNode>& initializer,
 	const SymbolTable& symbol_table,
 	Parser* parser,
 	const StructTypeInfo* struct_info,
-	const InlineVector<ASTNode, 4>& template_params,
+	const TemplateParamsContainer& template_params,
 	const std::vector<TemplateTypeArg>& template_args,
 	TypeIndex type_index,
 	size_t size_in_bytes,
@@ -1233,10 +1159,11 @@ static std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 		pointer_depth);
 }
 
+template <typename TemplateParamsContainer>
 static void retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 	StructTypeInfo* struct_info,
 	Parser* parser,
-	const InlineVector<ASTNode, 4>& template_params,
+	const TemplateParamsContainer& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	if (!struct_info || !parser) {
 		return;
@@ -1662,8 +1589,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	auto substitute_template_param_in_initializer = [this](
 														std::string_view param_name,
 														const std::vector<TemplateTypeArg>& args,
-														const std::vector<ASTNode>& params) -> std::optional<ASTNode> {
-		return substitute_nontype_template_param(param_name, args, params);
+														const auto& params) -> std::optional<ASTNode> {
+		std::vector<ASTNode> params_ast;
+		params_ast.reserve(params.size());
+		for (const auto& param : params) {
+			if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param);
+				typed_param != nullptr) {
+				params_ast.push_back(ASTNode::emplace_node<TemplateParameterNode>(*typed_param));
+			}
+		}
+		return substitute_nontype_template_param(param_name, args, params_ast);
 	};
 
 	// Helper lambda to substitute template parameters in member default initializers.
@@ -2741,7 +2676,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			// Get template parameters from the pattern (partial specialization), NOT the primary template
 			// The pattern stores its own template parameters (e.g., <typename First, typename... Rest>)
-			std::vector<ASTNode> pattern_template_params;
+			InlineVector<TemplateParameterNode, 4> pattern_template_params;
 			auto patterns_it = gTemplateRegistry.specialization_patterns_.find(template_name);
 			if (patterns_it != gTemplateRegistry.specialization_patterns_.end()) {
 				// Find the matching pattern to get its template params
@@ -2754,11 +2689,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						spec_struct_ptr = &pattern.specialized_node.as<TemplateClassDeclarationNode>().class_decl_node();
 					}
 					if (spec_struct_ptr && spec_struct_ptr == &pattern_struct) {
-						pattern_template_params.clear();
-						pattern_template_params.reserve(pattern.template_params.size());
-						for (const auto& param : pattern.template_params) {
-							pattern_template_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
-						}
+						pattern_template_params = pattern.template_params;
 						break;
 					}
 				}
@@ -2796,11 +2727,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 					if (best) {
-						const InlineVector<ASTNode, 4> best_template_params_ast =
-							cloneTemplateParameterNodes(best->template_parameters());
-						pattern_template_params.assign(
-							best_template_params_ast.begin(),
-							best_template_params_ast.end());
+						pattern_template_params = best->template_parameters();
 					}
 				}
 			}
@@ -2826,11 +2753,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			if (!pattern_args_for_member_copy.empty()) {
 				size_t template_param_slot = 0;
 				template_args_for_member_copy_storage.reserve(template_params.size());
-				for (const auto& template_param : template_params) {
-					if (!template_param.is<TemplateParameterNode>()) {
-						continue;
-					}
-
+				for (const TemplateParameterNode& template_param : template_params) {
 					std::optional<TemplateTypeArg> deduced_arg;
 					for (size_t pattern_idx = 0;
 						 pattern_idx < pattern_args_for_member_copy.size() && pattern_idx < template_args.size();
@@ -2872,9 +2795,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						pattern_type_name = StringTable::getStringView(pattern_type_info->name());
 					}
 				}
-				for (const ASTNode& template_param_node : template_params) {
-					if (template_param_node.is<TemplateParameterNode>() &&
-						template_param_node.as<TemplateParameterNode>().name() == pattern_type_name) {
+				for (const TemplateParameterNode& template_param_node : template_params) {
+					if (template_param_node.name() == pattern_type_name) {
 						substituted_type.limit_pointer_depth(pattern_type.pointer_depth());
 						return;
 					}
@@ -2888,16 +2810,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				std::vector<ClassTemplatePackInfo> pack_infos;
 				size_t non_variadic_count = 0;
 				for (size_t i = 0; i < template_params.size(); ++i) {
-					if (template_params[i].is<TemplateParameterNode>()) {
-						const auto& tparam = template_params[i].as<TemplateParameterNode>();
-						if (tparam.is_variadic()) {
-							size_t pack_size = template_args.size() >= non_variadic_count
-												   ? template_args.size() - non_variadic_count
-												   : 0;
-							pack_infos.push_back({tparam.name(), pack_size});
-						} else {
-							non_variadic_count++;
-						}
+					const auto& tparam = template_params[i];
+					if (tparam.is_variadic()) {
+						size_t pack_size = template_args.size() >= non_variadic_count
+											   ? template_args.size() - non_variadic_count
+											   : 0;
+						pack_infos.push_back({tparam.name(), pack_size});
+					} else {
+						non_variadic_count++;
 					}
 				}
 				if (!pack_infos.empty()) {
@@ -2975,19 +2895,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// If so, substitute it with the corresponding template argument
 				// This handles patterns like: template<typename T1, typename T2> struct __or_<T1, T2> : T1 { };
 				for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-					if (template_params[i].is<TemplateParameterNode>()) {
-						const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-						if (param.name() == base_name_str) {
-							// The base class is a template parameter - substitute with the corresponding argument
-							const TemplateTypeArg& arg = template_args[i];
+					const TemplateParameterNode& param = template_params[i];
+					if (param.name() == base_name_str) {
+						// The base class is a template parameter - substitute with the corresponding argument
+						const TemplateTypeArg& arg = template_args[i];
 
-							// Get the concrete type name for this argument
-							std::string substituted_name = arg.toString();
-							FLASH_LOG(Templates, Debug, "Substituting base class template parameter '", base_name_str,
-									  "' with '", substituted_name, "'");
-							base_name_str = substituted_name;
-							break;
-						}
+						// Get the concrete type name for this argument
+						std::string substituted_name = arg.toString();
+						FLASH_LOG(Templates, Debug, "Substituting base class template parameter '", base_name_str,
+								  "' with '", substituted_name, "'");
+						base_name_str = substituted_name;
+						break;
 					}
 				}
 
@@ -3010,8 +2928,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					bool base_uses_variadic_pack = false;
 					size_t first_variadic_index = template_params.size();
 					for (size_t i = 0; i < template_params.size(); ++i) {
-						if (template_params[i].is<TemplateParameterNode>() &&
-							template_params[i].as<TemplateParameterNode>().is_variadic()) {
+						if (template_params[i].is_variadic()) {
 							first_variadic_index = i;
 							base_uses_variadic_pack = true;
 							break;
@@ -3556,12 +3473,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							auto calculate_pack_size = [&](std::string_view pack_name) -> std::optional<size_t> {
 								FLASH_LOG(Templates, Debug, "Looking for pack: ", pack_name);
 								for (size_t i = 0; i < template_params.size(); ++i) {
-									const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
+									const TemplateParameterNode& tparam = template_params[i];
 									FLASH_LOG(Templates, Debug, "  Checking param ", tparam.name(), " is_variadic=", tparam.is_variadic() ? "true" : "false");
 									if (tparam.name() == pack_name && tparam.is_variadic()) {
 										size_t non_variadic_count = 0;
 										for (const auto& param : template_params) {
-											if (!param.as<TemplateParameterNode>().is_variadic()) {
+											if (!param.is_variadic()) {
 												non_variadic_count++;
 											}
 										}
@@ -3723,7 +3640,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								// Find the parameter pack in template parameters
 								std::optional<size_t> pack_param_idx;
 								for (size_t p = 0; p < template_params.size(); ++p) {
-									const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
+									const TemplateParameterNode& tparam = template_params[p];
 									if (tparam.name() == pack_name && tparam.is_variadic()) {
 										pack_param_idx = p;
 										break;
@@ -3738,7 +3655,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									// For variadic packs, arguments after non-variadic parameters are the pack values
 									size_t non_variadic_count = 0;
 									for (const auto& param : template_params) {
-										if (!param.as<TemplateParameterNode>().is_variadic()) {
+										if (!param.is_variadic()) {
 											non_variadic_count++;
 										}
 									}
@@ -3776,7 +3693,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 										// Look up the parameter value
 										for (size_t p = 0; p < template_params.size(); ++p) {
-											const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
+											const TemplateParameterNode& tparam = template_params[p];
 											if (tparam.name() == tparam_ref.param_name() && tparam.kind() == TemplateParameterKind::NonType) {
 												if (p < template_args.size() && template_args[p].is_value) {
 													cond_value = template_args[p].value;
@@ -3792,7 +3709,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 										// Look up the identifier as a template parameter
 										for (size_t p = 0; p < template_params.size(); ++p) {
-											const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
+											const TemplateParameterNode& tparam = template_params[p];
 											if (tparam.name() == id_name && tparam.kind() == TemplateParameterKind::NonType) {
 												if (p < template_args.size() && template_args[p].is_value) {
 													cond_value = template_args[p].value;
@@ -4022,11 +3939,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			if (!pattern_args.empty()) {
 				size_t template_param_slot = 0;
 				template_args_for_pattern_storage.reserve(template_params.size());
-				for (const auto& template_param : template_params) {
-					if (!template_param.is<TemplateParameterNode>()) {
-						continue;
-					}
-
+				for (const TemplateParameterNode& template_param : template_params) {
 					std::optional<TemplateTypeArg> deduced_arg;
 					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
 						const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
@@ -4095,11 +4008,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						alias_target_name = alias_target_info->name();
 					}
 					StringHandle alias_token_name = alias_type_spec.token().handle();
-					for (const ASTNode& template_param_node : template_params) {
-						if (!template_param_node.is<TemplateParameterNode>()) {
-							continue;
-						}
-						StringHandle param_name = template_param_node.as<TemplateParameterNode>().nameHandle();
+					for (const TemplateParameterNode& template_param_node : template_params) {
+						StringHandle param_name = template_param_node.nameHandle();
 						if (param_name == alias_token_name || param_name == alias_target_name) {
 							alias_refers_to_template_parameter = true;
 							break;
@@ -4123,43 +4033,41 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					// Find which template parameter index this alias type corresponds to
 					for (size_t param_idx = 0; param_idx < template_params.size(); ++param_idx) {
-						if (template_params[param_idx].is<TemplateParameterNode>()) {
-							// Find which pattern_arg position this template parameter appears at
-							for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
-								const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
+						// Find which pattern_arg position this template parameter appears at
+						for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
+							const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
 
-								// Check if this pattern_arg is a template parameter (not a concrete value/type)
-								if (!pattern_arg.is_value && pattern_arg.is_dependent) {
-									// This is a template parameter position
-									// Check if it's the parameter we're looking for
-									// We can match by counting dependent parameters
-									size_t dependent_param_index = 0;
-									for (size_t i = 0; i < pattern_idx; ++i) {
-										if (!pattern_args[i].is_value && pattern_args[i].is_dependent) {
-											dependent_param_index++;
-										}
+							// Check if this pattern_arg is a template parameter (not a concrete value/type)
+							if (!pattern_arg.is_value && pattern_arg.is_dependent) {
+								// This is a template parameter position
+								// Check if it's the parameter we're looking for
+								// We can match by counting dependent parameters
+								size_t dependent_param_index = 0;
+								for (size_t i = 0; i < pattern_idx; ++i) {
+									if (!pattern_args[i].is_value && pattern_args[i].is_dependent) {
+										dependent_param_index++;
 									}
+								}
 
-									if (dependent_param_index == param_idx) {
-										// Found it! Substitute with template_args[pattern_idx]
-										const TemplateTypeArg& concrete_arg = template_args[pattern_idx];
-										substituted_type = concrete_arg.typeEnum();
-										substituted_type_index = concrete_arg.type_index;
-										// Only call get_type_size_bits for basic types
-										if (!is_struct_type(substituted_type)) {
-											substituted_size = static_cast<unsigned char>(get_type_size_bits(substituted_type));
-										} else {
-											// For UserDefined types, look up the size from the type registry
-											substituted_size = 0;
-											if (const TypeInfo* sub_ti = tryGetTypeInfo(substituted_type_index)) {
+								if (dependent_param_index == param_idx) {
+									// Found it! Substitute with template_args[pattern_idx]
+									const TemplateTypeArg& concrete_arg = template_args[pattern_idx];
+									substituted_type = concrete_arg.typeEnum();
+									substituted_type_index = concrete_arg.type_index;
+									// Only call get_type_size_bits for basic types
+									if (!is_struct_type(substituted_type)) {
+										substituted_size =get_type_size_bits(substituted_type);
+									} else {
+										// For UserDefined types, look up the size from the type registry
+										substituted_size = 0;
+										if (const TypeInfo* sub_ti = tryGetTypeInfo(substituted_type_index)) {
 											substituted_size = toSizeT(sub_ti->sizeInBytes());
-											}
 										}
-										FLASH_LOG(Templates, Debug, "Substituted template parameter '",
-												  template_params[param_idx].as<TemplateParameterNode>().name(),
-												  "' at pattern position ", pattern_idx, " with type=", static_cast<int>(substituted_type));
-										goto substitution_done;
 									}
+									FLASH_LOG(Templates, Debug, "Substituted template parameter '",
+												template_params[param_idx].name(),
+												"' at pattern position ", pattern_idx, " with type=", static_cast<int>(substituted_type));
+									goto substitution_done;
 								}
 							}
 						}
@@ -4432,10 +4340,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						true); // Force resolved TypeIndex onto full AST substitutions
 					std::unordered_map<std::string_view, TemplateTypeArg> deduced_args;
 					for (size_t i = 0; i < template_params.size() && i < template_args_for_pattern.size(); ++i) {
-						if (!template_params[i].is<TemplateParameterNode>()) {
-							continue;
-						}
-						std::string_view pname = template_params[i].as<TemplateParameterNode>().name();
+						std::string_view pname = template_params[i].name();
 						deduced_args[pname] = template_args_for_pattern[i];
 					}
 					if (orig_func.is_materialized()) {
@@ -4659,10 +4564,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	const TemplateClassDeclarationNode& template_class = template_node.as<TemplateClassDeclarationNode>();
 	const auto& template_params = template_class.template_parameters();
-	const InlineVector<ASTNode, 4> template_params_inline_ast = cloneTemplateParameterNodes(template_params);
-	const std::vector<ASTNode> template_params_ast(
-		template_params_inline_ast.begin(),
-		template_params_inline_ast.end());
+	std::vector<ASTNode> template_params_ast;
+	template_params_ast.reserve(template_params.size());
+	for (const TemplateParameterNode& template_param : template_params) {
+		template_params_ast.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
+	}
 	const std::vector<TemplateParameterNode> template_params_typed(
 		template_params.begin(),
 		template_params.end());
@@ -6651,7 +6557,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::optional<ASTNode> substituted_initializer = static_member.initializer.has_value()
 				? std::optional<ASTNode>(substituteTemplateParameters(
 					*static_member.initializer,
-					template_params_inline_ast,
+					template_params,
 					template_args_to_use))
 				: std::nullopt;
 
@@ -6663,7 +6569,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					gSymbolTable,
 					this,
 					struct_info.get(),
-					template_params_inline_ast,
+					template_params,
 					template_args_to_use,
 					substituted_type_index,
 					substituted_size,
@@ -7509,7 +7415,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -7541,7 +7447,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -7609,7 +7515,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -7627,7 +7533,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -7794,7 +7700,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -7812,7 +7718,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_ast,
+					template_params,
 					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
@@ -9069,7 +8975,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 		struct_info_ptr,
 		this,
-		template_params_inline_ast,
+		template_params,
 		template_args_to_use);
 
 	FLASH_LOG(Templates, Debug, "About to return instantiated_struct for ", instantiated_name);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -535,8 +535,8 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	const ASTNode& original_return_type_node,
 	const Token& fallback_return_token,
 	StringHandle parent_struct_name,
-	const InlineVector<ASTNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const ASTNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
 	const StructDeclarationNode* owner_decl,
 	TypeIndex instantiated_owner_type_index,
 	TypeIndex override_return_type_index,
@@ -545,14 +545,25 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	StringHandle partial_pattern_owner_name,
 	bool apply_bound_metadata_to_full_substitution,
 	bool apply_resolved_index_to_full_substitution) {
+	InlineVector<ASTNode, 4> template_params_inline;
+	template_params_inline.reserve(template_params.size());
+	for (const ASTNode& param : template_params) {
+		template_params_inline.push_back(param);
+	}
+	InlineVector<TemplateTypeArg, 4> template_args_inline;
+	template_args_inline.reserve(template_args.size());
+	for (const TemplateTypeArg& arg : template_args) {
+		template_args_inline.push_back(arg);
+	}
+
 	const DeclarationNode& original_decl = original_func.decl_node();
 	const TypeSpecifierNode& original_return_type = original_decl.type_specifier_node();
 	TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
 		original_return_type,
 		original_return_type_node,
 		fallback_return_token,
-		template_params,
-		template_args,
+		template_params_inline,
+		template_args_inline,
 		[this](const ASTNode& node, const auto& params, const auto& args) {
 			return substituteTemplateParameters(node, params, args);
 		},
@@ -569,7 +580,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 			substituted_return_type,
 			original_return_type,
 			partial_pattern_owner_name,
-			template_params);
+			template_params_inline);
 	}
 
 	StringHandle effective_name = effective_name_override.isValid()
@@ -592,7 +603,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
 		new_func_decl_ref,
 		parent_struct_name);
-	setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args);
+	setOuterTemplateBindingsFromParams(new_func_ref, template_params_inline, template_args_inline);
 
 	return {
 		new_func_decl_node,
@@ -606,8 +617,8 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 void Parser::substituteAndCopyMemberFunctionParameters(
 	const std::vector<ASTNode>& original_params,
 	FunctionDeclarationNode& target_node,
-	const InlineVector<ASTNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const ASTNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
 	const StructDeclarationNode* owner_decl,
 	TypeIndex instantiated_owner_type_index,
 	TypeIndex self_type_from_index,
@@ -616,6 +627,20 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 	bool preserve_parameter_cv_qualifier,
 	bool apply_bound_metadata_to_full_substitution,
 	bool apply_resolved_index_to_full_substitution) {
+	if (self_type_from_index.is_valid() != self_type_to_index.is_valid()) {
+		throw InternalError("substituteAndCopyMemberFunctionParameters requires both self rewrite indices or neither.");
+	}
+	InlineVector<ASTNode, 4> template_params_inline;
+	template_params_inline.reserve(template_params.size());
+	for (const ASTNode& param : template_params) {
+		template_params_inline.push_back(param);
+	}
+	InlineVector<TemplateTypeArg, 4> template_args_inline;
+	template_args_inline.reserve(template_args.size());
+	for (const TemplateTypeArg& arg : template_args) {
+		template_args_inline.push_back(arg);
+	}
+
 	TemplateArgSubstitutionMap name_substitution_map;
 	TemplateArgPackSubstitutionMap pack_substitution_map;
 	std::vector<std::string_view> template_param_order;
@@ -625,8 +650,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			return;
 		}
 		buildTemplateArgSubstitutionMaps(
-			template_params,
-			template_args,
+			template_params_inline,
+			template_args_inline,
 			[](const TemplateParameterNode&, const TemplateTypeArg& arg) {
 				return arg;
 			},
@@ -654,8 +679,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			size_t non_variadic = 0;
 			size_t pack_size = 0;
 			bool found_pack = false;
-			for (size_t i = 0; i < template_params.size(); ++i) {
-				const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+			for (size_t i = 0; i < template_params_inline.size(); ++i) {
+				const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params_inline[i]);
 				if (tparam == nullptr) {
 					continue;
 				}
@@ -664,8 +689,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 					continue;
 				}
 				if (tparam->name() == type_name) {
-					pack_size = template_args.size() > non_variadic
-						? template_args.size() - non_variadic
+					pack_size = template_args_inline.size() > non_variadic
+						? template_args_inline.size() - non_variadic
 						: 0;
 					found_pack = true;
 					break;
@@ -675,7 +700,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 				if (pack_size != 0) {
 					std::string_view original_name = param_decl.identifier_token().value();
 					for (size_t pi = 0; pi < pack_size; ++pi) {
-						const TemplateTypeArg& elem = template_args[non_variadic + pi];
+						const TemplateTypeArg& elem = template_args_inline[non_variadic + pi];
 						TypeCategory elem_type = elem.typeEnum();
 						TypeIndex elem_type_index = elem.type_index;
 						TypeSpecifierNode substituted_type(
@@ -718,8 +743,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			param_type_spec,
 			param_decl.type_node(),
 			param_decl.identifier_token(),
-			template_params,
-			template_args,
+			template_params_inline,
+			template_args_inline,
 			[this](const ASTNode& node, const auto& params, const auto& args) {
 				return substituteTemplateParameters(node, params, args);
 			},
@@ -753,8 +778,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			if (default_argument_policy == SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters) {
 				ASTNode substituted_default = substituteTemplateParameters(
 					param_decl.default_value(),
-					template_params,
-					template_args);
+					template_params_inline,
+					template_args_inline);
 				substituted_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
 			} else if (default_argument_policy == SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor) {
 				ensure_default_substitution_maps();
@@ -3330,23 +3355,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					const FunctionDeclarationNode& orig_func = mem_func.function_declaration.as<FunctionDeclarationNode>();
 					const DeclarationNode& orig_decl = orig_func.decl_node();
 
-					InlineVector<ASTNode, 4> member_copy_template_params;
-					member_copy_template_params.reserve(template_params.size());
-					for (const ASTNode& template_param : template_params) {
-						member_copy_template_params.push_back(template_param);
-					}
-					InlineVector<TemplateTypeArg, 4> member_copy_template_args;
-					member_copy_template_args.reserve(template_args_for_member_copy.size());
-					for (const TemplateTypeArg& template_arg : template_args_for_member_copy) {
-						member_copy_template_args.push_back(template_arg);
-					}
 					SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
 						orig_func,
 						orig_decl.type_node(),
 						orig_decl.identifier_token(),
 						instantiated_name,
-						member_copy_template_params,
-						member_copy_template_args,
+						template_params,
+						template_args_for_member_copy,
 						nullptr,
 						TypeIndex{}, // No self-owner rewrite for this specialization member-copy path
 						TypeIndex{}, // No pre-resolved return TypeIndex override
@@ -3362,8 +3377,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituteAndCopyMemberFunctionParameters(
 						orig_func.parameter_nodes(),
 						new_func_ref,
-						member_copy_template_params,
-						member_copy_template_args,
+						template_params,
+						template_args_for_member_copy,
 						nullptr,
 						TypeIndex{},
 						TypeIndex{},
@@ -4316,23 +4331,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_args_for_pattern,
 						return_type_index);
 
-					InlineVector<ASTNode, 4> pattern_template_params_inline;
-					pattern_template_params_inline.reserve(template_params.size());
-					for (const ASTNode& template_param : template_params) {
-						pattern_template_params_inline.push_back(template_param);
-					}
-					InlineVector<TemplateTypeArg, 4> pattern_template_args_inline;
-					pattern_template_args_inline.reserve(template_args_for_pattern.size());
-					for (const TemplateTypeArg& template_arg : template_args_for_pattern) {
-						pattern_template_args_inline.push_back(template_arg);
-					}
 					SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
 						orig_func,
 						ASTNode(&orig_return_type),
 						orig_decl.identifier_token(),
 						instantiated_name,
-						pattern_template_params_inline,
-						pattern_template_args_inline,
+						template_params,
+						template_args_for_pattern,
 						&pattern_struct,
 						TypeIndex{},		 // No self-owner rewrite for this path
 						return_type_index,	 // Return TypeIndex already alias-resolved above
@@ -4349,8 +4354,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituteAndCopyMemberFunctionParameters(
 						orig_func.parameter_nodes(),
 						new_func,
-						pattern_template_params_inline,
-						pattern_template_args_inline,
+						template_params,
+						template_args_for_pattern,
 						&pattern_struct,
 						TypeIndex{},
 						TypeIndex{},
@@ -4982,11 +4987,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Use the filled template args for the rest of the function
 	const std::vector<TemplateTypeArg>& template_args_to_use = filled_template_args;
-	InlineVector<TemplateTypeArg, 4> template_args_to_use_inline;
-	template_args_to_use_inline.reserve(template_args_to_use.size());
-	for (const TemplateTypeArg& arg : template_args_to_use) {
-		template_args_to_use_inline.push_back(arg);
-	}
 	auto normalized_cache_key = FlashCpp::makeInstantiationKey(template_name_handle, template_args_to_use);
 	cache_key = normalized_cache_key;
 	if (!can_use_raw_cache_key) {
@@ -7440,8 +7440,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
@@ -7472,8 +7472,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
@@ -7540,8 +7540,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
@@ -7558,8 +7558,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
@@ -7725,8 +7725,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(),
 					decl.identifier_token(),
 					instantiated_name,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
@@ -7743,8 +7743,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituteAndCopyMemberFunctionParameters(
 					func_decl.parameter_nodes(),
 					new_func_ref,
-					template_params_inline_ast,
-					template_args_to_use_inline,
+					template_params_ast,
+					template_args_to_use,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -236,7 +236,7 @@ static void clampPartialPatternTemplateParamIndirectionForOwner(
 	TypeSpecifierNode& substituted_type,
 	const TypeSpecifierNode& pattern_type,
 	StringHandle pattern_struct_name,
-	const InlineVector<ASTNode, 4>& template_params) {
+	std::span<const TemplateParameterNode> template_params) {
 	if (!pattern_struct_name.isValid() ||
 		StringTable::getStringView(pattern_struct_name).find("$pattern_") == std::string_view::npos ||
 		substituted_type.pointer_depth() <= pattern_type.pointer_depth()) {
@@ -248,9 +248,8 @@ static void clampPartialPatternTemplateParamIndirectionForOwner(
 			pattern_type_name = StringTable::getStringView(pattern_type_info->name());
 		}
 	}
-	for (const ASTNode& template_param_node : template_params) {
-		if (template_param_node.is<TemplateParameterNode>() &&
-			template_param_node.as<TemplateParameterNode>().name() == pattern_type_name) {
+	for (const TemplateParameterNode& template_param_node : template_params) {
+		if (template_param_node.name() == pattern_type_name) {
 			substituted_type.limit_pointer_depth(pattern_type.pointer_depth());
 			return;
 		}
@@ -535,7 +534,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	const ASTNode& original_return_type_node,
 	const Token& fallback_return_token,
 	StringHandle parent_struct_name,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	const StructDeclarationNode* owner_decl,
 	TypeIndex instantiated_owner_type_index,
@@ -545,11 +544,6 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	StringHandle partial_pattern_owner_name,
 	bool apply_bound_metadata_to_full_substitution,
 	bool apply_resolved_index_to_full_substitution) {
-	InlineVector<ASTNode, 4> template_params_inline;
-	template_params_inline.reserve(template_params.size());
-	for (const ASTNode& param : template_params) {
-		template_params_inline.push_back(param);
-	}
 	InlineVector<TemplateTypeArg, 4> template_args_inline;
 	template_args_inline.reserve(template_args.size());
 	for (const TemplateTypeArg& arg : template_args) {
@@ -562,7 +556,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 		original_return_type,
 		original_return_type_node,
 		fallback_return_token,
-		template_params_inline,
+		template_params,
 		template_args_inline,
 		[this](const ASTNode& node, const auto& params, const auto& args) {
 			return substituteTemplateParameters(node, params, args);
@@ -580,7 +574,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 			substituted_return_type,
 			original_return_type,
 			partial_pattern_owner_name,
-			template_params_inline);
+			template_params);
 	}
 
 	StringHandle effective_name = effective_name_override.isValid()
@@ -603,7 +597,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
 		new_func_decl_ref,
 		parent_struct_name);
-	setOuterTemplateBindingsFromParams(new_func_ref, template_params_inline, template_args_inline);
+	setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_inline);
 
 	return {
 		new_func_decl_node,
@@ -614,10 +608,50 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 		effective_name};
 }
 
+SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
+	const FunctionDeclarationNode& original_func,
+	const ASTNode& original_return_type_node,
+	const Token& fallback_return_token,
+	StringHandle parent_struct_name,
+	std::span<const ASTNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	const StructDeclarationNode* owner_decl,
+	TypeIndex instantiated_owner_type_index,
+	TypeIndex override_return_type_index,
+	OverloadableOperator operator_kind,
+	StringHandle effective_name_override,
+	StringHandle partial_pattern_owner_name,
+	bool apply_bound_metadata_to_full_substitution,
+	bool apply_resolved_index_to_full_substitution) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return createSubstitutedMemberFunctionShell(
+		original_func,
+		original_return_type_node,
+		fallback_return_token,
+		parent_struct_name,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args,
+		owner_decl,
+		instantiated_owner_type_index,
+		override_return_type_index,
+		operator_kind,
+		effective_name_override,
+		partial_pattern_owner_name,
+		apply_bound_metadata_to_full_substitution,
+		apply_resolved_index_to_full_substitution);
+}
+
 void Parser::substituteAndCopyMemberFunctionParameters(
 	const std::vector<ASTNode>& original_params,
 	FunctionDeclarationNode& target_node,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	const StructDeclarationNode* owner_decl,
 	TypeIndex instantiated_owner_type_index,
@@ -629,11 +663,6 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 	bool apply_resolved_index_to_full_substitution) {
 	if (self_type_from_index.is_valid() != self_type_to_index.is_valid()) {
 		throw InternalError("substituteAndCopyMemberFunctionParameters requires both self rewrite indices or neither.");
-	}
-	InlineVector<ASTNode, 4> template_params_inline;
-	template_params_inline.reserve(template_params.size());
-	for (const ASTNode& param : template_params) {
-		template_params_inline.push_back(param);
 	}
 	InlineVector<TemplateTypeArg, 4> template_args_inline;
 	template_args_inline.reserve(template_args.size());
@@ -650,7 +679,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			return;
 		}
 		buildTemplateArgSubstitutionMaps(
-			template_params_inline,
+			template_params,
 			template_args_inline,
 			[](const TemplateParameterNode&, const TemplateTypeArg& arg) {
 				return arg;
@@ -679,11 +708,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			size_t non_variadic = 0;
 			size_t pack_size = 0;
 			bool found_pack = false;
-			for (size_t i = 0; i < template_params_inline.size(); ++i) {
-				const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params_inline[i]);
-				if (tparam == nullptr) {
-					continue;
-				}
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				const TemplateParameterNode* tparam = &template_params[i];
 				if (!tparam->is_variadic()) {
 					non_variadic++;
 					continue;
@@ -743,7 +769,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			param_type_spec,
 			param_decl.type_node(),
 			param_decl.identifier_token(),
-			template_params_inline,
+			template_params,
 			template_args_inline,
 			[this](const ASTNode& node, const auto& params, const auto& args) {
 				return substituteTemplateParameters(node, params, args);
@@ -778,7 +804,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			if (default_argument_policy == SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters) {
 				ASTNode substituted_default = substituteTemplateParameters(
 					param_decl.default_value(),
-					template_params_inline,
+					template_params,
 					template_args_inline);
 				substituted_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
 			} else if (default_argument_policy == SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor) {
@@ -796,6 +822,42 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 		}
 		target_node.add_parameter_node(substituted_param_decl);
 	}
+}
+
+void Parser::substituteAndCopyMemberFunctionParameters(
+	const std::vector<ASTNode>& original_params,
+	FunctionDeclarationNode& target_node,
+	std::span<const ASTNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	const StructDeclarationNode* owner_decl,
+	TypeIndex instantiated_owner_type_index,
+	TypeIndex self_type_from_index,
+	TypeIndex self_type_to_index,
+	SubstitutedDefaultArgumentPolicy default_argument_policy,
+	bool preserve_parameter_cv_qualifier,
+	bool apply_bound_metadata_to_full_substitution,
+	bool apply_resolved_index_to_full_substitution) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	substituteAndCopyMemberFunctionParameters(
+		original_params,
+		target_node,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args,
+		owner_decl,
+		instantiated_owner_type_index,
+		self_type_from_index,
+		self_type_to_index,
+		default_argument_policy,
+		preserve_parameter_cv_qualifier,
+		apply_bound_metadata_to_full_substitution,
+		apply_resolved_index_to_full_substitution);
 }
 
 static int getTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1620,7 +1620,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
 		eval_ctx.sema = getActiveSemanticAnalysis();
-		eval_ctx.template_args = std::vector<TemplateTypeArg>(args.begin(), args.end());
+		eval_ctx.template_args.assign(args.begin(), args.end());
 		eval_ctx.template_param_names.reserve(params.size());
 		for (const auto& param : params) {
 			if (const TemplateParameterNode* template_param = tryGetTemplateParameterNode(param);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1243,7 +1243,7 @@ static std::optional<StringHandle> findUnresolvedHardUseTypeSpecifier(const ASTN
 	return unresolved_name;
 }
 
-std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args, bool force_eager) {
+std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view template_name, std::span<const TemplateTypeArg> template_args, bool force_eager) {
 	PROFILE_TEMPLATE_INSTANTIATION(std::string(template_name));
 
 	// Push a parser-level instantiation context for provenance tracking and backtraces.
@@ -1588,7 +1588,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Helper lambda delegates to extracted member function for non-type template parameter substitution
 	auto substitute_template_param_in_initializer = [this](
 														std::string_view param_name,
-														const std::vector<TemplateTypeArg>& args,
+														std::span<const TemplateTypeArg> args,
 														const auto& params) -> std::optional<ASTNode> {
 		InlineVector<TemplateParameterNode, 4> typed_params;
 		typed_params.reserve(params.size());
@@ -1606,7 +1606,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// and nested template-dependent expressions are handled uniformly.
 	auto substitute_default_initializer = [&](
 											  const std::optional<ASTNode>& default_init,
-											  const std::vector<TemplateTypeArg>& args,
+											  std::span<const TemplateTypeArg> args,
 											  const auto& params) -> std::optional<ASTNode> {
 		if (!default_init.has_value()) {
 			return std::nullopt;
@@ -1620,7 +1620,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
 		eval_ctx.sema = getActiveSemanticAnalysis();
-		eval_ctx.template_args = args;
+		eval_ctx.template_args = std::vector<TemplateTypeArg>(args.begin(), args.end());
 		eval_ctx.template_param_names.reserve(params.size());
 		for (const auto& param : params) {
 			if (const TemplateParameterNode* template_param = tryGetTemplateParameterNode(param);
@@ -2073,7 +2073,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	auto resolve_bitfield_width = [&](
 									  const StructMemberDecl& member_decl,
 									  const auto& params,
-									  const std::vector<TemplateTypeArg>& args) -> std::optional<size_t> {
+									  std::span<const TemplateTypeArg> args) -> std::optional<size_t> {
 		if (member_decl.bitfield_width.has_value())
 			return member_decl.bitfield_width;
 		if (!member_decl.bitfield_width_expr.has_value())
@@ -2099,7 +2099,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	auto resolve_array_dimensions = [&](
 										const DeclarationNode& decl,
 										const auto& params,
-										const std::vector<TemplateTypeArg>& args) -> std::vector<size_t> {
+										std::span<const TemplateTypeArg> args) -> std::vector<size_t> {
 		std::vector<size_t> resolved_dims;
 		if (!decl.is_array()) {
 			return resolved_dims;
@@ -2359,7 +2359,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// This is critical for patterns like: template<typename T, typename = void> struct has_type;
 	// with specialization: template<typename T> struct has_type<T, void_t<typename T::type>>;
 	// When has_type<WithType> is instantiated, we need to fill in the default (void) before pattern matching.
-	std::vector<TemplateTypeArg> filled_args_for_pattern_match = template_args;
+	std::vector<TemplateTypeArg> filled_args_for_pattern_match(template_args.begin(), template_args.end());
 	{
 		auto primary_template_opt = gTemplateRegistry.lookupTemplate(template_name);
 		if (primary_template_opt.has_value() && primary_template_opt->is<TemplateClassDeclarationNode>()) {
@@ -2782,8 +2782,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					template_param_slot++;
 				}
 			}
-			const std::vector<TemplateTypeArg>& template_args_for_member_copy =
-				template_args_for_member_copy_storage.empty() ? template_args : template_args_for_member_copy_storage;
+			std::span<const TemplateTypeArg> template_args_for_member_copy =
+				template_args_for_member_copy_storage.empty() ? template_args : std::span<const TemplateTypeArg>(template_args_for_member_copy_storage);
 			auto clampPartialPatternTemplateParamIndirection = [&](TypeSpecifierNode& substituted_type, const TypeSpecifierNode& pattern_type) {
 				if (StringTable::getStringView(pattern_struct.name()).find("$pattern_") == std::string_view::npos ||
 					substituted_type.pointer_depth() <= pattern_type.pointer_depth()) {
@@ -3966,8 +3966,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					template_param_slot++;
 				}
 			}
-			const std::vector<TemplateTypeArg>& template_args_for_pattern =
-				template_args_for_pattern_storage.empty() ? template_args : template_args_for_pattern_storage;
+			std::span<const TemplateTypeArg> template_args_for_pattern =
+				template_args_for_pattern_storage.empty() ? template_args : std::span<const TemplateTypeArg>(template_args_for_pattern_storage);
 			const StructTypeInfo* instantiated_struct_info = struct_type_info.getStructInfo();
 
 			for (const auto& type_alias : pattern_struct.type_aliases()) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2751,9 +2751,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 			std::vector<TemplateTypeArg> template_args_for_member_copy_storage;
 			if (!pattern_args_for_member_copy.empty()) {
-				size_t template_param_slot = 0;
 				template_args_for_member_copy_storage.reserve(template_params.size());
-				for (const TemplateParameterNode& template_param : template_params) {
+				for (size_t template_param_slot = 0; template_param_slot < template_params.size(); ++template_param_slot) {
 					std::optional<TemplateTypeArg> deduced_arg;
 					for (size_t pattern_idx = 0;
 						 pattern_idx < pattern_args_for_member_copy.size() && pattern_idx < template_args.size();
@@ -2779,30 +2778,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (deduced_arg.has_value()) {
 						template_args_for_member_copy_storage.push_back(*deduced_arg);
 					}
-					template_param_slot++;
 				}
 			}
 			std::span<const TemplateTypeArg> template_args_for_member_copy =
 				template_args_for_member_copy_storage.empty() ? template_args : std::span<const TemplateTypeArg>(template_args_for_member_copy_storage);
-			auto clampPartialPatternTemplateParamIndirection = [&](TypeSpecifierNode& substituted_type, const TypeSpecifierNode& pattern_type) {
-				if (StringTable::getStringView(pattern_struct.name()).find("$pattern_") == std::string_view::npos ||
-					substituted_type.pointer_depth() <= pattern_type.pointer_depth()) {
-					return;
-				}
-				std::string_view pattern_type_name = pattern_type.token().value();
-				if (pattern_type_name.empty()) {
-					if (const TypeInfo* pattern_type_info = tryGetTypeInfo(pattern_type.type_index())) {
-						pattern_type_name = StringTable::getStringView(pattern_type_info->name());
-					}
-				}
-				for (const TemplateParameterNode& template_param_node : template_params) {
-					if (template_param_node.name() == pattern_type_name) {
-						substituted_type.limit_pointer_depth(pattern_type.pointer_depth());
-						return;
-					}
-				}
-			};
-
 			// Push class template pack info for specialization path
 			ClassTemplatePackGuard spec_pack_guard(class_template_pack_stack_);
 			bool has_spec_pack_info = false;
@@ -3937,9 +3916,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// sema-owned AST copy path so bindings stay positional.
 			std::vector<TemplateTypeArg> template_args_for_pattern_storage;
 			if (!pattern_args.empty()) {
-				size_t template_param_slot = 0;
 				template_args_for_pattern_storage.reserve(template_params.size());
-				for (const TemplateParameterNode& template_param : template_params) {
+				for (size_t template_param_slot = 0; template_param_slot < template_params.size(); ++template_param_slot) {
 					std::optional<TemplateTypeArg> deduced_arg;
 					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
 						const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
@@ -3963,7 +3941,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (deduced_arg.has_value()) {
 						template_args_for_pattern_storage.push_back(*deduced_arg);
 					}
-					template_param_slot++;
 				}
 			}
 			std::span<const TemplateTypeArg> template_args_for_pattern =

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -232,6 +232,31 @@ static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param
 	return &type_node.as<TypeSpecifierNode>();
 }
 
+static void clampPartialPatternTemplateParamIndirectionForOwner(
+	TypeSpecifierNode& substituted_type,
+	const TypeSpecifierNode& pattern_type,
+	StringHandle pattern_struct_name,
+	const InlineVector<ASTNode, 4>& template_params) {
+	if (!pattern_struct_name.isValid() ||
+		StringTable::getStringView(pattern_struct_name).find("$pattern_") == std::string_view::npos ||
+		substituted_type.pointer_depth() <= pattern_type.pointer_depth()) {
+		return;
+	}
+	std::string_view pattern_type_name = pattern_type.token().value();
+	if (pattern_type_name.empty()) {
+		if (const TypeInfo* pattern_type_info = tryGetTypeInfo(pattern_type.type_index())) {
+			pattern_type_name = StringTable::getStringView(pattern_type_info->name());
+		}
+	}
+	for (const ASTNode& template_param_node : template_params) {
+		if (template_param_node.is<TemplateParameterNode>() &&
+			template_param_node.as<TemplateParameterNode>().name() == pattern_type_name) {
+			substituted_type.limit_pointer_depth(pattern_type.pointer_depth());
+			return;
+		}
+	}
+}
+
 static const TemplateTypeArg* findResolvedTypeTemplateArg(
 	const TypeSpecifierNode& type_spec,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
@@ -439,7 +464,7 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 // For conversion operators (operator with an identifier suffix, e.g. "operator value_type"),
 // the substituted return type gives the canonical name (e.g. "operator int").
 // For all other functions the original name is canonical.
-static StringHandle computeInstantiatedLookupName(
+StringHandle Parser::computeInstantiatedLookupName(
 	StringHandle original_name,
 	OverloadableOperator op_kind,
 	const TypeSpecifierNode& substituted_return_type) {
@@ -503,6 +528,249 @@ static StringHandle computeInstantiatedLookupName(
 		}
 	}
 	return original_name;
+}
+
+SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
+	const FunctionDeclarationNode& original_func,
+	const ASTNode& original_return_type_node,
+	const Token& fallback_return_token,
+	StringHandle parent_struct_name,
+	const InlineVector<ASTNode, 4>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	const StructDeclarationNode* owner_decl,
+	TypeIndex instantiated_owner_type_index,
+	TypeIndex override_return_type_index,
+	OverloadableOperator operator_kind,
+	StringHandle effective_name_override,
+	StringHandle partial_pattern_owner_name,
+	bool apply_bound_metadata_to_full_substitution,
+	bool apply_resolved_index_to_full_substitution) {
+	const DeclarationNode& original_decl = original_func.decl_node();
+	const TypeSpecifierNode& original_return_type = original_decl.type_specifier_node();
+	TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
+		original_return_type,
+		original_return_type_node,
+		fallback_return_token,
+		template_params,
+		template_args,
+		[this](const ASTNode& node, const auto& params, const auto& args) {
+			return substituteTemplateParameters(node, params, args);
+		},
+		[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+			return substitute_template_parameter(type_spec, params, args);
+		},
+		owner_decl,
+		instantiated_owner_type_index,
+		override_return_type_index,
+		apply_bound_metadata_to_full_substitution,
+		apply_resolved_index_to_full_substitution);
+	if (partial_pattern_owner_name.isValid()) {
+		clampPartialPatternTemplateParamIndirectionForOwner(
+			substituted_return_type,
+			original_return_type,
+			partial_pattern_owner_name,
+			template_params);
+	}
+
+	StringHandle effective_name = effective_name_override.isValid()
+		? effective_name_override
+		: computeInstantiatedLookupName(
+			  original_decl.identifier_token().handle(),
+			  operator_kind,
+			  substituted_return_type);
+	Token effective_identifier_token(
+		Token::Type::Identifier,
+		StringTable::getStringView(effective_name),
+		original_decl.identifier_token().line(),
+		original_decl.identifier_token().column(),
+		original_decl.identifier_token().file_index());
+
+	auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
+	auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
+		substituted_return_node,
+		effective_identifier_token);
+	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
+		new_func_decl_ref,
+		parent_struct_name);
+	setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args);
+
+	return {
+		new_func_decl_node,
+		&new_func_decl_ref,
+		new_func_node,
+		&new_func_ref,
+		substituted_return_type,
+		effective_name};
+}
+
+void Parser::substituteAndCopyMemberFunctionParameters(
+	const std::vector<ASTNode>& original_params,
+	FunctionDeclarationNode& target_node,
+	const InlineVector<ASTNode, 4>& template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	const StructDeclarationNode* owner_decl,
+	TypeIndex instantiated_owner_type_index,
+	TypeIndex self_type_from_index,
+	TypeIndex self_type_to_index,
+	SubstitutedDefaultArgumentPolicy default_argument_policy,
+	bool preserve_parameter_cv_qualifier,
+	bool apply_bound_metadata_to_full_substitution,
+	bool apply_resolved_index_to_full_substitution) {
+	TemplateArgSubstitutionMap name_substitution_map;
+	TemplateArgPackSubstitutionMap pack_substitution_map;
+	std::vector<std::string_view> template_param_order;
+	bool substitution_maps_built = false;
+	auto ensure_default_substitution_maps = [&]() {
+		if (substitution_maps_built) {
+			return;
+		}
+		buildTemplateArgSubstitutionMaps(
+			template_params,
+			template_args,
+			[](const TemplateParameterNode&, const TemplateTypeArg& arg) {
+				return arg;
+			},
+			name_substitution_map,
+			pack_substitution_map,
+			&template_param_order);
+		substitution_maps_built = true;
+	};
+
+	for (const auto& param : original_params) {
+		if (!param.is<DeclarationNode>()) {
+			target_node.add_parameter_node(param);
+			continue;
+		}
+
+		const DeclarationNode& param_decl = param.as<DeclarationNode>();
+		const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
+
+		bool handled_as_pack = false;
+		if (param_decl.is_parameter_pack() &&
+			(param_type_spec.category() == TypeCategory::UserDefined ||
+			 param_type_spec.category() == TypeCategory::TypeAlias ||
+			 param_type_spec.category() == TypeCategory::Template)) {
+			std::string_view type_name = param_type_spec.token().value();
+			size_t non_variadic = 0;
+			size_t pack_size = 0;
+			bool found_pack = false;
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+				if (tparam == nullptr) {
+					continue;
+				}
+				if (!tparam->is_variadic()) {
+					non_variadic++;
+					continue;
+				}
+				if (tparam->name() == type_name) {
+					pack_size = template_args.size() > non_variadic
+						? template_args.size() - non_variadic
+						: 0;
+					found_pack = true;
+					break;
+				}
+			}
+			if (found_pack) {
+				if (pack_size != 0) {
+					std::string_view original_name = param_decl.identifier_token().value();
+					for (size_t pi = 0; pi < pack_size; ++pi) {
+						const TemplateTypeArg& elem = template_args[non_variadic + pi];
+						TypeCategory elem_type = elem.typeEnum();
+						TypeIndex elem_type_index = elem.type_index;
+						TypeSpecifierNode substituted_type(
+							elem_type,
+							param_type_spec.qualifier(),
+							getSubstitutedTypeSizeBits(elem_type_index.withCategory(elem_type)),
+							param_decl.identifier_token(),
+							param_type_spec.cv_qualifier());
+						substituted_type.set_type_index(elem_type_index);
+						for (const auto& pointer_level : param_type_spec.pointer_levels()) {
+							substituted_type.add_pointer_level(pointer_level.cv_qualifier);
+						}
+						substituted_type.set_reference_qualifier(param_type_spec.reference_qualifier());
+						if (elem.function_signature.has_value()) {
+							substituted_type.set_function_signature(*elem.function_signature);
+						}
+						normalizeSubstitutedTypeSpec(substituted_type);
+						StringBuilder name_builder;
+						name_builder.append(original_name).append('_').append(pi);
+						Token elem_token(
+							Token::Type::Identifier,
+							name_builder.commit(),
+							param_decl.identifier_token().line(),
+							param_decl.identifier_token().column(),
+							param_decl.identifier_token().file_index());
+						target_node.add_parameter_node(emplace_node<DeclarationNode>(
+							emplace_node<TypeSpecifierNode>(substituted_type),
+							elem_token));
+					}
+					pack_param_info_.push_back({original_name, 0, pack_size});
+				}
+				handled_as_pack = true;
+			}
+		}
+		if (handled_as_pack) {
+			continue;
+		}
+
+		TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
+			param_type_spec,
+			param_decl.type_node(),
+			param_decl.identifier_token(),
+			template_params,
+			template_args,
+			[this](const ASTNode& node, const auto& params, const auto& args) {
+				return substituteTemplateParameters(node, params, args);
+			},
+			[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+				return substitute_template_parameter(type_spec, params, args);
+			},
+			owner_decl,
+			instantiated_owner_type_index,
+			TypeIndex{},
+			apply_bound_metadata_to_full_substitution,
+			apply_resolved_index_to_full_substitution);
+		if (!preserve_parameter_cv_qualifier) {
+			// Declaration-only member-instantiation historically cleared parameter-level cv here.
+			// Keep that behavior configurable to avoid semantic drift across refactored paths.
+			substituted_param_type.set_cv_qualifier(CVQualifier::None);
+		}
+
+		if (self_type_from_index.is_valid() &&
+			self_type_to_index.is_valid() &&
+			substituted_param_type.type_index() == self_type_from_index) {
+			substituted_param_type.set_type_index(self_type_to_index.withCategory(self_type_to_index.category()));
+			substituted_param_type.set_category(self_type_to_index.category());
+			normalizeSubstitutedTypeSpec(substituted_param_type);
+		}
+
+		auto substituted_param_type_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
+		auto substituted_param_decl = emplace_node<DeclarationNode>(
+			substituted_param_type_node,
+			param_decl.identifier_token());
+		if (param_decl.has_default_value()) {
+			if (default_argument_policy == SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters) {
+				ASTNode substituted_default = substituteTemplateParameters(
+					param_decl.default_value(),
+					template_params,
+					template_args);
+				substituted_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
+			} else if (default_argument_policy == SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor) {
+				ensure_default_substitution_maps();
+				ExpressionSubstitutor substitutor(
+					name_substitution_map,
+					pack_substitution_map,
+					*this,
+					template_param_order);
+				std::optional<ASTNode> substituted_default = substitutor.substitute(param_decl.default_value());
+				if (substituted_default.has_value()) {
+					substituted_param_decl.as<DeclarationNode>().set_default_value(*substituted_default);
+				}
+			}
+		}
+		target_node.add_parameter_node(substituted_param_decl);
+	}
 }
 
 static int getTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {
@@ -3062,57 +3330,48 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					const FunctionDeclarationNode& orig_func = mem_func.function_declaration.as<FunctionDeclarationNode>();
 					const DeclarationNode& orig_decl = orig_func.decl_node();
 
-					// Substitute return type if it uses a template parameter
-					// For partial specializations like Container<T*>, the return type T* needs substitution
-					// The pattern has Type::UserDefined for T, which needs to be replaced with the concrete type
-					const TypeSpecifierNode& orig_return_type = orig_decl.type_specifier_node();
-
-					TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-						orig_return_type,
+					InlineVector<ASTNode, 4> member_copy_template_params;
+					member_copy_template_params.reserve(template_params.size());
+					for (const ASTNode& template_param : template_params) {
+						member_copy_template_params.push_back(template_param);
+					}
+					InlineVector<TemplateTypeArg, 4> member_copy_template_args;
+					member_copy_template_args.reserve(template_args_for_member_copy.size());
+					for (const TemplateTypeArg& template_arg : template_args_for_member_copy) {
+						member_copy_template_args.push_back(template_arg);
+					}
+					SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+						orig_func,
 						orig_decl.type_node(),
 						orig_decl.identifier_token(),
-						template_params,
-						template_args_for_member_copy,
-						[this](const ASTNode& node, const auto& params, const auto& args) {
-							return substituteTemplateParameters(node, params, args);
-						},
-						[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-							return substitute_template_parameter(type_spec, params, args);
-						},
+						instantiated_name,
+						member_copy_template_params,
+						member_copy_template_args,
+						nullptr,
+						TypeIndex{}, // No self-owner rewrite for this specialization member-copy path
+						TypeIndex{}, // No pre-resolved return TypeIndex override
+						mem_func.operator_kind,
+						StringHandle{},	   // Compute effective lookup name from substituted return type/operator kind
+						pattern_struct.name(), // Enable partial-pattern pointer-depth clamp
+						false,				   // Do not re-apply bound metadata to full substitution
+						false);			   // Do not force resolved TypeIndex onto full AST substitutions
+					ASTNode new_func_node = shell.function_node;
+					FunctionDeclarationNode& new_func_ref = *shell.function;
+
+					size_t saved_pack_info = pack_param_info_.size();
+					substituteAndCopyMemberFunctionParameters(
+						orig_func.parameter_nodes(),
+						new_func_ref,
+						member_copy_template_params,
+						member_copy_template_args,
 						nullptr,
 						TypeIndex{},
 						TypeIndex{},
-						false,
-						false);
-					clampPartialPatternTemplateParamIndirection(
-						substituted_return_type,
-						orig_return_type);
-					auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-					StringHandle effective_name = computeInstantiatedLookupName(
-						orig_decl.identifier_token().handle(),
-						mem_func.operator_kind,
-						substituted_return_type);
-					Token effective_identifier_token(
-						Token::Type::Identifier,
-						StringTable::getStringView(effective_name),
-						orig_decl.identifier_token().line(),
-						orig_decl.identifier_token().column(),
-						orig_decl.identifier_token().file_index());
-
-					auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-						substituted_return_node,
-						effective_identifier_token);
-					auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-						new_func_decl_ref,
-						instantiated_name);
-					setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_for_member_copy);
-
-					size_t saved_pack_info = pack_param_info_.size();
-					substituteAndCopyParams(
-						orig_func.parameter_nodes(),
-						new_func_ref,
-						template_params,
-						template_args_for_member_copy);
+						TypeIndex{},
+						SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+						true,  // Preserve declared parameter cv-qualifier in this path
+						false, // Do not re-apply bound metadata to full substitution
+						false);// Do not force resolved TypeIndex onto full AST substitutions
 
 					copy_function_properties(new_func_ref, orig_func);
 					// Ensure is_const_member_function is set from pattern so propagateAstProperties derives cv_qualifier.
@@ -3135,7 +3394,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					// Add the function to the struct info (with substituted signature)
 					struct_info->addMemberFunction(
-						effective_name,
+						shell.effective_name,
 						new_func_node,
 						mem_func.access,
 						mem_func.is_virtual,
@@ -4057,37 +4316,49 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_args_for_pattern,
 						return_type_index);
 
-					TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-						orig_return_type,
+					InlineVector<ASTNode, 4> pattern_template_params_inline;
+					pattern_template_params_inline.reserve(template_params.size());
+					for (const ASTNode& template_param : template_params) {
+						pattern_template_params_inline.push_back(template_param);
+					}
+					InlineVector<TemplateTypeArg, 4> pattern_template_args_inline;
+					pattern_template_args_inline.reserve(template_args_for_pattern.size());
+					for (const TemplateTypeArg& template_arg : template_args_for_pattern) {
+						pattern_template_args_inline.push_back(template_arg);
+					}
+					SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+						orig_func,
 						ASTNode(&orig_return_type),
 						orig_decl.identifier_token(),
-						template_params,
-						template_args_for_pattern,
-						[this](const ASTNode& node, const auto& params, const auto& args) {
-							return substituteTemplateParameters(node, params, args);
-						},
-						[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-							return substitute_template_parameter(type_spec, params, args);
-						},
+						instantiated_name,
+						pattern_template_params_inline,
+						pattern_template_args_inline,
 						&pattern_struct,
-						TypeIndex{},
-						return_type_index,
-						false,
-						true);
-					clampPartialPatternTemplateParamIndirection(substituted_return_type, orig_return_type);
-
-					auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-					auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-						substituted_return_node, orig_decl.identifier_token());
-					auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-						new_func_decl_ref,
-						instantiated_name);
+						TypeIndex{},		 // No self-owner rewrite for this path
+						return_type_index,	 // Return TypeIndex already alias-resolved above
+						mem_func.operator_kind,
+						StringHandle{},	   // Compute effective lookup name from substituted return type/operator kind
+						pattern_struct.name(), // Enable partial-pattern pointer-depth clamp
+						false,				   // Do not re-apply bound metadata to full substitution
+						true);				   // Force resolved TypeIndex onto full AST substitutions
+					ASTNode new_func_node = shell.function_node;
 
 					// Copy all parameters and definition
-					FunctionDeclarationNode& new_func = new_func_ref;
-					setOuterTemplateBindingsFromParams(new_func, template_params, template_args_for_pattern);
+					FunctionDeclarationNode& new_func = *shell.function;
 					size_t saved_pack_info = pack_param_info_.size();
-					substituteAndCopyParams(orig_func.parameter_nodes(), new_func, template_params, template_args_for_pattern);
+					substituteAndCopyMemberFunctionParameters(
+						orig_func.parameter_nodes(),
+						new_func,
+						pattern_template_params_inline,
+						pattern_template_args_inline,
+						&pattern_struct,
+						TypeIndex{},
+						TypeIndex{},
+						TypeIndex{},
+						SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+						true,  // Preserve declared parameter cv-qualifier in this path
+						false, // Do not re-apply bound metadata to full substitution
+						true); // Force resolved TypeIndex onto full AST substitutions
 					std::unordered_map<std::string_view, TemplateTypeArg> deduced_args;
 					for (size_t i = 0; i < template_params.size() && i < template_args_for_pattern.size(); ++i) {
 						if (!template_params[i].is<TemplateParameterNode>()) {
@@ -4711,6 +4982,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Use the filled template args for the rest of the function
 	const std::vector<TemplateTypeArg>& template_args_to_use = filled_template_args;
+	InlineVector<TemplateTypeArg, 4> template_args_to_use_inline;
+	template_args_to_use_inline.reserve(template_args_to_use.size());
+	for (const TemplateTypeArg& arg : template_args_to_use) {
+		template_args_to_use_inline.push_back(arg);
+	}
 	auto normalized_cache_key = FlashCpp::makeInstantiationKey(template_name_handle, template_args_to_use);
 	cache_key = normalized_cache_key;
 	if (!can_use_raw_cache_key) {
@@ -7108,13 +7384,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		instantiated_owner_it != getTypesByNameMap().end()) {
 		instantiated_member_owner_type_index = instantiated_owner_it->second->type_index_;
 	}
-	auto resolve_member_self_type = [&](TypeIndex& type_index) {
-		if (type_index.category() == TypeCategory::Struct &&
-			instantiated_member_owner_type_index.is_valid()) {
-			type_index = resolveSelfRefParamIndex(type_index, instantiated_member_owner_type_index);
-		}
-	};
-
 	// Extract a stable identity key from an ASTNode (raw pointer of the stored node).
 	auto astNodeKey = [](const ASTNode& n) -> const void* {
 		if (!n.has_value())
@@ -7166,31 +7435,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Create function declaration with signature but WITHOUT body
 				// This allows the function to be found during name lookup, but defers code generation
 
-				// Substitute return type
-				const TypeSpecifierNode& return_type_spec = decl.type_specifier_node();
-				TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-					return_type_spec,
+				SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+					func_decl,
 					decl.type_node(),
 					decl.identifier_token(),
-					template_params,
-					template_args_to_use,
-					[this](const ASTNode& node, const auto& params, const auto& args) {
-						return substituteTemplateParameters(node, params, args);
-					},
-					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-						return substitute_template_parameter(type_spec, params, args);
-					},
+					instantiated_name,
+					template_params_inline_ast,
+					template_args_to_use_inline,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
-					false,
-					true);
+					mem_func.operator_kind,
+					StringHandle{},
+					StringHandle{},
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
 
 				// Slice 2: fill canonical instantiated lookup name (conversion operator renaming)
-				lazy_info.identity.instantiated_lookup_name = computeInstantiatedLookupName(
-					lazy_info.identity.original_lookup_name,
-					lazy_info.identity.operator_kind,
-					substituted_return_type);
+				lazy_info.identity.instantiated_lookup_name = shell.effective_name;
 
 				// Save the effective lookup name before moving lazy_info, since
 				// effectiveLookupName accesses lazy_info.identity which will be
@@ -7204,97 +7466,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				FLASH_LOG(Templates, Debug, "Registered lazy member function: ",
 						  instantiated_name, "::", decl.identifier_token().value());
 
-				auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-				Token effective_identifier_token(
-					Token::Type::Identifier,
-					StringTable::getStringView(effective_name),
-					decl.identifier_token().line(),
-					decl.identifier_token().column(),
-					decl.identifier_token().file_index());
-
-				// Create a new function declaration with substituted return type but NO BODY
-				auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-					substituted_return_node, effective_identifier_token);
-				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-					new_func_decl_ref, instantiated_name);
-				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
-				// Substitute and copy parameters
-				for (const auto& param : func_decl.parameter_nodes()) {
-					if (param.is<DeclarationNode>()) {
-						const DeclarationNode& param_decl = param.as<DeclarationNode>();
-						const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-						// Substitute parameter type
-						TypeIndex param_type_index = substitute_template_parameter(
-							param_type_spec, template_params, template_args_to_use);
-						param_type_index = resolveOwnerAliasTypeIndex(
-							[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-								return substitute_template_parameter(type_spec, params, args);
-							},
-							class_decl,
-							param_type_spec,
-							template_params,
-							template_args_to_use,
-							param_type_index);
-						resolve_member_self_type(param_type_index);
-
-						// Create substituted parameter type
-						TypeSpecifierNode substituted_param_type(
-							param_type_index.category(),
-							param_type_spec.qualifier(),
-							get_substituted_type_size_bits(param_type_index),
-							param_decl.identifier_token(),
-							param_type_spec.cv_qualifier());
-						substituted_param_type.set_type_index(param_type_index);
-
-						// Copy pointer levels and reference qualifiers
-						for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-							substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
-						}
-						substituted_param_type.set_reference_qualifier(param_type_spec.reference_qualifier());
-						applyBoundTemplateArgMetadata(
-							substituted_param_type,
-							param_type_spec,
-							template_params,
-							template_args_to_use);
-						if (param_type_spec.has_function_signature()) {
-							substituted_param_type.set_function_signature(param_type_spec.function_signature());
-						} else if (param_type_index.category() == TypeCategory::FunctionPointer ||
-								   param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-							if (const auto* arg = findTemplateArgByName(
-									param_type_spec.token().value(),
-									template_params,
-									template_args_to_use)) {
-								if (arg->function_signature.has_value()) {
-									substituted_param_type.set_function_signature(*arg->function_signature);
-								}
-							}
-						}
-						normalizeSubstitutedTypeSpec(substituted_param_type);
-
-						auto substituted_param_type_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
-						auto substituted_param_decl = emplace_node<DeclarationNode>(
-							substituted_param_type_node, param_decl.identifier_token());
-						// Copy default value if present
-						if (param_decl.has_default_value()) {
-							// Substitute template parameters in the default value expression
-							ensure_substitution_maps();
-							ExpressionSubstitutor substitutor(
-								name_substitution_map,
-								pack_substitution_map,
-								*this,
-								template_param_order);
-							std::optional<ASTNode> substituted_default = substitutor.substitute(param_decl.default_value());
-							if (substituted_default.has_value()) {
-								substituted_param_decl.as<DeclarationNode>().set_default_value(*substituted_default);
-							}
-						}
-						new_func_ref.add_parameter_node(substituted_param_decl);
-					} else {
-						// Non-declaration parameter, copy as-is
-						new_func_ref.add_parameter_node(param);
-					}
-				}
+				ASTNode new_func_node = shell.function_node;
+				FunctionDeclarationNode& new_func_ref = *shell.function;
+				size_t saved_pack_info = pack_param_info_.size();
+				substituteAndCopyMemberFunctionParameters(
+					func_decl.parameter_nodes(),
+					new_func_ref,
+					template_params_inline_ast,
+					template_args_to_use_inline,
+					&class_decl,
+					instantiated_member_owner_type_index,
+					TypeIndex{},
+					TypeIndex{},
+					SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor,
+					true,  // Preserve declared parameter cv-qualifier in this path
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
+				pack_param_info_.resize(saved_pack_info);
 
 				// Copy function properties but DO NOT set definition. Delay mangling until
 				// a body/finalized signature exists to avoid caching stale self-type encodings.
@@ -7347,123 +7535,39 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// EAGER INSTANTIATION PATH (original code)
 			// If the function has a definition or deferred body, we need to substitute template parameters
 			if (func_decl.has_any_body_source()) {
-				// Substitute return type
-				const TypeSpecifierNode& return_type_spec = decl.type_specifier_node();
-				TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-					return_type_spec,
+				SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+					func_decl,
 					decl.type_node(),
 					decl.identifier_token(),
-					template_params,
-					template_args_to_use,
-					[this](const ASTNode& node, const auto& params, const auto& args) {
-						return substituteTemplateParameters(node, params, args);
-					},
-					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-						return substitute_template_parameter(type_spec, params, args);
-					},
+					instantiated_name,
+					template_params_inline_ast,
+					template_args_to_use_inline,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
-					false,
-					true);
-
-				auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-				StringHandle effective_name = computeInstantiatedLookupName(
-					decl.identifier_token().handle(),
 					mem_func.operator_kind,
-					substituted_return_type);
-				Token effective_identifier_token(
-					Token::Type::Identifier,
-					StringTable::getStringView(effective_name),
-					decl.identifier_token().line(),
-					decl.identifier_token().column(),
-					decl.identifier_token().file_index());
+					StringHandle{},
+					StringHandle{},
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
+				ASTNode new_func_node = shell.function_node;
+				FunctionDeclarationNode& new_func_ref = *shell.function;
+				StringHandle effective_name = shell.effective_name;
 
-				// Create a new function declaration with substituted return type
-				auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-					substituted_return_node, effective_identifier_token);
-				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-					new_func_decl_ref, instantiated_name);
-				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
-
-				// Substitute and copy parameters
-				for (const auto& param : func_decl.parameter_nodes()) {
-					if (param.is<DeclarationNode>()) {
-						const DeclarationNode& param_decl = param.as<DeclarationNode>();
-						const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-						// Substitute parameter type
-						TypeIndex param_type_index = substitute_template_parameter(
-							param_type_spec, template_params, template_args_to_use);
-						param_type_index = resolveOwnerAliasTypeIndex(
-							[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-								return substitute_template_parameter(type_spec, params, args);
-							},
-							class_decl,
-							param_type_spec,
-							template_params,
-							template_args_to_use,
-							param_type_index);
-						resolve_member_self_type(param_type_index);
-
-						// Create substituted parameter type
-						TypeSpecifierNode substituted_param_type(
-							param_type_index.category(),
-							param_type_spec.qualifier(),
-							get_substituted_type_size_bits(param_type_index),
-							param_decl.identifier_token(),
-							param_type_spec.cv_qualifier() // Preserve const/volatile qualifiers
-						);
-						substituted_param_type.set_type_index(param_type_index);
-
-						// Copy pointer levels and reference qualifiers
-						for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-							substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
-						}
-						substituted_param_type.set_reference_qualifier(param_type_spec.reference_qualifier());
-						applyBoundTemplateArgMetadata(
-							substituted_param_type,
-							param_type_spec,
-							template_params,
-							template_args_to_use);
-						if (param_type_spec.has_function_signature()) {
-							substituted_param_type.set_function_signature(param_type_spec.function_signature());
-						} else if (param_type_index.category() == TypeCategory::FunctionPointer ||
-								   param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-							if (const auto* arg = findTemplateArgByName(
-									param_type_spec.token().value(),
-									template_params,
-									template_args_to_use)) {
-								if (arg->function_signature.has_value()) {
-									substituted_param_type.set_function_signature(*arg->function_signature);
-								}
-							}
-						}
-						normalizeSubstitutedTypeSpec(substituted_param_type);
-
-						auto substituted_param_type_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
-						auto substituted_param_decl = emplace_node<DeclarationNode>(
-							substituted_param_type_node, param_decl.identifier_token());
-						// Copy default value if present
-						if (param_decl.has_default_value()) {
-							// Substitute template parameters in the default value expression
-							ensure_substitution_maps();
-							ExpressionSubstitutor substitutor(
-								name_substitution_map,
-								pack_substitution_map,
-								*this,
-								template_param_order);
-							std::optional<ASTNode> substituted_default = substitutor.substitute(param_decl.default_value());
-							if (substituted_default.has_value()) {
-								substituted_param_decl.as<DeclarationNode>().set_default_value(*substituted_default);
-							}
-						}
-						new_func_ref.add_parameter_node(substituted_param_decl);
-					} else {
-						// Non-declaration parameter, copy as-is
-						new_func_ref.add_parameter_node(param);
-					}
-				}
+				size_t saved_pack_info = pack_param_info_.size();
+				substituteAndCopyMemberFunctionParameters(
+					func_decl.parameter_nodes(),
+					new_func_ref,
+					template_params_inline_ast,
+					template_args_to_use_inline,
+					&class_decl,
+					instantiated_member_owner_type_index,
+					TypeIndex{},
+					TypeIndex{},
+					SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor,
+					true,  // Preserve declared parameter cv-qualifier in this path
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
 
 				// Get the function body - either from definition or by re-parsing from saved position
 				std::optional<ASTNode> body_to_substitute;
@@ -7583,6 +7687,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (new_func_ref.is_materialized()) {
 					finalize_function_after_definition(new_func_ref);
 				}
+				pack_param_info_.resize(saved_pack_info);
 
 				// Add the substituted function to the instantiated struct
 				if (mem_func.operator_kind != OverloadableOperator::None) {
@@ -7615,105 +7720,40 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			} else {
 				// No definition, but still need to substitute parameter types and return type
 
-				// Substitute return type
-				const TypeSpecifierNode& return_type_spec = decl.type_specifier_node();
-				TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-					return_type_spec,
+				SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+					func_decl,
 					decl.type_node(),
 					decl.identifier_token(),
-					template_params,
-					template_args_to_use,
-					[this](const ASTNode& node, const auto& params, const auto& args) {
-						return substituteTemplateParameters(node, params, args);
-					},
-					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-						return substitute_template_parameter(type_spec, params, args);
-					},
+					instantiated_name,
+					template_params_inline_ast,
+					template_args_to_use_inline,
 					&class_decl,
 					instantiated_member_owner_type_index,
 					TypeIndex{},
-					false,
-					true);
-
-				auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-				StringHandle effective_name = computeInstantiatedLookupName(
-					decl.identifier_token().handle(),
 					mem_func.operator_kind,
-					substituted_return_type);
-				Token effective_identifier_token(
-					Token::Type::Identifier,
-					StringTable::getStringView(effective_name),
-					decl.identifier_token().line(),
-					decl.identifier_token().column(),
-					decl.identifier_token().file_index());
+					StringHandle{},
+					StringHandle{},
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
+				ASTNode new_func_node = shell.function_node;
+				FunctionDeclarationNode& new_func_ref = *shell.function;
+				StringHandle effective_name = shell.effective_name;
 
-				// Create a new function declaration with substituted return type
-				auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-					substituted_return_node, effective_identifier_token);
-				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-					new_func_decl_ref, instantiated_name);
-
-				// Substitute and copy parameters
-				for (const auto& param : func_decl.parameter_nodes()) {
-					if (param.is<DeclarationNode>()) {
-						const DeclarationNode& param_decl = param.as<DeclarationNode>();
-						const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-						// Substitute parameter type
-						TypeIndex param_type_index = substitute_template_parameter(
-							param_type_spec, template_params, template_args_to_use);
-						param_type_index = resolveOwnerAliasTypeIndex(
-							[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-								return substitute_template_parameter(type_spec, params, args);
-							},
-							class_decl,
-							param_type_spec,
-							template_params,
-							template_args_to_use,
-							param_type_index);
-						resolve_member_self_type(param_type_index);
-
-						// Create substituted parameter type
-						TypeSpecifierNode substituted_param_type(
-							param_type_index.category(),
-							param_type_spec.qualifier(),
-							get_substituted_type_size_bits(param_type_index),
-							param_decl.identifier_token(),
-							CVQualifier::None);
-						substituted_param_type.set_type_index(param_type_index);
-
-						// Copy pointer levels and reference qualifiers
-						for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-							substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
-						}
-						substituted_param_type.set_reference_qualifier(param_type_spec.reference_qualifier());
-						applyBoundTemplateArgMetadata(
-							substituted_param_type,
-							param_type_spec,
-							template_params,
-							template_args_to_use);
-						if (param_type_spec.has_function_signature()) {
-							substituted_param_type.set_function_signature(param_type_spec.function_signature());
-						} else if (param_type_index.category() == TypeCategory::FunctionPointer ||
-								   param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-							if (const auto* arg = findTemplateArgByName(
-									param_type_spec.token().value(),
-									template_params,
-									template_args_to_use)) {
-								if (arg->function_signature.has_value()) {
-									substituted_param_type.set_function_signature(*arg->function_signature);
-								}
-							}
-						}
-						normalizeSubstitutedTypeSpec(substituted_param_type);
-
-						auto substituted_param_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
-						auto [param_decl_node, param_decl_ref] = emplace_node_ref<DeclarationNode>(
-							substituted_param_node, param_decl.identifier_token());
-
-						new_func_ref.add_parameter_node(param_decl_node);
-					}
-				}
+				size_t saved_pack_info = pack_param_info_.size();
+				substituteAndCopyMemberFunctionParameters(
+					func_decl.parameter_nodes(),
+					new_func_ref,
+					template_params_inline_ast,
+					template_args_to_use_inline,
+					&class_decl,
+					instantiated_member_owner_type_index,
+					TypeIndex{},
+					TypeIndex{},
+					SubstitutedDefaultArgumentPolicy::None,
+					false, // Declaration-only path: clear parameter cv-qualifier to preserve legacy behavior
+					false, // Do not re-apply bound metadata to full substitution
+					true); // Force resolved TypeIndex onto full AST substitutions
+				pack_param_info_.resize(saved_pack_info);
 
 				// Copy other function properties
 				copy_function_properties(new_func_ref, func_decl);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1590,15 +1590,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 														std::string_view param_name,
 														const std::vector<TemplateTypeArg>& args,
 														const auto& params) -> std::optional<ASTNode> {
-		std::vector<ASTNode> params_ast;
-		params_ast.reserve(params.size());
+		InlineVector<TemplateParameterNode, 4> typed_params;
+		typed_params.reserve(params.size());
 		for (const auto& param : params) {
 			if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param);
 				typed_param != nullptr) {
-				params_ast.push_back(ASTNode::emplace_node<TemplateParameterNode>(*typed_param));
+				typed_params.push_back(*typed_param);
 			}
 		}
-		return substitute_nontype_template_param(param_name, args, params_ast);
+		return substitute_nontype_template_param(param_name, args, std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()));
 	};
 
 	// Helper lambda to substitute template parameters in member default initializers.
@@ -4564,14 +4564,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	const TemplateClassDeclarationNode& template_class = template_node.as<TemplateClassDeclarationNode>();
 	const auto& template_params = template_class.template_parameters();
-	std::vector<ASTNode> template_params_ast;
-	template_params_ast.reserve(template_params.size());
+	InlineVector<TemplateParameterNode, 4> template_params_typed;
+	template_params_typed.reserve(template_params.size());
 	for (const TemplateParameterNode& template_param : template_params) {
-		template_params_ast.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
+		template_params_typed.push_back(template_param);
 	}
-	const std::vector<TemplateParameterNode> template_params_typed(
-		template_params.begin(),
-		template_params.end());
 	const StructDeclarationNode& class_decl = template_class.class_decl_node();
 
 	// Count non-variadic parameters
@@ -8690,7 +8687,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 
 						// Use shared helper lambda defined at function scope
-						if (auto subst = substitute_template_param_in_initializer(param_name, template_args_to_use, template_params_ast)) {
+						if (auto subst = substitute_template_param_in_initializer(param_name, template_args_to_use, template_params_typed)) {
 							substituted_initializer = subst;
 							FLASH_LOG(Templates, Debug, "Substituted static member initializer template parameter '", param_name, "'");
 						}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2692,7 +2692,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						spec_struct_ptr = &pattern.specialized_node.as<TemplateClassDeclarationNode>().class_decl_node();
 					}
 					if (spec_struct_ptr && spec_struct_ptr == &pattern_struct) {
-						pattern_template_params = pattern.template_params;
+						pattern_template_params.clear();
+						pattern_template_params.reserve(pattern.template_params.size());
+						for (const auto& param : pattern.template_params) {
+							pattern_template_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
+						}
 						break;
 					}
 				}
@@ -4597,6 +4601,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	const std::vector<ASTNode> template_params_ast(
 		template_params_inline_ast.begin(),
 		template_params_inline_ast.end());
+	const std::vector<TemplateParameterNode> template_params_typed(
+		template_params.begin(),
+		template_params.end());
 	const StructDeclarationNode& class_decl = template_class.class_decl_node();
 
 	// Count non-variadic parameters
@@ -6548,7 +6555,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				lazy_info.is_array = static_member.is_array;
 				lazy_info.array_dimensions = static_member.array_dimensions;
 				lazy_info.pointer_depth = static_member.pointer_depth;
-				lazy_info.template_params = template_params_ast;
+				lazy_info.template_params = template_params_typed;
 				lazy_info.template_args = template_args_to_use;
 				lazy_info.needs_substitution = true;
 
@@ -7424,7 +7431,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					id.cv_qualifier = mem_func.cv_qualifier;
 					id.kind = DeferredMemberIdentity::Kind::Function;
 				}
-				lazy_info.template_params = template_params_inline_ast;
+				lazy_info.template_params = template_params;
 				lazy_info.template_args = template_args_to_use;
 				lazy_info.access = mem_func.access;
 				lazy_info.is_virtual = mem_func.is_virtual;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -198,7 +198,7 @@ static void mergeAliasAndUseSiteTypeSpec(
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
 	std::span<const TemplateParameterNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	if (!type_node.is<TypeSpecifierNode>())
 		return DependentAliasResolutionStatus::NotApplicable;
 	auto& ts = type_node.as<TypeSpecifierNode>();
@@ -435,32 +435,6 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	return status;
 }
 
-Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
-	ASTNode& type_node,
-	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
-	return resolveDependentMemberAlias(type_node, template_params, vector_args);
-}
-
-Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
-	ASTNode& type_node,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
-	return resolveDependentMemberAlias(
-		type_node,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args);
-}
-
-Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
-	ASTNode& type_node,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
-	return resolveDependentMemberAlias(type_node, template_params, vector_args);
-}
-
 static bool hasUsableTemplateFunctionDefinition(const FunctionDeclarationNode& func_decl) {
 	return func_decl.has_template_body_position() ||
 		   func_decl.is_materialized() ||
@@ -679,7 +653,7 @@ static int computeTemplateFunctionSpecificity(const TemplateFunctionDeclarationN
 
 bool Parser::tryAppendDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
+	std::span<const TemplateParameterNode> template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
 	FLASH_LOG_FORMAT(Templates, Debug,
@@ -874,19 +848,6 @@ bool Parser::tryAppendDefaultTemplateArg(
 	return false;
 }
 
-bool Parser::tryAppendDefaultTemplateArg(
-	const TemplateParameterNode& param,
-	std::span<const TemplateParameterNode> template_params,
-	InlineVector<TemplateTypeArg, 4>& template_args,
-	NamespaceHandle source_namespace) {
-	InlineVector<TemplateParameterNode, 4> copied_template_params;
-	copied_template_params.reserve(template_params.size());
-	for (const TemplateParameterNode& template_param : template_params) {
-		copied_template_params.push_back(template_param);
-	}
-	return tryAppendDefaultTemplateArg(param, copied_template_params, template_args, source_namespace);
-}
-
 template <typename ParamContainer, typename ArgContainer>
 static void applyTemplateArgIndirection(
 	TypeSpecifierNode& substituted_type,
@@ -1033,6 +994,42 @@ void registerTypeParamsInScope(
 		});
 }
 
+void registerTypeParamsInScope(
+	std::span<const TemplateParameterNode> template_param_nodes,
+	std::span<const TemplateTypeArg> template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	bool preserve_ref_qualifier) {
+	forEachNonPackTemplateParamArgBinding(
+		template_param_nodes,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (arg.is_value || arg.is_template_template_arg)
+				return;
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
+			scope.addParameter(&type_info);
+		});
+}
+
+void registerTypeParamsInScope(
+	std::span<const TemplateParameterNode> template_param_nodes,
+	std::span<const TemplateTypeArg> template_args,
+	FlashCpp::TemplateParameterScope& scope,
+	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
+	forEachNonPackTemplateParamArgBinding(
+		template_param_nodes,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (arg.is_value || arg.is_template_template_arg)
+				return;
+			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
+			applyRegisteredTypeBindingMetadata(type_info, arg, true);
+			scope.addParameter(&type_info);
+			if (sfinae_map)
+				(*sfinae_map)[type_info.name()] = arg.type_index;
+		});
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // registerOuterBindingInScope
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1144,37 +1141,6 @@ void Parser::populateTemplateParamSubstitutions(
 			subs.push_back(subst);
 		});
 }
-
-void Parser::populateTemplateParamSubstitutions(
-	InlineVector<TemplateParamSubstitution, 4>& subs,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	forEachNonPackTemplateParamArgBinding(
-		template_params,
-		template_args,
-		[&](const TemplateParameterNode& template_param, const TemplateTypeArg& arg, size_t) {
-			if (arg.is_template_template_arg) {
-				TemplateParamSubstitution subst;
-				subst.param_name = template_param.nameHandle();
-				subst.is_template_template_param = true;
-				subst.concrete_template_name = arg.template_name_handle;
-				subs.push_back(subst);
-				return;
-			}
-			TemplateParamSubstitution subst;
-			subst.param_name = template_param.nameHandle();
-			if (arg.is_value) {
-				subst.is_value_param = true;
-				subst.value = arg.value;
-				subst.value_type = arg.typeEnum();
-			} else {
-				subst.is_value_param = false;
-				subst.is_type_param = true;
-				subst.substituted_type = arg;
-			}
-			subs.push_back(subst);
-		});
-}
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared helper: re-parse a template function body with concrete argument
 // substitution and set the result as new_func_ref's definition.
@@ -1188,7 +1154,7 @@ void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
 	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	bool preserve_ref_qualifier) {
 	// Depth guard: function-template body replay can recursively re-enter via
 	// expressions inside the body that instantiate further templates.  libstdc++
@@ -1305,20 +1271,6 @@ void Parser::reparse_template_function_body(
 			std::string("non-dependent name '").append(tok.value()).append("' was not declared before the template definition (C++20 [temp.res]/9)"));
 	}
 	// template_scope RAII guard removes TypeInfo entries automatically.
-}
-
-void Parser::reparse_template_function_body(
-	FunctionDeclarationNode& new_func_ref,
-	const FunctionDeclarationNode& func_decl,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
-	bool preserve_ref_qualifier) {
-	reparse_template_function_body(
-		new_func_ref,
-		func_decl,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args,
-		preserve_ref_qualifier);
 }
 
 namespace {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -197,7 +197,7 @@ static void mergeAliasAndUseSiteTypeSpec(
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	if (!type_node.is<TypeSpecifierNode>())
 		return DependentAliasResolutionStatus::NotApplicable;
@@ -437,6 +437,32 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
+	std::span<const TemplateParameterNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
+	return resolveDependentMemberAlias(type_node, template_params, vector_args);
+}
+
+Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
+	ASTNode& type_node,
+	std::span<const ASTNode> template_params,
+	const std::vector<TemplateTypeArg>& template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return resolveDependentMemberAlias(
+		type_node,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args);
+}
+
+Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
+	ASTNode& type_node,
 	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
@@ -447,12 +473,10 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
-	InlineVector<ASTNode, 4> ast_params;
-	ast_params.reserve(template_params.size());
-	for (const TemplateParameterNode& param : template_params) {
-		ast_params.push_back(emplace_node<TemplateParameterNode>(param));
-	}
-	return resolveDependentMemberAlias(type_node, ast_params, template_args);
+	return resolveDependentMemberAlias(
+		type_node,
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+		template_args);
 }
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
@@ -878,18 +902,35 @@ bool Parser::tryAppendDefaultTemplateArg(
 
 bool Parser::tryAppendDefaultTemplateArg(
 	const TemplateParameterNode& param,
+	std::span<const TemplateParameterNode> template_params,
+	InlineVector<TemplateTypeArg, 4>& template_args,
+	NamespaceHandle source_namespace) {
+	InlineVector<TemplateParameterNode, 4> copied_template_params;
+	copied_template_params.reserve(template_params.size());
+	for (const TemplateParameterNode& template_param : template_params) {
+		copied_template_params.push_back(template_param);
+	}
+	return tryAppendDefaultTemplateArg(param, copied_template_params, template_args, source_namespace);
+}
+
+bool Parser::tryAppendDefaultTemplateArg(
+	const TemplateParameterNode& param,
 	std::span<const ASTNode> template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
-	InlineVector<TemplateParameterNode, 4> typed_template_params;
-	typed_template_params.reserve(template_params.size());
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
 	for (const ASTNode& template_param : template_params) {
 		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
 			typed_param != nullptr) {
-			typed_template_params.push_back(*typed_param);
+			typed_params.push_back(*typed_param);
 		}
 	}
-	return tryAppendDefaultTemplateArg(param, typed_template_params, template_args, source_namespace);
+	return tryAppendDefaultTemplateArg(
+		param,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args,
+		source_namespace);
 }
 
 template <typename ParamContainer, typename ArgContainer>
@@ -1121,7 +1162,7 @@ void Parser::populateTemplateParamSubstitutions(
 
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	forEachNonPackTemplateParamArgBinding(
 		template_params,
@@ -1148,6 +1189,24 @@ void Parser::populateTemplateParamSubstitutions(
 			}
 			subs.push_back(subst);
 		});
+}
+
+void Parser::populateTemplateParamSubstitutions(
+	InlineVector<TemplateParamSubstitution, 4>& subs,
+	std::span<const ASTNode> template_params,
+	const std::vector<TemplateTypeArg>& template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	populateTemplateParamSubstitutions(
+		subs,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args);
 }
 
 void Parser::populateTemplateParamSubstitutions(
@@ -1192,7 +1251,7 @@ void Parser::populateTemplateParamSubstitutions(
 void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	bool preserve_ref_qualifier) {
 	// Depth guard: function-template body replay can recursively re-enter via
@@ -1232,18 +1291,14 @@ void Parser::reparse_template_function_body(
 	FlashCpp::TemplateParameterScope template_scope;
 	InlineVector<StringHandle, 4> param_names;
 	param_names.reserve(template_params.size());
-	for (const auto& tparam_node : template_params) {
-		const TemplateParameterNode* template_param = tryGetTemplateParameterNode(tparam_node);
-		if (template_param == nullptr) {
-			continue;
-		}
-		param_names.push_back(template_param->nameHandle());
+	for (const TemplateParameterNode& template_param : template_params) {
+		param_names.push_back(template_param.nameHandle());
 	}
 	// preserve_ref_qualifier=true for the explicit path (user-written T=int& must be
 	// reflected in TypeInfo); false for the deduced path.
-	InlineVector<ASTNode, 4> template_param_nodes;
+	InlineVector<TemplateParameterNode, 4> template_param_nodes;
 	template_param_nodes.reserve(template_params.size());
-	for (const ASTNode& template_param_node : template_params) {
+	for (const TemplateParameterNode& template_param_node : template_params) {
 		template_param_nodes.push_back(template_param_node);
 	}
 	registerTypeParamsInScope(template_param_nodes, template_args, template_scope, preserve_ref_qualifier);
@@ -1319,13 +1374,35 @@ void Parser::reparse_template_function_body(
 void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
+	std::span<const ASTNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	bool preserve_ref_qualifier) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	reparse_template_function_body(
+		new_func_ref,
+		func_decl,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args,
+		preserve_ref_qualifier);
+}
+
+void Parser::reparse_template_function_body(
+	FunctionDeclarationNode& new_func_ref,
+	const FunctionDeclarationNode& func_decl,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	bool preserve_ref_qualifier) {
 	reparse_template_function_body(
 		new_func_ref,
 		func_decl,
-		cloneTemplateParameterNodes(template_params),
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
 		template_args,
 		preserve_ref_qualifier);
 }

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -1009,7 +1009,7 @@ void registerTypeParamsInScope(
 // ─────────────────────────────────────────────────────────────────────────────
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
 	forEachNonPackTemplateParamArgBinding(
@@ -1026,7 +1026,7 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier) {
 	forEachNonPackTemplateParamArgBinding(
@@ -1043,7 +1043,7 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
 	forEachNonPackTemplateParamArgBinding(
@@ -1062,7 +1062,7 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	FlashCpp::TemplateParameterScope& scope,
 	std::unordered_map<StringHandle, TypeIndex, StringHash, StringEqual>* sfinae_map) {
 	forEachNonPackTemplateParamArgBinding(
@@ -1131,7 +1131,7 @@ void registerOuterBindingInScope(
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
 	const InlineVector<StringHandle, 4>& param_names,
-	const std::vector<TemplateTypeArg>& type_args) {
+	std::span<const TemplateTypeArg> type_args) {
 	for (size_t i = 0; i < param_names.size() && i < type_args.size(); ++i) {
 		const TemplateTypeArg& arg = type_args[i];
 		if (arg.is_template_template_arg) {
@@ -1163,7 +1163,7 @@ void Parser::populateTemplateParamSubstitutions(
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
 	std::span<const TemplateParameterNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	forEachNonPackTemplateParamArgBinding(
 		template_params,
 		template_args,
@@ -1194,7 +1194,7 @@ void Parser::populateTemplateParamSubstitutions(
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
 	std::span<const ASTNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	InlineVector<TemplateParameterNode, 4> typed_params;
 	typed_params.reserve(template_params.size());
 	for (const ASTNode& template_param : template_params) {
@@ -1212,7 +1212,7 @@ void Parser::populateTemplateParamSubstitutions(
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	forEachNonPackTemplateParamArgBinding(
 		template_params,
 		template_args,

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -197,7 +197,7 @@ static void mergeAliasAndUseSiteTypeSpec(
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	if (!type_node.is<TypeSpecifierNode>())
 		return DependentAliasResolutionStatus::NotApplicable;
@@ -437,7 +437,7 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
 	return resolveDependentMemberAlias(type_node, template_params, vector_args);
@@ -878,7 +878,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 
 bool Parser::tryAppendDefaultTemplateArg(
 	const TemplateParameterNode& param,
-	const std::vector<ASTNode>& template_params,
+	std::span<const ASTNode> template_params,
 	InlineVector<TemplateTypeArg, 4>& template_args,
 	NamespaceHandle source_namespace) {
 	InlineVector<TemplateParameterNode, 4> typed_template_params;
@@ -1121,7 +1121,7 @@ void Parser::populateTemplateParamSubstitutions(
 
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
-	const std::vector<ASTNode>& template_params,
+	std::span<const ASTNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	forEachNonPackTemplateParamArgBinding(
 		template_params,
@@ -1192,7 +1192,7 @@ void Parser::populateTemplateParamSubstitutions(
 void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	bool preserve_ref_qualifier) {
 	// Depth guard: function-template body replay can recursively re-enter via
@@ -1241,7 +1241,12 @@ void Parser::reparse_template_function_body(
 	}
 	// preserve_ref_qualifier=true for the explicit path (user-written T=int& must be
 	// reflected in TypeInfo); false for the deduced path.
-	registerTypeParamsInScope(template_params, template_args, template_scope, preserve_ref_qualifier);
+	InlineVector<ASTNode, 4> template_param_nodes;
+	template_param_nodes.reserve(template_params.size());
+	for (const ASTNode& template_param_node : template_params) {
+		template_param_nodes.push_back(template_param_node);
+	}
+	registerTypeParamsInScope(template_param_nodes, template_args, template_scope, preserve_ref_qualifier);
 
 	// Save lexer position and function context.
 	SaveHandle current_pos = save_token_position();

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -445,32 +445,6 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 
 Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	ASTNode& type_node,
-	std::span<const ASTNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return resolveDependentMemberAlias(
-		type_node,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
-Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
-	ASTNode& type_node,
-	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	std::vector<TemplateTypeArg> vector_args(template_args.begin(), template_args.end());
-	return resolveDependentMemberAlias(type_node, template_params, vector_args);
-}
-
-Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
-	ASTNode& type_node,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	return resolveDependentMemberAlias(
@@ -913,26 +887,6 @@ bool Parser::tryAppendDefaultTemplateArg(
 	return tryAppendDefaultTemplateArg(param, copied_template_params, template_args, source_namespace);
 }
 
-bool Parser::tryAppendDefaultTemplateArg(
-	const TemplateParameterNode& param,
-	std::span<const ASTNode> template_params,
-	InlineVector<TemplateTypeArg, 4>& template_args,
-	NamespaceHandle source_namespace) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return tryAppendDefaultTemplateArg(
-		param,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		source_namespace);
-}
-
 template <typename ParamContainer, typename ArgContainer>
 static void applyTemplateArgIndirection(
 	TypeSpecifierNode& substituted_type,
@@ -1193,24 +1147,6 @@ void Parser::populateTemplateParamSubstitutions(
 
 void Parser::populateTemplateParamSubstitutions(
 	InlineVector<TemplateParamSubstitution, 4>& subs,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	populateTemplateParamSubstitutions(
-		subs,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
-void Parser::populateTemplateParamSubstitutions(
-	InlineVector<TemplateParamSubstitution, 4>& subs,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	std::span<const TemplateTypeArg> template_args) {
 	forEachNonPackTemplateParamArgBinding(
@@ -1369,28 +1305,6 @@ void Parser::reparse_template_function_body(
 			std::string("non-dependent name '").append(tok.value()).append("' was not declared before the template definition (C++20 [temp.res]/9)"));
 	}
 	// template_scope RAII guard removes TypeInfo entries automatically.
-}
-
-void Parser::reparse_template_function_body(
-	FunctionDeclarationNode& new_func_ref,
-	const FunctionDeclarationNode& func_decl,
-	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
-	bool preserve_ref_qualifier) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	reparse_template_function_body(
-		new_func_ref,
-		func_decl,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		preserve_ref_qualifier);
 }
 
 void Parser::reparse_template_function_body(
@@ -2546,11 +2460,20 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 				const InlineVector<ASTNode, 4>& materialized_template_params,
 				const InlineVector<TemplateTypeArg, 4>& materialized_template_args) {
 				const TypeSpecifierNode& original_param_type = original_param_decl.type_specifier_node();
+				InlineVector<TemplateParameterNode, 4> typed_params;
+				typed_params.reserve(materialized_template_params.size());
+				for (const ASTNode& param_node : materialized_template_params) {
+					if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+						typed_param != nullptr) {
+						typed_params.push_back(*typed_param);
+					}
+				}
+
 				TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
 					original_param_type,
 					original_param_decl.type_node(),
 					original_param_decl.identifier_token(),
-					materialized_template_params,
+					typed_params,
 					materialized_template_args,
 					[this](const ASTNode& node, const auto& params, const auto& args) {
 						return substituteTemplateParameters(node, params, args);
@@ -2564,7 +2487,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 					false,
 					true);
 				ASTNode param_type = emplace_node<TypeSpecifierNode>(substituted_param_type);
-				resolveDependentMemberAlias(param_type, materialized_template_params, materialized_template_args);
+				resolveDependentMemberAlias(param_type, typed_params, materialized_template_args);
 				normalizeSubstitutedTypeSpec(param_type.as<TypeSpecifierNode>());
 				return param_type;
 			};

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -831,7 +831,7 @@ bool Parser::buildSubstitutionForPackElement(
 	StringHandle pack_param_name,
 	size_t pack_element_offset,
 	const std::unordered_set<StringHandle, StringHash, StringEqual>& dependent_pack_names,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const std::vector<size_t>& template_param_arg_starts,
 	const std::vector<size_t>& template_param_arg_counts,
 	const std::vector<TemplateTypeArg>& template_args,

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -86,10 +86,19 @@ bool Parser::tryAppendMemberDefaultTemplateArg(
 		combined_template_args.push_back(current_arg);
 	}
 
+	InlineVector<TemplateParameterNode, 4> typed_combined_params;
+	typed_combined_params.reserve(combined_template_params.size());
+	for (const ASTNode& param_node : combined_template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+			typed_param != nullptr) {
+			typed_combined_params.push_back(*typed_param);
+		}
+	}
+
 	ASTNode substituted_default = substituteTemplateParameters(
 		param.default_value(),
-		std::span<const ASTNode>(combined_template_params.data(), combined_template_params.size()),
-		std::span<const TemplateTypeArg>(combined_template_args.data(), combined_template_args.size()));
+		typed_combined_params,
+		combined_template_args);
 	if (param.kind() == TemplateParameterKind::Type && substituted_default.is<TypeSpecifierNode>()) {
 		current_template_args.push_back(TemplateTypeArg(substituted_default.as<TypeSpecifierNode>()));
 		return true;
@@ -879,10 +888,19 @@ ASTNode Parser::buildMaterializedParamType(
 	const TypeSpecifierNode& original_param_type,
 	const InlineVector<ASTNode, 4>& materialized_template_params,
 	const InlineVector<TemplateTypeArg, 4>& materialized_template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(materialized_template_params.size());
+	for (const ASTNode& param_node : materialized_template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+
 	TypeIndex substituted_type_index = substitute_template_parameter(
 		original_param_type,
-		std::span<const ASTNode>(materialized_template_params.data(), materialized_template_params.size()),
-		std::span<const TemplateTypeArg>(materialized_template_args.data(), materialized_template_args.size()));
+		typed_params,
+		materialized_template_args);
 	ASTNode param_type = emplace_node<TypeSpecifierNode>(
 		substituted_type_index,
 		get_type_size_bits(substituted_type_index.category()),
@@ -1562,10 +1580,18 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					InlineVector<ASTNode, 4> outer_params;
 					InlineVector<TemplateTypeArg, 4> outer_args;
 					appendOuterBindingSubstitutionInputs(*outer_binding, outer_params, outer_args);
+					InlineVector<TemplateParameterNode, 4> typed_outer_params;
+					typed_outer_params.reserve(outer_params.size());
+					for (const ASTNode& param_node : outer_params) {
+						if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+							typed_param != nullptr) {
+							typed_outer_params.push_back(*typed_param);
+						}
+					}
 					substituted_body = substituteTemplateParameters(
 						substituted_body,
-						std::span<const ASTNode>(outer_params.data(), outer_params.size()),
-						std::span<const TemplateTypeArg>(outer_args.data(), outer_args.size()));
+						typed_outer_params,
+						outer_args);
 				}
 				new_func_ref.set_definition(substituted_body);
 			}

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -308,7 +308,7 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 
 	for (StringHandle outer_name : ctor_decl.outer_template_param_names()) {
 		Token outer_token(Token::Type::Identifier, StringTable::getStringView(outer_name), 0, 0, 0);
-		lazy_info.template_params.push_back(emplace_node<TemplateParameterNode>(outer_name, outer_token));
+		lazy_info.template_params.push_back(TemplateParameterNode(outer_name, outer_token));
 	}
 	for (const auto& outer_arg : ctor_decl.outer_template_args()) {
 		const std::vector<ASTNode> no_params;
@@ -320,7 +320,7 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 			nullptr));
 	}
 	for (const auto& template_param : template_params) {
-		lazy_info.template_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
+		lazy_info.template_params.push_back(template_param);
 	}
 	for (const auto& template_arg : ctor_template_args) {
 		lazy_info.template_args.push_back(template_arg);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -88,8 +88,8 @@ bool Parser::tryAppendMemberDefaultTemplateArg(
 
 	ASTNode substituted_default = substituteTemplateParameters(
 		param.default_value(),
-		combined_template_params,
-		combined_template_args);
+		std::span<const ASTNode>(combined_template_params.data(), combined_template_params.size()),
+		std::span<const TemplateTypeArg>(combined_template_args.data(), combined_template_args.size()));
 	if (param.kind() == TemplateParameterKind::Type && substituted_default.is<TypeSpecifierNode>()) {
 		current_template_args.push_back(TemplateTypeArg(substituted_default.as<TypeSpecifierNode>()));
 		return true;
@@ -834,7 +834,7 @@ bool Parser::buildSubstitutionForPackElement(
 	std::span<const TemplateParameterNode> template_params,
 	const std::vector<size_t>& template_param_arg_starts,
 	const std::vector<size_t>& template_param_arg_counts,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	InlineVector<ASTNode, 4>& subst_params,
 	InlineVector<TemplateTypeArg, 4>& subst_args) {
 	std::optional<std::pair<size_t, size_t>> pack_binding;
@@ -880,7 +880,9 @@ ASTNode Parser::buildMaterializedParamType(
 	const InlineVector<ASTNode, 4>& materialized_template_params,
 	const InlineVector<TemplateTypeArg, 4>& materialized_template_args) {
 	TypeIndex substituted_type_index = substitute_template_parameter(
-		original_param_type, materialized_template_params, materialized_template_args);
+		original_param_type,
+		std::span<const ASTNode>(materialized_template_params.data(), materialized_template_params.size()),
+		std::span<const TemplateTypeArg>(materialized_template_args.data(), materialized_template_args.size()));
 	ASTNode param_type = emplace_node<TypeSpecifierNode>(
 		substituted_type_index,
 		get_type_size_bits(substituted_type_index.category()),
@@ -912,7 +914,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	std::string_view struct_name, std::string_view member_name,
 	StringHandle qualified_name,
 	const ASTNode& template_node,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	const FlashCpp::TemplateInstantiationKey& key,
 	const std::vector<TypeSpecifierNode>& call_arg_types) {
 
@@ -947,6 +949,11 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 	const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
+	InlineVector<TemplateTypeArg, 4> inline_template_args;
+	inline_template_args.reserve(template_args.size());
+	for (const TemplateTypeArg& template_arg : template_args) {
+		inline_template_args.push_back(template_arg);
+	}
 	auto deduction_info = buildDeductionMapFromCallArgs(
 		template_params,
 		func_decl,
@@ -1431,7 +1438,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	if (!func_decl.has_template_body_position()) {
 		if (orig_body.has_value()) {
 			new_func_ref.set_definition(
-				substituteTemplateParameters(*orig_body, template_params, template_args));
+				substituteTemplateParameters(*orig_body, template_params, inline_template_args));
 			finalize_function_after_definition(new_func_ref);
 		} else {
 			compute_and_set_mangled_name(new_func_ref);
@@ -1550,15 +1557,15 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				ASTNode substituted_body = substituteTemplateParameters(
 					*block_result.node(),
 					template_params,
-					template_args);
+					inline_template_args);
 				if (outer_binding && (!outer_binding->params.empty() || !outer_binding->param_names.empty())) {
 					InlineVector<ASTNode, 4> outer_params;
 					InlineVector<TemplateTypeArg, 4> outer_args;
 					appendOuterBindingSubstitutionInputs(*outer_binding, outer_params, outer_args);
 					substituted_body = substituteTemplateParameters(
 						substituted_body,
-						outer_params,
-						outer_args);
+						std::span<const ASTNode>(outer_params.data(), outer_params.size()),
+						std::span<const TemplateTypeArg>(outer_args.data(), outer_args.size()));
 				}
 				new_func_ref.set_definition(substituted_body);
 			}

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -831,7 +831,7 @@ bool Parser::buildSubstitutionForPackElement(
 	StringHandle pack_param_name,
 	size_t pack_element_offset,
 	const std::unordered_set<StringHandle, StringHash, StringEqual>& dependent_pack_names,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const std::vector<size_t>& template_param_arg_starts,
 	const std::vector<size_t>& template_param_arg_counts,
 	const std::vector<TemplateTypeArg>& template_args,
@@ -839,10 +839,7 @@ bool Parser::buildSubstitutionForPackElement(
 	InlineVector<TemplateTypeArg, 4>& subst_args) {
 	std::optional<std::pair<size_t, size_t>> pack_binding;
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
-		if (tparam == nullptr) {
-			continue;
-		}
+		const TemplateParameterNode* tparam = &template_params[i];
 		if (tparam->is_variadic() && tparam->nameHandle() == pack_param_name) {
 			pack_binding = std::pair<size_t, size_t>{
 				template_param_arg_starts[i],
@@ -854,10 +851,7 @@ bool Parser::buildSubstitutionForPackElement(
 		return false;
 	}
 	for (size_t i = 0; i < template_params.size(); ++i) {
-		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
-		if (tparam == nullptr) {
-			continue;
-		}
+		const TemplateParameterNode* tparam = &template_params[i];
 		if (tparam->is_variadic()) {
 			const bool is_primary = (tparam->nameHandle() == pack_param_name);
 			const bool is_co_pack = !is_primary &&
@@ -875,7 +869,7 @@ bool Parser::buildSubstitutionForPackElement(
 		if (template_param_arg_starts[i] == SIZE_MAX || template_param_arg_starts[i] >= template_args.size()) {
 			continue;
 		}
-		subst_params.push_back(template_params[i]);
+		subst_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(*tparam));
 		subst_args.push_back(template_args[template_param_arg_starts[i]]);
 	}
 	return true;
@@ -951,7 +945,6 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const auto& template_params = template_func.template_parameters();
-	const InlineVector<ASTNode, 4> template_params_ast = cloneTemplateParameterNodes(template_params);
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 	const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
 	auto deduction_info = buildDeductionMapFromCallArgs(
@@ -1364,7 +1357,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 								primary_pack_name,
 								pi,
 								dependent_pack_names,
-								template_params_ast,
+								std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
 								template_param_arg_starts,
 								template_param_arg_counts,
 								template_args,

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -153,7 +153,7 @@ std::optional<TemplateTypeArg> Parser::substituteAndEvaluateNonTypeDefault(
 		template_param_names);
 }
 
-std::string_view Parser::get_instantiated_class_name(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args) {
+std::string_view Parser::get_instantiated_class_name(std::string_view template_name, std::span<const TemplateTypeArg> template_args) {
 	if (size_t last_colon = template_name.rfind("::"); last_colon != std::string_view::npos) {
 		template_name = template_name.substr(last_colon + 2);
 	}
@@ -165,7 +165,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
 	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	const TemplateParameterNode* target_template_param) {
 	const auto find_param_index = [&](StringHandle param_name) -> std::optional<size_t> {
 		for (size_t i = 0; i < param_names.size(); ++i) {
@@ -282,7 +282,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
 	const InlineVector<ASTNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	const TemplateParameterNode* target_template_param) {
 	InlineVector<TemplateParameterNode, 4> typed_template_parameters;
 	typed_template_parameters.reserve(template_parameters.size());
@@ -303,7 +303,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 
 std::optional<std::vector<TemplateTypeArg>> Parser::materializeDeferredAliasTemplateArgs(
 	const TemplateAliasNode& alias_node,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	std::vector<TemplateTypeArg> substituted_args;
 	const auto& param_names = alias_node.template_param_names();
 	const auto& target_template_args = alias_node.target_template_args();
@@ -381,7 +381,7 @@ std::optional<TemplateTypeArg> Parser::tryRebindAliasTargetTemplateArg(
 
 
 void Parser::normalizeDependentNonTypeTemplateArgs(
-	const InlineVector<TemplateParameterNode, 4>& template_parameters,
+	std::span<const TemplateParameterNode> template_parameters,
 	std::vector<TemplateTypeArg>& template_args) {
 	size_t arg_index = 0;
 	for (size_t param_index = 0;
@@ -430,7 +430,7 @@ void Parser::normalizeDependentNonTypeTemplateArgs(
 
 Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInstantiation(
 	std::string_view alias_template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	AliasTemplateMaterializationResult result;
 	const TemplateAliasNode* alias_node = nullptr;
 	if (auto alias_entry = gTemplateRegistry.lookup_alias_template(alias_template_name);
@@ -552,7 +552,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 
 Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiationForLookup(
 	std::string_view template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	if (gTemplateRegistry.lookup_alias_template(template_name).has_value()) {
 		AliasTemplateMaterializationResult alias_result =
 			materializeAliasTemplateInstantiation(template_name, template_args);
@@ -596,7 +596,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
 	std::span<const TemplateParameterNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	const TypeInfo* original_alias_target_info = tryGetTypeInfo(alias_type_spec.type_index());
 	if (!original_alias_target_info) {
 		return nullptr;
@@ -671,20 +671,10 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	return nullptr;
 }
 
-const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
-	const TypeSpecifierNode& alias_type_spec,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
-	return materializeInstantiatedMemberAliasTarget(
-		alias_type_spec,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args);
-}
-
 bool Parser::resolveAliasTemplateInstantiation(
 	TypeSpecifierNode& type_spec,
 	std::string_view alias_template_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	AliasTemplateMaterializationResult materialized_alias =
 		materializeAliasTemplateInstantiation(alias_template_name, template_args);
 	if (!materialized_alias.resolved_type_info) {
@@ -725,7 +715,7 @@ bool Parser::resolveAliasTemplateInstantiation(TypeSpecifierNode& type_spec) {
 // Returns the instantiated name, or empty string_view if not a template
 std::string_view Parser::instantiate_and_register_base_template(
 	std::string_view& base_class_name,
-	const std::vector<TemplateTypeArg>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 
 	// First check if the base class is a template alias (like bool_constant)
 	auto alias_entry = gTemplateRegistry.lookup_alias_template(base_class_name);
@@ -782,7 +772,7 @@ std::string_view Parser::instantiate_and_register_base_template(
 				buildTemplateParamNames(primary_params);
 
 			// Fill in defaults for missing arguments
-			std::vector<TemplateTypeArg> filled_args = template_args;
+			std::vector<TemplateTypeArg> filled_args(template_args.begin(), template_args.end());
 			for (size_t i = filled_args.size(); i < primary_params.size(); ++i) {
 				const TemplateParameterNode* param = tryGetTemplateParameterNode(primary_params[i]);
 				if (param == nullptr)
@@ -1147,7 +1137,7 @@ ASTNode Parser::substitute_template_params_in_expression(
 // Returns the instantiated StructDeclarationNode if successful
 // Try to instantiate a variable template with the given template arguments
 // Returns the instantiated variable declaration node or nullopt if already instantiated
-std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args) {
+std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_view template_name, std::span<const TemplateTypeArg> template_args) {
 	// First, try to find a partial specialization that matches the template arguments
 	// For example, is_reference_v<int&> should match is_reference_v<T&>
 	// Pattern names are: template_name_R (lvalue ref), template_name_RR (rvalue ref), template_name_P (pointer)
@@ -1582,7 +1572,7 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 // Helper to instantiate a full template specialization (e.g., template<> struct Tuple<> {})
 std::optional<ASTNode> Parser::instantiate_full_specialization(
 	std::string_view template_name,
-	const std::vector<TemplateTypeArg>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	ASTNode& spec_node) {
 	// Generate the instantiated class name
 	std::string_view instantiated_name = get_instantiated_class_name(template_name, template_args);
@@ -2071,7 +2061,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 // Extracted from try_instantiate_class_template to reduce function size
 std::optional<ASTNode> Parser::substitute_nontype_template_param(
 	std::string_view param_name,
-	const std::vector<TemplateTypeArg>& args,
+	std::span<const TemplateTypeArg> args,
 	std::span<const TemplateParameterNode> params) {
 	for (size_t i = 0; i < params.size(); ++i) {
 		const TemplateParameterNode& tparam = params[i];

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -673,24 +673,6 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
-	std::span<const ASTNode> template_params,
-	const std::vector<TemplateTypeArg>& template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return materializeInstantiatedMemberAliasTarget(
-		alias_type_spec,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
-const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
-	const TypeSpecifierNode& alias_type_spec,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	return materializeInstantiatedMemberAliasTarget(
@@ -1612,7 +1594,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 	}
 
 	StructDeclarationNode& spec_struct = spec_node.as<StructDeclarationNode>();
-	InlineVector<ASTNode, 4> no_template_params;
+	InlineVector<TemplateParameterNode, 4> no_template_params;
 
 	// Helper lambda to register type aliases with qualified names
 	auto register_type_aliases = [&]() {

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -587,7 +587,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	const TypeInfo* original_alias_target_info = tryGetTypeInfo(alias_type_spec.type_index());
 	if (!original_alias_target_info) {
@@ -667,9 +667,10 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
 	const InlineVector<TemplateParameterNode, 4>& template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
+	InlineVector<ASTNode, 4> cloned_template_params = cloneTemplateParameterNodes(template_params);
 	return materializeInstantiatedMemberAliasTarget(
 		alias_type_spec,
-		cloneTemplateParameterNodes(template_params),
+		std::span<const ASTNode>(cloned_template_params),
 		template_args);
 }
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2090,13 +2090,10 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 std::optional<ASTNode> Parser::substitute_nontype_template_param(
 	std::string_view param_name,
 	const std::vector<TemplateTypeArg>& args,
-	const std::vector<ASTNode>& params) {
+	std::span<const TemplateParameterNode> params) {
 	for (size_t i = 0; i < params.size(); ++i) {
-		const TemplateParameterNode* tparam = tryGetTemplateParameterNode(params[i]);
-		if (tparam == nullptr) {
-			continue;
-		}
-		if (tparam->name() == param_name && tparam->kind() == TemplateParameterKind::NonType) {
+		const TemplateParameterNode& tparam = params[i];
+		if (tparam.name() == param_name && tparam.kind() == TemplateParameterKind::NonType) {
 			if (i < args.size() && args[i].is_value) {
 				int64_t val = args[i].value;
 				TypeCategory val_type = args[i].typeEnum();

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -587,7 +587,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
 	const TypeInfo* original_alias_target_info = tryGetTypeInfo(alias_type_spec.type_index());
 	if (!original_alias_target_info) {
@@ -665,12 +665,29 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const std::vector<TemplateTypeArg>& template_args) {
-	InlineVector<ASTNode, 4> cloned_template_params = cloneTemplateParameterNodes(template_params);
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
 	return materializeInstantiatedMemberAliasTarget(
 		alias_type_spec,
-		std::span<const ASTNode>(cloned_template_params),
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args);
+}
+
+const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
+	const TypeSpecifierNode& alias_type_spec,
+	const InlineVector<TemplateParameterNode, 4>& template_params,
+	const std::vector<TemplateTypeArg>& template_args) {
+	return materializeInstantiatedMemberAliasTarget(
+		alias_type_spec,
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
 		template_args);
 }
 
@@ -2100,7 +2117,7 @@ std::optional<ASTNode> Parser::substitute_nontype_template_param(
 // Returns the evaluated value and its category if successful, or nullopt if evaluation fails.
 std::optional<TemplateTypeArg> Parser::evaluateDependentNTTPExpression(
 	const ASTNode& dependent_expr,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args) {
 
 	// Build type substitution map from template params to args
@@ -2108,10 +2125,7 @@ std::optional<TemplateTypeArg> Parser::evaluateDependentNTTPExpression(
 	// Build non-type substitution map for value parameters
 	std::unordered_map<std::string_view, int64_t> nontype_substitution_map;
 	for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
-		const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
-		if (param == nullptr) {
-			continue;
-		}
+		const TemplateParameterNode* param = &template_params[i];
 		if (param->kind() == TemplateParameterKind::Type) {
 			// For typename/class parameters, registered_type_index() is the TypeIndex assigned
 			// when the template was parsed (via add_user_type in Parser_Templates_Function.cpp).

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -163,7 +163,7 @@ std::string_view Parser::get_instantiated_class_name(std::string_view template_n
 
 std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
-	const InlineVector<ASTNode, 4>& template_parameters,
+	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
 	const std::vector<TemplateTypeArg>& template_args,
 	const TemplateParameterNode* target_template_param) {
@@ -178,12 +178,12 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const auto normalize_alias_param_arg = [&](size_t alias_param_idx, const TemplateTypeArg& source_arg) {
 		TemplateTypeArg normalized = source_arg;
 		if (alias_param_idx < template_parameters.size()) {
-			const TemplateParameterNode* alias_param = tryGetTemplateParameterNode(template_parameters[alias_param_idx]);
-			if (alias_param != nullptr && alias_param->kind() == TemplateParameterKind::NonType && !normalized.is_value) {
+			const TemplateParameterNode& alias_param = template_parameters[alias_param_idx];
+			if (alias_param.kind() == TemplateParameterKind::NonType && !normalized.is_value) {
 				normalized.is_value = true;
 				normalized.is_dependent = normalized.is_dependent || normalized.dependent_name.isValid();
-				if (alias_param->has_type()) {
-					const auto& param_type = alias_param->type_specifier_node();
+				if (alias_param.has_type()) {
+					const auto& param_type = alias_param.type_specifier_node();
 					normalized.type_index = param_type.type_index();
 					normalized.setCategory(param_type.type());
 				} else if (!normalized.type_index.is_valid()) {
@@ -198,16 +198,16 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 		if (!alias_param_idx.has_value() || *alias_param_idx >= template_parameters.size()) {
 			return std::nullopt;
 		}
-		const TemplateParameterNode* alias_param = tryGetTemplateParameterNode(template_parameters[*alias_param_idx]);
-		if (alias_param == nullptr || alias_param->kind() != TemplateParameterKind::NonType) {
+		const TemplateParameterNode& alias_param = template_parameters[*alias_param_idx];
+		if (alias_param.kind() != TemplateParameterKind::NonType) {
 			return std::nullopt;
 		}
-		if (!alias_param->has_type()) {
+		if (!alias_param.has_type()) {
 			throw InternalError("Non-type alias template parameter is missing a declared type");
 		}
 		return TemplateTypeArg::makeDependentValue(
 			param_name,
-			alias_param->type_specifier_node().type());
+			alias_param.type_specifier_node().type());
 	};
 
 	if (arg_node.is<TypeSpecifierNode>()) {
@@ -259,12 +259,8 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 
 	InlineVector<TemplateParameterNode, 4> typed_template_parameters;
 	typed_template_parameters.reserve(template_parameters.size());
-	for (const ASTNode& template_param : template_parameters) {
-		const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-		if (typed_param == nullptr) {
-			return std::nullopt;
-		}
-		typed_template_parameters.push_back(*typed_param);
+	for (const TemplateParameterNode& template_param : template_parameters) {
+		typed_template_parameters.push_back(template_param);
 	}
 
 	if (auto substituted_eval = substituteAndEvaluateNonTypeDefault(
@@ -284,13 +280,22 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 
 std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	const ASTNode& arg_node,
-	const InlineVector<TemplateParameterNode, 4>& template_parameters,
+	const InlineVector<ASTNode, 4>& template_parameters,
 	const InlineVector<StringHandle, 4>& param_names,
 	const std::vector<TemplateTypeArg>& template_args,
 	const TemplateParameterNode* target_template_param) {
+	InlineVector<TemplateParameterNode, 4> typed_template_parameters;
+	typed_template_parameters.reserve(template_parameters.size());
+	for (const ASTNode& template_param : template_parameters) {
+		const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+		if (typed_param == nullptr) {
+			return std::nullopt;
+		}
+		typed_template_parameters.push_back(*typed_param);
+	}
 	return materializeDeferredAliasTemplateArg(
 		arg_node,
-		cloneTemplateParameterNodes(template_parameters),
+		typed_template_parameters,
 		param_names,
 		template_args,
 		target_template_param);
@@ -376,18 +381,13 @@ std::optional<TemplateTypeArg> Parser::tryRebindAliasTargetTemplateArg(
 
 
 void Parser::normalizeDependentNonTypeTemplateArgs(
-	const InlineVector<ASTNode, 4>& template_parameters,
+	const InlineVector<TemplateParameterNode, 4>& template_parameters,
 	std::vector<TemplateTypeArg>& template_args) {
 	size_t arg_index = 0;
 	for (size_t param_index = 0;
 		 param_index < template_parameters.size() && arg_index < template_args.size();
 		 ++param_index) {
-		if (!template_parameters[param_index].is<TemplateParameterNode>()) {
-			continue;
-		}
-
-		const TemplateParameterNode& template_param =
-			template_parameters[param_index].as<TemplateParameterNode>();
+		const TemplateParameterNode& template_param = template_parameters[param_index];
 		if (template_param.is_variadic()) {
 			break;
 		}
@@ -413,10 +413,18 @@ void Parser::normalizeDependentNonTypeTemplateArgs(
 }
 
 void Parser::normalizeDependentNonTypeTemplateArgs(
-	const InlineVector<TemplateParameterNode, 4>& template_parameters,
+	const InlineVector<ASTNode, 4>& template_parameters,
 	std::vector<TemplateTypeArg>& template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_template_parameters;
+	typed_template_parameters.reserve(template_parameters.size());
+	for (const ASTNode& template_param : template_parameters) {
+		if (!template_param.is<TemplateParameterNode>()) {
+			continue;
+		}
+		typed_template_parameters.push_back(template_param.as<TemplateParameterNode>());
+	}
 	normalizeDependentNonTypeTemplateArgs(
-		cloneTemplateParameterNodes(template_parameters),
+		typed_template_parameters,
 		template_args);
 }
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -25,6 +25,26 @@ namespace {
 		.commit()));
 }
 
+InlineVector<TemplateParameterNode, 4> toInlineTemplateParams(
+	const std::vector<TemplateParameterNode>& template_params) {
+	InlineVector<TemplateParameterNode, 4> result;
+	result.reserve(template_params.size());
+	for (const TemplateParameterNode& param : template_params) {
+		result.push_back(param);
+	}
+	return result;
+}
+
+std::vector<ASTNode> toAstTemplateParams(
+	const std::vector<TemplateParameterNode>& template_params) {
+	std::vector<ASTNode> result;
+	result.reserve(template_params.size());
+	for (const TemplateParameterNode& param : template_params) {
+		result.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
+	}
+	return result;
+}
+
 } // namespace
 
 std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key) {
@@ -112,9 +132,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 					size_t pack_size = 0;
 					bool found_pack = false;
 					for (size_t i = 0; i < lazy_info.template_params.size(); ++i) {
-						if (!lazy_info.template_params[i].is<TemplateParameterNode>())
-							continue;
-						const TemplateParameterNode& tparam = lazy_info.template_params[i].as<TemplateParameterNode>();
+						const TemplateParameterNode& tparam = lazy_info.template_params[i];
 						if (!tparam.is_variadic()) {
 							non_variadic++;
 							continue;
@@ -285,9 +303,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			InlineVector<StringHandle, 4> param_names;
 			param_names.reserve(lazy_info.template_params.size());
 			for (const auto& tparam_node : lazy_info.template_params) {
-				if (tparam_node.is<TemplateParameterNode>()) {
-					param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
-				}
+				param_names.push_back(tparam_node.nameHandle());
 			}
 			registerTypeParamsInScope(param_names, lazy_info.template_args, template_scope, true);
 
@@ -442,11 +458,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			ctx.parser = this;
 			ctx.sema = getActiveSemanticAnalysis();
 			ctx.template_args = converted_template_args;
-			for (const ASTNode& template_param : lazy_info.template_params) {
-				if (const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_param);
-					tparam != nullptr) {
-					ctx.template_param_names.push_back(tparam->name());
-				}
+			for (const TemplateParameterNode& tparam : lazy_info.template_params) {
+				ctx.template_param_names.push_back(tparam.name());
 			}
 			auto owner_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
 			if (owner_it != getTypesByNameMap().end() && owner_it->second) {
@@ -508,12 +521,14 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	// Slice 4: use the canonical instantiated lookup name (from identity) as the
 	// function identifier token so the emitted body matches the stub's registered name.
 	StringHandle fn_name_handle = effectiveLookupName(lazy_info.identity);
+	const InlineVector<ASTNode, 4> lazy_template_params_ast =
+		cloneTemplateParameterNodes(lazy_info.template_params);
 	SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
 		func_decl,
 		decl.type_node(),
 		decl.type_specifier_node().token(),
 		lazy_info.identity.instantiated_owner_name,
-		lazy_info.template_params,
+		lazy_template_params_ast,
 		lazy_info.template_args,
 		owner_struct_decl,
 		instantiated_owner_type_index,
@@ -532,7 +547,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	substituteAndCopyMemberFunctionParameters(
 		func_decl.parameter_nodes(),
 		new_func_ref,
-		lazy_info.template_params,
+		lazy_template_params_ast,
 		lazy_info.template_args,
 		owner_struct_decl,
 		instantiated_owner_type_index,
@@ -564,9 +579,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		InlineVector<StringHandle, 4> param_names;
 		param_names.reserve(lazy_info.template_params.size());
 		for (const auto& tparam_node : lazy_info.template_params) {
-			if (tparam_node.is<TemplateParameterNode>()) {
-				param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
-			}
+			param_names.push_back(tparam_node.nameHandle());
 		}
 
 		registerTypeParamsInScope(param_names, lazy_info.template_args, template_scope, true);
@@ -781,6 +794,10 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 	}
 
 	const LazyStaticMemberInfo& lazy_info = *lazy_info_ptr;
+	const InlineVector<TemplateParameterNode, 4> lazy_template_params_inline =
+		toInlineTemplateParams(lazy_info.template_params);
+	const std::vector<ASTNode> lazy_template_params_ast =
+		toAstTemplateParams(lazy_info.template_params);
 
 	// Find the struct_info to add the member to
 	auto type_it = getTypesByNameMap().find(instantiated_class_name);
@@ -808,14 +825,12 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		}
 
 		FlashCpp::TemplateParameterScope template_scope;
-		registerTypeParamsInScope(lazy_info.template_params, lazy_info.template_args, template_scope, true);
+		registerTypeParamsInScope(lazy_template_params_inline, lazy_info.template_args, template_scope, true);
 
 		InlineVector<StringHandle, 4> param_names;
 		param_names.reserve(lazy_info.template_params.size());
 		for (const auto& tparam_node : lazy_info.template_params) {
-			if (tparam_node.is<TemplateParameterNode>()) {
-				param_names.push_back(tparam_node.as<TemplateParameterNode>().nameHandle());
-			}
+			param_names.push_back(tparam_node.nameHandle());
 		}
 
 		SaveHandle current_pos = save_token_position();
@@ -888,19 +903,17 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		!initializer_replayed &&
 		lazy_info.initializer->is<ExpressionNode>()) {
 		const ExpressionNode& expr = lazy_info.initializer->as<ExpressionNode>();
-		const auto& template_params = lazy_info.template_params;
+		const auto& template_params = lazy_template_params_inline;
 		const auto& template_args = lazy_info.template_args;
 
 		// Helper to calculate pack size for substitution
 		auto calculate_pack_size = [&](std::string_view pack_name) -> std::optional<size_t> {
 			for (size_t i = 0; i < template_params.size(); ++i) {
-				if (!template_params[i].is<TemplateParameterNode>())
-					continue;
-				const TemplateParameterNode& tparam = template_params[i].as<TemplateParameterNode>();
+				const TemplateParameterNode& tparam = template_params[i];
 				if (tparam.name() == pack_name && tparam.is_variadic()) {
 					size_t non_variadic_count = 0;
 					for (const auto& param : template_params) {
-						if (param.is<TemplateParameterNode>() && !param.as<TemplateParameterNode>().is_variadic()) {
+						if (!param.is_variadic()) {
 							non_variadic_count++;
 						}
 					}
@@ -934,9 +947,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			// Find the parameter pack
 			std::optional<size_t> pack_param_idx;
 			for (size_t p = 0; p < template_params.size(); ++p) {
-				if (!template_params[p].is<TemplateParameterNode>())
-					continue;
-				const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
+				const TemplateParameterNode& tparam = template_params[p];
 				if (tparam.name() == pack_name && tparam.is_variadic()) {
 					pack_param_idx = p;
 					break;
@@ -950,7 +961,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 
 				size_t non_variadic_count = 0;
 				for (const auto& param : template_params) {
-					if (param.is<TemplateParameterNode>() && !param.as<TemplateParameterNode>().is_variadic()) {
+					if (!param.is_variadic()) {
 						non_variadic_count++;
 					}
 				}
@@ -985,7 +996,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		else if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
 			const TemplateParameterReferenceNode& tparam_ref = std::get<TemplateParameterReferenceNode>(expr);
 			if (auto subst = substitute_nontype_template_param(
-					tparam_ref.param_name().view(), template_args, template_params)) {
+					tparam_ref.param_name().view(), template_args, lazy_template_params_ast)) {
 				substituted_initializer = subst;
 			}
 		}
@@ -993,7 +1004,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		else if (std::holds_alternative<IdentifierNode>(expr)) {
 			const IdentifierNode& id_node = std::get<IdentifierNode>(expr);
 			if (auto subst = substitute_nontype_template_param(
-					id_node.name(), template_args, template_params)) {
+					id_node.name(), template_args, lazy_template_params_ast)) {
 				substituted_initializer = subst;
 			}
 		}
@@ -1057,10 +1068,8 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			eval_ctx.struct_info = struct_info;
 			// Provide template args so sizeof(T) etc. resolve correctly.
 			for (size_t i = 0; i < lazy_info.template_params.size() && i < lazy_info.template_args.size(); ++i) {
-				if (lazy_info.template_params[i].is<TemplateParameterNode>()) {
-					eval_ctx.template_param_names.push_back(lazy_info.template_params[i].as<TemplateParameterNode>().name());
-					eval_ctx.template_args.push_back(lazy_info.template_args[i]);
-				}
+				eval_ctx.template_param_names.push_back(lazy_info.template_params[i].name());
+				eval_ctx.template_args.push_back(lazy_info.template_args[i]);
 			}
 			auto eval_result = ConstExpr::Evaluator::evaluate(*substituted_initializer, eval_ctx);
 			if (eval_result.success()) {
@@ -1092,7 +1101,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 	original_type_spec.set_type_index(lazy_info.type_index);
 
 	TypeIndex substituted_type_index = substitute_template_parameter(
-		original_type_spec, lazy_info.template_params, lazy_info.template_args);
+		original_type_spec, lazy_template_params_inline, lazy_info.template_args);
 
 	size_t substituted_size = get_type_size_bits(substituted_type_index.category()) / 8;
 	if (lazy_info.is_array) {
@@ -1255,8 +1264,10 @@ std::optional<TypeIndex> Parser::evaluateLazyTypeAlias(
 	const TypeSpecifierNode& target_type = lazy_info->unevaluated_target.as<TypeSpecifierNode>();
 
 	// Perform template parameter substitution
+	const InlineVector<TemplateParameterNode, 4> lazy_template_params_inline =
+		toInlineTemplateParams(lazy_info->template_params);
 	TypeIndex substituted_type_index = substitute_template_parameter(
-		target_type, lazy_info->template_params, lazy_info->template_args);
+		target_type, lazy_template_params_inline, lazy_info->template_args);
 
 	// Cache the result
 	registry.markEvaluated(instantiated_class_name, member_name, substituted_type_index);
@@ -1327,13 +1338,15 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 	auto nested_struct_info = std::make_unique<StructTypeInfo>(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
 
 	// Process members with template parameter substitution
+	const InlineVector<TemplateParameterNode, 4> parent_template_params_inline =
+		toInlineTemplateParams(lazy_info->parent_template_params);
 	for (const auto& member_decl : nested_struct.members()) {
 		const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 		const TypeSpecifierNode& type_spec = decl.type_specifier_node();
 
 		// Substitute template parameters using parent's template args
 		TypeIndex substituted_type_index = substitute_template_parameter(
-			type_spec, lazy_info->parent_template_params, lazy_info->parent_template_args);
+			type_spec, parent_template_params_inline, lazy_info->parent_template_args);
 
 		// Get size and alignment for the member
 		size_t member_size = get_type_size_bits(substituted_type_index.category()) / 8;

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -503,190 +503,45 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		it != getTypesByNameMap().end()) {
 		instantiated_owner_type_index = it->second->type_index_;
 	}
-	auto resolve_self_type = [&](TypeIndex& type_index) {
-		if (instantiated_owner_type_index.is_valid()) {
-			type_index = resolveSelfRefParamIndex(type_index, instantiated_owner_type_index);
-		}
-	};
-
-	const TypeSpecifierNode& return_type_spec = decl.type_specifier_node();
-	TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
-		return_type_spec,
-		decl.type_node(),
-		return_type_spec.token(),
-		lazy_info.template_params,
-		lazy_info.template_args,
-		[this](const ASTNode& node, const auto& params, const auto& args) {
-			return substituteTemplateParameters(node, params, args);
-		},
-		[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-			return substitute_template_parameter(type_spec, params, args);
-		},
-		owner_struct_decl,
-		instantiated_owner_type_index,
-		TypeIndex{},
-		false,
-		true);
-
-	auto substituted_return_node = emplace_node<TypeSpecifierNode>(substituted_return_type);
-
 	// Invariant: fn_identifier_token.handle() == effectiveLookupName(lazy_info.identity).
 	// This is asserted below after finalization (Slice 5).
 	// Slice 4: use the canonical instantiated lookup name (from identity) as the
 	// function identifier token so the emitted body matches the stub's registered name.
 	StringHandle fn_name_handle = effectiveLookupName(lazy_info.identity);
-	Token fn_identifier_token(Token::Type::Identifier,
-							  StringTable::getStringView(fn_name_handle),
-							  decl.identifier_token().line(), decl.identifier_token().column(),
-							  decl.identifier_token().file_index());
-	auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(
-		substituted_return_node, fn_identifier_token);
-	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-		new_func_decl_ref, lazy_info.identity.instantiated_owner_name);
-	setOuterTemplateBindingsFromParams(new_func_ref, lazy_info.template_params, lazy_info.template_args);
+	SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+		func_decl,
+		decl.type_node(),
+		decl.type_specifier_node().token(),
+		lazy_info.identity.instantiated_owner_name,
+		lazy_info.template_params,
+		lazy_info.template_args,
+		owner_struct_decl,
+		instantiated_owner_type_index,
+		TypeIndex{}, // No pre-resolved return TypeIndex override
+		lazy_info.identity.operator_kind,
+		fn_name_handle, // Keep registry canonical lookup name stable across replay
+		StringHandle{}, // No partial-pattern pointer-depth clamp in lazy replay path
+		false,		   // Do not re-apply bound metadata to full substitution
+		true);		   // Force resolved TypeIndex onto full AST substitutions
+	ASTNode new_func_node = shell.function_node;
+	FunctionDeclarationNode& new_func_ref = *shell.function;
 
 	// Substitute and copy parameters, expanding variadic pack parameters into N individual
 	// parameters (args_0, args_1, ...) and populating pack_param_info_ for body expansion.
 	size_t saved_pack_info = pack_param_info_.size();
-	for (const auto& param : func_decl.parameter_nodes()) {
-		if (param.is<DeclarationNode>()) {
-			const DeclarationNode& param_decl = param.as<DeclarationNode>();
-			const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-			// Expand variadic pack parameters (e.g. "Args... args") into N params.
-			bool handled_as_pack = false;
-			if (param_decl.is_parameter_pack() && (param_type_spec.category() == TypeCategory::UserDefined || param_type_spec.category() == TypeCategory::TypeAlias || param_type_spec.category() == TypeCategory::Template)) {
-				std::string_view type_name = param_type_spec.token().value();
-				size_t non_variadic = 0;
-				size_t pack_size = 0;
-				bool found_pack = false;
-				for (size_t i = 0; i < lazy_info.template_params.size(); ++i) {
-					if (!lazy_info.template_params[i].is<TemplateParameterNode>())
-						continue;
-					const TemplateParameterNode& tparam = lazy_info.template_params[i].as<TemplateParameterNode>();
-					if (!tparam.is_variadic()) {
-						non_variadic++;
-						continue;
-					}
-					if (tparam.name() == type_name) {
-						pack_size = lazy_info.template_args.size() > non_variadic
-										? lazy_info.template_args.size() - non_variadic
-										: 0;
-						found_pack = true;
-						break;
-					}
-				}
-				if (found_pack) {
-					if (pack_size == 0) {
-						handled_as_pack = true;
-					} // empty pack, skip
-					else {
-						std::string_view orig_name = param_decl.identifier_token().value();
-						for (size_t pi = 0; pi < pack_size; ++pi) {
-							const TemplateTypeArg& elem = lazy_info.template_args[non_variadic + pi];
-							TypeCategory elem_type = elem.typeEnum();
-							TypeIndex elem_type_index = elem.type_index;
-							TypeSpecifierNode sub_type(
-								elem_type, param_type_spec.qualifier(),
-								get_type_size_bits(elem_type),
-								param_decl.identifier_token(), param_type_spec.cv_qualifier());
-							sub_type.set_type_index(elem_type_index);
-							for (const auto& pl : param_type_spec.pointer_levels())
-								sub_type.add_pointer_level(pl.cv_qualifier);
-							sub_type.set_reference_qualifier(param_type_spec.reference_qualifier());
-							if (elem.function_signature.has_value()) {
-								sub_type.set_function_signature(*elem.function_signature);
-							}
-							normalizeSubstitutedTypeSpec(sub_type);
-							StringBuilder name_builder;
-							name_builder.append(orig_name).append('_').append(pi);
-							Token elem_token(Token::Type::Identifier, name_builder.commit(),
-											 param_decl.identifier_token().line(),
-											 param_decl.identifier_token().column(),
-											 param_decl.identifier_token().file_index());
-							new_func_ref.add_parameter_node(emplace_node<DeclarationNode>(
-								emplace_node<TypeSpecifierNode>(sub_type), elem_token));
-						}
-						pack_param_info_.push_back({orig_name, 0, pack_size});
-						handled_as_pack = true;
-					}
-				}
-			}
-			if (handled_as_pack)
-				continue;
-
-			// Substitute parameter type
-			TypeIndex param_type_index = substitute_template_parameter(
-				param_type_spec, lazy_info.template_params, lazy_info.template_args);
-			if (owner_struct_decl) {
-				param_type_index = resolveOwnerAliasTypeIndex(
-					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-						return substitute_template_parameter(type_spec, params, args);
-					},
-					*owner_struct_decl,
-					param_type_spec,
-					lazy_info.template_params,
-					lazy_info.template_args,
-					param_type_index);
-			}
-
-			// Resolve self-referential class types (same as return type)
-			resolve_self_type(param_type_index);
-
-			// Use substituteTemplateParameters as the primary substitution to correctly
-			// propagate pointer depth from template args (e.g. I→int* gives ptr_depth=1).
-			// The TypeIndex from substitute_template_parameter+resolve_self_type is then
-			// applied on top to handle self-referential types.
-			ASTNode full_substituted_param_node = substituteTemplateParameters(
-				param_decl.type_node(), lazy_info.template_params, lazy_info.template_args);
-			TypeSpecifierNode substituted_param_type = full_substituted_param_node.is<TypeSpecifierNode>()
-				? full_substituted_param_node.as<TypeSpecifierNode>()
-				: TypeSpecifierNode(
-					  param_type_index.category(),
-					  param_type_spec.qualifier(),
-					  get_type_size_bits(param_type_index.category()),
-					  param_decl.identifier_token(),
-					  param_type_spec.cv_qualifier());
-			// Apply the self-type-resolved TypeIndex.
-			if (param_type_index.is_valid()) {
-				substituted_param_type.set_type_index(param_type_index);
-			}
-			if (!full_substituted_param_node.is<TypeSpecifierNode>()) {
-				// Fallback: copy pointer levels and reference qualifiers from original.
-				for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-					substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
-				}
-				substituted_param_type.set_reference_qualifier(param_type_spec.reference_qualifier());
-			}
-			if (param_type_spec.has_function_signature()) {
-				substituted_param_type.set_function_signature(param_type_spec.function_signature());
-			} else if (param_type_index.category() == TypeCategory::FunctionPointer ||
-					   param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-				// The original param_type_spec is a dependent placeholder (e.g. "F")
-				// that has no function_signature.  Look up the concrete TemplateTypeArg.
-				if (const auto* arg = findTemplateArgByName(param_type_spec.token().value(),
-															lazy_info.template_params, lazy_info.template_args)) {
-					if (arg->function_signature.has_value())
-						substituted_param_type.set_function_signature(*arg->function_signature);
-				}
-			}
-			normalizeSubstitutedTypeSpec(substituted_param_type);
-
-			auto substituted_param_type_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
-			auto substituted_param_decl = emplace_node<DeclarationNode>(
-				substituted_param_type_node, param_decl.identifier_token());
-			// Copy default value if present
-			if (param_decl.has_default_value()) {
-				ASTNode substituted_default = substituteTemplateParameters(
-					param_decl.default_value(), lazy_info.template_params, lazy_info.template_args);
-				substituted_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
-			}
-			new_func_ref.add_parameter_node(substituted_param_decl);
-		} else {
-			// Non-declaration parameter, copy as-is
-			new_func_ref.add_parameter_node(param);
-		}
-	}
+	substituteAndCopyMemberFunctionParameters(
+		func_decl.parameter_nodes(),
+		new_func_ref,
+		lazy_info.template_params,
+		lazy_info.template_args,
+		owner_struct_decl,
+		instantiated_owner_type_index,
+		TypeIndex{},
+		TypeIndex{},
+		SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+		true,  // Preserve declared parameter cv-qualifier in this path
+		false, // Do not re-apply bound metadata to full substitution
+		true); // Force resolved TypeIndex onto full AST substitutions
 
 	// Get the function body - either from definition or by re-parsing from saved position
 	std::optional<ASTNode> body_to_substitute;

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -25,26 +25,6 @@ namespace {
 		.commit()));
 }
 
-InlineVector<TemplateParameterNode, 4> toInlineTemplateParams(
-	const std::vector<TemplateParameterNode>& template_params) {
-	InlineVector<TemplateParameterNode, 4> result;
-	result.reserve(template_params.size());
-	for (const TemplateParameterNode& param : template_params) {
-		result.push_back(param);
-	}
-	return result;
-}
-
-std::vector<ASTNode> toAstTemplateParams(
-	const std::vector<TemplateParameterNode>& template_params) {
-	std::vector<ASTNode> result;
-	result.reserve(template_params.size());
-	for (const TemplateParameterNode& param : template_params) {
-		result.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
-	}
-	return result;
-}
-
 } // namespace
 
 std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key) {
@@ -792,10 +772,8 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 	}
 
 	const LazyStaticMemberInfo& lazy_info = *lazy_info_ptr;
-	const InlineVector<TemplateParameterNode, 4> lazy_template_params_inline =
-		toInlineTemplateParams(lazy_info.template_params);
-	const std::vector<ASTNode> lazy_template_params_ast =
-		toAstTemplateParams(lazy_info.template_params);
+	const InlineVector<TemplateParameterNode, 4>& lazy_template_params_inline =
+		lazy_info.template_params;
 
 	// Find the struct_info to add the member to
 	auto type_it = getTypesByNameMap().find(instantiated_class_name);
@@ -994,7 +972,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		else if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
 			const TemplateParameterReferenceNode& tparam_ref = std::get<TemplateParameterReferenceNode>(expr);
 			if (auto subst = substitute_nontype_template_param(
-					tparam_ref.param_name().view(), template_args, lazy_template_params_ast)) {
+					tparam_ref.param_name().view(), template_args, lazy_info.template_params)) {
 				substituted_initializer = subst;
 			}
 		}
@@ -1002,7 +980,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		else if (std::holds_alternative<IdentifierNode>(expr)) {
 			const IdentifierNode& id_node = std::get<IdentifierNode>(expr);
 			if (auto subst = substitute_nontype_template_param(
-					id_node.name(), template_args, lazy_template_params_ast)) {
+					id_node.name(), template_args, lazy_info.template_params)) {
 				substituted_initializer = subst;
 			}
 		}
@@ -1262,8 +1240,8 @@ std::optional<TypeIndex> Parser::evaluateLazyTypeAlias(
 	const TypeSpecifierNode& target_type = lazy_info->unevaluated_target.as<TypeSpecifierNode>();
 
 	// Perform template parameter substitution
-	const InlineVector<TemplateParameterNode, 4> lazy_template_params_inline =
-		toInlineTemplateParams(lazy_info->template_params);
+	const InlineVector<TemplateParameterNode, 4>& lazy_template_params_inline =
+		lazy_info->template_params;
 	TypeIndex substituted_type_index = substitute_template_parameter(
 		target_type, lazy_template_params_inline, lazy_info->template_args);
 
@@ -1336,8 +1314,8 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 	auto nested_struct_info = std::make_unique<StructTypeInfo>(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
 
 	// Process members with template parameter substitution
-	const InlineVector<TemplateParameterNode, 4> parent_template_params_inline =
-		toInlineTemplateParams(lazy_info->parent_template_params);
+	const InlineVector<TemplateParameterNode, 4>& parent_template_params_inline =
+		lazy_info->parent_template_params;
 	for (const auto& member_decl : nested_struct.members()) {
 		const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 		const TypeSpecifierNode& type_spec = decl.type_specifier_node();

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -521,14 +521,12 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	// Slice 4: use the canonical instantiated lookup name (from identity) as the
 	// function identifier token so the emitted body matches the stub's registered name.
 	StringHandle fn_name_handle = effectiveLookupName(lazy_info.identity);
-	const InlineVector<ASTNode, 4> lazy_template_params_ast =
-		cloneTemplateParameterNodes(lazy_info.template_params);
 	SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
 		func_decl,
 		decl.type_node(),
 		decl.type_specifier_node().token(),
 		lazy_info.identity.instantiated_owner_name,
-		lazy_template_params_ast,
+		lazy_info.template_params,
 		lazy_info.template_args,
 		owner_struct_decl,
 		instantiated_owner_type_index,
@@ -547,7 +545,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	substituteAndCopyMemberFunctionParameters(
 		func_decl.parameter_nodes(),
 		new_func_ref,
-		lazy_template_params_ast,
+		lazy_info.template_params,
 		lazy_info.template_args,
 		owner_struct_decl,
 		instantiated_owner_type_index,

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -607,7 +607,7 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 
 		// Register the static member variable definition
 		OutOfLineMemberVariable out_of_line_var;
-		out_of_line_var.template_params = cloneTemplateParameterNodes(template_params);
+		out_of_line_var.template_params = template_params;
 		out_of_line_var.member_name = function_name_token.handle();	// Actually the variable name
 		out_of_line_var.type_node = return_type_node;				  // Actually the variable type
 		out_of_line_var.initializer = *init_result.node();
@@ -631,7 +631,7 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 		// Register the static member variable definition without initializer
 		// This is used for providing storage for static constexpr members declared in the class
 		OutOfLineMemberVariable out_of_line_var;
-		out_of_line_var.template_params = cloneTemplateParameterNodes(template_params);
+		out_of_line_var.template_params = template_params;
 		out_of_line_var.member_name = function_name_token.handle();	// Actually the variable name
 		out_of_line_var.type_node = return_type_node;				  // Actually the variable type
 		// No initializer for this case

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -191,12 +191,10 @@ ParseResult Parser::parse_template_parameter() {
 		}
 
 		// Create template template parameter node
-		std::vector<TemplateParameterNode> nested_params_vec;
-		nested_params_vec.reserve(nested_params.size());
-		for (const TemplateParameterNode& nested_param : nested_params) {
-			nested_params_vec.push_back(nested_param);
-		}
-		auto param_node = emplace_node<TemplateParameterNode>(StringTable::getOrInternStringHandle(param_name), std::move(nested_params_vec), param_name_token);
+		auto param_node = emplace_node<TemplateParameterNode>(
+			StringTable::getOrInternStringHandle(param_name),
+			std::span<const TemplateParameterNode>(nested_params.data(), nested_params.size()),
+			param_name_token);
 
 		// Handle default arguments (e.g., template<typename> class Container = std::vector)
 		if (peek() == "="_tok) {

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -130,15 +130,6 @@ Parser::TemplateParameterMetadata Parser::registerTemplateParametersInScope(
 	return metadata;
 }
 
-InlineVector<ASTNode, 4> Parser::cloneTemplateParameterNodes(const InlineVector<TemplateParameterNode, 4>& template_params) {
-	InlineVector<ASTNode, 4> ast_nodes;
-	ast_nodes.reserve(template_params.size());
-	for (const TemplateParameterNode& template_param : template_params) {
-		ast_nodes.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_param));
-	}
-	return ast_nodes;
-}
-
 // Parse a single template parameter: typename T, class T, int N, etc.
 ParseResult Parser::parse_template_parameter() {
 	ScopedTokenPosition saved_position(*this);
@@ -157,7 +148,7 @@ ParseResult Parser::parse_template_parameter() {
 		advance(); // consume '<'
 
 		// Parse nested template parameter forms (just type specifiers, no names)
-		std::vector<ASTNode> nested_params;
+		InlineVector<TemplateParameterNode, 4> nested_params;
 		auto param_list_result = parse_template_template_parameter_forms(nested_params);
 		if (param_list_result.is_error()) {
 			FLASH_LOG(Parser, Error, "parse_template_template_parameter_forms failed");
@@ -200,7 +191,12 @@ ParseResult Parser::parse_template_parameter() {
 		}
 
 		// Create template template parameter node
-		auto param_node = emplace_node<TemplateParameterNode>(StringTable::getOrInternStringHandle(param_name), std::move(nested_params), param_name_token);
+		std::vector<TemplateParameterNode> nested_params_vec;
+		nested_params_vec.reserve(nested_params.size());
+		for (const TemplateParameterNode& nested_param : nested_params) {
+			nested_params_vec.push_back(nested_param);
+		}
+		auto param_node = emplace_node<TemplateParameterNode>(StringTable::getOrInternStringHandle(param_name), std::move(nested_params_vec), param_name_token);
 
 		// Handle default arguments (e.g., template<typename> class Container = std::vector)
 		if (peek() == "="_tok) {
@@ -527,7 +523,7 @@ ParseResult Parser::parse_template_parameter() {
 
 // Parse template template parameter forms (just type specifiers without names)
 // Used for template<template<typename> class Container> syntax
-ParseResult Parser::parse_template_template_parameter_forms(std::vector<ASTNode>& out_params) {
+ParseResult Parser::parse_template_template_parameter_forms(InlineVector<TemplateParameterNode, 4>& out_params) {
 	// Parse first parameter form
 	auto param_result = parse_template_template_parameter_form();
 	if (param_result.is_error()) {
@@ -535,7 +531,10 @@ ParseResult Parser::parse_template_template_parameter_forms(std::vector<ASTNode>
 	}
 
 	if (param_result.node().has_value()) {
-		out_params.push_back(*param_result.node());
+		if (!param_result.node()->is<TemplateParameterNode>()) {
+			return ParseResult::error("Expected template parameter node", current_token_);
+		}
+		out_params.push_back(param_result.node()->as<TemplateParameterNode>());
 	}
 
 	// Parse additional parameter forms separated by commas
@@ -548,7 +547,10 @@ ParseResult Parser::parse_template_template_parameter_forms(std::vector<ASTNode>
 		}
 
 		if (param_result.node().has_value()) {
-			out_params.push_back(*param_result.node());
+			if (!param_result.node()->is<TemplateParameterNode>()) {
+				return ParseResult::error("Expected template parameter node", current_token_);
+			}
+			out_params.push_back(param_result.node()->as<TemplateParameterNode>());
 		}
 	}
 

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -283,7 +283,7 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	std::span<const TemplateTypeArg> template_args) {
 	// Helper function to get type name as string
 	auto get_type_name = [](TypeCategory type) -> std::string_view {
 		switch (type) {
@@ -792,7 +792,7 @@ ASTNode Parser::substituteTemplateParameters(
 					if (!func_pack_name.empty() && expanded_pack_expr.has_value()) {
 						expanded_pack_expr = replacePackIdentifierInExpr(expanded_pack_expr, func_pack_name, i);
 					}
-					ASTNode substituted = substituteTemplateParameters(expanded_pack_expr, subst_params, subst_args);
+					ASTNode substituted = substituteTemplateParameters(expanded_pack_expr, std::span<const ASTNode>(subst_params.data(), subst_params.size()), std::span<const TemplateTypeArg>(subst_args.data(), subst_args.size()));
 					pack_values.push_back(substituted);
 				}
 			} else {
@@ -1627,34 +1627,6 @@ ASTNode Parser::substituteTemplateParameters(
 	return node;
 }
 
-ASTNode Parser::substituteTemplateParameters(
-	const ASTNode& node,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	return substituteTemplateParameters(
-		node,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args);
-}
-
-ASTNode Parser::substituteTemplateParameters(
-	const ASTNode& node,
-	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return substituteTemplateParameters(
-		node,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
 // Extract base template name from a mangled template instantiation name
 // Supports underscore-based naming: "enable_if_void_int" -> "enable_if"
 // Future: Will support hash-based naming: "enable_if$abc123" -> "enable_if"
@@ -1803,13 +1775,31 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 	return nullptr;
 }
 
+ASTNode Parser::substituteTemplateParameters(
+	const ASTNode& node,
+	std::span<const ASTNode> template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return substituteTemplateParameters(
+		node,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args);
+}
+
 // Expand a PackExpansionExprNode into multiple substituted arguments for function calls.
 // For each pack element, the pattern expression is cloned with the pack identifier replaced,
 // then template parameters are substituted.
 bool Parser::expandPackExpansionArgs(
 	const PackExpansionExprNode& pack_expansion,
 	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	ChunkedVector<ASTNode>& out_args) {
 
 	const ASTNode& pattern = pack_expansion.pattern();
@@ -1872,7 +1862,7 @@ bool Parser::expandPackExpansionArgs(
 		// Replace the function parameter pack identifier (e.g., "args") with
 		// the expanded element name (e.g., "args_0") in the pattern before substitution
 		ASTNode expanded_pattern = replacePackIdentifierInExpr(pattern, func_pack_name, pi);
-		ASTNode substituted = substituteTemplateParameters(expanded_pattern, subst_params, subst_args);
+		ASTNode substituted = substituteTemplateParameters(expanded_pattern, std::span<const TemplateParameterNode>(subst_params.data(), subst_params.size()), std::span<const TemplateTypeArg>(subst_args.data(), subst_args.size()));
 		out_args.push_back(substituted);
 	}
 	return true;
@@ -1880,20 +1870,8 @@ bool Parser::expandPackExpansionArgs(
 
 bool Parser::expandPackExpansionArgs(
 	const PackExpansionExprNode& pack_expansion,
-	const InlineVector<TemplateParameterNode, 4>& template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
-	ChunkedVector<ASTNode>& out_args) {
-	return expandPackExpansionArgs(
-		pack_expansion,
-		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
-		template_args,
-		out_args);
-}
-
-bool Parser::expandPackExpansionArgs(
-	const PackExpansionExprNode& pack_expansion,
 	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	ChunkedVector<ASTNode>& out_args) {
 	InlineVector<TemplateParameterNode, 4> typed_params;
 	typed_params.reserve(template_params.size());
@@ -1916,7 +1894,7 @@ bool Parser::expandPackExpansionArgs(
 void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
 	std::span<const TemplateParameterNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	ChunkedVector<ASTNode>& out) {
 	if (arg.is<ExpressionNode>()) {
 		const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
@@ -1932,7 +1910,7 @@ void Parser::substituteArgWithPackExpansion(
 void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
 	std::span<const ASTNode> template_params,
-	const InlineVector<TemplateTypeArg, 4>& template_args,
+	std::span<const TemplateTypeArg> template_args,
 	ChunkedVector<ASTNode>& out) {
 	InlineVector<TemplateParameterNode, 4> typed_params;
 	typed_params.reserve(template_params.size());

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -757,7 +757,7 @@ ASTNode Parser::substituteTemplateParameters(
 				// (mirroring buildSubstitutionForPackElement) so each pack reads from its own slice.
 				for (size_t i = 0; i < num_pack_elements; ++i) {
 					// Also include the non-variadic parameters so they get substituted too
-					std::vector<ASTNode> subst_params;
+					std::vector<TemplateParameterNode> subst_params;
 					std::vector<TemplateTypeArg> subst_args;
 					size_t template_arg_index = 0;
 					for (size_t p = 0; p < template_params.size(); ++p) {
@@ -775,13 +775,13 @@ ASTNode Parser::substituteTemplateParameters(
 								// Create a non-variadic version of this parameter for single substitution
 								TemplateParameterNode single_tparam(tparam.nameHandle(), tparam.token());
 								// Don't set variadic - we're substituting one element at a time
-								subst_params.push_back(emplace_node<TemplateParameterNode>(single_tparam));
+								subst_params.push_back(single_tparam);
 								subst_args.push_back(template_args[template_arg_index + i]);
 							}
 							template_arg_index += pack_size;
 						} else {
 							if (template_arg_index < template_args.size()) {
-								subst_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_params[p]));
+								subst_params.push_back(template_params[p]);
 								subst_args.push_back(template_args[template_arg_index]);
 							}
 							++template_arg_index;
@@ -792,7 +792,7 @@ ASTNode Parser::substituteTemplateParameters(
 					if (!func_pack_name.empty() && expanded_pack_expr.has_value()) {
 						expanded_pack_expr = replacePackIdentifierInExpr(expanded_pack_expr, func_pack_name, i);
 					}
-					ASTNode substituted = substituteTemplateParameters(expanded_pack_expr, std::span<const ASTNode>(subst_params.data(), subst_params.size()), std::span<const TemplateTypeArg>(subst_args.data(), subst_args.size()));
+					ASTNode substituted = substituteTemplateParameters(expanded_pack_expr, subst_params, subst_args);
 					pack_values.push_back(substituted);
 				}
 			} else {
@@ -1775,24 +1775,6 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 	return nullptr;
 }
 
-ASTNode Parser::substituteTemplateParameters(
-	const ASTNode& node,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return substituteTemplateParameters(
-		node,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args);
-}
-
 // Expand a PackExpansionExprNode into multiple substituted arguments for function calls.
 // For each pack element, the pattern expression is cloned with the pack identifier replaced,
 // then template parameters are substituted.
@@ -1868,26 +1850,6 @@ bool Parser::expandPackExpansionArgs(
 	return true;
 }
 
-bool Parser::expandPackExpansionArgs(
-	const PackExpansionExprNode& pack_expansion,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	ChunkedVector<ASTNode>& out_args) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	return expandPackExpansionArgs(
-		pack_expansion,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		out_args);
-}
-
 // Substitute a single argument, expanding PackExpansionExprNode when present.
 // Consolidates the repeated check-expand-or-substitute pattern used in
 // ordinary call-expression, constructor-call, and member-call handlers.
@@ -1905,26 +1867,6 @@ void Parser::substituteArgWithPackExpansion(
 		}
 	}
 	out.push_back(substituteTemplateParameters(arg, template_params, template_args));
-}
-
-void Parser::substituteArgWithPackExpansion(
-	const ASTNode& arg,
-	std::span<const ASTNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	ChunkedVector<ASTNode>& out) {
-	InlineVector<TemplateParameterNode, 4> typed_params;
-	typed_params.reserve(template_params.size());
-	for (const ASTNode& template_param : template_params) {
-		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
-			typed_param != nullptr) {
-			typed_params.push_back(*typed_param);
-		}
-	}
-	substituteArgWithPackExpansion(
-		arg,
-		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
-		template_args,
-		out);
 }
 
 // Replace a pack parameter identifier in an expression pattern with its expanded element name.

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -282,7 +282,7 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	// Helper function to get type name as string
 	auto get_type_name = [](TypeCategory type) -> std::string_view {
@@ -1801,7 +1801,7 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 // then template parameters are substituted.
 bool Parser::expandPackExpansionArgs(
 	const PackExpansionExprNode& pack_expansion,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	ChunkedVector<ASTNode>& out_args) {
 
@@ -1892,7 +1892,7 @@ bool Parser::expandPackExpansionArgs(
 // ordinary call-expression, constructor-call, and member-call handlers.
 void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
-	const InlineVector<ASTNode, 4>& template_params,
+	std::span<const ASTNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	ChunkedVector<ASTNode>& out) {
 	if (arg.is<ExpressionNode>()) {

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -282,7 +282,7 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	// Helper function to get type name as string
 	auto get_type_name = [](TypeCategory type) -> std::string_view {
@@ -374,10 +374,7 @@ ASTNode Parser::substituteTemplateParameters(
 		std::vector<std::string_view> template_param_order;
 		size_t arg_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (!template_params[i].is<TemplateParameterNode>()) {
-				continue;
-			}
-			const auto& tparam = template_params[i].as<TemplateParameterNode>();
+			const auto& tparam = template_params[i];
 			template_param_order.push_back(tparam.name());
 			if (tparam.is_variadic()) {
 				size_t remaining_args = arg_index < template_args.size()
@@ -557,9 +554,7 @@ ASTNode Parser::substituteTemplateParameters(
 							if (const TypeInfo* parg_type_info = tryGetTypeInfo(parg.type_index)) {
 								std::string_view arg_type_name = StringTable::getStringView(parg_type_info->name());
 								for (size_t p = 0; p < template_params.size() && p < template_args.size(); ++p) {
-									if (!template_params[p].is<TemplateParameterNode>())
-										continue;
-									const TemplateParameterNode& tparam = template_params[p].as<TemplateParameterNode>();
+									const TemplateParameterNode& tparam = template_params[p];
 									if (tparam.name() == arg_type_name) {
 									// Substitute with the concrete type
 										const TemplateTypeArg& concrete_arg = template_args[p];
@@ -703,13 +698,11 @@ ASTNode Parser::substituteTemplateParameters(
 				size_t variadic_param_idx = SIZE_MAX;
 				size_t non_variadic_count = 0;
 				for (size_t p = 0; p < template_params.size(); ++p) {
-					if (template_params[p].is<TemplateParameterNode>()) {
-						const auto& tparam = template_params[p].as<TemplateParameterNode>();
-						if (tparam.is_variadic()) {
-							variadic_param_idx = p;
-						} else {
-							non_variadic_count++;
-						}
+					const auto& tparam = template_params[p];
+					if (tparam.is_variadic()) {
+						variadic_param_idx = p;
+					} else {
+						non_variadic_count++;
 					}
 				}
 
@@ -717,7 +710,7 @@ ASTNode Parser::substituteTemplateParameters(
 				std::string_view func_pack_name;
 				if (variadic_param_idx != SIZE_MAX) {
 					NamedPackBinding primary_pack_binding = resolveNamedPackBinding(
-						template_params[variadic_param_idx].as<TemplateParameterNode>().name());
+						template_params[variadic_param_idx].name());
 					if (primary_pack_binding.found) {
 						num_pack_elements = primary_pack_binding.count;
 					} else if (template_args.size() >= non_variadic_count) {
@@ -768,32 +761,30 @@ ASTNode Parser::substituteTemplateParameters(
 					std::vector<TemplateTypeArg> subst_args;
 					size_t template_arg_index = 0;
 					for (size_t p = 0; p < template_params.size(); ++p) {
-						if (template_params[p].is<TemplateParameterNode>()) {
-							const auto& tparam = template_params[p].as<TemplateParameterNode>();
-							if (tparam.is_variadic()) {
-								// Determine this pack's size from template_param_pack_sizes_ if available;
-								// fall back to num_pack_elements (correct for single-pack functions).
-								size_t pack_size = num_pack_elements;
-								if (NamedPackBinding pack_binding = resolveNamedPackBinding(
-										tparam.name());
-									pack_binding.found) {
-									pack_size = pack_binding.count;
-								}
-								if (template_arg_index + i < template_args.size()) {
-									// Create a non-variadic version of this parameter for single substitution
-									TemplateParameterNode single_tparam(tparam.nameHandle(), tparam.token());
-									// Don't set variadic - we're substituting one element at a time
-									subst_params.push_back(emplace_node<TemplateParameterNode>(single_tparam));
-									subst_args.push_back(template_args[template_arg_index + i]);
-								}
-								template_arg_index += pack_size;
-							} else {
-								if (template_arg_index < template_args.size()) {
-									subst_params.push_back(template_params[p]);
-									subst_args.push_back(template_args[template_arg_index]);
-								}
-								++template_arg_index;
+						const auto& tparam = template_params[p];
+						if (tparam.is_variadic()) {
+							// Determine this pack's size from template_param_pack_sizes_ if available;
+							// fall back to num_pack_elements (correct for single-pack functions).
+							size_t pack_size = num_pack_elements;
+							if (NamedPackBinding pack_binding = resolveNamedPackBinding(
+									tparam.name());
+								pack_binding.found) {
+								pack_size = pack_binding.count;
 							}
+							if (template_arg_index + i < template_args.size()) {
+								// Create a non-variadic version of this parameter for single substitution
+								TemplateParameterNode single_tparam(tparam.nameHandle(), tparam.token());
+								// Don't set variadic - we're substituting one element at a time
+								subst_params.push_back(emplace_node<TemplateParameterNode>(single_tparam));
+								subst_args.push_back(template_args[template_arg_index + i]);
+							}
+							template_arg_index += pack_size;
+						} else {
+							if (template_arg_index < template_args.size()) {
+								subst_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(template_params[p]));
+								subst_args.push_back(template_args[template_arg_index]);
+							}
+							++template_arg_index;
 						}
 					}
 
@@ -811,11 +802,9 @@ ASTNode Parser::substituteTemplateParameters(
 				size_t num_pack_elements = pack_binding.found ? pack_binding.count : 0;
 				std::optional<size_t> pack_param_idx;
 				for (size_t p = 0; p < template_params.size(); ++p) {
-					if (template_params[p].is<TemplateParameterNode>()) {
-						const auto& tparam = template_params[p].as<TemplateParameterNode>();
-						if (tparam.is_variadic() && tparam.name() == fold.pack_name()) {
-							pack_param_idx = p;
-						}
+					const auto& tparam = template_params[p];
+					if (tparam.is_variadic() && tparam.name() == fold.pack_name()) {
+						pack_param_idx = p;
 					}
 				}
 
@@ -854,7 +843,7 @@ ASTNode Parser::substituteTemplateParameters(
 								TypeCategory result_type = TypeCategory::Int;
 								int result_size_bits = 32;
 								if (pack_param_idx.has_value()) {
-									const auto& tparam = template_params[*pack_param_idx].as<TemplateParameterNode>();
+									const auto& tparam = template_params[*pack_param_idx];
 									if (tparam.has_type()) {
 										const TypeSpecifierNode& param_type_spec = tparam.type_specifier_node();
 										result_type = param_type_spec.type();
@@ -1644,7 +1633,25 @@ ASTNode Parser::substituteTemplateParameters(
 	const InlineVector<TemplateTypeArg, 4>& template_args) {
 	return substituteTemplateParameters(
 		node,
-		cloneTemplateParameterNodes(template_params),
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+		template_args);
+}
+
+ASTNode Parser::substituteTemplateParameters(
+	const ASTNode& node,
+	std::span<const ASTNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return substituteTemplateParameters(
+		node,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
 		template_args);
 }
 
@@ -1801,7 +1808,7 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 // then template parameters are substituted.
 bool Parser::expandPackExpansionArgs(
 	const PackExpansionExprNode& pack_expansion,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	ChunkedVector<ASTNode>& out_args) {
 
@@ -1811,13 +1818,11 @@ bool Parser::expandPackExpansionArgs(
 	size_t variadic_param_idx = SIZE_MAX;
 	size_t non_variadic_count = 0;
 	for (size_t p = 0; p < template_params.size(); ++p) {
-		if (template_params[p].is<TemplateParameterNode>()) {
-			const auto& tparam = template_params[p].as<TemplateParameterNode>();
-			if (tparam.is_variadic())
-				variadic_param_idx = p;
-			else
-				non_variadic_count++;
-		}
+		const auto& tparam = template_params[p];
+		if (tparam.is_variadic())
+			variadic_param_idx = p;
+		else
+			non_variadic_count++;
 	}
 
 	size_t num_pack_elements = 0;
@@ -1850,15 +1855,13 @@ bool Parser::expandPackExpansionArgs(
 	FLASH_LOG(Templates, Debug, "Expanding PackExpansionExprNode in function call args: ", num_pack_elements, " elements");
 	for (size_t pi = 0; pi < num_pack_elements; ++pi) {
 		// Build substitution params for this single pack element
-		std::vector<ASTNode> subst_params;
-		std::vector<TemplateTypeArg> subst_args;
+		InlineVector<TemplateParameterNode, 4> subst_params;
+		InlineVector<TemplateTypeArg, 4> subst_args;
 		for (size_t p = 0; p < template_params.size(); ++p) {
-			if (!template_params[p].is<TemplateParameterNode>())
-				continue;
-			const auto& tparam = template_params[p].as<TemplateParameterNode>();
+			const auto& tparam = template_params[p];
 			if (tparam.is_variadic()) {
 				TemplateParameterNode single_tparam(tparam.nameHandle(), tparam.token());
-				subst_params.push_back(emplace_node<TemplateParameterNode>(single_tparam));
+				subst_params.push_back(single_tparam);
 				subst_args.push_back(template_args[non_variadic_count + pi]);
 			} else if (p < template_args.size()) {
 				subst_params.push_back(template_params[p]);
@@ -1882,7 +1885,27 @@ bool Parser::expandPackExpansionArgs(
 	ChunkedVector<ASTNode>& out_args) {
 	return expandPackExpansionArgs(
 		pack_expansion,
-		cloneTemplateParameterNodes(template_params),
+		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+		template_args,
+		out_args);
+}
+
+bool Parser::expandPackExpansionArgs(
+	const PackExpansionExprNode& pack_expansion,
+	std::span<const ASTNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	ChunkedVector<ASTNode>& out_args) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	return expandPackExpansionArgs(
+		pack_expansion,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
 		template_args,
 		out_args);
 }
@@ -1892,7 +1915,7 @@ bool Parser::expandPackExpansionArgs(
 // ordinary call-expression, constructor-call, and member-call handlers.
 void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
-	std::span<const ASTNode> template_params,
+	std::span<const TemplateParameterNode> template_params,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
 	ChunkedVector<ASTNode>& out) {
 	if (arg.is<ExpressionNode>()) {
@@ -1904,6 +1927,26 @@ void Parser::substituteArgWithPackExpansion(
 		}
 	}
 	out.push_back(substituteTemplateParameters(arg, template_params, template_args));
+}
+
+void Parser::substituteArgWithPackExpansion(
+	const ASTNode& arg,
+	std::span<const ASTNode> template_params,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	ChunkedVector<ASTNode>& out) {
+	InlineVector<TemplateParameterNode, 4> typed_params;
+	typed_params.reserve(template_params.size());
+	for (const ASTNode& template_param : template_params) {
+		if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_param);
+			typed_param != nullptr) {
+			typed_params.push_back(*typed_param);
+		}
+	}
+	substituteArgWithPackExpansion(
+		arg,
+		std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+		template_args,
+		out);
 }
 
 // Replace a pack parameter identifier in an expression pattern with its expanded element name.

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -14,7 +14,7 @@ static StringHandle normalizeClassName(StringHandle handle) {
 
 struct LazyMemberFunctionInfo {
 	DeferredMemberIdentity identity;
-	InlineVector<ASTNode, 4> template_params;		  // Template parameters from class template
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters from class template
 	InlineVector<TemplateTypeArg, 4> template_args; // Concrete template arguments used for instantiation
 	AccessSpecifier access;						// Access specifier (public/private/protected)
 	bool is_virtual = false;					 // Virtual function flag
@@ -403,7 +403,7 @@ struct LazyStaticMemberInfo {
 	bool is_array = false;
 	std::vector<size_t> array_dimensions;
 	int pointer_depth = 0;					   // Pointer depth (e.g., 1 for int*, 2 for int**)
-	std::vector<ASTNode> template_params;	  // Template parameters from class template
+	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
 	std::vector<TemplateTypeArg> template_args; // Concrete template arguments
 	bool needs_substitution;					 // True if initializer contains template parameters
 
@@ -501,7 +501,7 @@ struct LazyClassInstantiationInfo {
 	StringHandle template_name;					// Original template name (e.g., "vector")
 	StringHandle instantiated_name;				// Instantiated class name (e.g., "vector_int")
 	std::vector<TemplateTypeArg> template_args;	// Concrete template arguments
-	std::vector<ASTNode> template_params;		  // Template parameters from class template
+	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
 	ASTNode template_declaration;				  // Reference to primary template declaration
 	ClassInstantiationPhase current_phase = ClassInstantiationPhase::None;
 	// Flags for tracking what needs to be instantiated in Full phase
@@ -620,7 +620,7 @@ struct LazyTypeAliasInfo {
 	StringHandle instantiated_class_name;		  // Instantiated class name (e.g., "remove_const_int")
 	StringHandle member_name;					  // Member alias name (e.g., "type")
 	ASTNode unevaluated_target;					// Unevaluated target type expression
-	std::vector<ASTNode> template_params;		  // Template parameters from class template
+	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
 	std::vector<TemplateTypeArg> template_args;	// Concrete template arguments
 	bool needs_substitution = true;				// True if target contains template parameters
 	bool is_evaluated = false;					   // True once evaluation has been performed
@@ -753,7 +753,7 @@ struct LazyNestedTypeInfo {
 	StringHandle nested_type_name;				   // Nested type name (e.g., "inner")
 	StringHandle qualified_name;					 // Fully qualified name (e.g., "outer_int::inner")
 	ASTNode nested_type_declaration;				 // The nested struct/class declaration AST node
-	std::vector<ASTNode> parent_template_params;	 // Template parameters from parent class
+	std::vector<TemplateParameterNode> parent_template_params; // Template parameters from parent class
 	std::vector<TemplateTypeArg> parent_template_args; // Concrete template arguments for parent
 };
 

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -403,7 +403,7 @@ struct LazyStaticMemberInfo {
 	bool is_array = false;
 	std::vector<size_t> array_dimensions;
 	int pointer_depth = 0;					   // Pointer depth (e.g., 1 for int*, 2 for int**)
-	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters from class template
 	std::vector<TemplateTypeArg> template_args; // Concrete template arguments
 	bool needs_substitution;					 // True if initializer contains template parameters
 
@@ -501,7 +501,7 @@ struct LazyClassInstantiationInfo {
 	StringHandle template_name;					// Original template name (e.g., "vector")
 	StringHandle instantiated_name;				// Instantiated class name (e.g., "vector_int")
 	std::vector<TemplateTypeArg> template_args;	// Concrete template arguments
-	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters from class template
 	ASTNode template_declaration;				  // Reference to primary template declaration
 	ClassInstantiationPhase current_phase = ClassInstantiationPhase::None;
 	// Flags for tracking what needs to be instantiated in Full phase
@@ -620,7 +620,7 @@ struct LazyTypeAliasInfo {
 	StringHandle instantiated_class_name;		  // Instantiated class name (e.g., "remove_const_int")
 	StringHandle member_name;					  // Member alias name (e.g., "type")
 	ASTNode unevaluated_target;					// Unevaluated target type expression
-	std::vector<TemplateParameterNode> template_params; // Template parameters from class template
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters from class template
 	std::vector<TemplateTypeArg> template_args;	// Concrete template arguments
 	bool needs_substitution = true;				// True if target contains template parameters
 	bool is_evaluated = false;					   // True once evaluation has been performed
@@ -753,7 +753,7 @@ struct LazyNestedTypeInfo {
 	StringHandle nested_type_name;				   // Nested type name (e.g., "inner")
 	StringHandle qualified_name;					 // Fully qualified name (e.g., "outer_int::inner")
 	ASTNode nested_type_declaration;				 // The nested struct/class declaration AST node
-	std::vector<TemplateParameterNode> parent_template_params; // Template parameters from parent class
+	InlineVector<TemplateParameterNode, 4> parent_template_params; // Template parameters from parent class
 	std::vector<TemplateTypeArg> parent_template_args; // Concrete template arguments for parent
 };
 

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -1047,7 +1047,7 @@ struct ConstraintEvaluationResult {
 // isIntegralType and isFloatingPointType moved to AstNodeTypes_TypeSystem.h
 
 // Helper function to evaluate type traits like std::is_integral_v<T>
-inline bool evaluateTypeTrait(std::string_view trait_name, const std::vector<TemplateTypeArg>& type_args) {
+inline bool evaluateTypeTrait(std::string_view trait_name, std::span<const TemplateTypeArg> type_args) {
 	if (type_args.empty()) {
 		return false;  // Type traits need at least one argument
 	}
@@ -1098,8 +1098,8 @@ inline bool evaluateTypeTrait(std::string_view trait_name, const std::vector<Tem
 // Used for evaluating comparisons in requires clauses like: requires sizeof(T) < 8
 inline std::optional<long long> evaluateConstraintExpression(
 	const ASTNode& expr,
-	const std::vector<TemplateTypeArg>& template_args,
-	const std::vector<std::string_view>& template_param_names) {
+	std::span<const TemplateTypeArg> template_args,
+	std::span<const std::string_view> template_param_names) {
 
 	// Handle ExpressionNode wrapper
 	if (expr.is<ExpressionNode>()) {

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -72,7 +72,7 @@ struct OuterTemplateBinding {
 
 // Out-of-line template static member variable definition
 struct OutOfLineMemberVariable {
-	InlineVector<ASTNode, 4> template_params; // Template parameters (e.g., <typename T>)
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters (e.g., <typename T>)
 	StringHandle member_name; // Name of the static member variable
 	ASTNode type_node; // Type of the variable (TypeSpecifierNode)
 	std::optional<ASTNode> initializer; // Initializer expression
@@ -84,7 +84,7 @@ struct OutOfLineMemberVariable {
 //   template<typename T> struct Outer<T>::Inner { ... };     (partial — applies to all instantiations)
 //   template<> struct Wrapper<int>::Nested { int x; };       (full — applies only when args match)
 struct OutOfLineNestedClass {
-	InlineVector<ASTNode, 4> template_params; // Outer template parameters (e.g., <typename T>)
+	InlineVector<TemplateParameterNode, 4> template_params; // Outer template parameters (e.g., <typename T>)
 	StringHandle nested_class_name; // Name of the nested class (e.g., "Inner")
 	SaveHandle body_start; // Saved position at the struct/class keyword for re-parsing via parse_struct_declaration()
 	InlineVector<StringHandle, 4> template_param_names; // Names of template parameters
@@ -105,14 +105,14 @@ struct SfinaeCondition {
 
 // Template specialization pattern - represents a pattern like T&, T*, const T, etc.
 struct TemplatePattern {
-	InlineVector<ASTNode, 4> template_params; // Template parameters (e.g., typename T)
+	InlineVector<TemplateParameterNode, 4> template_params; // Template parameters (e.g., typename T)
 	InlineVector<TemplateTypeArg, 4> pattern_args; // Pattern like T&, T*, etc.
 	ASTNode specialized_node; // The AST node for the specialized template
 	std::optional<SfinaeCondition> sfinae_condition; // Optional SFINAE check for void_t patterns
 
 	// Constructor to avoid aggregate initialization issues with mutable cache fields
 	TemplatePattern() = default;
-	TemplatePattern(InlineVector<ASTNode, 4> tp, InlineVector<TemplateTypeArg, 4> pa,
+	TemplatePattern(InlineVector<TemplateParameterNode, 4> tp, InlineVector<TemplateTypeArg, 4> pa,
 					ASTNode sn, std::optional<SfinaeCondition> sc)
 		: template_params(std::move(tp)), pattern_args(std::move(pa)),
 		  specialized_node(std::move(sn)), sfinae_condition(std::move(sc)) {}
@@ -127,9 +127,7 @@ struct TemplatePattern {
 			cached_template_param_names_.clear();
 			cached_template_param_names_.reserve(template_params.size());
 			for (const auto& tp : template_params) {
-				if (tp.is<TemplateParameterNode>()) {
-					cached_template_param_names_.insert(tp.as<TemplateParameterNode>().nameHandle());
-				}
+				cached_template_param_names_.insert(tp.nameHandle());
 			}
 			template_param_names_valid_ = true;
 		}
@@ -351,13 +349,11 @@ struct TemplatePattern {
 		bool has_variadic_pack = false;
 		[[maybe_unused]] size_t pack_param_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			if (template_params[i].is<TemplateParameterNode>()) {
-				const TemplateParameterNode& param = template_params[i].as<TemplateParameterNode>();
-				if (param.is_variadic()) {
-					has_variadic_pack = true;
-					pack_param_index = i;
-					break;
-				}
+			const TemplateParameterNode& param = template_params[i];
+			if (param.is_variadic()) {
+				has_variadic_pack = true;
+				pack_param_index = i;
+				break;
 			}
 		}
 
@@ -395,8 +391,8 @@ struct TemplatePattern {
 			if (i >= concrete_args.size()) {
 				// This should only happen for the variadic pack parameter
 				// Check if this pattern position corresponds to a variadic pack
-				if (param_index < template_params.size() && template_params[param_index].is<TemplateParameterNode>()) {
-					const TemplateParameterNode& param = template_params[param_index].as<TemplateParameterNode>();
+				if (param_index < template_params.size()) {
+					const TemplateParameterNode& param = template_params[param_index];
 					if (param.is_variadic()) {
 						// Empty pack is valid - continue without error
 						continue;
@@ -515,12 +511,7 @@ struct TemplatePattern {
 								  " >= template_params.size() ", template_params.size());
 						return false;
 					}
-					if (!template_params[param_index].is<TemplateParameterNode>()) {
-						FLASH_LOG(Templates, Trace, "  FAILED: dependent value template parameter at param_index ",
-								  param_index, " is not a TemplateParameterNode");
-						return false;
-					}
-					param_name = template_params[param_index].as<TemplateParameterNode>().nameHandle();
+					param_name = template_params[param_index].nameHandle();
 				}
 				if (!recordDeduction(param_name, concrete_arg, param_substitutions)) {
 					return false;
@@ -648,16 +639,9 @@ struct TemplatePattern {
 					return false; // More template params needed than available - invalid pattern
 				}
 
-				if (template_params[param_index].is<TemplateParameterNode>()) {
-					const TemplateParameterNode& template_param = template_params[param_index].as<TemplateParameterNode>();
-					param_name = template_param.nameHandle();
-					found_param = true;
-				}
-
-				if (!found_param) {
-					FLASH_LOG(Templates, Trace, "  FAILED: Template parameter at param_index ", param_index, " is not a TemplateParameterNode");
-					return false; // Template parameter at position param_index is not a TemplateParameterNode
-				}
+				const TemplateParameterNode& template_param = template_params[param_index];
+				param_name = template_param.nameHandle();
+				found_param = true;
 			}
 
 			// Check if we've already seen this parameter

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -590,7 +590,7 @@ public:
 
 	// Register a template specialization pattern (StringHandle overload)
 	void registerSpecializationPattern(StringHandle template_name,
-									   const std::vector<ASTNode>& template_params,
+									   const InlineVector<TemplateParameterNode, 4>& template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
@@ -608,24 +608,11 @@ public:
 
 		// Debug: log each template param type
 		for (size_t i = 0; i < template_params.size(); ++i) {
-			FLASH_LOG(Templates, Debug, "  template_param[", i, "]: type_name=", template_params[i].type_name(),
-					  ", is_TemplateParameterNode=", template_params[i].is<TemplateParameterNode>());
-		}
-
-		InlineVector<TemplateParameterNode, 4> typed_template_params;
-		typed_template_params.reserve(template_params.size());
-		for (size_t i = 0; i < template_params.size(); ++i) {
-			const ASTNode& template_param = template_params[i];
-			if (!template_param.is<TemplateParameterNode>()) {
-				FLASH_LOG(Templates, Error, "registerSpecializationPattern: template_param[", i,
-						  "] is not a TemplateParameterNode");
-				continue;
-			}
-			typed_template_params.push_back(template_param.as<TemplateParameterNode>());
+			FLASH_LOG(Templates, Debug, "  template_param[", i, "]: name=", template_params[i].name());
 		}
 
 		TemplatePattern pattern;
-		pattern.template_params = std::move(typed_template_params);
+		pattern.template_params = template_params;
 		pattern.pattern_args = pattern_args;
 		pattern.specialized_node = specialized_node;
 		pattern.sfinae_condition = sfinae_cond;
@@ -691,8 +678,31 @@ public:
 					  "]::", StringTable::getStringView(stored_pattern.sfinae_condition->member_name));
 		}
 	}
+	void registerSpecializationPattern(StringHandle template_name,
+									   const std::vector<ASTNode>& template_params,
+									   const std::vector<TemplateTypeArg>& pattern_args,
+									   ASTNode specialized_node,
+									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+		InlineVector<TemplateParameterNode, 4> typed_template_params;
+		typed_template_params.reserve(template_params.size());
+		for (const ASTNode& template_param : template_params) {
+			if (!template_param.is<TemplateParameterNode>()) {
+				continue;
+			}
+			typed_template_params.push_back(template_param.as<TemplateParameterNode>());
+		}
+		registerSpecializationPattern(template_name, typed_template_params, pattern_args, specialized_node, sfinae_cond);
+	}
 
 	// Register a template specialization pattern (string_view overload)
+	void registerSpecializationPattern(std::string_view template_name,
+									   const InlineVector<TemplateParameterNode, 4>& template_params,
+									   const std::vector<TemplateTypeArg>& pattern_args,
+									   ASTNode specialized_node,
+									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+		StringHandle key = StringTable::getOrInternStringHandle(template_name);
+		registerSpecializationPattern(key, template_params, pattern_args, specialized_node, sfinae_cond);
+	}
 	void registerSpecializationPattern(std::string_view template_name,
 									   const std::vector<ASTNode>& template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,
@@ -703,6 +713,15 @@ public:
 	}
 
 	// Register a template specialization pattern using QualifiedIdentifier.
+	void registerSpecializationPattern(QualifiedIdentifier qi,
+									   const InlineVector<TemplateParameterNode, 4>& template_params,
+									   const std::vector<TemplateTypeArg>& pattern_args,
+									   ASTNode specialized_node,
+									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+		forEachQualifiedName(qi, [&](std::string_view name) {
+			registerSpecializationPattern(name, template_params, pattern_args, specialized_node, sfinae_cond);
+		});
+	}
 	void registerSpecializationPattern(QualifiedIdentifier qi,
 									   const std::vector<ASTNode>& template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "TemplateRegistry_Pattern.h"
+#include <span>
 
 class TemplateRegistry {
 public:
@@ -134,32 +135,18 @@ public:
 
 	// Register a variable template partial specialization with its pattern args
 	void registerVariableTemplateSpecialization(std::string_view base_name,
-												const std::vector<ASTNode>& template_params,
+												std::span<const TemplateParameterNode> template_params,
 												const std::vector<TemplateTypeArg>& pattern_args,
 												ASTNode specialized_node) {
 		StringHandle key = StringTable::getOrInternStringHandle(base_name);
 		InlineVector<TemplateParameterNode, 4> typed_template_params;
 		typed_template_params.reserve(template_params.size());
-		for (const ASTNode& param : template_params) {
-			if (!param.is<TemplateParameterNode>()) {
-				continue;
-			}
-			typed_template_params.push_back(param.as<TemplateParameterNode>());
+		for (const TemplateParameterNode& template_param : template_params) {
+			typed_template_params.push_back(template_param);
 		}
 		variable_template_specializations_[key].push_back(
 			TemplatePattern{std::move(typed_template_params), pattern_args, specialized_node, std::nullopt});
 	}
-	void registerVariableTemplateSpecialization(std::string_view base_name,
-												const InlineVector<TemplateParameterNode, 4>& template_params,
-												const std::vector<TemplateTypeArg>& pattern_args,
-												ASTNode specialized_node) {
-		InlineVector<ASTNode, 4> ast_params;
-		for (const auto& param : template_params) {
-			ast_params.push_back(ASTNode::emplace_node<TemplateParameterNode>(param));
-		}
-		registerVariableTemplateSpecialization(base_name, std::vector<ASTNode>(ast_params.begin(), ast_params.end()), pattern_args, specialized_node);
-	}
-
 	// Find the best matching variable template partial specialization for concrete args.
 	// Returns the specialized ASTNode and the deduced parameter substitutions.
 	struct VarTemplateSpecMatch {
@@ -682,32 +669,21 @@ public:
 		}
 	}
 	void registerSpecializationPattern(StringHandle template_name,
-									   const std::vector<ASTNode>& template_params,
+									   std::span<const TemplateParameterNode> template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
 		InlineVector<TemplateParameterNode, 4> typed_template_params;
 		typed_template_params.reserve(template_params.size());
-		for (const ASTNode& template_param : template_params) {
-			if (!template_param.is<TemplateParameterNode>()) {
-				continue;
-			}
-			typed_template_params.push_back(template_param.as<TemplateParameterNode>());
+		for (const TemplateParameterNode& template_param : template_params) {
+			typed_template_params.push_back(template_param);
 		}
 		registerSpecializationPattern(template_name, typed_template_params, pattern_args, specialized_node, sfinae_cond);
 	}
 
 	// Register a template specialization pattern (string_view overload)
 	void registerSpecializationPattern(std::string_view template_name,
-									   const InlineVector<TemplateParameterNode, 4>& template_params,
-									   const std::vector<TemplateTypeArg>& pattern_args,
-									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-		StringHandle key = StringTable::getOrInternStringHandle(template_name);
-		registerSpecializationPattern(key, template_params, pattern_args, specialized_node, sfinae_cond);
-	}
-	void registerSpecializationPattern(std::string_view template_name,
-									   const std::vector<ASTNode>& template_params,
+									   std::span<const TemplateParameterNode> template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
@@ -717,16 +693,7 @@ public:
 
 	// Register a template specialization pattern using QualifiedIdentifier.
 	void registerSpecializationPattern(QualifiedIdentifier qi,
-									   const InlineVector<TemplateParameterNode, 4>& template_params,
-									   const std::vector<TemplateTypeArg>& pattern_args,
-									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-		forEachQualifiedName(qi, [&](std::string_view name) {
-			registerSpecializationPattern(name, template_params, pattern_args, specialized_node, sfinae_cond);
-		});
-	}
-	void registerSpecializationPattern(QualifiedIdentifier qi,
-									   const std::vector<ASTNode>& template_params,
+									   std::span<const TemplateParameterNode> template_params,
 									   const std::vector<TemplateTypeArg>& pattern_args,
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -138,8 +138,16 @@ public:
 												const std::vector<TemplateTypeArg>& pattern_args,
 												ASTNode specialized_node) {
 		StringHandle key = StringTable::getOrInternStringHandle(base_name);
+		InlineVector<TemplateParameterNode, 4> typed_template_params;
+		typed_template_params.reserve(template_params.size());
+		for (const ASTNode& param : template_params) {
+			if (!param.is<TemplateParameterNode>()) {
+				continue;
+			}
+			typed_template_params.push_back(param.as<TemplateParameterNode>());
+		}
 		variable_template_specializations_[key].push_back(
-			TemplatePattern{template_params, pattern_args, specialized_node, std::nullopt});
+			TemplatePattern{std::move(typed_template_params), pattern_args, specialized_node, std::nullopt});
 	}
 	void registerVariableTemplateSpecialization(std::string_view base_name,
 												const InlineVector<TemplateParameterNode, 4>& template_params,
@@ -604,8 +612,20 @@ public:
 					  ", is_TemplateParameterNode=", template_params[i].is<TemplateParameterNode>());
 		}
 
+		InlineVector<TemplateParameterNode, 4> typed_template_params;
+		typed_template_params.reserve(template_params.size());
+		for (size_t i = 0; i < template_params.size(); ++i) {
+			const ASTNode& template_param = template_params[i];
+			if (!template_param.is<TemplateParameterNode>()) {
+				FLASH_LOG(Templates, Error, "registerSpecializationPattern: template_param[", i,
+						  "] is not a TemplateParameterNode");
+				continue;
+			}
+			typed_template_params.push_back(template_param.as<TemplateParameterNode>());
+		}
+
 		TemplatePattern pattern;
-		pattern.template_params = template_params;
+		pattern.template_params = std::move(typed_template_params);
 		pattern.pattern_args = pattern_args;
 		pattern.specialized_node = specialized_node;
 		pattern.sfinae_condition = sfinae_cond;

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -323,7 +323,7 @@ public:
 
 	// Convenience method: lookup instantiation using template name and TemplateTypeArg args
 	std::optional<ASTNode> getInstantiation(StringHandle template_name,
-											const std::vector<TemplateTypeArg>& args) const {
+											std::span<const TemplateTypeArg> args) const {
 		auto key = FlashCpp::makeInstantiationKey(template_name, args);
 		return getInstantiation(key);
 	}

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -437,7 +437,7 @@ public:
 	// Example: max<int> -> max$a1b2c3d4, max<int, 5> -> max$e5f6g7h8
 	// Build a unique hash-based name for a template instantiation and register it.
 	// This avoids collisions from underscore-based naming (e.g., type names with underscores)
-	std::string_view mangleTemplateName(std::string_view base_name, const std::vector<TemplateTypeArg>& args) {
+	std::string_view mangleTemplateName(std::string_view base_name, std::span<const TemplateTypeArg> args) {
 		auto result = FlashCpp::generateInstantiatedNameFromArgs(base_name, args);
 		return result;
 	}
@@ -717,8 +717,9 @@ public:
 	}
 
 	// Look up an exact template specialization (no pattern matching)
-	std::optional<ASTNode> lookupExactSpecialization(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args) const {
-		SpecializationKey key{std::string(template_name), canonicalizeTemplateArgsForExactSpecialization(template_args)};
+	std::optional<ASTNode> lookupExactSpecialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args) const {
+		std::vector<TemplateTypeArg> owned_template_args(template_args.begin(), template_args.end());
+		SpecializationKey key{std::string(template_name), canonicalizeTemplateArgsForExactSpecialization(owned_template_args)};
 
 		FLASH_LOG(Templates, Debug, "lookupExactSpecialization: '", template_name, "' with ", template_args.size(), " args");
 
@@ -730,11 +731,12 @@ public:
 	}
 
 	// Look up a template specialization (exact match first, then pattern match)
-	std::optional<ASTNode> lookupSpecialization(std::string_view template_name, const std::vector<TemplateTypeArg>& template_args) const {
+	std::optional<ASTNode> lookupSpecialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args) const {
+		std::vector<TemplateTypeArg> owned_template_args(template_args.begin(), template_args.end());
 		FLASH_LOG(Templates, Debug, "lookupSpecialization: template_name='", template_name, "', num_args=", template_args.size());
 
 		// First, try exact match
-		auto exact = lookupExactSpecialization(template_name, template_args);
+		auto exact = lookupExactSpecialization(template_name, owned_template_args);
 		if (exact.has_value()) {
 			FLASH_LOG(Templates, Debug, "  Found exact specialization match");
 			return exact;
@@ -742,7 +744,7 @@ public:
 
 		// No exact match - try pattern matching
 		FLASH_LOG(Templates, Debug, "  No exact match, trying pattern matching...");
-		auto pattern_result = matchSpecializationPattern(template_name, template_args);
+		auto pattern_result = matchSpecializationPattern(template_name, owned_template_args);
 		if (pattern_result.has_value()) {
 			FLASH_LOG(Templates, Debug, "  Found pattern match!");
 		} else {
@@ -753,7 +755,7 @@ public:
 
 	// Look up a template specialization using QualifiedIdentifier.
 	// Tries qualified name first, then falls back to unqualified.
-	std::optional<ASTNode> lookupSpecialization(QualifiedIdentifier qi, const std::vector<TemplateTypeArg>& template_args) const {
+	std::optional<ASTNode> lookupSpecialization(QualifiedIdentifier qi, std::span<const TemplateTypeArg> template_args) const {
 		if (qi.hasNamespace()) {
 			StringHandle qualified = gNamespaceRegistry.buildQualifiedIdentifier(
 				qi.namespace_handle, qi.identifier_handle);

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -594,21 +594,24 @@ public:
 									   const std::vector<TemplateTypeArg>& pattern_args,
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-		FLASH_LOG(Templates, Debug, "registerSpecializationPattern: template_name='", StringTable::getStringView(template_name),
-				  "', num_template_params=", template_params.size(), ", num_pattern_args=", pattern_args.size());
 
-		// Debug: log each pattern arg
-		for (size_t i = 0; i < pattern_args.size(); ++i) {
-			const auto& arg = pattern_args[i];
-			std::string_view dep_name_view = arg.dependent_name.isValid() ? StringTable::getStringView(arg.dependent_name) : "";
-			FLASH_LOG(Templates, Debug, "  pattern_arg[", i, "]: base_type=", static_cast<int>(arg.category()),
-					  ", type_index=", arg.type_index, ", is_dependent=", arg.is_dependent,
-					  ", is_value=", arg.is_value, ", dependent_name='", dep_name_view, "'");
-		}
+		if (FLASH_LOG_ENABLED(Templates, Debug)) {
+			FLASH_LOG(Templates, Debug, "registerSpecializationPattern: template_name='", StringTable::getStringView(template_name),
+					  "', num_template_params=", template_params.size(), ", num_pattern_args=", pattern_args.size());
 
-		// Debug: log each template param type
-		for (size_t i = 0; i < template_params.size(); ++i) {
-			FLASH_LOG(Templates, Debug, "  template_param[", i, "]: name=", template_params[i].name());
+			// Debug: log each pattern arg
+			for (size_t i = 0; i < pattern_args.size(); ++i) {
+				const auto& arg = pattern_args[i];
+				std::string_view dep_name_view = arg.dependent_name.isValid() ? StringTable::getStringView(arg.dependent_name) : "";
+				FLASH_LOG(Templates, Debug, "  pattern_arg[", i, "]: base_type=", static_cast<int>(arg.category()),
+						  ", type_index=", arg.type_index, ", is_dependent=", arg.is_dependent,
+						  ", is_value=", arg.is_value, ", dependent_name='", dep_name_view, "'");
+			}
+
+			// Debug: log each template param type
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				FLASH_LOG(Templates, Debug, "  template_param[", i, "]: name=", template_params[i].name());
+			}
 		}
 
 		TemplatePattern pattern;

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -709,7 +709,7 @@ inline TypeIndexArg makeTypeIndexArg(const TemplateTypeArg& arg) {
  */
 inline TemplateInstantiationKey makeInstantiationKey(
 	StringHandle template_name,
-	const std::vector<TemplateTypeArg>& args) {
+	std::span<const TemplateTypeArg> args) {
 
 	TemplateInstantiationKey key(template_name);
 	key.type_args.reserve(args.size());
@@ -742,7 +742,7 @@ inline TemplateInstantiationKey makeInstantiationKey(
  */
 inline std::string_view generateInstantiatedNameFromArgs(
 	std::string_view template_name,
-	const std::vector<TemplateTypeArg>& args) {
+	std::span<const TemplateTypeArg> args) {
 
 	auto key = makeInstantiationKey(
 		StringTable::getOrInternStringHandle(template_name), args);

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -531,7 +531,7 @@ inline std::string_view generateInstantiatedName(std::string_view template_name,
 //
 // Available functions:
 //   - FlashCpp::makeTypeIndexArg(const TemplateTypeArg& arg) -> TypeIndexArg
-//   - FlashCpp::makeInstantiationKey(StringHandle, const std::vector<TemplateTypeArg>&) -> TemplateInstantiationKey
+//   - FlashCpp::makeInstantiationKey(StringHandle, std::span<const TemplateTypeArg>) -> TemplateInstantiationKey
 
 } // namespace FlashCpp
 


### PR DESCRIPTION
## Summary

This PR consolidates the template parameter/argument machinery throughout the compiler front-end, reducing duplication and making the code more type-safe and maintainable.

## Changes

### 1. Centralized member-function substitution helpers
Introduced SubstitutedMemberFunctionShell and substituteAndCopyMemberFunctionParameters to eliminate ~6 copies of the same substituted-return-type + parameter-copy pattern across class template instantiation paths.

### 2. Typed template parameter containers
Replaced generic \ASTNode\ containers for template parameters with typed \TemplateParameterNode\ throughout:
- All template registries and type structs now store \InlineVector<TemplateParameterNode, 4>\ instead of \std::vector<ASTNode>\
- Converted \TemplateParameterNode::nested_params_\ accessor to return \std::span\

### 3. Unified \substituteTemplateParameters\ overloads
Consolidated 3 overloads into 1 canonical signature taking two spans:
\\\cpp
ASTNode substituteTemplateParameters(
    const ASTNode& node,
    std::span<const TemplateParameterNode> template_params,
    std::span<const TemplateTypeArg> template_args);
\\\
Also unified related helpers: \xpandPackExpansionArgs\, \substituteArgWithPackExpansion\, \substitute_template_parameter\.

### 4. Removed \std::span<const ASTNode>\ overloads
Eliminated all overloads that accepted untyped \ASTNode\ spans for template parameters (9 functions), replacing with the typed \TemplateParameterNode\ variants.

### 5. Converted \std::vector\ / \InlineVector\ overloads to \std::span\
Across ~20 Parser functions, replaced \const std::vector<TemplateTypeArg>&\ and \const InlineVector<...>&\ parameters with \std::span<const TemplateTypeArg>\, reducing overload counts:
- \esolveDependentMemberAlias\: 4 → 1
- \populateTemplateParamSubstitutions\: 3 → 1
- \getSubstitutedTemplateTypeOrCreate\: 5 → 1
- \	ryAppendDefaultTemplateArg\: 3 → 2
- 4 local ASTNode-conversion lambdas removed

### 6. \EvaluationContext\ members converted to \InlineVector\
\\\cpp
// Before
std::vector<std::string_view> template_param_names;
std::vector<TemplateTypeArg> template_args;

// After
InlineVector<std::string_view, 4> template_param_names;
InlineVector<TemplateTypeArg, 4> template_args;
\\\
Added \ssign(first, last)\ to \InlineVector\ to support iterator-range construction.

### 7. Removed implicit \operator std::vector<T>()\ from \InlineVector\
Replaced with explicit \.toVector()\ method to prevent silent heap allocations.

## Net effect
- **~500+ lines removed** across the template substitution and instantiation files
- **Zero new overloads** — the API surface is strictly smaller
- **Type-safe by default** — template parameter slots are always \TemplateParameterNode\, never raw \ASTNode\
- All 2259 regular tests pass, 170 expected-fail tests fail as expected