### PR TITLE
[codex] template instantiation failure mode contract

### DIFF
--- a/FlashCpp.vcxproj
+++ b/FlashCpp.vcxproj
@@ -393,6 +393,9 @@
     <ClCompile Include="src\Parser_Templates_Inst_Deduction.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="src\Parser_Templates_Inst_Failure.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\Parser_Templates_Inst_MemberFunc.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
     </ClCompile>

--- a/FlashCpp.vcxproj.filters
+++ b/FlashCpp.vcxproj.filters
@@ -177,6 +177,9 @@
     <ClCompile Include="src\Parser_Templates_Inst_Deduction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Parser_Templates_Inst_Failure.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Parser_Templates_Inst_MemberFunc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -362,6 +362,9 @@
     <ClCompile Include="src\Parser_Templates_Inst_Deduction.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="src\Parser_Templates_Inst_Failure.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="src\Parser_Templates_Inst_MemberFunc.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)'!='Modular'">true</ExcludedFromBuild>
     </ClCompile>

--- a/FlashCppMSVC.vcxproj.filters
+++ b/FlashCppMSVC.vcxproj.filters
@@ -180,6 +180,9 @@
     <ClCompile Include="src\Parser_Templates_Inst_Deduction.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Parser_Templates_Inst_Failure.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Parser_Templates_Inst_MemberFunc.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1172,7 +1172,7 @@ public:
 	//   NotMaterialized   — freshly constructed; not yet instantiated.
 	//   ShapeOnly         — type layout/signatures computed under ShapeOnly mode;
 	//                       member function bodies have NOT been materialised.
-	//   Materialized      — full instantiation committed (HardUse / SfinaeProbe path).
+	//   Materialized      — full instantiation committed (HardUse / SoftProbe path).
 	//   FailedSubstitution — substitution failed; node must not be re-probed.
 	enum class StructBodyStateTag : uint8_t {
 		NotMaterialized = 0,

--- a/src/CompilerIncludes.h
+++ b/src/CompilerIncludes.h
@@ -107,6 +107,7 @@
 #include "Parser_Templates_Concepts.cpp"			 // Concepts and requires expressions
 #include "Parser_Templates_Inst_Deduction.cpp"	   // Template deduction
 #include "Parser_Templates_Inst_Substitution.cpp"	  // Template substitution
+#include "Parser_Templates_Inst_Failure.cpp"		  // Template instantiation failure helpers
 #include "Parser_Templates_Inst_ClassTemplate.cpp"  // Class template instantiation
 #include "Parser_Templates_Inst_MemberFunc.cpp"		// Member function template instantiation
 #include "Parser_Templates_Lazy.cpp"				 // Lazy template flows

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -874,10 +874,13 @@ private:
 	enum class TemplateInstantiationMode {
 		// Ordinary instantiation request: commit cache, symbol-table, and AST/lazy-member side effects.
 		HardUse,
-		// SFINAE-driven probe: substitution failures are soft and the caller may try another overload.
-		// Unlike ShapeOnly, substitution errors in SfinaeProbe cause the probe to soft-fail and the
-		// caller may select an alternative overload.  Commit-time side effects are also suppressed.
-		SfinaeProbe,
+		// SFINAE-driven probe: substitution failures are soft and SFINAE-only
+		// expression validation is enabled.
+		SoftProbe,
+		// Speculative overload viability check started by a hard-use request.
+		// Substitution failures are soft so overload resolution can continue, but
+		// SFINAE-only expression validation remains disabled.
+		HardUseCandidateProbe,
 		// Declaration-time shape probe: used when parsing default template arguments and computing
 		// type/signature shapes that do not yet require a full, committed instantiation.
 		//
@@ -885,7 +888,7 @@ private:
 		//   - Compute types and member signatures (layout, return types, overload sets) as normal.
 		//   - Suppress ALL commit-time side effects: type-map commits, symbol-table entries,
 		//     AST registration, and lazy-member side-effect callbacks.
-		//   - Unlike SfinaeProbe, substitution failures are NOT soft-failures: an error in
+		//   - Unlike SoftProbe, substitution failures are NOT soft-failures: an error in
 		//     ShapeOnly mode is still an error.  The mode only controls the commit phase.
 		//   - ShapeOnly is STICKY: selectTemplateInstantiationMode() propagates ShapeOnly
 		//     downward into nested instantiations so an entire shape-probe subtree stays in
@@ -2128,6 +2131,12 @@ private:
 	bool shouldCommitTemplateInstantiationArtifacts() const {
 		return template_instantiation_mode_ != TemplateInstantiationMode::ShapeOnly;
 	}
+	bool isHardUseLikeInstantiationMode() const;
+	bool isTemplateInstantiationFailureProbeMode() const;
+	std::optional<ASTNode> failTemplateInstantiation(
+		std::string_view reason,
+		const FlashCpp::TemplateInstantiationKey* key,
+		std::optional<uintptr_t> overload_id);
 	// Select the instantiation mode to use for a nested instantiation triggered from
 	// the current context.
 	//
@@ -2137,16 +2146,25 @@ private:
 	// (e.g. default-template-argument parsing) never commits artifacts to global state.
 	//
 	// Outside of ShapeOnly mode, the mode is determined by the caller's SFINAE context:
-	// outer_sfinae_context == true  → SfinaeProbe (soft substitution failures)
+	// outer_sfinae_context == true  → SoftProbe (soft substitution failures)
 	// outer_sfinae_context == false → HardUse (full commit)
 	TemplateInstantiationMode selectTemplateInstantiationMode(bool outer_sfinae_context) const {
 		if (template_instantiation_mode_ == TemplateInstantiationMode::ShapeOnly) {
 			return TemplateInstantiationMode::ShapeOnly;
 		}
 		if (outer_sfinae_context) {
-			return TemplateInstantiationMode::SfinaeProbe;
+			return TemplateInstantiationMode::SoftProbe;
 		}
 		return TemplateInstantiationMode::HardUse;
+	}
+	TemplateInstantiationMode selectTemplateCandidateProbeMode() const {
+		if (template_instantiation_mode_ == TemplateInstantiationMode::ShapeOnly) {
+			return TemplateInstantiationMode::ShapeOnly;
+		}
+		if (template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe) {
+			return TemplateInstantiationMode::SoftProbe;
+		}
+		return TemplateInstantiationMode::HardUseCandidateProbe;
 	}
 	std::optional<ASTNode> lookupLateMaterializedOwningStructRoot(StringHandle struct_name) const {
 		std::string_view struct_name_view = StringTable::getStringView(struct_name);

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -192,7 +192,7 @@ const FunctionDeclarationNode* Parser::tryInstantiateOperatorTemplateForBinary(
 					tmpl.as<TemplateFunctionDeclarationNode>().function_decl_node();
 				NamespaceHandle tmpl_ns = fdecl.namespace_handle();
 				if (tmpl_ns.isValid() && !eligible_ns.count(tmpl_ns)) continue;
-				ScopedParserInstantiationContext inst_guard(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+				ScopedParserInstantiationContext inst_guard(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 				int depth = initial_template_instantiation_depth;
 				if (auto instantiated = try_instantiate_single_template(tmpl, op_name, arg_types, depth)) {
 					if (const FunctionDeclarationNode* func_decl = get_function_decl_node(*instantiated)) {
@@ -216,7 +216,7 @@ const FunctionDeclarationNode* Parser::tryInstantiateOperatorTemplateForBinary(
 			continue;
 		}
 
-		ScopedParserInstantiationContext guard_instantiation_mode_phase2(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+		ScopedParserInstantiationContext guard_instantiation_mode_phase2(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 		std::optional<ASTNode> instantiated = try_instantiate_single_template(
 			candidate,
 			op_name,
@@ -328,7 +328,7 @@ void Parser::annotateConcreteBinaryOperatorOverload(BinaryOperatorNode& binary_o
 			*right_type_spec,
 			op_kind,
 			gSymbolTable);
-		if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse) {
+		if (isHardUseLikeInstantiationMode()) {
 			if (const FunctionDeclarationNode* instantiated_overload =
 					tryInstantiateOperatorTemplateForBinary(binary_operator_node.op(), *left_type_spec, *right_type_spec)) {
 				if (!overload_result.has_match ||
@@ -698,7 +698,7 @@ ParseResult Parser::parse_expression(int precedence, ExpressionContext context) 
 				// When in SFINAE context (e.g., decltype(a + b)), check that the
 				// operator is actually defined for the operand types. For struct types,
 				// this means checking member operator overloads and free operator functions.
-				if (template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe &&
+				if (template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe &&
 					!sfinae_type_map_.empty()) {
 					auto resolve_operand_type_index = [&](const ASTNode& operand) -> TypeIndex {
 						if (!operand.is<ExpressionNode>())
@@ -838,7 +838,7 @@ ParseResult Parser::parse_expression(int precedence, ExpressionContext context) 
 								*right_type_spec,
 								op_kind,
 								gSymbolTable);
-							if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse) {
+							if (isHardUseLikeInstantiationMode()) {
 								if (const FunctionDeclarationNode* instantiated_overload =
 										tryInstantiateOperatorTemplateForBinary(operator_token.value(), *left_type_spec, *right_type_spec)) {
 								if (!overload_result.has_match ||

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -113,10 +113,15 @@ std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
 		return std::nullopt;
 	}
 	if (call_arg_types.empty()) {
-		FLASH_LOG(Templates, Debug,
-			"Deferring member template instantiation for ", struct_name, "::", member_name,
-			" because no concrete argument types were collected at this parse point");
-		return std::nullopt;
+		std::string_view failure_reason = StringBuilder()
+			.append("cannot instantiate member function template '")
+			.append(struct_name)
+			.append("::")
+			.append(member_name)
+			.append("' because no concrete call argument types were collected")
+			.commit();
+		FLASH_LOG(Templates, Debug, failure_reason);
+		return failTemplateInstantiation(failure_reason, nullptr, std::nullopt);
 	}
 	return try_instantiate_member_function_template(
 		struct_name,
@@ -270,7 +275,7 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 			}
 		}
 
-		if (template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe &&
+		if (template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe &&
 			object_struct_name.has_value() && !sfinae_type_map_.empty()) {
 			StringHandle obj_name_handle = StringTable::getOrInternStringHandle(*object_struct_name);
 			auto subst_it = sfinae_type_map_.find(obj_name_handle);
@@ -333,7 +338,7 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		}
 
 		if (object_struct_name.has_value() && !instantiating_lazy_member_ &&
-			template_instantiation_mode_ == TemplateInstantiationMode::HardUse) {
+			isHardUseLikeInstantiationMode()) {
 			std::string_view func_name = member_name_token.value();
 			if (!func_name.empty()) {
 				StringHandle class_name_handle = StringTable::getOrInternStringHandle(*object_struct_name);
@@ -356,7 +361,7 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		}
 
 		if (object_struct_name.has_value() &&
-			template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
+			isHardUseLikeInstantiationMode() &&
 			!known_member_func && !instantiated_func.has_value()) {
 			auto checkHasMemberTemplate = [&]() {
 				StringBuilder qualified_name_sb;
@@ -403,7 +408,7 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		// the argument count, the call is ill-formed.
 		if (!known_member_func && !instantiated_func.has_value() &&
 			!explicit_template_args && object_struct_name.has_value() &&
-			template_instantiation_mode_ == TemplateInstantiationMode::HardUse) {
+			isHardUseLikeInstantiationMode()) {
 			if (auto type_opt = get_expression_type(*result); type_opt.has_value() &&
 														  is_struct_type(type_opt->category())) {
 				TypeIndex type_idx = type_opt->type_index();

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2761,7 +2761,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										class_name_handle,
 										member_name_handle,
 										member_is_const);
-									if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
+									if (isHardUseLikeInstantiationMode() &&
 										LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 										auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
 										if (!instantiated_func.has_value() || !instantiated_func->is<FunctionDeclarationNode>()) {
@@ -3720,7 +3720,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								class_name_handle,
 								member_name_handle,
 								member_is_const);
-							if (template_instantiation_mode_ == TemplateInstantiationMode::HardUse &&
+							if (isHardUseLikeInstantiationMode() &&
 								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
 								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
 								if (!instantiated_func.has_value() || !instantiated_func->is<FunctionDeclarationNode>()) {
@@ -4160,7 +4160,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// Template instantiation failure is an expected substitution failure in
 				// SFINAE contexts (e.g. decltype(...) inside a default template arg).
 				// Let the caller reject the overload without emitting a hard parser error.
-				if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+				if (!isHardUseLikeInstantiationMode()) {
 					FLASH_LOG_FORMAT(Templates, Debug, "SFINAE: template instantiation failed for call to '{}'", identifier_token.value());
 				} else {
 					FLASH_LOG(Parser, Error, "Template instantiation failed");
@@ -4609,7 +4609,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 																		  "accessible via argument-dependent lookup when an argument of the associated class type is provided",
 							identifier_token);
 					}
-					if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+					if (!isHardUseLikeInstantiationMode()) {
 						result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
 						return ParseResult::success(*result);
 					}
@@ -4672,7 +4672,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							"no matching function for call to '" + std::string(identifier_token.value()) + "\'",
 							identifier_token);
 					}
-					if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+					if (!isHardUseLikeInstantiationMode()) {
 						result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
 						return ParseResult::success(*result);
 					}
@@ -4796,7 +4796,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						parsing_template_depth_ > 0 ||
 						hasActiveTemplateParameters() ||
 						!struct_parsing_context_stack_.empty() ||
-						template_instantiation_mode_ != TemplateInstantiationMode::HardUse ||
+						!isHardUseLikeInstantiationMode() ||
 						context == ExpressionContext::TemplateTypeArg ||
 						context == ExpressionContext::RequiresClause ||
 						context == ExpressionContext::ConceptDefinition;
@@ -6751,7 +6751,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										}
 										// In SFINAE context (e.g., requires expression), function lookup failure
 										// means the constraint is not satisfied - not an error
-										if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+										if (!isHardUseLikeInstantiationMode()) {
 											// Create a placeholder node to indicate failed lookup
 												// The requires expression will treat this as "constraint not satisfied"
 												result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
@@ -6814,7 +6814,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											}
 											// In SFINAE context (e.g., requires expression), function lookup failure
 											// means the constraint is not satisfied - not an error
-											if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+											if (!isHardUseLikeInstantiationMode()) {
 												// Create a placeholder node to indicate failed lookup
 													result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
 												} else {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -310,7 +310,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 
 	// Trigger lazy member function instantiation if needed
 	if (!instantiated_func.has_value() &&
-		template_instantiation_mode_ == TemplateInstantiationMode::HardUse) {
+		isHardUseLikeInstantiationMode()) {
 		StringHandle class_name_handle = StringTable::getOrInternStringHandle(instantiated_class_name);
 		StringHandle member_name_handle = StringTable::getOrInternStringHandle(member_name);
 		LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -233,10 +233,10 @@ ParseResult Parser::parse_requires_expression() {
 		return ParseResult::error("Expected '{' to begin requires expression body", current_token_);
 	}
 
-	// Enter SfinaeProbe mode for the requires expression body.
+	// Enter SoftProbe mode for the requires expression body.
 	// In requires expressions, function lookup failures and type errors should not produce errors -
 	// they indicate that the constraint is not satisfied (the expression is invalid)
-	ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+	ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 
 	// Parse requirements (expressions that must be valid)
 	std::vector<ASTNode> requirements;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1279,21 +1279,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		}
 	} nesting_guard;
 	if (s_instantiation_nesting_depth > MAX_INSTANTIATION_NESTING_DEPTH) {
-		std::string error_msg = std::string(StringBuilder()
+		std::string_view error_msg = StringBuilder()
 			.append("Max template instantiation depth (")
 			.append(static_cast<uint64_t>(MAX_INSTANTIATION_NESTING_DEPTH))
 			.append(") exceeded for '")
 			.append(template_name)
 			.append("'. Possible recursive template instantiation.")
-			.commit());
+			.commit();
 		if (!s_instantiation_depth_warned) {
 			FLASH_LOG(Templates, Error, error_msg);
 			s_instantiation_depth_warned = true;
 		}
 		if (force_eager) {
-			throw CompileError(error_msg);
+			throw CompileError(std::string(error_msg));
 		}
-		return std::nullopt;
+		return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 	}
 
 	// Iteration guard: prevents retry storms for the entire compilation.
@@ -1304,11 +1304,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (force_eager) {
 			throw CompileError("Template instantiation iteration limit was already exceeded earlier in this translation unit");
 		}
-		return std::nullopt;
+		return failTemplateInstantiation(
+			"Template instantiation iteration limit was already exceeded earlier in this translation unit",
+			nullptr,
+			std::nullopt);
 	}
 	g_template_inst_iteration_count++;
 	if (g_template_inst_iteration_count > g_template_inst_max_iterations) {
-		std::string error_msg = std::string(StringBuilder()
+		std::string_view error_msg = StringBuilder()
 			.append("Template instantiation iteration limit exceeded (")
 			.append(static_cast<int64_t>(g_template_inst_max_iterations))
 			.append("). Last template: '")
@@ -1316,13 +1319,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			.append("' with ")
 			.append(static_cast<uint64_t>(template_args.size()))
 			.append(" args. Possible infinite loop.")
-			.commit());
+			.commit();
 		FLASH_LOG(Templates, Error, error_msg);
 		g_template_inst_iteration_limit_tripped = true;
 		if (force_eager) {
-			throw CompileError(error_msg);
+			throw CompileError(std::string(error_msg));
 		}
-		return std::nullopt;
+		return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 	}
 
 	// Log entry to help debug which call sites are causing issues
@@ -1543,7 +1546,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		auto cached = gTemplateRegistry.getInstantiation(cache_key);
 		if (cached.has_value()) {
 			// If the cached entry was produced under ShapeOnly mode but the current
-			// request is a full materialization (HardUse or SfinaeProbe), treat the
+			// request is a full materialization (HardUse or SoftProbe), treat the
 			// cache as a miss so we re-enter instantiation and fully materialise the
 			// struct.  This is safe because ShapeOnly entries are always committed to
 			// the cache, so a concurrent ShapeOnly path will still hit them.
@@ -4468,7 +4471,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Tag the struct with its materialization level before caching.
 			// Commit point: state transition NotMaterialized|ShapeOnly -> ShapeOnly|Materialized.
 			// ShapeOnly   -> mode is ShapeOnly (shape probe, no commit side effects).
-			// Materialized -> mode is HardUse or SfinaeProbe (full commit, all artifacts registered).
+			// Materialized -> mode is HardUse or SoftProbe (full commit, all artifacts registered).
 			if (template_instantiation_mode_ == TemplateInstantiationMode::ShapeOnly) {
 				instantiated_struct.as<StructDeclarationNode>().mark_shape_only();
 			} else {
@@ -7721,7 +7724,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 					FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 					FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
-					ScopedParserInstantiationContext guard_inst_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+					ScopedParserInstantiationContext guard_inst_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 					parsing_template_depth_ = 0;
 					clearCurrentTemplateParameters();
 					sfinae_type_map_.clear();
@@ -9107,7 +9110,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Tag the struct with its materialization level before caching.
 	// Commit point: state transition NotMaterialized|ShapeOnly -> ShapeOnly|Materialized.
 	// ShapeOnly   -> mode is ShapeOnly (shape probe, no commit side effects).
-	// Materialized -> mode is HardUse or SfinaeProbe (full commit, all artifacts registered).
+	// Materialized -> mode is HardUse or SoftProbe (full commit, all artifacts registered).
 	if (template_instantiation_mode_ == TemplateInstantiationMode::ShapeOnly) {
 		instantiated_struct.as<StructDeclarationNode>().mark_shape_only();
 	} else {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -735,7 +735,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 		FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 		FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 		FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
-		ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+		ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 		parsing_template_depth_ = 0;
 		clearCurrentTemplateParameters();
 		sfinae_type_map_.clear();
@@ -766,7 +766,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 			FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 			FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
-			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 			parsing_template_depth_ = 0;
 			clearCurrentTemplateParameters();
 			sfinae_type_map_.clear();
@@ -2177,7 +2177,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 			FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 			FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
-			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 			parsing_template_depth_ = 0;	 // suppress template body context during SFINAE
 			clearCurrentTemplateParameters();  // No dependent names during SFINAE
 			sfinae_type_map_.clear();
@@ -2702,7 +2702,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 	// Try each template overload in order.
 	// For SFINAE: collect all viable matches and return the most specific one.
 	// For non-SFINAE: return the first successful non-deferred match.
-	bool outer_sfinae_context = template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe;
+	bool outer_sfinae_context = template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe;
 
 	struct SfinaeCandidateEntry {
 		ASTNode result;
@@ -2748,7 +2748,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 						 recursion_depth, overload_idx, template_name);
 
 		// Enter the mode appropriate for this instantiation attempt.
-		ScopedParserInstantiationContext guard_instantiation_mode(*this, selectTemplateInstantiationMode(outer_sfinae_context), StringHandle{});
+		ScopedParserInstantiationContext guard_instantiation_mode(*this, selectTemplateCandidateProbeMode(), StringHandle{});
 
 		// Try to instantiate this specific template
 		std::optional<ASTNode> result = try_instantiate_single_template(
@@ -3227,9 +3227,14 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 			// entry fast-path instead of re-evaluating the requires-clause.
 			// The failure is deterministic in those keys: the requires-clause
 			// is a pure predicate over the deduced template arguments.
-			gTemplateRegistry.markFailedInstantiation(key, overload_id);
-
-			return std::nullopt;
+			return failTemplateInstantiation(
+				StringBuilder()
+					.append("constraint not satisfied for template function '")
+					.append(template_name)
+					.append("'")
+					.commit(),
+				&key,
+				overload_id);
 		}
 	}
 
@@ -3270,8 +3275,14 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 			// this same (template_name, args, overload) tuple will fail
 			// identically.  Short-circuiting at the entry fast-path avoids
 			// redoing concept evaluation on every SFINAE retry.
-			gTemplateRegistry.markFailedInstantiation(key, overload_id);
-			return std::nullopt;
+			return failTemplateInstantiation(
+				StringBuilder()
+					.append("concept constraint not satisfied for template function '")
+					.append(template_name)
+					.append("'")
+					.commit(),
+				&key,
+				overload_id);
 		}
 	}
 
@@ -3301,7 +3312,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 			Templates,
 			Debug,
 			"Re-parsing function declaration for SFINAE validation, sfinae_probe={}",
-			template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe);
+			template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe);
 
 		// Cycle detection for trailing return type re-parsing: when evaluating a
 		// function's decltype trailing return type, encountering the same function
@@ -3359,14 +3370,19 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 			// not been emplaced yet (that happens further down after the return
 			// type is known).  The registry-side memo is the failure record.
 			FLASH_LOG_FORMAT(Templates, Debug, "SFINAE: Return type parsing failed: {}", return_type_result.error_message());
-			gTemplateRegistry.markFailedInstantiation(key, overload_id);
-			return std::nullopt;	 // Substitution failure - try next overload
+			return failTemplateInstantiation(return_type_result.error_message(), &key, overload_id);
 		}
 
 		if (!return_type_result.node().has_value()) {
 			FLASH_LOG(Templates, Debug, "SFINAE: Return type parsing returned no node");
-			gTemplateRegistry.markFailedInstantiation(key, overload_id);
-			return std::nullopt;
+			return failTemplateInstantiation(
+				StringBuilder()
+					.append("template function '")
+					.append(template_name)
+					.append("' return type parsing returned no node")
+					.commit(),
+				&key,
+				overload_id);
 		}
 
 		return_type = *return_type_result.node();
@@ -3825,8 +3841,14 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 		// preserve_ref_qualifier=false: deduced args carry call-site lvalue-ness which must
 		// NOT be propagated to TypeInfo (see registerTypeParamsInScope comment).
 		const auto& func_template_params = template_func.template_parameters();
-		reparse_template_function_body(new_func_ref, func_decl, func_template_params, template_args,
-									   /*preserve_ref_qualifier=*/false);
+		if (template_instantiation_mode_ == TemplateInstantiationMode::HardUseCandidateProbe) {
+			ScopedParserInstantiationContext body_instantiation_mode(*this, TemplateInstantiationMode::HardUse, StringHandle{});
+			reparse_template_function_body(new_func_ref, func_decl, func_template_params, template_args,
+										   /*preserve_ref_qualifier=*/false);
+		} else {
+			reparse_template_function_body(new_func_ref, func_decl, func_template_params, template_args,
+										   /*preserve_ref_qualifier=*/false);
+		}
 		if (!new_func_ref.is_materialized()) {
 			StringBuilder reason_builder;
 			StringHandle body_reparse_failure_reason = StringTable::getOrInternStringHandle(
@@ -3835,7 +3857,10 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 					.append(saved_mangled_name)
 					.commit());
 			new_func_ref.mark_failed_substitution(body_reparse_failure_reason);
-			gTemplateRegistry.markFailedInstantiation(key, overload_id);
+			failTemplateInstantiation(
+				StringTable::getStringView(body_reparse_failure_reason),
+				&key,
+				overload_id);
 			body_reparse_failed = true;
 			FLASH_LOG(Templates, Debug, "Marked template instantiation as failed substitution after body reparse: ",
 					  StringTable::getStringView(body_reparse_failure_reason));

--- a/src/Parser_Templates_Inst_Failure.cpp
+++ b/src/Parser_Templates_Inst_Failure.cpp
@@ -1,0 +1,25 @@
+#include "Parser.h"
+
+bool Parser::isHardUseLikeInstantiationMode() const {
+	return template_instantiation_mode_ == TemplateInstantiationMode::HardUse ||
+		   template_instantiation_mode_ == TemplateInstantiationMode::HardUseCandidateProbe;
+}
+
+bool Parser::isTemplateInstantiationFailureProbeMode() const {
+	return template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe ||
+		   template_instantiation_mode_ == TemplateInstantiationMode::HardUseCandidateProbe;
+}
+
+std::optional<ASTNode> Parser::failTemplateInstantiation(
+	std::string_view reason,
+	const FlashCpp::TemplateInstantiationKey* key,
+	std::optional<uintptr_t> overload_id) {
+	if (isTemplateInstantiationFailureProbeMode()) {
+		if (key != nullptr && overload_id.has_value()) {
+			gTemplateRegistry.markFailedInstantiation(*key, *overload_id);
+		}
+		return std::nullopt;
+	}
+	// HardUse and ShapeOnly are both non-probe modes: failures are not soft.
+	throw CompileError(std::string(reason));
+}

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -718,7 +718,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 			FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 			FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
-			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SfinaeProbe, StringHandle{});
+			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 			parsing_template_depth_ = 0;	 // suppress template body context during SFINAE
 			clearCurrentTemplateParameters();  // No dependent names during SFINAE
 			sfinae_type_map_.clear();
@@ -954,13 +954,18 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		}
 	} depth_guard;
 	if (s_member_inst_depth > MAX_MEMBER_INST_DEPTH) {
+		std::string_view failure_reason = StringBuilder()
+			.append("Max member function template instantiation depth (")
+			.append(static_cast<uint64_t>(MAX_MEMBER_INST_DEPTH))
+			.append(") exceeded for '")
+			.append(qualified_name)
+			.append("'. Possible recursive template instantiation.")
+			.commit();
 		if (!s_member_inst_depth_warned) {
-			FLASH_LOG(Templates, Error, "Max member function template instantiation depth (",
-					  MAX_MEMBER_INST_DEPTH, ") exceeded for '", StringTable::getStringView(qualified_name),
-					  "'. Possible recursive template instantiation.");
+			FLASH_LOG(Templates, Error, failure_reason);
 			s_member_inst_depth_warned = true;
 		}
-		return std::nullopt;
+		return failTemplateInstantiation(failure_reason, &key, reinterpret_cast<uintptr_t>(&template_node));
 	}
 
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1,4 +1,4 @@
-﻿#include "Parser.h"
+#include "Parser.h"
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
 #include "NameMangling.h"
@@ -682,7 +682,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 		Templates,
 		Debug,
 		"parse_explicit_template_arguments called, sfinae_probe={}",
-		template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe);
+		template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe);
 
 	// Save position in case this isn't template arguments
 	auto saved_pos = save_token_position();
@@ -1117,13 +1117,13 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 			// 2. When NOT parsing a template body (e.g., global scope type alias like `using X = holder<1 ? 2 : 3>`)
 			// Only skip evaluation during template DECLARATION when template parameters are not yet instantiated
 			bool should_try_constant_eval =
-				template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe || parsing_template_depth_ == 0;
+				template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe || parsing_template_depth_ == 0;
 			if (should_try_constant_eval) {
 				FLASH_LOG(
 					Templates,
 					Debug,
 					"Trying to evaluate non-literal expression as constant (sfinae_probe=",
-					template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe,
+					template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe,
 					", parsing_template_body=",
 					parsing_template_depth_ > 0,
 					")");
@@ -2060,7 +2060,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 			"Checking dependency for template argument: type={}, type_index={}, sfinae_probe={}",
 			static_cast<int>(type_node.type()),
 			type_node.type_index(),
-			template_instantiation_mode_ == TemplateInstantiationMode::SfinaeProbe);
+			template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe);
 		if (!arg.is_value &&
 			(type_node.category() == TypeCategory::UserDefined || type_node.category() == TypeCategory::TypeAlias || type_node.category() == TypeCategory::Template)) {
 			// Prefer the source token spelling when it exists, but fall back to the
@@ -2104,7 +2104,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 				// During SFINAE context (re-parsing), template parameters are substituted with concrete types
 				// so we should NOT mark them as dependent
 				bool is_template_param = false;
-				if (template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
+				if (template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe) {
 					for (const auto& param_name : currentTemplateParamNames()) {
 						std::string_view param_sv = StringTable::getStringView(param_name);
 						if (type_name == param_sv || matches_identifier(type_name, param_sv)) {
@@ -2118,7 +2118,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 					arg.is_dependent = true;
 					arg.dependent_name = StringTable::getOrInternStringHandle(type_name);
 					FLASH_LOG_FORMAT(Templates, Debug, "Template argument is dependent (type name: {})", type_name);
-				} else if (template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
+				} else if (template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe) {
 					// Also check the full type name from gTypeInfo for composite/qualified types
 					std::string_view check_name = !full_type_name.empty() ? full_type_name : type_name;
 
@@ -2189,7 +2189,7 @@ std::optional<std::vector<TemplateTypeArg>> Parser::parse_explicit_template_argu
 		if (!arg.is_dependent &&
 			type_node.category() == TypeCategory::Struct &&
 			parsing_template_depth_ > 0 &&
-			template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
+			template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe) {
 			TypeIndex idx = type_node.type_index();
 			if (const TypeInfo* type_info = tryGetTypeInfo(idx)) {
 				std::string_view type_name = StringTable::getStringView(type_info->name());

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2041,7 +2041,7 @@ ParseResult Parser::parse_type_specifier() {
 
 					// SFINAE: If we're in a substitution context and can't find the nested type,
 					// this is a substitution failure, not a hard error
-					if (template_instantiation_mode_ != TemplateInstantiationMode::HardUse) {
+					if (!isHardUseLikeInstantiationMode()) {
 						FLASH_LOG_FORMAT(Parser, Debug, "SFINAE: Substitution failure - unknown nested type: {}", qualified_type_name);
 						// Return a placeholder type that will cause instantiation to fail
 						// The caller (try_instantiate_single_template) will catch this and try the next overload
@@ -2197,11 +2197,11 @@ ParseResult Parser::parse_type_specifier() {
 		// Check if the identifier is a template parameter (e.g., _Tp in template<typename _Tp>)
 		// This must be checked BEFORE looking up in getTypesByNameMap() to handle patterns like:
 		// __has_trivial_destructor(_Tp) where _Tp is a template parameter
-		// IMPORTANT: Skip this check during SfinaeProbe mode, because in that case
+		// IMPORTANT: Skip this check during SoftProbe mode, because in that case
 		// the template parameters have been substituted with concrete types in getTypesByNameMap(), and we
 		// should use the substituted types instead of creating dependent type placeholders.
 		if (isTemplateBodyWithActiveParameters() &&
-			template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
+			template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe) {
 			StringHandle type_name_handle = StringTable::getOrInternStringHandle(type_name);
 			for (const auto& param_name : currentTemplateParamNames()) {
 				if (param_name == type_name_handle) {
@@ -2558,7 +2558,7 @@ ParseResult Parser::parse_decltype_specifier() {
 		bool is_recursion_error = expr_result.error_message().find("recursion depth") != std::string::npos ||
 								  expr_result.error_message().find("recursion") != std::string::npos;
 		bool should_recover = tokenRangeMentionsActiveTemplateParam(expr_start_pos) &&
-							  (template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe || is_recursion_error);
+							  (template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe || is_recursion_error);
 		if (should_recover) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for failed decltype expression in template context");
 			// Restore position to start of expression for reliable paren counting
@@ -2596,7 +2596,7 @@ ParseResult Parser::parse_decltype_specifier() {
 			// Restore to position before the failed parse_expression to ensure
 			// reliable paren depth counting (mirrors the first-expression recovery above).
 			if (tokenRangeMentionsActiveTemplateParam(comma_expr_pos) &&
-				template_instantiation_mode_ != TemplateInstantiationMode::SfinaeProbe) {
+				template_instantiation_mode_ != TemplateInstantiationMode::SoftProbe) {
 				restore_token_position(comma_expr_pos);
 				int paren_depth = 1;
 				while (!peek().is_eof() && paren_depth > 0) {


### PR DESCRIPTION
## Summary
- add explicit template-instantiation failure helpers and mode predicates
- split hard-use candidate probing from SFINAE soft probing so overload candidates can fail softly without enabling SFINAE-only expression behavior
- route focused template-instantiation failures through the helper, including the member-template hard-use fallback and selected function/member/class instantiation failures
- include the new helper source in unity and MSVC project files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced template instantiation failure handling with improved distinction between probe and hard-use compilation contexts.
  * Improved consistency in how template substitution errors are reported during compilation.

* **Chores**
  * Updated build system configuration to support improved template instantiation failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->