### PR TITLE
Standards-faithful template substitution and removal of non-standard fallbacks (PR #1490)

### DIFF
--- a/followup-lazy-member-key-redesign.md
+++ b/followup-lazy-member-key-redesign.md
@@ -1,0 +1,31 @@
+# Agent Prompt: Restore full lazy-member identity in canonical owner lookup
+
+Investigate and redesign lazy-member lookup keys so canonical lazy-member materialization does not collapse distinct overloads or template-ids onto the same key.
+
+## Context
+- Repository: FlashCpp
+- Relevant review concern: `src/Parser_Templates_Inst_Substitution.cpp` and `src/TemplateRegistry_Lazy.h` currently use a lazy-member key that effectively tracks owner, member name, and constness, but not the full overload/template-id discriminator.
+- This was judged valid but too large for the current PR because it requires a broader key redesign and registry migration.
+
+## Goals
+1. Preserve standards-faithful member lookup for overload sets and member template specializations.
+2. Ensure lazy materialization keys uniquely identify the target declaration being materialized.
+3. Avoid introducing fallback probing that guesses between overloads.
+
+## Constraints
+- No platform-specific commands or tooling assumptions.
+- Maintain compatibility with existing lazy-member caches where possible, or provide a safe migration path.
+- Do not reduce correctness to recover performance.
+
+## Suggested investigation areas
+- `Parser_Templates_Inst_Substitution.cpp`
+- `TemplateRegistry_Lazy.h`
+- lazy-member registration and lookup
+- overload resolution interactions
+- member template explicit-arg and const-qualified call paths
+
+## Deliverables
+1. A precise statement of what identity must be encoded in the key.
+2. The key/registry redesign.
+3. Tests covering overloaded members, member templates, and const/non-const distinctions.
+4. Validation against the existing regression suite.

--- a/followup-remove-legacy-environment-bridge.md
+++ b/followup-remove-legacy-environment-bridge.md
@@ -1,0 +1,32 @@
+# Agent Prompt: Remove the legacy template lookup environment bridge
+
+Investigate what is still required to remove `legacy_environment` from dependent template-argument lookup and replace it with a fully environment-driven model.
+
+## Context
+- Repository: FlashCpp
+- Relevant code: `trySubstituteDependentTemplateArgForLookup()` in `src/ConstExprEvaluator_Members.cpp`
+- Current state: `legacy_environment` is still live and cannot simply be deleted. It bridges older constexpr/member-evaluation paths that still populate `template_param_names` and `template_args` instead of a full `TemplateEnvironment`.
+
+## Goals
+1. Identify every path that still depends on the legacy name/arg arrays.
+2. Migrate those paths to populate and consume `TemplateEnvironment` directly.
+3. Remove the bridge only after behavior matches current standards-faithful substitution and lookup semantics.
+
+## Constraints
+- No platform-specific commands or tooling assumptions.
+- Do not remove the bridge until all callers are migrated.
+- Avoid fallback behavior that guesses missing bindings.
+- Preserve current constexpr, member-evaluation, and dependent lookup behavior during the migration.
+
+## Suggested investigation areas
+- `src/ConstExprEvaluator_Members.cpp`
+- `EvaluationContext`
+- construction of `template_environment`
+- any code that still reads `template_param_names` / `template_args`
+- member-evaluation and constexpr replay paths
+
+## Deliverables
+1. A migration inventory of remaining legacy users.
+2. A staged plan for converting them to `TemplateEnvironment`.
+3. The implementation once all paths are covered.
+4. Regression coverage for dependent member lookup, constexpr substitution, and nested template environments.

--- a/followup-specialization-alias-alignment.md
+++ b/followup-specialization-alias-alignment.md
@@ -1,0 +1,33 @@
+# Agent Prompt: Audit specialization-aligned alias substitution paths
+
+Investigate the class-template instantiation paths that mix primary filled arguments with specialization-aligned pattern arguments, and make alias substitution consistently use the correct argument view at each step.
+
+## Context
+- Repository: FlashCpp
+- Relevant review concern: `src/Parser_Templates_Inst_ClassTemplate.cpp` has subtle interactions between:
+  - `filled_args_for_pattern_match` (primary/default-filled argument view)
+  - specialization-aligned pattern argument vectors
+- Part of this was fixed in the current PR, but the broader audit was judged valid and too large because multiple alias, substitution, and default-argument paths still depend on choosing the right argument projection.
+
+## Goals
+1. Document which operations must use primary/default-filled args vs specialization-pattern-aligned args.
+2. Remove accidental mixing of those two views.
+3. Preserve correct alias materialization, SFINAE, and default-argument replay behavior.
+
+## Constraints
+- No platform-specific commands or tooling assumptions.
+- Keep the solution standards-faithful; do not paper over mismatches with fallback recovery.
+- Prefer explicit helpers or named abstractions over ad-hoc positional indexing.
+
+## Suggested investigation areas
+- `Parser_Templates_Inst_ClassTemplate.cpp`
+- alias target materialization helpers
+- specialization pattern matching
+- dependent default template argument evaluation
+- tests involving `enable_if`, alias templates, and specialization-based substitution
+
+## Deliverables
+1. A map of which argument view each helper should consume.
+2. Refactors or helper APIs that make the distinction explicit.
+3. Regression tests for alias-based specializations and defaulted dependent arguments.
+4. Validation on the full existing test suite.

--- a/followup-template-environment-snapshot.md
+++ b/followup-template-environment-snapshot.md
@@ -1,0 +1,32 @@
+# Agent Prompt: Remove quadratic template-environment snapshot flattening
+
+Investigate and redesign template-environment snapshot storage so nested template instantiations do not copy all parent bindings into every child snapshot.
+
+## Context
+- Repository: FlashCpp
+- Relevant review concern: `src/TemplateEnvironment.cpp` currently flattens `TemplateEnvironmentSnapshot` by copying parent bindings into each new snapshot, which causes O(N^2) total binding storage across deep template nesting.
+- This was judged valid but too large for the current PR because it affects environment persistence, replay, and lookup behavior across the compiler.
+
+## Goals
+1. Preserve existing C++20-correct lookup behavior for nested template environments.
+2. Reduce snapshot storage and construction cost so deep template hierarchies do not duplicate parent bindings repeatedly.
+3. Keep legacy views and replay paths working until they can be migrated safely.
+
+## Constraints
+- No platform-specific commands or tooling assumptions.
+- Prefer architectural fixes over caching hacks.
+- Do not silently change lookup precedence or pack behavior.
+- Keep behavior compatible with existing parser, constexpr, and instantiation paths.
+
+## Suggested investigation areas
+- `TemplateEnvironment.cpp`
+- `TemplateEnvironmentSnapshot`
+- snapshot serialization / deserialization helpers
+- any code that assumes snapshots are already flattened
+- lookup sites that walk parent chains vs stored snapshots
+
+## Deliverables
+1. A short design note explaining the chosen representation.
+2. The implementation.
+3. Regression coverage proving nested template lookup still works.
+4. Before/after validation on the existing build and test workflow.

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -131,7 +131,7 @@ std::optional<TemplateTypeArg> trySubstituteDependentTemplateArgForLookup(
 	EvaluationContext& context,
 	const TypeInfo* owner_type_info = nullptr,
 	int recursion_depth = 0) {
-	constexpr int kMaxDependentLookupMaterializationDepth = 8;
+	constexpr int kMaxDependentLookupMaterializationDepth = 32;
 	if (recursion_depth > kMaxDependentLookupMaterializationDepth) {
 		return std::nullopt;
 	}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -8698,6 +8698,7 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 
 	const TypeSpecifierNode& type_spec = type_node.as<TypeSpecifierNode>();
 	TypeCategory type_cat = type_spec.category();
+	CVQualifier type_cv = type_spec.cv_qualifier();
 	bool is_reference = type_spec.is_reference();
 	bool is_rvalue_reference = type_spec.is_rvalue_reference();
 	size_t pointer_depth = type_spec.pointer_depth();
@@ -8711,13 +8712,14 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 		 type_cat == TypeCategory::Template ||
 		 type_cat == TypeCategory::Invalid)) {
 		type_cat = resolved_trait_type.typeEnum();
+		type_cv |= resolved_trait_type.cv_qualifier;
 		if (resolved_trait_type.reference_qualifier != ReferenceQualifier::None) {
 			is_reference = true;
 			is_rvalue_reference =
 				resolved_trait_type.reference_qualifier == ReferenceQualifier::RValueReference;
 		}
 		pointer_depth += resolved_trait_type.pointer_depth;
-		if (resolved_trait_type.isArray()) {
+		if (!is_array && resolved_trait_type.isArray()) {
 			is_array = true;
 			if (!resolved_trait_type.array_dimensions.empty()) {
 				array_size = resolved_trait_type.array_dimensions.front();
@@ -8796,11 +8798,11 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 		break;
 
 	case TypeTraitKind::IsConst:
-		result = type_spec.is_const();
+		result = hasCVQualifier(type_cv, CVQualifier::Const);
 		break;
 
 	case TypeTraitKind::IsVolatile:
-		result = type_spec.is_volatile();
+		result = hasCVQualifier(type_cv, CVQualifier::Volatile);
 		break;
 
 	case TypeTraitKind::IsSigned:

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -129,8 +129,8 @@ InlineVector<TemplateParameterNode, 4> getTemplateParametersForTypeInfo(
 std::optional<TemplateTypeArg> trySubstituteDependentTemplateArgForLookup(
 	const TemplateTypeArg& dependent_arg,
 	EvaluationContext& context,
-	const TypeInfo* owner_type_info = nullptr,
-	int recursion_depth = 0) {
+	const TypeInfo* owner_type_info,
+	int recursion_depth) {
 	constexpr int kMaxDependentLookupMaterializationDepth = 32;
 	if (recursion_depth > kMaxDependentLookupMaterializationDepth) {
 		return std::nullopt;
@@ -300,12 +300,12 @@ std::optional<TemplateTypeArg> trySubstituteDependentTemplateArgForLookup(
 			context.template_param_names = std::move(saved_template_param_names);
 			context.template_args = std::move(saved_template_args);
 			if (evaluated.success()) {
-				const TypeCategory evaluated_category = evaluated.exact_type.has_value()
-					? evaluated.exact_type->type()
-					: (dependent_arg.category() != TypeCategory::Invalid
-						   ? dependent_arg.category()
-						   : TypeCategory::Int);
-				return TemplateTypeArg(evaluated.as_int(), evaluated_category);
+				TemplateTypeArg evaluated_arg = templateTypeArgFromEvalResult(evaluated);
+				if (evaluated_arg.category() == TypeCategory::Invalid &&
+					dependent_arg.category() != TypeCategory::Invalid) {
+					evaluated_arg.setCategory(dependent_arg.category());
+				}
+				return evaluated_arg;
 			}
 			TemplateTypeArg substituted_dependent_arg = dependent_arg;
 			substituted_dependent_arg.dependent_expr = std::move(substituted_expr);
@@ -8701,6 +8701,8 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 	bool is_reference = type_spec.is_reference();
 	bool is_rvalue_reference = type_spec.is_rvalue_reference();
 	size_t pointer_depth = type_spec.pointer_depth();
+	bool is_array = type_spec.is_array();
+	std::optional<size_t> array_size = type_spec.array_size();
 	const ResolvedAliasTypeInfo resolved_trait_type =
 		resolveAliasTypeInfo(type_spec.type_index());
 	if (resolved_trait_type.terminal_type_info != nullptr &&
@@ -8709,6 +8711,18 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 		 type_cat == TypeCategory::Template ||
 		 type_cat == TypeCategory::Invalid)) {
 		type_cat = resolved_trait_type.typeEnum();
+		if (resolved_trait_type.reference_qualifier != ReferenceQualifier::None) {
+			is_reference = true;
+			is_rvalue_reference =
+				resolved_trait_type.reference_qualifier == ReferenceQualifier::RValueReference;
+		}
+		pointer_depth += resolved_trait_type.pointer_depth;
+		if (resolved_trait_type.isArray()) {
+			is_array = true;
+			if (!resolved_trait_type.array_dimensions.empty()) {
+				array_size = resolved_trait_type.array_dimensions.front();
+			}
+		}
 	}
 
 	bool result = false;
@@ -8750,7 +8764,7 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 		break;
 
 	case TypeTraitKind::IsArray:
-		result = type_spec.is_array() && !is_reference && pointer_depth == 0;
+		result = is_array && !is_reference && pointer_depth == 0;
 		break;
 
 	case TypeTraitKind::IsReference:
@@ -8799,16 +8813,16 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 		break;
 
 	case TypeTraitKind::IsBoundedArray:
-		result = type_spec.is_array() & int(type_spec.array_size() > 0) & !is_reference & (pointer_depth == 0);
+		result = is_array & int(array_size.value_or(0) > 0) & !is_reference & (pointer_depth == 0);
 		break;
 
 	case TypeTraitKind::IsUnboundedArray:
-		result = type_spec.is_array() & int(type_spec.array_size() == 0) & !is_reference & (pointer_depth == 0);
+		result = is_array & int(array_size.value_or(0) == 0) & !is_reference & (pointer_depth == 0);
 		break;
 
 	case TypeTraitKind::IsAggregate:
 			// Arrays are aggregates
-		result = type_spec.is_array() & !is_reference & (pointer_depth == 0);
+		result = is_array & !is_reference & (pointer_depth == 0);
 			// For struct types, we need runtime type info, so fall through to default
 		break;
 

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -2,9 +2,11 @@
 #include "ConstExprEvaluator.h"
 #include "BuiltinListInitNarrowing.h"
 #include "CallNodeHelpers.h"
+#include "ExpressionSubstitutor.h"
 #include "OverloadResolution.h"
 #include "SemanticAnalysis.h"
 #include "TypeTraitEvaluator.h"
+#include <algorithm>
 #include <limits>
 
 namespace ConstExpr {
@@ -47,37 +49,372 @@ std::optional<EvalResult> tryEvaluateEnumConstant(
 	return result;
 }
 
-bool tryRebindSingleArgumentFallback(
-	TemplateTypeArg& dependent_arg,
-	const EvaluationContext& context,
-	std::string_view debug_context,
-	bool enable_ambiguity_warnings) {
-	if (!dependent_arg.isTypeArgument()) {
-		return false;
+TemplateParameterKind inferTemplateBindingKindForLookup(const TemplateTypeArg& arg) {
+	if (arg.is_template_template_arg) {
+		return TemplateParameterKind::Template;
 	}
+	if (arg.is_value) {
+		return TemplateParameterKind::NonType;
+	}
+	return TemplateParameterKind::Type;
+}
 
-	// Alias-template chains can preserve alias-local parameter names after
-	// substitution. For single-argument dependent owners in default template
-	// argument substitution, exactly one non-value context argument is the only
-	// viable rebound candidate when direct name matching fails.
-	size_t non_value_context_arg_count = 0;
-	const TemplateTypeArg* only_non_value_context_arg = nullptr;
-	for (const TemplateTypeArg& context_arg : context.template_args) {
-		if (!context_arg.is_value) {
-			++non_value_context_arg_count;
-			only_non_value_context_arg = &context_arg;
+TemplateEnvironment buildLegacyTemplateLookupEnvironment(const EvaluationContext& context) {
+	TemplateEnvironment legacy_environment;
+	const size_t pair_count =
+		std::min(context.template_param_names.size(), context.template_args.size());
+	legacy_environment.bindings.reserve(pair_count);
+	for (size_t i = 0; i < pair_count; ++i) {
+		TemplateBinding binding;
+		binding.name =
+			StringTable::getOrInternStringHandle(context.template_param_names[i]);
+		binding.kind = inferTemplateBindingKindForLookup(context.template_args[i]);
+		binding.is_pack = false;
+		binding.args.push_back(context.template_args[i]);
+		legacy_environment.bindings.push_back(std::move(binding));
+	}
+	return legacy_environment;
+}
+
+void populateLegacyTemplateBindingsFromEnvironment(
+	const TemplateEnvironment& environment,
+	InlineVector<std::string_view, 4>& out_param_names,
+	InlineVector<TemplateTypeArg, 4>& out_args) {
+	out_param_names.clear();
+	out_args.clear();
+	for (const TemplateEnvironment* current = &environment;
+		 current != nullptr;
+		 current = current->parent) {
+		for (const TemplateBinding& binding : current->bindings) {
+			if (binding.is_pack || binding.args.empty()) {
+				continue;
+			}
+			out_param_names.push_back(StringTable::getStringView(binding.name));
+			out_args.push_back(binding.args.front());
 		}
 	}
-	if (non_value_context_arg_count == 1 &&
-		only_non_value_context_arg != nullptr) {
-		dependent_arg = *only_non_value_context_arg;
-		FLASH_LOG(ConstExpr, Debug, "Rebound single-argument dependent owner fallback for ", debug_context);
-		return true;
+}
+
+InlineVector<TemplateParameterNode, 4> getTemplateParametersForTypeInfo(
+	const TypeInfo& owner_type_info) {
+	const StringHandle qualified_template_name =
+		gNamespaceRegistry.buildQualifiedIdentifier(
+			owner_type_info.sourceNamespace(),
+			owner_type_info.baseTemplateName());
+	if (auto alias_template_opt =
+			gTemplateRegistry.lookup_alias_template(qualified_template_name);
+		alias_template_opt.has_value() &&
+		alias_template_opt->is<TemplateAliasNode>()) {
+		return alias_template_opt->as<TemplateAliasNode>().template_parameters();
 	}
-	if (enable_ambiguity_warnings && non_value_context_arg_count > 1) {
-		FLASH_LOG(ConstExpr, Warning, "Single-argument dependent owner fallback skipped due to ambiguous non-value context arguments for ", debug_context);
+	if (auto alias_template_opt =
+			gTemplateRegistry.lookup_alias_template(owner_type_info.baseTemplateName());
+		alias_template_opt.has_value() &&
+		alias_template_opt->is<TemplateAliasNode>()) {
+		return alias_template_opt->as<TemplateAliasNode>().template_parameters();
 	}
-	return false;
+	if (auto template_opt = gTemplateRegistry.lookupTemplate(qualified_template_name);
+		template_opt.has_value() &&
+		template_opt->is<TemplateClassDeclarationNode>()) {
+		return template_opt->as<TemplateClassDeclarationNode>().template_parameters();
+	}
+	if (auto template_opt = gTemplateRegistry.lookupTemplate(owner_type_info.baseTemplateName());
+		template_opt.has_value() &&
+		template_opt->is<TemplateClassDeclarationNode>()) {
+		return template_opt->as<TemplateClassDeclarationNode>().template_parameters();
+	}
+	return {};
+}
+
+std::optional<TemplateTypeArg> trySubstituteDependentTemplateArgForLookup(
+	const TemplateTypeArg& dependent_arg,
+	EvaluationContext& context,
+	const TypeInfo* owner_type_info = nullptr,
+	int recursion_depth = 0) {
+	constexpr int kMaxDependentLookupMaterializationDepth = 8;
+	if (recursion_depth > kMaxDependentLookupMaterializationDepth) {
+		return std::nullopt;
+	}
+	TemplateEnvironment legacy_environment;
+	TemplateEnvironment context_environment;
+	bool context_environment_initialized = false;
+	TemplateEnvironment owner_environment;
+	bool owner_environment_initialized = false;
+	const auto ensure_legacy_environment = [&]() -> bool {
+		if (!legacy_environment.bindings.empty()) {
+			return true;
+		}
+		legacy_environment = buildLegacyTemplateLookupEnvironment(context);
+		return !legacy_environment.bindings.empty();
+	};
+	const auto ensure_context_environment = [&]() -> const TemplateEnvironment* {
+		if (context_environment_initialized) {
+			return (!context_environment.bindings.empty() || context_environment.parent != nullptr)
+				? &context_environment
+				: nullptr;
+		}
+		context_environment_initialized = true;
+		if (context.template_environment.bindings.empty() &&
+			context.template_environment.parent == nullptr) {
+			return nullptr;
+		}
+		context_environment = context.template_environment;
+		if (context_environment.parent == nullptr && ensure_legacy_environment()) {
+			context_environment.parent = &legacy_environment;
+		}
+		return &context_environment;
+	};
+	const auto ensure_owner_environment = [&]() -> const TemplateEnvironment* {
+		if (owner_environment_initialized) {
+			return (!owner_environment.bindings.empty() || owner_environment.parent != nullptr)
+				? &owner_environment
+				: nullptr;
+		}
+		owner_environment_initialized = true;
+		if (owner_type_info == nullptr || !owner_type_info->hasInstantiationContext()) {
+			return nullptr;
+		}
+		owner_environment = buildTemplateEnvironment(*owner_type_info->instantiationContext());
+		if (const TemplateEnvironment* context_env = ensure_context_environment();
+			context_env != nullptr) {
+			owner_environment.parent = context_env;
+		} else if (ensure_legacy_environment()) {
+			owner_environment.parent = &legacy_environment;
+		}
+		return &owner_environment;
+	};
+	const auto select_lookup_environment = [&]() -> const TemplateEnvironment* {
+		if (const TemplateEnvironment* owner_env = ensure_owner_environment();
+			owner_env != nullptr) {
+			return owner_env;
+		}
+		if (const TemplateEnvironment* context_env = ensure_context_environment();
+			context_env != nullptr) {
+			return context_env;
+		}
+		if (ensure_legacy_environment()) {
+			return &legacy_environment;
+		}
+		return nullptr;
+	};
+
+	StringHandle lookup_name = dependent_arg.dependent_name;
+	if (!lookup_name.isValid() &&
+		!dependent_arg.is_value &&
+		dependent_arg.type_index.is_valid()) {
+		if (const TypeInfo* arg_type_info = tryGetTypeInfo(dependent_arg.type_index);
+			arg_type_info != nullptr && arg_type_info->name().isValid()) {
+			if (const TemplateEnvironment* lookup_environment = select_lookup_environment();
+				lookup_environment != nullptr) {
+				if (resolveContextBinding(arg_type_info->name(), *lookup_environment).has_value() ||
+					lookup_environment->findOne(arg_type_info->name()) != nullptr) {
+					lookup_name = arg_type_info->name();
+				}
+			}
+		}
+	}
+	const bool can_try_dependent_expression_substitution =
+		dependent_arg.is_value &&
+		dependent_arg.dependent_expr.has_value() &&
+		context.parser != nullptr;
+	if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+		FLASH_LOG(ConstExpr, Debug, "trySubstituteDependentTemplateArgForLookup: is_value=", dependent_arg.is_value,
+			", is_dependent=", dependent_arg.is_dependent,
+			", dep_name=", StringTable::getStringView(dependent_arg.dependent_name),
+			", lookup_name=", StringTable::getStringView(lookup_name),
+			", type_index=", dependent_arg.type_index,
+			", owner_has_inst_ctx=", (owner_type_info != nullptr && owner_type_info->hasInstantiationContext()));
+		if (owner_type_info != nullptr && owner_type_info->hasInstantiationContext()) {
+			const auto* inst_ctx = owner_type_info->instantiationContext();
+			for (size_t i = 0; i < inst_ctx->param_names.size() && i < inst_ctx->param_args.size(); ++i) {
+				const TemplateTypeArg arg = toTemplateTypeArg(inst_ctx->param_args[i]);
+				FLASH_LOG(ConstExpr, Debug, "  owner inst_ctx[", i, "] name=",
+					StringTable::getStringView(inst_ctx->param_names[i]),
+					", is_value=", arg.is_value,
+					", is_dependent=", arg.is_dependent,
+					", dep_name=", StringTable::getStringView(arg.dependent_name),
+					", type_index=", arg.type_index);
+			}
+		}
+	}
+	if (!lookup_name.isValid() && !can_try_dependent_expression_substitution) {
+		return std::nullopt;
+	}
+
+	auto resolve_from_environment =
+		[&](const TemplateEnvironment& environment) -> std::optional<TemplateTypeArg> {
+		if (!lookup_name.isValid()) {
+			return std::nullopt;
+		}
+		std::optional<TemplateTypeArg> resolved = resolveContextBinding(
+			lookup_name,
+			environment);
+		if (!resolved.has_value()) {
+			if (const TemplateTypeArg* direct_binding =
+					environment.findOne(lookup_name);
+				direct_binding != nullptr) {
+				resolved = *direct_binding;
+			}
+		}
+		return resolved;
+	};
+
+	std::optional<TemplateTypeArg> resolved_binding;
+	const TemplateEnvironment* resolved_environment = nullptr;
+	if (lookup_name.isValid()) {
+		if (const TemplateEnvironment* lookup_environment = select_lookup_environment();
+			lookup_environment != nullptr) {
+			resolved_binding = resolve_from_environment(*lookup_environment);
+			if (resolved_binding.has_value()) {
+				if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+					FLASH_LOG(ConstExpr, Debug, "lookup binding resolved for '",
+						StringTable::getStringView(lookup_name),
+						"': is_value=", resolved_binding->is_value,
+						", is_dependent=", resolved_binding->is_dependent,
+						", dep_name=", StringTable::getStringView(resolved_binding->dependent_name),
+						", type_index=", resolved_binding->type_index);
+				}
+				resolved_environment = lookup_environment;
+			}
+		}
+	}
+
+	if (dependent_arg.is_value && dependent_arg.dependent_expr.has_value() && context.parser != nullptr) {
+		const TemplateEnvironment* evaluation_environment = resolved_environment;
+		if (evaluation_environment == nullptr) {
+			evaluation_environment = select_lookup_environment();
+		}
+		if (evaluation_environment != nullptr) {
+			ExpressionSubstitutor substitutor(*evaluation_environment, *context.parser);
+			ASTNode substituted_expr = substitutor.substitute(*dependent_arg.dependent_expr);
+			auto saved_template_environment = context.template_environment;
+			auto saved_template_param_names = context.template_param_names;
+			auto saved_template_args = context.template_args;
+			context.template_environment = *evaluation_environment;
+			populateLegacyTemplateBindingsFromEnvironment(
+				context.template_environment,
+				context.template_param_names,
+				context.template_args);
+			EvalResult evaluated = Evaluator::evaluate(substituted_expr, context);
+			context.template_environment = std::move(saved_template_environment);
+			context.template_param_names = std::move(saved_template_param_names);
+			context.template_args = std::move(saved_template_args);
+			if (evaluated.success()) {
+				const TypeCategory evaluated_category = evaluated.exact_type.has_value()
+					? evaluated.exact_type->type()
+					: (dependent_arg.category() != TypeCategory::Invalid
+						   ? dependent_arg.category()
+						   : TypeCategory::Int);
+				return TemplateTypeArg(evaluated.as_int(), evaluated_category);
+			}
+			TemplateTypeArg substituted_dependent_arg = dependent_arg;
+			substituted_dependent_arg.dependent_expr = std::move(substituted_expr);
+			substituted_dependent_arg.is_dependent = true;
+			return substituted_dependent_arg;
+		}
+	}
+
+	if (!resolved_binding.has_value()) {
+		if (lookup_name.isValid() &&
+			owner_type_info != nullptr &&
+			owner_type_info->isTemplateInstantiation()) {
+			InlineVector<TemplateParameterNode, 4> owner_template_params =
+				getTemplateParametersForTypeInfo(*owner_type_info);
+			const size_t owner_pair_count = std::min(
+				owner_template_params.size(),
+				owner_type_info->templateArgs().size());
+			for (size_t i = 0; i < owner_pair_count; ++i) {
+				if (owner_template_params[i].name() !=
+					StringTable::getStringView(lookup_name)) {
+					continue;
+				}
+				TemplateTypeArg owner_bound_arg =
+					toTemplateTypeArg(owner_type_info->templateArgs()[i]);
+				if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+					FLASH_LOG(ConstExpr, Debug, "owner param positional rebound for '",
+						owner_template_params[i].name(),
+						"': is_value=", owner_bound_arg.is_value,
+						", is_dependent=", owner_bound_arg.is_dependent,
+						", dep_name=", StringTable::getStringView(owner_bound_arg.dependent_name),
+						", type_index=", owner_bound_arg.type_index);
+				}
+				if (std::optional<TemplateTypeArg> rematerialized =
+						trySubstituteDependentTemplateArgForLookup(
+							owner_bound_arg,
+							context,
+							owner_type_info,
+							recursion_depth + 1);
+					rematerialized.has_value()) {
+					owner_bound_arg = std::move(*rematerialized);
+				}
+				if (!dependent_arg.is_value && !owner_bound_arg.is_value) {
+					return rebindDependentTemplateTypeArg(
+						owner_bound_arg,
+						dependent_arg);
+				}
+				if (dependent_arg.is_value &&
+					dependent_arg.dependent_expr.has_value() &&
+					!owner_bound_arg.is_value) {
+					return std::nullopt;
+				}
+				return owner_bound_arg;
+			}
+		}
+		return std::nullopt;
+	}
+	if (!dependent_arg.is_value && !resolved_binding->is_value) {
+		TemplateTypeArg materialized_binding = *resolved_binding;
+		const TemplateEnvironment* lookup_environment = resolved_environment;
+		if (lookup_environment == nullptr) {
+			lookup_environment = select_lookup_environment();
+		}
+		if (lookup_environment != nullptr) {
+			constexpr size_t kMaxBindingMaterializationDepth = 16;
+			size_t materialization_depth = 0;
+			while (materialization_depth < kMaxBindingMaterializationDepth) {
+				bool advanced = false;
+				if (materialized_binding.is_dependent &&
+					materialized_binding.dependent_name.isValid()) {
+					if (auto rebound_binding = resolveContextBinding(
+							materialized_binding.dependent_name,
+							*lookup_environment);
+						rebound_binding.has_value() && !rebound_binding->is_value) {
+						materialized_binding = rebindDependentTemplateTypeArg(
+							*rebound_binding,
+							materialized_binding);
+						advanced = true;
+					}
+				}
+				if (!advanced &&
+					materialized_binding.type_index.is_valid()) {
+					if (const TypeInfo* materialized_type_info = tryGetTypeInfo(materialized_binding.type_index);
+						materialized_type_info != nullptr &&
+						materialized_type_info->isDependentPlaceholder()) {
+						if (auto rebound_binding = resolveContextBinding(
+								materialized_type_info->name(),
+								*lookup_environment);
+							rebound_binding.has_value() && !rebound_binding->is_value) {
+							materialized_binding = rebindDependentTemplateTypeArg(
+								*rebound_binding,
+								materialized_binding);
+							advanced = true;
+						}
+					}
+				}
+				if (!advanced) {
+					break;
+				}
+				++materialization_depth;
+			}
+		}
+		return rebindDependentTemplateTypeArg(materialized_binding, dependent_arg);
+	}
+
+	if (dependent_arg.is_value && !resolved_binding->is_value) {
+		return std::nullopt;
+	}
+
+	return *resolved_binding;
 }
 
 struct ShiftEvaluationInfo {
@@ -4329,7 +4666,8 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 
 				if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
 					FLASH_LOG(ConstExpr, Debug, "Found type_info, isStruct=", type_info->isStruct(),
-							  ", type_index=", type_info->type_index_, ", hasStructInfo=", (type_info->getStructInfo() != nullptr));
+							  ", type_index=", type_info->type_index_, ", hasStructInfo=", (type_info->getStructInfo() != nullptr),
+							  ", hasInstCtx=", type_info->hasInstantiationContext());
 				}
 
 				// A constexpr qualified-id can name a dependent template-instantiation
@@ -4340,35 +4678,89 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 				if (type_info->isTemplateInstantiation() &&
 					type_info->getStructInfo() == nullptr &&
 					context.parser != nullptr) {
+					auto materialize_template_arg_for_owner =
+						[&](auto&& self,
+							const TemplateTypeArg& source_arg,
+							const TypeInfo* source_owner,
+							int depth) -> TemplateTypeArg {
+						constexpr int kMaxOwnerArgMaterializationDepth = 8;
+						TemplateTypeArg concrete_arg = source_arg;
+						if (std::optional<TemplateTypeArg> rebound_arg =
+								trySubstituteDependentTemplateArgForLookup(
+									concrete_arg,
+									context,
+									source_owner,
+									depth);
+							rebound_arg.has_value()) {
+							concrete_arg = std::move(*rebound_arg);
+						}
+
+						if (depth >= kMaxOwnerArgMaterializationDepth ||
+							concrete_arg.is_value ||
+							!concrete_arg.type_index.is_valid() ||
+							context.parser == nullptr) {
+							return concrete_arg;
+						}
+
+						const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+						if (concrete_type_info == nullptr ||
+							!concrete_type_info->isTemplateInstantiation()) {
+							return concrete_arg;
+						}
+
+						std::string_view nested_base_template_name =
+							StringTable::getStringView(concrete_type_info->baseTemplateName());
+						if (nested_base_template_name.empty()) {
+							return concrete_arg;
+						}
+
+						std::vector<TemplateTypeArg> nested_concrete_args;
+						nested_concrete_args.reserve(concrete_type_info->templateArgs().size());
+						for (const auto& nested_arg_info : concrete_type_info->templateArgs()) {
+							TemplateTypeArg nested_arg = self(
+								self,
+								toTemplateTypeArg(nested_arg_info),
+								concrete_type_info,
+								depth + 1);
+							nested_concrete_args.push_back(std::move(nested_arg));
+						}
+
+						Parser::AliasTemplateMaterializationResult nested_materialized_type =
+							context.parser->materializeTemplateInstantiationForLookup(
+								nested_base_template_name,
+								nested_concrete_args);
+						const TypeInfo* nested_resolved_info =
+							nested_materialized_type.resolved_type_info;
+						if (nested_resolved_info == nullptr &&
+							!nested_materialized_type.instantiated_name.empty()) {
+							nested_resolved_info = findTypeByName(
+								StringTable::getOrInternStringHandle(
+									nested_materialized_type.instantiated_name));
+						}
+						if (nested_resolved_info == nullptr) {
+							return concrete_arg;
+						}
+
+						TemplateTypeArg resolved_type_arg;
+						resolved_type_arg.type_index =
+							nested_resolved_info->registeredTypeIndex().withCategory(
+								nested_resolved_info->typeEnum());
+						resolved_type_arg.setCategory(nested_resolved_info->typeEnum());
+						return rebindDependentTemplateTypeArg(
+							resolved_type_arg,
+							concrete_arg);
+					};
 					std::string_view base_template_name =
 						StringTable::getStringView(type_info->baseTemplateName());
 					if (!base_template_name.empty()) {
 						std::vector<TemplateTypeArg> concrete_args;
 						concrete_args.reserve(type_info->templateArgs().size());
 						for (const auto& arg_info : type_info->templateArgs()) {
-							TemplateTypeArg concrete_arg = toTemplateTypeArg(arg_info);
-							if (concrete_arg.dependent_name.isValid()) {
-								bool rebound_arg = false;
-								std::string_view dependent_arg_name =
-									StringTable::getStringView(concrete_arg.dependent_name);
-								for (size_t i = 0;
-									 i < context.template_param_names.size() &&
-									 i < context.template_args.size();
-									 ++i) {
-									if (context.template_param_names[i] == dependent_arg_name) {
-										concrete_arg = context.template_args[i];
-										rebound_arg = true;
-										break;
-									}
-								}
-								if (!rebound_arg && type_info->templateArgs().size() == 1) {
-									rebound_arg = tryRebindSingleArgumentFallback(
-										concrete_arg,
-										context,
-										"constexpr qualified-id owner",
-										false);
-								}
-							}
+							TemplateTypeArg concrete_arg = materialize_template_arg_for_owner(
+								materialize_template_arg_for_owner,
+								toTemplateTypeArg(arg_info),
+								type_info,
+								0);
 							concrete_args.push_back(std::move(concrete_arg));
 						}
 
@@ -4549,32 +4941,81 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 							nested_target_info->isTemplateInstantiation() &&
 							nested_target_info->getStructInfo() == nullptr &&
 							context.parser != nullptr) {
+							const TypeInfo* nested_lookup_owner = nested_target_info;
+							if (resolved_type_info != nullptr &&
+								resolved_type_info->hasInstantiationContext()) {
+								nested_lookup_owner = resolved_type_info;
+							}
+							auto materialize_nested_lookup_arg =
+								[&](auto&& self,
+									const TemplateTypeArg& source_arg,
+									const TypeInfo* source_owner,
+									int depth) -> TemplateTypeArg {
+								constexpr int kMaxNestedLookupArgDepth = 8;
+								TemplateTypeArg concrete_arg = source_arg;
+								if (std::optional<TemplateTypeArg> rebound_arg =
+										trySubstituteDependentTemplateArgForLookup(
+											concrete_arg,
+											context,
+											source_owner,
+											depth);
+									rebound_arg.has_value()) {
+									concrete_arg = std::move(*rebound_arg);
+								}
+								if (depth >= kMaxNestedLookupArgDepth ||
+									concrete_arg.is_value ||
+									!concrete_arg.type_index.is_valid()) {
+									return concrete_arg;
+								}
+								const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+								if (concrete_type_info == nullptr ||
+									!concrete_type_info->isTemplateInstantiation()) {
+									return concrete_arg;
+								}
+								std::string_view concrete_base_name =
+									StringTable::getStringView(concrete_type_info->baseTemplateName());
+								if (concrete_base_name.empty()) {
+									return concrete_arg;
+								}
+								std::vector<TemplateTypeArg> concrete_nested_args;
+								concrete_nested_args.reserve(concrete_type_info->templateArgs().size());
+								for (const auto& concrete_nested_arg_info : concrete_type_info->templateArgs()) {
+									TemplateTypeArg concrete_nested_arg = self(
+										self,
+										toTemplateTypeArg(concrete_nested_arg_info),
+										concrete_type_info,
+										depth + 1);
+									concrete_nested_args.push_back(std::move(concrete_nested_arg));
+								}
+								Parser::AliasTemplateMaterializationResult concrete_materialized =
+									context.parser->materializeTemplateInstantiationForLookup(
+										concrete_base_name,
+										concrete_nested_args);
+								const TypeInfo* concrete_resolved_info = concrete_materialized.resolved_type_info;
+								if (concrete_resolved_info == nullptr &&
+									!concrete_materialized.instantiated_name.empty()) {
+									concrete_resolved_info = findTypeByName(
+										StringTable::getOrInternStringHandle(
+											concrete_materialized.instantiated_name));
+								}
+								if (concrete_resolved_info == nullptr) {
+									return concrete_arg;
+								}
+								TemplateTypeArg resolved_type_arg;
+								resolved_type_arg.type_index =
+									concrete_resolved_info->registeredTypeIndex().withCategory(
+										concrete_resolved_info->typeEnum());
+								resolved_type_arg.setCategory(concrete_resolved_info->typeEnum());
+								return rebindDependentTemplateTypeArg(resolved_type_arg, concrete_arg);
+							};
 							std::vector<TemplateTypeArg> nested_template_args;
 							nested_template_args.reserve(nested_target_info->templateArgs().size());
 							for (const auto& arg_info : nested_target_info->templateArgs()) {
-								TemplateTypeArg nested_arg = toTemplateTypeArg(arg_info);
-								if (nested_arg.dependent_name.isValid()) {
-									bool rebound_nested_arg = false;
-									std::string_view nested_arg_name =
-										StringTable::getStringView(nested_arg.dependent_name);
-									for (size_t i = 0;
-										 i < context.template_param_names.size() &&
-										 i < context.template_args.size();
-										 ++i) {
-										if (context.template_param_names[i] == nested_arg_name) {
-											nested_arg = context.template_args[i];
-											rebound_nested_arg = true;
-											break;
-										}
-									}
-									if (!rebound_nested_arg && nested_target_info->templateArgs().size() == 1) {
-										rebound_nested_arg = tryRebindSingleArgumentFallback(
-											nested_arg,
-											context,
-											"nested alias target",
-											true);
-									}
-								}
+								TemplateTypeArg nested_arg = materialize_nested_lookup_arg(
+									materialize_nested_lookup_arg,
+									toTemplateTypeArg(arg_info),
+									nested_lookup_owner,
+									0);
 								nested_template_args.push_back(std::move(nested_arg));
 							}
 							std::string_view nested_base_name =
@@ -8260,6 +8701,15 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 	bool is_reference = type_spec.is_reference();
 	bool is_rvalue_reference = type_spec.is_rvalue_reference();
 	size_t pointer_depth = type_spec.pointer_depth();
+	const ResolvedAliasTypeInfo resolved_trait_type =
+		resolveAliasTypeInfo(type_spec.type_index());
+	if (resolved_trait_type.terminal_type_info != nullptr &&
+		(type_cat == TypeCategory::UserDefined ||
+		 type_cat == TypeCategory::TypeAlias ||
+		 type_cat == TypeCategory::Template ||
+		 type_cat == TypeCategory::Invalid)) {
+		type_cat = resolved_trait_type.typeEnum();
+	}
 
 	bool result = false;
 
@@ -8365,7 +8815,9 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 	case TypeTraitKind::IsCompleteOrUnbounded:
 		{
 			const StructTypeInfo* struct_info = nullptr;
-			if (type_spec.type_index().is_valid() && is_struct_type(type_cat)) {
+			if (resolved_trait_type.terminal_type_info != nullptr) {
+				struct_info = resolved_trait_type.terminal_type_info->getStructInfo();
+			} else if (type_spec.type_index().is_valid() && is_struct_type(type_cat)) {
 				struct_info = getTypeInfo(type_spec.type_index()).getStructInfo();
 			}
 			TypeTraitResult trait_result = evaluateTypeTrait(
@@ -8388,7 +8840,9 @@ EvalResult Evaluator::evaluate_type_trait(const TypeTraitExprNode& trait_expr) {
 	case TypeTraitKind::IsPod:
 		{
 			const StructTypeInfo* struct_info = nullptr;
-			if (type_spec.type_index().is_valid() && is_struct_type(type_cat)) {
+			if (resolved_trait_type.terminal_type_info != nullptr) {
+				struct_info = resolved_trait_type.terminal_type_info->getStructInfo();
+			} else if (type_spec.type_index().is_valid() && is_struct_type(type_cat)) {
 				struct_info = getTypeInfo(type_spec.type_index()).getStructInfo();
 			}
 			TypeTraitResult trait_result = evaluateTypeTrait(trait_expr.kind(), type_spec, struct_info);

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -960,12 +960,89 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 				return instantiated;
 			};
+			auto tryInstantiateExplicitMemberTemplateForCurrentOwner =
+				[&](std::string_view member_name) -> std::optional<ASTNode> {
+				if (!current_owner_type_name_.isValid() || member_name.empty()) {
+					return std::nullopt;
+				}
+				std::vector<TemplateTypeArg> current_inst_args;
+				if (auto owner_type_it = getTypesByNameMap().find(current_owner_type_name_);
+					owner_type_it != getTypesByNameMap().end() && owner_type_it->second != nullptr) {
+					const TypeInfo* owner_type_info = owner_type_it->second;
+					current_inst_args.reserve(owner_type_info->templateArgs().size());
+					for (const auto& stored_arg : owner_type_info->templateArgs()) {
+						current_inst_args.push_back(toTemplateTypeArg(stored_arg));
+					}
+				}
+				if (current_inst_args.empty()) {
+					current_inst_args =
+						collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteFunctionCallImpl");
+				}
+				FLASH_LOG(Templates, Debug,
+					"Trying member template lookup for owner ",
+					StringTable::getStringView(current_owner_type_name_),
+					" with ", current_inst_args.size(), " bound args");
+				Parser::AliasTemplateMaterializationResult canonical_owner =
+					parser_.resolveCanonicalInstantiatedOwnerForLookup(
+						StringTable::getStringView(current_owner_type_name_),
+						std::span<const TemplateTypeArg>(
+							current_inst_args.data(),
+							current_inst_args.size()));
+				std::string_view member_owner_name = canonical_owner.instantiated_name.empty()
+					? StringTable::getStringView(current_owner_type_name_)
+					: canonical_owner.instantiated_name;
+				FLASH_LOG(Templates, Debug,
+					"Member template canonical owner resolved to ", member_owner_name);
+				std::optional<ASTNode> instantiated =
+					parser_.try_instantiate_member_function_template_explicit(
+						member_owner_name,
+						member_name,
+						substituted_template_args);
+				if (instantiated.has_value()) {
+					normalizePendingSemanticRoots();
+				} else {
+					FLASH_LOG(Templates, Debug,
+						"Member template instantiation failed for ", member_owner_name,
+						"::", member_name);
+				}
+				return instantiated;
+			};
 			// First try function template instantiation to obtain accurate return type
 			std::optional<ASTNode> instantiated_template = std::nullopt;
 			if (!qualified_name.empty()) {
 				if (size_t scope_pos = qualified_name.rfind("::"); scope_pos != std::string_view::npos) {
 					std::string_view owner_name = qualified_name.substr(0, scope_pos);
 					std::string_view member_name = qualified_name.substr(scope_pos + 2);
+					if (current_owner_type_name_.isValid()) {
+						bool source_owner_matches_current_instantiation = false;
+						std::string_view current_owner_name = StringTable::getStringView(current_owner_type_name_);
+						if (owner_name == current_owner_name) {
+							source_owner_matches_current_instantiation = true;
+						} else if (auto owner_type_it = getTypesByNameMap().find(current_owner_type_name_);
+							owner_type_it != getTypesByNameMap().end() && owner_type_it->second != nullptr) {
+							const TypeInfo* owner_type_info = owner_type_it->second;
+							std::string_view base_template_name =
+								StringTable::getStringView(owner_type_info->baseTemplateName());
+							if (owner_name == base_template_name) {
+								source_owner_matches_current_instantiation = true;
+							} else {
+								std::string_view qualified_base_template_name =
+									buildQualifiedNameFromHandle(
+										owner_type_info->sourceNamespace(),
+										StringTable::getStringView(owner_type_info->baseTemplateName()));
+								source_owner_matches_current_instantiation =
+									!qualified_base_template_name.empty() &&
+									owner_name == qualified_base_template_name;
+							}
+						}
+						if (source_owner_matches_current_instantiation) {
+							instantiated_template =
+								tryInstantiateExplicitMemberTemplateForCurrentOwner(member_name);
+						}
+					}
+					if (instantiated_template.has_value()) {
+						// Current-instantiation member lookup already found the correct owner.
+					} else {
 					std::vector<TemplateTypeArg> current_inst_args =
 						collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteFunctionCallImpl");
 					Parser::AliasTemplateMaterializationResult canonical_owner =
@@ -987,10 +1064,15 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 							normalizePendingSemanticRoots();
 						}
 					}
+					}
 				}
 				if (!instantiated_template.has_value()) {
 					instantiated_template = tryInstantiateExplicitFunctionTemplate(qualified_name);
 				}
+			}
+			if (!instantiated_template.has_value()) {
+				instantiated_template =
+					tryInstantiateExplicitMemberTemplateForCurrentOwner(func_name);
 			}
 			if (!instantiated_template.has_value()) {
 				instantiated_template = tryInstantiateExplicitFunctionTemplate(func_name);
@@ -1224,18 +1306,12 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					substituted_args.push_back(substitute(call.arguments()[i]));
 				}
 
-				// Create new forward declaration with corrected name
-				auto& fwd_type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-				ASTNode fwd_type_ast(&fwd_type_node);
-				auto& new_decl = gChunkedAnyStorage.emplace_back<DeclarationNode>(fwd_type_ast, new_func_token);
-
 				// Try to trigger lazy member function instantiation for the target
 				parser_.instantiateLazyMemberForCanonicalOwner(instantiated_name, member_name);
 
 				StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
 				StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
 
-				const DeclarationNode* target_decl = &new_decl;
 				const FunctionDeclarationNode* target_func = nullptr;
 				auto type_it = getTypesByNameMap().find(inst_name_handle);
 				if (type_it != getTypesByNameMap().end()) {
@@ -1244,15 +1320,19 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 							if (member_func.getName() == member_handle &&
 								member_func.function_decl.is<FunctionDeclarationNode>()) {
 								target_func = &member_func.function_decl.as<FunctionDeclarationNode>();
-								target_decl = &target_func->decl_node();
 								break;
 							}
 						}
 					}
 				}
 
+				if (target_func == nullptr) {
+					FLASH_LOG(Templates, Debug, "  Canonical owner member not materialized yet, keeping original call");
+					return wrapOriginalCall();
+				}
+
 				ExpressionNode& new_expr = emplaceDirectCallExpr(
-					*target_decl,
+					target_func->decl_node(),
 					target_func,
 					std::move(substituted_args),
 					new_func_token);
@@ -1891,6 +1971,62 @@ ASTNode ExpressionSubstitutor::substituteSizeofExpr(const SizeofExprNode& sizeof
 	} else {
 		// This is sizeof(expression) - substitute the expression
 		ASTNode substituted_expr = substitute(type_or_expr);
+		if (substituted_expr.is<TypeSpecifierNode>()) {
+			const TypeSpecifierNode& substituted_type = substituted_expr.as<TypeSpecifierNode>();
+			const int size_bits = getTypeSpecSizeBits(substituted_type);
+			if (size_bits > 0) {
+				StringBuilder size_builder;
+				std::string_view size_str = size_builder.append(static_cast<size_t>(size_bits / 8)).commit();
+				Token literal_token(
+					Token::Type::Literal,
+					size_str,
+					sizeof_expr.sizeof_token().line(),
+					sizeof_expr.sizeof_token().column(),
+					sizeof_expr.sizeof_token().file_index());
+				return ASTNode::emplace_node<ExpressionNode>(NumericLiteralNode(
+					literal_token,
+					static_cast<unsigned long long>(size_bits / 8),
+					TypeCategory::UnsignedLongLong,
+					TypeQualifier::None,
+					64));
+			}
+		}
+		if (type_or_expr.is<ExpressionNode>()) {
+			const ExpressionNode& original_expr = type_or_expr.as<ExpressionNode>();
+			std::string_view dependent_name;
+			if (const auto* ident = std::get_if<IdentifierNode>(&original_expr)) {
+				dependent_name = ident->name();
+			} else if (const auto* tparam_ref = std::get_if<TemplateParameterReferenceNode>(&original_expr)) {
+				dependent_name = tparam_ref->param_name().view();
+			}
+			if (!dependent_name.empty()) {
+				auto it = param_map_.find(dependent_name);
+				if (it != param_map_.end() && it->second.isTypeArgument()) {
+					TypeSpecifierNode bound_type = makeTypeSpecifierFromTemplateTypeArg(
+						it->second,
+						sizeof_expr.sizeof_token());
+					int size_bits = getTypeSpecSizeBits(bound_type);
+					if (size_bits > 0) {
+						StringBuilder size_builder;
+						std::string_view size_str = size_builder.append(static_cast<size_t>(size_bits / 8)).commit();
+						Token literal_token(
+							Token::Type::Literal,
+							size_str,
+							sizeof_expr.sizeof_token().line(),
+							sizeof_expr.sizeof_token().column(),
+							sizeof_expr.sizeof_token().file_index());
+						return ASTNode::emplace_node<ExpressionNode>(NumericLiteralNode(
+							literal_token,
+							static_cast<unsigned long long>(size_bits / 8),
+							TypeCategory::UnsignedLongLong,
+							TypeQualifier::None,
+							64));
+					}
+					return ASTNode::emplace_node<ExpressionNode>(
+						SizeofExprNode(ASTNode::emplace_node<TypeSpecifierNode>(bound_type), sizeof_expr.sizeof_token()));
+				}
+			}
+		}
 
 		// Create new SizeofExprNode with substituted expression
 		SizeofExprNode new_sizeof = SizeofExprNode::from_expression(substituted_expr, sizeof_expr.sizeof_token());
@@ -1990,19 +2126,18 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 		}
 	}
 
-	// First, check if this is a template parameter type that needs substitution
-	// Template parameters can show up as Type::Template, Type::Auto, or Type::UserDefined
-	if (type.category() == TypeCategory::Template || isPlaceholderAutoType(type.category()) || type.category() == TypeCategory::UserDefined || type.category() == TypeCategory::TypeAlias) {
-		std::string_view type_name = type.token().value();
-		if (type_name.empty()) {
-			if (const TypeInfo* type_info = tryGetTypeInfo(type.type_index())) {
-				type_name = StringTable::getStringView(type_info->name());
-			}
+	// First, check whether this type spelling names a template parameter that needs substitution.
+	std::string_view type_name = type.token().value();
+	if (type_name.empty()) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(type.type_index())) {
+			type_name = StringTable::getStringView(type_info->name());
 		}
+	}
 
-		FLASH_LOG(Templates, Debug, "  Type is template parameter: ", type_name);
+	if (!type_name.empty()) {
+		FLASH_LOG(Templates, Debug, "  Type candidate for template substitution: ", type_name);
 
-		// Look up this template parameter in our substitution map
+		// Look up this template parameter in our substitution map.
 		auto it = param_map_.find(type_name);
 		if (it == param_map_.end()) {
 			if (std::optional<std::string_view> canonical_type_name = tryResolveCanonicalTypeName(type, type_name, param_map_)) {
@@ -2022,9 +2157,7 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 			return makeTypeSpecifierFromTemplateTypeArg(subst, type.token());
 		}
 
-		if (!type_name.empty()) {
-			FLASH_LOG(Templates, Warning, "  Template parameter not found in substitution map: ", type_name);
-		}
+		FLASH_LOG(Templates, Warning, "  Template parameter not found in substitution map: ", type_name);
 	}
 
 	// Check if this is a struct/class type that might have template arguments

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1307,7 +1307,10 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 
 				// Try to trigger lazy member function instantiation for the target
-				parser_.instantiateLazyMemberForCanonicalOwner(instantiated_name, member_name);
+				parser_.instantiateLazyMemberForCanonicalOwner(
+					instantiated_name,
+					member_name,
+					std::span<const TemplateTypeArg>{});
 
 				StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
 				StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
@@ -1375,7 +1378,8 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 						StringTable::getStringView(receiver_type_info->name());
 					if (parser_.instantiateLazyMemberForCanonicalOwner(
 							class_name,
-							call.called_from().value())
+							call.called_from().value(),
+							std::span<const TemplateTypeArg>{})
 							.has_value()) {
 						rebound_member =
 							parser_.tryResolveConcreteMemberFunction(substituted_receiver, call.called_from().value());

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2127,28 +2127,28 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 	}
 
 	// First, check whether this type spelling names a template parameter that needs substitution.
-	std::string_view type_name = type.token().value();
-	if (type_name.empty()) {
+	std::string_view token_type_name = type.token().value();
+	if (token_type_name.empty()) {
 		if (const TypeInfo* type_info = tryGetTypeInfo(type.type_index())) {
-			type_name = StringTable::getStringView(type_info->name());
+			token_type_name = StringTable::getStringView(type_info->name());
 		}
 	}
 
-	if (!type_name.empty()) {
-		FLASH_LOG(Templates, Debug, "  Type candidate for template substitution: ", type_name);
+	if (!token_type_name.empty()) {
+		FLASH_LOG(Templates, Debug, "  Type candidate for template substitution: ", token_type_name);
 
 		// Look up this template parameter in our substitution map.
-		auto it = param_map_.find(type_name);
+		auto it = param_map_.find(token_type_name);
 		if (it == param_map_.end()) {
-			if (std::optional<std::string_view> canonical_type_name = tryResolveCanonicalTypeName(type, type_name, param_map_)) {
-				FLASH_LOG(Templates, Debug, "  Resolved type token via canonical type info name: ", type_name, " -> ", *canonical_type_name);
-				type_name = *canonical_type_name;
-				it = param_map_.find(type_name);
+			if (std::optional<std::string_view> canonical_type_name = tryResolveCanonicalTypeName(type, token_type_name, param_map_)) {
+				FLASH_LOG(Templates, Debug, "  Resolved type token via canonical type info name: ", token_type_name, " -> ", *canonical_type_name);
+				token_type_name = *canonical_type_name;
+				it = param_map_.find(token_type_name);
 			}
 		}
 		if (it != param_map_.end()) {
 			const TemplateTypeArg& subst = it->second;
-			FLASH_LOG(Templates, Debug, "  Substituting template parameter: ", type_name,
+			FLASH_LOG(Templates, Debug, "  Substituting template parameter: ", token_type_name,
 					  " -> base_type=", (int)subst.typeEnum(), ", type_index=", subst.type_index);
 			if (subst.is_value) {
 				throw CompileError("Template argument used in a type position did not resolve to a type");
@@ -2157,7 +2157,7 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 			return makeTypeSpecifierFromTemplateTypeArg(subst, type.token());
 		}
 
-		FLASH_LOG(Templates, Warning, "  Template parameter not found in substitution map: ", type_name);
+		FLASH_LOG(Templates, Warning, "  Template parameter not found in substitution map: ", token_type_name);
 	}
 
 	// Check if this is a struct/class type that might have template arguments
@@ -2168,14 +2168,14 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 				owner_type_it->second != nullptr &&
 				owner_type_it->second->isTemplateInstantiation()) {
 				StringHandle owner_base_name = owner_type_it->second->baseTemplateName();
-				StringHandle type_name = type.token().handle();
-				if (!type_name.isValid()) {
+				StringHandle type_name_handle = type.token().handle();
+				if (!type_name_handle.isValid()) {
 					if (const TypeInfo* type_info = tryGetTypeInfo(type.type_index())) {
-						type_name = type_info->name();
+						type_name_handle = type_info->name();
 					}
 				}
 
-				if (owner_base_name.isValid() && type_name == owner_base_name) {
+				if (owner_base_name.isValid() && type_name_handle == owner_base_name) {
 					std::vector<TemplateTypeArg> current_inst_args =
 						collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteInType");
 					if (!current_inst_args.empty()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -960,11 +960,6 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 				return instantiated;
 			};
-			auto hasResolvedTypeOwner = [&](StringHandle owner_name_handle) {
-				const auto& types_by_name = getTypesByNameMap();
-				return types_by_name.find(owner_name_handle) != types_by_name.end();
-			};
-
 			// First try function template instantiation to obtain accurate return type
 			std::optional<ASTNode> instantiated_template = std::nullopt;
 			if (!qualified_name.empty()) {
@@ -973,20 +968,16 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					std::string_view member_name = qualified_name.substr(scope_pos + 2);
 					std::vector<TemplateTypeArg> current_inst_args =
 						collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteFunctionCallImpl");
-					if (!current_inst_args.empty() && extractBaseTemplateName(owner_name).empty()) {
-						auto owner_template = gTemplateRegistry.lookupTemplate(owner_name);
-						if (owner_template.has_value()) {
-							// Only class-template owners can be materialized here. Namespace-qualified
-							// calls like std::__atomic_impl::fn should skip this path entirely.
-							Parser::AliasTemplateMaterializationResult materialized_owner =
-								parser_.materializeTemplateInstantiationForLookup(owner_name, current_inst_args);
-							if (!materialized_owner.instantiated_name.empty()) {
-								owner_name = materialized_owner.instantiated_name;
-							}
-						}
+					Parser::AliasTemplateMaterializationResult canonical_owner =
+						parser_.resolveCanonicalInstantiatedOwnerForLookup(
+							owner_name,
+							std::span<const TemplateTypeArg>(
+								current_inst_args.data(),
+								current_inst_args.size()));
+					if (!canonical_owner.instantiated_name.empty()) {
+						owner_name = canonical_owner.instantiated_name;
 					}
-					StringHandle owner_name_handle = StringTable::getOrInternStringHandle(owner_name);
-					if (hasResolvedTypeOwner(owner_name_handle)) {
+					if (canonical_owner.resolved_type_info != nullptr) {
 						// Only try member-template recovery when the owner resolved to an actual type.
 						instantiated_template = parser_.try_instantiate_member_function_template_explicit(
 							owner_name,
@@ -1191,16 +1182,11 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		}
 	}
 
-	// If not a template function call or instantiation failed, check for dependent qualified names
-	// Pattern: Base$dependentHash::member(args) — needs re-instantiation with concrete types
-	// This happens when a template body is re-parsed: Base<T>::member() creates Base$hash1::member
-	// during initial template parsing, but the actual instantiation is Base$hash2.
+	// If not a template function call or instantiation failed, check for qualified owners
+	// that became concrete during substitution and need canonical owner identity rebound.
 	size_t scope_pos = func_name.find("::");
-	std::string_view base_template_name;
 	if (scope_pos != std::string_view::npos) {
-		base_template_name = extractBaseTemplateName(func_name.substr(0, scope_pos));
-	}
-	if (!base_template_name.empty() && scope_pos != std::string_view::npos) {
+		std::string_view owner_name = func_name.substr(0, scope_pos);
 		std::string_view member_name = func_name.substr(scope_pos + 2);
 
 		// Collect concrete template arguments from param_map_
@@ -1208,69 +1194,75 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteFunctionCallImpl");
 
 		if (!inst_args.empty()) {
-			Parser::AliasTemplateMaterializationResult materialized_base =
-				parser_.materializeTemplateInstantiationForLookup(base_template_name, inst_args);
-			std::string_view instantiated_name = materialized_base.instantiated_name;
+			Parser::AliasTemplateMaterializationResult canonical_owner =
+				parser_.resolveCanonicalInstantiatedOwnerForLookup(
+					owner_name,
+					std::span<const TemplateTypeArg>(inst_args.data(), inst_args.size()));
+			const bool owner_is_template_instantiation =
+				canonical_owner.resolved_type_info != nullptr &&
+				canonical_owner.resolved_type_info->isTemplateInstantiation();
+			const bool owner_has_template_hash = !extractBaseTemplateName(owner_name).empty();
+			if (owner_is_template_instantiation || owner_has_template_hash) {
+				std::string_view instantiated_name = canonical_owner.instantiated_name.empty()
+					? owner_name
+					: canonical_owner.instantiated_name;
 
-			// Build the corrected qualified function name
-			StringBuilder new_func_name_builder;
-			new_func_name_builder.append(instantiated_name).append("::").append(member_name);
-			std::string_view new_func_name = new_func_name_builder.commit();
+				// Build the corrected qualified function name
+				StringBuilder new_func_name_builder;
+				new_func_name_builder.append(instantiated_name).append("::").append(member_name);
+				std::string_view new_func_name = new_func_name_builder.commit();
 
-			FLASH_LOG(Templates, Debug, "  Substituted qualified function name: ", func_name, " -> ", new_func_name);
+				FLASH_LOG(Templates, Debug, "  Substituted qualified function name: ", func_name, " -> ", new_func_name);
 
-			// Create a new token with the corrected name
-			Token new_func_token(Token::Type::Identifier, new_func_name,
-								 call.called_from().line(), call.called_from().column(), call.called_from().file_index());
+				// Create a new token with the corrected name
+				Token new_func_token(Token::Type::Identifier, new_func_name,
+									 call.called_from().line(), call.called_from().column(), call.called_from().file_index());
 
-			// Substitute arguments
-			ChunkedVector<ASTNode> substituted_args;
-			for (size_t i = 0; i < call.arguments().size(); ++i) {
-				substituted_args.push_back(substitute(call.arguments()[i]));
-			}
-
-			// Create new forward declaration with corrected name
-			auto& fwd_type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
-			ASTNode fwd_type_ast(&fwd_type_node);
-			auto& new_decl = gChunkedAnyStorage.emplace_back<DeclarationNode>(fwd_type_ast, new_func_token);
-
-			// Try to trigger lazy member function instantiation for the target
-			StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
-			StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
-			LazyMemberKey member_key = LazyMemberKey::anyConst(inst_name_handle, member_handle);
-			if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-				if (parser_.instantiateLazyMemberIfNeeded(member_key).has_value()) {
-					normalizePendingSemanticRoots();
+				// Substitute arguments
+				ChunkedVector<ASTNode> substituted_args;
+				for (size_t i = 0; i < call.arguments().size(); ++i) {
+					substituted_args.push_back(substitute(call.arguments()[i]));
 				}
-			}
 
-			const DeclarationNode* target_decl = &new_decl;
-			const FunctionDeclarationNode* target_func = nullptr;
-			auto type_it = getTypesByNameMap().find(inst_name_handle);
-			if (type_it != getTypesByNameMap().end()) {
-				if (const StructTypeInfo* struct_info = type_it->second->getStructInfo()) {
-					for (const auto& member_func : struct_info->member_functions) {
-						if (member_func.getName() == member_handle &&
-							member_func.function_decl.is<FunctionDeclarationNode>()) {
-							target_func = &member_func.function_decl.as<FunctionDeclarationNode>();
-							target_decl = &target_func->decl_node();
-							break;
+				// Create new forward declaration with corrected name
+				auto& fwd_type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, Token(), CVQualifier::None);
+				ASTNode fwd_type_ast(&fwd_type_node);
+				auto& new_decl = gChunkedAnyStorage.emplace_back<DeclarationNode>(fwd_type_ast, new_func_token);
+
+				// Try to trigger lazy member function instantiation for the target
+				parser_.instantiateLazyMemberForCanonicalOwner(instantiated_name, member_name);
+
+				StringHandle inst_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
+				StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
+
+				const DeclarationNode* target_decl = &new_decl;
+				const FunctionDeclarationNode* target_func = nullptr;
+				auto type_it = getTypesByNameMap().find(inst_name_handle);
+				if (type_it != getTypesByNameMap().end()) {
+					if (const StructTypeInfo* struct_info = type_it->second->getStructInfo()) {
+						for (const auto& member_func : struct_info->member_functions) {
+							if (member_func.getName() == member_handle &&
+								member_func.function_decl.is<FunctionDeclarationNode>()) {
+								target_func = &member_func.function_decl.as<FunctionDeclarationNode>();
+								target_decl = &target_func->decl_node();
+								break;
+							}
 						}
 					}
 				}
-			}
 
-			ExpressionNode& new_expr = emplaceDirectCallExpr(
-				*target_decl,
-				target_func,
-				std::move(substituted_args),
-				new_func_token);
-			copyMetadataToExpr(new_expr);
-			setCallQualifiedName(new_expr, new_func_name);
-			if (target_func && target_func->has_mangled_name()) {
-				setCallMangledName(new_expr, target_func->mangled_name());
+				ExpressionNode& new_expr = emplaceDirectCallExpr(
+					*target_decl,
+					target_func,
+					std::move(substituted_args),
+					new_func_token);
+				copyMetadataToExpr(new_expr);
+				setCallQualifiedName(new_expr, new_func_name);
+				if (target_func && target_func->has_mangled_name()) {
+					setCallMangledName(new_expr, target_func->mangled_name());
+				}
+				return ASTNode(&new_expr);
 			}
-			return ASTNode(&new_expr);
 		}
 	}
 
@@ -1288,6 +1280,49 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 	ChunkedVector<ASTNode> substituted_args;
 	for (size_t i = 0; i < call.arguments().size(); ++i) {
 		substituted_args.push_back(substitute(call.arguments()[i]));
+	}
+
+	if ((call.callee().is_member() || call.callee().is_static_member()) &&
+		call.called_from().kind().is_identifier()) {
+		if (const FunctionDeclarationNode* rebound_member =
+				parser_.tryResolveConcreteMemberFunction(substituted_receiver, call.called_from().value());
+			rebound_member != nullptr) {
+			if (auto receiver_type = parser_.get_expression_type(substituted_receiver);
+				receiver_type.has_value() && is_struct_type(receiver_type->category())) {
+				if (const TypeInfo* receiver_type_info = tryGetTypeInfo(receiver_type->type_index());
+					receiver_type_info != nullptr) {
+					std::string_view class_name =
+						StringTable::getStringView(receiver_type_info->name());
+					if (parser_.instantiateLazyMemberForCanonicalOwner(
+							class_name,
+							call.called_from().value())
+							.has_value()) {
+						rebound_member =
+							parser_.tryResolveConcreteMemberFunction(substituted_receiver, call.called_from().value());
+					}
+				}
+			}
+
+			if (rebound_member != nullptr) {
+				CallExprNode rebound_call = makeResolvedMemberCallExpr(
+					substituted_receiver,
+					*rebound_member,
+					std::move(substituted_args),
+					call.called_from());
+				copyCallMetadataWithTransformedTemplateArguments(
+					rebound_call,
+					call,
+					[this](const ASTNode& template_arg) {
+						return substitute(template_arg);
+					},
+					CallMetadataCopyOptions{});
+				if (rebound_member->has_mangled_name()) {
+					rebound_call.set_mangled_name(rebound_member->mangled_name());
+				}
+				ExpressionNode& rebound_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(rebound_call);
+				return ASTNode(&rebound_expr);
+			}
+		}
 	}
 
 	CallExprNode substituted_call(call.callee(), substituted_receiver, std::move(substituted_args), call.called_from());

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -2134,7 +2134,7 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
  */
 inline FlashCpp::TypeIndexArg makeTypeIndexArgFromSpec(const TypeSpecifierNode& spec) {
 	FlashCpp::TypeIndexArg arg;
-	arg.type_index = spec.type_index();
+	arg.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(spec.type_index());
 	arg.cv_qualifier = spec.cv_qualifier();
 	arg.ref_qualifier = spec.reference_qualifier();
 	arg.pointer_depth = static_cast<uint8_t>(std::min(spec.pointer_depth(), size_t(255)));

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2348,6 +2348,7 @@ private:
 		// body parsing, scope management, and AST registration.
 	std::optional<ASTNode> instantiate_member_function_template_core(
 		std::string_view struct_name, std::string_view member_name,
+		StringHandle requested_qualified_name,
 		StringHandle qualified_name,
 		const ASTNode& template_node,
 		std::span<const TemplateTypeArg> template_args,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2689,6 +2689,13 @@ private:
 	AliasTemplateMaterializationResult materializeTemplateInstantiationForLookup(
 		std::string_view template_name,
 		std::span<const TemplateTypeArg> template_args);
+	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(
+		std::string_view owner_name,
+		std::span<const TemplateTypeArg> owner_template_args = {});
+	std::optional<ASTNode> instantiateLazyMemberForCanonicalOwner(
+		std::string_view& owner_name,
+		std::string_view member_name,
+		std::span<const TemplateTypeArg> owner_template_args = {});
 	AliasTemplateMaterializationResult materializePrimaryTemplateOwnerForLookup(
 		std::string_view primary_template_name,
 		std::string_view fallback_template_name,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2690,12 +2690,14 @@ private:
 		std::string_view template_name,
 		std::span<const TemplateTypeArg> template_args);
 	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(
+		std::string_view owner_name);
+	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(
 		std::string_view owner_name,
-		std::span<const TemplateTypeArg> owner_template_args = {});
+		std::span<const TemplateTypeArg> owner_template_args);
 	std::optional<ASTNode> instantiateLazyMemberForCanonicalOwner(
 		std::string_view& owner_name,
 		std::string_view member_name,
-		std::span<const TemplateTypeArg> owner_template_args = {});
+		std::span<const TemplateTypeArg> owner_template_args);
 	AliasTemplateMaterializationResult materializePrimaryTemplateOwnerForLookup(
 		std::string_view primary_template_name,
 		std::string_view fallback_template_name,
@@ -2787,8 +2789,12 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args);
+	ASTNode substituteTemplateParameters(
+		const ASTNode& node,
+		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
-		StringHandle current_owner_type_name = StringHandle{});
+		StringHandle current_owner_type_name);
 
 	// Helper to extract type from an expression for overload resolution.
 	// Public so codegen/constexpr consumers can reuse the parser's type deduction.
@@ -2929,6 +2935,7 @@ private:	 // Resume private methods
 		const ASTNode& arg,
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
+		StringHandle current_owner_type_name,
 		ChunkedVector<ASTNode>& out);
 
 		// Phase 3: Expression context tracking for template disambiguation

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2787,7 +2787,8 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args);
+		std::span<const TemplateTypeArg> template_args,
+		StringHandle current_owner_type_name = StringHandle{});
 
 	// Helper to extract type from an expression for overload resolution.
 	// Public so codegen/constexpr consumers can reuse the parser's type deduction.

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -26,7 +26,11 @@ std::optional<ASTNode> Parser::tryResolveMemberFunctionTemplate(
 	if (!type_info)
 		return std::nullopt;
 	if (type_info->is_incomplete_instantiation_) {
-		return std::nullopt;
+		instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
+		type_info = findTypeByName(type_info->name());
+		if (!type_info || type_info->is_incomplete_instantiation_) {
+			return std::nullopt;
+		}
 	}
 	auto struct_name = StringTable::getStringView(type_info->name());
 	instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
@@ -53,7 +57,11 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 	if (!type_info)
 		return nullptr;
 	if (type_info->is_incomplete_instantiation_) {
-		return nullptr;
+		instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
+		type_info = findTypeByName(type_info->name());
+		if (!type_info || type_info->is_incomplete_instantiation_) {
+			return nullptr;
+		}
 	}
 
 	StringHandle type_name = type_info->name();
@@ -73,7 +81,9 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 			continue;
 
 		const auto& candidate = member_func.function_decl.as<FunctionDeclarationNode>();
-		if (candidate.has_template_body_position()) {
+		// Keep deferred-body concrete members viable for overload selection.
+		// Their bodies are materialized lazily via LazyMemberInstantiationRegistry.
+		if (candidate.failed_substitution()) {
 			continue;
 		}
 		if (match) {
@@ -341,21 +351,16 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 			isHardUseLikeInstantiationMode()) {
 			std::string_view func_name = member_name_token.value();
 			if (!func_name.empty()) {
-				StringHandle class_name_handle = StringTable::getOrInternStringHandle(*object_struct_name);
-				StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
-				LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, func_name_handle);
-				if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-					FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for: ", *object_struct_name, "::", func_name);
-					if (!instantiated_func.has_value()) {
-						instantiating_lazy_member_ = true;
-						auto restore_lazy_instantiation = ScopeGuard([&]() {
-							instantiating_lazy_member_ = false;
-						});
-						instantiated_func = instantiateLazyMemberIfNeeded(member_key);
-					}
-					if (instantiated_func.has_value()) {
-						FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
-					}
+				if (!instantiated_func.has_value()) {
+					instantiating_lazy_member_ = true;
+					auto restore_lazy_instantiation = ScopeGuard([&]() {
+						instantiating_lazy_member_ = false;
+					});
+					instantiated_func =
+						instantiateLazyMemberForCanonicalOwner(*object_struct_name, func_name);
+				}
+				if (instantiated_func.has_value()) {
+					FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
 				}
 			}
 		}
@@ -979,15 +984,13 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						StringHandle class_name_handle = StringTable::getOrInternStringHandle(class_scope);
 						auto class_type_it = getTypesByNameMap().find(class_name_handle);
 						if (class_type_it != getTypesByNameMap().end() && class_type_it->second->isTemplateInstantiation()) {
-							StringHandle member_name_handle = final_identifier.handle();
-							LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
-							if (!instantiating_lazy_member_ &&
-								LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+							if (!instantiating_lazy_member_) {
 								instantiating_lazy_member_ = true;
 								auto restore_lazy_instantiation = ScopeGuard([&]() {
 									instantiating_lazy_member_ = false;
 								});
-								auto instantiated_func = instantiateLazyMemberIfNeeded(member_key);
+								auto instantiated_func =
+									instantiateLazyMemberForCanonicalOwner(class_scope, final_identifier.value());
 								if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
 									qualified_symbol = instantiated_func;
 									decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -357,7 +357,10 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 						instantiating_lazy_member_ = false;
 					});
 					instantiated_func =
-						instantiateLazyMemberForCanonicalOwner(*object_struct_name, func_name);
+						instantiateLazyMemberForCanonicalOwner(
+							*object_struct_name,
+							func_name,
+							std::span<const TemplateTypeArg>{});
 				}
 				if (instantiated_func.has_value()) {
 					FLASH_LOG(Templates, Debug, "Lazy instantiation completed for: ", *object_struct_name, "::", func_name);
@@ -990,7 +993,10 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									instantiating_lazy_member_ = false;
 								});
 								auto instantiated_func =
-									instantiateLazyMemberForCanonicalOwner(class_scope, final_identifier.value());
+									instantiateLazyMemberForCanonicalOwner(
+										class_scope,
+										final_identifier.value(),
+										std::span<const TemplateTypeArg>{});
 								if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
 									qualified_symbol = instantiated_func;
 									decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -458,7 +458,7 @@ bool typeRefersToCurrentTemplateParam(
 	if (!type_spec.type_index().is_valid()) {
 		return true;
 	}
-	StringHandle token_handle = StringTable::getOrInternStringHandle(type_spec.token().value());
+	StringHandle token_handle = type_spec.token().handle();
 	if (token_handle.isValid() &&
 		std::find(current_template_param_names.begin(), current_template_param_names.end(), token_handle) != current_template_param_names.end()) {
 		return true;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2395,23 +2395,23 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				advance(); // consume the identifier to check for the next ::
 			}
 
-		// current_token_ is now the token after the final identifier
+			// current_token_ is now the token after the final identifier
 
-		// Create a QualifiedIdentifierNode (stack-local; copied into ExpressionNode before returning)
+			// Create a QualifiedIdentifierNode (stack-local; copied into ExpressionNode before returning)
 			NamespaceHandle ns_handle = gSymbolTable.resolve_namespace_handle(namespaces);
 			QualifiedIdentifierNode qual_id(ns_handle, final_identifier);
 
-		// Check for std::forward intrinsic
-		// std::forward<T>(arg) is a compiler intrinsic for perfect forwarding
-		// Check if namespace is "std" (single-level namespace with name "std")
+			// Check for std::forward intrinsic
+			// std::forward<T>(arg) is a compiler intrinsic for perfect forwarding
+			// Check if namespace is "std" (single-level namespace with name "std")
 			std::string_view ns_qualified_name = gNamespaceRegistry.getQualifiedName(qual_id.namespace_handle());
 			if (ns_qualified_name == "std" && qual_id.name() == "forward") {
 
-			// Handle std::forward<T>(arg)
-			// For now, we'll treat it as an identity function that preserves references
-			// Skip template arguments if present
+				// Handle std::forward<T>(arg)
+				// For now, we'll treat it as an identity function that preserves references
+				// Skip template arguments if present
 				if (current_token_.value() == "<") {
-				// Skip template arguments: <T> or <iter_reference_t<_It>>
+					// Skip template arguments: <T> or <iter_reference_t<_It>>
 					int angle_bracket_depth = 1;
 					advance(); // consume <
 
@@ -2426,13 +2426,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
-			// Now expect (arg)
+				// Now expect (arg)
 				if (current_token_.kind().is_eof() || current_token_.value() != "(") {
 					return ParseResult::error("Expected '(' after std::forward", final_identifier);
 				}
 				advance(); // consume '('
 
-			// Parse the single argument
+				// Parse the single argument
 				auto arg_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 				if (arg_result.is_error()) {
 					return arg_result;
@@ -2443,27 +2443,27 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 				advance(); // consume ')'
 
-			// std::forward<T>(arg) is essentially an identity function
-			// Just return the argument expression itself
-			// The type system already preserves the reference type
+				// std::forward<T>(arg) is essentially an identity function
+				// Just return the argument expression itself
+				// The type system already preserves the reference type
 				result = arg_result.node();
 				return ParseResult::success(*result);
 			}
 
-		// Check if qualified identifier is followed by template arguments: ns::Template<Args>
-		// This must come BEFORE we try to use current_token_ as an operator
-		// Phase 1: C++20 Template Argument Disambiguation - try to parse template arguments
-		// after qualified identifiers, BUT check if the member is actually a template first
-		// to avoid misinterpreting comparisons like _R1::num < _R2::num
+			// Check if qualified identifier is followed by template arguments: ns::Template<Args>
+			// This must come BEFORE we try to use current_token_ as an operator
+			// Phase 1: C++20 Template Argument Disambiguation - try to parse template arguments
+			// after qualified identifiers, BUT check if the member is actually a template first
+			// to avoid misinterpreting comparisons like _R1::num < _R2::num
 			std::optional<InlineVector<TemplateTypeArg, 4>> template_args;
 			std::vector<ASTNode> template_arg_nodes;	 // Store the actual expression nodes
 			if (current_token_.value() == "<") {
-			// Build the qualified name from namespace handle
-				std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
-				std::string_view member_name = qual_id.name();
+				// Build the qualified name from namespace handle
+				StringHandle qualified_name = StringTable::getOrInternStringHandle(buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name()));
+				StringHandle member_name = qual_id.nameHandle();
 
-			// Check if the member is a known template before parsing < as template arguments
-			// This prevents misinterpreting patterns like _R1::num < _R2::num> where < is comparison
+				// Check if the member is a known template before parsing < as template arguments
+				// This prevents misinterpreting patterns like _R1::num < _R2::num> where < is comparison
 				auto member_template_opt = gTemplateRegistry.lookupTemplate(member_name);
 				auto member_var_template_opt = gTemplateRegistry.lookupVariableTemplate(member_name);
 				auto member_alias_template_opt = gTemplateRegistry.lookup_alias_template(member_name);
@@ -2476,7 +2476,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										 full_template_opt.has_value() || full_var_template_opt.has_value() ||
 										 full_alias_template_opt.has_value();
 
-			// Also check if the base is a template parameter - if so, the member is likely NOT a template
+				// Also check if the base is a template parameter - if so, the member is likely NOT a template
 				bool base_is_template_param = false;
 				if (!qual_id.namespace_handle().isGlobal()) {
 					std::string_view base_name = gNamespaceRegistry.getRootNamespaceName(qual_id.namespace_handle());
@@ -2488,10 +2488,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
-			// Decide whether to parse template arguments
+				// Decide whether to parse template arguments
 				bool should_parse_template_args = true;
 				if (!is_known_template && (context == ExpressionContext::TemplateTypeArg || base_is_template_param)) {
-				// Member is NOT a known template and we're in a context where < is likely comparison
+					// Member is NOT a known template and we're in a context where < is likely comparison
 					FLASH_LOG_FORMAT(Parser, Debug,
 									 "Qualified identifier '{}' member is not a known template - treating '<' as comparison operator (context={}, base_is_param={})",
 									 qualified_name, static_cast<int>(context), base_is_template_param);
@@ -2506,18 +2506,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (template_args.has_value()) {
 					FLASH_LOG_FORMAT(Parser, Debug, "Successfully parsed {} template arguments for '{}'", template_args->size(), qualified_name);
 
-				// First, check if this is a variable template (most common case for traits like is_reference_v<T>)
+					// First, check if this is a variable template (most common case for traits like is_reference_v<T>)
 					auto var_template_opt = gTemplateRegistry.lookupVariableTemplate(qualified_name);
 					if (!var_template_opt.has_value()) {
-					// Try with simple name
+						// Try with simple name
 						var_template_opt = gTemplateRegistry.lookupVariableTemplate(qual_id.name());
 					}
 
-				// If still not found, check if the base is a struct/class name (not a namespace)
-				// For patterns like StructName::member_template<Args>, we need to build the qualified name manually
+					// If still not found, check if the base is a struct/class name (not a namespace)
+					// For patterns like StructName::member_template<Args>, we need to build the qualified name manually
 					std::string_view struct_qualified_name;
 					if (!var_template_opt.has_value() && !namespaces.empty()) {
-					// Build struct-qualified name: "StructName::member"
+						// Build struct-qualified name: "StructName::member"
 						struct_qualified_name = buildQualifiedNameFromStrings(namespaces, qual_id.name());
 
 						FLASH_LOG_FORMAT(Templates, Debug, "Trying struct-qualified variable template lookup: '{}'", struct_qualified_name);
@@ -2530,20 +2530,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 
 					if (var_template_opt.has_value()) {
-					// Determine which name to use for instantiation
-						std::string_view template_name_for_instantiation = qualified_name;
+						// Determine which name to use for instantiation
+						std::string_view template_name_for_instantiation = qualified_name.view();
 						if (!struct_qualified_name.empty()) {
 							template_name_for_instantiation = struct_qualified_name;
 						}
 
 						FLASH_LOG(Templates, Debug, "Found variable template, instantiating: ", template_name_for_instantiation);
-					// Try instantiation with determined name first, fall back to simple name
+						// Try instantiation with determined name first, fall back to simple name
 						auto instantiated_var = try_instantiate_variable_template(template_name_for_instantiation, *template_args);
 						if (!instantiated_var.has_value()) {
 							instantiated_var = try_instantiate_variable_template(qual_id.name(), *template_args);
 						}
 						if (instantiated_var.has_value()) {
-						// Get the instantiated variable name
+							// Get the instantiated variable name
 							std::string_view inst_name;
 							if (instantiated_var->is<VariableDeclarationNode>()) {
 								const auto& var_decl = instantiated_var->as<VariableDeclarationNode>();
@@ -2553,12 +2553,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								const auto& decl = instantiated_var->as<DeclarationNode>();
 								inst_name = decl.identifier_token().value();
 							} else {
-								inst_name = qualified_name;	// Fallback
+								inst_name = qualified_name.view();	// Fallback
 							}
 
 							FLASH_LOG(Templates, Debug, "Successfully instantiated variable template: ", qualified_name);
 
-						// Return identifier reference to the instantiated variable
+							// Return identifier reference to the instantiated variable
 							Token inst_token(Token::Type::Identifier, inst_name,
 											 final_identifier.line(), final_identifier.column(), final_identifier.file_index());
 							result = emplace_node<ExpressionNode>(IdentifierNode(inst_token));
@@ -2566,25 +2566,25 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 					}
 
-				// Check if this is a concept application (e.g., std::same_as<T, U>)
-				// Concepts evaluate to boolean values at compile time
+					// Check if this is a concept application (e.g., std::same_as<T, U>)
+					// Concepts evaluate to boolean values at compile time
 					auto concept_opt = gConceptRegistry.lookupConcept(qualified_name);
 					if (!concept_opt.has_value()) {
-					// Try with simple name
+						// Try with simple name
 						concept_opt = gConceptRegistry.lookupConcept(qual_id.name());
 					}
 
 					if (concept_opt.has_value()) {
 						FLASH_LOG_FORMAT(Parser, Debug, "Found concept '{}' with template arguments (qualified lookup)", qualified_name);
 
-					// Evaluate the concept constraint with the provided template arguments
+						// Evaluate the concept constraint with the provided template arguments
 						auto constraint_result = evaluateConstraint(
 							concept_opt->as<ConceptDeclarationNode>().constraint_expr(),
 							*template_args,
 							{}  // No template param names needed for concrete types
 						);
 
-					// Create a BoolLiteralNode with the result
+						// Create a BoolLiteralNode with the result
 						bool concept_satisfied = constraint_result.satisfied;
 						Token bool_token(Token::Type::Keyword, concept_satisfied ? "true"sv : "false"sv,
 										 final_identifier.line(), final_identifier.column(), final_identifier.file_index());
@@ -2592,11 +2592,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return ParseResult::success(*result);
 					}
 
-				// Check if this is an alias template (like detail::cref<int> -> int)
-				// Alias templates should resolve to their underlying type
+					// Check if this is an alias template (like detail::cref<int> -> int)
+					// Alias templates should resolve to their underlying type
 					auto alias_opt = gTemplateRegistry.lookup_alias_template(qualified_name);
 					if (!alias_opt.has_value()) {
-					// Try with simple name
+						// Try with simple name
 						alias_opt = gTemplateRegistry.lookup_alias_template(qual_id.name());
 					}
 
@@ -2604,31 +2604,31 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						FLASH_LOG(Templates, Debug, "Found alias template, resolving: ", qualified_name);
 						const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
 
-					// Get the target type of the alias
-					// For a simple alias like `template<typename T> using cref = T;`, the target type is T
-					// We need to substitute the template parameter with the actual argument
+						// Get the target type of the alias
+						// For a simple alias like `template<typename T> using cref = T;`, the target type is T
+						// We need to substitute the template parameter with the actual argument
 						const TypeSpecifierNode& target_type = alias_node.target_type_node();
 						const auto& param_names = alias_node.template_param_names();
 
-					// Check if the target type is one of the template parameters
+						// Check if the target type is one of the template parameters
 						Token target_token = target_type.token();
 						if (target_token.type() == Token::Type::Identifier) {
 							std::string_view target_name = target_token.value();
 							for (size_t i = 0; i < param_names.size() && i < template_args->size(); ++i) {
 								if (target_name == param_names[i].view()) {
-								// The target type is the i-th template parameter
-								// Substitute it with the actual argument
+									// The target type is the i-th template parameter
+									// Substitute it with the actual argument
 									const TemplateTypeArg& arg = (*template_args)[i];
 									if (!arg.is_value) {
 										const TypeInfo* type_info = tryGetTypeInfo(arg.type_index);
 										if (!type_info)
 											continue;
-									// It's a type argument - get the type name and create an identifier
+										// It's a type argument - get the type name and create an identifier
 										StringHandle type_name_handle = type_info->name();
 										std::string_view type_name = StringTable::getStringView(type_name_handle);
 										FLASH_LOG_FORMAT(Templates, Debug, "Alias template parameter '{}' resolved to type '{}'", target_name, type_name);
 
-									// Return an IdentifierNode for the resolved type
+										// Return an IdentifierNode for the resolved type
 										Token resolved_token(Token::Type::Identifier, type_name,
 															 final_identifier.line(), final_identifier.column(), final_identifier.file_index());
 										result = emplace_node<ExpressionNode>(IdentifierNode(resolved_token));
@@ -2639,7 +2639,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							}
 						}
 
-					// If the target type is not a direct parameter reference, fall through to other handling
+						// If the target type is not a direct parameter reference, fall through to other handling
 						FLASH_LOG(Templates, Debug, "Alias template target is not a direct parameter, continuing with class template instantiation");
 					}
 
@@ -2661,12 +2661,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 					}
 
-				// Check if followed by :: for member access (Template<T>::member)
+					// Check if followed by :: for member access (Template<T>::member)
 					if (!instantiated_name.empty() && current_token_.value() == "::") {
-					// Build the owner scope from the concrete materialized owner, not the
-					// original qualifier chain. This keeps struct-local alias templates
-					// like `Outer::alias_t<...>::member` anchored to the resolved target
-					// type instead of incorrectly nesting the target under `Outer`.
+						// Build the owner scope from the concrete materialized owner, not the
+						// original qualifier chain. This keeps struct-local alias templates
+						// like `Outer::alias_t<...>::member` anchored to the resolved target
+						// type instead of incorrectly nesting the target under `Outer`.
 						std::string_view concrete_owner_name = instantiated_name;
 						if (materialized_owner.resolved_type_info != nullptr) {
 							concrete_owner_name = StringTable::getStringView(
@@ -2690,7 +2690,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							component_start = component_end + 2;
 						}
 
-					// Parse the :: and the member name
+						// Parse the :: and the member name
 						advance(); // consume ::
 						if (current_token_.kind().is_eof() || current_token_.type() != Token::Type::Identifier) {
 							return ParseResult::error("Expected identifier after '::'", current_token_);
@@ -2699,9 +2699,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						Token member_token = current_token_;
 						advance(); // consume member identifier
 
-					// Handle additional :: if present (nested member access)
+						// Handle additional :: if present (nested member access)
 						while (current_token_.value() == "::") {
-						// Add current member to namespace path
+							// Add current member to namespace path
 							StringHandle member_handle = member_token.handle();
 							full_ns_handle = gNamespaceRegistry.getOrCreateNamespace(full_ns_handle, member_handle);
 							advance(); // consume ::
@@ -2712,13 +2712,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							advance(); // consume identifier
 						}
 
-					// Create QualifiedIdentifierNode with the complete path (stack-local; copied into ExpressionNode before returning)
+						// Create QualifiedIdentifierNode with the complete path (stack-local; copied into ExpressionNode before returning)
 						QualifiedIdentifierNode full_qual_id(full_ns_handle, member_token);
 
-					// Look up the member in the instantiated struct's symbol table
+						// Look up the member in the instantiated struct's symbol table
 						auto member_lookup = gSymbolTable.lookup_qualified(full_ns_handle, member_token.value());
 
-					// If followed by '(', handle as function call (e.g., Template<T>::method())
+						// If followed by '(', handle as function call (e.g., Template<T>::method())
 						if (current_token_.value() == "(") {
 							advance(); // consume '('
 
@@ -2735,13 +2735,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								return ParseResult::error("Expected ')' after function call arguments", current_token_);
 							}
 
-						// Get the declaration node for the function
+							// Get the declaration node for the function
 							const DeclarationNode* decl_ptr = nullptr;
 							if (member_lookup.has_value()) {
 								decl_ptr = getDeclarationNode(*member_lookup);
 							}
 							if (!decl_ptr) {
-							// Member may not be in namespace symbol table - resolve from instantiated struct members.
+								// Member may not be in namespace symbol table - resolve from instantiated struct members.
 								auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(instantiated_name));
 								if (type_it != getTypesByNameMap().end() && type_it->second) {
 									const StructTypeInfo* struct_info = type_it->second->getStructInfo();
@@ -2818,26 +2818,26 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return ParseResult::success(*result);
 					}
 
-				// Template instantiation succeeded
-				// Don't return early - let it fall through to normal lookup which will find the instantiated type
+					// Template instantiation succeeded
+					// Don't return early - let it fall through to normal lookup which will find the instantiated type
 				}
-			// Not a template - let it fall through to be parsed as operator<
+				// Not a template - let it fall through to be parsed as operator<
 			}
 
-		// Try to look up the qualified identifier
+			// Try to look up the qualified identifier
 			auto identifierType = gSymbolTable.lookup_qualified(qual_id.qualifiedIdentifier());
 
-		// Check if this is a brace initialization: ns::Template<Args>{}
+			// Check if this is a brace initialization: ns::Template<Args>{}
 			if (template_args.has_value() && current_token_.value() == "{") {
-			// Parse the brace initialization using the helper
+				// Parse the brace initialization using the helper
 				ParseResult brace_init_result = parse_template_brace_initialization(*template_args, qual_id.name(), final_identifier);
 				if (!brace_init_result.is_error() && brace_init_result.node().has_value()) {
 					return brace_init_result;
 				}
-			// If parsing failed, fall through to function call check
+				// If parsing failed, fall through to function call check
 			}
 
-		// Check if this is a non-template brace initialization: ns::Type{args}
+			// Check if this is a non-template brace initialization: ns::Type{args}
 			if (!template_args.has_value() && current_token_.value() == "{") {
 				std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
 				StringHandle qualified_handle = StringTable::getOrInternStringHandle(qualified_name);
@@ -2879,7 +2879,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 			}
 
-		// Check if this is a qualified class-template functional-style cast: ns::Template<Args>()
+			// Check if this is a qualified class-template functional-style cast: ns::Template<Args>()
 			if (template_args.has_value() && current_token_.value() == "(") {
 				bool has_dependent_template_args = false;
 				for (const auto& template_arg : *template_args) {
@@ -2905,11 +2905,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 			}
 
-		// Check if followed by '(' for function call
+			// Check if followed by '(' for function call
 			if (current_token_.value() == "(") {
 				advance(); // consume '('
 
-			// Parse function arguments using unified helper (expand simple packs for qualified calls)
+				// Parse function arguments using unified helper (expand simple packs for qualified calls)
 				auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
 					.handle_pack_expansion = true,
 					.collect_types = true,
@@ -2949,11 +2949,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (((!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>()) ||
 					 (template_args.has_value() && !template_args->empty())) &&
 					current_linkage_ != Linkage::C) {
-				// Build qualified template name
+					// Build qualified template name
 					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
 					std::vector<TypeSpecifierNode> arg_types = apply_lvalue_reference_deduction(args, args_result.arg_types);
 
-				// Phase 1 C++20: If we have explicit template arguments, use them instead of deducing
+					// Phase 1 C++20: If we have explicit template arguments, use them instead of deducing
 					if (template_args.has_value() && !template_args->empty()) {
 						FLASH_LOG_FORMAT(Parser, Debug, "Using explicit template arguments for function call to '{}'", qualified_name);
 
@@ -2973,13 +2973,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 					}
 
-				// If still not found, try deducing from function arguments.
-				// But skip deduction when explicit template args are dependent -
-				// deduction cannot correctly handle this case and the expression
-				// must be deferred to template instantiation time.
+					// If still not found, try deducing from function arguments.
+					// But skip deduction when explicit template args are dependent -
+					// deduction cannot correctly handle this case and the expression
+					// must be deferred to template instantiation time.
 					if ((!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>()) &&
 						!has_dependent_explicit_template_args) {
-					// Try to instantiate the qualified template function
+						// Try to instantiate the qualified template function
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
 							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
@@ -2989,9 +2989,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
-			// When explicit template arguments are dependent and instantiation failed,
-			// the call expression must use a dependent placeholder return type so that
-			// decltype(...) defers resolution to template instantiation time.
+				// When explicit template arguments are dependent and instantiation failed,
+				// the call expression must use a dependent placeholder return type so that
+				// decltype(...) defers resolution to template instantiation time.
 				if (has_dependent_explicit_template_args &&
 					(!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>())) {
 					// Use Auto category to signal that the return type is dependent
@@ -3002,9 +3002,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					identifierType = placeholder_decl;
 				}
 
-			// If still not found, create a forward declaration
+				// If still not found, create a forward declaration
 				if (!identifierType) {
-				// Validate namespace exists before creating forward declaration (catches f2::func when f2 undeclared)
+					// Validate namespace exists before creating forward declaration (catches f2::func when f2 undeclared)
 					if (!validateQualifiedNamespace(qual_id.namespace_handle(), qual_id.identifier_token(), parsing_template_depth_ > 0)) {
 						return ParseResult::error(
 							std::string(StringBuilder().append("Use of undeclared identifier '").append(buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name())).append("'").commit()),
@@ -3015,7 +3015,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					identifierType = forward_decl;
 				}
 
-			// Get the DeclarationNode (works for both DeclarationNode and FunctionDeclarationNode)
+				// Get the DeclarationNode (works for both DeclarationNode and FunctionDeclarationNode)
 				const DeclarationNode* decl_ptr = getDeclarationNode(*identifierType);
 				if (!decl_ptr) {
 					return ParseResult::error("Invalid function declaration (template args path)", current_token_);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -13,6 +13,17 @@ std::optional<TypedNumeric> get_numeric_literal_type(std::string_view text);
 
 void applyDeclarationArrayBoundsToTypeSpec(const DeclarationNode& decl, TypeSpecifierNode& type_spec);
 
+namespace {
+bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<TemplateTypeArg, 4>& template_args) {
+	return std::any_of(
+		template_args.begin(),
+		template_args.end(),
+		[](const TemplateTypeArg& arg) {
+			return arg.is_dependent || arg.dependent_name.isValid();
+		});
+}
+}
+
 // Helper function to check if a template name is a template-template parameter
 bool Parser::isTemplateTemplateParameter(StringHandle template_name_handle) const {
 	// During function-template body reparse, parsing_template_depth_ is 0 but
@@ -2946,24 +2957,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (template_args.has_value() && !template_args->empty()) {
 						FLASH_LOG_FORMAT(Parser, Debug, "Using explicit template arguments for function call to '{}'", qualified_name);
 
-						// Check if any template args are dependent
-						for (const auto& targ : *template_args) {
-							if (targ.is_dependent || targ.dependent_name.isValid()) {
-								has_dependent_explicit_template_args = true;
-								break;
+						has_dependent_explicit_template_args =
+							explicitTemplateArgsRequireDeferredInstantiation(*template_args);
+
+						if (!has_dependent_explicit_template_args) {
+							std::optional<ASTNode> template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
+							if (!template_inst.has_value()) {
+								template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
 							}
-						}
 
-					// Try to instantiate with explicit template arguments
-						std::optional<ASTNode> template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
-						if (!template_inst.has_value()) {
-						// Try with simple name
-							template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
-						}
-
-						if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-							identifierType = *template_inst;
-							FLASH_LOG_FORMAT(Parser, Debug, "Successfully instantiated function template '{}' with explicit arguments", qualified_name);
+							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
+								identifierType = *template_inst;
+								FLASH_LOG_FORMAT(Parser, Debug, "Successfully instantiated function template '{}' with explicit arguments", qualified_name);
+							}
 						}
 					}
 
@@ -4137,7 +4143,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (has_dependent_call_args ||
 					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
 					FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
-					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 					auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 					result = emplace_node<ExpressionNode>(
 						makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
@@ -4587,22 +4593,26 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				auto make_dependent_call_result = [&]() -> ParseResult {
 					FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
-					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 					auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 					result = emplace_node<ExpressionNode>(
 						makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args_ref), identifier_token));
 					return ParseResult::success(*result);
 				};
 
+				const bool has_deferred_template_call_args =
+					argsHaveDeferredTemplateDependency(args_ref, currentTemplateParamNames()) ||
+					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
+
 				if (all_overloads.empty()) {
 					std::optional<ASTNode> instantiated_func;
-					if (current_linkage_ != Linkage::C) {
+					if (current_linkage_ != Linkage::C && !has_deferred_template_call_args) {
 						instantiated_func = try_instantiate_template(identifier_token.value(), arg_types);
 					}
 					if (instantiated_func.has_value()) {
 						const FunctionDeclarationNode* func_check = get_function_decl_node(*instantiated_func);
 						if (func_check && func_check->is_deleted()) {
-							if (argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+							if (has_deferred_template_call_args) {
 								return make_dependent_call_result();
 							}
 							return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "\'", identifier_token);
@@ -4624,7 +4634,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
 						return ParseResult::success(*result);
 					}
-					if (argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+					if (has_deferred_template_call_args) {
 						return make_dependent_call_result();
 					}
 					return ParseResult::error("No matching function for call to '" + std::string(identifier_token.value()) + "\'", identifier_token);
@@ -4663,13 +4673,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return make_call_result(*synthetic_builtin);
 					}
 					std::optional<ASTNode> instantiated_func;
-					if (current_linkage_ != Linkage::C) {
+					if (current_linkage_ != Linkage::C && !has_deferred_template_call_args) {
 						instantiated_func = try_instantiate_template(identifier_token.value(), arg_types);
 					}
 					if (instantiated_func.has_value()) {
 						const FunctionDeclarationNode* func_check = get_function_decl_node(*instantiated_func);
 						if (func_check && func_check->is_deleted()) {
-							if (argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+							if (has_deferred_template_call_args) {
 								return make_dependent_call_result();
 							}
 							return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "\'", identifier_token);
@@ -4690,7 +4700,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						result = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
 						return ParseResult::success(*result);
 					}
-					if (argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+					if (has_deferred_template_call_args) {
 						return make_dependent_call_result();
 					}
 					return ParseResult::error("No matching function for call to '" + std::string(identifier_token.value()) + "\'", identifier_token);
@@ -4795,9 +4805,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				auto make_dependent_decltype_call = [&](ChunkedVector<ASTNode>&& call_args) -> ParseResult {
 					FLASH_LOG(Templates, Debug, "Creating dependent call expression for decltype call to '", identifier_token.value(), "'");
 					auto type_node = emplace_node<TypeSpecifierNode>(
-						TypeCategory::Bool,
+						TypeCategory::Auto,
 						TypeQualifier::None,
-						get_type_size_bits(TypeCategory::Bool),
+						get_type_size_bits(TypeCategory::Auto),
 						identifier_token,
 						CVQualifier::None);
 					auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
@@ -4865,8 +4875,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 
 					// Try to instantiate the template function (skip in extern "C" contexts - C has no templates)
-					if (current_linkage_ != Linkage::C) {
+					if (current_linkage_ != Linkage::C && !has_dependent_call_args) {
 						template_func_inst = try_instantiate_template(identifier_token.value(), arg_types);
+					}
+
+					if (has_dependent_call_args) {
+						if (context == ExpressionContext::Decltype) {
+							return make_dependent_decltype_call(std::move(args));
+						}
+						create_unresolved_call_decl_if_deferred();
 					}
 
 					if (template_func_inst.has_value() && template_func_inst->is<FunctionDeclarationNode>()) {
@@ -6559,7 +6576,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 								auto make_late_dependent_call_result = [&]() -> ParseResult {
 									FLASH_LOG(Templates, Debug, "Creating dependent call expression for deleted dependent call to '", identifier_token.value(), "'");
-									auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+									auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 									auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 									result = emplace_node<ExpressionNode>(
 										makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
@@ -6717,7 +6734,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										FLASH_LOG(Templates, Debug, "Creating dependent call expression for call to '", identifier_token.value(), "'");
 
 										// Create a placeholder declaration for the dependent function call
-										TypeSpecifierNode placeholder_type(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+										TypeSpecifierNode placeholder_type(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 										if (const std::vector<ASTNode>* template_overloads = gTemplateRegistry.lookupAllTemplates(identifier_token.value())) {
 											for (const ASTNode& template_overload : *template_overloads) {
 												const FunctionDeclarationNode* function_decl = get_function_decl_node(template_overload);
@@ -6831,7 +6848,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										if (has_dependent_call_args ||
 											argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
 											FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
-											auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+											auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 											auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 											result = emplace_node<ExpressionNode>(
 												makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));
@@ -6897,7 +6914,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											if (has_dependent_call_args ||
 												argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
 												FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
-												auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Bool, TypeQualifier::None, get_type_size_bits(TypeCategory::Bool), identifier_token, CVQualifier::None);
+												auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 												auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
 												result = emplace_node<ExpressionNode>(
 													makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args), identifier_token));

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2494,17 +2494,17 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					// Member is NOT a known template and we're in a context where < is likely comparison
 					FLASH_LOG_FORMAT(Parser, Debug,
 									 "Qualified identifier '{}' member is not a known template - treating '<' as comparison operator (context={}, base_is_param={})",
-									 qualified_name, static_cast<int>(context), base_is_template_param);
+									 qualified_name.view(), static_cast<int>(context), base_is_template_param);
 					should_parse_template_args = false;
 				}
 
 				if (should_parse_template_args) {
-					FLASH_LOG_FORMAT(Parser, Debug, "Qualified identifier '{}' followed by '<', attempting template argument parsing", qualified_name);
+					FLASH_LOG_FORMAT(Parser, Debug, "Qualified identifier '{}' followed by '<', attempting template argument parsing", qualified_name.view());
 					template_args = parse_explicit_template_arguments(&template_arg_nodes);
 				}
 
 				if (template_args.has_value()) {
-					FLASH_LOG_FORMAT(Parser, Debug, "Successfully parsed {} template arguments for '{}'", template_args->size(), qualified_name);
+					FLASH_LOG_FORMAT(Parser, Debug, "Successfully parsed {} template arguments for '{}'", template_args->size(), qualified_name.view());
 
 					// First, check if this is a variable template (most common case for traits like is_reference_v<T>)
 					auto var_template_opt = gTemplateRegistry.lookupVariableTemplate(qualified_name);
@@ -2568,14 +2568,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 					// Check if this is a concept application (e.g., std::same_as<T, U>)
 					// Concepts evaluate to boolean values at compile time
-					auto concept_opt = gConceptRegistry.lookupConcept(qualified_name);
+					auto concept_opt = gConceptRegistry.lookupConcept(qualified_name.view());
 					if (!concept_opt.has_value()) {
 						// Try with simple name
 						concept_opt = gConceptRegistry.lookupConcept(qual_id.name());
 					}
 
 					if (concept_opt.has_value()) {
-						FLASH_LOG_FORMAT(Parser, Debug, "Found concept '{}' with template arguments (qualified lookup)", qualified_name);
+						FLASH_LOG_FORMAT(Parser, Debug, "Found concept '{}' with template arguments (qualified lookup)", qualified_name.view());
 
 						// Evaluate the concept constraint with the provided template arguments
 						auto constraint_result = evaluateConstraint(
@@ -2645,18 +2645,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 					Parser::AliasTemplateMaterializationResult materialized_owner =
 						materializePrimaryTemplateOwnerForLookup(
-							qualified_name,
+							qualified_name.view(),
 							qual_id.name(),
 							*template_args);
 					std::string_view instantiated_name = materialized_owner.instantiated_name;
 					if (instantiated_name.empty()) {
 						auto instantiation_result = try_instantiate_template_explicit(qual_id.name(), *template_args);
 						if (instantiation_result.has_value()) {
-							instantiation_result = try_instantiate_template_explicit(qualified_name, *template_args);
+							instantiation_result = try_instantiate_template_explicit(qualified_name.view(), *template_args);
 							if (instantiation_result.has_value()) {
 								// Template instantiation failed - this might not be a template after all
 								// But we successfully parsed template arguments, so continue with the parsed args
-								FLASH_LOG_FORMAT(Parser, Warning, "Parsed template arguments but instantiation failed for '{}'", qualified_name);
+								FLASH_LOG_FORMAT(Parser, Warning, "Parsed template arguments but instantiation failed for '{}'", qualified_name.view());
 							}
 						}
 					}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -19,7 +19,7 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 		template_args.begin(),
 		template_args.end(),
 		[](const TemplateTypeArg& arg) {
-			return arg.is_dependent || arg.dependent_name.isValid();
+			return arg.is_dependent || arg.dependent_name.isValid() || arg.is_pack;
 		});
 }
 }
@@ -2574,7 +2574,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						concept_opt = gConceptRegistry.lookupConcept(qual_id.name());
 					}
 
-					if (concept_opt.has_value()) {
+					const bool has_dependent_explicit_template_args =
+						explicitTemplateArgsRequireDeferredInstantiation(*template_args);
+					if (concept_opt.has_value() && !has_dependent_explicit_template_args) {
 						FLASH_LOG_FORMAT(Parser, Debug, "Found concept '{}' with template arguments (qualified lookup)", qualified_name.view());
 
 						// Evaluate the concept constraint with the provided template arguments
@@ -2590,6 +2592,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										 final_identifier.line(), final_identifier.column(), final_identifier.file_index());
 						result = emplace_node<ExpressionNode>(BoolLiteralNode(bool_token, concept_satisfied));
 						return ParseResult::success(*result);
+					}
+					if (concept_opt.has_value() && has_dependent_explicit_template_args) {
+						FLASH_LOG_FORMAT(
+							Parser,
+							Debug,
+							"Deferring eager concept evaluation for dependent concept-id '{}'",
+							qualified_name.view());
 					}
 
 					// Check if this is an alias template (like detail::cref<int> -> int)
@@ -2651,9 +2660,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					std::string_view instantiated_name = materialized_owner.instantiated_name;
 					if (instantiated_name.empty()) {
 						auto instantiation_result = try_instantiate_template_explicit(qual_id.name(), *template_args);
-						if (instantiation_result.has_value()) {
+						if (!instantiation_result.has_value()) {
 							instantiation_result = try_instantiate_template_explicit(qualified_name.view(), *template_args);
-							if (instantiation_result.has_value()) {
+							if (!instantiation_result.has_value()) {
 								// Template instantiation failed - this might not be a template after all
 								// But we successfully parsed template arguments, so continue with the parsed args
 								FLASH_LOG_FORMAT(Parser, Warning, "Parsed template arguments but instantiation failed for '{}'", qualified_name.view());

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -6581,12 +6581,35 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									// Skip template instantiation in extern "C" contexts - C has no templates
 									std::optional<ASTNode> instantiated_func;
 									bool resolved_as_struct_member = false;
+									bool defer_struct_member_template_instantiation = false;
 									if (current_linkage_ != Linkage::C && !has_dependent_template_args) {
+										auto should_defer_current_struct_member_template_instantiation =
+											[&](std::string_view struct_name, TypeIndex struct_type_index) -> bool {
+											if (struct_name.empty()) {
+												return false;
+											}
+											if (const TypeInfo* owner_type_info = tryGetTypeInfo(struct_type_index);
+												owner_type_info != nullptr && owner_type_info->isTemplateInstantiation()) {
+												return false;
+											}
+											if (current_function_ != nullptr && current_function_->has_outer_template_bindings()) {
+												return false;
+											}
+											return isTemplateBodyWithActiveParameters();
+										};
+
 										auto try_instantiate_current_struct_member_template = [&]() -> std::optional<ASTNode> {
 											if (!member_function_context_stack_.empty()) {
+												const auto& member_ctx = member_function_context_stack_.back();
 												std::string_view struct_name =
-													StringTable::getStringView(member_function_context_stack_.back().struct_name);
+													StringTable::getStringView(member_ctx.struct_name);
 												if (!struct_name.empty()) {
+													if (should_defer_current_struct_member_template_instantiation(
+															struct_name,
+															member_ctx.struct_type_index)) {
+														defer_struct_member_template_instantiation = true;
+														return std::nullopt;
+													}
 													if (auto member_inst = try_instantiate_member_function_template_explicit(
 															struct_name,
 															identifier_token.value(),
@@ -6599,6 +6622,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											if (!struct_parsing_context_stack_.empty()) {
 												const auto& struct_ctx = struct_parsing_context_stack_.back();
 												if (!struct_ctx.struct_name.empty()) {
+													TypeIndex struct_type_index{};
+													if (auto scope_type_it = getTypesByNameMap().find(
+															StringTable::getOrInternStringHandle(struct_ctx.struct_name));
+														scope_type_it != getTypesByNameMap().end()) {
+														struct_type_index = scope_type_it->second->type_index_;
+													}
+													if (should_defer_current_struct_member_template_instantiation(
+															struct_ctx.struct_name,
+															struct_type_index)) {
+														defer_struct_member_template_instantiation = true;
+														return std::nullopt;
+													}
 													return try_instantiate_member_function_template_explicit(
 														struct_ctx.struct_name,
 														identifier_token.value(),
@@ -6611,7 +6646,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 										instantiated_func = try_instantiate_current_struct_member_template();
 										resolved_as_struct_member = instantiated_func.has_value();
-										if (!resolved_as_struct_member) {
+										if (!resolved_as_struct_member && !defer_struct_member_template_instantiation) {
 											instantiated_func = try_instantiate_template_explicit(identifier_token.value(), *effective_template_args, arg_types);
 										}
 									}
@@ -6673,7 +6708,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 											}
 										}
-									} else if (has_dependent_template_args) {
+									} else if (has_dependent_template_args || defer_struct_member_template_instantiation) {
 										// Template arguments are dependent - this is a template-dependent expression
 										// Create a CallExprNode with a placeholder declaration that will be resolved during template instantiation
 										// IMPORTANT: We must create a call expression (not just IdentifierNode) to preserve the information
@@ -6701,13 +6736,32 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										result = emplace_node<ExpressionNode>(makeDirectCallExpr(decl_ref, std::move(args), identifier_token));
 
 										// Store the template arguments in the call expression for later resolution
-										if (explicit_template_arg_nodes.empty() && explicit_template_args.has_value()) {
-											explicit_template_arg_nodes = materializeTemplateArgumentNodes(*explicit_template_args, identifier_token);
-										} else if (explicit_template_args.has_value()) {
-											syncTemplateArgumentNodeMetadata(explicit_template_arg_nodes, *explicit_template_args);
+										if (explicit_template_arg_nodes.empty() && effective_template_args.has_value()) {
+											explicit_template_arg_nodes = materializeTemplateArgumentNodes(*effective_template_args, identifier_token);
+										} else if (effective_template_args.has_value()) {
+											syncTemplateArgumentNodeMetadata(explicit_template_arg_nodes, *effective_template_args);
 										}
 										if (!explicit_template_arg_nodes.empty()) {
 											setCallTemplateArguments(result->as<ExpressionNode>(), std::move(explicit_template_arg_nodes));
+										}
+										if (defer_struct_member_template_instantiation) {
+											std::string_view struct_name_for_qual;
+											if (!member_function_context_stack_.empty()) {
+												struct_name_for_qual =
+													StringTable::getStringView(member_function_context_stack_.back().struct_name);
+											} else if (!struct_parsing_context_stack_.empty()) {
+												struct_name_for_qual =
+													struct_parsing_context_stack_.back().struct_name;
+											}
+											if (!struct_name_for_qual.empty()) {
+												setCallQualifiedName(
+													result->as<ExpressionNode>(),
+													StringBuilder()
+														.append(struct_name_for_qual)
+														.append("::")
+														.append(identifier_token.value())
+														.commit());
+											}
 										}
 									} else {
 										return ParseResult::error("No matching template for call to '" + std::string(identifier_token.value()) + "'", identifier_token);

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -703,7 +703,7 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 							}
 
 							if (!trust_zero_sized_type_id) {
-								StringHandle tok_handle = StringTable::getOrInternStringHandle(type_spec.token().value());
+								StringHandle tok_handle = type_spec.token().handle();
 								auto struct_it = getTypesByNameMap().find(tok_handle);
 								if (struct_it != getTypesByNameMap().end() && struct_it->second->isStruct()) {
 									is_complete_type = false;

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -509,6 +509,48 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 
 	// If this is a type alias (no struct_info_), resolve the underlying type
 	if (!struct_type_info->struct_info_) {
+		if (struct_type_info->isTemplateInstantiation()) {
+			StringHandle alias_template_name = gNamespaceRegistry.buildQualifiedIdentifier(
+				struct_type_info->sourceNamespace(),
+				struct_type_info->baseTemplateName());
+			auto alias_template_entry = gTemplateRegistry.lookup_alias_template(alias_template_name);
+			if (!alias_template_entry.has_value()) {
+				alias_template_entry = gTemplateRegistry.lookup_alias_template(
+					struct_type_info->baseTemplateName());
+			}
+			if (alias_template_entry.has_value() && alias_template_entry->is<TemplateAliasNode>()) {
+				std::vector<TemplateTypeArg> concrete_args;
+				concrete_args.reserve(struct_type_info->templateArgs().size());
+				for (const auto& arg_info : struct_type_info->templateArgs()) {
+					TemplateTypeArg concrete_arg = toTemplateTypeArg(arg_info);
+					concrete_arg.setCategory(arg_info.category());
+					concrete_args.push_back(concrete_arg);
+				}
+
+				if (std::optional<TemplateTypeArg> rebound_arg =
+						tryRebindAliasTargetTemplateArg(
+							alias_template_entry->as<TemplateAliasNode>(),
+							concrete_args);
+					rebound_arg.has_value() &&
+					!rebound_arg->is_value &&
+					rebound_arg->type_index.is_valid()) {
+					if (const TypeInfo* rebound_type = tryGetTypeInfo(rebound_arg->type_index)) {
+						FLASH_LOG_FORMAT(
+							Templates,
+							Debug,
+							"Alias-template placeholder '{}' resolved '{}' through alias target '{}'",
+							StringTable::getStringView(struct_name),
+							StringTable::getStringView(member_name),
+							StringTable::getStringView(rebound_type->name()));
+						if (member_name == StringTable::getOrInternStringHandle("type")) {
+							return rebound_type;
+						}
+						return lookup_inherited_type_alias(rebound_type->name(), member_name, depth + 1);
+					}
+				}
+			}
+		}
+
 		// This might be a type alias - try to find the actual struct type
 		// Type aliases have a type_index that points to the underlying type
 		// Check if type_index_ is valid and points to a different TypeInfo entry

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -300,6 +300,11 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		}
 		deduced_arg_types.push_back(*type_opt);
 	}
+	if (AliasTemplateMaterializationResult canonical_owner =
+			resolveCanonicalInstantiatedOwnerForLookup(instantiated_class_name);
+		!canonical_owner.instantiated_name.empty()) {
+		instantiated_class_name = canonical_owner.instantiated_name;
+	}
 	std::optional<ASTNode> instantiated_func = tryInstantiateMemberFunctionTemplateCall(
 		instantiated_class_name,
 		member_name,
@@ -311,41 +316,9 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	// Trigger lazy member function instantiation if needed
 	if (!instantiated_func.has_value() &&
 		isHardUseLikeInstantiationMode()) {
-		StringHandle class_name_handle = StringTable::getOrInternStringHandle(instantiated_class_name);
-		StringHandle member_name_handle = StringTable::getOrInternStringHandle(member_name);
-		LazyMemberKey member_key = LazyMemberKey::anyConst(class_name_handle, member_name_handle);
 		FLASH_LOG(Templates, Debug, "Checking lazy instantiation for: ", instantiated_class_name, "::", member_name);
-		if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
-			FLASH_LOG(Templates, Debug, "Lazy instantiation triggered for qualified call: ", instantiated_class_name, "::", member_name);
-			instantiated_func = instantiateLazyMemberIfNeeded(member_key);
-		}
-		// If the hash-based name didn't match (dependent vs concrete hash mismatch),
-		// try to find the correct instantiation by looking up getTypesByNameMap() for a matching
-		// template instantiation with the same base template name.
-		if (!instantiated_func.has_value()) {
-			std::string_view base_tmpl = extractBaseTemplateName(instantiated_class_name);
-			if (!base_tmpl.empty()) {
-				// Search all types to find a matching template instantiation
-				for (const auto& [name_handle, type_info_ptr] : getTypesByNameMap()) {
-					if (type_info_ptr->isTemplateInstantiation() &&
-						StringTable::getStringView(type_info_ptr->baseTemplateName()) == base_tmpl &&
-						StringTable::getStringView(name_handle) != instantiated_class_name) {
-						StringHandle alt_class_handle = name_handle;
-						LazyMemberKey alt_member_key = LazyMemberKey::anyConst(alt_class_handle, member_name_handle);
-						if (LazyMemberInstantiationRegistry::getInstance().needsInstantiation(alt_member_key)) {
-							FLASH_LOG(Templates, Debug, "Lazy instantiation triggered via base template match: ",
-									  StringTable::getStringView(alt_class_handle), "::", member_name);
-							instantiated_func = instantiateLazyMemberIfNeeded(alt_member_key);
-							if (instantiated_func.has_value()) {
-								// Update instantiated_class_name to the correct one for mangling
-								instantiated_class_name = StringTable::getStringView(alt_class_handle);
-								break;
-							}
-						}
-					}
-				}
-			}
-		}
+		instantiated_func =
+			instantiateLazyMemberForCanonicalOwner(instantiated_class_name, member_name);
 	}
 
 	// Build qualified function name including template args

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -318,7 +318,10 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		isHardUseLikeInstantiationMode()) {
 		FLASH_LOG(Templates, Debug, "Checking lazy instantiation for: ", instantiated_class_name, "::", member_name);
 		instantiated_func =
-			instantiateLazyMemberForCanonicalOwner(instantiated_class_name, member_name);
+			instantiateLazyMemberForCanonicalOwner(
+				instantiated_class_name,
+				member_name,
+				std::span<const TemplateTypeArg>{});
 	}
 
 	// Build qualified function name including template args

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -598,7 +598,34 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
 		new_func_decl_ref,
 		parent_struct_name);
-	setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_inline);
+	if (original_func.has_outer_template_bindings()) {
+		InlineVector<TemplateParameterNode, 4> combined_params;
+		InlineVector<TemplateTypeArg, 4> combined_args;
+		combined_params.reserve(
+			original_func.outer_template_param_names().size() + template_params.size());
+		combined_args.reserve(
+			original_func.outer_template_args().size() + template_args_inline.size());
+		for (size_t i = 0; i < original_func.outer_template_param_names().size(); ++i) {
+			Token outer_token(
+				Token::Type::Identifier,
+				StringTable::getStringView(original_func.outer_template_param_names()[i]),
+				0,
+				0,
+				0);
+			combined_params.push_back(
+				TemplateParameterNode(original_func.outer_template_param_names()[i], outer_token));
+			combined_args.push_back(toTemplateTypeArg(original_func.outer_template_args()[i]));
+		}
+		for (const auto& param : template_params) {
+			combined_params.push_back(param);
+		}
+		for (const auto& arg : template_args_inline) {
+			combined_args.push_back(arg);
+		}
+		setOuterTemplateBindingsFromParams(new_func_ref, combined_params, combined_args);
+	} else {
+		setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_inline);
+	}
 
 	return {
 		new_func_decl_node,
@@ -5114,8 +5141,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 
 			concrete_type = instantiated_base_it->second;
-			concrete_arg.type_index = concrete_type->registeredTypeIndex();
-			concrete_arg.type_index.setCategory(concrete_type->typeEnum());
+			concrete_arg.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+				concrete_type->registeredTypeIndex().withCategory(concrete_type->typeEnum()));
 			return true;
 		};
 
@@ -5135,13 +5162,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 
 			concrete_type = underlying_type;
-			concrete_arg.type_index = concrete_type->registeredTypeIndex();
-			concrete_arg.type_index.setCategory(concrete_type->typeEnum());
+			concrete_arg.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+				concrete_type->registeredTypeIndex().withCategory(concrete_type->typeEnum()));
 		}
 
 		if (concrete_type && concrete_type->getStructInfo()) {
-			concrete_arg.type_index = concrete_type->registeredTypeIndex();
-			concrete_arg.type_index.setCategory(TypeCategory::Struct);
+			concrete_arg.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+				concrete_type->registeredTypeIndex().withCategory(TypeCategory::Struct));
 		}
 
 		return concrete_type;
@@ -7541,10 +7568,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 				lazy_info.template_params = template_params;
 				lazy_info.template_args = template_args_to_use;
+				const TemplateEnvironmentSnapshot* outer_parent_snapshot =
+					instantiated_struct_ref.has_outer_template_bindings()
+						? &instantiated_struct_ref.outer_template_environment_snapshot()
+						: nullptr;
 				lazy_info.outer_template_environment_snapshot = buildTemplateEnvironmentSnapshotFromBindings(
 					effective_template_params,
 					effective_template_args,
-					nullptr);
+					outer_parent_snapshot);
 				lazy_info.access = mem_func.access;
 				lazy_info.is_virtual = mem_func.is_virtual;
 				lazy_info.is_pure_virtual = mem_func.is_pure_virtual;
@@ -8044,10 +8075,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 						lazy_ctor_info.template_params = template_params;
 						lazy_ctor_info.template_args = template_args_to_use;
+						const TemplateEnvironmentSnapshot* outer_parent_snapshot =
+							instantiated_struct_ref.has_outer_template_bindings()
+								? &instantiated_struct_ref.outer_template_environment_snapshot()
+								: nullptr;
 						lazy_ctor_info.outer_template_environment_snapshot = buildTemplateEnvironmentSnapshotFromBindings(
 							effective_template_params,
 							effective_template_args,
-							nullptr);
+							outer_parent_snapshot);
 						lazy_ctor_info.access = mem_func.access;
 						LazyMemberInstantiationRegistry::getInstance().registerLazyMember(std::move(lazy_ctor_info));
 					}
@@ -8297,7 +8332,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				auto [new_decl_node, new_decl_ref] = emplace_node_ref<DeclarationNode>(
 					new_return_type, decl_node.identifier_token());
 				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-					new_decl_ref);
+					new_decl_ref,
+					instantiated_name);
 				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
 
 				// Copy parameter nodes with outer template parameter substitution
@@ -8422,18 +8458,47 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					FLASH_LOG(Templates, Debug, "Registered outer template bindings for ", StringTable::getStringView(qualified_name_handle));
 				}
 			} else {
-				// No substitution needed - copy as-is
+				// Even when no outer substitution is needed in the member template signature,
+				// we must still rebind ownership to the instantiated class.
+				auto [new_decl_node, new_decl_ref] = emplace_node_ref<DeclarationNode>(
+					decl_node.type_node(),
+					decl_node.identifier_token());
+				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
+					new_decl_ref,
+					instantiated_name);
+				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
+
+				for (const auto& param : func_decl.parameter_nodes()) {
+					new_func_ref.add_parameter_node(param);
+				}
+
+				copy_function_properties(new_func_ref, func_decl);
+				new_func_ref.set_is_const_member_function(mem_func.is_const());
+				new_func_ref.set_is_volatile_member_function(mem_func.is_volatile());
+				if (func_decl.is_materialized())
+					new_func_ref.set_definition(*func_decl.get_definition());
+				if (func_decl.has_template_body_position())
+					new_func_ref.set_template_body_position(func_decl.template_body_position());
+				if (func_decl.has_trailing_return_type_position())
+					new_func_ref.set_trailing_return_type_position(func_decl.trailing_return_type_position());
+				new_func_ref.set_is_template_pattern(true);
+
+				auto new_template_func = emplace_node<TemplateFunctionDeclarationNode>(
+					template_func.template_parameters(),
+					new_func_node,
+					template_func.requires_clause());
+
 				if (mem_func.operator_kind != OverloadableOperator::None) {
-					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, mem_func.function_declaration, mem_func.access);
-					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, mem_func.function_declaration, mem_func.access,
+					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_template_func, mem_func.access);
+					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_template_func, mem_func.access,
 														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
 				} else {
 					instantiated_struct_ref.add_member_function(
-						mem_func.function_declaration,
+						new_template_func,
 						mem_func.access);
 					struct_info_ptr->addMemberFunction(
 						decl_node.identifier_token().handle(),
-						mem_func.function_declaration,
+						new_template_func,
 						mem_func.access,
 						mem_func.is_virtual,
 						mem_func.is_pure_virtual,
@@ -8448,8 +8513,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					.append(decl_node.identifier_token().value());
 				StringHandle qualified_name_handle = StringTable::getOrInternStringHandle(qualified_name_builder.commit());
 
-				gTemplateRegistry.registerTemplate(qualified_name_handle, mem_func.function_declaration);
-				gTemplateRegistry.registerTemplate(decl_node.identifier_token().handle(), mem_func.function_declaration);
+				gTemplateRegistry.registerTemplate(qualified_name_handle, new_template_func);
+				gTemplateRegistry.registerTemplate(decl_node.identifier_token().handle(), new_template_func);
 
 				// Register outer template parameter bindings
 				{

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4092,7 +4092,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				trySubstituteIntrinsicTypeAlias(
 					alias_type_spec,
 					template_params,
-					filled_args_for_pattern_match,
+					template_args_for_pattern,
 					substituted_type,
 					substituted_type_index,
 					substituted_size);
@@ -4194,7 +4194,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						materializeInstantiatedMemberAliasTarget(
 							alias_type_spec,
 							template_params,
-							filled_args_for_pattern_match);
+							template_args_for_pattern);
 					concrete_member_info != nullptr) {
 					substituted_type = concrete_member_info->typeEnum();
 					substituted_type_index =
@@ -4258,7 +4258,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
-					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, filled_args_for_pattern_match);
+					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern);
 				const TypeSpecifierNode& alias_registration_type_spec = substituted_alias_type_spec.has_value()
 																		   ? substituted_alias_type_spec.value()
 																		   : alias_type_spec;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2377,6 +2377,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (primary_template_opt.has_value() && primary_template_opt->is<TemplateClassDeclarationNode>()) {
 			const TemplateClassDeclarationNode& primary_template = primary_template_opt->as<TemplateClassDeclarationNode>();
 			const auto& primary_params = primary_template.template_parameters();
+			InlineVector<TemplateParameterNode, 4> typed_primary_params = primary_params;
 
 			// Fill in defaults for missing arguments
 			for (size_t i = filled_args_for_pattern_match.size(); i < primary_params.size(); ++i) {
@@ -2570,6 +2571,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									primary_param_names.size()));
 							evaluated_default.has_value()) {
 							filled_args_for_pattern_match.push_back(*evaluated_default);
+						}
+					}
+					if (filled_args_for_pattern_match.size() == size_before) {
+						InlineVector<TemplateTypeArg, 4> retry_args =
+							toInlineTemplateArgs(filled_args_for_pattern_match);
+						if (tryAppendDefaultTemplateArg(
+								*param,
+								std::span<const TemplateParameterNode>(
+									typed_primary_params.data(),
+									typed_primary_params.size()),
+								retry_args,
+								NamespaceHandle{})) {
+							filled_args_for_pattern_match.assign(
+								retry_args.begin(),
+								retry_args.end());
 						}
 					}
 
@@ -5664,7 +5680,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								[[maybe_unused]] bool substituted = false;
 								TypeSpecifierNode substituted_type_spec = type_spec;
 
-								if ((is_struct_type(base_type)) && type_idx.is_valid()) {
+								if ((is_struct_type(base_type) ||
+									 base_type == TypeCategory::UserDefined ||
+									 base_type == TypeCategory::TypeAlias ||
+									 base_type == TypeCategory::Template) &&
+									type_idx.is_valid()) {
 									if (const TypeInfo* type_idx_ti = tryGetTypeInfo(type_idx)) {
 										std::string_view type_name = StringTable::getStringView(type_idx_ti->name());
 										auto subst_it = subst_map.find(type_name);
@@ -5688,6 +5708,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								ASTNode subst_type_node = emplace_node<TypeSpecifierNode>(substituted_type_spec);
 								ASTNode subst_trait_node = emplace_node<ExpressionNode>(
 									TypeTraitExprNode(trait_expr.kind(), subst_type_node, trait_expr.trait_token()));
+
+								if (typeSpecStillUsesDependentPlaceholder(substituted_type_spec)) {
+									StringHandle dependent_anchor;
+									if (const TypeInfo* dependent_ti = tryGetTypeInfo(substituted_type_spec.type_index());
+										dependent_ti != nullptr &&
+										dependent_ti->name().isValid()) {
+										dependent_anchor = dependent_ti->name();
+									}
+									TemplateTypeArg dependent_value =
+										TemplateTypeArg::makeDependentValue(
+											dependent_anchor,
+											TypeCategory::Bool,
+											0,
+											subst_trait_node);
+									dependent_value.is_pack = arg_info.is_pack;
+									resolved_args.push_back(std::move(dependent_value));
+									continue;
+								}
 
 								if (auto value = try_evaluate_constant_expression(subst_trait_node)) {
 									TemplateTypeArg val_arg(value->value, value->type);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3114,12 +3114,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											*ts_type_info,
 											template_params,
 											template_args_for_member_copy);
-									std::string_view instantiated_name = instantiateAndResolveBaseName(
+									std::string_view instantiated_base_name = instantiateAndResolveBaseName(
 										StringTable::getStringView(ts_type_info->baseTemplateName()),
 										instantiated_args,
 										true);
 									const TypeInfo* instantiated_type_info =
-										findTypeByName(StringTable::getOrInternStringHandle(instantiated_name));
+										findTypeByName(StringTable::getOrInternStringHandle(instantiated_base_name));
 									if (instantiated_type_info != nullptr) {
 										resolved_args.push_back(resolveTypeInfoToTemplateArg(*instantiated_type_info, ts));
 										resolved = true;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -222,6 +222,46 @@ static std::optional<TemplateTypeArg> tryResolveDeferredBaseTypeArgFromMap(
 	return resolved_type_arg;
 }
 
+template <typename ParamContainer, typename ArgContainer>
+static std::vector<TemplateTypeArg> materializeTemplateArgsExpandingPacks(
+	const TypeInfo& type_info,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args) {
+	std::vector<TemplateTypeArg> result;
+	result.reserve(type_info.templateArgs().size());
+	for (const auto& arg_info : type_info.templateArgs()) {
+		bool expanded_pack = false;
+		if (arg_info.dependent_name.isValid()) {
+			const std::string_view pack_name = StringTable::getStringView(arg_info.dependent_name);
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				const TemplateParameterNode* template_param = tryGetTemplateParameterNode(template_params[i]);
+				if (template_param == nullptr ||
+					template_param->name() != pack_name ||
+					!template_param->is_variadic()) {
+					continue;
+				}
+
+				for (size_t arg_index = i; arg_index < template_args.size(); ++arg_index) {
+					const TemplateTypeArg& substituted_arg = template_args[arg_index];
+					TemplateTypeArg concrete_arg = substituted_arg;
+					if (!arg_info.is_value && !substituted_arg.is_value) {
+						concrete_arg = rebindDependentTemplateTypeArg(substituted_arg, arg_info);
+					}
+					concrete_arg.is_pack = false;
+					result.push_back(concrete_arg);
+				}
+				expanded_pack = true;
+				break;
+			}
+		}
+
+		if (!expanded_pack) {
+			result.push_back(materializeTemplateArg(arg_info, template_params, template_args));
+		}
+	}
+	return result;
+}
+
 static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param) {
 	if (!param.is<DeclarationNode>()) {
 		return nullptr;
@@ -3067,6 +3107,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								resolved = true;
 							}
 							if (!resolved) {
+								if (const TypeInfo* ts_type_info = tryGetTypeInfo(ts.type_index());
+									ts_type_info != nullptr && ts_type_info->isTemplateInstantiation()) {
+									std::vector<TemplateTypeArg> instantiated_args =
+										materializeTemplateArgsExpandingPacks(
+											*ts_type_info,
+											template_params,
+											template_args_for_member_copy);
+									std::string_view instantiated_name = instantiateAndResolveBaseName(
+										StringTable::getStringView(ts_type_info->baseTemplateName()),
+										instantiated_args,
+										true);
+									const TypeInfo* instantiated_type_info =
+										findTypeByName(StringTable::getOrInternStringHandle(instantiated_name));
+									if (instantiated_type_info != nullptr) {
+										resolved_args.push_back(resolveTypeInfoToTemplateArg(*instantiated_type_info, ts));
+										resolved = true;
+									}
+								}
+							}
+							if (!resolved) {
 								resolved_args.emplace_back(ts);
 							}
 						} else if (arg_info.node.is<ExpressionNode>()) {
@@ -4006,13 +4066,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				trySubstituteIntrinsicTypeAlias(
 					alias_type_spec,
 					template_params,
-					template_args,
+					filled_args_for_pattern_match,
 					substituted_type,
 					substituted_type_index,
 					substituted_size);
 
 				// Check if the alias type is a template parameter that needs substitution
-				if ((alias_type_spec.category() == TypeCategory::UserDefined || alias_type_spec.category() == TypeCategory::TypeAlias || alias_type_spec.category() == TypeCategory::Template) && !template_args.empty() && !pattern_args.empty()) {
+				if ((alias_type_spec.category() == TypeCategory::UserDefined || alias_type_spec.category() == TypeCategory::TypeAlias || alias_type_spec.category() == TypeCategory::Template) &&
+					!filled_args_for_pattern_match.empty() &&
+					!pattern_args.empty()) {
 					bool alias_refers_to_template_parameter = false;
 					StringHandle alias_target_name{};
 					if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_type_spec.type_index())) {
@@ -4020,7 +4082,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					StringHandle alias_token_name = alias_type_spec.token().handle();
 					auto applyTemplateArgAliasSubstitution = [&](size_t pattern_idx, std::string_view parameter_name) {
-						const TemplateTypeArg& concrete_arg = template_args[pattern_idx];
+						const TemplateTypeArg& concrete_arg = filled_args_for_pattern_match[pattern_idx];
 						substituted_type = concrete_arg.typeEnum();
 						substituted_type_index = concrete_arg.type_index;
 						if (!is_struct_type(substituted_type)) {
@@ -4053,13 +4115,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// For enable_if<true, T>:
 					// - pattern_args = [true (is_value=true), T (is_value=false, is_dependent=true)]
 					// - template_params = [T] (template parameter at index 0)
-					// - template_args = [true (is_value=true), int (is_value=false)]
+					// - filled_args_for_pattern_match = [true (is_value=true), int (is_value=false)]
 					// - The alias "using type = T" has T which is template_params[0]
 					// - T appears at pattern_args[1]
-					// - So we substitute with template_args[1] = int
+					// - So we substitute with filled_args_for_pattern_match[1] = int
 
 					// Find which template parameter index this alias type corresponds to
-					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
+					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < filled_args_for_pattern_match.size(); ++pattern_idx) {
 						const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
 						if (!pattern_arg.is_value && pattern_arg.is_dependent && pattern_arg.dependent_name.isValid()) {
 							StringHandle pattern_param_name = pattern_arg.dependent_name;
@@ -4074,7 +4136,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					for (size_t param_idx = 0; param_idx < template_params.size(); ++param_idx) {
 						// Find which pattern_arg position this template parameter appears at
-						for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < template_args.size(); ++pattern_idx) {
+						for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < filled_args_for_pattern_match.size(); ++pattern_idx) {
 							const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
 
 							// Check if this pattern_arg is a template parameter (not a concrete value/type)
@@ -4106,7 +4168,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						materializeInstantiatedMemberAliasTarget(
 							alias_type_spec,
 							template_params,
-							template_args);
+							filled_args_for_pattern_match);
 					concrete_member_info != nullptr) {
 					substituted_type = concrete_member_info->typeEnum();
 					substituted_type_index =
@@ -4170,7 +4232,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
-					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args);
+					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, filled_args_for_pattern_match);
 				const TypeSpecifierNode& alias_registration_type_spec = substituted_alias_type_spec.has_value()
 																		   ? substituted_alias_type_spec.value()
 																		   : alias_type_spec;
@@ -5174,6 +5236,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		return concrete_type;
 	};
 
+	auto canonicalizeRecordedBase = [&](const TypeInfo* base_type_info, TypeIndex base_type_index)
+		-> std::pair<const TypeInfo*, TypeIndex> {
+		TypeIndex canonical_index = base_type_index;
+		if (canonical_index.is_valid()) {
+			canonical_index = canonicalize_type_alias(canonical_index).resolvedTypeIndex();
+		}
+		if (const TypeInfo* canonical_type = tryGetTypeInfo(canonical_index);
+			canonical_type != nullptr && canonical_type->getStructInfo() != nullptr) {
+			return {
+				canonical_type,
+				FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+					canonical_type->registeredTypeIndex().withCategory(TypeCategory::Struct))
+			};
+		}
+		if (base_type_info != nullptr && base_type_info->getStructInfo() != nullptr) {
+			return {
+				base_type_info,
+				FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+					base_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct))
+			};
+		}
+		return {base_type_info, base_type_index};
+	};
+
 	// Generate the instantiated class name (again, with filled args)
 	instantiated_name = StringTable::getOrInternStringHandle(get_instantiated_class_name(template_name, template_args_to_use));
 
@@ -5300,10 +5386,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					return false;
 				}
 
-				struct_info->addBaseClass(StringTable::getStringView(concrete_type->name()), concrete_arg.type_index, base.access, base.is_virtual);
+				auto [recorded_base_type, recorded_base_index] =
+					canonicalizeRecordedBase(concrete_type, concrete_arg.type_index);
+				struct_info->addBaseClass(
+					StringTable::getStringView(recorded_base_type->name()),
+					recorded_base_index,
+					base.access,
+					base.is_virtual);
 				FLASH_LOG(Templates, Debug, "Resolved deferred base '", base_class_name,
-						  "' to concrete type '", StringTable::getStringView(concrete_type->name()),
-						  "' with type_index=", concrete_arg.type_index);
+						  "' to concrete type '", StringTable::getStringView(recorded_base_type->name()),
+						  "' with type_index=", recorded_base_index);
 				return true;
 			};
 
@@ -5359,8 +5451,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			auto base_type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(base_class_name));
 			if (base_type_it != getTypesByNameMap().end()) {
 				const TypeInfo* base_type_info = base_type_it->second;
-				struct_info->addBaseClass(base_class_name, base_type_info->type_index_, base.access, base.is_virtual);
-				FLASH_LOG(Templates, Debug, "Added base class: ", base_class_name, " with type_index=", base_type_info->type_index_);
+				auto [recorded_base_type, recorded_base_index] =
+					canonicalizeRecordedBase(base_type_info, base_type_info->registeredTypeIndex().withCategory(base_type_info->typeEnum()));
+				struct_info->addBaseClass(
+					StringTable::getStringView(recorded_base_type->name()),
+					recorded_base_index,
+					base.access,
+					base.is_virtual);
+				FLASH_LOG(Templates, Debug, "Added base class: ", StringTable::getStringView(recorded_base_type->name()),
+						  " with type_index=", recorded_base_index);
 			} else {
 				FLASH_LOG(Templates, Warning, "Base class ", base_class_name, " not found in getTypesByNameMap()");
 			}
@@ -5508,7 +5607,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											gNamespaceRegistry.buildQualifiedIdentifier(
 												resolved_ti->sourceNamespace(),
 												resolved_ti->baseTemplateName());
-										std::vector<TemplateTypeArg> instantiated_args = materializeTemplateArgs(*resolved_ti, template_params, template_args_to_use);
+										std::vector<TemplateTypeArg> instantiated_args =
+											materializeTemplateArgsExpandingPacks(*resolved_ti, template_params, template_args_to_use);
 										auto alias_template_entry =
 											gTemplateRegistry.lookup_alias_template(qualified_base_template_name);
 										if (!alias_template_entry.has_value()) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -22,6 +22,28 @@ static thread_local int g_template_inst_iteration_count = 0;
 static thread_local bool g_template_inst_iteration_limit_tripped = false;
 static constexpr int g_template_inst_max_iterations = 10000;
 
+static TemplateParameterNode rebuildOuterTemplateParameter(
+	StringHandle param_name,
+	const TypeInfo::TemplateArgInfo& arg_info) {
+	Token outer_token(
+		Token::Type::Identifier,
+		StringTable::getStringView(param_name),
+		0,
+		0,
+		0);
+	if (arg_info.is_template_template_arg) {
+		return TemplateParameterNode(
+			param_name,
+			std::vector<TemplateParameterNode>{},
+			outer_token);
+	}
+	if (auto outer_type_spec = makeTypeSpecifierFromTemplateArgInfo(arg_info, outer_token);
+		outer_type_spec.has_value()) {
+		return TemplateParameterNode(param_name, *outer_type_spec, outer_token);
+	}
+	return TemplateParameterNode(param_name, outer_token);
+}
+
 void resetTemplateInstantiationCounters() {
 	g_template_inst_iteration_count = 0;
 	g_template_inst_iteration_limit_tripped = false;
@@ -646,14 +668,10 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 		combined_args.reserve(
 			original_func.outer_template_args().size() + template_args_inline.size());
 		for (size_t i = 0; i < original_func.outer_template_param_names().size(); ++i) {
-			Token outer_token(
-				Token::Type::Identifier,
-				StringTable::getStringView(original_func.outer_template_param_names()[i]),
-				0,
-				0,
-				0);
 			combined_params.push_back(
-				TemplateParameterNode(original_func.outer_template_param_names()[i], outer_token));
+				rebuildOuterTemplateParameter(
+					original_func.outer_template_param_names()[i],
+					original_func.outer_template_args()[i]));
 			combined_args.push_back(toTemplateTypeArg(original_func.outer_template_args()[i]));
 		}
 		for (const auto& param : template_params) {
@@ -2643,13 +2661,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (filled_args_for_pattern_match.size() == size_before) {
 						InlineVector<TemplateTypeArg, 4> retry_args =
 							toInlineTemplateArgs(filled_args_for_pattern_match);
+						NamespaceHandle declaration_namespace = NamespaceHandle{};
+						if (template_name.find("::") != std::string_view::npos) {
+							declaration_namespace =
+								QualifiedIdentifier::fromQualifiedName(
+									template_name,
+									NamespaceRegistry::GLOBAL_NAMESPACE)
+									.namespace_handle;
+						}
 						if (tryAppendDefaultTemplateArg(
 								*param,
 								std::span<const TemplateParameterNode>(
 									typed_primary_params.data(),
 									typed_primary_params.size()),
 								retry_args,
-								NamespaceHandle{})) {
+								declaration_namespace)) {
 							filled_args_for_pattern_match.assign(
 								retry_args.begin(),
 								retry_args.end());
@@ -8429,12 +8455,65 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 				normalizeSubstitutedTypeSpec(new_return_spec);
 
+				auto buildMergedOuterTemplateBinding = [&](OuterTemplateBinding& out_binding) {
+					if (func_decl.has_outer_template_bindings()) {
+						InlineVector<TemplateParameterNode, 4> combined_params;
+						InlineVector<TemplateTypeArg, 4> combined_args;
+						combined_params.reserve(
+							func_decl.outer_template_param_names().size() + template_params.size());
+						combined_args.reserve(
+							func_decl.outer_template_args().size() + template_args_to_use.size());
+						for (size_t i = 0; i < func_decl.outer_template_param_names().size(); ++i) {
+							combined_params.push_back(
+								rebuildOuterTemplateParameter(
+									func_decl.outer_template_param_names()[i],
+									func_decl.outer_template_args()[i]));
+							combined_args.push_back(toTemplateTypeArg(func_decl.outer_template_args()[i]));
+						}
+						for (const auto& param : template_params) {
+							combined_params.push_back(param);
+						}
+						for (const auto& arg : template_args_to_use) {
+							combined_args.push_back(arg);
+						}
+						collectOuterTemplateBinding(combined_params, combined_args, out_binding);
+						return;
+					}
+					collectOuterTemplateBinding(template_params, template_args_to_use, out_binding);
+				};
+				auto applyMergedOuterTemplateBindings = [&](FunctionDeclarationNode& target_func) {
+					if (func_decl.has_outer_template_bindings()) {
+						InlineVector<TemplateParameterNode, 4> combined_params;
+						InlineVector<TemplateTypeArg, 4> combined_args;
+						combined_params.reserve(
+							func_decl.outer_template_param_names().size() + template_params.size());
+						combined_args.reserve(
+							func_decl.outer_template_args().size() + template_args_to_use.size());
+						for (size_t i = 0; i < func_decl.outer_template_param_names().size(); ++i) {
+							combined_params.push_back(
+								rebuildOuterTemplateParameter(
+									func_decl.outer_template_param_names()[i],
+									func_decl.outer_template_args()[i]));
+							combined_args.push_back(toTemplateTypeArg(func_decl.outer_template_args()[i]));
+						}
+						for (const auto& param : template_params) {
+							combined_params.push_back(param);
+						}
+						for (const auto& arg : template_args_to_use) {
+							combined_args.push_back(arg);
+						}
+						setOuterTemplateBindingsFromParams(target_func, combined_params, combined_args);
+						return;
+					}
+					setOuterTemplateBindingsFromParams(target_func, template_params, template_args_to_use);
+				};
+
 				auto [new_decl_node, new_decl_ref] = emplace_node_ref<DeclarationNode>(
 					new_return_type, decl_node.identifier_token());
 				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
 					new_decl_ref,
 					instantiated_name);
-				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
+				applyMergedOuterTemplateBindings(new_func_ref);
 
 				// Copy parameter nodes with outer template parameter substitution
 				for (const auto& param : func_decl.parameter_nodes()) {
@@ -8553,20 +8632,46 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Register outer template parameter bindings
 				{
 					OuterTemplateBinding outer_binding;
-					collectOuterTemplateBinding(template_params, template_args_to_use, outer_binding);
+					buildMergedOuterTemplateBinding(outer_binding);
 					gTemplateRegistry.registerOuterTemplateBinding(qualified_name_handle, std::move(outer_binding));
 					FLASH_LOG(Templates, Debug, "Registered outer template bindings for ", StringTable::getStringView(qualified_name_handle));
 				}
 			} else {
 				// Even when no outer substitution is needed in the member template signature,
 				// we must still rebind ownership to the instantiated class.
+				auto applyMergedOuterTemplateBindings = [&](FunctionDeclarationNode& target_func) {
+					if (func_decl.has_outer_template_bindings()) {
+						InlineVector<TemplateParameterNode, 4> combined_params;
+						InlineVector<TemplateTypeArg, 4> combined_args;
+						combined_params.reserve(
+							func_decl.outer_template_param_names().size() + template_params.size());
+						combined_args.reserve(
+							func_decl.outer_template_args().size() + template_args_to_use.size());
+						for (size_t i = 0; i < func_decl.outer_template_param_names().size(); ++i) {
+							combined_params.push_back(
+								rebuildOuterTemplateParameter(
+									func_decl.outer_template_param_names()[i],
+									func_decl.outer_template_args()[i]));
+							combined_args.push_back(toTemplateTypeArg(func_decl.outer_template_args()[i]));
+						}
+						for (const auto& param : template_params) {
+							combined_params.push_back(param);
+						}
+						for (const auto& arg : template_args_to_use) {
+							combined_args.push_back(arg);
+						}
+						setOuterTemplateBindingsFromParams(target_func, combined_params, combined_args);
+						return;
+					}
+					setOuterTemplateBindingsFromParams(target_func, template_params, template_args_to_use);
+				};
 				auto [new_decl_node, new_decl_ref] = emplace_node_ref<DeclarationNode>(
 					decl_node.type_node(),
 					decl_node.identifier_token());
 				auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
 					new_decl_ref,
 					instantiated_name);
-				setOuterTemplateBindingsFromParams(new_func_ref, template_params, template_args_to_use);
+				applyMergedOuterTemplateBindings(new_func_ref);
 
 				for (const auto& param : func_decl.parameter_nodes()) {
 					new_func_ref.add_parameter_node(param);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -198,9 +198,13 @@ static TypeInfo& registerTemplateTypeBinding(
 			getTypeSizeFromTemplateArgument(arg),
 			alias_spec);
 	}
-	return add_template_param_type(
+	TypeIndex canonical_builtin = nativeTypeIndex(arg.typeEnum());
+	if (!canonical_builtin.is_valid()) {
+		canonical_builtin = TypeIndex{0, arg.typeEnum()};
+	}
+	return add_type_alias_copy(
 		param_name,
-		arg.typeEnum(),
+		canonical_builtin.withCategory(arg.typeEnum()),
 		getTypeSizeFromTemplateArgument(arg));
 }
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -160,52 +160,22 @@ static void applyRegisteredTypeBindingMetadata(
 static TypeInfo& registerTemplateTypeBinding(
 	StringHandle param_name,
 	const TemplateTypeArg& arg) {
-	if (arg.type_index.is_valid()) {
-		if (arg.cv_qualifier != CVQualifier::None) {
-			// Build a TypeSpecifierNode that carries the cv_qualifier so that
-			// resolveAliasTypeInfo (which reads aliasTypeSpecifier()->cv_qualifier())
-			// can recover it when the bound name is later used as a template argument.
-			// Without this, is_const<First> where First=const int sees plain int and
-			// the is_const<const T> specialization pattern fails to match.
-			TypeSpecifierNode alias_spec(
-				arg.type_index.withCategory(arg.typeEnum()),
-				static_cast<unsigned char>(get_type_size_bits(arg.typeEnum())),
-				Token(), arg.cv_qualifier, ReferenceQualifier::None);
-			return add_type_alias_copy(
-				param_name,
-				arg.type_index.withCategory(arg.typeEnum()),
-				getTypeSizeFromTemplateArgument(arg),
-				alias_spec);
+	TypeIndex registered_type_index = arg.type_index;
+	if (registered_type_index.is_valid()) {
+		registered_type_index = registered_type_index.withCategory(arg.typeEnum());
+	} else {
+		registered_type_index = nativeTypeIndex(arg.typeEnum());
+		if (!registered_type_index.is_valid()) {
+			registered_type_index = TypeIndex{0, arg.typeEnum()};
 		}
-		return add_type_alias_copy(
-			param_name,
-			arg.type_index.withCategory(arg.typeEnum()),
-			getTypeSizeFromTemplateArgument(arg));
 	}
-	// For primitive types the TypeIndex carries index=0 (is_valid()==false) but
-	// carries the TypeCategory in its category bits.  Still need to preserve
-	// cv_qualifier when binding e.g. First=const int: use a TypeAlias entry
-	// backed by TypeIndex{0, typeEnum()} so that resolveAliasTypeInfo can reach
-	// the primitive type via nativeTypeIndex() and pick up the aliasTypeSpecifier.
-	if (arg.cv_qualifier != CVQualifier::None) {
-		TypeSpecifierNode alias_spec(
-			TypeIndex{0, arg.typeEnum()},
-			static_cast<unsigned char>(get_type_size_bits(arg.typeEnum())),
-			Token(), arg.cv_qualifier, ReferenceQualifier::None);
-		return add_type_alias_copy(
-			param_name,
-			TypeIndex{0, arg.typeEnum()},
-			getTypeSizeFromTemplateArgument(arg),
-			alias_spec);
-	}
-	TypeIndex canonical_builtin = nativeTypeIndex(arg.typeEnum());
-	if (!canonical_builtin.is_valid()) {
-		canonical_builtin = TypeIndex{0, arg.typeEnum()};
-	}
+	TypeSpecifierNode alias_spec = makeTypeSpecifierFromTemplateTypeArg(arg, Token());
+	alias_spec.set_type_index(registered_type_index.withCategory(arg.typeEnum()));
 	return add_type_alias_copy(
 		param_name,
-		canonical_builtin.withCategory(arg.typeEnum()),
-		getTypeSizeFromTemplateArgument(arg));
+		registered_type_index.withCategory(arg.typeEnum()),
+		getTypeSizeFromTemplateArgument(arg),
+		alias_spec);
 }
 
 static void resetTypeIndirection(TypeSpecifierNode& type_spec) {
@@ -822,10 +792,13 @@ bool Parser::tryAppendDefaultTemplateArg(
 
 		FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 		FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
+		FlashCpp::ScopedState guard_subs(template_param_substitutions_);
 		FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
 		ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 		parsing_template_depth_ = 0;
 		clearCurrentTemplateParameters();
+		template_param_substitutions_.clear();
+		populateTemplateParamSubstitutions(template_param_substitutions_, default_arg_environment);
 		sfinae_type_map_.clear();
 
 		SaveHandle sfinae_pos = save_token_position();
@@ -853,10 +826,13 @@ bool Parser::tryAppendDefaultTemplateArg(
 		if (param.has_default_value_position() && !template_args.empty()) {
 			FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
+			FlashCpp::ScopedState guard_subs(template_param_substitutions_);
 			FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
 			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 			parsing_template_depth_ = 0;
 			clearCurrentTemplateParameters();
+			template_param_substitutions_.clear();
+			populateTemplateParamSubstitutions(template_param_substitutions_, default_arg_environment);
 			sfinae_type_map_.clear();
 
 			SaveHandle sfinae_pos = save_token_position();
@@ -1337,6 +1313,29 @@ void Parser::reparse_template_function_body(
 	// Restore lexer to the template body start.
 	restore_lexer_position_only(func_decl.template_body_position());
 
+	auto enterSourceNamespaceIfNeeded = [&]() -> int {
+		NamespaceHandle source_namespace = func_decl.namespace_handle();
+		if (!source_namespace.isValid() || source_namespace.isGlobal()) {
+			return 0;
+		}
+		InlineVector<NamespaceHandle, 8> chain;
+		NamespaceHandle current = source_namespace;
+		while (current.isValid() && !current.isGlobal()) {
+			chain.push_back(current);
+			current = gNamespaceRegistry.getParent(current);
+		}
+		for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
+			gSymbolTable.enter_namespace(chain[i]);
+		}
+		return static_cast<int>(chain.size());
+	};
+	auto exitSourceNamespaceIfNeeded = [&](int entered) {
+		for (int i = 0; i < entered; ++i) {
+			gSymbolTable.exit_scope();
+		}
+	};
+	const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+
 	// Enter function scope, set current function, register parameters.
 	gSymbolTable.enter_scope(ScopeType::Function);
 	current_function_ = &new_func_ref;
@@ -1387,6 +1386,7 @@ void Parser::reparse_template_function_body(
 	// Clean up scope.
 	current_function_ = nullptr;
 	gSymbolTable.exit_scope();
+	exitSourceNamespaceIfNeeded(entered_namespace_count);
 	restore_lexer_position_only(current_pos);
 	discard_saved_token(current_pos);
 
@@ -1939,6 +1939,25 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 
 		// Deduce: fp_name -> ca_type (call argument type for this parameter slot)
 		TemplateTypeArg new_arg = TemplateTypeArg::makeTypeSpecifier(ca_type);
+		if (fp_type.reference_qualifier() == ReferenceQualifier::None) {
+			// C++20 [temp.deduct.call]: for by-value parameters, top-level cv/ref on the
+			// call argument do not participate in deduction. Keep the underlying type
+			// identity, but drop the argument's top-level reference/cv wrapper.
+			new_arg.ref_qualifier = ReferenceQualifier::None;
+			new_arg.cv_qualifier = CVQualifier::None;
+		} else if (fp_type.reference_qualifier() == ReferenceQualifier::LValueReference) {
+			// For plain lvalue-reference parameters (T&, const T&), deduction binds T to the
+			// referred-to type rather than to a reference type. The parameter's own cv on the
+			// referred-to type is ignored, but cv carried by a plain T& argument participates.
+			new_arg.ref_qualifier = ReferenceQualifier::None;
+			const auto argument_cv = static_cast<uint8_t>(new_arg.cv_qualifier);
+			const auto parameter_cv = static_cast<uint8_t>(fp_type.cv_qualifier());
+			new_arg.cv_qualifier = static_cast<CVQualifier>(argument_cv & ~parameter_cv);
+		} else if (fp_type.reference_qualifier() == ReferenceQualifier::RValueReference) {
+			// Forwarding-reference deduction needs the full T&& vs lvalue/rvalue rules.
+			// Let the main deduction path handle it instead of pre-deducing the wrong shape.
+			continue;
+		}
 		param_name_to_arg.emplace(fp_name, new_arg);
 		pre_deduced_arg_indices.insert(concrete_arg_index);
 		FLASH_LOG_FORMAT(Templates, Debug,
@@ -2354,8 +2373,18 @@ bool Parser::materializeTemplateFunctionParameters(
 		resolveDependentMemberAlias(param_type, template_params, template_args);
 		TypeSpecifierNode& resolved_param_type = param_type.as<TypeSpecifierNode>();
 		const ResolvedAliasTypeInfo param_alias_info = resolveAliasTypeInfo(resolved_param_type.type_index());
-		if (param_alias_info.type_index.is_valid() && param_alias_info.type_index != resolved_param_type.type_index()) {
-			resolved_param_type.set_type_index(param_alias_info.type_index.withCategory(param_alias_info.typeEnum()));
+		TypeIndex resolved_param_alias_index = param_alias_info.type_index;
+		if (!resolved_param_alias_index.is_valid() && param_alias_info.typeEnum() != TypeCategory::Invalid) {
+			resolved_param_alias_index = nativeTypeIndex(param_alias_info.typeEnum());
+			if (!resolved_param_alias_index.is_valid()) {
+				resolved_param_alias_index = TypeIndex{0, param_alias_info.typeEnum()};
+			}
+		}
+		if (resolved_param_alias_index.category() != TypeCategory::Invalid &&
+			(resolved_param_alias_index != resolved_param_type.type_index() ||
+			 resolved_param_type.category() != param_alias_info.typeEnum())) {
+			resolved_param_type.set_type_index(resolved_param_alias_index.withCategory(param_alias_info.typeEnum()));
+			resolved_param_type.set_category(param_alias_info.typeEnum());
 		}
 		resolved_param_type.add_pointer_levels(static_cast<int>(param_alias_info.pointer_depth));
 		if (resolved_param_type.reference_qualifier() == ReferenceQualifier::None &&
@@ -2525,8 +2554,18 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			return;
 		}
 		const ResolvedAliasTypeInfo alias_info = resolveAliasTypeInfo(type_spec.type_index());
-		if (alias_info.type_index.is_valid() && alias_info.type_index != type_spec.type_index()) {
-			type_spec.set_type_index(alias_info.type_index.withCategory(alias_info.typeEnum()));
+		TypeIndex resolved_alias_index = alias_info.type_index;
+		if (!resolved_alias_index.is_valid() && alias_info.typeEnum() != TypeCategory::Invalid) {
+			resolved_alias_index = nativeTypeIndex(alias_info.typeEnum());
+			if (!resolved_alias_index.is_valid()) {
+				resolved_alias_index = TypeIndex{0, alias_info.typeEnum()};
+			}
+		}
+		if (resolved_alias_index.category() != TypeCategory::Invalid &&
+			(resolved_alias_index != type_spec.type_index() ||
+			 type_spec.category() != alias_info.typeEnum())) {
+			type_spec.set_type_index(resolved_alias_index.withCategory(alias_info.typeEnum()));
+			type_spec.set_category(alias_info.typeEnum());
 		}
 		type_spec.add_pointer_levels(static_cast<int>(alias_info.pointer_depth));
 		if (type_spec.reference_qualifier() == ReferenceQualifier::None &&
@@ -2539,6 +2578,28 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 		const int resolved_size_bits = getTypeSpecSizeBits(type_spec);
 		if (resolved_size_bits > 0) {
 			type_spec.set_size_in_bits(resolved_size_bits);
+		}
+	};
+
+	auto enterSourceNamespaceIfNeeded = [&]() -> int {
+		NamespaceHandle source_namespace = func_decl.namespace_handle();
+		if (!source_namespace.isValid() || source_namespace.isGlobal()) {
+			return 0;
+		}
+		InlineVector<NamespaceHandle, 8> chain;
+		NamespaceHandle current = source_namespace;
+		while (current.isValid() && !current.isGlobal()) {
+			chain.push_back(current);
+			current = gNamespaceRegistry.getParent(current);
+		}
+		for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
+			gSymbolTable.enter_namespace(chain[i]);
+		}
+		return static_cast<int>(chain.size());
+	};
+	auto exitSourceNamespaceIfNeeded = [&](int entered) {
+		for (int i = 0; i < entered; ++i) {
+			gSymbolTable.exit_scope();
 		}
 	};
 
@@ -2558,6 +2619,43 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				reparsed_return_type.set_size_in_bits(resolved_size_bits);
 			}
 			return_type = emplace_node<TypeSpecifierNode>(reparsed_return_type);
+		} else if (func_decl.has_template_declaration_position()) {
+			SaveHandle current_pos = save_token_position();
+			restore_lexer_position_only(func_decl.template_declaration_position());
+			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
+			FlashCpp::ScopedState guard_subs(template_param_substitutions_);
+			TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+				template_params,
+				template_args,
+				nullptr);
+			populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
+			for (const TemplateParameterNode& template_param : template_params) {
+				pushCurrentTemplateParamName(template_param.nameHandle());
+			}
+			FlashCpp::TemplateParameterScope template_scope;
+			registerTypeParamsInScope(substitution_environment, template_scope, preserve_ref_qualifier);
+			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			auto return_type_result = parse_type_specifier();
+			exitSourceNamespaceIfNeeded(entered_namespace_count);
+			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
+				auto& rt = return_type_result.node()->as<TypeSpecifierNode>();
+				consume_pointer_ref_modifiers(rt);
+			}
+			restore_lexer_position_only(current_pos);
+			if (return_type_result.is_error()) {
+				return failTemplateInstantiation(return_type_result.error_message(), &key, overload_id);
+			}
+			if (!return_type_result.node().has_value()) {
+				return failTemplateInstantiation(
+					StringBuilder()
+						.append("template function '")
+						.append(template_name)
+						.append("' return type parsing returned no node")
+						.commit(),
+					&key,
+					overload_id);
+			}
+			return_type = *return_type_result.node();
 		} else {
 			TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
 				orig_return_type,
@@ -2595,9 +2693,21 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			} trailing_return_guard{trailing_return_in_progress, mangled_name};
 			SaveHandle current_pos = save_token_position();
 			restore_lexer_position_only(func_decl.template_declaration_position());
+			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
+			FlashCpp::ScopedState guard_subs(template_param_substitutions_);
+			TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+				template_params,
+				template_args,
+				nullptr);
+			populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
+			for (const TemplateParameterNode& template_param : template_params) {
+				pushCurrentTemplateParamName(template_param.nameHandle());
+			}
 			FlashCpp::TemplateParameterScope template_scope;
-			registerTypeParamsInScope(template_params, template_args, template_scope, false);
+			registerTypeParamsInScope(substitution_environment, template_scope, false);
+			int entered_namespace_count = enterSourceNamespaceIfNeeded();
 			auto return_type_result = parse_type_specifier();
+			exitSourceNamespaceIfNeeded(entered_namespace_count);
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
 				auto& rt = return_type_result.node()->as<TypeSpecifierNode>();
 				consume_pointer_ref_modifiers(rt);
@@ -2619,8 +2729,10 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			return_type = *return_type_result.node();
 			restore_lexer_position_only(func_decl.template_declaration_position());
 			FlashCpp::TemplateParameterScope template_scope2;
-			registerTypeParamsInScope(template_params, template_args, template_scope2, false);
+			registerTypeParamsInScope(substitution_environment, template_scope2, false);
+			entered_namespace_count = enterSourceNamespaceIfNeeded();
 			auto type_and_name_result = parse_type_and_name();
+			exitSourceNamespaceIfNeeded(entered_namespace_count);
 			restore_lexer_position_only(current_pos);
 			if (!type_and_name_result.is_error() &&
 				type_and_name_result.node().has_value() &&
@@ -2652,19 +2764,20 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			apply_resolved_alias_metadata_local(new_return_type);
 			return_type = emplace_node<TypeSpecifierNode>(new_return_type);
 		}
+	}
 
-		resolveDependentMemberAlias(return_type, template_params, template_args);
-		if (return_type.is<TypeSpecifierNode>()) {
-			const auto& rt = return_type.as<TypeSpecifierNode>();
-			if ((rt.category() == TypeCategory::UserDefined ||
-				 rt.category() == TypeCategory::TypeAlias ||
-				 rt.category() == TypeCategory::Template) &&
-				rt.type_index().is_valid()) {
-				if (const TypeInfo* rt_info = tryGetTypeInfo(rt.type_index())) {
-					if (rt_info->is_incomplete_instantiation_ && rt_info->isDependentMemberType()) {
-						gTemplateRegistry.markFailedInstantiation(key, overload_id);
-						return std::nullopt;
-					}
+	resolveDependentMemberAlias(return_type, template_params, template_args);
+	if (return_type.is<TypeSpecifierNode>()) {
+		auto& rt = return_type.as<TypeSpecifierNode>();
+		apply_resolved_alias_metadata_local(rt);
+		if ((rt.category() == TypeCategory::UserDefined ||
+			 rt.category() == TypeCategory::TypeAlias ||
+			 rt.category() == TypeCategory::Template) &&
+			rt.type_index().is_valid()) {
+			if (const TypeInfo* rt_info = tryGetTypeInfo(rt.type_index())) {
+				if (rt_info->is_incomplete_instantiation_ && rt_info->isDependentMemberType()) {
+					gTemplateRegistry.markFailedInstantiation(key, overload_id);
+					return std::nullopt;
 				}
 			}
 		}
@@ -3028,6 +3141,21 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		}
 		if (overload_mismatch)
 			continue;  // SFINAE: try next overload
+
+		const auto has_structurally_dependent_template_args = [](std::span<const TemplateTypeArg> args) {
+			return std::any_of(
+				args.begin(),
+				args.end(),
+				[](const TemplateTypeArg& arg) {
+					return arg.is_dependent ||
+						   arg.dependent_name.isValid() ||
+						   arg.category() == TypeCategory::Auto ||
+						   arg.category() == TypeCategory::DeclTypeAuto;
+				});
+		};
+		if (has_structurally_dependent_template_args(template_args)) {
+			continue;
+		}
 
 		// CHECK REQUIRES CLAUSE CONSTRAINT BEFORE INSTANTIATION
 		if (template_func.has_requires_clause()) {
@@ -3673,6 +3801,20 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	}
 	InlineVector<TemplateTypeArg, 4> template_args = std::move(*deduced_template_args);
 	// template_args is already std::vector<TemplateTypeArg> — no conversion needed.
+	const auto has_structurally_dependent_template_args = [](std::span<const TemplateTypeArg> args) {
+		return std::any_of(
+			args.begin(),
+			args.end(),
+			[](const TemplateTypeArg& arg) {
+				return arg.is_dependent ||
+					   arg.dependent_name.isValid() ||
+					   arg.category() == TypeCategory::Auto ||
+					   arg.category() == TypeCategory::DeclTypeAuto;
+			});
+	};
+	if (has_structurally_dependent_template_args(template_args)) {
+		return std::nullopt;
+	}
 
 	// Step 2: Check if we already have this instantiation
 	auto key = FlashCpp::makeInstantiationKey(

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -1335,6 +1335,9 @@ void Parser::reparse_template_function_body(
 		}
 	};
 	const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+	auto exit_source_namespace = ScopeGuard([&]() {
+		exitSourceNamespaceIfNeeded(entered_namespace_count);
+	});
 
 	// Enter function scope, set current function, register parameters.
 	gSymbolTable.enter_scope(ScopeType::Function);
@@ -1386,7 +1389,6 @@ void Parser::reparse_template_function_body(
 	// Clean up scope.
 	current_function_ = nullptr;
 	gSymbolTable.exit_scope();
-	exitSourceNamespaceIfNeeded(entered_namespace_count);
 	restore_lexer_position_only(current_pos);
 	discard_saved_token(current_pos);
 
@@ -1954,9 +1956,17 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 			const auto parameter_cv = static_cast<uint8_t>(fp_type.cv_qualifier());
 			new_arg.cv_qualifier = static_cast<CVQualifier>(argument_cv & ~parameter_cv);
 		} else if (fp_type.reference_qualifier() == ReferenceQualifier::RValueReference) {
-			// Forwarding-reference deduction needs the full T&& vs lvalue/rvalue rules.
-			// Let the main deduction path handle it instead of pre-deducing the wrong shape.
-			continue;
+			const bool is_forwarding_reference =
+				fp_type.cv_qualifier() == CVQualifier::None;
+			if (is_forwarding_reference) {
+				// Forwarding-reference deduction needs the full T&& vs lvalue/rvalue rules.
+				// Let the main deduction path handle it instead of pre-deducing the wrong shape.
+				continue;
+			}
+			new_arg.ref_qualifier = ReferenceQualifier::None;
+			const auto argument_cv = static_cast<uint8_t>(new_arg.cv_qualifier);
+			const auto parameter_cv = static_cast<uint8_t>(fp_type.cv_qualifier());
+			new_arg.cv_qualifier = static_cast<CVQualifier>(argument_cv & ~parameter_cv);
 		}
 		param_name_to_arg.emplace(fp_name, new_arg);
 		pre_deduced_arg_indices.insert(concrete_arg_index);
@@ -2628,6 +2638,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				template_params,
 				template_args,
 				nullptr);
+			template_param_substitutions_.clear();
 			populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 			for (const TemplateParameterNode& template_param : template_params) {
 				pushCurrentTemplateParamName(template_param.nameHandle());
@@ -2635,8 +2646,10 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			FlashCpp::TemplateParameterScope template_scope;
 			registerTypeParamsInScope(substitution_environment, template_scope, preserve_ref_qualifier);
 			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			auto exit_source_namespace = ScopeGuard([&]() {
+				exitSourceNamespaceIfNeeded(entered_namespace_count);
+			});
 			auto return_type_result = parse_type_specifier();
-			exitSourceNamespaceIfNeeded(entered_namespace_count);
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
 				auto& rt = return_type_result.node()->as<TypeSpecifierNode>();
 				consume_pointer_ref_modifiers(rt);
@@ -2699,15 +2712,18 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				template_params,
 				template_args,
 				nullptr);
+			template_param_substitutions_.clear();
 			populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 			for (const TemplateParameterNode& template_param : template_params) {
 				pushCurrentTemplateParamName(template_param.nameHandle());
 			}
 			FlashCpp::TemplateParameterScope template_scope;
 			registerTypeParamsInScope(substitution_environment, template_scope, false);
-			int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			auto exit_return_type_namespace = ScopeGuard([&]() {
+				exitSourceNamespaceIfNeeded(entered_namespace_count);
+			});
 			auto return_type_result = parse_type_specifier();
-			exitSourceNamespaceIfNeeded(entered_namespace_count);
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
 				auto& rt = return_type_result.node()->as<TypeSpecifierNode>();
 				consume_pointer_ref_modifiers(rt);
@@ -2730,9 +2746,11 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			restore_lexer_position_only(func_decl.template_declaration_position());
 			FlashCpp::TemplateParameterScope template_scope2;
 			registerTypeParamsInScope(substitution_environment, template_scope2, false);
-			entered_namespace_count = enterSourceNamespaceIfNeeded();
+			const int entered_name_parse_namespace_count = enterSourceNamespaceIfNeeded();
+			auto exit_name_parse_namespace = ScopeGuard([&]() {
+				exitSourceNamespaceIfNeeded(entered_name_parse_namespace_count);
+			});
 			auto type_and_name_result = parse_type_and_name();
-			exitSourceNamespaceIfNeeded(entered_namespace_count);
 			restore_lexer_position_only(current_pos);
 			if (!type_and_name_result.is_error() &&
 				type_and_name_result.node().has_value() &&

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -160,6 +160,9 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	StringBuilder qualified_name_sb;
 	qualified_name_sb.append(struct_name).append("::").append(member_name);
 	StringHandle qualified_name = StringTable::getOrInternStringHandle(qualified_name_sb);
+	const StringHandle requested_qualified_name = qualified_name;
+	const OuterTemplateBinding* outer_binding =
+		gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view());
 
 	// Push a parser-level instantiation context for provenance tracking and backtraces.
 	ScopedParserInstantiationContext inst_ctx_guard(*this, template_instantiation_mode_, qualified_name);
@@ -195,7 +198,6 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 	const auto& template_params = template_func.template_parameters();
-	const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
 	if (arg_types.empty()) {
 		return std::nullopt;	 // Can't deduce without arguments
 	}
@@ -360,15 +362,14 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 		ctor_decl.outer_template_environment_snapshot(),
 		outer_param_names,
 		outer_args);
-	std::shared_ptr<const TemplateEnvironmentSnapshot> outer_parent_snapshot;
-	if (ctor_decl.has_outer_template_bindings()) {
-		outer_parent_snapshot = std::make_shared<const TemplateEnvironmentSnapshot>(
-			ctor_decl.outer_template_environment_snapshot());
-	}
+	const TemplateEnvironmentSnapshot* outer_parent_snapshot =
+		ctor_decl.has_outer_template_bindings()
+			? &ctor_decl.outer_template_environment_snapshot()
+			: nullptr;
 	lazy_info.outer_template_environment_snapshot = buildTemplateEnvironmentSnapshotFromBindings(
 		template_params,
 		ctor_template_args,
-		std::move(outer_parent_snapshot));
+		outer_parent_snapshot);
 	for (StringHandle outer_name : outer_param_names) {
 		Token outer_token(Token::Type::Identifier, StringTable::getStringView(outer_name), 0, 0, 0);
 		lazy_info.template_params.push_back(TemplateParameterNode(outer_name, outer_token));
@@ -549,6 +550,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 	StringBuilder qualified_name_sb;
 	qualified_name_sb.append(struct_name).append("::").append(member_name);
 	StringHandle qualified_name = StringTable::getOrInternStringHandle(qualified_name_sb);
+	const StringHandle requested_qualified_name = qualified_name;
 	StringHandle specialization_lookup_name = qualified_name;
 	StringHandle struct_name_handle = StringTable::getOrInternStringHandle(struct_name);
 	auto requested_key = FlashCpp::makeInstantiationKey(qualified_name, template_type_args);
@@ -738,7 +740,6 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 		const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 		const auto& template_params = template_func.template_parameters();
 		const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
-		const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
 		if (template_type_args.size() > template_params.size()) {
 			continue;
 		}
@@ -750,7 +751,11 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 		bool has_all_template_args = true;
 		for (size_t i = completed_template_args.size(); i < template_params.size(); ++i) {
 			const auto& template_param = template_params[i];
-			if (!tryAppendMemberDefaultTemplateArg(template_param, template_params, outer_binding, completed_template_args)) {
+			if (!tryAppendMemberDefaultTemplateArg(
+					template_param,
+					template_params,
+					gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view()),
+					completed_template_args)) {
 				has_all_template_args = false;
 				break;
 			}
@@ -789,8 +794,10 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 			// Add inner template params (the member function template's own params, e.g. U)
 			registerTypeParamsInScope(template_params, template_args, sfinae_scope, &sfinae_type_map_);
 			// Add outer template params (from enclosing class template, e.g. T→int)
-			if (outer_binding)
-				registerOuterBindingInScope(*outer_binding, sfinae_scope, &sfinae_type_map_);
+			if (const OuterTemplateBinding* sfinae_outer_binding =
+					gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view())) {
+				registerOuterBindingInScope(*sfinae_outer_binding, sfinae_scope, &sfinae_type_map_);
+			}
 
 			auto return_type_result = parse_type_specifier();
 			gSymbolTable.exit_scope();
@@ -1025,7 +1032,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
-	const OuterTemplateBinding* outer_binding = gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
+	const OuterTemplateBinding* outer_binding =
+		gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
 	InlineVector<TemplateTypeArg, 4> inline_template_args;
 	inline_template_args.reserve(template_args.size());
 	for (const TemplateTypeArg& template_arg : template_args) {
@@ -1521,8 +1529,31 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	// Check if the template has a body position stored
 	if (!func_decl.has_template_body_position()) {
 		if (orig_body.has_value()) {
-			new_func_ref.set_definition(
-				substituteTemplateParameters(*orig_body, template_params, inline_template_args));
+			ASTNode substituted_body = substituteTemplateParameters(
+				*orig_body,
+				template_params,
+				inline_template_args);
+			if (func_decl.has_outer_template_bindings()) {
+				InlineVector<StringHandle, 4> outer_param_names;
+				InlineVector<TypeInfo::TemplateArgInfo, 4> outer_arg_infos;
+				outer_param_names = func_decl.outer_template_param_names();
+				outer_arg_infos = func_decl.outer_template_args();
+				InlineVector<TemplateParameterNode, 4> typed_outer_params;
+				typed_outer_params.reserve(outer_param_names.size());
+				InlineVector<TemplateTypeArg, 4> outer_args;
+				outer_args.reserve(outer_arg_infos.size());
+				for (size_t i = 0; i < outer_param_names.size() && i < outer_arg_infos.size(); ++i) {
+					Token outer_token(Token::Type::Identifier, StringTable::getStringView(outer_param_names[i]), 0, 0, 0);
+					TemplateParameterNode outer_param(outer_param_names[i], outer_token);
+					typed_outer_params.push_back(outer_param);
+					outer_args.push_back(toTemplateTypeArg(outer_arg_infos[i]));
+				}
+				substituted_body = substituteTemplateParameters(
+					substituted_body,
+					typed_outer_params,
+					outer_args);
+			}
+			new_func_ref.set_definition(substituted_body);
 			finalize_function_after_definition(new_func_ref);
 		} else {
 			compute_and_set_mangled_name(new_func_ref);
@@ -1544,9 +1575,16 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	registerTypeParamsInScope(template_params, template_args, template_scope, false);
 
 	// Also add outer template parameter bindings (e.g., T→int from class template)
-	if (outer_binding) {
-		registerOuterBindingInScope(*outer_binding, template_scope, nullptr);
-		FLASH_LOG(Templates, Debug, "Added ", outer_binding->param_names.size(), " outer template param bindings for body parsing");
+	if (func_decl.has_outer_template_bindings()) {
+		InlineVector<StringHandle, 4> outer_param_names = func_decl.outer_template_param_names();
+		InlineVector<TypeInfo::TemplateArgInfo, 4> outer_arg_infos = func_decl.outer_template_args();
+		InlineVector<TemplateTypeArg, 4> outer_args;
+		outer_args.reserve(outer_arg_infos.size());
+		for (const auto& outer_arg : outer_arg_infos) {
+			outer_args.push_back(toTemplateTypeArg(outer_arg));
+		}
+		registerTypeParamsInScope(outer_param_names, outer_args, template_scope, false);
+		FLASH_LOG(Templates, Debug, "Added ", outer_param_names.size(), " outer template param bindings for body parsing");
 	}
 
 	// Save current position
@@ -1629,7 +1667,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		TemplateEnvironment substitution_environment = buildTemplateEnvironment(
 			template_params,
 			template_args,
-			nullptr);
+			outer_binding ? &outer_default_environment : nullptr);
 		populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 
 		// Parse the function body
@@ -1646,23 +1684,6 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					*block_result.node(),
 					template_params,
 					inline_template_args);
-				if (outer_binding && (!outer_binding->params.empty() || !outer_binding->param_names.empty())) {
-					InlineVector<ASTNode, 4> outer_params;
-					InlineVector<TemplateTypeArg, 4> outer_args;
-					appendOuterBindingSubstitutionInputs(*outer_binding, outer_params, outer_args);
-					InlineVector<TemplateParameterNode, 4> typed_outer_params;
-					typed_outer_params.reserve(outer_params.size());
-					for (const ASTNode& param_node : outer_params) {
-						if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
-							typed_param != nullptr) {
-							typed_outer_params.push_back(*typed_param);
-						}
-					}
-					substituted_body = substituteTemplateParameters(
-						substituted_body,
-						typed_outer_params,
-						outer_args);
-				}
 				new_func_ref.set_definition(substituted_body);
 			}
 		} // current_template_param_names_ restored here

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -299,7 +299,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	}
 
 	return instantiate_member_function_template_core(
-		struct_name, member_name, qualified_name, template_node, template_args, key, arg_types);
+		struct_name, member_name, requested_qualified_name, qualified_name, template_node, template_args, key, arg_types);
 }
 
 std::optional<ASTNode> Parser::try_instantiate_constructor_template(
@@ -816,7 +816,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 				? *current_explicit_call_arg_types_
 				: empty_call_arg_types;
 		auto result = instantiate_member_function_template_core(
-			struct_name, member_name, qualified_name, template_node, template_args, key, call_arg_types);
+			struct_name, member_name, requested_qualified_name, qualified_name, template_node, template_args, key, call_arg_types);
 		if (result.has_value()) {
 			return result;
 		}
@@ -991,6 +991,7 @@ ASTNode Parser::buildMaterializedParamType(
 
 std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	std::string_view struct_name, std::string_view member_name,
+	StringHandle requested_qualified_name,
 	StringHandle qualified_name,
 	const ASTNode& template_node,
 	std::span<const TemplateTypeArg> template_args,
@@ -1033,7 +1034,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
 	const OuterTemplateBinding* outer_binding =
-		gTemplateRegistry.getOuterTemplateBinding(qualified_name.view());
+		gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view());
 	InlineVector<TemplateTypeArg, 4> inline_template_args;
 	inline_template_args.reserve(template_args.size());
 	for (const TemplateTypeArg& template_arg : template_args) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1583,7 +1583,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		for (const auto& outer_arg : outer_arg_infos) {
 			outer_args.push_back(toTemplateTypeArg(outer_arg));
 		}
-		registerTypeParamsInScope(outer_param_names, outer_args, template_scope, false);
+		registerTypeParamsInScope(outer_param_names, outer_args, template_scope, true);
 		FLASH_LOG(Templates, Debug, "Added ", outer_param_names.size(), " outer template param bindings for body parsing");
 	}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -923,6 +923,15 @@ Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedO
 		owner_type_info != nullptr) {
 		result.resolved_type_info = owner_type_info;
 		if (!owner_type_info->isTemplateInstantiation()) {
+			if (!owner_template_args.empty() &&
+				can_materialize_owner_template(owner_name)) {
+				AliasTemplateMaterializationResult materialized_owner =
+					materializeTemplateInstantiationForLookup(owner_name, owner_template_args);
+				if (!materialized_owner.instantiated_name.empty() ||
+					materialized_owner.resolved_type_info != nullptr) {
+					return materialized_owner;
+				}
+			}
 			return result;
 		}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -250,6 +250,73 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 				return normalize_alias_param_arg(*alias_param_idx, template_args[*alias_param_idx]);
 			}
 		}
+		if (arg_type.type_index().is_valid()) {
+			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg_type.type_index());
+				arg_type_info != nullptr &&
+				arg_type_info->isTemplateInstantiation()) {
+				std::vector<TemplateTypeArg> concrete_instantiation_args = materializeTemplateArgs(
+					*arg_type_info,
+					template_parameters,
+					template_args);
+				TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+					std::span<const TemplateParameterNode>(
+						template_parameters.data(),
+						template_parameters.size()),
+					template_args,
+					nullptr);
+				for (TemplateTypeArg& concrete_arg : concrete_instantiation_args) {
+					if (concrete_arg.is_value) {
+						continue;
+					}
+					if (concrete_arg.is_dependent &&
+						concrete_arg.dependent_name.isValid()) {
+						if (std::optional<TemplateTypeArg> rebound =
+								resolveContextBinding(
+									concrete_arg.dependent_name,
+									substitution_environment);
+							rebound.has_value()) {
+							concrete_arg = !rebound->is_value
+								? rebindDependentTemplateTypeArg(*rebound, concrete_arg)
+								: *rebound;
+							continue;
+						}
+					}
+					if (!concrete_arg.type_index.is_valid()) {
+						continue;
+					}
+					const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+					if (concrete_type_info == nullptr || !concrete_type_info->name().isValid()) {
+						continue;
+					}
+					if (std::optional<TemplateTypeArg> rebound =
+							resolveContextBinding(
+								concrete_type_info->name(),
+								substitution_environment);
+						rebound.has_value()) {
+						concrete_arg = !rebound->is_value
+							? rebindDependentTemplateTypeArg(*rebound, concrete_arg)
+							: *rebound;
+					}
+				}
+				std::string_view base_template_name =
+					StringTable::getStringView(arg_type_info->baseTemplateName());
+				if (!base_template_name.empty()) {
+					AliasTemplateMaterializationResult materialized_type =
+						materializeTemplateInstantiationForLookup(
+							base_template_name,
+							concrete_instantiation_args);
+					const TypeInfo* resolved_type_info = materialized_type.resolved_type_info;
+					if (resolved_type_info == nullptr &&
+						!materialized_type.instantiated_name.empty()) {
+						resolved_type_info = findTypeByName(
+							StringTable::getOrInternStringHandle(materialized_type.instantiated_name));
+					}
+					if (resolved_type_info != nullptr) {
+						return resolveTypeInfoToTemplateArg(*resolved_type_info, arg_type);
+					}
+				}
+			}
+		}
 		return TemplateTypeArg(arg_type);
 	}
 
@@ -293,8 +360,24 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 		// rather than a concrete (wrong) one. When the outer template is later
 		// instantiated with a concrete type (e.g. FinalHead), this function will
 		// be called again with non-dependent args and will evaluate correctly.
+		const auto unresolved_dependent_anchor = [](const TemplateTypeArg& candidate) -> StringHandle {
+			if (candidate.dependent_name.isValid()) {
+				return candidate.dependent_name;
+			}
+			if (!candidate.is_value &&
+				candidate.type_index.is_valid() &&
+				typeIndexContainsDependentPlaceholder(candidate.type_index)) {
+				if (const TypeInfo* type_info = tryGetTypeInfo(candidate.type_index);
+					type_info != nullptr &&
+					type_info->name().isValid()) {
+					return type_info->name();
+				}
+			}
+			return {};
+		};
 		for (const TemplateTypeArg& arg : template_args) {
-			if (arg.is_dependent && arg.dependent_name.isValid()) {
+			if (StringHandle dependent_anchor = unresolved_dependent_anchor(arg);
+				dependent_anchor.isValid()) {
 				FLASH_LOG(Templates, Debug, "materializeDeferredAliasTemplateArg: arg is dependent, returning dependent bool placeholder");
 				// Pre-substitute the alias template parameters (e.g. 'Type' in __is_final(Type))
 				// into the outer dependent parameter (e.g. 'Head') so that when the outer
@@ -305,7 +388,7 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 					arg_node,
 					template_parameters,
 					std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
-				return TemplateTypeArg::makeDependentValue(arg.dependent_name, TypeCategory::Bool, 0, pre_substituted);
+				return TemplateTypeArg::makeDependentValue(dependent_anchor, TypeCategory::Bool, 0, pre_substituted);
 			}
 		}
 	} else {
@@ -2607,6 +2690,16 @@ std::optional<TemplateTypeArg> Parser::evaluateDependentNTTPExpression(
 	// Evaluate the substituted expression using the standard constant expression evaluator
 	ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 	eval_ctx.parser = this;
+	eval_ctx.sema = getActiveSemanticAnalysis();
+	eval_ctx.template_environment = buildTemplateEnvironment(
+		template_params,
+		template_args,
+		nullptr);
+	eval_ctx.template_args.assign(template_args.begin(), template_args.end());
+	eval_ctx.template_param_names.reserve(template_params.size());
+	for (const TemplateParameterNode& template_param : template_params) {
+		eval_ctx.template_param_names.push_back(template_param.name());
+	}
 	ConstExpr::EvalResult result = ConstExpr::Evaluator::evaluate(substituted, eval_ctx);
 	if (result.success()) {
 		return templateTypeArgFromEvalResult(result);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -894,6 +894,13 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 }
 
 Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedOwnerForLookup(
+	std::string_view owner_name) {
+	return resolveCanonicalInstantiatedOwnerForLookup(
+		owner_name,
+		std::span<const TemplateTypeArg>{});
+}
+
+Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedOwnerForLookup(
 	std::string_view owner_name,
 	std::span<const TemplateTypeArg> owner_template_args) {
 	AliasTemplateMaterializationResult result;
@@ -919,9 +926,20 @@ Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedO
 	};
 
 	const StringHandle owner_name_handle = StringTable::getOrInternStringHandle(owner_name);
-	if (const TypeInfo* owner_type_info = findTypeByName(owner_name_handle);
-		owner_type_info != nullptr) {
+	if (const TypeInfo* initial_owner_type_info = findTypeByName(owner_name_handle);
+		initial_owner_type_info != nullptr) {
+		const TypeInfo* owner_type_info = initial_owner_type_info;
 		result.resolved_type_info = owner_type_info;
+		if (!owner_type_info->isTemplateInstantiation()) {
+			ResolvedAliasTypeInfo resolved_owner_alias = resolveAliasTypeInfo(
+				owner_type_info->registeredTypeIndex().withCategory(owner_type_info->typeEnum()));
+			if (resolved_owner_alias.terminal_type_info != nullptr &&
+				resolved_owner_alias.terminal_type_info != owner_type_info &&
+				resolved_owner_alias.terminal_type_info->isTemplateInstantiation()) {
+				owner_type_info = resolved_owner_alias.terminal_type_info;
+				result.resolved_type_info = owner_type_info;
+			}
+		}
 		if (!owner_type_info->isTemplateInstantiation()) {
 			if (!owner_template_args.empty() &&
 				can_materialize_owner_template(owner_name)) {

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -893,6 +893,178 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 	return result;
 }
 
+Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedOwnerForLookup(
+	std::string_view owner_name,
+	std::span<const TemplateTypeArg> owner_template_args) {
+	AliasTemplateMaterializationResult result;
+	result.instantiated_name = owner_name;
+	if (owner_name.empty()) {
+		return result;
+	}
+
+	const auto can_materialize_owner_template =
+		[&](std::string_view candidate_name) {
+		if (candidate_name.empty()) {
+			return false;
+		}
+		if (gTemplateRegistry.lookup_alias_template(candidate_name).has_value()) {
+			return true;
+		}
+		if (auto template_entry = gTemplateRegistry.lookupTemplate(candidate_name);
+			template_entry.has_value() &&
+			template_entry->is<TemplateClassDeclarationNode>()) {
+			return true;
+		}
+		return false;
+	};
+
+	const StringHandle owner_name_handle = StringTable::getOrInternStringHandle(owner_name);
+	if (const TypeInfo* owner_type_info = findTypeByName(owner_name_handle);
+		owner_type_info != nullptr) {
+		result.resolved_type_info = owner_type_info;
+		if (!owner_type_info->isTemplateInstantiation()) {
+			return result;
+		}
+
+		const std::string_view base_template_name =
+			StringTable::getStringView(owner_type_info->baseTemplateName());
+		if (base_template_name.empty()) {
+			return result;
+		}
+
+		std::vector<TemplateTypeArg> concrete_template_args;
+		concrete_template_args.reserve(owner_type_info->templateArgs().size());
+		bool has_dependent_template_arg = false;
+		for (const auto& stored_arg : owner_type_info->templateArgs()) {
+			TemplateTypeArg concrete_arg = toTemplateTypeArg(stored_arg);
+			concrete_arg.setCategory(stored_arg.category());
+			if (concrete_arg.is_dependent || stored_arg.dependent_name.isValid()) {
+				has_dependent_template_arg = true;
+				break;
+			}
+			concrete_template_args.push_back(concrete_arg);
+		}
+		if (!has_dependent_template_arg) {
+			AliasTemplateMaterializationResult canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					base_template_name,
+					std::span<const TemplateTypeArg>(
+						concrete_template_args.data(),
+						concrete_template_args.size()));
+			if (!canonical_owner.instantiated_name.empty()) {
+				result.instantiated_name = canonical_owner.instantiated_name;
+			}
+			if (canonical_owner.resolved_type_info != nullptr) {
+				result.resolved_type_info = canonical_owner.resolved_type_info;
+			}
+			return result;
+		}
+
+		if (has_dependent_template_arg &&
+			owner_type_info->hasInstantiationContext() &&
+			owner_type_info->instantiationContext() != nullptr) {
+			concrete_template_args.clear();
+			has_dependent_template_arg = false;
+			for (const auto& context_arg : owner_type_info->instantiationContext()->param_args) {
+				TemplateTypeArg concrete_arg = toTemplateTypeArg(context_arg);
+				concrete_arg.setCategory(context_arg.category());
+				if (concrete_arg.is_dependent || context_arg.dependent_name.isValid()) {
+					has_dependent_template_arg = true;
+					break;
+				}
+				concrete_template_args.push_back(concrete_arg);
+			}
+			if (!has_dependent_template_arg) {
+				AliasTemplateMaterializationResult canonical_owner =
+					materializeTemplateInstantiationForLookup(
+						base_template_name,
+						std::span<const TemplateTypeArg>(
+							concrete_template_args.data(),
+							concrete_template_args.size()));
+				if (!canonical_owner.instantiated_name.empty()) {
+					result.instantiated_name = canonical_owner.instantiated_name;
+				}
+				if (canonical_owner.resolved_type_info != nullptr) {
+					result.resolved_type_info = canonical_owner.resolved_type_info;
+				}
+				return result;
+			}
+		}
+
+		if (!owner_template_args.empty() &&
+			can_materialize_owner_template(base_template_name)) {
+			AliasTemplateMaterializationResult canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					base_template_name,
+					owner_template_args);
+			if (!canonical_owner.instantiated_name.empty() ||
+				canonical_owner.resolved_type_info != nullptr) {
+				return canonical_owner;
+			}
+		}
+		return result;
+	}
+
+	if (!owner_template_args.empty()) {
+		if (can_materialize_owner_template(owner_name)) {
+			AliasTemplateMaterializationResult materialized_owner =
+				materializeTemplateInstantiationForLookup(owner_name, owner_template_args);
+			if (!materialized_owner.instantiated_name.empty() ||
+				materialized_owner.resolved_type_info != nullptr) {
+				return materialized_owner;
+			}
+		}
+
+		const std::string_view base_template_name = extractBaseTemplateName(owner_name);
+		if (!base_template_name.empty() &&
+			base_template_name != owner_name &&
+			can_materialize_owner_template(base_template_name)) {
+			AliasTemplateMaterializationResult materialized_owner =
+				materializeTemplateInstantiationForLookup(base_template_name, owner_template_args);
+			if (!materialized_owner.instantiated_name.empty() ||
+				materialized_owner.resolved_type_info != nullptr) {
+				return materialized_owner;
+			}
+		}
+	}
+
+	return result;
+}
+
+std::optional<ASTNode> Parser::instantiateLazyMemberForCanonicalOwner(
+	std::string_view& owner_name,
+	std::string_view member_name,
+	std::span<const TemplateTypeArg> owner_template_args) {
+	AliasTemplateMaterializationResult canonical_owner =
+		resolveCanonicalInstantiatedOwnerForLookup(owner_name, owner_template_args);
+	if (!canonical_owner.instantiated_name.empty()) {
+		owner_name = canonical_owner.instantiated_name;
+	}
+	if (owner_name.empty() || member_name.empty()) {
+		return std::nullopt;
+	}
+
+	StringHandle owner_handle = StringTable::getOrInternStringHandle(owner_name);
+	StringHandle member_handle = StringTable::getOrInternStringHandle(member_name);
+	LazyMemberKey member_key = LazyMemberKey::anyConst(owner_handle, member_handle);
+	if (!LazyMemberInstantiationRegistry::getInstance().needsInstantiation(member_key)) {
+		return std::nullopt;
+	}
+
+	FLASH_LOG(
+		Templates,
+		Debug,
+		"Lazy instantiation triggered for canonical owner: ",
+		owner_name,
+		"::",
+		member_name);
+	std::optional<ASTNode> instantiated = instantiateLazyMemberIfNeeded(member_key);
+	if (instantiated.has_value()) {
+		normalizePendingSemanticRootsIfAvailable();
+	}
+	return instantiated;
+}
+
 const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	const TypeSpecifierNode& alias_type_spec,
 	std::span<const TemplateParameterNode> template_params,

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -692,47 +692,22 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		body_to_substitute = func_decl.get_definition();
 	}
 
-	// Substitute template parameters in the function body
-	if (body_to_substitute.has_value()) {
-		// Build template argument vector for registration
+		// Substitute template parameters in the function body
+		if (body_to_substitute.has_value()) {
+		// Build template argument vector for registration.
+		// Use the full lazy-info parameter list here: for member templates this already
+		// contains both the enclosing class template bindings and the member template's own
+		// parameters. Using only the snapshot would drop the inner bindings and leave
+		// dependent uses like sizeof(U) unresolved.
 		InlineVector<TemplateParameterNode, 4> substitution_params;
 		std::vector<TemplateTypeArg> converted_template_args;
-		if (hasTemplateEnvironmentSnapshotBindings(lazy_info.outer_template_environment_snapshot)) {
-			InlineVector<StringHandle, 4> snapshot_param_names;
-			InlineVector<TypeInfo::TemplateArgInfo, 4> snapshot_args;
-			populateTemplateEnvironmentLegacyViews(
-				lazy_info.outer_template_environment_snapshot,
-				snapshot_param_names,
-				snapshot_args);
-			substitution_params.reserve(snapshot_param_names.size());
-			converted_template_args.reserve(snapshot_args.size());
-			for (size_t i = 0; i < snapshot_param_names.size() && i < snapshot_args.size(); ++i) {
-				TemplateTypeArg arg = toTemplateTypeArg(snapshot_args[i]);
-				Token param_token(Token::Type::Identifier, StringTable::getStringView(snapshot_param_names[i]), 0, 0, 0);
-				if (arg.is_value) {
-					TypeSpecifierNode type_node(
-						arg.type_index.withCategory(arg.typeEnum()),
-						get_type_size_bits(arg.typeEnum()),
-						param_token,
-						CVQualifier::None,
-						ReferenceQualifier::None);
-					substitution_params.push_back(TemplateParameterNode(snapshot_param_names[i], type_node, param_token));
-				} else {
-					TemplateParameterNode type_param(snapshot_param_names[i], param_token);
-					type_param.set_registered_type_index(arg.type_index.withCategory(arg.typeEnum()));
-					substitution_params.push_back(type_param);
-				}
-				converted_template_args.push_back(arg);
-			}
-		} else {
-			substitution_params.reserve(lazy_info.template_params.size());
-			converted_template_args.reserve(lazy_info.template_args.size());
-			for (const TemplateParameterNode& template_param : lazy_info.template_params) {
-				substitution_params.push_back(template_param);
-			}
-			for (const auto& ttype_arg : lazy_info.template_args) {
-				converted_template_args.push_back(ttype_arg);
-			}
+		substitution_params.reserve(lazy_info.template_params.size());
+		converted_template_args.reserve(lazy_info.template_args.size());
+		for (const TemplateParameterNode& template_param : lazy_info.template_params) {
+			substitution_params.push_back(template_param);
+		}
+		for (const auto& ttype_arg : lazy_info.template_args) {
+			converted_template_args.push_back(ttype_arg);
 		}
 
 		// Push struct parsing context so that get_class_template_pack_size can find pack info in the registry
@@ -761,7 +736,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		ASTNode substituted_body = substituteTemplateParameters(
 			*body_to_substitute,
 			substitution_params,
-			converted_template_args);
+			converted_template_args,
+			lazy_info.identity.instantiated_owner_name);
 		new_func_ref.set_definition(substituted_body);
 	}
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -296,13 +296,19 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		if (ctor_decl.is_materialized()) {
 			body_to_substitute = ctor_decl.get_definition();
 		} else if (ctor_decl.has_template_body_position()) {
-			FlashCpp::TemplateParameterScope template_scope;
 			InlineVector<StringHandle, 4> param_names;
 			param_names.reserve(lazy_info.template_params.size());
 			for (const auto& tparam_node : lazy_info.template_params) {
 				param_names.push_back(tparam_node.nameHandle());
 			}
-			registerTypeParamsInScope(param_names, lazy_info.template_args, template_scope, true);
+			std::optional<TemplateEnvironment> outer_environment;
+			TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
+				lazy_info.outer_template_environment_snapshot,
+				std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
+				std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
+				outer_environment);
+			FlashCpp::TemplateParameterScope template_scope;
+			registerTypeParamsInScope(substitution_environment, template_scope, true);
 
 			// When re-parsing a deferred template constructor body with concrete types,
 			// we're no longer in a dependent template context.
@@ -312,12 +318,6 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			SaveHandle current_pos = save_token_position();
 			auto parse_ctor_with_current_context = [&]() {
 				FlashCpp::ScopedState guard_subs(template_param_substitutions_);
-				std::optional<TemplateEnvironment> outer_environment;
-				TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
-					lazy_info.outer_template_environment_snapshot,
-					std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
-					std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
-					outer_environment);
 				populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 				DelayedFunctionBody delayed{
 					nullptr,
@@ -598,14 +598,19 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		// This is needed for member struct templates where body parsing is deferred
 
 		// Set up template parameter types in the type system for body parsing
-		FlashCpp::TemplateParameterScope template_scope;
 		InlineVector<StringHandle, 4> param_names;
 		param_names.reserve(lazy_info.template_params.size());
 		for (const auto& tparam_node : lazy_info.template_params) {
 			param_names.push_back(tparam_node.nameHandle());
 		}
-
-		registerTypeParamsInScope(param_names, lazy_info.template_args, template_scope, true);
+		std::optional<TemplateEnvironment> outer_environment;
+		TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
+			lazy_info.outer_template_environment_snapshot,
+			std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
+			std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
+			outer_environment);
+		FlashCpp::TemplateParameterScope template_scope;
+		registerTypeParamsInScope(substitution_environment, template_scope, true);
 
 		// Save current position and parsing context
 		SaveHandle current_pos = save_token_position();
@@ -623,12 +628,6 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			// Set up template parameter substitutions so non-type params (e.g., int N)
 			// are resolved during parse_block() just as in try_instantiate_single_template.
 			FlashCpp::ScopedState guard_subs(template_param_substitutions_);
-			std::optional<TemplateEnvironment> outer_environment;
-			TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
-				lazy_info.outer_template_environment_snapshot,
-				std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
-				std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
-				outer_environment);
 			populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 
 			// Parse the function body
@@ -872,14 +871,19 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			return false;
 		}
 
-		FlashCpp::TemplateParameterScope template_scope;
-		registerTypeParamsInScope(lazy_template_params_inline, lazy_info.template_args, template_scope, true);
-
 		InlineVector<StringHandle, 4> param_names;
 		param_names.reserve(lazy_info.template_params.size());
 		for (const auto& tparam_node : lazy_info.template_params) {
 			param_names.push_back(tparam_node.nameHandle());
 		}
+		std::optional<TemplateEnvironment> outer_environment;
+		TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
+			lazy_info.outer_template_environment_snapshot,
+			std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
+			std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
+			outer_environment);
+		FlashCpp::TemplateParameterScope template_scope;
+		registerTypeParamsInScope(substitution_environment, template_scope, true);
 
 		SaveHandle current_pos = save_token_position();
 		struct LexerRestoreGuard {
@@ -897,12 +901,6 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		FlashCpp::ScopedState guard_ptb(parsing_template_depth_);
 		parsing_template_depth_ = 0;
 		FlashCpp::ScopedState guard_subs(template_param_substitutions_);
-		std::optional<TemplateEnvironment> outer_environment;
-		TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
-			lazy_info.outer_template_environment_snapshot,
-			std::span<const TemplateParameterNode>(lazy_info.template_params.data(), lazy_info.template_params.size()),
-			std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
-			outer_environment);
 		populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 		FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 		for (StringHandle param_name : param_names) {

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1999,6 +1999,22 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		// Apply pointer/reference modifiers to the type
 		consume_pointer_ref_modifiers(type_node);
 
+		if (template_instantiation_mode_ == TemplateInstantiationMode::SoftProbe &&
+			(type_node.category() == TypeCategory::UserDefined || type_node.category() == TypeCategory::TypeAlias)) {
+			StringHandle type_name_handle = type_node.token().handle();
+			auto subst_it = sfinae_type_map_.find(type_name_handle);
+			if (subst_it != sfinae_type_map_.end() && subst_it->second.is_valid()) {
+				TypeIndex substituted_index = subst_it->second;
+				TypeCategory substituted_category = substituted_index.category();
+				type_node.set_type_index(substituted_index.withCategory(substituted_category));
+				type_node.set_category(substituted_category);
+				const int substituted_size_bits = getTypeSpecSizeBits(type_node);
+				if (substituted_size_bits > 0) {
+					type_node.set_size_in_bits(substituted_size_bits);
+				}
+			}
+		}
+
 		// Check for array declarators (e.g., T[], T[N])
 		bool is_array_type = false;
 		std::optional<size_t> parsed_array_size;
@@ -2057,6 +2073,37 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 					arg = TemplateTypeArg::makeValue(subst.value, subst.value_type);
 					arg.is_pack = is_pack_expansion;
 					break;
+				} else if (subst.is_type_param && subst.param_name == type_name_handle) {
+					const TemplateTypeArg& substituted_arg = subst.substituted_type;
+					TypeIndex substituted_index = substituted_arg.type_index;
+					if (!substituted_index.is_valid()) {
+						substituted_index = nativeTypeIndex(substituted_arg.typeEnum());
+					}
+					if (substituted_index.is_valid()) {
+						TypeCategory substituted_category = substituted_arg.typeEnum();
+						type_node.set_type_index(substituted_index.withCategory(substituted_category));
+						type_node.set_category(substituted_category);
+						for (const CVQualifier cv : substituted_arg.pointer_cv_qualifiers) {
+							type_node.add_pointer_level(cv);
+						}
+						if (substituted_arg.ref_qualifier != ReferenceQualifier::None) {
+							if (type_node.reference_qualifier() == ReferenceQualifier::None) {
+								type_node.set_reference_qualifier(substituted_arg.ref_qualifier);
+							} else if (type_node.reference_qualifier() == ReferenceQualifier::LValueReference ||
+									   substituted_arg.ref_qualifier == ReferenceQualifier::LValueReference) {
+								type_node.set_reference_qualifier(ReferenceQualifier::LValueReference);
+							} else {
+								type_node.set_reference_qualifier(ReferenceQualifier::RValueReference);
+							}
+						}
+						const int substituted_size_bits = getTypeSpecSizeBits(type_node);
+						if (substituted_size_bits > 0) {
+							type_node.set_size_in_bits(substituted_size_bits);
+						}
+						arg = TemplateTypeArg(type_node);
+						arg.is_pack = is_pack_expansion;
+						break;
+					}
 				}
 			}
 		}
@@ -2127,7 +2174,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 					}
 				}
 
-				if (is_template_param || (tryGetTypeInfo(idx) && tryGetTypeInfo(idx)->is_incomplete_instantiation_)) {
+				const TypeInfo* arg_type_info = tryGetTypeInfo(idx);
+				if (is_template_param ||
+					(arg_type_info != nullptr &&
+						(arg_type_info->isDependentPlaceholder() ||
+						 arg_type_info->is_incomplete_instantiation_))) {
 					arg.is_dependent = true;
 					arg.dependent_name = StringTable::getOrInternStringHandle(type_name);
 					FLASH_LOG_FORMAT(Templates, Debug, "Template argument is dependent (type name: {})", type_name);

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -283,8 +283,26 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	return substituteTemplateParameters(
+		node,
+		template_params,
+		template_args,
+		StringHandle{});
+}
+
+ASTNode Parser::substituteTemplateParameters(
+	const ASTNode& node,
+	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	StringHandle current_owner_type_name) {
+	const auto substitute_nested = [&](const ASTNode& child) -> ASTNode {
+		return substituteTemplateParameters(
+			child,
+			template_params,
+			template_args,
+			current_owner_type_name);
+	};
 	// Helper function to get type name as string
 	auto get_type_name = [](TypeCategory type) -> std::string_view {
 		switch (type) {
@@ -418,11 +436,16 @@ ASTNode Parser::substituteTemplateParameters(
 	auto substituteCallExprWithExpressionSubstitutor = [&](const CallExprNode& call) -> ASTNode {
 		std::optional<ASTNode> substituted_receiver;
 		if (call.has_receiver()) {
-			substituted_receiver = substituteTemplateParameters(call.receiver(), template_params, template_args);
+			substituted_receiver = substitute_nested(call.receiver());
 		}
 		ChunkedVector<ASTNode> substituted_args;
 		for (const auto& arg : call.arguments()) {
-			substituteArgWithPackExpansion(arg, template_params, template_args, substituted_args);
+			substituteArgWithPackExpansion(
+				arg,
+				template_params,
+				template_args,
+				current_owner_type_name,
+				substituted_args);
 		}
 		CallExprNode substituted_call = call.has_receiver()
 			? CallExprNode(
@@ -438,7 +461,7 @@ ASTNode Parser::substituteTemplateParameters(
 			substituted_call,
 			call,
 			[&](const ASTNode& template_arg) {
-				return substituteTemplateParameters(template_arg, template_params, template_args);
+				return substitute_nested(template_arg);
 			},
 			CallMetadataCopyOptions{});
 		return substituteWithExpressionSubstitutor(ASTNode(&substituted_call));
@@ -638,8 +661,8 @@ ASTNode Parser::substituteTemplateParameters(
 				member_access.is_arrow()));
 		} else if (const auto* pointer_to_member_access = std::get_if<PointerToMemberAccessNode>(&expr)) {
 			const PointerToMemberAccessNode& member_access = *pointer_to_member_access;
-			ASTNode substituted_object = substituteTemplateParameters(member_access.object(), template_params, template_args);
-			ASTNode substituted_member_pointer = substituteTemplateParameters(member_access.member_pointer(), template_params, template_args);
+			ASTNode substituted_object = substitute_nested(member_access.object());
+			ASTNode substituted_member_pointer = substitute_nested(member_access.member_pointer());
 			return makeRebuiltPointerToMemberAccessNode(
 				member_access,
 				substituted_object,
@@ -650,10 +673,16 @@ ASTNode Parser::substituteTemplateParameters(
 			ASTNode substituted_type = substituteTemplateParameters(
 				ASTNode(&constructor_call.type_node()),
 				template_params,
-				template_args);
+				template_args,
+				current_owner_type_name);
 			ChunkedVector<ASTNode> substituted_args;
 			for (size_t i = 0; i < constructor_call.arguments().size(); ++i) {
-				substituteArgWithPackExpansion(constructor_call.arguments()[i], template_params, template_args, substituted_args);
+				substituteArgWithPackExpansion(
+					constructor_call.arguments()[i],
+					template_params,
+					template_args,
+					current_owner_type_name,
+					substituted_args);
 			}
 			return makeRebuiltConstructorCallNode(
 				constructor_call,
@@ -663,10 +692,10 @@ ASTNode Parser::substituteTemplateParameters(
 		} else if (std::holds_alternative<TypeTraitExprNode>(expr)) {
 			const TypeTraitExprNode& trait_expr = std::get<TypeTraitExprNode>(expr);
 			ASTNode substituted_type = substituteTemplateParameters(
-				trait_expr.type_node(), template_params, template_args);
+				trait_expr.type_node(), template_params, template_args, current_owner_type_name);
 			if (trait_expr.has_second_type()) {
 				ASTNode substituted_second_type = substituteTemplateParameters(
-					trait_expr.second_type_node(), template_params, template_args);
+					trait_expr.second_type_node(), template_params, template_args, current_owner_type_name);
 				return emplace_node<ExpressionNode>(
 					TypeTraitExprNode(trait_expr.kind(), substituted_type, substituted_second_type, trait_expr.trait_token()));
 			}
@@ -675,7 +704,7 @@ ASTNode Parser::substituteTemplateParameters(
 				substituted_additional_types.reserve(trait_expr.additional_type_nodes().size());
 				for (const auto& type_node : trait_expr.additional_type_nodes()) {
 					substituted_additional_types.push_back(
-						substituteTemplateParameters(type_node, template_params, template_args));
+						substitute_nested(type_node));
 				}
 				return emplace_node<ExpressionNode>(
 					TypeTraitExprNode(trait_expr.kind(), substituted_type, std::move(substituted_additional_types), trait_expr.trait_token()));
@@ -688,8 +717,8 @@ ASTNode Parser::substituteTemplateParameters(
 				TypeTraitExprNode(trait_expr.kind(), substituted_type, trait_expr.trait_token()));
 		} else if (const auto* array_subscript = std::get_if<ArraySubscriptNode>(&expr)) {
 			const ArraySubscriptNode& array_sub = *array_subscript;
-			ASTNode substituted_array = substituteTemplateParameters(array_sub.array_expr(), template_params, template_args);
-			ASTNode substituted_index = substituteTemplateParameters(array_sub.index_expr(), template_params, template_args);
+			ASTNode substituted_array = substitute_nested(array_sub.array_expr());
+			ASTNode substituted_index = substitute_nested(array_sub.index_expr());
 			return emplace_node<ExpressionNode>(ArraySubscriptNode(substituted_array, substituted_index, array_sub.bracket_token()));
 		} else if (std::holds_alternative<FoldExpressionNode>(expr)) {
 			// C++17 Fold expressions - expand into nested binary operations
@@ -1099,14 +1128,10 @@ ASTNode Parser::substituteTemplateParameters(
 								expanded_args[0],
 								cast_node.cast_token()));
 						}
-						return emplace_node<ExpressionNode>(ConstructorCallNode(
-							substituted_type.as<TypeSpecifierNode>(),
-							std::move(expanded_args),
-							cast_node.cast_token()));
 					}
 				}
 			}
-			ASTNode substituted_expr = substituteTemplateParameters(cast_node.expr(), template_params, template_args);
+			ASTNode substituted_expr = substitute_nested(cast_node.expr());
 			return emplace_node<ExpressionNode>(StaticCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (const auto* dynamic_cast_node = std::get_if<DynamicCastNode>(&expr)) {
 			const DynamicCastNode& cast_node = *dynamic_cast_node;
@@ -1178,7 +1203,7 @@ ASTNode Parser::substituteTemplateParameters(
 					}
 
 					// Otherwise, recursively substitute the type node
-					ASTNode substituted_type = substituteTemplateParameters(type_or_expr, template_params, template_args);
+					ASTNode substituted_type = substitute_nested(type_or_expr);
 					if (auto folded_sizeof = tryFoldSubstitutedSizeofTypeNode(substituted_type, sizeof_expr.sizeof_token());
 						folded_sizeof.has_value()) {
 						return *folded_sizeof;
@@ -1187,7 +1212,7 @@ ASTNode Parser::substituteTemplateParameters(
 				}
 		} else {
 			// sizeof(expression) - substitute the expression
-			ASTNode substituted_expr = substituteTemplateParameters(sizeof_expr.type_or_expr(), template_params, template_args);
+			ASTNode substituted_expr = substitute_nested(sizeof_expr.type_or_expr());
 			if (sizeof_expr.type_or_expr().is<ExpressionNode>()) {
 				const ExpressionNode& original_expr = sizeof_expr.type_or_expr().as<ExpressionNode>();
 				std::string_view dependent_name;
@@ -1248,10 +1273,15 @@ ASTNode Parser::substituteTemplateParameters(
 			ASTNode(&constructor_call.type_node()),
 			template_params,
 			template_args);
-		ChunkedVector<ASTNode> substituted_args;
-		for (size_t i = 0; i < constructor_call.arguments().size(); ++i) {
-			substituteArgWithPackExpansion(constructor_call.arguments()[i], template_params, template_args, substituted_args);
-		}
+			ChunkedVector<ASTNode> substituted_args;
+			for (size_t i = 0; i < constructor_call.arguments().size(); ++i) {
+				substituteArgWithPackExpansion(
+					constructor_call.arguments()[i],
+					template_params,
+					template_args,
+					current_owner_type_name,
+					substituted_args);
+			}
 		return makeRebuiltConstructorCallNode(
 			constructor_call,
 			substituted_type.as<TypeSpecifierNode>(),
@@ -1284,7 +1314,7 @@ ASTNode Parser::substituteTemplateParameters(
 		const DeclarationNode& decl = node.as<DeclarationNode>();
 
 		// Substitute the type specifier
-		ASTNode substituted_type = substituteTemplateParameters(decl.type_node(), template_params, template_args);
+		ASTNode substituted_type = substitute_nested(decl.type_node());
 
 		// Create new declaration with substituted type while preserving declaration metadata
 		ASTNode new_decl_node = emplace_node<DeclarationNode>(substituted_type, decl.identifier_token());
@@ -1296,12 +1326,12 @@ ASTNode Parser::substituteTemplateParameters(
 			std::vector<ASTNode> substituted_dims;
 			substituted_dims.reserve(decl.array_dimensions().size());
 			for (const auto& dim : decl.array_dimensions()) {
-				substituted_dims.push_back(substituteTemplateParameters(dim, template_params, template_args));
+				substituted_dims.push_back(substitute_nested(dim));
 			}
 			new_decl.set_array_dimensions(std::move(substituted_dims));
 		}
 		if (decl.has_default_value()) {
-			new_decl.set_default_value(substituteTemplateParameters(decl.default_value(), template_params, template_args));
+			new_decl.set_default_value(substitute_nested(decl.default_value()));
 		}
 		return new_decl_node;
 
@@ -1538,7 +1568,7 @@ ASTNode Parser::substituteTemplateParameters(
 				}
 			}
 			ASTNode substituted_init = substituteTemplateParameters(
-				element, template_params, template_args);
+				element, template_params, template_args, current_owner_type_name);
 			if (init_list.is_designated(i)) {
 				new_init_list_ref.add_designated_initializer(init_list.member_name(i), substituted_init);
 			} else {
@@ -1918,6 +1948,7 @@ void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
+	StringHandle current_owner_type_name,
 	ChunkedVector<ASTNode>& out) {
 	if (arg.is<ExpressionNode>()) {
 		const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
@@ -1927,7 +1958,11 @@ void Parser::substituteArgWithPackExpansion(
 			}
 		}
 	}
-	out.push_back(substituteTemplateParameters(arg, template_params, template_args));
+	out.push_back(substituteTemplateParameters(
+		arg,
+		template_params,
+		template_args,
+		current_owner_type_name));
 }
 
 // Replace a pack parameter identifier in an expression pattern with its expanded element name.

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -283,7 +283,8 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	std::span<const TemplateParameterNode> template_params,
-	std::span<const TemplateTypeArg> template_args) {
+	std::span<const TemplateTypeArg> template_args,
+	StringHandle current_owner_type_name) {
 	// Helper function to get type name as string
 	auto get_type_name = [](TypeCategory type) -> std::string_view {
 		switch (type) {
@@ -409,6 +410,9 @@ ASTNode Parser::substituteTemplateParameters(
 		}
 
 		ExpressionSubstitutor substitutor(param_map, pack_map, *this, template_param_order);
+		if (current_owner_type_name.isValid()) {
+			substitutor.setCurrentOwnerTypeName(current_owner_type_name);
+		}
 		return substitutor.substitute(substituted_call_node);
 	};
 	auto substituteCallExprWithExpressionSubstitutor = [&](const CallExprNode& call) -> ASTNode {
@@ -437,10 +441,6 @@ ASTNode Parser::substituteTemplateParameters(
 				return substituteTemplateParameters(template_arg, template_params, template_args);
 			},
 			CallMetadataCopyOptions{});
-		if (call.has_receiver()) {
-			return emplace_node<ExpressionNode>(substituted_call);
-		}
-
 		return substituteWithExpressionSubstitutor(ASTNode(&substituted_call));
 	};
 
@@ -1167,11 +1167,48 @@ ASTNode Parser::substituteTemplateParameters(
 					}
 					return emplace_node<ExpressionNode>(SizeofExprNode(substituted_type, sizeof_expr.sizeof_token()));
 				}
-			} else {
-				// sizeof(expression) - substitute the expression
-				ASTNode substituted_expr = substituteTemplateParameters(sizeof_expr.type_or_expr(), template_params, template_args);
-				return emplace_node<ExpressionNode>(SizeofExprNode::from_expression(substituted_expr, sizeof_expr.sizeof_token()));
+		} else {
+			// sizeof(expression) - substitute the expression
+			ASTNode substituted_expr = substituteTemplateParameters(sizeof_expr.type_or_expr(), template_params, template_args);
+			if (sizeof_expr.type_or_expr().is<ExpressionNode>()) {
+				const ExpressionNode& original_expr = sizeof_expr.type_or_expr().as<ExpressionNode>();
+				std::string_view dependent_name;
+				if (const auto* ident = std::get_if<IdentifierNode>(&original_expr)) {
+					dependent_name = ident->name();
+				} else if (const auto* tparam_ref = std::get_if<TemplateParameterReferenceNode>(&original_expr)) {
+					dependent_name = tparam_ref->param_name().view();
+				}
+				if (!dependent_name.empty()) {
+					const TemplateTypeArg* bound_arg = findTemplateArgByName(
+						dependent_name,
+						template_params,
+						template_args);
+					if (bound_arg != nullptr && bound_arg->isTypeArgument()) {
+						TypeSpecifierNode bound_type = makeTypeSpecifierFromTemplateTypeArg(
+							*bound_arg,
+							sizeof_expr.sizeof_token());
+						int size_bits = getTypeSpecSizeBits(bound_type);
+						if (size_bits > 0) {
+							StringBuilder size_builder;
+							std::string_view size_str = size_builder.append(static_cast<size_t>(size_bits / 8)).commit();
+							Token literal_token(Token::Type::Literal, size_str,
+												sizeof_expr.sizeof_token().line(), sizeof_expr.sizeof_token().column(),
+												sizeof_expr.sizeof_token().file_index());
+							return emplace_node<ExpressionNode>(NumericLiteralNode(
+								literal_token,
+								static_cast<unsigned long long>(size_bits / 8),
+								TypeCategory::UnsignedLongLong,
+								TypeQualifier::None,
+								64));
+						}
+						return emplace_node<ExpressionNode>(SizeofExprNode(
+							ASTNode::emplace_node<TypeSpecifierNode>(bound_type),
+							sizeof_expr.sizeof_token()));
+					}
+				}
 			}
+			return emplace_node<ExpressionNode>(SizeofExprNode::from_expression(substituted_expr, sizeof_expr.sizeof_token()));
+		}
 
 			// Return the original node if no substitution was possible
 			return node;

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1088,6 +1088,24 @@ ASTNode Parser::substituteTemplateParameters(
 				ASTNode(&cast_node.target_type()),
 				template_params,
 				template_args);
+			if (cast_node.expr().is<ExpressionNode>()) {
+				const ExpressionNode& cast_expr = cast_node.expr().as<ExpressionNode>();
+				if (const auto* pack_expansion_expr = std::get_if<PackExpansionExprNode>(&cast_expr)) {
+					ChunkedVector<ASTNode> expanded_args;
+					if (expandPackExpansionArgs(*pack_expansion_expr, template_params, template_args, expanded_args)) {
+						if (expanded_args.size() == 1) {
+							return emplace_node<ExpressionNode>(StaticCastNode(
+								substituted_type.as<TypeSpecifierNode>(),
+								expanded_args[0],
+								cast_node.cast_token()));
+						}
+						return emplace_node<ExpressionNode>(ConstructorCallNode(
+							substituted_type.as<TypeSpecifierNode>(),
+							std::move(expanded_args),
+							cast_node.cast_token()));
+					}
+				}
+			}
 			ASTNode substituted_expr = substituteTemplateParameters(cast_node.expr(), template_params, template_args);
 			return emplace_node<ExpressionNode>(StaticCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (const auto* dynamic_cast_node = std::get_if<DynamicCastNode>(&expr)) {

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -121,37 +121,6 @@ TemplateParameterKind inferBindingKind(const TemplateTypeArg& arg) {
 	return TemplateParameterKind::Type;
 }
 
-void countSnapshotBindingsRecursive(const TemplateEnvironmentSnapshot& snapshot, size_t& count) {
-	if (snapshot.parent != nullptr) {
-		countSnapshotBindingsRecursive(*snapshot.parent, count);
-	}
-	count += snapshot.bindings.size();
-}
-
-void appendSnapshotLegacyViewsRecursive(
-	const TemplateEnvironmentSnapshot& snapshot,
-	InlineVector<StringHandle, 4>& out_param_names,
-	InlineVector<TypeInfo::TemplateArgInfo, 4>& out_args) {
-	if (snapshot.parent != nullptr) {
-		appendSnapshotLegacyViewsRecursive(*snapshot.parent, out_param_names, out_args);
-	}
-	for (const TemplateBindingSnapshot& binding : snapshot.bindings) {
-		if (binding.is_pack) {
-			for (const auto& arg : binding.args) {
-				out_param_names.push_back(binding.name);
-				out_args.push_back(arg);
-			}
-			continue;
-		}
-
-		if (binding.args.empty()) {
-			continue;
-		}
-		out_param_names.push_back(binding.name);
-		out_args.push_back(binding.args.front());
-	}
-}
-
 void appendContextBindings(
 	const TypeInfo::InstantiationContext* context,
 	InlineVector<TemplateBinding, 4>& out_bindings) {
@@ -200,11 +169,13 @@ void appendContextBindings(
 TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshot(
 	std::span<const StringHandle> param_names,
 	std::span<const TypeInfo::TemplateArgInfo> args,
-	std::shared_ptr<const TemplateEnvironmentSnapshot> parent) {
+	const TemplateEnvironmentSnapshot* parent) {
 	TemplateEnvironmentSnapshot snapshot;
-	snapshot.parent = std::move(parent);
+	if (parent != nullptr) {
+		snapshot.bindings = parent->bindings;
+	}
 	const size_t pair_count = std::min(param_names.size(), args.size());
-	snapshot.bindings.reserve(pair_count);
+	snapshot.bindings.reserve(snapshot.bindings.size() + pair_count);
 	for (size_t i = 0; i < pair_count; ++i) {
 		if (!snapshot.bindings.empty() &&
 			snapshot.bindings.back().name == param_names[i]) {
@@ -229,10 +200,7 @@ TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshot(
 }
 
 bool hasTemplateEnvironmentSnapshotBindings(const TemplateEnvironmentSnapshot& snapshot) {
-	if (!snapshot.bindings.empty()) {
-		return true;
-	}
-	return snapshot.parent != nullptr ? hasTemplateEnvironmentSnapshotBindings(*snapshot.parent) : false;
+	return !snapshot.bindings.empty();
 }
 
 void populateTemplateEnvironmentLegacyViews(
@@ -241,12 +209,23 @@ void populateTemplateEnvironmentLegacyViews(
 	InlineVector<TypeInfo::TemplateArgInfo, 4>& out_args) {
 	out_param_names.clear();
 	out_args.clear();
+	out_param_names.reserve(snapshot.bindings.size());
+	out_args.reserve(snapshot.bindings.size());
+	for (const TemplateBindingSnapshot& binding : snapshot.bindings) {
+		if (binding.is_pack) {
+			for (const auto& arg : binding.args) {
+				out_param_names.push_back(binding.name);
+				out_args.push_back(arg);
+			}
+			continue;
+		}
 
-	size_t binding_count = 0;
-	countSnapshotBindingsRecursive(snapshot, binding_count);
-	out_param_names.reserve(binding_count);
-	out_args.reserve(binding_count);
-	appendSnapshotLegacyViewsRecursive(snapshot, out_param_names, out_args);
+		if (binding.args.empty()) {
+			continue;
+		}
+		out_param_names.push_back(binding.name);
+		out_args.push_back(binding.args.front());
+	}
 }
 
 TemplateEnvironment buildTemplateEnvironment(
@@ -290,23 +269,18 @@ TemplateEnvironment buildTemplateEnvironment(
 
 TemplateEnvironment buildTemplateEnvironment(const TemplateEnvironmentSnapshot& snapshot) {
 	TemplateEnvironment environment;
-	auto append_snapshot = [&](auto&& self, const TemplateEnvironmentSnapshot& current) -> void {
-		for (const TemplateBindingSnapshot& snapshot_binding : current.bindings) {
-			TemplateBinding binding;
-			binding.name = snapshot_binding.name;
-			binding.kind = snapshot_binding.kind;
-			binding.is_pack = snapshot_binding.is_pack;
-			binding.args.reserve(snapshot_binding.args.size());
-			for (const TypeInfo::TemplateArgInfo& snapshot_arg : snapshot_binding.args) {
-				binding.args.push_back(toTemplateTypeArg(snapshot_arg));
-			}
-			environment.bindings.push_back(std::move(binding));
+	environment.bindings.reserve(snapshot.bindings.size());
+	for (const TemplateBindingSnapshot& snapshot_binding : snapshot.bindings) {
+		TemplateBinding binding;
+		binding.name = snapshot_binding.name;
+		binding.kind = snapshot_binding.kind;
+		binding.is_pack = snapshot_binding.is_pack;
+		binding.args.reserve(snapshot_binding.args.size());
+		for (const TypeInfo::TemplateArgInfo& snapshot_arg : snapshot_binding.args) {
+			binding.args.push_back(toTemplateTypeArg(snapshot_arg));
 		}
-		if (current.parent != nullptr) {
-			self(self, *current.parent);
-		}
-	};
-	append_snapshot(append_snapshot, snapshot);
+		environment.bindings.push_back(std::move(binding));
+	}
 	return environment;
 }
 

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -388,6 +388,21 @@ std::optional<TemplateTypeArg> resolveContextBinding(
 			resolution_stack.erase(current_name);
 			return std::nullopt;
 		}
+		if (!bound_arg->is_dependent &&
+			bound_arg->type_index.is_valid() &&
+			typeIndexContainsDependentPlaceholder(bound_arg->type_index)) {
+			if (const TypeInfo* dependent_type_info = tryGetTypeInfo(bound_arg->type_index);
+				dependent_type_info != nullptr &&
+				dependent_type_info->name().isValid() &&
+				dependent_type_info->name() != current_name) {
+				auto rebound = self(self, dependent_type_info->name());
+				if (rebound.has_value()) {
+					TemplateTypeArg resolved = rebindDependentTemplateTypeArg(*rebound, *bound_arg);
+					resolution_stack.erase(current_name);
+					return resolved;
+				}
+			}
+		}
 		if (!bound_arg->is_dependent) {
 			TemplateTypeArg resolved = *bound_arg;
 			resolution_stack.erase(current_name);

--- a/src/TemplateEnvironment.h
+++ b/src/TemplateEnvironment.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <optional>
 #include <span>
 
@@ -33,7 +32,6 @@ struct TemplateBindingSnapshot {
 
 struct TemplateEnvironmentSnapshot {
 	InlineVector<TemplateBindingSnapshot, 4> bindings;
-	std::shared_ptr<const TemplateEnvironmentSnapshot> parent;
 };
 
 struct TemplateEnvironment {
@@ -51,7 +49,7 @@ InlineVector<TemplateTypeArg, 4> toTemplateTypeArgList(std::span<const TypeInfo:
 TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshot(
 	std::span<const StringHandle> param_names,
 	std::span<const TypeInfo::TemplateArgInfo> args,
-	std::shared_ptr<const TemplateEnvironmentSnapshot> parent);
+	const TemplateEnvironmentSnapshot* parent);
 TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshot(
 	std::span<const StringHandle> param_names,
 	std::span<const TypeInfo::TemplateArgInfo> args);

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -16,7 +16,7 @@ template <typename ParamContainer, typename ArgContainer>
 TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshotFromBindings(
 	const ParamContainer& template_params,
 	const ArgContainer& template_args,
-	std::shared_ptr<const TemplateEnvironmentSnapshot> parent) {
+	const TemplateEnvironmentSnapshot* parent) {
 	InlineVector<TemplateTypeArg, 4> typed_args;
 	typed_args.reserve(template_args.size());
 	for (const auto& template_arg : template_args) {
@@ -60,7 +60,7 @@ TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshotFromBindings(
 	return buildTemplateEnvironmentSnapshot(
 		std::span<const StringHandle>(param_names.data(), param_names.size()),
 		std::span<const TypeInfo::TemplateArgInfo>(arg_infos.data(), arg_infos.size()),
-		std::move(parent));
+		parent);
 }
 
 struct LazyMemberFunctionInfo {

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -931,14 +931,11 @@ private:
 				const ResolvedAliasTypeInfo alias_info = resolveAliasTypeInfo(canonical_arg.type_index);
 				if (alias_info.type_index.is_valid()) {
 					const TypeCategory resolved_category = alias_info.typeEnum();
-					const bool should_use_resolved_category =
-						canonical_arg.category() == TypeCategory::Invalid ||
-						canonical_arg.category() == TypeCategory::TypeAlias ||
-						(canonical_arg.category() == TypeCategory::UserDefined && resolved_category != TypeCategory::UserDefined) ||
-						(canonical_arg.category() == TypeCategory::Template && resolved_category != TypeCategory::Template);
-					if (should_use_resolved_category) {
-						canonical_arg.type_index = alias_info.type_index.withCategory(resolved_category);
-					}
+					const TypeCategory canonical_category =
+						resolved_category != TypeCategory::Invalid
+							? resolved_category
+							: canonical_arg.category();
+					canonical_arg.type_index = alias_info.type_index.withCategory(canonical_category);
 					if (!canonical_arg.function_signature.has_value() && alias_info.function_signature.has_value()) {
 						canonical_arg.function_signature = alias_info.function_signature;
 					}

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -679,6 +679,34 @@ inline const TemplateTypeArg* findTemplateArgByName(
 
 namespace FlashCpp {
 
+inline TypeIndex canonicalizeTemplateIdentityTypeIndex(TypeIndex type_index) {
+	if (typeIndexContainsDependentPlaceholder(type_index)) {
+		return type_index;
+	}
+
+	ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_index);
+	TypeIndex canonical_type_index = resolved_alias.type_index.is_valid()
+		? resolved_alias.type_index.withCategory(resolved_alias.typeEnum())
+		: type_index.withCategory(type_index.category());
+
+	if (is_builtin_type(canonical_type_index.category())) {
+		if (TypeIndex canonical_builtin = nativeTypeIndex(canonical_type_index.category());
+			canonical_builtin.is_valid()) {
+			return canonical_builtin.withCategory(canonical_type_index.category());
+		}
+		return TypeIndex{0, canonical_type_index.category()};
+	}
+
+	return canonical_type_index;
+}
+
+inline bool hasConcreteTemplateIdentity(TypeIndex type_index) {
+	if (typeIndexContainsDependentPlaceholder(type_index)) {
+		return false;
+	}
+	return type_index.is_valid() || is_builtin_type(type_index.category());
+}
+
 /**
  * Create a TypeIndexArg from a TemplateTypeArg
  * 
@@ -687,15 +715,7 @@ namespace FlashCpp {
  */
 inline TypeIndexArg makeTypeIndexArg(const TemplateTypeArg& arg) {
 	TypeIndexArg result;
-	result.type_index = arg.type_index;
-	if (result.type_index.is_valid() &&
-		!typeIndexContainsDependentPlaceholder(result.type_index) &&
-		is_builtin_type(result.type_index.category())) {
-		if (TypeIndex canonical_builtin = nativeTypeIndex(result.type_index.category());
-			canonical_builtin.is_valid()) {
-			result.type_index = canonical_builtin;
-		}
-	}
+	result.type_index = canonicalizeTemplateIdentityTypeIndex(arg.type_index);
 	result.cv_qualifier = arg.cv_qualifier;
 	result.ref_qualifier = arg.reference_qualifier();
 	result.pointer_depth = std::min(arg.pointer_depth, uint8_t(255));
@@ -703,9 +723,7 @@ inline TypeIndexArg makeTypeIndexArg(const TemplateTypeArg& arg) {
 	result.is_array = arg.is_array;
 	result.array_sizes.assign(arg.array_dimensions.begin(), arg.array_dimensions.end());
 	result.function_signature = arg.function_signature;
-	const bool has_concrete_type_identity =
-		result.type_index.is_valid() &&
-		!typeIndexContainsDependentPlaceholder(result.type_index);
+	const bool has_concrete_type_identity = hasConcreteTemplateIdentity(result.type_index);
 	result.is_dependent = arg.is_dependent && !has_concrete_type_identity;
 	result.dependent_name = result.is_dependent ? arg.dependent_name : StringHandle{};
 	return result;

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -1071,6 +1071,33 @@ inline TemplateTypeArg materializeTemplateArg(
 			}
 		}
 	}
+	if (!substituted_dependent_name &&
+		!arg_info.is_value &&
+		arg_info.type_index.is_valid()) {
+		if (const TypeInfo* dependent_type_info = tryGetTypeInfo(arg_info.type_index);
+			dependent_type_info != nullptr &&
+			dependent_type_info->name().isValid()) {
+			for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
+				const TemplateParameterNode* template_param =
+					tryGetTemplateParameterNode(template_params[i]);
+				if (template_param == nullptr) {
+					continue;
+				}
+				if (template_param->nameHandle() != dependent_type_info->name()) {
+					continue;
+				}
+				const TemplateTypeArg& substituted_arg = template_args[i];
+				if (!substituted_arg.is_value) {
+					concrete_arg = rebindDependentTemplateTypeArg(substituted_arg, arg_info);
+					substituted_dependent_name = true;
+				} else {
+					concrete_arg = substituted_arg;
+					substituted_dependent_name = true;
+				}
+				break;
+			}
+		}
+	}
 	if (!substituted_dependent_name && arg_info.dependent_expr.has_value() && arg_info.is_value) {
 		// For dependent NTTP expressions (e.g., sizeof(T)), evaluate with concrete args.
 		// Only attempted when a non-null evaluator callback is provided.

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -234,6 +234,39 @@ struct TemplateTypeArg {
 		for (const auto& level : type_spec.pointer_levels()) {
 			pointer_cv_qualifiers.push_back(level.cv_qualifier);
 		}
+		auto isDependentTypeIndex = [](TypeIndex idx) -> bool {
+			if (idx.category() == TypeCategory::Auto ||
+				idx.category() == TypeCategory::DeclTypeAuto) {
+				return true;
+			}
+			if (!idx.is_valid()) {
+				return false;
+			}
+			const TypeInfo* type_info = tryGetTypeInfo(idx);
+			return type_info != nullptr &&
+				   (type_info->isDependentPlaceholder() || type_info->is_incomplete_instantiation_);
+		};
+		bool has_structural_dependency = isDependentTypeIndex(type_index);
+		if (!has_structural_dependency && function_signature.has_value()) {
+			has_structural_dependency = isDependentTypeIndex(function_signature->return_type_index);
+			if (!has_structural_dependency) {
+				for (TypeIndex parameter_type : function_signature->parameter_type_indices) {
+					if (isDependentTypeIndex(parameter_type)) {
+						has_structural_dependency = true;
+						break;
+					}
+				}
+			}
+		}
+		if (has_structural_dependency) {
+			is_dependent = true;
+			if (const TypeInfo* type_info = tryGetTypeInfo(type_index);
+				type_info != nullptr && type_info->name().isValid()) {
+				dependent_name = type_info->name();
+			} else if (!type_spec.token().value().empty()) {
+				dependent_name = StringTable::getOrInternStringHandle(type_spec.token().value());
+			}
+		}
 	}
 
 	// Constructor for non-type template parameters (default int type)

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -688,6 +688,14 @@ namespace FlashCpp {
 inline TypeIndexArg makeTypeIndexArg(const TemplateTypeArg& arg) {
 	TypeIndexArg result;
 	result.type_index = arg.type_index;
+	if (result.type_index.is_valid() &&
+		!typeIndexContainsDependentPlaceholder(result.type_index) &&
+		is_builtin_type(result.type_index.category())) {
+		if (TypeIndex canonical_builtin = nativeTypeIndex(result.type_index.category());
+			canonical_builtin.is_valid()) {
+			result.type_index = canonical_builtin;
+		}
+	}
 	result.cv_qualifier = arg.cv_qualifier;
 	result.ref_qualifier = arg.reference_qualifier();
 	result.pointer_depth = std::min(arg.pointer_depth, uint8_t(255));
@@ -695,8 +703,11 @@ inline TypeIndexArg makeTypeIndexArg(const TemplateTypeArg& arg) {
 	result.is_array = arg.is_array;
 	result.array_sizes.assign(arg.array_dimensions.begin(), arg.array_dimensions.end());
 	result.function_signature = arg.function_signature;
-	result.is_dependent = arg.is_dependent;
-	result.dependent_name = arg.dependent_name;
+	const bool has_concrete_type_identity =
+		result.type_index.is_valid() &&
+		!typeIndexContainsDependentPlaceholder(result.type_index);
+	result.is_dependent = arg.is_dependent && !has_concrete_type_identity;
+	result.dependent_name = result.is_dependent ? arg.dependent_name : StringHandle{};
 	return result;
 }
 

--- a/tests/test_template_lvalue_ref_cv_deduction_ret10.cpp
+++ b/tests/test_template_lvalue_ref_cv_deduction_ret10.cpp
@@ -1,0 +1,24 @@
+template<typename T>
+struct is_const {
+	static constexpr int value = 0;
+};
+
+template<typename T>
+struct is_const<const T> {
+	static constexpr int value = 1;
+};
+
+template<typename T>
+int plain_ref(T&) {
+	return is_const<T>::value;
+}
+
+template<typename T>
+int const_ref(const T&) {
+	return is_const<T>::value;
+}
+
+int main() {
+	const int c = 0;
+	return plain_ref(c) * 10 + const_ref(c);
+}


### PR DESCRIPTION
Standards-faithful template substitution and removal of non-standard fallbacks (PR #1490)

Summary:
This PR aggregates the work that removes non-standard fallback/recovery paths and implements a C++20-standards-faithful template substitution and materialization model. It preserves template-argument shape (references, cv, pointers, arrays), ensures proper alias-base materialization, carries template substitutions into default-argument reparses for SFINAE, and fixes lvalue-reference cv deduction.

Key commits included (branch HEAD contains all):
- 02026c77  Remove heuristic template-arg fallback and tighten dependent substitution
- e826efc0  Canonicalize template member materialization
- f72c93af  Tighten dependent member template replay
- 4ad36f8e  Fix standards-faithful template substitution regressions

Representative code examples (before -> after):

1) Lvalue-reference cv deduction:
Before (incorrect deduction):
  template<typename T> int f(T&);
  const int x = 0; f(x); // previously deduced T = int
After (correct deduction):
  template<typename T> int f(T&);
  const int x = 0; f(x); // now deduced T = const int

2) Recursive alias-base materialization (std::__and_-style):
Before: recursive alias remained dependent placeholder, causing unresolved bases and link errors.
After: pack-expanded alias templates are materialized prior to use so ::type resolves to a concrete class template.

Files modified (high level):
- src\Parser_Expr_PrimaryExpr.cpp
- src\Parser_Expr_QualLookup.cpp
- src\Parser_Templates_Inst_ClassTemplate.cpp
- src\Parser_Templates_Inst_Deduction.cpp
- src\Parser_Templates_Inst_Substitution.cpp
- src\Parser_Templates_Lazy.cpp
- src\Parser_Templates_Params.cpp
- src\Parser_Templates_Substitution.cpp
- src\TemplateRegistry_Registry.h
- src\TemplateRegistry_Types.h

Tests added/updated:
- tests\test_template_lvalue_ref_cv_deduction_ret10.cpp  -- verifies correct cv-preserving deduction for T& and non-preserving for const T&
- tests\test_std_swap_enable_if_alias_base_ret0.cpp    -- regression that drove recursive alias-base materialization fix

How to validate locally:
- Build: .\build_flashcpp.bat
- Run tests: pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1

Rationale for changes:
- Removed heuristic "fake" fallback types and speculative shared_ptr ownership; replaced with standards-compliant materialization and value/chunked allocation patterns.
- Ensures SFINAE/default-arg reparses receive the same substitution maps as normal template replay, preventing substitution-related spurious failures.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable template/member lookup, overload selection, and lazy member resolution in dependent/instantiated contexts
  * Improved alias and type-trait resolution (traits derive from resolved terminal types)
  * sizeof/substitution returns concrete sizes when bound types are known
  * Better recovery for member-function/template instantiation and qualified-owner lookups

* **Refactor**
  * Canonicalized template identity handling, flattened template-environment snapshots, and tightened substitution/instantiation flows
  * Simplified lazy member instantiation and recovery paths

* **Tests**
  * Added test for const/reference template deduction behavior

* **Documentation**
  * Added follow-up design notes for lazy-member keys, environment snapshot, and specialization/alias alignment
<!-- end of auto-generated comment: release notes by coderabbit.ai -->