### PR TITLE
[codex] Collapse static member add overloads

### DIFF
--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -473,48 +473,6 @@ struct StructTypeInfo {
 		return nullptr;
 	}
 
-	// Add static member
-	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
-						 AccessSpecifier access = AccessSpecifier::Public, std::optional<ASTNode> initializer = std::nullopt, CVQualifier cv_qual = CVQualifier::None,
-						 ReferenceQualifier ref_qual = ReferenceQualifier::None, int ptr_depth = 0) {
-		addStaticMember(member_name, type_index, size, member_alignment, access, initializer, cv_qual, ref_qual, ptr_depth, std::nullopt, std::nullopt);
-	}
-
-	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
-						 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						 ReferenceQualifier ref_qual, int ptr_depth,
-						 std::optional<ASTNode> declaration,
-						 std::optional<SaveHandle> initializer_position) {
-		static_members.push_back(StructStaticMember(member_name, type_index, size, member_alignment, access, initializer, cv_qual, ref_qual, ptr_depth));
-		if (declaration.has_value()) {
-			static_members.back().setDeclaration(*declaration);
-		}
-		if (initializer_position.has_value()) {
-			static_members.back().setInitializerPosition(*initializer_position);
-		}
-	}
-
-	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
-						 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						 ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::vector<size_t> array_dimensions) {
-		addStaticMember(member_name, type_index, size, member_alignment, access, initializer, cv_qual, ref_qual, ptr_depth, is_array, std::move(array_dimensions), std::nullopt, std::nullopt);
-	}
-
-	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
-						 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						 ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::vector<size_t> array_dimensions,
-						 std::optional<ASTNode> declaration,
-						 std::optional<SaveHandle> initializer_position) {
-		static_members.push_back(StructStaticMember(member_name, type_index, size, member_alignment, access, initializer, cv_qual, ref_qual, ptr_depth));
-		if (declaration.has_value()) {
-			static_members.back().setDeclaration(*declaration);
-		}
-		if (initializer_position.has_value()) {
-			static_members.back().setInitializerPosition(*initializer_position);
-		}
-		static_members.back().setArrayInfo(is_array, std::move(array_dimensions));
-	}
-
 	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
 						 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 						 ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1127,9 +1127,10 @@ public:
 	}
 
 	// Static member support (for template/partial specialization AST storage)
-	void add_static_member(StringHandle name, std::optional<ASTNode> declaration, TypeIndex type_index, size_t size, size_t alignment,
+	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
 						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
+						   std::optional<ASTNode> declaration,
 						   std::optional<SaveHandle> initializer_position, bool is_constexpr) {
 		addStaticMemberImpl(name, std::move(declaration), type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth,
 							is_array, array_dimensions, initializer_position, is_constexpr);

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -996,13 +996,12 @@ public:
 		: name_(name), is_class_(is_class), is_union_(is_union) {}
 
 	StringHandle name() const { return name_; }
-	const std::vector<StructMemberDecl>& members() const { return members_; }
-	const std::vector<StructMemberFunctionDecl>& member_functions() const { return member_functions_; }
+	std::span<const StructMemberDecl> members() const { return members_; }
+	std::span<const StructMemberFunctionDecl> member_functions() const { return member_functions_; }
 	std::vector<StructMemberFunctionDecl>& member_functions() { return member_functions_; }
-	const std::vector<BaseClassSpecifier>& base_classes() const { return base_classes_; }
-	const std::vector<DeferredBaseClassSpecifier>& deferred_base_classes() const { return deferred_base_classes_; }
-	std::vector<DeferredBaseClassSpecifier>& deferred_base_classes() { return deferred_base_classes_; }
-	const std::vector<DeferredTemplateBaseClassSpecifier>& deferred_template_base_classes() const { return deferred_template_base_classes_; }
+	std::span<const BaseClassSpecifier> base_classes() const { return base_classes_; }
+	std::span<const DeferredBaseClassSpecifier> deferred_base_classes() const { return deferred_base_classes_; }
+	std::span<const DeferredTemplateBaseClassSpecifier> deferred_template_base_classes() const { return deferred_template_base_classes_; }
 	bool is_class() const { return is_class_; }
 	bool is_union() const { return is_union_; }
 	bool is_final() const { return is_final_; }
@@ -1098,7 +1097,7 @@ public:
 		friend_declarations_.push_back(friend_decl);
 	}
 
-	const std::vector<ASTNode>& friend_declarations() const {
+	std::span<const ASTNode> friend_declarations() const {
 		return friend_declarations_;
 	}
 
@@ -1110,7 +1109,7 @@ public:
 		nested_classes_.push_back(nested_class);
 	}
 
-	const std::vector<ASTNode>& nested_classes() const {
+	std::span<const ASTNode> nested_classes() const {
 		return nested_classes_;
 	}
 
@@ -1123,7 +1122,7 @@ public:
 		type_aliases_.emplace_back(alias_name, type_node, std::move(array_dimensions), access);
 	}
 
-	const std::vector<TypeAliasDecl>& type_aliases() const {
+	std::span<const TypeAliasDecl> type_aliases() const {
 		return type_aliases_;
 	}
 
@@ -1153,7 +1152,7 @@ private:
 	}
 
 public:
-	const std::vector<StaticMemberDecl>& static_members() const {
+	std::span<const StaticMemberDecl> static_members() const {
 		return static_members_;
 	}
 
@@ -1322,7 +1321,7 @@ private:
 	std::vector<DeferredBaseClassSpecifier> deferred_base_classes_;	// Decltype base classes (for templates)
 	std::vector<DeferredTemplateBaseClassSpecifier> deferred_template_base_classes_;	 // Template-dependent base classes
 	std::vector<ASTNode> friend_declarations_;  // Friend declarations
-	std::vector<ASTNode> nested_classes_;  // Nested classes
+	InlineVector<ASTNode, 2> nested_classes_;  // Nested classes
 	std::vector<TypeAliasDecl> type_aliases_;  // Type aliases (using X = Y;)
 	std::vector<StaticMemberDecl> static_members_;  // Static members (for templates)
 	std::vector<AnonymousUnionInfo> anonymous_unions_;  // Anonymous union tracking info
@@ -1367,10 +1366,7 @@ public:
 	void set_deferred_bodies(std::vector<DeferredTemplateMemberBody> bodies) {
 		deferred_bodies_ = std::move(bodies);
 	}
-	const std::vector<DeferredTemplateMemberBody>& deferred_bodies() const {
-		return deferred_bodies_;
-	}
-	std::vector<DeferredTemplateMemberBody>& deferred_bodies() {
+	std::span<const DeferredTemplateMemberBody> deferred_bodies() const {
 		return deferred_bodies_;
 	}
 

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1128,50 +1128,7 @@ public:
 	}
 
 	// Static member support (for template/partial specialization AST storage)
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
-						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						   ReferenceQualifier ref_qual, int ptr_depth) {
-		static_members_.emplace_back(name, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth);
-	}
-
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
-						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::vector<size_t> array_dimensions) {
-		static_members_.emplace_back(name, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth);
-		static_members_.back().setArrayInfo(is_array, std::move(array_dimensions));
-	}
-
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
-						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::vector<size_t> array_dimensions,
-						   std::optional<SaveHandle> initializer_position) {
-		add_static_member(name, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth, is_array, std::move(array_dimensions));
-		if (initializer_position.has_value()) {
-			static_members_.back().setInitializerPosition(*initializer_position);
-		}
-	}
-
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
-						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
-						   std::optional<SaveHandle> initializer_position, bool is_constexpr) {
-		addStaticMemberImpl(name, std::nullopt, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth,
-							is_array, array_dimensions, initializer_position, is_constexpr);
-	}
-
-	void add_static_member(StringHandle name, ASTNode declaration, TypeIndex type_index, size_t size, size_t alignment,
-						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
-						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::vector<size_t> array_dimensions,
-						   std::optional<SaveHandle> initializer_position) {
-		static_members_.emplace_back(name, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth);
-		static_members_.back().setDeclaration(std::move(declaration));
-		static_members_.back().setArrayInfo(is_array, std::move(array_dimensions));
-		if (initializer_position.has_value()) {
-			static_members_.back().setInitializerPosition(*initializer_position);
-		}
-	}
-
-	void add_static_member(StringHandle name, ASTNode declaration, TypeIndex type_index, size_t size, size_t alignment,
+	void add_static_member(StringHandle name, std::optional<ASTNode> declaration, TypeIndex type_index, size_t size, size_t alignment,
 						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
 						   std::optional<SaveHandle> initializer_position, bool is_constexpr) {

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1619,7 +1619,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				ref_qual,
 				ptr_depth,
 				is_array,
-				std::move(array_dimensions),
+				array_dimensions,
 				type_and_name_result.node(),  // declaration AST for lazy re-parse
 				initializer_position,         // saved lexer position for lazy re-parse
 				is_static_constexpr);

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1973,34 +1973,34 @@ ParseResult Parser::parse_static_member_block(
 				type_spec.type_index(),
 				member_size,
 				member_alignment,
-				AccessSpecifier::Public,	 // Full specializations use Public
+				AccessSpecifier::Public,
 				init_expr_opt,
 				cv_qual,
 				ref_qual,
 				ptr_depth,
 				is_array,
 				array_dimensions,
-				*type_and_name.node(),
+				/* declaration */ *type_and_name.node(),
 				initializer_position,
 				is_static_constexpr);
 		}
 	} else {
 		// Normal case - use provided struct_info directly
-			struct_info->addStaticMember(
-				static_member_name_handle,
-				type_spec.type_index(),
+		struct_info->addStaticMember(
+			static_member_name_handle,
+			type_spec.type_index(),
 			member_size,
 			member_alignment,
 			access,
 			init_expr_opt,
 			cv_qual,
-				ref_qual,
-				ptr_depth,
-				is_array,
-				std::move(array_dimensions),
-				*type_and_name.node(),
-				initializer_position,
-				is_static_constexpr);
+			ref_qual,
+			ptr_depth,
+			is_array,
+			array_dimensions,
+			/* declaration */ *type_and_name.node(),
+			initializer_position,
+			is_static_constexpr);
 	}
 
 	return ParseResult::success();  // Signal caller to continue

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1973,7 +1973,7 @@ ParseResult Parser::parse_static_member_block(
 				type_spec.type_index(),
 				member_size,
 				member_alignment,
-				AccessSpecifier::Public,
+				AccessSpecifier::Public, // Full specializations use Public
 				init_expr_opt,
 				cv_qual,
 				ref_qual,

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -45,7 +45,6 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 
 		struct_ref.add_static_member(
 			enumerator_name,
-			/* declaration */ std::nullopt,
 			enum_type_index,
 			enum_size,
 			enum_alignment,
@@ -56,6 +55,7 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 			/* ptr_depth */ 0,
 			/* is_array */ false,
 			/* array_dimensions */ std::span<const size_t>{},
+			/* declaration */ std::nullopt,
 			/* initializer_position */ std::nullopt,
 			/* is_constexpr */ true);
 		if (struct_info != nullptr) {
@@ -5259,7 +5259,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						StringHandle static_member_name_handle = decl.identifier_token().handle();
 						member_struct_ref.add_static_member(
 							static_member_name_handle,
-							/* declaration */ *type_and_name_result.node(),
 							type_spec.type_index(),
 							static_member_size,
 							static_member_alignment,
@@ -5270,6 +5269,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 							ptr_depth,
 							is_array,
 							array_dimensions,
+							/* declaration */ *type_and_name_result.node(),
 							initializer_position,
 							is_constexpr);
 					}
@@ -5677,7 +5677,6 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 					member_struct_ref.add_static_member(
 						decl.identifier_token().handle(),
-						/* declaration */ *type_and_name_result.node(),
 						type_spec.type_index(),
 						static_member_size,
 						static_member_alignment,
@@ -5688,6 +5687,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						/* ptr_depth */ static_cast<int>(type_spec.pointer_depth()),
 						is_array,
 						array_dimensions,
+						/* declaration */ *type_and_name_result.node(),
 						initializer_position,
 						is_static_constexpr);
 				}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -45,6 +45,7 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 
 		struct_ref.add_static_member(
 			enumerator_name,
+			/* declaration */ std::nullopt,
 			enum_type_index,
 			enum_size,
 			enum_alignment,
@@ -52,7 +53,11 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 			initializer,
 			CVQualifier::None,
 			ReferenceQualifier::None,
-			0);
+			/* ptr_depth */ 0,
+			/* is_array */ false,
+			/* array_dimensions */ std::span<const size_t>{},
+			/* initializer_position */ std::nullopt,
+			/* is_constexpr */ true);
 		if (struct_info != nullptr) {
 			struct_info->addStaticMember(
 				enumerator_name,
@@ -63,7 +68,12 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 				initializer,
 				CVQualifier::None,
 				ReferenceQualifier::None,
-				0);
+				/* ptr_depth */ 0,
+				/* is_array */ false,
+				/* array_dimensions */ std::span<const size_t>{},
+				/* declaration */ std::nullopt,
+				/* initializer_position */ std::nullopt,
+				/* is_constexpr */ true);
 		}
 	}
 }
@@ -5249,7 +5259,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						StringHandle static_member_name_handle = decl.identifier_token().handle();
 						member_struct_ref.add_static_member(
 							static_member_name_handle,
-							*type_and_name_result.node(),
+							/* declaration */ *type_and_name_result.node(),
 							type_spec.type_index(),
 							static_member_size,
 							static_member_alignment,
@@ -5259,7 +5269,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 							ref_qual,
 							ptr_depth,
 							is_array,
-							std::move(array_dimensions),
+							array_dimensions,
 							initializer_position,
 							is_constexpr);
 					}
@@ -5667,7 +5677,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 					member_struct_ref.add_static_member(
 						decl.identifier_token().handle(),
-						*type_and_name_result.node(),
+						/* declaration */ *type_and_name_result.node(),
 						type_spec.type_index(),
 						static_member_size,
 						static_member_alignment,
@@ -5675,9 +5685,9 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						init_expr_opt,
 						cv_qual,
 						type_spec.reference_qualifier(),
-						static_cast<int>(type_spec.pointer_depth()),
+						/* ptr_depth */ static_cast<int>(type_spec.pointer_depth()),
 						is_array,
-						std::move(array_dimensions),
+						array_dimensions,
 						initializer_position,
 						is_static_constexpr);
 				}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4550,7 +4550,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 																	 : std::nullopt;
 				instantiated_struct_ref.add_static_member(
 					static_member.name,
-					/* declaration */ std::nullopt,
 					substituted_type_index,
 					substituted_size,
 					static_member.alignment,
@@ -4561,6 +4560,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					static_member.pointer_depth,
 					static_member.is_array,
 					static_member.array_dimensions,
+					/* declaration */ std::nullopt,
 					/* initializer_position */ std::nullopt,
 					static_member.is_constexpr);
 			}
@@ -7358,7 +7358,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.is_constexpr);
 					instantiated_nested_struct_ref.add_static_member(
 						static_member.getName(),
-						static_member.declaration,
 						substituted_type_index,
 						substituted_size,
 						static_member.alignment,
@@ -7369,6 +7368,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.pointer_depth,
 						static_member.is_array,
 						static_member.array_dimensions,
+						static_member.declaration,
 						static_member.initializer_position,
 						static_member.is_constexpr);
 				}
@@ -7949,7 +7949,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	for (const auto& static_member : struct_info_ptr->static_members) {
 		instantiated_struct_ref.add_static_member(
 			static_member.name,
-			static_member.declaration,
 			static_member.type_index,
 			static_member.size,
 			static_member.alignment,
@@ -7960,6 +7959,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			static_member.pointer_depth,
 			static_member.is_array,
 			static_member.array_dimensions,
+			static_member.declaration,
 			static_member.initializer_position,
 			static_member.is_constexpr);
 	}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4109,8 +4109,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							static_member.pointer_depth,
 							static_member.is_array,
 							static_member.array_dimensions,
-							std::nullopt,
-							std::nullopt,
+							/* declaration */ std::nullopt,
+							/* initializer_position */ std::nullopt,
 							static_member.is_constexpr);
 					}
 				}
@@ -4550,6 +4550,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 																	 : std::nullopt;
 				instantiated_struct_ref.add_static_member(
 					static_member.name,
+					/* declaration */ std::nullopt,
 					substituted_type_index,
 					substituted_size,
 					static_member.alignment,
@@ -4559,7 +4560,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					static_member.reference_qualifier,
 					static_member.pointer_depth,
 					static_member.is_array,
-					static_member.array_dimensions);
+					static_member.array_dimensions,
+					/* initializer_position */ std::nullopt,
+					static_member.is_constexpr);
 			}
 
 			// Copy member functions to AST node WITH CORRECT PARENT STRUCT NAME
@@ -7355,6 +7358,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.is_constexpr);
 					instantiated_nested_struct_ref.add_static_member(
 						static_member.getName(),
+						static_member.declaration,
 						substituted_type_index,
 						substituted_size,
 						static_member.alignment,
@@ -7945,6 +7949,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	for (const auto& static_member : struct_info_ptr->static_members) {
 		instantiated_struct_ref.add_static_member(
 			static_member.name,
+			static_member.declaration,
 			static_member.type_index,
 			static_member.size,
 			static_member.alignment,
@@ -9411,14 +9416,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					member_alignment,
 					AccessSpecifier::Public,
 					substituted_initializer,
-					type_spec.cv_qualifier(), // cv_qualifier
+					type_spec.cv_qualifier(),
 					type_spec.reference_qualifier(),
-					static_cast<int>(type_spec.pointer_depth()),
+					/* ptr_depth */ static_cast<int>(type_spec.pointer_depth()),
 					is_array,
-					std::move(array_dimensions),
-					std::nullopt,
-					std::nullopt,
-					false);
+					array_dimensions,
+					/* declaration */ std::nullopt,
+					/* initializer_position */ std::nullopt,
+					/* is_constexpr */ false);
 
 				FLASH_LOG(Templates, Debug, "Added out-of-line static member ", out_of_line_var.member_name,
 						  " to instantiated struct ", instantiated_name);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2835,8 +2835,8 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 				static_member.pointer_depth,
 				static_member.is_array,
 				static_member.array_dimensions,
-				std::nullopt,
-				std::nullopt,
+				/* declaration */ std::nullopt,
+				/* initializer_position */ std::nullopt,
 				static_member.is_constexpr);
 		}
 	} else {


### PR DESCRIPTION
## Summary

- Collapse `StructTypeInfo::addStaticMember` to one explicit overload with no default parameters.
- Collapse template AST `add_static_member` to one explicit overload with no default parameters.
- Update all static-member call sites to pass declaration, array, initializer-position, and constexpr state explicitly, with comments on non-obvious literal/null arguments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal APIs for improved efficiency and consistency in static member handling.
  * Modernized collection accessors to use more efficient data structures.
  * Enhanced metadata support for static members.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1506)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->