### PR TITLE
Implement C++20 template standard conformance refactor

### DIFF
--- a/FlashCpp.vcxproj
+++ b/FlashCpp.vcxproj
@@ -166,7 +166,7 @@
       <PreprocessorDefinitions>USE_LLVM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -178,7 +178,7 @@
       <PreprocessorDefinitions>USE_LLVM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Benchmark|x64'">
@@ -213,7 +213,7 @@
       <PreprocessorDefinitions>USE_LLVM;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Sharded|x64'">
@@ -230,7 +230,7 @@
     <Link>
       <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(LLVMInstallDir)\build\Release\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -157,7 +157,7 @@
     </ClCompile>
     <Link>
       <OutputFile>$(BenchmarkOutputFile)</OutputFile>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Test|x64'">
@@ -169,7 +169,7 @@
     </ClCompile>
     <Link>
       <OutputFile>$(OutDir)test.exe</OutputFile>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Modular|x64'">
@@ -183,7 +183,7 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Sharded|x64'">
@@ -199,7 +199,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -530,7 +530,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <Link>
       <AdditionalDependencies>ws2_32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
     <ClCompile>
       <Optimization>Disabled</Optimization>
@@ -543,7 +543,7 @@
         ws2_32.lib;
         %(AdditionalDependencies)
       </AdditionalDependencies>
-      <StackReserveSize>8388608</StackReserveSize>
+      <StackReserveSize>33554432</StackReserveSize>
     </Link>
     <ClCompile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -67,7 +67,42 @@ The remaining work is not another broad parser cleanup. The next useful passes
 should target the places where FlashCpp still lacks standard-owned semantic
 state.
 
-### Completed follow-up cleanup targets
+### Open next steps
+
+1. **Semantic lookup unification.**
+   Move template candidate discovery away from direct registry-by-name hot paths
+   and toward one lookup result that records declaration identity, lookup kind,
+   dependency, access/provenance, and definition-vs-POI timing.
+
+2. **Two-phase lookup expansion.**
+   Conservative definition-context records now cover selected non-dependent
+   unqualified function calls. Extend the model to qualified names, static
+   initializers, member templates, dependent bases, unknown specializations, and
+   ADL-sensitive dependent calls.
+
+3. **Structural NTTP implementation.**
+   Typed integral/enum/`nullptr` identity exists. Add real semantic values for
+   pointer, reference, function-pointer, member-pointer, floating-point, and
+   structural class-type NTTPs instead of keeping unsupported/placeholder
+   categories.
+
+4. **Deduction and constraint pipeline split.**
+   Expand signature-only candidate ranking beyond the selected free/member
+   function-template paths and replace remaining full-instantiation fallbacks
+   with sema-owned candidate construction, deduction, constraints, partial
+   ordering, and overload ranking.
+
+5. **Dependent-name and current-instantiation model.**
+   Build on `TypeInfo::DependentQualifiedNameRecord` with records for expression
+   qualified-ids, dependent bases, unknown specialization, injected-class-name,
+   current-instantiation identity, and alias ordering.
+
+6. **Constructor fallback hardening.**
+   Current valid test coverage no longer needs codegen-time constructor
+   fallback, but uncovered/invalid paths still use a soft fallback. Keep widening
+   sema coverage until this can become a diagnostic/invariant.
+
+### Recently closed follow-up cleanup targets
 
 1. **Typed NTTP identity completion.**
    Preserve exact integral categories in deferred evaluation and remove the
@@ -166,9 +201,12 @@ This makes many dependent names visible to ordinary type lookup machinery.
 - pack-related state through `is_pack`.
 
 `NonTypeValueIdentity` provides a canonical identity carrier for current non-type
-arguments, but it is still integral-centric: concrete values are represented by
-`int64_t` plus a `TypeIndex`, and dependent values are represented primarily by
-name and optional expression metadata.
+arguments. It now preserves typed identity for supported integral, enum, and
+`nullptr` arguments, including ordered identity for instantiation keys and
+mangling. Pointer, reference, function-pointer, member-pointer, floating-point,
+and structural class-type NTTPs are still explicit unsupported or placeholder
+categories until parsing and constant evaluation can produce standard semantic
+values for them.
 
 `TemplateArgIdentity`, `OrderedTemplateInstantiationIdentity`, and
 `TemplateInstantiationKey` preserve ordered identity in addition to legacy
@@ -456,24 +494,32 @@ ids, dependent expressions, aliases, variable templates, and static members.
 
 C++20 NTTPs include integral values, enumeration values, pointers, references,
 member pointers, `nullptr`, floating-point values, and structural class-type
-values subject to the C++20 structural-type rules. FlashCpp's concrete
-`NonTypeValueIdentity` is centered on `int64_t`, with partial type identity.
-That is not sufficient for standard NTTP equivalence or mangling.
+values subject to the C++20 structural-type rules. FlashCpp now has typed
+identity for supported integral, enum, and `nullptr` arguments, but the remaining
+NTTP categories are not yet represented as standard semantic values. Until
+pointer/reference/member-pointer/floating-point/structural class values are
+produced by the parser and constexpr evaluator, full C++20 NTTP equivalence and
+mangling remain incomplete.
 
 #### 3. Dependent names are represented as strings/placeholders
 
-Many dependent facts are stored as `dependent_name`, placeholder `TypeInfo`, or
-optional AST. C++20 requires a richer distinction among unknown specialization,
-member of current instantiation, dependent base lookup, dependent qualified
-name, dependent template-id, and dependent expression. String identity is not
-enough to implement these rules reliably.
+Many dependent facts are still stored as `dependent_name`, placeholder
+`TypeInfo`, or optional AST. The follow-up work added
+`TypeInfo::DependentQualifiedNameRecord` for important member-type placeholders,
+but C++20 requires a broader distinction among unknown specialization, member of
+current instantiation, dependent base lookup, dependent qualified name,
+dependent template-id, and dependent expression. String identity is not enough
+to implement these rules reliably.
 
 #### 4. Two-phase lookup is incomplete
 
-The current system reparses and substitutes using current parser state, global
-registries, and symbol tables. It does not yet have a complete point-of-definition
-ordinary lookup snapshot plus point-of-instantiation dependent lookup model.
-This risks both accepting ill-formed code and rejecting valid dependent code.
+The current system still has paths that reparse and substitute using current
+parser state, global registries, and symbol tables. Conservative
+definition-context records now protect selected non-dependent unqualified
+function calls, but the compiler does not yet have a complete
+point-of-definition ordinary lookup snapshot plus point-of-instantiation
+dependent lookup model. This risks both accepting ill-formed code and rejecting
+valid dependent code outside the covered call paths.
 
 #### 5. Qualified lookup is not one authoritative semantic service
 
@@ -495,8 +541,9 @@ and two-phase lookup.
 
 C++20 separates candidate construction, template argument deduction, constraint
 checking, viability, partial ordering, overload resolution, substitution, and
-instantiation. FlashCpp currently mixes several of these steps while searching
-the registry and materializing AST.
+instantiation. FlashCpp now has signature-only ranking for selected overloaded
+free and member function-template paths, but other paths still mix these steps
+while searching the registry and materializing AST.
 
 #### 8. Static member handling is too eager and repair-oriented
 
@@ -529,54 +576,38 @@ single parser bug; it is the absence of one semantic template system that owns:
 5. substitution and point-of-instantiation materialization;
 6. constant evaluation under an instantiated semantic context.
 
-## Implementation plan
+## Remaining implementation plan
 
-1. **Unify static constexpr evaluation entry points**
-   Extract one semantic helper for "read static member as constant if legal",
-   and make both qualified-id and member-access lowering call that helper.
+1. **Unify semantic lookup results**
+   Create one lookup result type used by template candidate discovery, qualified
+   lookup, member lookup, ADL-sensitive call resolution, and constexpr/static
+   initializer paths. Template registries should become indexes behind semantic
+   lookup rather than independent lookup authorities.
 
-2. **Centralize recursive static evaluation policy**
-   Move recursive `base::value + c` evaluation into shared constexpr/sema logic
-   so codegen and declaration-time normalization do not duplicate pattern logic.
+2. **Expand definition-vs-POI records**
+   Extend the existing non-dependent function-call records to qualified names,
+   member-template calls, static initializers, dependent bases, unknown
+   specializations, and expression qualified-ids.
 
-3. **Replace pattern-specific recursion with expression-driven evaluation**
-   Preserve current behavior as compatibility, then extend to a general
-   expression evaluator for dependent static initializers (not just binary `+`).
+3. **Complete structural NTTP values**
+   Add parser/constexpr support for pointer, reference, function-pointer,
+   member-pointer, floating-point, and structural class-type NTTP values, then
+   wire those categories through identity, hashing, mangling, specialization
+   lookup, and diagnostics.
 
-4. **Promote normalized initializer ownership to sema context**
-   Keep `normalized_init` as artifact, but make semantic evaluation result the
-   source of truth and write back normalized bytes only after semantic success.
+4. **Broaden signature-only deduction/ranking**
+   Move more overload and deduction paths onto shape-only candidate viability so
+   ranking does not instantiate losing bodies. Include constraints,
+   non-deduced contexts, forwarding references, packs, template-template
+   parameters, CTAD, deduction guides, and partial ordering.
 
-5. **Strengthen substitution ordering invariants**
-   Keep the "template-parameter substitution before expression substitution"
-   ordering as invariant and apply it consistently across class/member/alias
-   static initializer normalization paths.
+5. **Finish dependent-name/current-instantiation modeling**
+   Replace remaining string-like dependent placeholders with records for current
+   instantiation, dependent base members, unknown specializations, injected class
+   names, dependent template-ids, and expression qualified-ids.
 
-6. **Widen sema constructor annotation coverage to eliminate codegen fallback**
-   The current soft fallback (sema omits annotation → codegen-time resolution)
-   is a safety net for unhandled ConstructorCallNode forms. Extend sema coverage
-   in `inferExpressionType` and `tryAnnotateConstructorCallArgConversions` until
-   the fallback warning is never emitted for well-formed code. The hard failure
-   for mismatched annotations is already correct and should be preserved.
-
-7. **Extend alias size resolution to cover all concrete alias targets**
-   The alias-size fallback chain (TypeInfo size → TypeSpecifier size → struct
-   size) should be generalized and shared so any path that needs a concrete byte
-   size for an alias-derived type uses the same resolution order.
-
-8. **Add regression coverage focused on the new behavior envelope**
-   Include:
-   - recursive base static constexpr chains;
-   - scalar-vs-aggregate fold boundaries;
-   - template static members that depend on substituted alias/non-type args;
-   - recursion-depth boundary diagnostics/failure mode;
-   - struct with multiple member functions, one of which fails codegen (verify
-     IR rollback preserves already-emitted members);
-   - enum functional cast overload resolution (verify TypeCategory::Enum is
-     consistently chosen over TypeCategory::Struct or Int);
-   - qualified enum constant type inference via `enum_owner_type_index` fast path.
-
-9. **Introduce semantic invariants and remove repair paths in stages**
-   After each phase, convert one class of codegen fallback into an invariant
-   check (or hard error in internal paths) so non-semantic backdoors do not
-   silently reappear.
+6. **Convert repair paths into invariants**
+   Keep the current compatibility fallbacks only where they are still needed for
+   uncovered cases. As sema coverage expands, convert constructor fallback,
+   lookup fallback, and materialization fallback paths into explicit diagnostics
+   or internal invariants.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-13 (template infrastructure refactor completed)
+**Last updated:** 2026-05-13 (follow-up architecture slices completed)
 
 This document describes the current FlashCpp template-argument architecture for
 types, non-type values, template-template arguments, class templates, function
@@ -40,19 +40,23 @@ architecture pass while preserving the behavior described in this audit. The
 branch now includes:
 
 - centralized static `constexpr` member reads through one semantic service;
-- ordered and typed deferred NTTP identity preservation;
+- ordered and typed NTTP identity preservation, including exact integral/enum
+  identity and typed `nullptr` identity;
 - shared alias/type-size query infrastructure;
 - parameter-context-driven explicit template argument classification;
 - `TemplateInstantiationContext` plumbing for template lookup and substitution;
-- shape-only template deduction viability checks used before materialization;
+- conservative template definition lookup records for non-dependent calls;
+- shape-only template deduction viability checks used before body
+  materialization for selected free and member function-template overload paths;
+- dependent qualified-name records for high-value member-type placeholders;
 - dependent alias-size, nested pack/materialization, and dependent constexpr
   regression fixes;
 - explicit-template SFINAE repair so explicitly supplied template arguments are
   substituted before remaining call-argument deduction.
 
 Validation after these changes passed the Windows sharded build and the full
-PowerShell test suite: 2333 regular tests compiled, linked, and ran with the
-expected return values, and all 174 `_fail.cpp` tests failed as expected.
+PowerShell test suite: 2352 regular tests compiled, linked, and ran with the
+expected return values, and all 181 `_fail.cpp` tests failed as expected.
 
 The remaining non-conforming areas below are therefore forward-looking
 architecture gaps, not known regressions from the refactor.
@@ -63,29 +67,34 @@ The remaining work is not another broad parser cleanup. The next useful passes
 should target the places where FlashCpp still lacks standard-owned semantic
 state.
 
-### Short-term cleanup targets
+### Completed follow-up cleanup targets
 
 1. **Typed NTTP identity completion.**
    Preserve exact integral categories in deferred evaluation and remove the
    exact-lookup linear fallback that scans specializations for integral
-   mismatches.
+   mismatches. **Completed** by preserving evaluated expression/static-member
+   type identity and stable typed value identities.
 
 2. **Static `constexpr` correctness cleanup.**
    Treat namespace-qualified constexpr owners as valid lookup owners, and reject
    invalid non-dependent `static constexpr` initializers instead of recovering
-   through zero-like fallback behavior.
+   through zero-like fallback behavior. **Completed** with precise dependent
+   deferral and hard errors for invalid non-dependent initializers.
 
 3. **Dependent NTTP concretization simplification.**
    Reduce dependent value materialization to a deterministic bind/substitute/
-   evaluate pass.
+   evaluate pass. **Completed** for dependent alias/default NTTP paths.
 
 4. **Constructor annotation coverage.**
    Extend sema constructor-call inference until well-formed code no longer
-   falls back to codegen-time overload resolution.
+   falls back to codegen-time overload resolution. **Completed for current
+   valid test coverage**; the codegen fallback remains soft for uncovered or
+   invalid expected-failure cases.
 
 5. **Alias-size query ownership.**
    Move the concrete alias-size fallback chain into a shared sema helper instead
-   of keeping it as codegen-local recovery logic.
+   of keeping it as codegen-local recovery logic. **Completed** through shared
+   alias-aware size query helpers.
 
 ### Highest-impact architecture targets
 
@@ -94,21 +103,33 @@ state.
    definition-context lookup records, while dependent names need explicit
    point-of-instantiation completion records. This also gives qualified lookup,
    ADL, static initializers, and member-template calls a shared source of truth.
+   **Progress:** conservative definition-context records now guard
+   non-dependent unqualified function calls, with dependent POI/ADL behavior
+   regression-tested.
 
 2. **Structural NTTP value model.**
    The current concrete value identity remains too integral-centric for C++20.
    Pointer, reference, member-pointer, `nullptr`, floating-point, enum, and
    structural class-type arguments need typed equivalence and hashing.
+   **Progress:** the value model now distinguishes typed integral/enum,
+   `nullptr`, pointer/reference/member-pointer placeholder categories, and
+   explicitly rejects unsupported structural class-type NTTPs instead of
+   manufacturing scalar identities.
 
 3. **Deduction and constraint pipeline separation.**
    Candidate construction, deduction, constraint checking, partial ordering,
    overload ranking, substitution, and instantiation should keep moving into
-   separate sema-owned phases.
+   separate sema-owned phases. **Progress:** overloaded free function templates
+   and implicit member function templates can rank signature-only candidates
+   before instantiating the selected body.
 
 4. **Dependent-name and current-instantiation model.**
    Replace dependent strings/placeholders with first-class entities for current
    instantiation, unknown specialization, dependent bases, dependent
-   qualified-names, and dependent template-ids.
+   qualified-names, and dependent template-ids. **Progress:** dependent
+   qualified member-type placeholders now carry
+   `TypeInfo::DependentQualifiedNameRecord` metadata for `typename T::type` and
+   dependent member-template chains.
 
 ## Current representations
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-13 (dependent-name record slice added)
+**Last updated:** 2026-05-13 (follow-up architecture slices completed)
 
 This document describes how FlashCpp's template argument architecture can move
 toward C++20 conformance. It is intentionally architectural: it identifies the
@@ -49,26 +49,33 @@ Completed work:
 
 1. centralized static `constexpr` member reads and recursive base-member
    evaluation policy behind a shared semantic service;
-2. preserved ordered, typed deferred NTTP identities in instantiation keys;
+2. preserved ordered, typed NTTP identities in instantiation keys, including
+   exact integral/enum identity and typed `nullptr` identity;
 3. consolidated alias-aware concrete size queries;
 4. added parameter-context-driven classification for explicit template
    arguments across function, class, alias, and variable template use sites;
 5. introduced and threaded `TemplateInstantiationContext` through lookup and
    substitution paths;
-6. extracted shape-only template deduction viability so candidate filtering can
-   run before materializing definitions;
+6. extracted shape-only template deduction viability so selected free/member
+   function-template overload paths rank signatures before materializing bodies;
 7. fixed regressions found during full-suite validation in dependent alias size
    fallback, template-template leftovers, nested pack/materialization, dependent
-   constexpr evaluation, and explicit-template SFINAE deduction.
+   constexpr evaluation, and explicit-template SFINAE deduction;
+8. added conservative definition-context lookup records for non-dependent
+   template-body calls while preserving dependent POI/ADL completion;
+9. added dependent qualified-name records for high-value member-type placeholder
+   paths such as `typename T::type` and
+   `Traits<T>::template rebind<U>::type`.
 
 The final validation run passed `.\build_flashcpp.bat` and
 `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1`:
-2333 regular tests compiled, linked, and returned expected values, and all 174
+2352 regular tests compiled, linked, and returned expected values, and all 181
 expected-failure tests failed as expected.
 
 The remaining target architecture sections are retained as the next conformance
-roadmap, especially full two-phase lookup records, structural NTTP values, and
-constraint normalization/subsumption.
+roadmap, especially full semantic lookup, complete structural NTTP values,
+current-instantiation/dependent-base modeling, and constraint
+normalization/subsumption.
 
 ## What is left / next
 
@@ -76,32 +83,36 @@ The completed refactor should be treated as the foundation, not the finish line.
 The next work is split into immediate cleanup items that can be attacked in
 small PRs and larger architecture tracks that need focused design.
 
-### Immediate follow-up items
+### Completed immediate follow-up items
 
 1. **Close the remaining typed-NTTP identity holes.**
    `makeEvaluatedDeferredBaseValueArg` can still collapse non-bool integer
    values to `TypeCategory::Int`, and exact-template lookup still has a linear
    fallback for integral mismatches. These should be fixed first because they
-   directly affect specialization identity, matching, and mangling.
+   directly affect specialization identity, matching, and mangling. **Completed**
+   with expression/static-member type preservation and typed key hashing.
 
 2. **Finish static `constexpr` owner/error cleanup.**
    Namespace-qualified constexpr references should be distinguished from
    missing type/template owners, and invalid non-dependent `static constexpr`
    initializers should hard-fail instead of reaching any zero-value recovery
-   path.
+   path. **Completed** while preserving precise dependent deferral.
 
 3. **Simplify dependent NTTP concretization.**
    Concretization should bind names once, substitute once, and evaluate once.
    Duplicate substitute/evaluate attempts make lookup-order bugs hard to see.
+   **Completed** for dependent alias/default NTTP evaluation.
 
 4. **Remove the constructor-annotation safety net for valid code.**
    Widen `SemanticAnalysis.cpp` constructor inference until valid programs no
    longer need the codegen-time overload-resolution fallback. Only then should
-   the fallback become a hard diagnostic/invariant.
+   the fallback become a hard diagnostic/invariant. **Completed for current
+   valid coverage**; the fallback remains soft for uncovered/invalid paths.
 
 5. **Move alias-size fallback into shared sema-owned querying.**
    The current TypeInfo-size -> TypeSpecifier-size -> struct-size chain works
    but should become one shared helper used by every concrete-size consumer.
+   **Completed** with shared alias-aware size query helpers.
 
 ### Highest-impact architecture tracks
 
@@ -110,11 +121,19 @@ small PRs and larger architecture tracks that need focused design.
    dependent lookup to the point of instantiation. This is the highest-impact
    standard-conformance gap because it affects template bodies, static
    initializers, dependent calls, ADL, and qualified lookup.
+   The 2026-05-13 follow-up added a conservative definition-context record for
+   non-dependent unqualified function calls. Later point-of-instantiation
+   overloads are filtered out, while dependent calls still complete ADL at POI.
 
 2. **Structural NTTP value identity.**
    Replace the integral-centric `int64_t` model with typed template-argument
    equivalence for enums, `nullptr`, pointers/references/member pointers,
    floating-point values, and structural class-type values.
+   The 2026-05-13 follow-up introduced typed NTTP identity categories and wired
+   equality/hashing/mangling through them for currently supported cases. Pointer,
+   reference, function-pointer, member-pointer, floating-point, and structural
+   class-type NTTPs remain explicit unsupported/placeholder categories until the
+   parser and constant evaluator can produce standard semantic values for them.
 
 3. **Deduction/constraints split before materialization.**
    Continue extracting candidate viability, deduction, constraints, partial
@@ -537,8 +556,9 @@ behavior as compatibility constraints.
    class/function/alias/variable template use sites.
 
 2. **Gate B (lookup unification)**
-   **Status: partial.** `TemplateInstantiationContext` now carries more lookup
-   context, but template candidate discovery is not yet sourced from one
+   **Status: partial, advanced.** `TemplateInstantiationContext` carries lookup
+   context and non-dependent function calls now preserve a definition-context
+   record, but template candidate discovery is not yet sourced from one
    authoritative semantic lookup result everywhere.
 
 3. **Gate C (instantiation context)**
@@ -547,15 +567,18 @@ behavior as compatibility constraints.
    vectors/maps in places.
 
 4. **Gate D (deduction split)**
-   **Status: partial.** Shape-only viability exists and should be expanded until
-   overload viability and deduction run without body materialization in normal
-   selection paths.
+   **Status: partial, advanced.** Shape-only viability now covers selected
+   overloaded free/member function-template paths and should continue expanding
+   until all normal overload viability and deduction run without body
+   materialization.
 
 5. **Gate E (NTTP and two-phase lookup)**
-   **Status: open.** Structural NTTP identity and definition-vs-POI lookup
-   behavior still need implementation and regression coverage.
+   **Status: partial.** Typed NTTP identities and definition-vs-POI function
+   lookup are implemented for supported cases. Pointer/reference/member-pointer,
+   floating-point, structural class NTTP values, full semantic lookup, and full
+   dependent-base/current-instantiation behavior remain open.
 
-### Targeted TODOs to close known conformance gaps
+### Targeted TODOs closed by follow-up work
 
 1. **TODO: Preserve exact integral NTTP category during deferred evaluation**
    Never collapse evaluated integral NTTPs to a generic `int` category in
@@ -565,30 +588,32 @@ behavior as compatibility constraints.
    time and through overload resolution; the remaining gap is in
    `makeEvaluatedDeferredBaseValueArg`, which can collapse any non-bool integer
    NTTP to `TypeCategory::Int`. Apply the same TypeInfo-backed category lookup
-   that parser and overload-resolution layers now use.
+   that parser and overload-resolution layers now use. **Closed.**
 
 2. **TODO: Remove linear specialization fallback for integral mismatches**
    Replace O(N) "scan all specializations" fallback behavior in exact template
    lookup with canonical argument normalization that preserves type identity and
    allows stable hash/key lookup. This keeps behavior deterministic and avoids
    lookup policy that can diverge from proper template-argument equivalence.
+   **Closed.**
 
 3. **TODO: Treat namespace-qualified names as valid owners in constexpr paths**
    In static-member constexpr normalization/evaluation, distinguish namespace
    owners from missing type/template owners. Namespace-qualified references must
    participate in normal lookup/evaluation instead of being classified as
-   missing-owner deferrals.
+   missing-owner deferrals. **Closed.**
 
 4. **TODO: Reject invalid `static constexpr` initializers instead of zero-fallback**
    Remove broad recoverable fallback that can zero-initialize non-constant
    `static constexpr` members. Only defer where a precise dependent/missing-owner
    condition is proven; otherwise produce the required hard diagnostic.
+   **Closed.**
 
 5. **TODO: Simplify dependent NTTP concretization to a single evaluation pass**
    Ensure dependent-argument concretization does not perform duplicate
    substitute/evaluate cycles that can diverge or hide lookup-order bugs.
    Prefer deterministic order: name binding first, then one expression
-   substitution/evaluation attempt.
+   substitution/evaluation attempt. **Closed.**
 
 6. **TODO: Eliminate sema constructor annotation fallback for well-formed code**
    The current soft fallback (sema omits annotation → codegen-time overload
@@ -596,14 +621,16 @@ behavior as compatibility constraints.
    incomplete. Extend `inferExpressionType` and
    `tryAnnotateConstructorCallArgConversions` coverage in `SemanticAnalysis.cpp`
    until the warning log is never emitted for valid C++20 code. Once coverage is
-   complete, convert the fallback to a hard `CompileError`.
+   complete, convert the fallback to a hard `CompileError`. **Closed for current
+   valid coverage; fallback intentionally remains soft for uncovered/invalid
+   paths.**
 
 7. **TODO: Consolidate alias size resolution into a shared sema helper**
    The TypeInfo-size → TypeSpecifier-size → struct-size fallback chain in
    `resolveCodegenSizeBits` should be extracted into a shared size-query service
    used by all codegen paths that need a concrete byte/bit count for an
    alias-resolved type, avoiding duplication across independent codegen call
-   sites.
+   sites. **Closed.**
 
 ### Exit criteria
 
@@ -611,10 +638,13 @@ behavior as compatibility constraints.
   identifiers;
 - static-member constexpr reads use one sema service (no duplicated ad-hoc
   recursive evaluators in IR paths);
-- deduction and overload ordering run without incidental instantiation;
-- two-phase lookup behavior is test-covered for non-dependent vs dependent
-  names;
-- NTTP equivalence is type-accurate and structural where C++20 requires it.
+- selected deduction and overload-ordering paths run without incidental body
+  instantiation;
+- two-phase lookup behavior is test-covered for non-dependent function calls vs
+  dependent POI/ADL calls;
+- NTTP equivalence is type-accurate for supported integral/enum/`nullptr` cases,
+  while unsupported structural categories diagnose instead of collapsing to
+  scalar identities.
 
 ### Minimum regression suite required before declaring completion
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-13 (template infrastructure refactor completed)
+**Last updated:** 2026-05-13 (dependent-name record slice added)
 
 This document describes how FlashCpp's template argument architecture can move
 toward C++20 conformance. It is intentionally architectural: it identifies the
@@ -130,6 +130,14 @@ small PRs and larger architecture tracks that need focused design.
    Replace string-like placeholders with semantic dependent entities for
    current instantiation, unknown specialization, dependent bases, dependent
    qualified names, and dependent template-ids.
+   The 2026-05-13 follow-up slice added a narrow
+   `TypeInfo::DependentQualifiedNameRecord` for dependent member-type
+   placeholders and taught type substitution/member declaration copying to
+   prefer that record for `typename T::type` and dependent member-template
+   chains such as `Traits<T>::template rebind<U>::type`.  It intentionally
+   leaves full current-instantiation alias ordering, expression qualified-id
+   records, and dependent base/unknown-specialization lookup classification as
+   later `[temp.dep]` work.
 
 ## Target architecture
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -123,6 +123,19 @@ should be split into focused investigations.
    paths. Keep widening sema coverage until the fallback can be converted into a
    hard diagnostic or invariant without losing valid code.
 
+7. **Replace `std::unique_ptr` with a raw pointer with an entry created from a gChunkedVector for `template_arguments` in
+   `ExpressionSubstitutor.cpp`.**
+   Each segment of a dependent member chain creates a `std::make_shared<std::vector<TemplateTypeArg>>`
+   at the substitution call site (`ExpressionSubstitutor.cpp`, around the
+   `member_chain.push_back` loop). Since we will keep the pointer the whole lifetime of the. ompiler, the allocation could be sped up by using a ChunkedVector backed pointer, switching
+   to a raw pointer (or storing the vector by value if the `DependentMemberAccess`
+   ownership model permits) would reduce the two heap allocations per segment
+   to one and improve cache locality on the hot template substitution path.
+   This requires auditing all consumers of the `template_arguments` shared_ptr
+   field on `DependentMemberAccess` (or equivalent) to confirm none alias the
+   pointer after the vector is moved.
+
+
 ### Recently closed follow-up items
 
 1. **Close the remaining typed-NTTP identity holes.**

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -120,6 +120,11 @@ small PRs and larger architecture tracks that need focused design.
    Continue extracting candidate viability, deduction, constraints, partial
    ordering, and overload ranking so normal selection paths do not instantiate
    function or class bodies incidentally.
+   The 2026-05-13 follow-up slice routes overloaded free function templates
+   and implicit member function templates through signature-only candidate
+   materialization for overload conversion ranking before instantiating the
+   selected body.  It deliberately keeps the older full-instantiation fallback
+   for cases the shape path cannot rank safely.
 
 4. **First-class dependent-name/current-instantiation model.**
    Replace string-like placeholders with semantic dependent entities for

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -80,10 +80,50 @@ normalization/subsumption.
 ## What is left / next
 
 The completed refactor should be treated as the foundation, not the finish line.
-The next work is split into immediate cleanup items that can be attacked in
-small PRs and larger architecture tracks that need focused design.
+The immediate cleanup items from the first follow-up pass are closed. The
+remaining work is now mostly architecture work plus a few hardening passes that
+should be split into focused investigations.
 
-### Completed immediate follow-up items
+### Open next steps
+
+1. **Unify semantic lookup for template candidate discovery.**
+   Template lookup still has direct registry-by-name paths. The next pass should
+   route class/function/alias/variable template candidate discovery through one
+   semantic lookup result that records declaration identity, lookup kind,
+   dependency, and definition-vs-POI timing.
+
+2. **Broaden two-phase lookup records beyond non-dependent function calls.**
+   Definition-context records now protect selected non-dependent unqualified
+   calls, but qualified names, static initializers, member templates, dependent
+   bases, unknown specializations, and broader ADL still need explicit
+   definition/POI records.
+
+3. **Implement real structural NTTP values.**
+   Typed integral/enum/`nullptr` identity is implemented. Pointer, reference,
+   function-pointer, member-pointer, floating-point, and structural class-type
+   NTTPs are still unsupported or placeholder categories until parser and
+   constexpr evaluation can produce standard semantic values.
+
+4. **Expand shape-only deduction and ranking.**
+   Selected overloaded free/member function-template paths can rank
+   signature-only candidates before body materialization. The older
+   full-instantiation fallback remains for unhandled cases; keep moving
+   candidate construction, deduction, constraints, partial ordering, and ranking
+   into sema-owned phases.
+
+5. **Complete dependent-name and current-instantiation modeling.**
+   `TypeInfo::DependentQualifiedNameRecord` covers high-value member-type
+   placeholders, but full `[temp.dep]` support still needs current-instantiation
+   identity, dependent base lookup, unknown specialization classification,
+   expression qualified-id records, and alias ordering.
+
+6. **Harden constructor annotation fallback into an invariant.**
+   Current valid coverage no longer needs the fallback in tested cases, but
+   codegen still intentionally keeps a soft fallback for uncovered/invalid
+   paths. Keep widening sema coverage until the fallback can be converted into a
+   hard diagnostic or invariant without losing valid code.
+
+### Recently closed follow-up items
 
 1. **Close the remaining typed-NTTP identity holes.**
    `makeEvaluatedDeferredBaseValueArg` can still collapse non-bool integer
@@ -484,44 +524,40 @@ Converge from parser/codegen repair paths to a sema-owned, declaration-context
 template system while preserving the newly stabilized static `constexpr`
 behavior as compatibility constraints.
 
-### Work plan (phased delivery)
+### Work plan (remaining phased delivery)
 
-1. **Stabilize current static-constexpr semantics as explicit contracts**
-   Document and test the current scalar-only folding gate, normalized-bytes
-   preference, recursive base-chain behavior, and depth-limit behavior so later
-   refactors preserve expected outcomes.
-
-2. **Introduce one semantic static-member constant-evaluation service**
-   Build a sema service that answers: "Can this static member be read as a
-   constant here?" Move recursive/base-chain policy and normalized-init
-   interpretation into this service; make IR callers consume only the service.
-
-3. **Complete parameter-context argument classification first**
-   Keep this as top priority architecture work:
-   parse argument syntax first, resolve template declaration, match parameters,
-   then classify each argument by parameter kind.
-
-4. **Unify declaration lookup for template names**
+1. **Unify declaration lookup for template names**
    Route class/function/alias/variable template candidate discovery through one
    semantic lookup result so template-id classification and deduction use the
    same declaration identity model.
 
-5. **Consolidate substitution context ownership**
-   Replace ad-hoc name/vector substitution channels with a single
-   `TemplateInstantiationContext` carrying bindings, pack state, definition/POI
-   lookup context, and constexpr/sema context.
-
-6. **Separate deduction from instantiation/materialization**
-   Ensure candidate viability, deduction, constraints, and partial ordering run
-   without body materialization. Instantiate only after winner selection.
-
-7. **Advance two-phase lookup records**
+2. **Advance two-phase lookup records**
    Persist non-dependent lookup at definition time and defer only dependent
-   completion to instantiation time, including static initializer paths.
+   completion to instantiation time. Extend the current function-call record
+   slice to qualified names, member templates, static initializer paths,
+   dependent bases, unknown specializations, and ADL-sensitive dependent calls.
 
-8. **Expand NTTP identity beyond integral-centric representation**
-   Implement structural constant-value identity (pointers/references/member
-   pointers/nullptr/fp/structural class values), then migrate keys and mangling.
+3. **Consolidate substitution context ownership**
+   Continue replacing ad-hoc name/vector substitution channels with
+   `TemplateInstantiationContext` as the authoritative owner of scalar
+   bindings, pack bindings, current-instantiation identity, lookup context,
+   constexpr context, and failure policy.
+
+4. **Separate deduction from instantiation/materialization**
+   Expand shape-only candidate viability until deduction, constraints, partial
+   ordering, and overload ranking can run without body materialization in normal
+   selection paths. Instantiate only after winner selection.
+
+5. **Expand structural NTTP identity beyond supported scalar cases**
+   Typed integral/enum/`nullptr` identities are implemented. Add standard
+   semantic values and equivalence for pointer, reference, function-pointer,
+   member-pointer, floating-point, and structural class-type NTTPs, then migrate
+   keys and mangling for those categories.
+
+6. **Complete dependent-name/current-instantiation modeling**
+   Build on `DependentQualifiedNameRecord` with semantic records for expression
+   qualified-ids, dependent bases, unknown specialization, injected-class-name,
+   and current-instantiation member lookup.
 
 ### Concrete artifacts to implement
 
@@ -540,13 +576,15 @@ behavior as compatibility constraints.
    bindings, pack bindings, current-instantiation identity, lookup context,
    constexpr context, and failure policy.
 
-4. **Static member constexpr semantic service**
-   Centralize "can read as constant" decisions and recursive base-member
-   evaluation in sema/constexpr logic; IR should consume service outputs only.
+4. **Structural NTTP value representation**
+   Extend the current typed scalar identity into value variants and
+   equivalence/hashing rules for pointer, reference, function-pointer,
+   member-pointer, floating-point, and structural class-type NTTPs.
 
-5. **Structural NTTP value representation**
-   Introduce typed value variants and equivalence/hashing rules that match C++20
-   template-argument equivalence requirements.
+5. **Dependent-name/current-instantiation records**
+   Preserve current-instantiation, dependent base, unknown specialization,
+   dependent qualified-name, and dependent template-id identity without falling
+   back to string-only placeholders.
 
 ### Phase gates and dependency order
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1017,6 +1017,29 @@ struct TypeInfo {
 		StringHandle stringValue() const { return FlashCpp::get_if<StringHandle>(value); }
 	};
 
+	struct DependentQualifiedNameRecord {
+		enum class OwnerKind : uint8_t {
+			TemplateParameter,
+			DependentInstantiation,
+			CurrentInstantiation,
+			UnknownSpecialization
+		};
+
+		struct Member {
+			StringHandle name;
+			InlineVector<TemplateArgInfo, 4> template_arguments;
+			bool has_template_arguments = false;
+			bool has_template_keyword = false;
+		};
+
+		OwnerKind owner_kind = OwnerKind::UnknownSpecialization;
+		StringHandle owner_name;
+		TypeIndex owner_type;
+		InlineVector<TemplateArgInfo, 4> owner_template_arguments;
+		InlineVector<Member, 4> member_chain;
+		bool names_current_instantiation = false;
+	};
+
  // Canonical template environment owned by instantiated types.
  // Stores both parameter names and concrete arguments so that later phases
  // (codegen, constexpr evaluation) can resolve template bindings without
@@ -1044,6 +1067,8 @@ struct TypeInfo {
 
 	InlineVector<TemplateArgInfo, 4> template_args_;
 
+	std::optional<DependentQualifiedNameRecord> dependent_qualified_name_;
+
  // Type-owned instantiation context (non-null for template instantiations
  // and for types nested inside a template instantiation).
 	std::unique_ptr<InstantiationContext> instantiation_context_;
@@ -1061,6 +1086,8 @@ struct TypeInfo {
 	StringHandle baseTemplateName() const { return base_template_.identifier_handle; }
 	NamespaceHandle sourceNamespace() const { return base_template_.namespace_handle; }
 	const InlineVector<TemplateArgInfo, 4>& templateArgs() const { return template_args_; }
+	bool hasDependentQualifiedName() const { return dependent_qualified_name_.has_value(); }
+	const DependentQualifiedNameRecord* dependentQualifiedName() const { return dependent_qualified_name_ ? &*dependent_qualified_name_ : nullptr; }
 
  // Access the type-owned instantiation context (may be null).
 	const InstantiationContext* instantiationContext() const { return instantiation_context_.get(); }
@@ -1075,6 +1102,9 @@ struct TypeInfo {
 
 	void clearAliasTypeSpecifier();
 	void setAliasTypeSpecifier(const TypeSpecifierNode& type_spec);
+	void setDependentQualifiedName(DependentQualifiedNameRecord record) {
+		dependent_qualified_name_ = std::move(record);
+	}
 
  // Set the type-owned instantiation context for template instantiations.
 	void setInstantiationContext(InlineVector<StringHandle, 4> param_names,

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -989,6 +989,7 @@ struct TypeInfo {
 		ReferenceQualifier ref_qualifier;
 		std::variant<int64_t, double, StringHandle> value;	// For non-type arguments
 		bool is_value;		   // true if this is a non-type argument
+		bool is_pack;
 		bool is_array;
 		InlineVector<size_t, 2> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
 		StringHandle dependent_name;	 // Name of the dependent template parameter (for inner deduction)
@@ -1005,6 +1006,7 @@ struct TypeInfo {
 			  ref_qualifier(ReferenceQualifier::None),
 			  value(int64_t{0}),
 			  is_value(false),
+			  is_pack(false),
 			  is_array(false),
 			  is_template_template_arg(false),
 			  member_pointer_kind(MemberPointerKind::None) {}
@@ -1017,6 +1019,7 @@ struct TypeInfo {
 			  ref_qualifier(other.ref_qualifier),
 			  value(other.value),
 			  is_value(other.is_value),
+			  is_pack(other.is_pack),
 			  is_array(other.is_array),
 			  array_dimensions(other.array_dimensions),
 			  dependent_name(other.dependent_name),
@@ -1037,6 +1040,7 @@ struct TypeInfo {
 				ref_qualifier = other.ref_qualifier;
 				value = other.value;
 				is_value = other.is_value;
+				is_pack = other.is_pack;
 				is_array = other.is_array;
 				array_dimensions = other.array_dimensions;
 				dependent_name = other.dependent_name;

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -982,21 +982,74 @@ struct TypeInfo {
 	// For type arguments: stores TypeIndex (index into gTypeInfo)
 	// For non-type arguments: stores the value directly (supports int64_t, double, StringHandle)
 	struct TemplateArgInfo {
-		TypeIndex type_index{};		// Carries both gTypeInfo slot and TypeCategory
+		TypeIndex type_index;		// Carries both gTypeInfo slot and TypeCategory
 		InlineVector<CVQualifier, 4> pointer_cv_qualifiers;
-		size_t pointer_depth = 0;		  // Pointer indirection level
-		CVQualifier cv_qualifier = CVQualifier::None;  // cv-qualifiers on the argument
-		ReferenceQualifier ref_qualifier = ReferenceQualifier::None;
-		std::variant<int64_t, double, StringHandle> value = int64_t{0};	// For non-type arguments
-		bool is_value = false;		   // true if this is a non-type argument
-		bool is_array = false;
+		size_t pointer_depth;		  // Pointer indirection level
+		CVQualifier cv_qualifier;  // cv-qualifiers on the argument
+		ReferenceQualifier ref_qualifier;
+		std::variant<int64_t, double, StringHandle> value;	// For non-type arguments
+		bool is_value;		   // true if this is a non-type argument
+		bool is_array;
 		InlineVector<size_t, 2> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
 		StringHandle dependent_name;	 // Name of the dependent template parameter (for inner deduction)
 		std::optional<FunctionSignature> function_signature; // For function pointer template arguments
 		std::optional<ASTNode> dependent_expr;  // Original AST for dependent NTTP expressions (e.g., sizeof(T))
-		bool is_template_template_arg = false;  // true if this is a template template argument
+		bool is_template_template_arg;  // true if this is a template template argument
 		StringHandle template_name;  // Name of the template for template-template arguments
-		MemberPointerKind member_pointer_kind = MemberPointerKind::None;  // Distinguish member function vs data pointers
+		MemberPointerKind member_pointer_kind;  // Distinguish member function vs data pointers
+
+		TemplateArgInfo()
+			: type_index(),
+			  pointer_depth(0),
+			  cv_qualifier(CVQualifier::None),
+			  ref_qualifier(ReferenceQualifier::None),
+			  value(int64_t{0}),
+			  is_value(false),
+			  is_array(false),
+			  is_template_template_arg(false),
+			  member_pointer_kind(MemberPointerKind::None) {}
+
+		TemplateArgInfo(const TemplateArgInfo& other)
+			: type_index(other.type_index),
+			  pointer_cv_qualifiers(other.pointer_cv_qualifiers),
+			  pointer_depth(other.pointer_depth),
+			  cv_qualifier(other.cv_qualifier),
+			  ref_qualifier(other.ref_qualifier),
+			  value(other.value),
+			  is_value(other.is_value),
+			  is_array(other.is_array),
+			  array_dimensions(other.array_dimensions),
+			  dependent_name(other.dependent_name),
+			  function_signature(other.function_signature),
+			  dependent_expr(other.dependent_expr),
+			  is_template_template_arg(other.is_template_template_arg),
+			  template_name(other.template_name),
+			  member_pointer_kind(other.member_pointer_kind) {}
+
+		TemplateArgInfo(TemplateArgInfo&&) noexcept = default;
+
+		TemplateArgInfo& operator=(const TemplateArgInfo& other) {
+			if (this != &other) {
+				type_index = other.type_index;
+				pointer_cv_qualifiers = other.pointer_cv_qualifiers;
+				pointer_depth = other.pointer_depth;
+				cv_qualifier = other.cv_qualifier;
+				ref_qualifier = other.ref_qualifier;
+				value = other.value;
+				is_value = other.is_value;
+				is_array = other.is_array;
+				array_dimensions = other.array_dimensions;
+				dependent_name = other.dependent_name;
+				function_signature = other.function_signature;
+				dependent_expr = other.dependent_expr;
+				is_template_template_arg = other.is_template_template_arg;
+				template_name = other.template_name;
+				member_pointer_kind = other.member_pointer_kind;
+			}
+			return *this;
+		}
+
+		TemplateArgInfo& operator=(TemplateArgInfo&&) noexcept = default;
 
 		// Backward-compatible accessor: returns the first (outermost) array dimension if the type
 		// is a 1-D or multi-dimensional array, or nullopt if it is not an array.
@@ -1028,16 +1081,34 @@ struct TypeInfo {
 		struct Member {
 			StringHandle name;
 			InlineVector<TemplateArgInfo, 4> template_arguments;
-			bool has_template_arguments = false;
-			bool has_template_keyword = false;
+			bool has_template_arguments;
+			bool has_template_keyword;
+
+			Member()
+				: has_template_arguments(false),
+				  has_template_keyword(false) {}
+
+			Member(const Member&) = default;
+			Member(Member&&) noexcept = default;
+			Member& operator=(const Member&) = default;
+			Member& operator=(Member&&) noexcept = default;
 		};
 
-		OwnerKind owner_kind = OwnerKind::UnknownSpecialization;
+		OwnerKind owner_kind;
 		StringHandle owner_name;
 		TypeIndex owner_type;
 		InlineVector<TemplateArgInfo, 4> owner_template_arguments;
 		InlineVector<Member, 4> member_chain;
-		bool names_current_instantiation = false;
+		bool names_current_instantiation;
+
+		DependentQualifiedNameRecord()
+			: owner_kind(OwnerKind::UnknownSpecialization),
+			  names_current_instantiation(false) {}
+
+		DependentQualifiedNameRecord(const DependentQualifiedNameRecord&) = default;
+		DependentQualifiedNameRecord(DependentQualifiedNameRecord&&) noexcept = default;
+		DependentQualifiedNameRecord& operator=(const DependentQualifiedNameRecord&) = default;
+		DependentQualifiedNameRecord& operator=(DependentQualifiedNameRecord&&) noexcept = default;
 	};
 
  // Canonical template environment owned by instantiated types.

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2635,6 +2635,36 @@ private:
 // Unified call-expression node (consolidation plan step 1)
 // ============================================================================
 
+// Definition-context lookup state used by the first two-phase lookup record.
+// This is intentionally small: it snapshots the lexical point and namespace in
+// which a template definition was parsed.  Consumers may re-run ordinary lookup
+// and ADL against the current symbol table only after filtering candidates to
+// declarations whose source token was visible at this definition point.
+struct TemplateDefinitionLookupContext {
+	size_t definition_line = 0;
+	size_t definition_file_index = SIZE_MAX;
+	NamespaceHandle definition_namespace{};
+	StringHandle current_instantiation_name{};
+
+	bool is_valid() const {
+		return definition_line != 0 && definition_file_index != SIZE_MAX;
+	}
+};
+
+// Per-call semantic record for non-dependent unqualified function calls whose
+// lookup was completed in the template definition context.  The callee pointer
+// follows the same stable FunctionDeclarationNode identity already stored by
+// CalleeDescriptor; the definition context documents the lookup boundary used
+// to exclude later point-of-instantiation declarations.
+struct FunctionCallDefinitionLookupRecord {
+	TemplateDefinitionLookupContext definition_context;
+	StringHandle callee_name{};
+	const FunctionDeclarationNode* resolved_function = nullptr;
+	StringHandle resolved_mangled_name{};
+	bool ordinary_lookup_included = true;
+	bool argument_dependent_lookup_included = true;
+};
+
 // Describes what kind of call site this is.
 enum class CalleeKind : uint8_t {
 	FreeFunction,           // Direct call to a free/namespace-scoped function
@@ -2743,6 +2773,15 @@ public:
 	std::span<const ASTNode> template_arguments() const { return template_arguments_; }
 	bool has_template_arguments() const { return !template_arguments_.empty(); }
 
+// --- Definition-context lookup record ---
+void set_definition_lookup_record(const FunctionCallDefinitionLookupRecord& record) {
+	definition_lookup_record_ = record;
+}
+const std::optional<FunctionCallDefinitionLookupRecord>& definition_lookup_record() const {
+	return definition_lookup_record_;
+}
+bool has_definition_lookup_record() const { return definition_lookup_record_.has_value(); }
+
 private:
 	CalleeDescriptor callee_;
 	ASTNode receiver_;                   // Object for member-style calls (empty when absent)
@@ -2751,6 +2790,7 @@ private:
 	StringHandle mangled_name_;          // Pre-computed mangled name
 	StringHandle qualified_name_;        // Source-level qualified name (e.g., "ns::func")
 	std::vector<ASTNode> template_arguments_;  // Explicit template arguments
+	std::optional<FunctionCallDefinitionLookupRecord> definition_lookup_record_;
 };
 
 // Constructor call node - represents constructor calls like T(args)

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -960,9 +960,31 @@ struct TemplateArgumentNodeInfo {
 
 struct QualifiedTypeMemberAccess {
 	StringHandle member_name;
-	std::shared_ptr<std::vector<TemplateTypeArg>> template_arguments;
+	std::unique_ptr<std::vector<TemplateTypeArg>> template_arguments;
 	std::vector<TemplateArgumentNodeInfo> template_argument_infos;
 	bool has_template_arguments = false;
+
+	QualifiedTypeMemberAccess() = default;
+	QualifiedTypeMemberAccess(QualifiedTypeMemberAccess&&) = default;
+	QualifiedTypeMemberAccess& operator=(QualifiedTypeMemberAccess&&) = default;
+	QualifiedTypeMemberAccess(const QualifiedTypeMemberAccess& o)
+		: member_name(o.member_name)
+		, template_arguments(o.template_arguments
+			? std::make_unique<std::vector<TemplateTypeArg>>(*o.template_arguments)
+			: nullptr)
+		, template_argument_infos(o.template_argument_infos)
+		, has_template_arguments(o.has_template_arguments) {}
+	QualifiedTypeMemberAccess& operator=(const QualifiedTypeMemberAccess& o) {
+		if (this != &o) {
+			member_name = o.member_name;
+			template_arguments = o.template_arguments
+				? std::make_unique<std::vector<TemplateTypeArg>>(*o.template_arguments)
+				: nullptr;
+			template_argument_infos = o.template_argument_infos;
+			has_template_arguments = o.has_template_arguments;
+		}
+		return *this;
+	}
 };
 
 struct DeferredTemplateBaseClassSpecifier {

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -36,6 +36,7 @@ struct CallInfo {
 	StringHandle mangled_name;
 	StringHandle qualified_name;
 	std::span<const ASTNode> template_arguments;
+	const std::optional<FunctionCallDefinitionLookupRecord>* definition_lookup_record;
 	bool is_indirect;
 
 	// --- Factory helpers ---------------------------------------------------
@@ -51,6 +52,7 @@ struct CallInfo {
 		info.mangled_name          = node.mangled_name_handle();
 		info.qualified_name        = node.qualified_name_handle();
 		info.template_arguments    = node.template_arguments();
+		info.definition_lookup_record = &node.definition_lookup_record();
 		info.is_indirect           = node.callee().is_indirect();
 		return info;
 	}
@@ -68,6 +70,7 @@ struct CallMetadataCopyOptions {
 	bool copy_mangled_name = true;
 	bool copy_qualified_name = true;
 	bool copy_template_arguments = true;
+	bool copy_definition_lookup_record = true;
 };
 
 template <typename CallNodeT>
@@ -89,6 +92,11 @@ inline void copyCallMetadataFromInfo(
 			copied_template_args.push_back(template_arg);
 		}
 		target.set_template_arguments(std::move(copied_template_args));
+	}
+	if (options.copy_definition_lookup_record &&
+		source.definition_lookup_record != nullptr &&
+		source.definition_lookup_record->has_value()) {
+		target.set_definition_lookup_record(**source.definition_lookup_record);
 	}
 }
 
@@ -212,6 +220,16 @@ inline void setCallTemplateArguments(ExpressionNode& expr, std::vector<ASTNode>&
 	if (auto* call_expr = std::get_if<CallExprNode>(&expr)) {
 		call_expr->set_template_arguments(std::move(template_args));
 	}
+}
+
+inline void setCallDefinitionLookupRecord(ExpressionNode& expr, const FunctionCallDefinitionLookupRecord& record) {
+	if (auto* call_expr = std::get_if<CallExprNode>(&expr)) {
+		call_expr->set_definition_lookup_record(record);
+	}
+}
+
+inline void setCallDefinitionLookupRecord(CallExprNode& call_expr, const FunctionCallDefinitionLookupRecord& record) {
+	call_expr.set_definition_lookup_record(record);
 }
 
 inline void setCallTemplateArguments(CallExprNode& call_expr, std::vector<ASTNode>&& template_args) {

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -7202,18 +7202,10 @@ EvalResult Evaluator::materialize_constructor_object_value(
 		return std::move(*ctor_result);
 	}
 
-	// No matching constructor found - try aggregate initialization if arguments are provided.
-	// This handles cases like Pt{3, 7} where Pt is an aggregate with no user-defined constructors.
-	if (ctor_call.arguments().size() > 0) {
-		if (struct_info->hasUserDeclaredConstructor()) {
-			return EvalResult::error(std::string(StringBuilder()
-				.append("No matching constructor for '"sv)
-				.append(StringTable::getStringView(struct_info->getName()))
-				.append("' with "sv)
-				.append(std::to_string(ctor_call.arguments().size()))
-				.append(" argument(s) in constexpr evaluation"sv)
-				.commit()));
-		}
+	// No matching constructor found - try aggregate initialization for aggregates.
+	// This handles cases like Pt{3, 7}, and also empty list-initialization
+	// such as true_type{} where the object has no non-static data members.
+	if (!struct_info->hasUserDeclaredConstructor()) {
 		// Convert arguments to InitializerListNode for aggregate initialization
 		InitializerListNode init_list;
 		for (size_t i = 0; i < ctor_call.arguments().size(); ++i) {
@@ -7224,6 +7216,14 @@ EvalResult Evaluator::materialize_constructor_object_value(
 		if (agg_result.success()) {
 			return agg_result;
 		}
+	} else if (ctor_call.arguments().size() > 0) {
+		return EvalResult::error(std::string(StringBuilder()
+			.append("No matching constructor for '"sv)
+			.append(StringTable::getStringView(struct_info->getName()))
+			.append("' with "sv)
+			.append(std::to_string(ctor_call.arguments().size()))
+			.append(" argument(s) in constexpr evaluation"sv)
+			.commit()));
 	}
 	return EvalResult::error("No matching constructor found for constexpr object");
 }

--- a/src/ElfFileWriter_EH.cpp
+++ b/src/ElfFileWriter_EH.cpp
@@ -24,7 +24,7 @@ void ElfFileWriter::add_function_exception_info(std::string_view mangled_name, u
 	fde_info.function_length = function_size;
 	fde_info.function_symbol = std::move(mangled_name_str);
 	fde_info.has_exception_handling = !try_blocks.empty() || !cleanup_blocks.empty();
-	fde_info.cfi_instructions = cfi_instructions;  // Store CFI instructions
+	fde_info.cfi_instructions.assign(cfi_instructions.begin(), cfi_instructions.end());	// Store CFI instructions
 
 	functions_with_fdes_.push_back(fde_info);
 
@@ -43,7 +43,7 @@ void ElfFileWriter::add_function_exception_info(std::string_view mangled_name, u
 		// Landing pads are exception handlers and should not be in the call site table.
 
 		// Sort try blocks by start offset to process them in order
-		std::vector<ObjectFileWriter::TryBlockInfo> sorted_try_blocks = try_blocks;
+		std::vector<ObjectFileWriter::TryBlockInfo> sorted_try_blocks(try_blocks.begin(), try_blocks.end());
 		std::sort(sorted_try_blocks.begin(), sorted_try_blocks.end(),
 				  [](const auto& a, const auto& b) { return a.try_start_offset < b.try_start_offset; });
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -641,6 +641,136 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 		return nullptr;
 	}
 
+	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
+			type_info.dependentQualifiedName()) {
+		auto materialize_record_args =
+			[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) {
+			std::vector<TemplateTypeArg> materialized_args;
+			materialized_args.reserve(stored_args.size());
+			for (const TypeInfo::TemplateArgInfo& stored_arg : stored_args) {
+				TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
+				if (arg.dependent_name.isValid()) {
+					std::string_view dependent_arg_name =
+						StringTable::getStringView(arg.dependent_name);
+					if (auto subst_it = param_map_.find(dependent_arg_name);
+						subst_it != param_map_.end()) {
+						arg = rebindDependentTemplateTypeArg(subst_it->second, arg);
+					} else if (auto context_binding =
+							resolveContextBinding(arg.dependent_name, environment_);
+						context_binding.has_value()) {
+						arg = rebindDependentTemplateTypeArg(*context_binding, arg);
+					}
+				} else if (!arg.is_value && arg.type_index.is_valid()) {
+					if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+						std::string_view arg_type_name =
+							StringTable::getStringView(arg_type_info->name());
+						if (auto subst_it = param_map_.find(arg_type_name);
+							subst_it != param_map_.end()) {
+							arg = rebindDependentTemplateTypeArg(subst_it->second, arg);
+						}
+					}
+				}
+				materialized_args.push_back(std::move(arg));
+			}
+			return materialized_args;
+		};
+
+		std::string_view owner_name =
+			StringTable::getStringView(dependent_name->owner_name);
+		std::string_view materialized_owner_name;
+		if (dependent_name->owner_kind ==
+				TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter &&
+			dependent_name->owner_template_arguments.empty()) {
+			if (auto owner_subst_it = param_map_.find(owner_name);
+				owner_subst_it != param_map_.end()) {
+				const TypeInfo* owner_type_info =
+					tryGetTypeInfo(owner_subst_it->second.type_index);
+				if (owner_type_info != nullptr) {
+					materialized_owner_name =
+						StringTable::getStringView(owner_type_info->name());
+				}
+			}
+		} else {
+			std::vector<TemplateTypeArg> owner_args =
+				materialize_record_args(dependent_name->owner_template_arguments);
+			bool owner_args_still_dependent = false;
+			for (const TemplateTypeArg& arg : owner_args) {
+				if (arg.is_dependent) {
+					owner_args_still_dependent = true;
+					break;
+				}
+			}
+			if (!owner_args.empty() && !owner_args_still_dependent) {
+				if (auto owner_template_subst_it = param_map_.find(owner_name);
+					owner_template_subst_it != param_map_.end() &&
+					owner_template_subst_it->second.is_template_template_arg) {
+					owner_name = StringTable::getStringView(
+						owner_template_subst_it->second.template_name_handle);
+				}
+				Parser::AliasTemplateMaterializationResult materialized_owner =
+					parser_.materializeTemplateInstantiationForLookup(
+						owner_name,
+						owner_args);
+				if (!materialized_owner.instantiated_name.empty()) {
+					materialized_owner_name = materialized_owner.instantiated_name;
+				} else if (materialized_owner.resolved_type_info != nullptr) {
+					materialized_owner_name =
+						StringTable::getStringView(
+							materialized_owner.resolved_type_info->name());
+				}
+			}
+		}
+
+		if (!materialized_owner_name.empty()) {
+			std::vector<QualifiedTypeMemberAccess> member_chain;
+			member_chain.reserve(dependent_name->member_chain.size());
+			for (const auto& member_record : dependent_name->member_chain) {
+				QualifiedTypeMemberAccess member_access;
+				member_access.member_name = member_record.name;
+				if (member_record.has_template_arguments) {
+					std::vector<TemplateTypeArg> member_args =
+						materialize_record_args(member_record.template_arguments);
+					bool member_args_still_dependent = false;
+					for (const TemplateTypeArg& arg : member_args) {
+						if (arg.is_dependent) {
+							member_args_still_dependent = true;
+							break;
+						}
+					}
+					if (member_args_still_dependent) {
+						return nullptr;
+					}
+					member_access.has_template_arguments = true;
+					member_access.template_arguments =
+						std::make_shared<std::vector<TemplateTypeArg>>(
+							std::move(member_args));
+				}
+				member_chain.push_back(std::move(member_access));
+			}
+
+			const TypeInfo* resolved_type =
+				parser_.resolveBaseClassMemberTypeChain(
+					materialized_owner_name,
+					member_chain);
+			if (resolved_type != nullptr) {
+				const TypeInfo* next_dependent_type = nullptr;
+				if (const TypeInfo* alias_target =
+						tryGetTypeInfo(resolved_type->type_index_);
+					alias_target != nullptr &&
+					alias_target != resolved_type &&
+					alias_target->isDependentMemberType()) {
+					next_dependent_type = alias_target;
+				} else if (resolved_type->isDependentMemberType()) {
+					next_dependent_type = resolved_type;
+				}
+				if (next_dependent_type != nullptr) {
+					return resolveDependentMemberType(*next_dependent_type, depth + 1);
+				}
+				return resolved_type;
+			}
+		}
+	}
+
 	std::string_view type_name = StringTable::getStringView(type_info.name());
 	size_t member_sep = type_name.rfind("::");
 	if (member_sep == std::string_view::npos) {
@@ -700,6 +830,10 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 	}
 
 	return resolved_type;
+}
+
+const TypeInfo* ExpressionSubstitutor::resolveDependentMemberTypeForSubstitution(const TypeInfo& type_info) {
+	return resolveDependentMemberType(type_info, kInitialDependentMemberTypeResolutionDepth);
 }
 
 ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& call) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2,6 +2,7 @@
 #include "CallNodeHelpers.h"
 #include "Parser.h"
 #include "TemplateInstantiationHelper.h"
+#include "AstTraversal.h"
 #include "Log.h"
 #include <charconv>
 #include <limits>
@@ -240,7 +241,10 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 		}
 		self(self, current->parent);
 		for (const TemplateBinding& binding : current->bindings) {
-			if (!binding.name.isValid() || binding.args.empty()) {
+			if (!binding.name.isValid()) {
+				continue;
+			}
+			if (!binding.is_pack && binding.args.empty()) {
 				continue;
 			}
 			std::string_view binding_name = StringTable::getStringView(binding.name);
@@ -521,6 +525,81 @@ ExpressionSubstitutor::MaterializedStoredTemplateArgs ExpressionSubstitutor::mat
 		active_environment.bindings.empty() && active_environment.parent != nullptr
 		? *active_environment.parent
 		: active_environment;
+	auto expressionReferencesPackBinding = [&](const ASTNode& expr) {
+		bool references_pack = false;
+		AstTraversal::visitAST(expr, [&](const ASTNode& node) {
+			if (references_pack) {
+				return;
+			}
+			StringHandle candidate_name;
+			if (node.is<TemplateParameterReferenceNode>()) {
+				candidate_name = node.as<TemplateParameterReferenceNode>().param_name();
+			} else if (node.is<IdentifierNode>()) {
+				candidate_name = node.as<IdentifierNode>().getOrInternNameHandle();
+			} else if (node.is<QualifiedIdentifierNode>()) {
+				std::string_view ns_name =
+					gNamespaceRegistry.getQualifiedName(node.as<QualifiedIdentifierNode>().namespace_handle());
+				if (!ns_name.empty()) {
+					candidate_name = StringTable::getOrInternStringHandle(ns_name);
+				}
+			}
+			if (candidate_name.isValid() && pack_map_.find(candidate_name) != pack_map_.end()) {
+				references_pack = true;
+			}
+		});
+		return references_pack;
+	};
+	auto expandDependentValuePack =
+		[&](const TemplateTypeArg& pack_arg) -> std::optional<std::vector<TemplateTypeArg>> {
+		if (!pack_arg.is_value || !pack_arg.dependent_expr.has_value()) {
+			return std::nullopt;
+		}
+		if (!pack_arg.is_pack &&
+			!expressionReferencesPackBinding(*pack_arg.dependent_expr)) {
+			return std::nullopt;
+		}
+
+		std::optional<size_t> expansion_count;
+		for (const auto& [pack_name, pack_args] : pack_map_) {
+			(void)pack_name;
+			if (!expansion_count.has_value()) {
+				expansion_count = pack_args.size();
+			} else if (*expansion_count != pack_args.size()) {
+				return std::nullopt;
+			}
+		}
+		if (!expansion_count.has_value()) {
+			return std::nullopt;
+		}
+
+		std::vector<TemplateTypeArg> expanded_args;
+		expanded_args.reserve(*expansion_count);
+		for (size_t expansion_index = 0; expansion_index < *expansion_count; ++expansion_index) {
+			std::unordered_map<std::string_view, TemplateTypeArg> scalar_bindings = param_map_;
+			for (const auto& [pack_name, pack_args] : pack_map_) {
+				if (expansion_index >= pack_args.size()) {
+					return std::nullopt;
+				}
+				scalar_bindings[StringTable::getStringView(pack_name)] = pack_args[expansion_index];
+			}
+
+			ExpressionSubstitutor element_substitutor(scalar_bindings, parser_, template_param_order_);
+			element_substitutor.setCurrentOwnerTypeName(current_owner_type_name_);
+			ASTNode substituted_expr = element_substitutor.substitute(*pack_arg.dependent_expr);
+			if (auto eval_result = parser_.try_evaluate_constant_expression(substituted_expr)) {
+				expanded_args.emplace_back(eval_result->value, eval_result->type);
+				continue;
+			}
+
+			TemplateTypeArg unresolved_arg = pack_arg;
+			unresolved_arg.is_pack = false;
+			unresolved_arg.is_dependent = true;
+			unresolved_arg.dependent_expr = std::move(substituted_expr);
+			expanded_args.push_back(std::move(unresolved_arg));
+		}
+
+		return expanded_args;
+	};
 
 	for (const auto& arg : stored_args) {
 		TemplateTypeArg materialized_arg = toTemplateTypeArg(arg);
@@ -534,6 +613,16 @@ ExpressionSubstitutor::MaterializedStoredTemplateArgs ExpressionSubstitutor::mat
 			result.had_substitution = true;
 			substituted = true;
 		};
+
+		if (std::optional<std::vector<TemplateTypeArg>> expanded_pack_args =
+				expandDependentValuePack(materialized_arg);
+			expanded_pack_args.has_value()) {
+			result.had_substitution = true;
+			for (TemplateTypeArg& expanded_arg : *expanded_pack_args) {
+				result.args.push_back(std::move(expanded_arg));
+			}
+			continue;
+		}
 
 		if (materialized_arg.is_value && materialized_arg.dependent_expr.has_value()) {
 			const ASTNode& stored_expr = *materialized_arg.dependent_expr;
@@ -1995,6 +2084,7 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 	// has 1 arg), not the outer template's full param_map_ (e.g., ratio<_Num, _Den> has 2 params).
 	std::vector<TemplateTypeArg> inst_args;
 	bool source_instantiation_is_dependent = false;
+	bool materialized_had_substitution = false;
 
 	auto ns_name_handle = StringTable::getOrInternStringHandle(ns_name);
 	auto type_it = getTypesByNameMap().find(ns_name_handle);
@@ -2026,6 +2116,7 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 		}
 		MaterializedStoredTemplateArgs materialized_args =
 			materializeStoredTemplateArgs(*type_it->second, /*evaluate_dependent_member_values=*/true, kInitialDependentMemberTypeResolutionDepth);
+		materialized_had_substitution = materialized_args.had_substitution;
 		inst_args = std::move(materialized_args.args);
 	}
 
@@ -2084,7 +2175,8 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 	if (!inst_args.empty() &&
 		type_it != getTypesByNameMap().end() &&
 		type_it->second != nullptr &&
-		!source_instantiation_is_dependent) {
+		!source_instantiation_is_dependent &&
+		!materialized_had_substitution) {
 		// Namespace already names a concrete instantiation; keep it stable instead
 		// of rebuilding from reconstructed args, which can lose canonical type indices.
 		ExpressionNode& concrete_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
@@ -2111,6 +2203,26 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 			qual_id.identifier_token());
 		ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_qual_id);
 		return ASTNode(&new_expr);
+	}
+
+	// Empty pack expansion case: pack expanded to 0 elements, instantiate base template with 0 args
+	if (materialized_had_substitution && inst_args.empty() && !base_template_name.empty()) {
+		FLASH_LOG(Templates, Debug, "  Empty pack expansion for '", base_template_name, "', instantiating with 0 args");
+		Parser::AliasTemplateMaterializationResult materialized_namespace =
+			parser_.materializeTemplateInstantiationForLookup(base_template_name, {});
+		std::string_view instantiated_name = materialized_namespace.instantiated_name;
+		if (!instantiated_name.empty()) {
+			FLASH_LOG(Templates, Debug, "  Empty-pack substituted namespace: ", ns_name, " -> ", instantiated_name);
+			StringHandle instantiated_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
+			NamespaceHandle new_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+				NamespaceRegistry::GLOBAL_NAMESPACE,
+				instantiated_name_handle);
+			QualifiedIdentifierNode& new_qual_id = gChunkedAnyStorage.emplace_back<QualifiedIdentifierNode>(
+				new_ns_handle,
+				qual_id.identifier_token());
+			ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_qual_id);
+			return ASTNode(&new_expr);
+		}
 	}
 
 	// No template arguments - just return as-is
@@ -2327,6 +2439,30 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 
 	if (!token_type_name.empty()) {
 		FLASH_LOG(Templates, Debug, "  Type candidate for template substitution: ", token_type_name);
+
+		if (auto builtin_type = parser_.get_builtin_type_info(token_type_name); builtin_type.has_value()) {
+			TypeSpecifierNode builtin_spec(
+				nativeTypeIndex(builtin_type->first),
+				type.size_in_bits(),
+				type.token(),
+				type.cv_qualifier(),
+				type.reference_qualifier());
+			for (const PointerLevel& pointer_level : type.pointer_levels()) {
+				builtin_spec.add_pointer_level(pointer_level.cv_qualifier);
+			}
+			if (type.is_pack_expansion()) {
+				builtin_spec.set_pack_expansion(true);
+			}
+			if (type.is_array()) {
+				for (size_t dim : type.array_dimensions()) {
+					builtin_spec.add_array_dimension(dim);
+				}
+			}
+			if (type.has_function_signature()) {
+				builtin_spec.set_function_signature(type.function_signature());
+			}
+			return builtin_spec;
+		}
 
 		// Look up this template parameter in our substitution map.
 		auto it = param_map_.find(token_type_name);

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -831,8 +831,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 					}
 					member_access.has_template_arguments = true;
 					member_access.template_arguments =
-						std::make_shared<std::vector<TemplateTypeArg>>(
-							std::move(member_args));
+						std::make_unique<std::vector<TemplateTypeArg>>(std::move(member_args));
 				}
 				member_chain.push_back(std::move(member_access));
 			}

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -97,6 +97,8 @@ public:
 	/// @return A new expression with template parameters substituted
 	ASTNode substitute(const ASTNode& expr);
 
+	const TypeInfo* resolveDependentMemberTypeForSubstitution(const TypeInfo& type_info);
+
 	void setCurrentOwnerTypeName(StringHandle owner_type_name) {
 		current_owner_type_name_ = owner_type_name;
 	}

--- a/src/InlineVector.h
+++ b/src/InlineVector.h
@@ -83,7 +83,7 @@ public:
 		if (!using_inline_storage_) {
 			return heap_data_;
 		}
-		return std::vector<T>(begin(), end());
+		return std::vector<T>(cbegin(), cend());
 	}
 
 	InlineVector(const InlineVector& other) {
@@ -249,11 +249,11 @@ public:
 	using const_iterator = const T*;
 
 	iterator begin() noexcept { return data(); }
-	iterator end() noexcept { return size() == 0 ? begin() : begin() + static_cast<std::ptrdiff_t>(size()); }
+	iterator end() noexcept { return data() + static_cast<std::ptrdiff_t>(size()); }
 	const_iterator begin() const noexcept { return data(); }
-	const_iterator end() const noexcept { return size() == 0 ? begin() : begin() + static_cast<std::ptrdiff_t>(size()); }
+	const_iterator end() const noexcept { return data() + static_cast<std::ptrdiff_t>(size()); }
 	const_iterator cbegin() const noexcept { return data(); }
-	const_iterator cend() const noexcept { return size() == 0 ? cbegin() : cbegin() + static_cast<std::ptrdiff_t>(size()); }
+	const_iterator cend() const noexcept { return data() + static_cast<std::ptrdiff_t>(size()); }
 
 	iterator insert_at(size_t idx, const T& value) {
 		assert(idx <= size() && "Insert position out of bounds in InlineVector::insert_at");

--- a/src/IrGenerator_Expr_Primitives.cpp
+++ b/src/IrGenerator_Expr_Primitives.cpp
@@ -342,39 +342,8 @@ ExprResult AstToIr::generatePointerToMemberAccessIr(const PointerToMemberAccessN
 	return makeExprResult(member_type_index.withCategory(member_type), SizeInBits{static_cast<int>(member_size)}, IrOperand{result_var}, PointerDepth{}, ValueStorage::ContainsData);
 }
 
-static void requireResolvedCodegenType(TypeCategory type, std::string_view context) {
-	if (isPlaceholderAutoType(type)) {
-		throw InternalError(std::string(StringBuilder()
-											.append("Unresolved placeholder type reached codegen in ")
-											.append(context)
-											.append(" (type=")
-											.append(static_cast<int64_t>(type))
-											.append(")")
-											.commit()));
-	}
-}
-
 static TypeCategory resolveCodegenTypeCategory(const TypeSpecifierNode& type_node, std::string_view context) {
-	TypeCategory type = type_node.type();
-	if (!isPlaceholderAutoType(type)) {
-		return type;
-	}
-	if (type_node.type_index().is_valid()) {
-		if (const TypeInfo* type_info = tryGetTypeInfo(type_node.type_index())) {
-			TypeCategory resolved_type = type_info->typeEnum();
-			if (!isPlaceholderAutoType(resolved_type) && resolved_type != TypeCategory::Invalid) {
-				return resolved_type;
-			}
-		}
-	}
-	requireResolvedCodegenType(type, context);
-	return type;
-}
-
-static int resolveCodegenSizeBits(const TypeSpecifierNode& type_node, std::string_view context) {
-	TypeSpecifierNode resolved_type_node = type_node;
-	resolved_type_node.set_category(resolveCodegenTypeCategory(type_node, context));
-	return requireConcreteAliasResolvedTypeSizeBits(resolved_type_node, context);
+	return requireConcreteAliasResolvedCodegenTypeCategory(type_node, context);
 }
 
 int AstToIr::calculateIdentifierSizeBits(const TypeSpecifierNode& type_node, bool is_array, std::string_view identifier_name) {
@@ -391,11 +360,9 @@ int AstToIr::calculateIdentifierSizeBits(const TypeSpecifierNode& type_node, boo
 			// Fallback: if size_bits is 0, calculate from type. Placeholder types must
 			// be resolved before codegen reaches identifier lowering.
 		if (size_bits == 0) {
-			TypeSpecifierNode resolved_type_node = type_node;
-			resolved_type_node.set_category(resolveCodegenTypeCategory(type_node, "identifier size calculation"));
-			const int fallback_size = requireConcreteAliasResolvedTypeSizeBits(resolved_type_node, "identifier size calculation");
+			const int fallback_size = requireConcreteAliasResolvedCodegenSizeBits(type_node, "identifier size calculation");
 			FLASH_LOG(Codegen, Warning, "Parser returned size_bits=0 for identifier '", identifier_name,
-					  "' (type=", static_cast<int>(resolved_type_node.type()), ") - using fallback calculation (fallback_size=",
+					  "' (type=", static_cast<int>(type_node.type()), ") - using fallback calculation (fallback_size=",
 					  fallback_size, ")");
 			size_bits = fallback_size;
 		}
@@ -978,13 +945,8 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 					auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(current_struct_name_).append("::"sv).append(var_name_str));
 
 					int member_size_bits = static_cast<int>(static_member->size * 8);
-						// If size is 0 for struct types, look up from type info
 					if (member_size_bits == 0) {
-						const TypeInfo* member_type_info = tryGetTypeInfo(static_member->type_index);
-						const StructTypeInfo* member_si = member_type_info ? member_type_info->getStructInfo() : nullptr;
-						if (member_si) {
-							member_size_bits = static_cast<int>(member_si->sizeInBits().value);
-						}
+						member_size_bits = queryConcreteAliasResolvedStaticMemberSizeBits(*static_member);
 					}
 
 					if (context == ExpressionContext::LValueAddress && !static_member->is_reference()) {
@@ -1102,14 +1064,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 						.commit());
 				int member_size_bits = static_cast<int>(unique_match->static_member->size * 8);
 				if (member_size_bits == 0) {
-					if (const TypeInfo* member_type_info = tryGetTypeInfo(unique_match->static_member->type_index)) {
-						if (member_type_info->hasStoredSize()) {
-							member_size_bits = static_cast<int>(member_type_info->sizeInBits().value);
-						}
-					}
-					if (member_size_bits == 0) {
-						member_size_bits = get_type_size_bits(resolve_type_alias(unique_match->static_member->type_index));
-					}
+					member_size_bits = queryConcreteAliasResolvedStaticMemberSizeBits(*unique_match->static_member);
 				}
 
 				if (context == ExpressionContext::LValueAddress && !unique_match->static_member->is_reference()) {
@@ -1231,7 +1186,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 				// For simple assignments and function calls, we can return the reference directly
 			if (context == ExpressionContext::LValueAddress) {
 				TypeCategory pointee_type = type_node.type();
-				int pointee_size = resolveCodegenSizeBits(type_node, "reference identifier lvalue lowering");
+				int pointee_size = requireConcreteAliasResolvedCodegenSizeBits(type_node, "reference identifier lvalue lowering");
 
 				TypeIndex type_index = preserveSemanticTypeIndex(pointee_type, type_node.type_index());
 
@@ -1267,7 +1222,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 				// For non-array references in Load context, we need to dereference to get the value
 
 			TypeCategory pointee_type = type_node.category();
-			int pointee_size = resolveCodegenSizeBits(type_node, "reference identifier load lowering");
+			int pointee_size = requireConcreteAliasResolvedCodegenSizeBits(type_node, "reference identifier load lowering");
 
 			TypeCategory semantic_pointee_type = type_node.type();
 
@@ -1406,7 +1361,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 				if (context == ExpressionContext::LValueAddress) {
 					FLASH_LOG_FORMAT(Codegen, Debug, "VariableDecl reference '{}': Creating addr_temp for LValueAddress", identifierNode.name());
 					TypeCategory pointee_type = type_node.type();
-					int pointee_size = resolveCodegenSizeBits(type_node, "reference variable lvalue lowering");
+					int pointee_size = requireConcreteAliasResolvedCodegenSizeBits(type_node, "reference variable lvalue lowering");
 
 						// The reference variable holds a pointer address
 						// We need to load it into a temp and mark it with Indirect LValue metadata
@@ -1438,7 +1393,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 					// For Load context (reading the value), dereference to get the value
 
 				TypeCategory pointee_type = type_node.type();
-				int pointee_size = resolveCodegenSizeBits(type_node, "reference variable load lowering");
+				int pointee_size = requireConcreteAliasResolvedCodegenSizeBits(type_node, "reference variable load lowering");
 
 				int ptr_depth = type_node.pointer_depth() > 0 ? type_node.pointer_depth() : 1;
 				TempVar result_temp = emitDereference(pointee_type, 64, ptr_depth,
@@ -1847,13 +1802,8 @@ ExprResult AstToIr::generateQualifiedIdentifierIr(const QualifiedIdentifierNode&
 						// This is a static member access - generate GlobalLoad
 					FLASH_LOG(Codegen, Debug, "Found static member in owner struct: ", owner_struct->getName(), ", using qualified name with: ", qualified_struct_name);
 					int qsm_size_bits = static_cast<int>(static_member->size * 8);
-						// If size is 0 for struct types, look up from type info
 					if (qsm_size_bits == 0) {
-						const TypeInfo* qsm_type_info = tryGetTypeInfo(static_member->type_index);
-						const StructTypeInfo* qsm_si = qsm_type_info ? qsm_type_info->getStructInfo() : nullptr;
-						if (qsm_si) {
-							qsm_size_bits = static_cast<int>(qsm_si->sizeInBits().value);
-						}
+						qsm_size_bits = queryConcreteAliasResolvedStaticMemberSizeBits(*static_member);
 					}
 					TempVar result_temp = var_counter.next();
 					GlobalLoadOp op;

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -113,12 +113,14 @@ static int deriveElementStrideBitsFromType(
 	TypeIndex element_type_index,
 	int aggregate_fallback_bits) {
 	int element_stride_bits = get_type_size_bits(element_type);
-	if (element_stride_bits == 0 && element_type == TypeCategory::Struct && element_type_index.is_valid()) {
-		if (const TypeInfo* element_type_info = tryGetTypeInfo(element_type_index)) {
-			if (const StructTypeInfo* element_struct_info = element_type_info->getStructInfo()) {
-				element_stride_bits = static_cast<int>(element_struct_info->sizeInBits().value);
-			}
-		}
+	if (element_stride_bits == 0 && element_type_index.is_valid()) {
+		TypeSpecifierNode element_type_spec(
+			element_type_index.withCategory(element_type),
+			SizeInBits{0},
+			Token{},
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		element_stride_bits = queryConcreteAliasResolvedTypeSizeBits(element_type_spec).size_bits;
 	}
 
 	// Element type provided no usable stride — trust the carry-through verbatim.
@@ -457,13 +459,8 @@ ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubs
 			int element_size_bits = static_cast<int>(type_node.size_in_bits());
 			TypeIndex element_type_index = (type_node.category() == TypeCategory::Struct) ? type_node.type_index() : nativeTypeIndex(type_node.type());
 
-			// Get element size for struct types
-			if (element_size_bits == 0 && type_node.category() == TypeCategory::Struct && element_type_index.is_valid()) {
-				const TypeInfo& type_info = getTypeInfo(element_type_index);
-				const StructTypeInfo* struct_info = type_info.getStructInfo();
-				if (struct_info) {
-					element_size_bits = static_cast<int>(struct_info->sizeInBits().value);
-				}
+			if (element_size_bits == 0) {
+				element_size_bits = queryConcreteAliasResolvedTypeSizeBits(type_node).size_bits;
 			}
 
 			// Get all dimension sizes
@@ -837,12 +834,14 @@ ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubs
 						element_size_bits = element_pointer_depth > 0
 												? POINTER_SIZE_BITS
 												: get_type_size_bits(element_type);
-						if (element_size_bits == 0 && element_type == TypeCategory::Struct && element_type_index.is_valid()) {
-							if (const TypeInfo* element_type_info = tryGetTypeInfo(element_type_index)) {
-								if (const StructTypeInfo* element_struct_info = element_type_info->getStructInfo()) {
-									element_size_bits = static_cast<int>(element_struct_info->sizeInBits().value);
-								}
-							}
+						if (element_size_bits == 0 && element_type_index.is_valid()) {
+							TypeSpecifierNode element_spec(
+								element_type_index.withCategory(element_type),
+								SizeInBits{0},
+								Token{},
+								CVQualifier::None,
+								ReferenceQualifier::None);
+							element_size_bits = queryConcreteAliasResolvedTypeSizeBits(element_spec).size_bits;
 						}
 						is_pointer_to_array = true;
 						applied_subscript_pointer_conversion = true;
@@ -878,13 +877,8 @@ ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubs
 				} else {
 					// Get the element size from type_node
 					element_size_bits = static_cast<int>(type_node.size_in_bits());
-					// If still 0, compute from type info for struct types
-					if (element_size_bits == 0 && type_node.category() == TypeCategory::Struct && element_type_index.is_valid()) {
-						const TypeInfo& type_info = getTypeInfo(element_type_index);
-						const StructTypeInfo* struct_info = type_info.getStructInfo();
-						if (struct_info) {
-							element_size_bits = static_cast<int>(struct_info->sizeInBits().value);
-						}
+					if (element_size_bits == 0) {
+						element_size_bits = queryConcreteAliasResolvedTypeSizeBits(type_node).size_bits;
 					}
 				}
 			}
@@ -910,12 +904,8 @@ ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubs
 				} else {
 					// Single-level pointer/reference indexing yields the base object.
 					element_size_bits = static_cast<int>(type_node.size_in_bits());
-					if (element_size_bits == 0 && type_node.category() == TypeCategory::Struct && element_type_index.is_valid()) {
-						const TypeInfo& type_info = getTypeInfo(element_type_index);
-						const StructTypeInfo* struct_info = type_info.getStructInfo();
-						if (struct_info) {
-							element_size_bits = static_cast<int>(struct_info->sizeInBits().value);
-						}
+					if (element_size_bits == 0) {
+						element_size_bits = queryConcreteAliasResolvedTypeSizeBits(type_node).size_bits;
 					}
 					if (element_size_bits == 0) {
 						element_size_bits = get_type_size_bits(type_node.category());
@@ -1299,16 +1289,19 @@ ExprResult AstToIr::generateMemberAccessIr(const MemberAccessNode& memberAccessN
 	};
 
 	auto getStructObjectSizeBits = [&](TypeIndex object_type_index) -> int {
-		int size_bits = 0;
-		if (const TypeInfo* type_info = tryGetTypeInfo(object_type_index)) {
-			size_bits = type_info->sizeInBits().value;
-			if (size_bits == 0) {
-				if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
-					size_bits = struct_info->sizeInBits().value;
-				}
+		if (object_type_index.is_valid()) {
+			TypeSpecifierNode object_type(
+				object_type_index.withCategory(object_type_index.category()),
+				SizeInBits{0},
+				Token{},
+				CVQualifier::None,
+				ReferenceQualifier::None);
+			const int size_bits = queryConcreteAliasResolvedTypeSizeBits(object_type).size_bits;
+			if (size_bits > 0) {
+				return size_bits;
 			}
 		}
-		return size_bits == 0 ? 64 : size_bits;
+		return 64;
 	};
 
 	// OPERATOR-> OVERLOAD RESOLUTION
@@ -1698,11 +1691,8 @@ ExprResult AstToIr::generateMemberAccessIr(const MemberAccessNode& memberAccessN
 		TempVar result_var = var_counter.next();
 
 		int sm_size_bits = static_cast<int>(static_member->size * 8);
-		// If size is 0 for struct types, look up from type info
-		if (sm_size_bits == 0 && static_member->type_index.is_valid()) {
-			if (const StructTypeInfo* sm_si = tryGetStructTypeInfo(static_member->type_index)) {
-				sm_size_bits = static_cast<int>(sm_si->sizeInBits().value);
-			}
+		if (sm_size_bits == 0) {
+			sm_size_bits = queryConcreteAliasResolvedStaticMemberSizeBits(*static_member);
 		}
 
 		// Build GlobalLoadOp for the static member
@@ -1896,13 +1886,11 @@ std::optional<size_t> AstToIr::calculateArraySize(const DeclarationNode& decl) {
 	}
 
 	const TypeSpecifierNode& type_spec = decl.type_specifier_node();
-	size_t element_size = type_spec.size_in_bits() / 8;
-
-	// For struct types, get size from gTypeInfo instead of size_in_bits()
-	if (element_size == 0 && type_spec.category() == TypeCategory::Struct) {
-		if (const StructTypeInfo* struct_info = tryGetStructTypeInfo(type_spec.type_index())) {
-			element_size = toSizeT(struct_info->sizeInBytes());
-		}
+	TypeSpecifierNode element_type = type_spec;
+	element_type.set_array_dimensions({});
+	size_t element_size = 0;
+	if (std::optional<size_t> resolved_element_size = tryGetTypeSizeForSizeof(element_type)) {
+		element_size = *resolved_element_size;
 	}
 
 	if (element_size == 0) {
@@ -1965,12 +1953,8 @@ ExprResult AstToIr::generateSizeofIr(const SizeofExprNode& sizeofNode) {
 				if (static_member) {
 					// sizeof on a reference yields the size of the referenced type
 					if (static_member->is_reference()) {
-						size_t ref_size = get_type_size_bits(static_member->memberType()) / 8;
-						if (ref_size == 0 && static_member->memberType() == TypeCategory::Struct && static_member->type_index.is_valid()) {
-							if (const StructTypeInfo* si = tryGetStructTypeInfo(static_member->type_index)) {
-								ref_size = toSizeT(si->sizeInBytes());
-							}
-						}
+						const int ref_size_bits = queryConcreteAliasResolvedStaticMemberSizeBits(*static_member);
+						size_t ref_size = static_cast<size_t>(ref_size_bits) / 8;
 						FLASH_LOG(Codegen, Debug, "sizeof(struct_member): found static ref member, referenced type size=", ref_size);
 						return ref_size;
 					}
@@ -2089,29 +2073,8 @@ ExprResult AstToIr::generateSizeofIr(const SizeofExprNode& sizeofNode) {
 
 				// For regular variables, get the type size from the declaration
 				const TypeSpecifierNode& var_type = decl->type_specifier_node();
-				if (var_type.category() == TypeCategory::Struct) {
-					if (const TypeInfo* type_info = tryGetTypeInfo(var_type.type_index())) {
-						if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
-							if (struct_info->sizeInBytes().is_set()) {
-								return makeSizeTExprResult(toSizeT(struct_info->sizeInBytes()));
-							}
-						}
-						// Fallback: use fallback_size_bits_ from TypeInfo (works for template instantiations at global scope)
-						if (type_info->hasStoredSize()) {
-							return makeSizeTExprResult(static_cast<size_t>(type_info->sizeInBits().value) / 8);
-						}
-					}
-					// Fallback: use size_in_bits from the type specifier node
-					if (var_type.size_in_bits() > 0) {
-						return makeSizeTExprResult(var_type.size_in_bits() / 8);
-					}
-				} else {
-					// Primitive type - use get_type_size_bits to handle cases where size_in_bits wasn't set
-					int size_bits = var_type.size_in_bits();
-					if (size_bits == 0) {
-						size_bits = get_type_size_bits(var_type.category());
-					}
-					size_in_bytes = size_bits / 8;
+				if (std::optional<size_t> resolved_size = tryGetTypeSizeForSizeof(var_type)) {
+					size_in_bytes = *resolved_size;
 					return makeSizeTExprResult(size_in_bytes);
 				}
 			}
@@ -2222,16 +2185,11 @@ ExprResult AstToIr::generateSizeofIr(const SizeofExprNode& sizeofNode) {
 						const TypeSpecifierNode& var_type = decl->type_specifier_node();
 
 						// Get the base element type size
-						size_t element_size = var_type.size_in_bits() / 8;
-						if (element_size == 0) {
-							element_size = get_type_size_bits(var_type.category()) / 8;
-						}
-
-						// Handle struct element types
-						if (element_size == 0 && var_type.category() == TypeCategory::Struct) {
-							if (const StructTypeInfo* struct_info = tryGetStructTypeInfo(var_type.type_index())) {
-								element_size = toSizeT(struct_info->sizeInBytes());
-							}
+						size_t element_size = 0;
+						TypeSpecifierNode element_type = var_type;
+						element_type.set_array_dimensions({});
+						if (std::optional<size_t> resolved_element_size = tryGetTypeSizeForSizeof(element_type)) {
+							element_size = *resolved_element_size;
 						}
 
 						// For multidimensional arrays, arr[0] should return size of the sub-array

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -1652,7 +1652,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								ctor_op.resolved_constructor = matching_ctor;
 
 								// Get constructor parameter types for reference handling
-								const auto& ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::vector<ASTNode>{};
+								std::span<const ASTNode> ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::span<const ASTNode>{};
 
 								// Add each initializer as a constructor parameter
 								size_t arg_index = 0;
@@ -2548,7 +2548,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							ctor_op.resolved_constructor = matching_ctor;
 
 							// Get constructor parameter types for reference handling
-							const auto& ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::vector<ASTNode>{};
+							std::span<const ASTNode> ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::span<const ASTNode>{};
 
 							// Process constructor arguments with reference parameter handling
 							size_t arg_index = 0;

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -2232,11 +2232,6 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 				if (bits > 0) {
 					return bits;
 				}
-				if (type_node.category() == TypeCategory::Struct) {
-					if (const StructTypeInfo* si = tryGetStructTypeInfo(type_node.type_index())) {
-						return static_cast<int>(si->sizeInBits().value);
-					}
-				}
 				return get_type_size_bits(type_node.category());
 			};
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -3510,7 +3510,7 @@ ExprResult AstToIr::generateConstructorCallIr(const ConstructorCallNode& constru
 		}
 	}
 
-	const auto& ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::vector<ASTNode>{};
+	std::span<const ASTNode> ctor_params = matching_ctor ? matching_ctor->parameter_nodes() : std::span<const ASTNode>{};
 
 	// Generate IR for constructor arguments and add them to ctor_op.arguments
 	size_t arg_index = 0;

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -710,6 +710,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 					if (ns_handle.isGlobal()) {
 						return false;
 					}
+					if (global_symbol_table_ != nullptr &&
+						global_symbol_table_->has_namespace_symbols(ns_handle)) {
+						return false;
+					}
 					StringHandle owner_handle = gNamespaceRegistry.getQualifiedNameHandle(ns_handle);
 					if (!owner_handle.isValid()) {
 						owner_handle = StringTable::getOrInternStringHandle(gNamespaceRegistry.getName(ns_handle));
@@ -758,6 +762,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 			const auto& qualified_id = std::get<QualifiedIdentifierNode>(expr);
 			NamespaceHandle ns_handle = qualified_id.namespace_handle();
 			if (ns_handle.isGlobal()) {
+				return false;
+			}
+			if (global_symbol_table_ != nullptr &&
+				global_symbol_table_->has_namespace_symbols(ns_handle)) {
 				return false;
 			}
 			StringHandle owner_handle = gNamespaceRegistry.getQualifiedNameHandle(ns_handle);
@@ -898,9 +906,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 
 				// Check if static member has an initializer
 				op.is_initialized = static_member.initializer.has_value() || unresolved_identifier_initializer;
+				bool defer_constexpr_initializer = false;
 
- // Phase C: if a NormalizedInitializer with pre-packed bytes exists, use it
- // directly and skip all AST-based classification / evaluation.
+				// Phase C: if a NormalizedInitializer with pre-packed bytes exists, use it
+				// directly and skip all AST-based classification / evaluation.
 				if (static_member.normalized_init.has_value() && static_member.normalized_init->isConstant()) {
 					op.is_initialized = true;
 					op.init_data = static_member.normalized_init->constant_bytes;
@@ -922,16 +931,22 @@ void AstToIr::generateStaticMemberDeclarations() {
 						op.init_data.push_back(0);
 					}
 				};
+				auto can_defer_constexpr_initializer = [&]() {
+					if (!static_member.initializer.has_value()) {
+						return false;
+					}
+					if (!static_member_owner_is_template_dependent) {
+						return false;
+					}
+					if (hasUnsubstitutedTemplateDependency(*static_member.initializer, struct_info)) {
+						return true;
+					}
+					return hasMissingQualifiedOwner(*static_member.initializer);
+				};
 				auto fail_constexpr_initializer = [&](std::string_view reason) {
 					if (static_member.isStaticConstexpr()) {
-						if (static_member_owner_is_template_dependent &&
-							static_member.initializer.has_value() &&
-							hasUnsubstitutedTemplateDependency(*static_member.initializer, struct_info)) {
-							return;
-						}
-						if (reason == "initializer did not evaluate" &&
-							(!static_member.initializer.has_value() ||
-							 !hasMissingQualifiedOwner(*static_member.initializer))) {
+						if (can_defer_constexpr_initializer()) {
+							defer_constexpr_initializer = true;
 							return;
 						}
 						throw CompileError(
@@ -942,7 +957,7 @@ void AstToIr::generateStaticMemberDeclarations() {
 					}
 				};
 				auto write_back_constant_bytes = [&]() {
-					if (!op.init_data.empty()) {
+					if (!defer_constexpr_initializer && !op.init_data.empty()) {
 						if (StructStaticMember* mutable_member =
 								const_cast<StructTypeInfo*>(struct_info)->findStaticMember(static_member.getName())) {
 							NormalizedInitializer ni;
@@ -988,6 +1003,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 												node.as<InitializerListNode>(),
 												element_ctx);
 											if (!object_result.success()) {
+												fail_constexpr_initializer(
+													object_result.error_message.empty()
+														? "struct-array element initializer did not evaluate"
+														: std::string_view(object_result.error_message));
 												auto eval_leaf = [&](const ASTNode& leaf_expr, TypeCategory target_type) {
 													return evalAggregateLeafToRaw(leaf_expr, target_type, struct_info);
 												};
@@ -1085,6 +1104,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 									0,
 									0);
 							} else {
+								fail_constexpr_initializer(
+									object_result.error_message.empty()
+										? "aggregate initializer did not evaluate"
+										: std::string_view(object_result.error_message));
 								auto eval_leaf = [&](const ASTNode& leaf_expr, TypeCategory target_type) {
 									return evalAggregateLeafToRaw(leaf_expr, target_type, struct_info);
 								};
@@ -1633,6 +1656,13 @@ void AstToIr::generateStaticMemberDeclarations() {
 				} else if (!allowNormalizedWriteBack && !op.init_data.empty()) {
 					FLASH_LOG(Codegen, Debug, "Skipping Phase C write-back for '", qualified_name,
 							  "' because bytes came from a fallback zero-initialization path");
+				}
+
+				if (defer_constexpr_initializer) {
+					FLASH_LOG(Codegen, Debug, "Deferring static constexpr member '", qualified_name,
+							  "' because its initializer still depends on an unavailable template owner");
+					emitted_static_members_.erase(name_handle);
+					continue;
 				}
 
 				// static const/constexpr members with constant initializers go to .rodata (read-only).

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -669,14 +669,68 @@ void AstToIr::generateStaticMemberDeclarations() {
 		return 0;
 	};
 
+	auto isDependentStaticInitTypeInfo = [](const TypeInfo* type_info) {
+		if (type_info == nullptr) {
+			return false;
+		}
+		return type_info->isDependentPlaceholder() ||
+			   type_info->is_incomplete_instantiation_ ||
+			   type_info->hasDependentQualifiedName() ||
+			   type_info->isTemplatePlaceholder();
+	};
+	auto isTemplateOwnedOrDependentTypeInfo = [&](const TypeInfo* type_info) {
+		return isDependentStaticInitTypeInfo(type_info) ||
+			   (type_info != nullptr &&
+				(type_info->isTemplateInstantiation() || type_info->hasInstantiationContext()));
+	};
+	auto isTemplateOwnedOrDependentTypeName = [&](StringHandle type_name_handle) {
+		if (!type_name_handle.isValid()) {
+			return false;
+		}
+		if (gTemplateRegistry.lookupTemplate(type_name_handle).has_value()) {
+			return true;
+		}
+		if (gTemplateRegistry.isPatternStructName(type_name_handle)) {
+			return true;
+		}
+		std::string_view type_name_view = StringTable::getStringView(type_name_handle);
+		size_t separator = type_name_view.size();
+		while ((separator = type_name_view.rfind("::", separator)) != std::string_view::npos) {
+			std::string_view owner_name_view = type_name_view.substr(0, separator);
+			StringHandle owner_name_handle = StringTable::getOrInternStringHandle(owner_name_view);
+			if (gTemplateRegistry.lookupTemplate(owner_name_handle).has_value()) {
+				return true;
+			}
+			if (gTemplateRegistry.isPatternStructName(owner_name_handle)) {
+				return true;
+			}
+			if (auto owner_it = getTypesByNameMap().find(owner_name_handle);
+				owner_it != getTypesByNameMap().end() &&
+				isTemplateOwnedOrDependentTypeInfo(owner_it->second)) {
+				return true;
+			}
+			if (separator == 0) {
+				break;
+			}
+			--separator;
+		}
+		return false;
+	};
 	auto hasUnsubstitutedTemplateDependency = [&](const ASTNode& initializer, const StructTypeInfo* owner_struct) -> bool {
-		auto hasUnresolvedTypeSpecifier = [](const ASTNode& node) {
+		auto hasUnresolvedTypeSpecifier = [&](const ASTNode& node) {
 			if (!node.is<TypeSpecifierNode>()) {
 				return false;
 			}
 
 			const auto& type_spec = node.as<TypeSpecifierNode>();
-			return type_spec.type_index().needsTypeIndex() && !type_spec.type_index().is_valid();
+			const TypeIndex type_index = type_spec.type_index();
+			if (type_index.needsTypeIndex()) {
+				if (!type_index.is_valid()) {
+					return true;
+				}
+				return isDependentStaticInitTypeInfo(tryGetTypeInfo(type_index));
+			}
+			return false;
 		};
 
 		return RebindStaticMemberAst::visitASTUntil(initializer, [&](const ASTNode& current) {
@@ -702,10 +756,7 @@ void AstToIr::generateStaticMemberDeclarations() {
 				return true;
 			}
 
-			if (current.is<ExpressionNode>()) {
-				const ExpressionNode& expr = current.as<ExpressionNode>();
-				if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
-					const auto& qualified_id = std::get<QualifiedIdentifierNode>(expr);
+			auto qualifiedIdentifierHasDependency = [&](const QualifiedIdentifierNode& qualified_id) {
 					NamespaceHandle ns_handle = qualified_id.namespace_handle();
 					if (ns_handle.isGlobal()) {
 						return false;
@@ -721,19 +772,33 @@ void AstToIr::generateStaticMemberDeclarations() {
 					if (!owner_handle.isValid()) {
 						return false;
 					}
+					std::string_view owner_name_view = StringTable::getStringView(owner_handle);
+					if (owner_name_view.find('$') != std::string_view::npos) {
+						return true;
+					}
 
 					if (const TypeInfo* owner_type = lookupTypeInCurrentContext(owner_handle)) {
-						if (!owner_type->isDependentPlaceholder() && !owner_type->is_incomplete_instantiation_) {
+						if (!isTemplateOwnedOrDependentTypeInfo(owner_type)) {
 							return false;
 						}
+						return true;
 					}
-					if (getTypesByNameMap().find(owner_handle) != getTypesByNameMap().end()) {
-						return false;
+					if (auto type_it = getTypesByNameMap().find(owner_handle);
+						type_it != getTypesByNameMap().end()) {
+						return isTemplateOwnedOrDependentTypeInfo(type_it->second);
 					}
 					if (gTemplateRegistry.lookupTemplate(owner_handle).has_value()) {
 						return false;
 					}
 					return true;
+			};
+			if (current.is<QualifiedIdentifierNode>()) {
+				return qualifiedIdentifierHasDependency(current.as<QualifiedIdentifierNode>());
+			}
+			if (current.is<ExpressionNode>()) {
+				const ExpressionNode& expr = current.as<ExpressionNode>();
+				if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
+					return qualifiedIdentifierHasDependency(std::get<QualifiedIdentifierNode>(expr));
 				}
 			}
 
@@ -752,14 +817,19 @@ void AstToIr::generateStaticMemberDeclarations() {
 	};
 	auto hasMissingQualifiedOwner = [&](const ASTNode& initializer) -> bool {
 		return RebindStaticMemberAst::visitASTUntil(initializer, [&](const ASTNode& current) {
-			if (!current.is<ExpressionNode>()) {
+			const QualifiedIdentifierNode* qualified_id_ptr = nullptr;
+			if (current.is<QualifiedIdentifierNode>()) {
+				qualified_id_ptr = &current.as<QualifiedIdentifierNode>();
+			} else if (current.is<ExpressionNode>()) {
+				const ExpressionNode& expr = current.as<ExpressionNode>();
+				if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
+					qualified_id_ptr = &std::get<QualifiedIdentifierNode>(expr);
+				}
+			}
+			if (qualified_id_ptr == nullptr) {
 				return false;
 			}
-			const ExpressionNode& expr = current.as<ExpressionNode>();
-			if (!std::holds_alternative<QualifiedIdentifierNode>(expr)) {
-				return false;
-			}
-			const auto& qualified_id = std::get<QualifiedIdentifierNode>(expr);
+			const auto& qualified_id = *qualified_id_ptr;
 			NamespaceHandle ns_handle = qualified_id.namespace_handle();
 			if (ns_handle.isGlobal()) {
 				return false;
@@ -775,8 +845,9 @@ void AstToIr::generateStaticMemberDeclarations() {
 			if (!owner_handle.isValid()) {
 				return false;
 			}
-			if (getTypesByNameMap().find(owner_handle) != getTypesByNameMap().end()) {
-				return false;
+			if (auto type_it = getTypesByNameMap().find(owner_handle);
+				type_it != getTypesByNameMap().end()) {
+				return isDependentStaticInitTypeInfo(type_it->second);
 			}
 			return !gTemplateRegistry.lookupTemplate(owner_handle).has_value();
 		});
@@ -819,6 +890,10 @@ void AstToIr::generateStaticMemberDeclarations() {
 				bool static_member_owner_is_template_dependent =
 					type_info->isTemplateInstantiation() ||
 					type_info->is_incomplete_instantiation_ ||
+					type_info->hasInstantiationContext() ||
+					type_info->hasDependentQualifiedName() ||
+					type_info->isDependentPlaceholder() ||
+					isTemplateOwnedOrDependentTypeName(static_member_owner_name) ||
 					gTemplateRegistry.lookupTemplate(static_member_owner_name).has_value();
 
 				bool unresolved_identifier_initializer = false;

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -1006,9 +1006,10 @@ inline void appendItaniumTypeTemplateArgs(
 		arg = normalizeTemplateTypeArgForMangling(arg);
 		if (arg.is_value) {
 			// Non-type template argument (value)
+			FlashCpp::NonTypeValueIdentity identity = arg.valueIdentity();
 			output += 'L';
 			// Use type code based on arg.category()
-			switch (arg.category()) {
+			switch (identity.valueTypeCategory()) {
 			case TypeCategory::Int:
 				output += 'i';
 				break;
@@ -1033,11 +1034,37 @@ inline void appendItaniumTypeTemplateArgs(
 			case TypeCategory::Char:
 				output += 'c';
 				break;
-			default:
-				output += 'i';
-				break;  // Default to int
+			case TypeCategory::Nullptr:
+				output += "Dn";
+				break;
+			case TypeCategory::Struct:
+			case TypeCategory::UserDefined:
+			case TypeCategory::TypeAlias:
+			case TypeCategory::Enum: {
+				if (identity.value_type_index.index() >= getTypeInfoCount()) {
+					throw CompileError("Itanium name mangling: unknown struct/enum NTTP type index — cannot generate valid symbol");
+				}
+				const TypeInfo& type_info = getTypeInfo(identity.value_type_index);
+				auto type_name = StringTable::getStringView(type_info.name());
+				output += std::to_string(type_name.size());
+				output += type_name;
+				break;
 			}
-			output += std::to_string(arg.value);
+			default:
+				throw CompileError("Itanium name mangling: unsupported non-type template argument category — cannot generate valid symbol");
+			}
+			if (identity.kind == FlashCpp::NonTypeValueIdentityKind::ObjectPointer ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::Reference ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::FunctionPointer ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer) {
+				const size_t identity_hash = identity.hash();
+				output += "u";
+				output += std::to_string(identity_hash);
+			} else if (identity.kind == FlashCpp::NonTypeValueIdentityKind::Nullptr) {
+				output += "0";
+			} else {
+				output += std::to_string(identity.value);
+			}
 			output += 'E';
 		} else {
 			// Type template argument - encode the type

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -1053,10 +1053,31 @@ inline void appendItaniumTypeTemplateArgs(
 			default:
 				throw CompileError("Itanium name mangling: unsupported non-type template argument category — cannot generate valid symbol");
 			}
-			if (identity.kind == FlashCpp::NonTypeValueIdentityKind::ObjectPointer ||
-				identity.kind == FlashCpp::NonTypeValueIdentityKind::Reference ||
-				identity.kind == FlashCpp::NonTypeValueIdentityKind::FunctionPointer ||
-				identity.kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer) {
+			if (identity.kind == FlashCpp::NonTypeValueIdentityKind::ObjectPointer &&
+				identity.entity_name.isValid()) {
+				// Itanium ABI: address-of external name → X ad L _Z <len><name> E E
+				std::string_view entity = identity.entity_name.view();
+				output += "XadL_Z";
+				output += std::to_string(entity.size());
+				output += entity;
+				output += "EE";
+			} else if (identity.kind == FlashCpp::NonTypeValueIdentityKind::Reference &&
+				identity.entity_name.isValid()) {
+				// Itanium ABI: external-name reference → X L _Z <len><name> E E
+				std::string_view entity = identity.entity_name.view();
+				output += "XL_Z";
+				output += std::to_string(entity.size());
+				output += entity;
+				output += "EE";
+			} else if (identity.kind == FlashCpp::NonTypeValueIdentityKind::FunctionPointer ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::ObjectPointer ||
+				identity.kind == FlashCpp::NonTypeValueIdentityKind::Reference) {
+				// TODO(item-8): Encode FunctionPointer with full Itanium function-signature
+				// mangling (XadL_Z<mangled-function>EE) once function-pointer NTTP evaluation
+				// is implemented. MemberPointer encoding (Xad<member-external-name>EE) likewise
+				// requires constexpr member-pointer evaluation. Until then use a vendor-extended
+				// hash to ensure uniqueness.
 				const size_t identity_hash = identity.hash();
 				output += "u";
 				output += std::to_string(identity_hash);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1062,6 +1062,7 @@ private:
 	size_t phase1_cutoff_line_ = 0;
 	size_t phase1_cutoff_file_idx_ = SIZE_MAX;
 	std::optional<Token> phase1_violation_token_;
+	const TemplateDefinitionLookupContext* current_template_definition_lookup_context_ = nullptr;
 
 	// Add parsing depth counter to detect infinite loops
 	// This is incremented/decremented in critical parsing functions
@@ -3227,18 +3228,28 @@ private:	 // Resume private methods
 	std::optional<ASTNode> lookup_symbol_with_template_check(StringHandle identifier);
 
 	void filterPhase1OrdinaryFunctionOverloads(std::vector<ASTNode>& overloads) {
-		if (phase1_cutoff_line_ == 0) {
+		const TemplateDefinitionLookupContext* definition_context =
+			current_template_definition_lookup_context_;
+		const size_t cutoff_line =
+			definition_context != nullptr && definition_context->is_valid()
+			? definition_context->definition_line
+			: phase1_cutoff_line_;
+		const size_t cutoff_file_idx =
+			definition_context != nullptr && definition_context->is_valid()
+			? definition_context->definition_file_index
+			: phase1_cutoff_file_idx_;
+		if (cutoff_line == 0) {
 			return;
 		}
 		auto declaration_is_after_definition = [&](const Token& decl_tok) {
-			if (decl_tok.file_index() != phase1_cutoff_file_idx_) {
+			if (decl_tok.file_index() != cutoff_file_idx) {
 				return false;
 			}
 			size_t decl_src_line = lexer_.getSourceLine(decl_tok.line());
-			size_t cutoff_src_line = lexer_.getSourceLine(phase1_cutoff_line_);
+			size_t cutoff_src_line = lexer_.getSourceLine(cutoff_line);
 			return (decl_src_line > 0 && cutoff_src_line > 0)
 				? decl_src_line > cutoff_src_line
-				: decl_tok.line() > phase1_cutoff_line_;
+				: decl_tok.line() > cutoff_line;
 		};
 		overloads.erase(
 			std::remove_if(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1528,6 +1528,7 @@ private:
 		int64_t value;
 		TypeCategory type;
 		TypeIndex type_index{};
+		FlashCpp::NonTypeValueIdentity identity{};
 	};
 
 	enum TokenDestroyPattern {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1792,7 +1792,8 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		CommitInstantiation = 1u << 3,
 		RegisterInstantiation = 1u << 4,
 		MemoizeBodyReparseFailure = 1u << 5,
-		RunInlineHeuristic = 1u << 6
+		RunInlineHeuristic = 1u << 6,
+		SkipBodyMaterialization = 1u << 7
 	};
 	static constexpr FunctionTemplateInstantiationFlags mergeInstantiationFlags(
 		FunctionTemplateInstantiationFlags lhs,
@@ -2399,7 +2400,8 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		const ASTNode& template_node,
 		std::span<const TemplateTypeArg> template_args,
 		const FlashCpp::TemplateInstantiationKey& key,
-		std::span<const TypeSpecifierNode> call_arg_types);
+		std::span<const TypeSpecifierNode> call_arg_types,
+		bool materialize_body);
 	bool buildSubstitutionForPackElement(
 		StringHandle pack_param_name,
 		size_t pack_element_offset,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2162,7 +2162,7 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 				concrete_arg.is_value = true;
 				concrete_arg.is_dependent = false;
 				concrete_arg.dependent_name = {};
-				concrete_arg.type_index = nativeTypeIndex(value->type);
+				concrete_arg.type_index = value->type_index;
 				concrete_arg.value = value->value;
 				continue;
 			}
@@ -2212,7 +2212,12 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 								concrete_arg.is_value = true;
 								concrete_arg.is_dependent = false;
 								concrete_arg.dependent_name = {};
-								concrete_arg.type_index = nativeTypeIndex(value->type);
+								concrete_arg.type_index = static_member_decl.type_index;
+								if (concrete_arg.type_index.category() == TypeCategory::Invalid ||
+									concrete_arg.type_index.category() == TypeCategory::Auto ||
+									concrete_arg.type_index.category() == TypeCategory::DeclTypeAuto) {
+									concrete_arg.type_index = value->type_index;
+								}
 								concrete_arg.value = value->value;
 								break;
 							}
@@ -2238,7 +2243,12 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 				concrete_arg.is_value = true;
 				concrete_arg.is_dependent = false;
 				concrete_arg.dependent_name = {};
-				concrete_arg.type_index = nativeTypeIndex(value->type);
+				concrete_arg.type_index = static_member->type_index;
+				if (concrete_arg.type_index.category() == TypeCategory::Invalid ||
+					concrete_arg.type_index.category() == TypeCategory::Auto ||
+					concrete_arg.type_index.category() == TypeCategory::DeclTypeAuto) {
+					concrete_arg.type_index = value->type_index;
+				}
 				concrete_arg.value = value->value;
 			}
 		}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -22,6 +22,29 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 			return arg.is_dependent || arg.dependent_name.isValid() || arg.is_pack;
 		});
 }
+
+bool isEligibleDefinitionLookupCall(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const ASTNode& resolved_decl) {
+	if (definition_context == nullptr ||
+		!definition_context->is_valid() ||
+		has_deferred_template_call_args ||
+		callee_token.type() != Token::Type::Identifier ||
+		!resolved_decl.is<FunctionDeclarationNode>()) {
+		return false;
+	}
+	for (const TypeSpecifierNode& arg_type : arg_types) {
+		if (arg_type.category() == TypeCategory::Auto ||
+			arg_type.category() == TypeCategory::Template ||
+			!arg_type.type_index().is_valid()) {
+			return false;
+		}
+	}
+	return true;
+}
 }
 
 // Helper function to check if a template name is a template-template parameter
@@ -4648,6 +4671,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
+				const bool has_deferred_template_call_args =
+					argsHaveDeferredTemplateDependency(args_ref, currentTemplateParamNames()) ||
+					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
+
 				auto make_call_result = [&](const ASTNode& resolved_decl) -> ParseResult {
 					const DeclarationNode* decl_ptr = getDeclarationNode(resolved_decl);
 					if (!decl_ptr) {
@@ -4662,6 +4689,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (!func_decl.parent_struct_name().empty()) {
 							setCallQualifiedName(result->as<ExpressionNode>(), StringBuilder().append(func_decl.parent_struct_name()).append("::").append(func_decl.decl_node().identifier_token().value()).commit());
 						}
+						if (isEligibleDefinitionLookupCall(
+								current_template_definition_lookup_context_,
+								identifier_token,
+								arg_types,
+								has_deferred_template_call_args,
+								resolved_decl)) {
+							FunctionCallDefinitionLookupRecord record;
+							record.definition_context = *current_template_definition_lookup_context_;
+							record.callee_name = identifier_token.handle();
+							record.resolved_function = &func_decl;
+							if (func_decl.has_mangled_name()) {
+								record.resolved_mangled_name =
+									StringTable::getOrInternStringHandle(func_decl.mangled_name());
+							}
+							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), record);
+						}
 					}
 					return ParseResult::success(*result);
 				};
@@ -4674,10 +4717,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						makeDirectCallExpr(placeholder_decl.as<DeclarationNode>(), std::move(args_ref), identifier_token));
 					return ParseResult::success(*result);
 				};
-
-				const bool has_deferred_template_call_args =
-					argsHaveDeferredTemplateDependency(args_ref, currentTemplateParamNames()) ||
-					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 
 				if (all_overloads.empty()) {
 					std::optional<ASTNode> instantiated_func;

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -705,7 +705,7 @@ std::optional<BaseClassPostTemplateInfo> Parser::consume_base_class_qualifiers_a
 				return std::nullopt;
 			}
 			member_access.has_template_arguments = true;
-			member_access.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>(std::move(member_template_args).value().toVector());
+			member_access.template_arguments = std::make_unique<std::vector<TemplateTypeArg>>(std::move(member_template_args).value().toVector());
 			member_access.template_argument_infos =
 				build_template_arg_infos(*member_access.template_arguments, member_template_arg_nodes);
 		}
@@ -1392,7 +1392,7 @@ TypeIndex Parser::substitute_template_parameter(
 					}
 					member_access.has_template_arguments = true;
 					member_access.template_arguments =
-						std::make_shared<std::vector<TemplateTypeArg>>(std::move(member_args));
+						std::make_unique<std::vector<TemplateTypeArg>>(std::move(member_args));
 				}
 				member_type_chain.push_back(std::move(member_access));
 			}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -744,7 +744,9 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 
 	const TypeInfo* resolved_type = nullptr;
 	std::string_view current_base_name = base_class_name;
-	for (const QualifiedTypeMemberAccess& member_access : member_type_chain) {
+	for (size_t member_index = 0; member_index < member_type_chain.size(); ++member_index) {
+		const QualifiedTypeMemberAccess& member_access = member_type_chain[member_index];
+		const bool is_last_member = member_index + 1 == member_type_chain.size();
 		std::string_view member_name = StringTable::getStringView(member_access.member_name);
 		if (member_access.has_template_arguments) {
 			std::string_view qualified_member_template_name =
@@ -818,25 +820,27 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 			return nullptr;
 		}
 
-		size_t max_alias_depth = 10;
-		while (max_alias_depth-- > 0) {
-			const TypeInfo* underlying = tryGetTypeInfo(resolved_type->type_index_);
-			if (underlying == nullptr || underlying == resolved_type) {
-				break;
-			}
+		if (!is_last_member) {
+			size_t max_alias_depth = 10;
+			while (max_alias_depth-- > 0) {
+				const TypeInfo* underlying = tryGetTypeInfo(resolved_type->type_index_);
+				if (underlying == nullptr || underlying == resolved_type) {
+					break;
+				}
 
-			FLASH_LOG_FORMAT(
-				Templates,
-				Debug,
-				"Resolving base member alias '{}::{}' -> underlying type_index={}, type={}",
-				current_base_name,
-				member_name,
-				resolved_type->type_index_,
-				static_cast<int>(underlying->category()));
+				FLASH_LOG_FORMAT(
+					Templates,
+					Debug,
+					"Resolving base member alias '{}::{}' -> underlying type_index={}, type={}",
+					current_base_name,
+					member_name,
+					resolved_type->type_index_,
+					static_cast<int>(underlying->category()));
 
-			resolved_type = underlying;
-			if (underlying->isStruct()) {
-				break;
+				resolved_type = underlying;
+				if (underlying->isStruct()) {
+					break;
+				}
 			}
 		}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1320,6 +1320,88 @@ TypeIndex Parser::substitute_template_parameter(
 		return current_type_index.withCategory(current_type);
 	}
 
+	if (const TypeInfo* indexed_type_info = tryGetTypeInfo(current_type_index);
+		indexed_type_info != nullptr &&
+		indexed_type_info->isDependentMemberType() &&
+		indexed_type_info->hasDependentQualifiedName()) {
+		const TypeInfo::DependentQualifiedNameRecord* dependent_name =
+			indexed_type_info->dependentQualifiedName();
+		auto materializeRecordArgs =
+			[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) {
+			std::vector<TemplateTypeArg> materialized_args;
+			materialized_args.reserve(stored_args.size());
+			for (const TypeInfo::TemplateArgInfo& stored_arg : stored_args) {
+				TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
+				if (arg.dependent_name.isValid()) {
+					forEachNonPackTemplateParamArgBinding(
+						template_params,
+						template_args,
+						[&](const TemplateParameterNode& template_param, const TemplateTypeArg& template_arg, size_t) {
+							if (template_param.nameHandle() == arg.dependent_name) {
+								arg = rebindDependentTemplateTypeArg(template_arg, arg);
+							}
+						});
+				}
+				materialized_args.push_back(std::move(arg));
+			}
+			return materialized_args;
+		};
+		std::string_view owner_name = StringTable::getStringView(dependent_name->owner_name);
+		std::string_view materialized_owner_name;
+		if (dependent_name->owner_kind ==
+				TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter &&
+			dependent_name->owner_template_arguments.empty()) {
+			forEachNonPackTemplateParamArgBinding(
+				template_params,
+				template_args,
+				[&](const TemplateParameterNode& template_param, const TemplateTypeArg& template_arg, size_t) {
+					if (!materialized_owner_name.empty() || template_param.name() != owner_name) {
+						return;
+					}
+					if (const TypeInfo* owner_type_info = tryGetTypeInfo(template_arg.type_index)) {
+						materialized_owner_name = StringTable::getStringView(owner_type_info->name());
+					}
+				});
+		} else {
+			std::vector<TemplateTypeArg> owner_args =
+				materializeRecordArgs(dependent_name->owner_template_arguments);
+			if (areTemplateArgsConcrete(owner_args)) {
+				if (const TypeInfo* owner_type =
+						resolveConcreteInstantiatedMemberChain(owner_name, owner_args, {})) {
+					materialized_owner_name = StringTable::getStringView(owner_type->name());
+				}
+			}
+		}
+		if (!materialized_owner_name.empty()) {
+			std::vector<QualifiedTypeMemberAccess> member_type_chain;
+			member_type_chain.reserve(dependent_name->member_chain.size());
+			bool member_args_concrete = true;
+			for (const auto& member_record : dependent_name->member_chain) {
+				QualifiedTypeMemberAccess member_access;
+				member_access.member_name = member_record.name;
+				if (member_record.has_template_arguments) {
+					std::vector<TemplateTypeArg> member_args =
+						materializeRecordArgs(member_record.template_arguments);
+					if (!areTemplateArgsConcrete(member_args)) {
+						member_args_concrete = false;
+						break;
+					}
+					member_access.has_template_arguments = true;
+					member_access.template_arguments =
+						std::make_shared<std::vector<TemplateTypeArg>>(std::move(member_args));
+				}
+				member_type_chain.push_back(std::move(member_access));
+			}
+			if (member_args_concrete) {
+				if (const TypeInfo* resolved_member =
+						resolveBaseClassMemberTypeChain(materialized_owner_name, member_type_chain)) {
+					assignResolvedType(*resolved_member);
+					return current_type_index.withCategory(current_type);
+				}
+			}
+		}
+	}
+
 	if (isEncodedUnderlyingTypeIntrinsic(type_name)) {
 		std::string_view underlying_arg_name = extractEncodedUnderlyingTypeArgument(type_name);
 		bool resolved_underlying_type = false;

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1013,7 +1013,8 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 
 	const ExpressionNode& expr = expr_node.as<ExpressionNode>();
 	auto makeConstantValue = [](int64_t value, TypeCategory category, TypeIndex type_index) {
-		return ConstantValue{value, category, makeConstantValueTypeIndex(category, type_index)};
+		TypeIndex identity_type_index = makeConstantValueTypeIndex(category, type_index);
+		return ConstantValue{value, category, identity_type_index, FlashCpp::NonTypeValueIdentity::makeConcrete(value, identity_type_index)};
 	};
 	auto makeConstantValueFromCategory = [&](int64_t value, TypeCategory category) {
 		return makeConstantValue(value, category, TypeIndex{});
@@ -1031,7 +1032,28 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		} else if (std::holds_alternative<double>(eval_result.value)) {
 			category = TypeCategory::Double;
 		}
-		return makeConstantValue(eval_result.as_int(), category, type_index);
+		ConstantValue value = makeConstantValue(eval_result.as_int(), category, type_index);
+		if (category == TypeCategory::Nullptr) {
+			value.identity = FlashCpp::NonTypeValueIdentity::makeNullptr(value.type_index);
+		} else if (eval_result.pointer_to_var.isValid()) {
+			value.identity = FlashCpp::NonTypeValueIdentity::makeObjectPointer(
+				value.type_index,
+				eval_result.pointer_to_var,
+				eval_result.pointer_offset);
+		} else if (eval_result.member_pointer_member.isValid() || eval_result.is_null_member_pointer) {
+			if (eval_result.member_pointer_member.isValid()) {
+				value.identity = FlashCpp::NonTypeValueIdentity::makeMemberPointer(
+					value.type_index,
+					eval_result.member_pointer_member,
+					eval_result.as_int());
+			} else {
+				value.identity = FlashCpp::NonTypeValueIdentity::makeMemberPointer(
+					value.type_index,
+					StringHandle{},
+					eval_result.as_int());
+			}
+		}
+		return value;
 	};
 	auto retargetConstantValueToDeclaredType = [&](ConstantValue value, TypeIndex declared_type_index) {
 		TypeCategory declared_category = declared_type_index.category();
@@ -1049,6 +1071,13 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		}
 		value.type = declared_category;
 		value.type_index = makeConstantValueTypeIndex(declared_category, declared_type_index);
+		value.identity.value_type_index = value.type_index;
+		if (declared_category == TypeCategory::FunctionPointer ||
+				   declared_category == TypeCategory::MemberFunctionPointer) {
+			value.identity.kind = FlashCpp::NonTypeValueIdentityKind::FunctionPointer;
+		} else if (declared_category == TypeCategory::MemberObjectPointer) {
+			value.identity.kind = FlashCpp::NonTypeValueIdentityKind::MemberPointer;
+		}
 		return value;
 	};
 

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1033,6 +1033,24 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		}
 		return makeConstantValue(eval_result.as_int(), category, type_index);
 	};
+	auto retargetConstantValueToDeclaredType = [&](ConstantValue value, TypeIndex declared_type_index) {
+		TypeCategory declared_category = declared_type_index.category();
+		if (declared_type_index.is_valid()) {
+			if (const TypeInfo* declared_type_info = tryGetTypeInfo(declared_type_index)) {
+				if (declared_type_info->typeEnum() != TypeCategory::Invalid) {
+					declared_category = declared_type_info->typeEnum();
+				}
+			}
+		}
+		if (declared_category == TypeCategory::Invalid ||
+			declared_category == TypeCategory::Auto ||
+			declared_category == TypeCategory::DeclTypeAuto) {
+			return value;
+		}
+		value.type = declared_category;
+		value.type_index = makeConstantValueTypeIndex(declared_category, declared_type_index);
+		return value;
+	};
 
 	// Handle boolean literals directly
 	if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
@@ -1103,7 +1121,11 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 				!static_member_decl.initializer.has_value()) {
 				continue;
 			}
-			return try_evaluate_constant_expression(*static_member_decl.initializer);
+			auto value = try_evaluate_constant_expression(*static_member_decl.initializer);
+			if (!value.has_value()) {
+				return std::nullopt;
+			}
+			return retargetConstantValueToDeclaredType(*value, static_member_decl.type_index);
 		}
 
 		return std::nullopt;
@@ -1221,7 +1243,11 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		// For type traits, this is typically a bool literal (true/false)
 		const ASTNode& init_node = *static_member->initializer;
 		// Recursively evaluate the initializer
-		return try_evaluate_constant_expression(init_node);
+		auto value = try_evaluate_constant_expression(init_node);
+		if (!value.has_value()) {
+			return std::nullopt;
+		}
+		return retargetConstantValueToDeclaredType(*value, static_member->type_index);
 	}
 
 	// Handle member access expressions (e.g., obj.member or obj->member)

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1130,11 +1130,31 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 
 		return std::nullopt;
 	};
+	// Helper: create a constexpr evaluation context with struct context and parser.
+	// is_speculative = true disables short-circuit && / || so that a truthy LHS of `||`
+	// does not give a false-positive result during template-argument disambiguation.
+	auto makeConstExprContext = [&]() {
+		ConstExpr::EvaluationContext ctx(gSymbolTable);
+		if (!struct_parsing_context_stack_.empty()) {
+			const auto& struct_ctx = struct_parsing_context_stack_.back();
+			ctx.struct_node = struct_ctx.struct_node;
+			ctx.struct_info = struct_ctx.local_struct_info;
+		}
+		ctx.parser = this;
+		ctx.is_speculative = true;
+		return ctx;
+	};
 
 	// Handle qualified identifier expressions (e.g., is_int<double>::value)
 	// This is the most common case for template member access in C++
 	if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
 		const QualifiedIdentifierNode& qualified_id = std::get<QualifiedIdentifierNode>(expr);
+		auto ctx = makeConstExprContext();
+		auto eval_result = ConstExpr::Evaluator::evaluate(expr_node, ctx);
+		if (eval_result.success()) {
+			FLASH_LOG_FORMAT(Templates, Debug, "Qualified identifier constexpr evaluation succeeded: {}", eval_result.as_int());
+			return makeConstantValueFromEvalResult(eval_result);
+		}
 
 		// The qualified identifier represents something like "is_int<double>::value"
 		// We need to extract: type_name = "is_int<double>" and member_name = "value"
@@ -1359,21 +1379,6 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		FLASH_LOG_FORMAT(Templates, Debug, "Type trait evaluation result: {}", eval_result.value);
 		return makeConstantValueFromCategory(eval_result.value ? 1 : 0, TypeCategory::Bool);
 	}
-
-	// Helper: create a constexpr evaluation context with struct context and parser.
-	// is_speculative = true disables short-circuit && / || so that a truthy LHS of `||`
-	// does not give a false-positive result during template-argument disambiguation.
-	auto makeConstExprContext = [&]() {
-		ConstExpr::EvaluationContext ctx(gSymbolTable);
-		if (!struct_parsing_context_stack_.empty()) {
-			const auto& struct_ctx = struct_parsing_context_stack_.back();
-			ctx.struct_node = struct_ctx.struct_node;
-			ctx.struct_info = struct_ctx.local_struct_info;
-		}
-		ctx.parser = this;
-		ctx.is_speculative = true;
-		return ctx;
-	};
 
 	// Handle ternary operator expressions (e.g., (5 < 0) ? -1 : 1)
 	if (std::holds_alternative<TernaryOperatorNode>(expr)) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -230,10 +230,6 @@ static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeIndex type_in
 	return TemplateTypeArg::makeValue(value, type_index);
 }
 
-static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeCategory type) {
-	return makeDeferredBaseValueArg(value, makeDeferredBaseValueTypeIndex(type, TypeIndex{}));
-}
-
 // Resolve a deferred-base type argument through the ordinary substitution map,
 // then apply the use-site cv/ref/pointer modifiers carried by the original type
 // specifier. This keeps the pattern/member-chain paths on their historical

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3523,6 +3523,36 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				FLASH_LOG(Templates, Debug, "Copying member: ", decl.identifier_token().value(),
 						  " has_initializer=", member_decl.default_initializer.has_value());
 				const TypeSpecifierNode& type_spec = decl.type_specifier_node();
+				TypeSpecifierNode resolved_dependent_member_type_spec = type_spec;
+				const TypeSpecifierNode* effective_type_spec = &type_spec;
+				if (type_spec.type_index().is_valid()) {
+					if (const TypeInfo* member_type_info = tryGetTypeInfo(type_spec.type_index());
+						member_type_info != nullptr &&
+						member_type_info->isDependentMemberType() &&
+						member_type_info->hasDependentQualifiedName()) {
+						ASTNode substituted_type_node = substituteTemplateParameters(
+							ASTNode::emplace_node<TypeSpecifierNode>(type_spec),
+							template_params,
+							template_args_for_member_copy,
+							struct_info->getName());
+						if (substituted_type_node.is<TypeSpecifierNode>()) {
+							const TypeSpecifierNode& substituted_type =
+								substituted_type_node.as<TypeSpecifierNode>();
+							bool substituted_still_dependent = false;
+							if (substituted_type.type_index().is_valid()) {
+								if (const TypeInfo* substituted_type_info =
+										tryGetTypeInfo(substituted_type.type_index())) {
+									substituted_still_dependent =
+										substituted_type_info->isDependentPlaceholder();
+								}
+							}
+							if (!substituted_still_dependent) {
+								resolved_dependent_member_type_spec = substituted_type;
+								effective_type_spec = &resolved_dependent_member_type_spec;
+							}
+						}
+					}
+				}
 
 				// For pattern specializations, member types need substitution!
 				// The pattern has T* (Type::UserDefined with ptr_depth=1)
@@ -3531,8 +3561,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// For pattern specializations, member types need substitution!
 				// Use substitute_template_parameter to properly match template parameters by name
 				TypeIndex member_type_index = substitute_template_parameter(
-					type_spec, template_params, template_args_for_member_copy);
-				size_t ptr_depth = type_spec.pointer_depth();
+					*effective_type_spec, template_params, template_args_for_member_copy);
+				size_t ptr_depth = effective_type_spec->pointer_depth();
 				ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(member_type_index);
 				std::vector<size_t> resolved_array_dimensions = resolve_array_dimensions(
 					decl, template_params, template_args_for_member_copy);
@@ -3545,7 +3575,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Calculate member size accounting for pointer depth
 				TypeIndex member_size_type_index = resolved_member_alias.isArray() ? resolved_member_alias.type_index : member_type_index;
 				size_t member_size = get_substituted_type_size_bytes(member_size_type_index);
-				if (ptr_depth > 0 || type_spec.is_reference() || type_spec.is_rvalue_reference()) {
+				if (ptr_depth > 0 || effective_type_spec->is_reference() || effective_type_spec->is_rvalue_reference()) {
 					// Pointers and references are always 8 bytes (64-bit)
 					member_size = 8;
 				}
@@ -3555,13 +3585,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Calculate member alignment
 				// For pointers and references, use 8-byte alignment (pointer alignment on x64)
 				size_t member_alignment = get_type_alignment(member_type_index.category(), member_size);
-				if (ptr_depth > 0 || type_spec.is_reference() || type_spec.is_rvalue_reference()) {
+				if (ptr_depth > 0 || effective_type_spec->is_reference() || effective_type_spec->is_rvalue_reference()) {
 					member_alignment = 8; // Pointer/reference alignment on x64
 				} else if (const StructTypeInfo* member_struct_info = tryGetStructTypeInfo(member_size_type_index)) {
 					member_alignment = member_struct_info->alignment;
 				}
 
-				ReferenceQualifier ref_qual = type_spec.reference_qualifier();
+				ReferenceQualifier ref_qual = effective_type_spec->reference_qualifier();
 
 				// Substitute template parameters in default member initializers
 				std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
@@ -3586,7 +3616,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					static_cast<int>(ptr_depth),
 					resolve_bitfield_width(member_decl, template_params, template_args_for_member_copy),
 					resolveTemplateFunctionPointerSignature(
-						type_spec,
+						*effective_type_spec,
 						member_type_index,
 						template_params,
 						template_args_for_member_copy),

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1353,9 +1353,12 @@ static std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 	}
 
 	if (initializer->is<ExpressionNode>()) {
-		auto sub_map = buildSubstitutionParamMap(template_params, template_args);
-		if (!sub_map.empty()) {
-			ExpressionSubstitutor substitutor(sub_map.param_map, *parser, sub_map.param_order);
+		TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+			std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+			template_args,
+			nullptr);
+		if (!substitution_environment.bindings.empty()) {
+			ExpressionSubstitutor substitutor(substitution_environment, *parser);
 			substitutor.setCurrentOwnerTypeName(struct_info->getName());
 			initializer = substitutor.substitute(initializer.value());
 		}
@@ -4221,12 +4224,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Use ExpressionSubstitutor to handle all types of template-dependent expressions
 					std::optional<ASTNode> substituted_initializer = static_member.initializer;
 					if (static_member.initializer.has_value()) {
-						// Build parameter substitution map and preserve parameter order
-						auto sub_map = buildSubstitutionParamMap(template_params, template_args);
+						TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+							std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+							template_args,
+							nullptr);
 
 						// Use ExpressionSubstitutor to substitute template parameters in the initializer
-						if (!sub_map.empty()) {
-							ExpressionSubstitutor substitutor(sub_map.param_map, *this, sub_map.param_order);
+						if (!substitution_environment.bindings.empty()) {
+							ExpressionSubstitutor substitutor(substitution_environment, *this);
 							substitutor.setCurrentOwnerTypeName(struct_info->getName());
 							substituted_initializer = substitutor.substitute(static_member.initializer.value());
 							FLASH_LOG(Templates, Debug, "Substituted template parameters in static member initializer");

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1039,6 +1039,25 @@ static InlineVector<StringHandle, 4> collectParamNameHandles(
 	return names;
 }
 
+template <typename ParamContainer>
+static InlineVector<TypeInfo::TemplateArgInfo, 4> collectEnrichedTemplateArgInfos(
+	const ParamContainer& template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	InlineVector<TypeInfo::TemplateArgInfo, 4> result;
+	result.reserve(template_args.size());
+	for (size_t i = 0; i < template_args.size(); ++i) {
+		TemplateTypeArg arg = template_args[i];
+		if (i < template_params.size()) {
+			if (const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
+				param != nullptr) {
+				arg = enrichTemplateArgForParameter(*param, arg);
+			}
+		}
+		result.push_back(toTemplateArgInfo(arg));
+	}
+	return result;
+}
+
 ASTNode rebindStaticMemberInitializerFunctionCalls(
 	const ASTNode& node,
 	const StructTypeInfo* struct_info,
@@ -5593,7 +5612,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Store template instantiation metadata for O(1) lookup (Phase 6)
 	// This allows us to check if a type is a template instantiation without parsing the name
 	// QualifiedIdentifier captures both the namespace and unqualified name.
-	auto template_args_info = toTemplateArgInfoList(template_args_to_use);
+	auto template_args_info = collectEnrichedTemplateArgInfos(template_params, template_args_to_use);
 	struct_type_info.setTemplateInstantiationInfo(
 		QualifiedIdentifier::fromQualifiedName(template_name, decl_ns),
 		template_args_info);
@@ -7521,7 +7540,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
  // one and needs the enclosing template's bindings for constexpr evaluation.
 			nested_type_info.setInstantiationContext(
 				collectParamNameHandles(template_params, template_args_to_use.size()),
-				toTemplateArgInfoList(template_args_to_use),
+				collectEnrichedTemplateArgInfos(template_params, template_args_to_use),
 				struct_type_info.instantiationContext());
 
 			struct_info->addNestedClass(nested_type_info.getStructInfo());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -220,10 +220,21 @@ static TypeIndex makeDeferredBaseValueTypeIndex(TypeCategory category, TypeIndex
 }
 
 static bool isPlaceholderNttpTypeIndex(TypeIndex type_index) {
+	// An invalid TypeIndex represents an unevaluated/unresolved type and must be
+	// treated as a placeholder so the caller falls back to the concrete evaluated type.
+	if (!type_index.is_valid()) {
+		return true;
+	}
 	TypeCategory category = type_index.category();
-	return category == TypeCategory::Invalid ||
-		   category == TypeCategory::Auto ||
-		   category == TypeCategory::DeclTypeAuto;
+	if (category == TypeCategory::Invalid ||
+		category == TypeCategory::Auto ||
+		category == TypeCategory::DeclTypeAuto) {
+		return true;
+	}
+	if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
+		return type_info->isDependentPlaceholder();
+	}
+	return false;
 }
 
 static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeIndex type_index) {
@@ -552,17 +563,16 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 		resolved_member.member_name = member_access.member_name;
 		resolved_member.has_template_arguments = member_access.has_template_arguments;
 		if (member_access.has_template_arguments) {
-			resolved_member.template_arguments = std::make_shared<std::vector<TemplateTypeArg>>();
+			resolved_member.template_arguments = std::make_unique<std::vector<TemplateTypeArg>>();
 			resolved_member.template_arguments->reserve(member_access.template_argument_infos.size());
 			for (const auto& member_arg_info : member_access.template_argument_infos) {
 				if (member_arg_info.is_pack) {
 					auto try_expand = [&](StringHandle pack_name) -> bool {
 						auto it = pack_substitution_map.find(pack_name);
 						if (it != pack_substitution_map.end()) {
-							resolved_member.template_arguments->insert(
-								resolved_member.template_arguments->end(),
-								it->second.begin(),
-								it->second.end());
+							for (const TemplateTypeArg& pack_arg : it->second) {
+								resolved_member.template_arguments->push_back(pack_arg);
+							}
 							return true;
 						}
 						return false;
@@ -1041,12 +1051,24 @@ static InlineVector<TypeInfo::TemplateArgInfo, 4> collectEnrichedTemplateArgInfo
 	std::span<const TemplateTypeArg> template_args) {
 	InlineVector<TypeInfo::TemplateArgInfo, 4> result;
 	result.reserve(template_args.size());
+	size_t param_index = 0;
+	const TemplateParameterNode* active_param = nullptr;
 	for (size_t i = 0; i < template_args.size(); ++i) {
+		// Advance to the next non-null parameter, unless the current active_param is variadic
+		while (active_param == nullptr && param_index < template_params.size()) {
+			active_param = tryGetTemplateParameterNode(template_params[param_index]);
+			if (active_param == nullptr) {
+				++param_index;
+			}
+		}
+
 		TemplateTypeArg arg = template_args[i];
-		if (i < template_params.size()) {
-			if (const TemplateParameterNode* param = tryGetTemplateParameterNode(template_params[i]);
-				param != nullptr) {
-				arg = enrichTemplateArgForParameter(*param, arg);
+		if (active_param != nullptr) {
+			arg = enrichTemplateArgForParameter(*active_param, arg);
+			// Advance past non-variadic params; hold variadic ones across remaining args
+			if (!active_param->is_variadic()) {
+				++param_index;
+				active_param = nullptr;
 			}
 		}
 		result.push_back(toTemplateArgInfo(arg));

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -203,12 +203,35 @@ static TemplateArgSubstitutionMap makeDeferredBaseExpansionSubstitutionMap(
 	return subst_map;
 }
 
+static TypeIndex makeDeferredBaseValueTypeIndex(TypeCategory category, TypeIndex type_index) {
+	TypeCategory resolved_category = category;
+	if (type_index.is_valid()) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
+			if (type_info->typeEnum() != TypeCategory::Invalid) {
+				resolved_category = type_info->typeEnum();
+			}
+		}
+		return type_index.withCategory(resolved_category);
+	}
+	if (TypeIndex native_index = nativeTypeIndex(resolved_category); native_index.is_valid()) {
+		return native_index.withCategory(resolved_category);
+	}
+	return TypeIndex{0, resolved_category};
+}
+
+static bool isPlaceholderNttpTypeIndex(TypeIndex type_index) {
+	TypeCategory category = type_index.category();
+	return category == TypeCategory::Invalid ||
+		   category == TypeCategory::Auto ||
+		   category == TypeCategory::DeclTypeAuto;
+}
+
+static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeIndex type_index) {
+	return TemplateTypeArg::makeValue(value, type_index);
+}
+
 static TemplateTypeArg makeDeferredBaseValueArg(int64_t value, TypeCategory type) {
-	TemplateTypeArg arg;
-	arg.is_value = true;
-	arg.value = value;
-	arg.type_index = nativeTypeIndex(type);
-	return arg;
+	return makeDeferredBaseValueArg(value, makeDeferredBaseValueTypeIndex(type, TypeIndex{}));
 }
 
 // Resolve a deferred-base type argument through the ordinary substitution map,
@@ -616,7 +639,7 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 						const ASTNode substituted_expr = substitute_expression(member_arg_info.node);
 						if (auto evaluated_value = evaluate_constant_expression(substituted_expr)) {
 							resolved_member.template_arguments->push_back(
-								makeDeferredBaseValueArg(evaluated_value->value, evaluated_value->type));
+								makeDeferredBaseValueArg(evaluated_value->value, evaluated_value->type_index));
 							member_arg_resolved = true;
 						}
 					}
@@ -3384,12 +3407,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							}
 							if (!resolved) {
 								// Helper: build a non-type value TemplateTypeArg
-								auto makeValueArg = [](int64_t value, TypeCategory type) {
-									TemplateTypeArg va;
-									va.is_value = true;
-									va.value = value;
-									va.type_index = nativeTypeIndex(type);
-									return va;
+								auto makeValueArg = [](int64_t value, TypeIndex type_index) {
+									return makeDeferredBaseValueArg(value, type_index);
 								};
 
 								// Non-type value argument - try to convert to TemplateTypeArg
@@ -3399,10 +3418,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									int64_t int_val = std::holds_alternative<unsigned long long>(nv)
 														   ? static_cast<int64_t>(std::get<unsigned long long>(nv))
 														   : static_cast<int64_t>(std::get<double>(nv));
-									resolved_args.push_back(makeValueArg(int_val, num_lit.type()));
+									resolved_args.push_back(makeValueArg(
+										int_val,
+										makeDeferredBaseValueTypeIndex(num_lit.type(), TypeIndex{})));
 									resolved = true;
 								} else if (const auto* bool_literal = std::get_if<BoolLiteralNode>(&expr)) {
-									resolved_args.push_back(makeValueArg(bool_literal->value() ? 1 : 0, TypeCategory::Bool));
+									resolved_args.push_back(makeValueArg(
+										bool_literal->value() ? 1 : 0,
+										makeDeferredBaseValueTypeIndex(TypeCategory::Bool, TypeIndex{})));
 									resolved = true;
 								} else {
 									ASTNode substituted_expr = substituteTemplateParameters(
@@ -3411,7 +3434,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										template_args);
 									auto evaluated_value = try_evaluate_constant_expression(substituted_expr);
 									if (evaluated_value.has_value()) {
-										resolved_args.push_back(makeValueArg(evaluated_value->value, evaluated_value->type));
+										resolved_args.push_back(makeValueArg(evaluated_value->value, evaluated_value->type_index));
 										resolved = true;
 									} else {
 										// Unresolvable expression argument - cannot safely instantiate
@@ -6112,21 +6135,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 						auto makeEvaluatedDeferredBaseValueArg = [&](const auto& constant_value) {
 							TypeIndex target_index = makeTypeIndexForDeferredBaseNttp(deferred_arg_index, resolved_args);
-							if (target_index.category() == TypeCategory::Invalid) {
-								TypeCategory target_category = constant_value.type;
-								target_index = constant_value.type_index;
-								if (target_index.is_valid()) {
-									if (const TypeInfo* target_type_info = tryGetTypeInfo(target_index)) {
-										if (target_type_info->typeEnum() != TypeCategory::Invalid) {
-											target_category = target_type_info->typeEnum();
-										}
-									}
-									target_index = target_index.withCategory(target_category);
-								} else if (TypeIndex native_index = nativeTypeIndex(target_category); native_index.is_valid()) {
-									target_index = native_index.withCategory(target_category);
-								} else {
-									target_index = TypeIndex{0, target_category};
-								}
+							if (isPlaceholderNttpTypeIndex(target_index)) {
+								target_index = makeDeferredBaseValueTypeIndex(
+									constant_value.type,
+									constant_value.type_index);
 							}
 							TemplateTypeArg val_arg;
 							val_arg.is_value = true;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3478,10 +3478,13 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 
 	static int recursion_depth = 0;
 	recursion_depth++;
+	struct DepthGuard {
+		int& depth;
+		~DepthGuard() { depth--; }
+	} depth_guard{recursion_depth};
 
 	if (recursion_depth > 64) {
 		FLASH_LOG(Templates, Error, "try_instantiate_template recursion depth exceeded 64! Possible infinite loop for template '", template_name, "'");
-		recursion_depth--;
 		return std::nullopt;
 	}
 
@@ -3533,7 +3536,6 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 		// This is expected for regular (non-template) functions - the caller will fall back
 		// to creating a forward declaration. Only log at Debug level to avoid noise.
 		FLASH_LOG(Templates, Debug, "[depth=", recursion_depth, "]: Template '", template_name, "' not found in registry");
-		recursion_depth--;
 		return std::nullopt;
 	}
 
@@ -3579,6 +3581,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 		std::vector<ASTNode> shape_overloads;
 		shape_candidate_indices.reserve(all_templates->size());
 		shape_overloads.reserve(all_templates->size());
+		StringHandle template_name_handle = StringTable::getOrInternStringHandle(template_name);
 
 		for (size_t sorted_idx = 0; sorted_idx < overload_iteration_order.size(); ++sorted_idx) {
 			size_t overload_idx = overload_iteration_order[sorted_idx];
@@ -3616,7 +3619,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 			}
 
 			auto key = FlashCpp::makeInstantiationKey(
-				StringTable::getOrInternStringHandle(template_name),
+				template_name_handle,
 				template_args);
 			const uintptr_t overload_id = reinterpret_cast<uintptr_t>(&func_decl);
 			if (gTemplateRegistry.isFailedInstantiation(key, overload_id)) {
@@ -3686,7 +3689,6 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 								recursion_depth,
 								selected_overload_idx,
 								template_name);
-							recursion_depth--;
 							return result;
 						}
 						break;
@@ -3748,7 +3750,6 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 				// Non-SFINAE: success — return first good match.
 				FLASH_LOG_FORMAT(Templates, Debug, "[depth={}]: Successfully instantiated overload {} for '{}'",
 								 recursion_depth, overload_idx, template_name);
-				recursion_depth--;
 				return result;
 			}
 		} else {
@@ -3784,13 +3785,11 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 			FLASH_LOG_FORMAT(Templates, Debug,
 				"[depth={}]: SFINAE failure for '{}': all best-specificity candidates are = delete (specificity={})",
 				recursion_depth, template_name, best_specificity);
-			recursion_depth--;
 			return std::nullopt;
 		}
 		FLASH_LOG_FORMAT(Templates, Debug,
 			"[depth={}]: SFINAE best match for '{}' is overload {} specificity={} deleted=false",
 			recursion_depth, template_name, best_non_deleted->overload_idx, best_specificity);
-		recursion_depth--;
 		return best_non_deleted->result;
 	}
 
@@ -3801,14 +3800,12 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 			"[depth={}]: Falling back to deferred bodyless overload for '{}'",
 			recursion_depth,
 			template_name);
-		recursion_depth--;
 		return deferred_forward_declaration_result;
 	}
 
 	// All overloads failed
 	FLASH_LOG_FORMAT(Templates, Error, "[depth={}]: All {} template overload(s) failed for '{}'",
 					 recursion_depth, all_templates->size(), template_name);
-	recursion_depth--;
 	return std::nullopt;
 }
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -2646,6 +2646,8 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::CommitInstantiation);
 	const bool register_instantiation =
 		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::RegisterInstantiation);
+	const bool skip_body_materialization =
+		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::SkipBodyMaterialization);
 	const DeclarationNode& orig_decl = func_decl.decl_node();
 	std::string_view mangled_name = gTemplateRegistry.mangleTemplateName(template_name, template_args);
 
@@ -2948,7 +2950,11 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 	}
 
 	bool body_reparse_failed = false;
-	if (func_decl.has_template_body_position()) {
+	if (skip_body_materialization) {
+		// Shape-only overload selection needs a concrete function signature for
+		// conversion ranking, but it must not parse or substitute the body of
+		// candidates that may not be selected.
+	} else if (func_decl.has_template_body_position()) {
 		if (use_explicit_materialization) {
 			static thread_local std::unordered_set<StringHandle> body_parse_in_progress;
 			StringHandle cycle_key = StringTable::getOrInternStringHandle(mangled_name);
@@ -3566,6 +3572,128 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 			[&](size_t lhs_idx, size_t rhs_idx) {
 				return scores[lhs_idx] > scores[rhs_idx];
 			});
+	}
+
+	if (!outer_sfinae_context && all_templates->size() > 1) {
+		std::vector<size_t> shape_candidate_indices;
+		std::vector<ASTNode> shape_overloads;
+		shape_candidate_indices.reserve(all_templates->size());
+		shape_overloads.reserve(all_templates->size());
+
+		for (size_t sorted_idx = 0; sorted_idx < overload_iteration_order.size(); ++sorted_idx) {
+			size_t overload_idx = overload_iteration_order[sorted_idx];
+			const ASTNode& template_node = (*all_templates)[overload_idx];
+			if (!template_node.is<TemplateFunctionDeclarationNode>()) {
+				continue;
+			}
+
+			const TemplateFunctionDeclarationNode& template_func =
+				template_node.as<TemplateFunctionDeclarationNode>();
+			const auto& template_params = template_func.template_parameters();
+			const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
+
+			auto deduction_candidate = deduceTemplateCandidateViability(
+				template_params,
+				func_decl,
+				arg_types,
+				recursion_depth);
+			if (!deduction_candidate.has_value()) {
+				continue;
+			}
+
+			InlineVector<TemplateTypeArg, 4> template_args = deduction_candidate->template_args;
+			const bool has_structurally_dependent_template_args = std::any_of(
+				template_args.begin(),
+				template_args.end(),
+				[](const TemplateTypeArg& arg) {
+					return arg.is_dependent ||
+						   arg.dependent_name.isValid() ||
+						   arg.category() == TypeCategory::Auto ||
+						   arg.category() == TypeCategory::DeclTypeAuto;
+				});
+			if (has_structurally_dependent_template_args) {
+				continue;
+			}
+
+			auto key = FlashCpp::makeInstantiationKey(
+				StringTable::getOrInternStringHandle(template_name),
+				template_args);
+			const uintptr_t overload_id = reinterpret_cast<uintptr_t>(&func_decl);
+			if (gTemplateRegistry.isFailedInstantiation(key, overload_id)) {
+				continue;
+			}
+
+			std::optional<CallArgDeductionInfo> helper_deduction_info =
+				std::move(deduction_candidate->deduction_info);
+			FunctionTemplateInstantiationContext instantiation_context{
+				template_name,
+				template_func,
+				func_decl,
+				template_params,
+				template_args,
+				key,
+				overload_id,
+				recursion_depth};
+			FunctionTemplateBindingData binding_data{
+				&arg_types,
+				nullptr,
+				nullptr,
+				&helper_deduction_info,
+				nullptr};
+			FunctionTemplateInstantiationFlags instantiation_flags =
+				FunctionTemplateInstantiationFlags::SkipBodyMaterialization;
+
+			ScopedParserInstantiationContext shape_guard(
+				*this,
+				TemplateInstantiationMode::HardUseCandidateProbe,
+				StringHandle{});
+			std::optional<ASTNode> signature_node = instantiateBoundFunctionTemplate(
+				instantiation_context,
+				binding_data,
+				instantiation_flags);
+			if (!signature_node.has_value() ||
+				!signature_node->is<FunctionDeclarationNode>() ||
+				signature_node->as<FunctionDeclarationNode>().failed_substitution()) {
+				continue;
+			}
+			shape_candidate_indices.push_back(overload_idx);
+			shape_overloads.push_back(*signature_node);
+		}
+
+		if (shape_overloads.size() > 1) {
+			auto resolution = resolve_overload(shape_overloads, arg_types);
+			if (resolution.has_match &&
+				!resolution.is_ambiguous &&
+				resolution.selected_overload != nullptr) {
+				for (size_t i = 0; i < shape_overloads.size(); ++i) {
+					if (resolution.selected_overload == &shape_overloads[i]) {
+						size_t selected_overload_idx = shape_candidate_indices[i];
+						const ASTNode& template_node = (*all_templates)[selected_overload_idx];
+						ScopedParserInstantiationContext guard_instantiation_mode(
+							*this,
+							selectTemplateCandidateProbeMode(),
+							StringHandle{});
+						std::optional<ASTNode> result = try_instantiate_single_template(
+							template_node,
+							template_name,
+							arg_types,
+							recursion_depth);
+						if (result.has_value()) {
+							FLASH_LOG_FORMAT(
+								Templates,
+								Debug,
+								"[depth={}]: Shape-selected template overload {} for '{}'",
+								recursion_depth,
+								selected_overload_idx,
+								template_name);
+							recursion_depth--;
+							return result;
+						}
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	std::optional<ASTNode> deferred_forward_declaration_result;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3577,9 +3577,16 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 	}
 
 	if (!outer_sfinae_context && all_templates->size() > 1) {
-		std::vector<size_t> shape_candidate_indices;
+		struct ShapeCandidate {
+			size_t overload_idx;
+			InlineVector<TemplateTypeArg, 4> template_args;
+			FlashCpp::TemplateInstantiationKey key;
+			uintptr_t overload_id;
+			std::optional<CallArgDeductionInfo> deduction_info;
+		};
+		std::vector<ShapeCandidate> shape_candidates;
 		std::vector<ASTNode> shape_overloads;
-		shape_candidate_indices.reserve(all_templates->size());
+		shape_candidates.reserve(all_templates->size());
 		shape_overloads.reserve(all_templates->size());
 		StringHandle template_name_handle = StringTable::getOrInternStringHandle(template_name);
 
@@ -3659,7 +3666,12 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 				signature_node->as<FunctionDeclarationNode>().failed_substitution()) {
 				continue;
 			}
-			shape_candidate_indices.push_back(overload_idx);
+			shape_candidates.push_back(ShapeCandidate{
+				overload_idx,
+				std::move(template_args),
+				std::move(key),
+				overload_id,
+				std::move(helper_deduction_info)});
 			shape_overloads.push_back(*signature_node);
 		}
 
@@ -3670,24 +3682,134 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 				resolution.selected_overload != nullptr) {
 				for (size_t i = 0; i < shape_overloads.size(); ++i) {
 					if (resolution.selected_overload == &shape_overloads[i]) {
-						size_t selected_overload_idx = shape_candidate_indices[i];
-						const ASTNode& template_node = (*all_templates)[selected_overload_idx];
+						// Reuse the precomputed template_args from the shape probe to skip
+						// redundant argument deduction for the winning candidate.
+						ShapeCandidate& winner = shape_candidates[i];
+						const ASTNode& winner_template_node = (*all_templates)[winner.overload_idx];
+						const TemplateFunctionDeclarationNode& winner_template_func =
+							winner_template_node.as<TemplateFunctionDeclarationNode>();
+						const FunctionDeclarationNode& winner_func_decl =
+							winner_template_func.function_decl_node();
+						const auto& winner_template_params =
+							winner_template_func.template_parameters();
+
+						// Check explicit specializations before body instantiation.
+						auto specialization_opt = gTemplateRegistry.lookupSpecialization(
+							template_name, winner.template_args);
+						if (specialization_opt.has_value()) {
+							FLASH_LOG_FORMAT(Templates, Debug,
+								"[depth={}]: Shape-winner: found explicit specialization for '{}'",
+								recursion_depth, template_name);
+							return *specialization_opt;
+						}
+
+						// Evaluate requires clause and concept constraints.
+						if (winner_template_func.has_requires_clause()) {
+							const RequiresClauseNode& rc =
+								winner_template_func.requires_clause()->as<RequiresClauseNode>();
+							InlineVector<std::string_view, 4> param_names;
+							for (const auto& tp : winner_template_params)
+								param_names.push_back(tp.name());
+							auto cr = evaluateConstraint(rc.constraint_expr(), winner.template_args, param_names);
+							if (!cr.satisfied) {
+								failTemplateInstantiation(
+									StringBuilder()
+										.append("constraint not satisfied for template function '")
+										.append(template_name)
+										.append("'")
+										.commit(),
+									&winner.key,
+									winner.overload_id);
+								break;
+							}
+						}
+						{
+							bool concept_failed = false;
+							forEachNonPackTemplateParamArgBinding(
+								winner_template_params,
+								winner.template_args,
+								[&](const TemplateParameterNode& param, const TemplateTypeArg& bound_arg, size_t) {
+									if (!param.has_concept_constraint() || concept_failed)
+										return;
+									auto concept_opt = gConceptRegistry.lookupConcept(param.concept_constraint());
+									if (!concept_opt.has_value())
+										return;
+									const auto& concept_node = concept_opt->as<ConceptDeclarationNode>();
+									TemplateTypeArg concept_arg = bound_arg;
+									concept_arg.ref_qualifier = ReferenceQualifier::None;
+									InlineVector<TemplateTypeArg, 4> concept_args;
+									concept_args.push_back(concept_arg);
+									auto cr = evaluateConstraint(concept_node, concept_args);
+									if (!cr.satisfied) {
+										concept_failed = true;
+									}
+								});
+							if (concept_failed) {
+								failTemplateInstantiation(
+									StringBuilder()
+										.append("concept constraint not satisfied for template function '")
+										.append(template_name)
+										.append("'")
+										.commit(),
+									&winner.key,
+									winner.overload_id);
+								break;
+							}
+						}
+
+						const bool cacheable = hasUsableTemplateFunctionDefinition(winner_func_decl);
+						const bool commit = shouldCommitTemplateInstantiationArtifacts();
+						FunctionTemplateInstantiationContext winner_ctx{
+							template_name,
+							winner_template_func,
+							winner_func_decl,
+							winner_template_params,
+							winner.template_args,
+							winner.key,
+							winner.overload_id,
+							recursion_depth};
+						FunctionTemplateBindingData winner_binding{
+							&arg_types,
+							nullptr,
+							nullptr,
+							&winner.deduction_info,
+							nullptr};
+						FunctionTemplateInstantiationFlags winner_flags =
+							FunctionTemplateInstantiationFlags::None;
+						if (cacheable) {
+							winner_flags = mergeInstantiationFlags(
+								winner_flags,
+								FunctionTemplateInstantiationFlags::CacheableInstantiation);
+						}
+						if (commit) {
+							winner_flags = mergeInstantiationFlags(
+								winner_flags,
+								FunctionTemplateInstantiationFlags::CommitInstantiation);
+						}
+						winner_flags = mergeInstantiationFlags(
+							winner_flags,
+							FunctionTemplateInstantiationFlags::RegisterInstantiation);
+						winner_flags = mergeInstantiationFlags(
+							winner_flags,
+							FunctionTemplateInstantiationFlags::MemoizeBodyReparseFailure);
+						winner_flags = mergeInstantiationFlags(
+							winner_flags,
+							FunctionTemplateInstantiationFlags::RunInlineHeuristic);
 						ScopedParserInstantiationContext guard_instantiation_mode(
 							*this,
 							selectTemplateCandidateProbeMode(),
 							StringHandle{});
-						std::optional<ASTNode> result = try_instantiate_single_template(
-							template_node,
-							template_name,
-							arg_types,
-							recursion_depth);
+						std::optional<ASTNode> result = instantiateBoundFunctionTemplate(
+							winner_ctx,
+							winner_binding,
+							winner_flags);
 						if (result.has_value()) {
 							FLASH_LOG_FORMAT(
 								Templates,
 								Debug,
 								"[depth={}]: Shape-selected template overload {} for '{}'",
 								recursion_depth,
-								selected_overload_idx,
+								winner.overload_idx,
 								template_name);
 							return result;
 						}

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -1385,6 +1385,23 @@ void Parser::reparse_template_function_body(
 				phase1_violation_token_.reset();
 			}
 		}
+		TemplateDefinitionLookupContext definition_lookup_context;
+		definition_lookup_context.definition_line = phase1_cutoff_line_;
+		definition_lookup_context.definition_file_index = phase1_cutoff_file_idx_;
+		definition_lookup_context.definition_namespace = gSymbolTable.get_current_namespace_handle();
+		if (current_function_ != nullptr && !current_function_->parent_struct_name().empty()) {
+			definition_lookup_context.current_instantiation_name =
+				StringTable::getOrInternStringHandle(current_function_->parent_struct_name());
+		}
+		substitution_context.definition_lookup_context = definition_lookup_context.is_valid()
+			? &definition_lookup_context
+			: nullptr;
+		const TemplateDefinitionLookupContext* previous_definition_lookup_context =
+			current_template_definition_lookup_context_;
+		current_template_definition_lookup_context_ = substitution_context.definition_lookup_context;
+		auto restore_definition_lookup_context = ScopeGuard([&]() {
+			current_template_definition_lookup_context_ = previous_definition_lookup_context;
+		});
 
 		// Parse the body, substitute template parameters, then install as definition.
 		{

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -410,6 +410,58 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 		return std::nullopt;
 	}
 
+	if (viable.size() > 1) {
+		std::vector<ASTNode> shape_overloads;
+		std::vector<size_t> shape_candidate_indices;
+		shape_overloads.reserve(viable.size());
+		shape_candidate_indices.reserve(viable.size());
+		for (size_t i = 0; i < viable.size(); ++i) {
+			const CandidateResult& candidate = viable[i];
+			StringHandle shape_key_qualified_name = qualified_name;
+			if (all_templates->size() > 1) {
+				StringBuilder discriminated_sb;
+				discriminated_sb.append(qualified_name.view())
+					.append("$ol")
+					.append(static_cast<uint64_t>(candidate.overload_index));
+				shape_key_qualified_name = StringTable::getOrInternStringHandle(discriminated_sb);
+			}
+			auto shape_key = FlashCpp::makeInstantiationKey(shape_key_qualified_name, candidate.template_args);
+			if (auto existing_inst = gTemplateRegistry.getInstantiation(shape_key);
+				existing_inst.has_value() && existing_inst->is<FunctionDeclarationNode>()) {
+				shape_overloads.push_back(*existing_inst);
+				shape_candidate_indices.push_back(i);
+				continue;
+			}
+			auto shape_node = instantiate_member_function_template_core(
+				struct_name,
+				member_name,
+				requested_qualified_name,
+				qualified_name,
+				*candidate.template_node,
+				candidate.template_args,
+				shape_key,
+				arg_types,
+				false);
+			if (shape_node.has_value() && shape_node->is<FunctionDeclarationNode>()) {
+				shape_overloads.push_back(*shape_node);
+				shape_candidate_indices.push_back(i);
+			}
+		}
+		if (shape_overloads.size() > 1) {
+			auto resolution = resolve_overload(shape_overloads, arg_types);
+			if (resolution.has_match &&
+				!resolution.is_ambiguous &&
+				resolution.selected_overload != nullptr) {
+				for (size_t i = 0; i < shape_overloads.size(); ++i) {
+					if (resolution.selected_overload == &shape_overloads[i]) {
+						best_idx = shape_candidate_indices[i];
+						break;
+					}
+				}
+			}
+		}
+	}
+
 	const CandidateResult& best = viable[best_idx];
 
 	// Build the instantiation key.
@@ -435,7 +487,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 
 	return instantiate_member_function_template_core(
 		struct_name, member_name, requested_qualified_name, qualified_name,
-		*best.template_node, best.template_args, key, arg_types);
+		*best.template_node, best.template_args, key, arg_types, true);
 }
 
 std::optional<ASTNode> Parser::try_instantiate_constructor_template(
@@ -927,7 +979,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 				? *current_explicit_call_arg_types_
 				: empty_call_arg_types;
 		auto result = instantiate_member_function_template_core(
-			struct_name, member_name, requested_qualified_name, qualified_name, template_node, template_args, key, call_arg_types);
+			struct_name, member_name, requested_qualified_name, qualified_name, template_node, template_args, key, call_arg_types, true);
 		if (result.has_value()) {
 			return result;
 		}
@@ -1108,7 +1160,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const ASTNode& template_node,
 	std::span<const TemplateTypeArg> template_args,
 	const FlashCpp::TemplateInstantiationKey& key,
-	std::span<const TypeSpecifierNode> call_arg_types) {
+	std::span<const TypeSpecifierNode> call_arg_types,
+	bool materialize_body) {
 
 	// Depth guard: instantiating a member function template replays its body,
 	// and body expressions can recursively trigger further member-function
@@ -1639,6 +1692,10 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 	copy_function_properties(new_func_ref, func_decl);
 	auto orig_body = func_decl.get_definition();
+	if (!materialize_body) {
+		compute_and_set_mangled_name(new_func_ref);
+		return new_func_node;
+	}
 
 	// Check if the template has a body position stored
 	if (!func_decl.has_template_body_position()) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -454,7 +454,10 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 				resolution.selected_overload != nullptr) {
 				for (size_t i = 0; i < shape_overloads.size(); ++i) {
 					if (resolution.selected_overload == &shape_overloads[i]) {
-						best_idx = shape_candidate_indices[i];
+						size_t selected_idx = shape_candidate_indices[i];
+						if (viable[selected_idx].specificity >= best_specificity) {
+							best_idx = selected_idx;
+						}
 						break;
 					}
 				}

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -349,7 +349,11 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 	// evaluated before template parameter substitution: the placeholder type held
 	// inside them does not carry flags like is_final/is_empty, so an early
 	// unsubstituted evaluation would silently return the wrong value (false) and
-	// prevent the correct substituted evaluation below from running.
+	// prevent the correct substituted evaluation below from running.  The same
+	// rule applies to all dependent NTTP expressions: bind alias parameters first,
+	// then perform exactly one substitute/evaluate pass below.  Do not add a
+	// context-free evaluation fallback here, because it can bind hidden outer names
+	// before alias-parameter substitution and produce a different value.
 	const bool is_type_trait_expr = std::get_if<TypeTraitExprNode>(&arg_expr) != nullptr;
 	if (is_type_trait_expr) {
 		FLASH_LOG(Templates, Debug, "materializeDeferredAliasTemplateArg: skipping early eval for TypeTraitExprNode");
@@ -392,12 +396,6 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 					std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
 				return TemplateTypeArg::makeDependentValue(dependent_anchor, TypeCategory::Bool, 0, pre_substituted);
 			}
-		}
-	} else {
-		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
-		auto eval_result = ConstExpr::Evaluator::evaluate(arg_node, eval_ctx);
-		if (eval_result.success()) {
-			return templateTypeArgFromEvalResult(eval_result);
 		}
 	}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -7,6 +7,33 @@
 #include "TypeTraitEvaluator.h"
 
 TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_result) {
+	TypeIndex value_type_index = eval_result.exact_type.has_value()
+		? eval_result.exact_type->type_index().withCategory(eval_result.exact_type->category())
+		: TypeIndex{};
+	if (eval_result.exact_type.has_value() && eval_result.exact_type->category() == TypeCategory::Nullptr) {
+		return TemplateTypeArg::makeValueIdentity(
+			FlashCpp::NonTypeValueIdentity::makeNullptr(nativeTypeIndex(TypeCategory::Nullptr)));
+	}
+	if (eval_result.pointer_to_var.isValid()) {
+		if (!value_type_index.is_valid()) {
+			value_type_index = nativeTypeIndex(TypeCategory::Int);
+		}
+		return TemplateTypeArg::makeValueIdentity(
+			FlashCpp::NonTypeValueIdentity::makeObjectPointer(
+				value_type_index,
+				eval_result.pointer_to_var,
+				eval_result.pointer_offset));
+	}
+	if (eval_result.member_pointer_member.isValid() || eval_result.is_null_member_pointer) {
+		if (!value_type_index.is_valid()) {
+			value_type_index = nativeTypeIndex(TypeCategory::MemberObjectPointer);
+		}
+		return TemplateTypeArg::makeValueIdentity(
+			FlashCpp::NonTypeValueIdentity::makeMemberPointer(
+				value_type_index,
+				eval_result.member_pointer_member,
+				eval_result.as_int()));
+	}
 	if (const auto* bool_value = std::get_if<bool>(&eval_result.value)) {
 		return TemplateTypeArg(*bool_value ? 1LL : 0LL, TypeCategory::Bool);
 	}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -444,6 +444,20 @@ ParseResult Parser::parse_template_parameter() {
 	if (!type_result.node().has_value()) {
 		return ParseResult::error("Expected type specifier for non-type template parameter", current_token_);
 	}
+	const TypeSpecifierNode& nttp_type = type_result.node()->as<TypeSpecifierNode>();
+	if ((nttp_type.type() == TypeCategory::Struct ||
+		 nttp_type.type() == TypeCategory::UserDefined ||
+		 nttp_type.type() == TypeCategory::TypeAlias) &&
+		nttp_type.type_index().is_valid()) {
+		const TypeInfo* nttp_type_info = tryGetTypeInfo(nttp_type.type_index());
+		if (nttp_type_info != nullptr &&
+			!nttp_type_info->isDependentPlaceholder() &&
+			nttp_type_info->getStructInfo() != nullptr) {
+			return ParseResult::error(
+				"Structural class-type non-type template parameters are not supported yet",
+				type_result.node()->as<TypeSpecifierNode>().token());
+		}
+	}
 
 	// Check for ellipsis (parameter pack): int... Ns
 	bool is_variadic = false;
@@ -1085,6 +1099,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				TemplateTypeArg num_arg;
 				if (const auto* ull_val = std::get_if<unsigned long long>(&val)) {
 					num_arg = TemplateTypeArg(static_cast<int64_t>(*ull_val), literal_type);
+					if (literal_type == TypeCategory::Nullptr) {
+						num_arg.setValueIdentity(FlashCpp::NonTypeValueIdentity::makeNullptr(nativeTypeIndex(TypeCategory::Nullptr)));
+					}
 					discard_saved_token(arg_saved_pos);
 					// Successfully parsed a non-type template argument, continue to check for ',' or '>' or '...'
 				} else if (const auto* d_val = std::get_if<double>(&val)) {
@@ -2534,11 +2551,23 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 		if (syntax_node != nullptr && syntax_node->is<ExpressionNode>()) {
 			const ASTNode& expr_node = *syntax_node;
 			if (auto const_value = try_evaluate_constant_expression(expr_node)) {
-				TemplateTypeArg result = TemplateTypeArg::makeValue(
-					const_value->value,
-					const_value->type_index.category() != TypeCategory::Invalid
-						? const_value->type_index.category()
-						: const_value->type);
+				FlashCpp::NonTypeValueIdentity identity = const_value->identity;
+				TypeIndex declared_type_index = param.has_type()
+					? param.type_specifier_node().type_index().withCategory(param.type_specifier_node().type())
+					: TypeIndex{};
+				if (declared_type_index.category() != TypeCategory::Invalid) {
+					identity.value_type_index = declared_type_index.is_valid()
+						? declared_type_index
+						: nativeTypeIndex(declared_type_index.category());
+					if (param.type_specifier_node().is_reference() &&
+						identity.kind == FlashCpp::NonTypeValueIdentityKind::ObjectPointer) {
+						identity.kind = FlashCpp::NonTypeValueIdentityKind::Reference;
+					} else if (param.type_specifier_node().pointer_depth() > 0 &&
+							   identity.kind == FlashCpp::NonTypeValueIdentityKind::Nullptr) {
+						identity.kind = FlashCpp::NonTypeValueIdentityKind::ObjectPointer;
+					}
+				}
+				TemplateTypeArg result = TemplateTypeArg::makeValueIdentity(identity);
 				return result;
 			}
 			const ExpressionNode& expr = syntax_node->as<ExpressionNode>();
@@ -2561,7 +2590,7 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 				const VariableDeclarationNode& variable_decl = symbol_lookup->as<VariableDeclarationNode>();
 				if (variable_decl.initializer().has_value()) {
 					if (auto const_value = try_evaluate_constant_expression(*variable_decl.initializer())) {
-						return TemplateTypeArg::makeValue(const_value->value, const_value->type);
+						return TemplateTypeArg::makeValueIdentity(const_value->identity);
 					}
 				}
 			}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1280,7 +1280,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							std::holds_alternative<OffsetofExprNode>(expr) ||
 							std::holds_alternative<NoexceptExprNode>(expr) ||
 							std::holds_alternative<TypeTraitExprNode>(expr) ||
-							std::holds_alternative<BinaryOperatorNode>(expr)) {
+							std::holds_alternative<BinaryOperatorNode>(expr) ||
+							std::holds_alternative<UnaryOperatorNode>(expr) ||
+							std::holds_alternative<StaticCastNode>(expr)) {
 							if (expr_result.node().has_value()) {
 								stored_expr = *expr_result.node();
 							}
@@ -1654,6 +1656,8 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								std::holds_alternative<OffsetofExprNode>(expr) ||
 								std::holds_alternative<TypeTraitExprNode>(expr) ||
 								std::holds_alternative<BinaryOperatorNode>(expr) ||
+								std::holds_alternative<UnaryOperatorNode>(expr) ||
+								std::holds_alternative<StaticCastNode>(expr) ||
 								simple_identifier_kind == SimpleTemplateArgKind::ValueLike;
 							if (is_value_like_dependent_expr) {
 								// Store the original AST expression for dependent NTTP expressions
@@ -1667,7 +1671,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 									 std::holds_alternative<OffsetofExprNode>(expr) ||
 									 std::holds_alternative<NoexceptExprNode>(expr) ||
 									 std::holds_alternative<TypeTraitExprNode>(expr) ||
-									 std::holds_alternative<BinaryOperatorNode>(expr)) &&
+									 std::holds_alternative<BinaryOperatorNode>(expr) ||
+									 std::holds_alternative<UnaryOperatorNode>(expr) ||
+									 std::holds_alternative<StaticCastNode>(expr)) &&
 									expr_result.node().has_value()) {
 									stored_expr = *expr_result.node();
 									FLASH_LOG(Templates, Debug, "Storing dependent NTTP expression (sizeof/alignof/etc) for re-evaluation");

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1430,7 +1430,11 @@ ASTNode Parser::substituteTemplateParameters(
 				}
 				if (const TypeInfo* resolved_dependent_type =
 						substitutor.resolveDependentMemberTypeForSubstitution(*dependent_type_info)) {
-					return makeTypeSpecifier(*resolved_dependent_type);
+					TypeSpecifierNode substituted_spec =
+						makeTypeSpecifierFromTemplateTypeArg(
+							resolveTypeInfoToTemplateArg(*resolved_dependent_type, type_spec),
+							type_spec.token());
+					return emplace_node<TypeSpecifierNode>(substituted_spec);
 				}
 			}
 		}

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1418,6 +1418,23 @@ ASTNode Parser::substituteTemplateParameters(
 			return emplace_node<TypeSpecifierNode>(substituted_spec);
 		};
 
+		if (type_spec.type_index().is_valid()) {
+			if (const TypeInfo* dependent_type_info = tryGetTypeInfo(type_spec.type_index());
+				dependent_type_info != nullptr &&
+				dependent_type_info->isDependentMemberType() &&
+				dependent_type_info->hasDependentQualifiedName()) {
+				auto sub_map = buildSubstitutionParamMap(template_params, template_args);
+				ExpressionSubstitutor substitutor(sub_map.param_map, *this, sub_map.param_order);
+				if (current_owner_type_name.isValid()) {
+					substitutor.setCurrentOwnerTypeName(current_owner_type_name);
+				}
+				if (const TypeInfo* resolved_dependent_type =
+						substitutor.resolveDependentMemberTypeForSubstitution(*dependent_type_info)) {
+					return makeTypeSpecifier(*resolved_dependent_type);
+				}
+			}
+		}
+
 		// Check if this is a user-defined type that matches a template parameter
 		if (type_spec.category() == TypeCategory::UserDefined ||
 			type_spec.category() == TypeCategory::Struct ||

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -7,13 +7,17 @@
 
 namespace {
 
+struct DependentMemberSegmentInfo {
+	bool has_template_keyword = false;
+	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> template_args;
+};
+
 TypeInfo::DependentQualifiedNameRecord makeDependentQualifiedNameRecord(
 	StringHandle owner_name,
 	TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
 	InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments,
 	std::string_view member_path,
-	bool first_member_has_template_keyword,
-	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> first_member_template_arguments) {
+	std::span<const DependentMemberSegmentInfo> segment_infos) {
 	TypeInfo::DependentQualifiedNameRecord record;
 	record.owner_kind = owner_kind;
 	record.owner_name = owner_name;
@@ -22,7 +26,7 @@ TypeInfo::DependentQualifiedNameRecord makeDependentQualifiedNameRecord(
 	record.owner_template_arguments = std::move(owner_template_arguments);
 
 	size_t start = 0;
-	bool first_member = true;
+	size_t member_index = 0;
 	while (start < member_path.size()) {
 		size_t sep = member_path.find("::", start);
 		std::string_view component = sep == std::string_view::npos
@@ -35,14 +39,17 @@ TypeInfo::DependentQualifiedNameRecord makeDependentQualifiedNameRecord(
 			}
 			TypeInfo::DependentQualifiedNameRecord::Member member;
 			member.name = StringTable::getOrInternStringHandle(component);
-			if (first_member && first_member_template_arguments.has_value()) {
-				member.template_arguments = *first_member_template_arguments;
-				member.has_template_arguments = true;
+			if (member_index < segment_infos.size()) {
+				const DependentMemberSegmentInfo& seg = segment_infos[member_index];
+				if (seg.template_args.has_value()) {
+					member.template_arguments = *seg.template_args;
+					member.has_template_arguments = true;
+				}
+				member.has_template_keyword = seg.has_template_keyword;
 			}
-			member.has_template_keyword = first_member && first_member_has_template_keyword;
 			record.member_chain.push_back(std::move(member));
+			++member_index;
 		}
-		first_member = false;
 		if (sep == std::string_view::npos) {
 			break;
 		}
@@ -1201,8 +1208,7 @@ ParseResult Parser::parse_type_specifier() {
 							TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
 							InlineVector<TypeInfo::TemplateArgInfo, 4>{},
 							type_name.substr(type_name.find("::") + 2),
-							false,
-							std::nullopt));
+							{}));
 					getTypesByNameMap()[type_handle] = &placeholder_type;
 					type_idx = placeholder_type.type_index_;
 				} else {
@@ -1215,8 +1221,7 @@ ParseResult Parser::parse_type_specifier() {
 								TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
 								InlineVector<TypeInfo::TemplateArgInfo, 4>{},
 								type_name.substr(type_name.find("::") + 2),
-								false,
-								std::nullopt));
+								{}));
 					}
 					type_idx = type_it->second->type_index_;
 				}
@@ -2043,13 +2048,16 @@ ParseResult Parser::parse_type_specifier() {
 					// before creating a placeholder
 					std::string_view member_name = qualified_node.identifier_token().value();
 					bool has_template_args = (peek() == "<"_tok);
+					std::vector<DependentMemberSegmentInfo> nested_segment_infos;
 					auto append_nested_qualified_type_chain = [&]() {
 						while (peek() == "::"_tok) {
 							SaveHandle nested_pos = save_token_position();
 							advance(); // consume '::'
 
+							bool nested_has_template_keyword = false;
 							if (peek() == "template"_tok) {
 								advance(); // consume 'template'
+								nested_has_template_keyword = true;
 							}
 
 							if (!peek().is_identifier()) {
@@ -2068,9 +2076,11 @@ ParseResult Parser::parse_type_specifier() {
 													  .commit();
 							discard_saved_token(nested_pos);
 
+							std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> nested_seg_args;
 							if (peek() == "<"_tok) {
 								auto nested_tmpl_args = parse_explicit_template_arguments();
 								if (nested_tmpl_args.has_value()) {
+									nested_seg_args = convertToTemplateArgInfo(*nested_tmpl_args);
 									StringBuilder tmpl_builder;
 									qualified_type_name = tmpl_builder
 															  .append(qualified_type_name)
@@ -2080,6 +2090,7 @@ ParseResult Parser::parse_type_specifier() {
 															  .commit();
 								}
 							}
+							nested_segment_infos.push_back({nested_has_template_keyword, std::move(nested_seg_args)});
 						}
 					};
 					auto create_dependent_qualified_type_placeholder =
@@ -2116,14 +2127,17 @@ ParseResult Parser::parse_type_specifier() {
 						}
 						std::string_view dependent_member_path =
 							member_path_builder.commit();
+						InlineVector<DependentMemberSegmentInfo, 4> all_segment_infos;
+						all_segment_infos.push_back({had_template_keyword, dependent_member_template_args});
+						for (const DependentMemberSegmentInfo& seg : nested_segment_infos)
+							all_segment_infos.push_back(seg);
 						type_info.setDependentQualifiedName(
 							makeDependentQualifiedNameRecord(
 								StringTable::getOrInternStringHandle(type_name),
 								owner_kind,
 								convertToTemplateArgInfo(*template_args),
 								dependent_member_path,
-								had_template_keyword,
-								dependent_member_template_args));
+								all_segment_infos));
 						if (dependent_member_template_base.has_value() && dependent_member_template_args.has_value()) {
 							type_info.setTemplateInstantiationInfo(
 								QualifiedIdentifier::fromQualifiedName(

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -5,6 +5,55 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
+namespace {
+
+TypeInfo::DependentQualifiedNameRecord makeDependentQualifiedNameRecord(
+	StringHandle owner_name,
+	TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
+	InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments,
+	std::string_view member_path,
+	bool first_member_has_template_keyword,
+	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> first_member_template_arguments) {
+	TypeInfo::DependentQualifiedNameRecord record;
+	record.owner_kind = owner_kind;
+	record.owner_name = owner_name;
+	record.names_current_instantiation =
+		owner_kind == TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation;
+	record.owner_template_arguments = std::move(owner_template_arguments);
+
+	size_t start = 0;
+	bool first_member = true;
+	while (start < member_path.size()) {
+		size_t sep = member_path.find("::", start);
+		std::string_view component = sep == std::string_view::npos
+			? member_path.substr(start)
+			: member_path.substr(start, sep - start);
+		if (!component.empty()) {
+			if (size_t template_marker = component.find('<');
+				template_marker != std::string_view::npos) {
+				component = component.substr(0, template_marker);
+			}
+			TypeInfo::DependentQualifiedNameRecord::Member member;
+			member.name = StringTable::getOrInternStringHandle(component);
+			if (first_member && first_member_template_arguments.has_value()) {
+				member.template_arguments = *first_member_template_arguments;
+				member.has_template_arguments = true;
+			}
+			member.has_template_keyword = first_member && first_member_has_template_keyword;
+			record.member_chain.push_back(std::move(member));
+		}
+		first_member = false;
+		if (sep == std::string_view::npos) {
+			break;
+		}
+		start = sep + 2;
+	}
+
+	return record;
+}
+
+}
+
 // Helper function to get TypeCategory and size for built-in type keywords
 // Used by both parse_type_specifier and functional-style cast parsing
 std::optional<std::pair<TypeCategory, unsigned char>> Parser::get_builtin_type_info(std::string_view type_name) {
@@ -1146,9 +1195,29 @@ ParseResult Parser::parse_type_specifier() {
 					placeholder_type.name_ = type_handle;
 					placeholder_type.is_incomplete_instantiation_ = true;
 					placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+					placeholder_type.setDependentQualifiedName(
+						makeDependentQualifiedNameRecord(
+							StringTable::getOrInternStringHandle(base_part),
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
+							InlineVector<TypeInfo::TemplateArgInfo, 4>{},
+							type_name.substr(type_name.find("::") + 2),
+							false,
+							std::nullopt));
 					getTypesByNameMap()[type_handle] = &placeholder_type;
 					type_idx = placeholder_type.type_index_;
 				} else {
+					if (type_it->second != nullptr &&
+						type_it->second->isDependentMemberType() &&
+						!type_it->second->hasDependentQualifiedName()) {
+						type_it->second->setDependentQualifiedName(
+							makeDependentQualifiedNameRecord(
+								StringTable::getOrInternStringHandle(base_part),
+								TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
+								InlineVector<TypeInfo::TemplateArgInfo, 4>{},
+								type_name.substr(type_name.find("::") + 2),
+								false,
+								std::nullopt));
+					}
 					type_idx = type_it->second->type_index_;
 				}
 
@@ -1580,13 +1649,22 @@ ParseResult Parser::parse_type_specifier() {
 						dependent_type_builder.append(type_name);
 						dependent_type_builder.append("<...>");
 						Token nested_token = peek_info();
+						TypeInfo::DependentQualifiedNameRecord dependent_name_record;
+						dependent_name_record.owner_kind =
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter;
+						dependent_name_record.owner_name =
+							StringTable::getOrInternStringHandle(type_name);
+						dependent_name_record.owner_template_arguments =
+							convertToTemplateArgInfo(*template_args);
 
 						while (peek() == "::"_tok) {
 							advance(); // consume '::'
 
 							// Handle optional 'template' keyword for dependent contexts
+							bool has_template_keyword = false;
 							if (peek() == "template"_tok) {
 								advance(); // consume 'template'
+								has_template_keyword = true;
 							}
 
 							if (!peek().is_identifier()) {
@@ -1596,16 +1674,23 @@ ParseResult Parser::parse_type_specifier() {
 							nested_token = peek_info();
 							advance(); // consume the identifier
 							dependent_type_builder.append("::").append(nested_token.value());
+							TypeInfo::DependentQualifiedNameRecord::Member member_record;
+							member_record.name = nested_token.handle();
+							member_record.has_template_keyword = has_template_keyword;
 
 							if (peek() == "<"_tok) {
 								auto nested_template_args = parse_explicit_template_arguments();
 								if (!nested_template_args.has_value()) {
 									return ParseResult::error("Failed to parse template arguments for dependent nested type", nested_token);
 								}
+								member_record.template_arguments =
+									convertToTemplateArgInfo(*nested_template_args);
+								member_record.has_template_arguments = true;
 								dependent_type_builder.append("<")
 													.append(nested_template_args->size())
 													.append(" args>");
 							}
+							dependent_name_record.member_chain.push_back(std::move(member_record));
 						}
 						std::string_view dependent_type_name = dependent_type_builder.commit();
 
@@ -1620,6 +1705,7 @@ ParseResult Parser::parse_type_specifier() {
 							placeholder_type.name_ = type_handle;
 							placeholder_type.is_incomplete_instantiation_ = true;
 							placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+							placeholder_type.setDependentQualifiedName(dependent_name_record);
 							placeholder_type.setTemplateInstantiationInfo(
 								QualifiedIdentifier::fromQualifiedName(type_name, gSymbolTable.get_current_namespace_handle()),
 								convertToTemplateArgInfo(*template_args));
@@ -2006,6 +2092,38 @@ ParseResult Parser::parse_type_specifier() {
 						type_info.name_ = type_name_handle;
 						type_info.is_incomplete_instantiation_ = true;
 						type_info.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+						TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind =
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
+						if (!struct_parsing_context_stack_.empty() &&
+							struct_parsing_context_stack_.back().struct_name == type_name) {
+							owner_kind = TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation;
+						} else if (is_dependent_template_param) {
+							owner_kind = TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter;
+						}
+						StringBuilder member_path_builder;
+						if (qualified_type_name.starts_with(instantiated_name) &&
+							qualified_type_name.size() > instantiated_name.size() + 2 &&
+							qualified_type_name.substr(instantiated_name.size(), 2) == "::") {
+							member_path_builder.append(qualified_type_name.substr(instantiated_name.size() + 2));
+						} else if (!ns_qualified.empty() && ns_qualified != type_name &&
+							ns_qualified.starts_with(type_name) &&
+							ns_qualified.size() > type_name.size() + 2 &&
+							ns_qualified.substr(type_name.size(), 2) == "::") {
+							member_path_builder.append(ns_qualified.substr(type_name.size() + 2)).append("::");
+							member_path_builder.append(member_name);
+						} else {
+							member_path_builder.append(member_name);
+						}
+						std::string_view dependent_member_path =
+							member_path_builder.commit();
+						type_info.setDependentQualifiedName(
+							makeDependentQualifiedNameRecord(
+								StringTable::getOrInternStringHandle(type_name),
+								owner_kind,
+								convertToTemplateArgInfo(*template_args),
+								dependent_member_path,
+								had_template_keyword,
+								dependent_member_template_args));
 						if (dependent_member_template_base.has_value() && dependent_member_template_args.has_value()) {
 							type_info.setTemplateInstantiationInfo(
 								QualifiedIdentifier::fromQualifiedName(

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4915,10 +4915,18 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::buildOverloadResolutionArgTyp
 		if (const auto* ctor_call = std::get_if<ConstructorCallNode>(&expr)) {
 			const TypeSpecifierNode& ctor_type = ctor_call->type_node();
 			if (ctor_type.type_index().is_valid()) {
-				if (const TypeInfo* ctor_type_info = tryGetTypeInfo(ctor_type.type_index());
-					ctor_type_info && ctor_type_info->isEnum()) {
+				const ResolvedAliasTypeInfo alias_info = resolveAliasTypeInfo(ctor_type.type_index());
+				const TypeInfo* ctor_type_info = alias_info.terminal_type_info;
+				if (!ctor_type_info) {
+					ctor_type_info = tryGetTypeInfo(ctor_type.type_index());
+				}
+				if (ctor_type_info && ctor_type_info->isEnum()) {
+					TypeIndex enum_type_index = alias_info.type_index.is_valid()
+						? alias_info.type_index
+						: ctor_type_info->type_index_;
+					enum_type_index = enum_type_index.withCategory(TypeCategory::Enum);
 					TypeSpecifierNode enum_arg_type(
-						ctor_type_info->type_index_.withCategory(TypeCategory::Enum),
+						enum_type_index,
 						ctor_type_info->sizeInBits(),
 						ctor_type.token(),
 						ctor_type.cv_qualifier(),
@@ -4927,7 +4935,7 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::buildOverloadResolutionArgTyp
 					storeArgType(enum_arg_type);
 					if (inferred_type_id) {
 						CanonicalTypeDesc desc;
-						desc.type_index = ctor_type_info->type_index_.withCategory(TypeCategory::Enum);
+						desc.type_index = enum_type_index;
 						*inferred_type_id = type_context_.intern(desc);
 					}
 					return enum_arg_type;
@@ -6982,11 +6990,20 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 			type_info = type_it->second;
 		}
 	}
-	if (type_info && type_info->aliasTypeSpecifier()) {
-		const TypeSpecifierNode& alias_spec = *type_info->aliasTypeSpecifier();
-		if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_spec.type_index())) {
-			type_info = alias_target_info;
-			resolved_type_spec = alias_spec;
+	const StringHandle spelled_constructed_name = resolved_type_spec.token().handle();
+	if (type_info) {
+		TypeIndex alias_source_index = type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
+		if (!alias_source_index.is_valid()) {
+			alias_source_index = type_info->type_index_.withCategory(type_info->typeEnum());
+		}
+		const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(alias_source_index);
+		if (resolved_alias.terminal_type_info) {
+			type_info = resolved_alias.terminal_type_info;
+			if (resolved_alias.type_index.is_valid()) {
+				resolved_type_spec.set_type_index(resolved_alias.type_index);
+			} else {
+				resolved_type_spec.set_type_index(type_info->registeredTypeIndex().withCategory(type_info->typeEnum()));
+			}
 		}
 	}
 	if (const MemberContext* member_context = getCurrentMemberContext();
@@ -6998,9 +7015,15 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 			StringHandle constructed_name = type_info ? type_info->name() : resolved_type_spec.token().handle();
 			const std::string_view current_base_template_name =
 				StringTable::getStringView(member_type_info->baseTemplateName());
-			if (constructed_name.isValid() &&
+			const bool terminal_name_matches =
+				constructed_name.isValid() &&
 				!current_base_template_name.empty() &&
-				current_base_template_name == StringTable::getStringView(constructed_name)) {
+				current_base_template_name == StringTable::getStringView(constructed_name);
+			const bool spelled_name_matches =
+				spelled_constructed_name.isValid() &&
+				!current_base_template_name.empty() &&
+				current_base_template_name == StringTable::getStringView(spelled_constructed_name);
+			if (terminal_name_matches || spelled_name_matches) {
 				type_info = member_type_info;
 			}
 		}

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -38,6 +38,7 @@ TypeInfo::TemplateArgInfo toTemplateArgInfo(const TemplateTypeArg& arg) {
 	info.array_dimensions.assign(arg.array_dimensions.begin(), arg.array_dimensions.end());
 	info.value = arg.value;
 	info.is_value = arg.is_value;
+	info.is_pack = arg.is_pack;
 	info.dependent_name = arg.dependent_name;
 	info.function_signature = arg.function_signature;
 	info.dependent_expr = arg.dependent_expr;
@@ -51,6 +52,7 @@ TemplateTypeArg toTemplateTypeArg(const TypeInfo::TemplateArgInfo& arg) {
 	TemplateTypeArg ta;
 	ta.type_index = arg.type_index;
 	ta.is_value = arg.is_value;
+	ta.is_pack = arg.is_pack;
 	ta.cv_qualifier = arg.cv_qualifier;
 	ta.ref_qualifier = arg.ref_qualifier;
 	ta.pointer_depth = static_cast<uint8_t>(arg.pointer_depth);
@@ -151,6 +153,7 @@ void appendContextBindings(
 		binding.name = context->param_names[i];
 		TemplateTypeArg arg = toTemplateTypeArg(context->param_args[i]);
 		binding.kind = inferBindingKind(arg);
+		binding.is_pack = arg.is_pack;
 		binding.args.push_back(std::move(arg));
 
 		size_t next_index = i + 1;
@@ -184,6 +187,7 @@ InlineVector<TemplateBindingSnapshot, 4> buildSnapshotBindingsForCurrentScope(
 		TemplateBindingSnapshot binding;
 		binding.name = param_names[i];
 		binding.kind = inferBindingKind(args[i]);
+		binding.is_pack = args[i].is_pack;
 		binding.args.push_back(args[i]);
 		bindings.push_back(std::move(binding));
 	}

--- a/src/TemplateEnvironment.h
+++ b/src/TemplateEnvironment.h
@@ -91,6 +91,7 @@ struct TemplateInstantiationContext {
 	StringHandle current_instantiation_name{};
 	TypeIndex current_instantiation_type{};
 	TemplateLookupContext lookup_context;
+	const TemplateDefinitionLookupContext* definition_lookup_context = nullptr;
 	const ConstExpr::EvaluationContext* constexpr_context = nullptr;
 	const SemanticAnalysis* semantic_context = nullptr;
 	TemplateSubstitutionFailurePolicy failure_policy = TemplateSubstitutionFailurePolicy::HardUse;

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -516,7 +516,7 @@ struct TemplatePattern {
 				}
 				// For non-type template parameters, also check the value matches
 				if (pattern_arg.is_value && concrete_arg.is_value) {
-					if (pattern_arg.value != concrete_arg.value) {
+					if (!(pattern_arg.valueIdentity() == concrete_arg.valueIdentity())) {
 						FLASH_LOG(Templates, Trace, "    FAILED: values don't match");
 						return false; // Different values - no match
 					}

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -34,6 +34,29 @@ public:
 				}
 			}
 		}
+		if (template_node.is<TemplateFunctionDeclarationNode>()) {
+			auto& entries = templates_[name];
+			const auto& new_template = template_node.as<TemplateFunctionDeclarationNode>();
+			const FunctionDeclarationNode& new_function = new_template.function_decl_node();
+			if (new_function.has_any_body_source()) {
+				for (ASTNode& entry : entries) {
+					if (!entry.is<TemplateFunctionDeclarationNode>()) {
+						continue;
+					}
+					const auto& old_template = entry.as<TemplateFunctionDeclarationNode>();
+					const FunctionDeclarationNode& old_function = old_template.function_decl_node();
+					if (old_function.has_any_body_source()) {
+						continue;
+					}
+					if (old_template.template_parameters().size() != new_template.template_parameters().size() ||
+						old_function.parameter_nodes().size() != new_function.parameter_nodes().size()) {
+						continue;
+					}
+					entry = template_node;
+					return;
+				}
+			}
+		}
 		templates_[name].push_back(template_node);
 	}
 

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -170,6 +170,8 @@ struct TemplateTypeArg {
 	// For non-type template parameters
 	bool is_value;  // true if this represents a value instead of a type
 	int64_t value;  // the value for non-type parameters
+	bool has_typed_value_identity;  // true when non-integral NTTP identity carries semantic payload
+	FlashCpp::NonTypeValueIdentity typed_value_identity;
 
 	// For variadic templates (parameter packs)
 	bool is_pack;  // true if this represents a parameter pack (typename... Args)
@@ -215,10 +217,23 @@ struct TemplateTypeArg {
 	// Callers should prefer this accessor over directly reading value/dependent_name/type fields
 	// when building instantiation keys, hashes, or mangled names for non-type arguments.
 	FlashCpp::NonTypeValueIdentity valueIdentity() const {
+		if (is_value && has_typed_value_identity) {
+			return typed_value_identity;
+		}
 		if (is_dependent) {
 			return FlashCpp::NonTypeValueIdentity::makeDependentWithPlaceholder(dependent_name, value, type_index);
 		}
 		return FlashCpp::NonTypeValueIdentity::makeConcrete(value, type_index);
+	}
+
+	void setValueIdentity(const FlashCpp::NonTypeValueIdentity& identity) {
+		is_value = true;
+		has_typed_value_identity = identity.kind != FlashCpp::NonTypeValueIdentityKind::Integral;
+		typed_value_identity = identity;
+		type_index = identity.value_type_index;
+		value = identity.value;
+		is_dependent = identity.is_dependent;
+		dependent_name = identity.dependent_name;
 	}
 
 	// Builds a TypeIndex with category directly.
@@ -227,10 +242,10 @@ struct TemplateTypeArg {
 	}
 
 	TemplateTypeArg()
-		: type_index(TypeIndex{}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), is_pack(false), is_dependent(false), dependent_name(), is_template_template_arg(false), template_name_handle() {}
+		: type_index(TypeIndex{}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), dependent_name(), is_template_template_arg(false), template_name_handle() {}
 
 	explicit TemplateTypeArg(const TypeSpecifierNode& type_spec)
-		: type_index(makeTypeIndex(type_spec.type_index().withCategory(type_spec.type()))), ref_qualifier(type_spec.reference_qualifier()), pointer_depth(type_spec.pointer_depth()), pointer_cv_qualifiers(), cv_qualifier(type_spec.cv_qualifier()), is_array(type_spec.is_array()), array_dimensions(type_spec.array_dimensions().begin(), type_spec.array_dimensions().end()), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle(), function_signature(type_spec.has_function_signature() ? std::optional(type_spec.function_signature()) : std::nullopt) {
+		: type_index(makeTypeIndex(type_spec.type_index().withCategory(type_spec.type()))), ref_qualifier(type_spec.reference_qualifier()), pointer_depth(type_spec.pointer_depth()), pointer_cv_qualifiers(), cv_qualifier(type_spec.cv_qualifier()), is_array(type_spec.is_array()), array_dimensions(type_spec.array_dimensions().begin(), type_spec.array_dimensions().end()), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle(), function_signature(type_spec.has_function_signature() ? std::optional(type_spec.function_signature()) : std::nullopt) {
 		for (const auto& level : type_spec.pointer_levels()) {
 			pointer_cv_qualifiers.push_back(level.cv_qualifier);
 		}
@@ -271,11 +286,11 @@ struct TemplateTypeArg {
 
 	// Constructor for non-type template parameters (default int type)
 	explicit TemplateTypeArg(int64_t val)
-		: type_index(nativeTypeIndex(TypeCategory::Int)), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
+		: type_index(nativeTypeIndex(TypeCategory::Int)), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
 
 	// Constructor for non-type template parameters with explicit type
 	TemplateTypeArg(int64_t val, TypeCategory category)
-		: type_index(TypeIndex{0, category}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
+		: type_index(TypeIndex{0, category}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
 
 	// Factory methods
 	static TemplateTypeArg makeType(TypeIndex idx) {
@@ -295,6 +310,12 @@ struct TemplateTypeArg {
 	static TemplateTypeArg makeValue(int64_t v, TypeIndex idx) {
 		TemplateTypeArg arg(v, idx.category());
 		arg.type_index = makeTypeIndex(idx);
+		return arg;
+	}
+
+	static TemplateTypeArg makeValueIdentity(const FlashCpp::NonTypeValueIdentity& identity) {
+		TemplateTypeArg arg;
+		arg.setValueIdentity(identity);
 		return arg;
 	}
 
@@ -402,7 +423,7 @@ struct TemplateTypeArg {
 			  is_dependent == other.is_dependent &&
 			  // dependent_name only contributes when the arg is still dependent.
 			  (!is_dependent || dependent_name == other.dependent_name) &&
-			  (!is_value || value == other.value) &&
+			  (!is_value || valueIdentity() == other.valueIdentity()) &&
 			  is_template_template_arg == other.is_template_template_arg &&
 			  (!is_template_template_arg || template_name_handle == other.template_name_handle)))
 			return false;

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -292,6 +292,12 @@ struct TemplateTypeArg {
 		return TemplateTypeArg(v, cat);
 	}
 
+	static TemplateTypeArg makeValue(int64_t v, TypeIndex idx) {
+		TemplateTypeArg arg(v, idx.category());
+		arg.type_index = makeTypeIndex(idx);
+		return arg;
+	}
+
 	static TemplateTypeArg makeDependentValue(StringHandle name, TypeCategory category) {
 		return makeDependentValue(name, category, 0, std::nullopt);
 	}

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -276,7 +276,7 @@ struct NonTypeValueIdentity {
 	static size_t hashValueTypeIdentity(TypeIndex type_index) {
 		TypeCategory normalized_category = normalizedTypeForComparison(type_index.category());
 		size_t h = std::hash<uint8_t>{}(static_cast<uint8_t>(normalized_category));
-		if (normalized_category != TypeCategory::Int && type_index.needsTypeIndex()) {
+		if (type_index.needsTypeIndex()) {
 			h ^= hashTypeIndexIdentity(type_index) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		}
 		return h;

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -199,9 +199,25 @@ struct TypeIndexArg {
  * 
  * The goal is one canonical representation that TemplateInstantiationKey consumes directly.
  */
+enum class NonTypeValueIdentityKind : uint8_t {
+	Integral,
+	Nullptr,
+	ObjectPointer,
+	Reference,
+	FunctionPointer,
+	MemberPointer,
+	Floating,
+	StructuralClass,
+	Unsupported
+};
+
 struct NonTypeValueIdentity {
-	int64_t value = 0;              // The concrete value (meaningful when !is_dependent)
+	NonTypeValueIdentityKind kind = NonTypeValueIdentityKind::Integral;
+	int64_t value = 0;              // Integral value or ABI offset/sentinel for pointer-to-member
 	TypeIndex value_type_index = nativeTypeIndex(TypeCategory::Int);  // The full type identity of the value
+	StringHandle entity_name{};     // Named object/function for pointer/reference/function-pointer identities
+	StringHandle member_name{};     // Class member for pointer-to-member identities
+	int64_t pointer_offset = 0;     // Array-element offset for object pointer identities
 	StringHandle dependent_name{};  // Name when dependent (e.g., "N" for template<int N>)
 	bool is_dependent = false;      // True if this is a dependent (not yet substituted) value
 
@@ -216,8 +232,59 @@ struct NonTypeValueIdentity {
 
 	static NonTypeValueIdentity makeConcrete(int64_t val, TypeIndex type_index) {
 		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::Integral;
 		id.value = val;
 		id.value_type_index = type_index;
+		id.is_dependent = false;
+		id.dependent_name = {};
+		return id;
+	}
+
+	static NonTypeValueIdentity makeNullptr(TypeIndex type_index) {
+		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::Nullptr;
+		id.value = 0;
+		id.value_type_index = type_index;
+		id.is_dependent = false;
+		id.dependent_name = {};
+		return id;
+	}
+
+	static NonTypeValueIdentity makeObjectPointer(TypeIndex type_index, StringHandle target_name, int64_t offset) {
+		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::ObjectPointer;
+		id.value = 0;
+		id.value_type_index = type_index;
+		id.entity_name = target_name;
+		id.pointer_offset = offset;
+		id.is_dependent = false;
+		id.dependent_name = {};
+		return id;
+	}
+
+	static NonTypeValueIdentity makeReference(TypeIndex type_index, StringHandle target_name) {
+		NonTypeValueIdentity id = makeObjectPointer(type_index, target_name, 0);
+		id.kind = NonTypeValueIdentityKind::Reference;
+		return id;
+	}
+
+	static NonTypeValueIdentity makeFunctionPointer(TypeIndex type_index, StringHandle function_name) {
+		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::FunctionPointer;
+		id.value = 0;
+		id.value_type_index = type_index;
+		id.entity_name = function_name;
+		id.is_dependent = false;
+		id.dependent_name = {};
+		return id;
+	}
+
+	static NonTypeValueIdentity makeMemberPointer(TypeIndex type_index, StringHandle target_member, int64_t offset) {
+		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::MemberPointer;
+		id.value = offset;
+		id.value_type_index = type_index;
+		id.member_name = target_member;
 		id.is_dependent = false;
 		id.dependent_name = {};
 		return id;
@@ -229,6 +296,7 @@ struct NonTypeValueIdentity {
 
 	static NonTypeValueIdentity makeDependent(StringHandle name, TypeIndex type_index) {
 		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::Integral;
 		id.value = 0;
 		id.value_type_index = type_index;
 		id.is_dependent = true;
@@ -242,6 +310,7 @@ struct NonTypeValueIdentity {
 
 	static NonTypeValueIdentity makeDependentWithPlaceholder(StringHandle name, int64_t placeholder_value, TypeIndex type_index) {
 		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::Integral;
 		id.value = placeholder_value;
 		id.value_type_index = type_index;
 		id.is_dependent = true;
@@ -289,9 +358,29 @@ struct NonTypeValueIdentity {
 			// Dependent args: identity is the name only
 			return dependent_name == other.dependent_name;
 		}
-		// Concrete args: identity is value + exact type.
-		return value == other.value &&
-			   equalValueTypeIdentity(value_type_index, other.value_type_index);
+		if (kind != other.kind ||
+			!equalValueTypeIdentity(value_type_index, other.value_type_index)) {
+			return false;
+		}
+		switch (kind) {
+		case NonTypeValueIdentityKind::Integral:
+		case NonTypeValueIdentityKind::Floating:
+		case NonTypeValueIdentityKind::StructuralClass:
+		case NonTypeValueIdentityKind::Unsupported:
+			return value == other.value;
+		case NonTypeValueIdentityKind::Nullptr:
+			return true;
+		case NonTypeValueIdentityKind::ObjectPointer:
+			return entity_name == other.entity_name &&
+				   pointer_offset == other.pointer_offset;
+		case NonTypeValueIdentityKind::Reference:
+		case NonTypeValueIdentityKind::FunctionPointer:
+			return entity_name == other.entity_name;
+		case NonTypeValueIdentityKind::MemberPointer:
+			return member_name == other.member_name &&
+				   value == other.value;
+		}
+		return false;
 	}
 
 	size_t hash() const {
@@ -302,7 +391,17 @@ struct NonTypeValueIdentity {
 			}
 			return h;
 		}
+		h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(kind)) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		h ^= std::hash<int64_t>{}(value) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		if (entity_name.isValid()) {
+			h ^= std::hash<StringHandle>{}(entity_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
+		if (member_name.isValid()) {
+			h ^= std::hash<StringHandle>{}(member_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
+		if (kind == NonTypeValueIdentityKind::ObjectPointer) {
+			h ^= std::hash<int64_t>{}(pointer_offset) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
 		h ^= hashValueTypeIdentity(value_type_index) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		return h;
 	}
@@ -315,6 +414,27 @@ struct NonTypeValueIdentity {
 		// For boolean values, use "true" or "false" instead of "1" or "0"
 		if (valueTypeCategory() == TypeCategory::Bool) {
 			return value != 0 ? "true" : "false";
+		}
+		if (kind == NonTypeValueIdentityKind::Nullptr) {
+			return "nullptr";
+		}
+		if (entity_name.isValid()) {
+			std::string result;
+			if (kind == NonTypeValueIdentityKind::ObjectPointer ||
+				kind == NonTypeValueIdentityKind::FunctionPointer) {
+				result += "&";
+			}
+			result += StringTable::getStringView(entity_name);
+			if (pointer_offset != 0) {
+				result += "+";
+				result += std::to_string(pointer_offset);
+			}
+			return result;
+		}
+		if (member_name.isValid()) {
+			std::string result = "&";
+			result += StringTable::getStringView(member_name);
+			return result;
 		}
 		return std::to_string(value);
 	}
@@ -661,14 +781,18 @@ inline std::string_view generateInstantiatedName(std::string_view template_name,
 												 const TemplateInstantiationKey& key) {
 	// Compute the hash of the template arguments
 	size_t h = 0;
-	for (const auto& arg : key.type_args) {
-		h ^= arg.hash() + 0x9e3779b9 + (h << 6) + (h >> 2);
-	}
-	for (const auto& arg : key.value_args) {
-		h ^= arg.hash() + 0x9e3779b9 + (h << 6) + (h >> 2);
-	}
-	for (const auto& arg : key.template_template_args) {
-		h ^= std::hash<uint32_t>{}(arg.handle) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	if (!key.ordered_identity.empty()) {
+		h = key.ordered_identity.hash();
+	} else {
+		for (const auto& arg : key.type_args) {
+			h ^= arg.hash() + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
+		for (const auto& arg : key.value_args) {
+			h ^= arg.hash() + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
+		for (const auto& arg : key.template_template_args) {
+			h ^= std::hash<uint32_t>{}(arg.handle) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
 	}
 
 	// Build the name: template_name$hash (using $ as unambiguous separator)

--- a/src/TypeSizeQuery.h
+++ b/src/TypeSizeQuery.h
@@ -258,6 +258,29 @@ inline ConcreteTypeSizeQueryResult queryConcreteAliasResolvedTypeSizeBits(const 
 	return queryConcreteAliasResolvedTypeSizeBitsImpl(type_spec, 64);
 }
 
+inline TypeSpecifierNode makeStaticMemberSizeQueryTypeSpecifier(const StructStaticMember& member) {
+	TypeSpecifierNode member_type(
+		member.type_index.withCategory(member.memberType()),
+		SizeInBits{static_cast<int>(member.size * 8)},
+		Token{},
+		member.cv_qualifier,
+		member.reference_qualifier);
+	member_type.add_pointer_levels(member.pointer_depth);
+	if (member.is_array) {
+		member_type.set_array_dimensions(member.array_dimensions);
+	}
+	return member_type;
+}
+
+inline int queryConcreteAliasResolvedStaticMemberSizeBits(const StructStaticMember& member) {
+	TypeSpecifierNode member_type = makeStaticMemberSizeQueryTypeSpecifier(member);
+	const int size_bits = queryConcreteAliasResolvedTypeSizeBits(member_type).size_bits;
+	if (size_bits > 0) {
+		return size_bits;
+	}
+	return get_type_size_bits(resolve_type_alias(member.type_index));
+}
+
 inline int requireConcreteAliasResolvedTypeSizeBits(const TypeSpecifierNode& type_spec, std::string_view context) {
 	const ConcreteTypeSizeQueryResult query = queryConcreteAliasResolvedTypeSizeBits(type_spec);
 	if (query.hasSize()) {
@@ -313,4 +336,37 @@ inline int requireConcreteAliasResolvedTypeSizeBits(const TypeSpecifierNode& typ
 										.append(static_cast<int64_t>(type_spec.pointer_depth()))
 										.append(")")
 										.commit()));*/
+}
+
+inline TypeCategory requireConcreteAliasResolvedCodegenTypeCategory(const TypeSpecifierNode& type_spec, std::string_view context) {
+	TypeCategory type = type_spec.type();
+	if (!isPlaceholderAutoType(type)) {
+		return type;
+	}
+	if (type_spec.type_index().is_valid()) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
+			TypeCategory resolved_type = type_info->typeEnum();
+			if (!isPlaceholderAutoType(resolved_type) && resolved_type != TypeCategory::Invalid) {
+				return resolved_type;
+			}
+		}
+	}
+	throw InternalError(std::string(StringBuilder()
+										.append("Unresolved placeholder type reached codegen in ")
+										.append(context)
+										.append(" (type=")
+										.append(static_cast<int64_t>(type))
+										.append(")")
+										.commit()));
+}
+
+inline TypeSpecifierNode makeConcreteAliasResolvedCodegenSizeQueryType(const TypeSpecifierNode& type_spec, std::string_view context) {
+	TypeSpecifierNode resolved_type_spec = type_spec;
+	resolved_type_spec.set_category(requireConcreteAliasResolvedCodegenTypeCategory(type_spec, context));
+	return resolved_type_spec;
+}
+
+inline int requireConcreteAliasResolvedCodegenSizeBits(const TypeSpecifierNode& type_spec, std::string_view context) {
+	TypeSpecifierNode resolved_type_spec = makeConcreteAliasResolvedCodegenSizeQueryType(type_spec, context);
+	return requireConcreteAliasResolvedTypeSizeBits(resolved_type_spec, context);
 }

--- a/tests/deferred_base_auto_nttp_static_long_exact_ret43.cpp
+++ b/tests/deferred_base_auto_nttp_static_long_exact_ret43.cpp
@@ -1,0 +1,26 @@
+template <auto V>
+struct Pick {
+	static constexpr int value = 0;
+};
+
+template <>
+struct Pick<7> {
+	static constexpr int value = 1;
+};
+
+template <>
+struct Pick<7L> {
+	static constexpr int value = 43;
+};
+
+template <long N>
+struct Source {
+	static constexpr long value = N;
+};
+
+template <long N>
+struct Derived : Pick<Source<N>::value> {};
+
+int main() {
+	return Derived<7>::value;
+}

--- a/tests/deferred_base_auto_nttp_static_unsigned_exact_ret42.cpp
+++ b/tests/deferred_base_auto_nttp_static_unsigned_exact_ret42.cpp
@@ -1,0 +1,26 @@
+template <auto V>
+struct Pick {
+	static constexpr int value = 0;
+};
+
+template <>
+struct Pick<7> {
+	static constexpr int value = 1;
+};
+
+template <>
+struct Pick<7u> {
+	static constexpr int value = 42;
+};
+
+template <unsigned N>
+struct Source {
+	static constexpr unsigned value = N;
+};
+
+template <unsigned N>
+struct Derived : Pick<Source<N>::value> {};
+
+int main() {
+	return Derived<7>::value;
+}

--- a/tests/deferred_base_auto_nttp_width_identity_ret44.cpp
+++ b/tests/deferred_base_auto_nttp_width_identity_ret44.cpp
@@ -1,0 +1,26 @@
+template <auto V>
+struct Pick {
+	static constexpr int value = 0;
+};
+
+template <>
+struct Pick<5> {
+	static constexpr int value = 1;
+};
+
+template <>
+struct Pick<5LL> {
+	static constexpr int value = 44;
+};
+
+template <long long N>
+struct Source {
+	static constexpr long long value = N;
+};
+
+template <long long N>
+struct Derived : Pick<Source<N>::value> {};
+
+int main() {
+	return Derived<5>::value;
+}

--- a/tests/dependent_member_template_record_ret42.cpp
+++ b/tests/dependent_member_template_record_ret42.cpp
@@ -1,0 +1,18 @@
+template<typename T>
+struct Traits {
+	template<typename U>
+	struct rebind {
+		using type = U;
+	};
+};
+
+template<typename T, typename U>
+struct UseMemberTemplate {
+	typename Traits<T>::template rebind<U>::type value;
+};
+
+int main() {
+	UseMemberTemplate<char, int> use;
+	use.value = 42;
+	return use.value;
+}

--- a/tests/dependent_nttp_alias_shadow_single_pass_ret42.cpp
+++ b/tests/dependent_nttp_alias_shadow_single_pass_ret42.cpp
@@ -1,0 +1,13 @@
+constexpr int N = 1;
+
+template<int Value>
+struct Tag {
+	static constexpr int value = Value;
+};
+
+template<int N>
+using Alias = Tag<N + 40>;
+
+int main() {
+	return Alias<2>::value;
+}

--- a/tests/dependent_nttp_alias_static_constexpr_ret42.cpp
+++ b/tests/dependent_nttp_alias_static_constexpr_ret42.cpp
@@ -1,0 +1,16 @@
+template<int Value>
+struct Tag {
+	static constexpr int value = Value;
+};
+
+template<typename T>
+struct Holder {
+	static constexpr int value = sizeof(T) + 34;
+};
+
+template<typename T>
+using Alias = Tag<Holder<T>::value>;
+
+int main() {
+	return Alias<long long>::value;
+}

--- a/tests/dependent_typename_record_ret42.cpp
+++ b/tests/dependent_typename_record_ret42.cpp
@@ -1,0 +1,14 @@
+struct Holder {
+	using type = int;
+};
+
+template<typename T>
+struct UseDependentTypename {
+	typename T::type value;
+};
+
+int main() {
+	UseDependentTypename<Holder> use;
+	use.value = 42;
+	return use.value;
+}

--- a/tests/member_template_shape_select_skips_bad_body_ret24.cpp
+++ b/tests/member_template_shape_select_skips_bad_body_ret24.cpp
@@ -1,0 +1,16 @@
+struct ShapeMember {
+	template <typename T = ShapeMember>
+	int call(long) {
+		return T::missing;
+	}
+
+	template <typename T = int>
+	int call(int) {
+		return 24;
+	}
+};
+
+int main() {
+	ShapeMember object;
+	return object.call(0);
+}

--- a/tests/template_overload_shape_select_skips_bad_body_ret42.cpp
+++ b/tests/template_overload_shape_select_skips_bad_body_ret42.cpp
@@ -1,0 +1,16 @@
+struct NoMember {
+};
+
+template <typename T = NoMember>
+int shape_selected(long) {
+	return T::missing;
+}
+
+template <typename T = int>
+int shape_selected(int) {
+	return 42;
+}
+
+int main() {
+	return shape_selected(0);
+}

--- a/tests/test_auto_enum_nttp_typed_identity_ret0.cpp
+++ b/tests/test_auto_enum_nttp_typed_identity_ret0.cpp
@@ -1,0 +1,28 @@
+enum First {
+	FirstValue = 7
+};
+
+enum Second {
+	SecondValue = 7
+};
+
+template <auto V>
+struct tag {
+	static constexpr int value = 9;
+};
+
+template <>
+struct tag<FirstValue> {
+	static constexpr int value = 1;
+};
+
+template <>
+struct tag<SecondValue> {
+	static constexpr int value = 2;
+};
+
+int main() {
+	if (tag<FirstValue>::value != 1) return 1;
+	if (tag<SecondValue>::value != 2) return 2;
+	return 0;
+}

--- a/tests/test_function_pointer_nttp_unsupported_fail.cpp
+++ b/tests/test_function_pointer_nttp_unsupported_fail.cpp
@@ -1,0 +1,12 @@
+int target() {
+	return 42;
+}
+
+template <int (*F)()>
+struct function_pointer_tag {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return function_pointer_tag<&target>::value;
+}

--- a/tests/test_member_pointer_nttp_unsupported_fail.cpp
+++ b/tests/test_member_pointer_nttp_unsupported_fail.cpp
@@ -1,0 +1,17 @@
+struct S {
+	int member;
+};
+
+template <int S::* P>
+struct member_pointer_tag {
+	static constexpr int value = 1;
+};
+
+template <>
+struct member_pointer_tag<&S::member> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return member_pointer_tag<&S::member>::value;
+}

--- a/tests/test_member_template_ctor_alias_chain_sema_ret42.cpp
+++ b/tests/test_member_template_ctor_alias_chain_sema_ret42.cpp
@@ -1,0 +1,19 @@
+struct Source {
+	int value;
+	Source(int v) : value(v) {}
+};
+
+using SourceAlias1 = Source;
+using SourceAlias2 = SourceAlias1;
+
+struct Box {
+	int value;
+
+	template<typename T>
+	Box(T t) : value(t.value) {}
+};
+
+int main() {
+	Box box = Box(SourceAlias2(42));
+	return box.value;
+}

--- a/tests/test_namespace_qualified_constexpr_template_arg_ret42.cpp
+++ b/tests/test_namespace_qualified_constexpr_template_arg_ret42.cpp
@@ -1,0 +1,12 @@
+namespace config {
+	constexpr int value = 42;
+}
+
+template <int N>
+struct Holder {
+	static constexpr int value = N;
+};
+
+int main() {
+	return Holder<config::value>::value;
+}

--- a/tests/test_namespace_qualified_static_constexpr_ret0.cpp
+++ b/tests/test_namespace_qualified_static_constexpr_ret0.cpp
@@ -1,0 +1,12 @@
+namespace config {
+	constexpr int base = 5;
+}
+
+template <int N>
+struct Add {
+	static constexpr int value = config::base + N;
+};
+
+int main() {
+	return Add<37>::value == 42 ? 0 : 1;
+}

--- a/tests/test_nullptr_nttp_typed_identity_ret0.cpp
+++ b/tests/test_nullptr_nttp_typed_identity_ret0.cpp
@@ -1,0 +1,14 @@
+template <decltype(nullptr) P>
+struct null_tag {
+	static constexpr int value = 1;
+};
+
+template <>
+struct null_tag<nullptr> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	if (null_tag<nullptr>::value != 42) return 1;
+	return 0;
+}

--- a/tests/test_pointer_nttp_unsupported_fail.cpp
+++ b/tests/test_pointer_nttp_unsupported_fail.cpp
@@ -1,0 +1,15 @@
+int global_value = 0;
+
+template <int* P>
+struct pointer_tag {
+	static constexpr int value = 1;
+};
+
+template <>
+struct pointer_tag<&global_value> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return pointer_tag<&global_value>::value;
+}

--- a/tests/test_reference_nttp_unsupported_fail.cpp
+++ b/tests/test_reference_nttp_unsupported_fail.cpp
@@ -1,0 +1,10 @@
+int global_value = 0;
+
+template <int& R>
+struct reference_tag {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return reference_tag<global_value>::value;
+}

--- a/tests/test_static_constexpr_runtime_aggregate_initializer_fail.cpp
+++ b/tests/test_static_constexpr_runtime_aggregate_initializer_fail.cpp
@@ -1,0 +1,13 @@
+int runtime_value();
+
+struct X {
+	int value;
+};
+
+struct Broken {
+	static constexpr X value = { runtime_value() };
+};
+
+int main() {
+	return Broken::value.value;
+}

--- a/tests/test_static_constexpr_runtime_ctor_initializer_fail.cpp
+++ b/tests/test_static_constexpr_runtime_ctor_initializer_fail.cpp
@@ -1,0 +1,14 @@
+int runtime_value();
+
+struct X {
+	int value;
+	X(int input) : value(input) {}
+};
+
+struct Broken {
+	static constexpr X value = X(runtime_value());
+};
+
+int main() {
+	return Broken::value.value;
+}

--- a/tests/test_static_member_alias_sizeof_ret0.cpp
+++ b/tests/test_static_member_alias_sizeof_ret0.cpp
@@ -1,0 +1,24 @@
+struct Payload {
+	int a;
+	short b;
+	char c;
+};
+
+using PayloadAlias = Payload;
+using PayloadRefAlias = PayloadAlias&;
+
+struct Holder {
+	static PayloadAlias object;
+	static PayloadRefAlias ref;
+};
+
+PayloadAlias Holder::object = {7, 3, 1};
+PayloadRefAlias Holder::ref = Holder::object;
+
+int main() {
+	return sizeof(Holder::object) == sizeof(Payload) &&
+			sizeof(Holder::ref) == sizeof(Payload) &&
+			Holder::object.a == 7
+		? 0
+		: 1;
+}

--- a/tests/test_structural_class_nttp_unsupported_fail.cpp
+++ b/tests/test_structural_class_nttp_unsupported_fail.cpp
@@ -1,0 +1,14 @@
+struct Key {
+	int value;
+};
+
+template <Key K>
+struct structural_tag {
+	static constexpr int value = K.value;
+};
+
+constexpr Key key{42};
+
+int main() {
+	return structural_tag<key>::value;
+}

--- a/tests/test_template_two_phase_dependent_adl_poi_ret0.cpp
+++ b/tests/test_template_two_phase_dependent_adl_poi_ret0.cpp
@@ -1,0 +1,21 @@
+namespace lib {
+	struct Value {
+		int n;
+	};
+}
+
+template <class T>
+int call_dependent(T value) {
+	return f(value);
+}
+
+namespace lib {
+	int f(Value value) {
+		return value.n;
+	}
+}
+
+int main() {
+	lib::Value value{42};
+	return call_dependent(value) - 42;
+}

--- a/tests/test_template_two_phase_nondependent_later_better_overload_ret42.cpp
+++ b/tests/test_template_two_phase_nondependent_later_better_overload_ret42.cpp
@@ -1,0 +1,16 @@
+int f(long) {
+	return 42;
+}
+
+template <class T>
+int call_nondependent() {
+	return f(0);
+}
+
+int f(int) {
+	return 7;
+}
+
+int main() {
+	return call_nondependent<int>();
+}

--- a/tests/test_type_alias_chain_struct_paren_ctor_ret42.cpp
+++ b/tests/test_type_alias_chain_struct_paren_ctor_ret42.cpp
@@ -1,0 +1,12 @@
+struct S {
+	int x;
+	S(int v) : x(v) {}
+};
+
+using A1 = S;
+using A2 = A1;
+using A3 = A2;
+
+int main() {
+	return A3(42).x;
+}

--- a/tests/test_type_alias_enum_functional_cast_ctor_arg_ret42.cpp
+++ b/tests/test_type_alias_enum_functional_cast_ctor_arg_ret42.cpp
@@ -1,0 +1,17 @@
+enum class Color : int {
+	Red = 1,
+	Blue = 42
+};
+
+using ColorAlias1 = Color;
+using ColorAlias2 = ColorAlias1;
+
+struct Paint {
+	Color color;
+	Paint(Color c) : color(c) {}
+};
+
+int main() {
+	Paint paint{ColorAlias2(42)};
+	return static_cast<int>(paint.color);
+}


### PR DESCRIPTION
## Summary

Completed comprehensive template infrastructure refactoring to improve C++20 standard conformance. This PR implements five high-impact architecture passes that establish a more conforming foundation for template argument handling, overload resolution, and instantiation semantics.

## Phases Implemented

### 1. Conservative Template Definition Lookup Records
- Records source location context at template parse time
- Filters Phase 1 ordinary function overloads to exclude declarations after template definition
- Preserves dependent/ADL lookup at point-of-instantiation
- Commit: 2012845d

### 2. Typed NTTP Value Identity Model
- Distinguishes integral, enum, nullptr, and placeholder categories for non-type parameters
- Replaces scalar-only int64_t approach with category-aware identity
- Establishes infrastructure for future reference/pointer/member-pointer support
- Commit: cd34eab1

### 3. Deduction/Body Materialization Split
- Separates template overload ranking (shape-only) from body instantiation
- Selected candidates materialized in full; unranked paths use fallback
- Improves error messages and reduces unnecessary instantiations
- Commit: 9dc31c0c

### 4. Dependent Qualified Name Records
- Preserves semantic owner and member-chain for dependent qualified-name lookups
- Handles 	ypename T::type, Traits<T>::template rebind<U>::type patterns
- Records stored for high-value path segments
- Commit: 18bc7e55

### 5. Regression Fixes & Full Validation
- Fixed 7 root causes in constexpr evaluation, alias unwrapping, template preservation, and recursion depth
- All 2352 regular tests passing; all 181 expected-fail tests fail as expected
- Commit: 164ac021

## Documentation

- docs/2026-05-12-template-argument-architecture-audit.md: Full architecture audit with completed phases and progress notes
- docs/2026-05-12-template-argument-standard-conformance-investigation.md: Roadmap for future C++20 conformance work and gate status

## Test Coverage

Added 10+ regression tests covering:
- Two-phase lookup (non-dependent vs dependent/ADL)
- Typed NTTP identity (enum, nullptr)
- Dependent qualified names
- Overload ranking without full body materialization

All tests pass. No regressions introduced.

## Breaking Changes

None. This is a conservative refactor that preserves existing behavior while establishing C++20-conforming infrastructure.

## Next Steps

Future work identified in updated documentation:
- Full reference/pointer/member-pointer NTTP support
- Variable template instantiation improvements
- Constrained template deduction
- And 4+ additional high-impact improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richer non-type template-argument identity handling and improved dependent-qualified-name tracking
  * Shape-only overload probing to avoid materializing unselected template bodies
  * Enhanced dependent-member/template-argument substitution and two‑phase lookup behavior

* **Bug Fixes**
  * Better constexpr constructor/aggregate initialization behavior and diagnostics
  * More accurate alias-aware sizing/sizeof and static-member handling
  * Improved overload/instantiation selection robustness

* **Documentation**
  * Architecture audit and standard-conformance investigation docs refreshed

* **Tests**
  * Many new compile-time tests covering NTTP, substitution, overload-shape selection, and sizeof cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1508)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->