### PR TITLE
Advance template lookup and NTTP refactors

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-14 (template infrastructure pass 3 completed)
+**Last updated:** 2026-05-14 (template infrastructure pass 4 completed)
 
 This document describes the current FlashCpp template-argument architecture for
 types, non-type values, template-template arguments, class templates, function
@@ -64,10 +64,13 @@ infrastructure tracks. The branch now includes:
 - typed NTTP identity for integral/enum/`nullptr`, object pointers, references,
   function pointers, and null member pointers, with unsupported structural-class
   cases still explicit.
+- qualified non-dependent template-body calls now preserve definition-context
+  lookup records on the call expression, including qualified-name metadata;
+- floating-point NTTP identity now flows through constexpr evaluation and Itanium
+  mangling for standard-shaped floating arguments.
 
-Validation after these changes passed the Windows sharded build and the full
-PowerShell test suite: 2375 regular tests compiled, linked, and ran with the
-expected return values, and all 183 `_fail.cpp` tests failed as expected.
+Validation after these changes passed the Windows sharded build and the targeted
+template regression tests for qualified calls and floating NTTP specialization.
 
 The remaining non-conforming areas below are therefore forward-looking
 architecture gaps, not known regressions from the refactor.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-14 (template infrastructure pass 3 completed)
+**Last updated:** 2026-05-14 (template infrastructure pass 4 completed)
 
 This document describes how FlashCpp's template argument architecture can move
 toward C++20 conformance. It is intentionally architectural: it identifies the
@@ -34,6 +34,11 @@ preserved through refactoring:
 8. alias types that resolve to non-struct concrete types participate in codegen
    size resolution through a TypeInfo-size → TypeSpecifier-size → struct-size
    fallback chain.
+9. qualified template-body calls preserve definition-context lookup records so
+   template-body lookup can distinguish definition-time and point-of-instantiation
+   resolution boundaries;
+10. floating-point non-type template arguments preserve typed identity through
+    constexpr evaluation and mangling.
 
 These rules are compatibility constraints while migrating ownership to semantic
 lookup, deduction, and instantiation services.
@@ -77,16 +82,17 @@ Completed work:
 13. extended dependent qualified-name records to current-instantiation owners,
     unknown-specialization owners, and expression qualified-ids, with stricter
     missing-`typename` diagnostics for covered unknown-specialization paths.
+14. preserved definition-context records for qualified non-dependent calls and
+    added floating-point NTTP identity flow through constexpr evaluation and
+    Itanium mangling.
 
-The final validation run passed `.\build_flashcpp.bat` and
-`pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1`:
-2375 regular tests compiled, linked, and returned expected values, and all 183
-expected-failure tests failed as expected.
+The latest validation run passed `.\build_flashcpp.bat Sharded` and targeted
+regression tests for qualified template calls and floating NTTP specialization.
 
 The remaining target architecture sections are retained as the next conformance
-roadmap, especially the remaining low-frequency semantic lookup paths, complete
-structural/floating/member-pointer NTTP values, richer dependent-base and
-segment-chain modeling, and constraint normalization/subsumption.
+roadmap, especially the remaining low-frequency semantic lookup paths, richer
+dependent-base and segment-chain modeling, and constraint
+normalization/subsumption.
 
 ## What is left / next
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2767,11 +2767,12 @@ struct TemplateDefinitionLookupContext {
 	}
 };
 
-// Per-call semantic record for non-dependent unqualified function calls whose
-// lookup was completed in the template definition context.  The callee pointer
-// follows the same stable FunctionDeclarationNode identity already stored by
+// Per-call semantic record for non-dependent function calls whose lookup was
+// completed in the template definition context.  The callee pointer follows the
+// same stable FunctionDeclarationNode identity already stored by
 // CalleeDescriptor; the definition context documents the lookup boundary used
-// to exclude later point-of-instantiation declarations.
+// to exclude later point-of-instantiation declarations.  For qualified calls,
+// the CallExprNode qualified_name records the qualifier and ADL is disabled.
 struct FunctionCallDefinitionLookupRecord {
 	TemplateDefinitionLookupContext definition_context;
 	StringHandle callee_name{};
@@ -2889,14 +2890,14 @@ public:
 	std::span<const ASTNode> template_arguments() const { return template_arguments_; }
 	bool has_template_arguments() const { return !template_arguments_.empty(); }
 
-// --- Definition-context lookup record ---
-void set_definition_lookup_record(const FunctionCallDefinitionLookupRecord& record) {
-	definition_lookup_record_ = record;
-}
-const std::optional<FunctionCallDefinitionLookupRecord>& definition_lookup_record() const {
-	return definition_lookup_record_;
-}
-bool has_definition_lookup_record() const { return definition_lookup_record_.has_value(); }
+	// --- Definition-context lookup record ---
+	void set_definition_lookup_record(const FunctionCallDefinitionLookupRecord& record) {
+		definition_lookup_record_ = record;
+	}
+	const std::optional<FunctionCallDefinitionLookupRecord>& definition_lookup_record() const {
+		return definition_lookup_record_;
+	}
+	bool has_definition_lookup_record() const { return definition_lookup_record_.has_value(); }
 
 private:
 	CalleeDescriptor callee_;

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -6,6 +6,7 @@
 #include "TemplateRegistry.h"
 #include "CompileError.h"
 #include <array>
+#include <cstdint>
 
 // =============================================================================
 // Name Mangling Utilities - Unified Architecture
@@ -41,6 +42,14 @@
 // =============================================================================
 
 namespace NameMangling {
+
+template<typename OutputType>
+inline void appendHexNttpBits(OutputType& output, uint64_t bits, size_t digits) {
+	static constexpr char hex_digits[] = "0123456789abcdef";
+	for (size_t shift = digits * 4; shift != 0; shift -= 4) {
+		output += hex_digits[(bits >> (shift - 4)) & 0xf];
+	}
+}
 
 // Mangling style enum for cross-platform support
 enum class ManglingStyle {
@@ -1031,6 +1040,15 @@ inline void appendItaniumTypeTemplateArgs(
 			case TypeCategory::Bool:
 				output += 'b';
 				break;
+			case TypeCategory::Float:
+				output += 'f';
+				break;
+			case TypeCategory::Double:
+				output += 'd';
+				break;
+			case TypeCategory::LongDouble:
+				output += 'e';
+				break;
 			case TypeCategory::Char:
 				output += 'c';
 				break;
@@ -1092,6 +1110,15 @@ inline void appendItaniumTypeTemplateArgs(
 				output += std::to_string(identity_hash);
 			} else if (identity.kind == FlashCpp::NonTypeValueIdentityKind::Nullptr) {
 				output += "0";
+			} else if (identity.kind == FlashCpp::NonTypeValueIdentityKind::Floating) {
+				if (identity.valueTypeCategory() == TypeCategory::Float) {
+					appendHexNttpBits(output, static_cast<uint64_t>(identity.value) & 0xffffffffULL, 8);
+				} else if (identity.valueTypeCategory() == TypeCategory::Double ||
+						   identity.valueTypeCategory() == TypeCategory::LongDouble) {
+					appendHexNttpBits(output, static_cast<uint64_t>(identity.value), 16);
+				} else {
+					throw CompileError("Itanium name mangling: floating NTTP identity has non-floating type");
+				}
 			} else {
 				output += std::to_string(identity.value);
 			}

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -5,6 +5,7 @@
 #include "StringBuilder.h"
 #include "TemplateRegistry.h"
 #include "CompileError.h"
+#include <algorithm>
 #include <array>
 #include <cstdint>
 
@@ -46,8 +47,12 @@ namespace NameMangling {
 template<typename OutputType>
 inline void appendHexNttpBits(OutputType& output, uint64_t bits, size_t digits) {
 	static constexpr char hex_digits[] = "0123456789abcdef";
-	for (size_t shift = digits * 4; shift != 0; shift -= 4) {
-		output += hex_digits[(bits >> (shift - 4)) & 0xf];
+	const size_t significant_digits = std::min<size_t>(digits, 16);
+	for (size_t i = 0; i < digits - significant_digits; ++i) {
+		output += '0';
+	}
+	for (size_t i = significant_digits; i != 0; --i) {
+		output += hex_digits[(bits >> ((i - 1) * 4)) & 0xf];
 	}
 }
 
@@ -1115,7 +1120,11 @@ inline void appendItaniumTypeTemplateArgs(
 					appendHexNttpBits(output, static_cast<uint64_t>(identity.value) & 0xffffffffULL, 8);
 				} else if (identity.valueTypeCategory() == TypeCategory::Double ||
 						   identity.valueTypeCategory() == TypeCategory::LongDouble) {
-					appendHexNttpBits(output, static_cast<uint64_t>(identity.value), 16);
+					const size_t digits =
+						identity.valueTypeCategory() == TypeCategory::LongDouble
+							? std::max<size_t>(1, static_cast<size_t>(get_type_size_bits(TypeCategory::LongDouble) / 4))
+							: 16;
+					appendHexNttpBits(output, static_cast<uint64_t>(identity.value), digits);
 				} else {
 					throw CompileError("Itanium name mangling: floating NTTP identity has non-floating type");
 				}

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3292,6 +3292,14 @@ private:	 // Resume private methods
 			overloads.end());
 	}
 
+	std::optional<ParseResult> tryQualifiedPhase1Lookup(
+		const QualifiedIdentifierNode& qual_id,
+		std::string_view display_name,
+		const std::optional<InlineVector<TemplateTypeArg, 4>>& template_args,
+		bool has_deferred_qualified_call_args,
+		const std::vector<TypeSpecifierNode>& arg_types,
+		std::optional<ASTNode>& identifierType);
+
 	bool hasActiveTemplateParameters() const {
 		return !current_template_params_.empty();
 	}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -66,6 +66,37 @@ bool isEligibleDefinitionLookupCall(
 	}
 	return true;
 }
+
+std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLookupRecord(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const ASTNode& resolved_decl,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included) {
+	if (!isEligibleDefinitionLookupCall(
+			definition_context,
+			callee_token,
+			arg_types,
+			has_deferred_template_call_args,
+			resolved_decl)) {
+		return std::nullopt;
+	}
+
+	const FunctionDeclarationNode& func_decl = resolved_decl.as<FunctionDeclarationNode>();
+	FunctionCallDefinitionLookupRecord record;
+	record.definition_context = *definition_context;
+	record.callee_name = callee_token.handle();
+	record.resolved_function = &func_decl;
+	if (func_decl.has_mangled_name()) {
+		record.resolved_mangled_name =
+			StringTable::getOrInternStringHandle(func_decl.mangled_name());
+	}
+	record.ordinary_lookup_included = ordinary_lookup_included;
+	record.argument_dependent_lookup_included = argument_dependent_lookup_included;
+	return record;
+}
 }
 
 // Helper function to check if a template name is a template-template parameter
@@ -2263,9 +2294,41 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				return ParseResult::error(args_result.error_message, args_result.error_token.value_or(current_token_));
 			}
 			ChunkedVector<ASTNode> args = std::move(args_result.args);
+			std::vector<TypeSpecifierNode> arg_types =
+				apply_lvalue_reference_deduction(args, args_result.arg_types);
+			const bool has_deferred_qualified_call_args =
+				argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+				argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 
 			if (!consume(")"_tok)) {
 				return ParseResult::error("Expected ')' after function call arguments", current_token_);
+			}
+
+			if ((!template_args.has_value() || template_args->empty()) &&
+				!has_deferred_qualified_call_args) {
+				std::vector<ASTNode> qualified_overloads =
+					gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
+				const bool had_qualified_overloads = !qualified_overloads.empty();
+				filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
+				if (!qualified_overloads.empty()) {
+					OverloadResolutionResult resolution =
+						resolve_overload(qualified_overloads, arg_types);
+					if (resolution.is_ambiguous) {
+						return ParseResult::error(
+							"Ambiguous call to qualified function '" +
+								std::string(buildQualifiedNameFromStrings(namespaces, qual_id.name())) + "'",
+							qual_id.identifier_token());
+					}
+					if (resolution.has_match && resolution.selected_overload != nullptr) {
+						identifierType = *resolution.selected_overload;
+					}
+				} else if (had_qualified_overloads &&
+					current_template_definition_lookup_context_ != nullptr &&
+					current_template_definition_lookup_context_->is_valid() &&
+					!phase1_violation_token_.has_value()) {
+					phase1_violation_token_ = qual_id.identifier_token();
+					identifierType.reset();
+				}
 			}
 
 			// If not found (or explicit template arguments were provided) and we're not in extern "C",
@@ -2273,7 +2336,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			// same explicit-template parsing as the regular qualified-identifier path.
 			if (current_linkage_ != Linkage::C) {
 				std::string_view qualified_name = buildQualifiedNameFromStrings(namespaces, qual_id.name());
-				std::vector<TypeSpecifierNode> arg_types = apply_lvalue_reference_deduction(args, args_result.arg_types);
 
 				if (template_args.has_value() && !template_args->empty()) {
 					auto template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
@@ -2339,6 +2401,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (func_decl.has_mangled_name()) {
 					setCallMangledName(function_call_node.as<ExpressionNode>(), func_decl.mangled_name());
 					FLASH_LOG(Parser, Debug, "Set mangled name on qualified call expression: {}", func_decl.mangled_name());
+				}
+				if (std::optional<FunctionCallDefinitionLookupRecord> record =
+						makeFunctionCallDefinitionLookupRecord(
+							current_template_definition_lookup_context_,
+							qual_id.identifier_token(),
+							arg_types,
+							has_deferred_qualified_call_args,
+							*identifierType,
+							true,
+							false);
+					record.has_value()) {
+					setCallDefinitionLookupRecord(function_call_node.as<ExpressionNode>(), *record);
 				}
 			}
 			result = function_call_node;
@@ -3045,6 +3119,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					return ParseResult::error(args_result.error_message, args_result.error_token.value_or(current_token_));
 				}
 				ChunkedVector<ASTNode> args = std::move(args_result.args);
+				std::vector<TypeSpecifierNode> arg_types =
+					apply_lvalue_reference_deduction(args, args_result.arg_types);
+				const bool has_deferred_qualified_call_args =
+					argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 
 				if (!consume(")"_tok)) {
 					return ParseResult::error("Expected ')' after function call arguments", current_token_);
@@ -3072,15 +3151,41 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
-			// If not found OR if it's a template (not an instantiated function), try template instantiation
-			// Also try if explicit template arguments were provided (to handle overload resolution)
-			bool has_dependent_explicit_template_args = false;
+				if ((!template_args.has_value() || template_args->empty()) &&
+					!has_deferred_qualified_call_args) {
+					std::vector<ASTNode> qualified_overloads =
+						gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
+					const bool had_qualified_overloads = !qualified_overloads.empty();
+					filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
+					if (!qualified_overloads.empty()) {
+						OverloadResolutionResult resolution =
+							resolve_overload(qualified_overloads, arg_types);
+						if (resolution.is_ambiguous) {
+							return ParseResult::error(
+								"Ambiguous call to qualified function '" +
+									std::string(buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name())) + "'",
+								qual_id.identifier_token());
+						}
+						if (resolution.has_match && resolution.selected_overload != nullptr) {
+							identifierType = *resolution.selected_overload;
+						}
+					} else if (had_qualified_overloads &&
+						current_template_definition_lookup_context_ != nullptr &&
+						current_template_definition_lookup_context_->is_valid() &&
+						!phase1_violation_token_.has_value()) {
+						phase1_violation_token_ = qual_id.identifier_token();
+						identifierType.reset();
+					}
+				}
+
+				// If not found OR if it's a template (not an instantiated function), try template instantiation
+				// Also try if explicit template arguments were provided (to handle overload resolution)
+				bool has_dependent_explicit_template_args = false;
 				if (((!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>()) ||
 					 (template_args.has_value() && !template_args->empty())) &&
 					current_linkage_ != Linkage::C) {
 					// Build qualified template name
 					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
-					std::vector<TypeSpecifierNode> arg_types = apply_lvalue_reference_deduction(args, args_result.arg_types);
 
 					// Phase 1 C++20: If we have explicit template arguments, use them instead of deducing
 					if (template_args.has_value() && !template_args->empty()) {
@@ -3178,6 +3283,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
 					if (func_decl.has_mangled_name()) {
 						setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
+					}
+					if (std::optional<FunctionCallDefinitionLookupRecord> record =
+							makeFunctionCallDefinitionLookupRecord(
+								current_template_definition_lookup_context_,
+								qual_id.identifier_token(),
+								arg_types,
+								has_deferred_qualified_call_args,
+								*identifierType,
+								true,
+								false);
+						record.has_value()) {
+						setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
 					}
 				}
 			} else {
@@ -4777,21 +4894,17 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (!func_decl.parent_struct_name().empty()) {
 							setCallQualifiedName(result->as<ExpressionNode>(), StringBuilder().append(func_decl.parent_struct_name()).append("::").append(func_decl.decl_node().identifier_token().value()).commit());
 						}
-						if (isEligibleDefinitionLookupCall(
-								current_template_definition_lookup_context_,
-								identifier_token,
-								arg_types,
-								has_deferred_template_call_args,
-								resolved_decl)) {
-							FunctionCallDefinitionLookupRecord record;
-							record.definition_context = *current_template_definition_lookup_context_;
-							record.callee_name = identifier_token.handle();
-							record.resolved_function = &func_decl;
-							if (func_decl.has_mangled_name()) {
-								record.resolved_mangled_name =
-									StringTable::getOrInternStringHandle(func_decl.mangled_name());
-							}
-							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), record);
+						if (std::optional<FunctionCallDefinitionLookupRecord> record =
+								makeFunctionCallDefinitionLookupRecord(
+									current_template_definition_lookup_context_,
+									identifier_token,
+									arg_types,
+									has_deferred_template_call_args,
+									resolved_decl,
+									true,
+									true);
+							record.has_value()) {
+							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
 						}
 					}
 					return ParseResult::success(*result);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -99,6 +99,42 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 }
 }
 
+std::optional<ParseResult> Parser::tryQualifiedPhase1Lookup(
+	const QualifiedIdentifierNode& qual_id,
+	std::string_view display_name,
+	const std::optional<InlineVector<TemplateTypeArg, 4>>& template_args,
+	bool has_deferred_qualified_call_args,
+	const std::vector<TypeSpecifierNode>& arg_types,
+	std::optional<ASTNode>& identifierType) {
+	if ((!template_args.has_value() || template_args->empty()) &&
+		!has_deferred_qualified_call_args) {
+		std::vector<ASTNode> qualified_overloads =
+			gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
+		const bool had_qualified_overloads = !qualified_overloads.empty();
+		filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
+		if (!qualified_overloads.empty()) {
+			OverloadResolutionResult resolution =
+				resolve_overload(qualified_overloads, arg_types);
+			if (resolution.is_ambiguous) {
+				return ParseResult::error(
+					"Ambiguous call to qualified function '" +
+						std::string(display_name) + "'",
+					qual_id.identifier_token());
+			}
+			if (resolution.has_match && resolution.selected_overload != nullptr) {
+				identifierType = *resolution.selected_overload;
+			}
+		} else if (had_qualified_overloads &&
+			current_template_definition_lookup_context_ != nullptr &&
+			current_template_definition_lookup_context_->is_valid() &&
+			!phase1_violation_token_.has_value()) {
+			phase1_violation_token_ = qual_id.identifier_token();
+			identifierType.reset();
+		}
+	}
+	return std::nullopt;
+}
+
 // Helper function to check if a template name is a template-template parameter
 bool Parser::isTemplateTemplateParameter(StringHandle template_name_handle) const {
 	// During function-template body reparse, parsing_template_depth_ is 0 but
@@ -2304,37 +2340,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				return ParseResult::error("Expected ')' after function call arguments", current_token_);
 			}
 
-			if ((!template_args.has_value() || template_args->empty()) &&
-				!has_deferred_qualified_call_args) {
-				std::vector<ASTNode> qualified_overloads =
-					gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
-				const bool had_qualified_overloads = !qualified_overloads.empty();
-				filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
-				if (!qualified_overloads.empty()) {
-					OverloadResolutionResult resolution =
-						resolve_overload(qualified_overloads, arg_types);
-					if (resolution.is_ambiguous) {
-						return ParseResult::error(
-							"Ambiguous call to qualified function '" +
-								std::string(buildQualifiedNameFromStrings(namespaces, qual_id.name())) + "'",
-							qual_id.identifier_token());
-					}
-					if (resolution.has_match && resolution.selected_overload != nullptr) {
-						identifierType = *resolution.selected_overload;
-					}
-				} else if (had_qualified_overloads &&
-					current_template_definition_lookup_context_ != nullptr &&
-					current_template_definition_lookup_context_->is_valid() &&
-					!phase1_violation_token_.has_value()) {
-					phase1_violation_token_ = qual_id.identifier_token();
-					identifierType.reset();
-				}
+			if (auto err = tryQualifiedPhase1Lookup(qual_id,
+					buildQualifiedNameFromStrings(namespaces, qual_id.name()),
+					template_args, has_deferred_qualified_call_args, arg_types, identifierType)) {
+				return *err;
 			}
 
 			// If not found (or explicit template arguments were provided) and we're not in extern "C",
 			// try template instantiation. The global-scope `::ns::func<T>(...)` path must support the
 			// same explicit-template parsing as the regular qualified-identifier path.
-			if (current_linkage_ != Linkage::C) {
+			if (current_linkage_ != Linkage::C && !has_deferred_qualified_call_args) {
 				std::string_view qualified_name = buildQualifiedNameFromStrings(namespaces, qual_id.name());
 
 				if (template_args.has_value() && !template_args->empty()) {
@@ -3151,31 +3166,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 				}
 
-				if ((!template_args.has_value() || template_args->empty()) &&
-					!has_deferred_qualified_call_args) {
-					std::vector<ASTNode> qualified_overloads =
-						gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
-					const bool had_qualified_overloads = !qualified_overloads.empty();
-					filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
-					if (!qualified_overloads.empty()) {
-						OverloadResolutionResult resolution =
-							resolve_overload(qualified_overloads, arg_types);
-						if (resolution.is_ambiguous) {
-							return ParseResult::error(
-								"Ambiguous call to qualified function '" +
-									std::string(buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name())) + "'",
-								qual_id.identifier_token());
-						}
-						if (resolution.has_match && resolution.selected_overload != nullptr) {
-							identifierType = *resolution.selected_overload;
-						}
-					} else if (had_qualified_overloads &&
-						current_template_definition_lookup_context_ != nullptr &&
-						current_template_definition_lookup_context_->is_valid() &&
-						!phase1_violation_token_.has_value()) {
-						phase1_violation_token_ = qual_id.identifier_token();
-						identifierType.reset();
-					}
+				if (auto err = tryQualifiedPhase1Lookup(qual_id,
+						buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name()),
+						template_args, has_deferred_qualified_call_args, arg_types, identifierType)) {
+					return *err;
 				}
 
 				// If not found OR if it's a template (not an instantiated function), try template instantiation
@@ -3183,7 +3177,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				bool has_dependent_explicit_template_args = false;
 				if (((!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>()) ||
 					 (template_args.has_value() && !template_args->empty())) &&
-					current_linkage_ != Linkage::C) {
+					current_linkage_ != Linkage::C &&
+					!has_deferred_qualified_call_args) {
 					// Build qualified template name
 					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
 
@@ -4864,6 +4859,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				// ADL per C++20 [basic.lookup.argdep]: suppressed only by blocking non-function decls
 				// (variables, structs, enums). Plain DeclarationNode stubs do NOT block ADL.
+				bool argumentDependentLookupIncluded = false;
 				if (!arg_types.empty()) {
 					auto is_adl_blocking = [](const ASTNode& n) -> bool {
 						return !n.is<FunctionDeclarationNode>() &&
@@ -4871,6 +4867,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								n.is<EnumDeclarationNode>());
 					};
 					if (!std::any_of(all_overloads.begin(), all_overloads.end(), is_adl_blocking)) {
+						argumentDependentLookupIncluded = true;
 						auto adl_candidates = gSymbolTable.lookup_adl(identifier_token.value(), arg_types);
 						all_overloads.insert(all_overloads.end(), adl_candidates.begin(), adl_candidates.end());
 					}
@@ -4902,7 +4899,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									has_deferred_template_call_args,
 									resolved_decl,
 									true,
-									true);
+									argumentDependentLookupIncluded);
 							record.has_value()) {
 							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
 						}

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1016,6 +1016,11 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		TypeIndex identity_type_index = makeConstantValueTypeIndex(category, type_index);
 		return ConstantValue{value, category, identity_type_index, FlashCpp::NonTypeValueIdentity::makeConcrete(value, identity_type_index)};
 	};
+	auto makeFloatingConstantValue = [](double value, TypeCategory category, TypeIndex type_index) {
+		TypeIndex identity_type_index = makeConstantValueTypeIndex(category, type_index);
+		FlashCpp::NonTypeValueIdentity identity = FlashCpp::NonTypeValueIdentity::makeFloating(value, identity_type_index);
+		return ConstantValue{identity.value, category, identity_type_index, identity};
+	};
 	auto makeConstantValueFromCategory = [&](int64_t value, TypeCategory category) {
 		return makeConstantValue(value, category, TypeIndex{});
 	};
@@ -1032,7 +1037,9 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		} else if (std::holds_alternative<double>(eval_result.value)) {
 			category = TypeCategory::Double;
 		}
-		ConstantValue value = makeConstantValue(eval_result.as_int(), category, type_index);
+		ConstantValue value = std::holds_alternative<double>(eval_result.value)
+			? makeFloatingConstantValue(std::get<double>(eval_result.value), category, type_index)
+			: makeConstantValue(eval_result.as_int(), category, type_index);
 		if (category == TypeCategory::Nullptr) {
 			value.identity = FlashCpp::NonTypeValueIdentity::makeNullptr(value.type_index);
 		} else if (eval_result.pointer_to_var.isValid()) {
@@ -1094,7 +1101,7 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 		if (const auto* ull_val = std::get_if<unsigned long long>(&val)) {
 			return makeConstantValueFromCategory(static_cast<int64_t>(*ull_val), lit.type());
 		} else if (const auto* d_val = std::get_if<double>(&val)) {
-			return makeConstantValueFromCategory(static_cast<int64_t>(*d_val), lit.type());
+			return makeFloatingConstantValue(*d_val, lit.type(), TypeIndex{});
 		}
 	}
 

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -39,6 +39,7 @@
 #include <array>
 #include <vector>
 #include <cstdint>
+#include <cstring>
 #include <functional>  // For std::hash
 #include <variant>
 
@@ -234,6 +235,25 @@ struct NonTypeValueIdentity {
 		NonTypeValueIdentity id;
 		id.kind = NonTypeValueIdentityKind::Integral;
 		id.value = val;
+		id.value_type_index = type_index;
+		id.is_dependent = false;
+		id.dependent_name = {};
+		return id;
+	}
+
+	static NonTypeValueIdentity makeFloating(double val, TypeIndex type_index) {
+		NonTypeValueIdentity id;
+		id.kind = NonTypeValueIdentityKind::Floating;
+		uint64_t bits = 0;
+		if (type_index.category() == TypeCategory::Float) {
+			float float_value = static_cast<float>(val);
+			uint32_t float_bits = 0;
+			std::memcpy(&float_bits, &float_value, sizeof(float_bits));
+			bits = float_bits;
+		} else {
+			std::memcpy(&bits, &val, sizeof(bits));
+		}
+		id.value = static_cast<int64_t>(bits);
 		id.value_type_index = type_index;
 		id.is_dependent = false;
 		id.dependent_name = {};

--- a/tests/qualified_template_call_ret42.cpp
+++ b/tests/qualified_template_call_ret42.cpp
@@ -1,0 +1,14 @@
+namespace detail {
+	int value() {
+		return 42;
+	}
+}
+
+template<typename T>
+int run() {
+	return detail::value();
+}
+
+int main() {
+	return run<int>();
+}

--- a/tests/template_float_nttp_specialization_ret42.cpp
+++ b/tests/template_float_nttp_specialization_ret42.cpp
@@ -1,0 +1,13 @@
+template<double V>
+struct Box {
+	static constexpr int value = 1;
+};
+
+template<>
+struct Box<1.5> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return Box<1.5>::value;
+}

--- a/tests/template_long_double_nttp_specialization_ret43.cpp
+++ b/tests/template_long_double_nttp_specialization_ret43.cpp
@@ -1,0 +1,13 @@
+template<long double V>
+struct Box {
+	static constexpr int value = 1;
+};
+
+template<>
+struct Box<1.5L> {
+	static constexpr int value = 43;
+};
+
+int main() {
+	return Box<1.5L>::value;
+}

--- a/tests/test_adl_qualified_call_deferred_ret0.cpp
+++ b/tests/test_adl_qualified_call_deferred_ret0.cpp
@@ -1,0 +1,21 @@
+// Test: ADL participation tracking - verify that when ordinary lookup finds a
+// blocking non-function declaration, ADL is correctly suppressed and the lookup
+// record does not falsely record argument_dependent_lookup_included.
+// This tests that in a template body, the replay of the lookup record is accurate.
+namespace Lib {
+struct Tag {};
+int run(Tag) { return 0; }
+}
+
+// A variable 'run' blocks ADL for 'run' in the global namespace
+int run_int = 0;
+
+template<typename T>
+int callRun(Lib::Tag t) {
+return Lib::run(t);
+}
+
+int main() {
+Lib::Tag t;
+return callRun<int>(t);  // 0
+}

--- a/tests/test_deferred_ns_qualified_template_call_ret42.cpp
+++ b/tests/test_deferred_ns_qualified_template_call_ret42.cpp
@@ -1,0 +1,16 @@
+// Test: ns::f(t) with dependent arg t should defer instantiation in template body.
+// Before fix 2, has_deferred_qualified_call_args did not gate try_instantiate_template,
+// so the call could be bound eagerly instead of remaining dependent.
+namespace compute {
+template<typename T>
+T add(T a, T b) { return a + b; }
+}
+
+template<typename T>
+T computeSum(T x, T y) {
+return compute::add(x, y);
+}
+
+int main() {
+return computeSum(20, 22);  // 42
+}

--- a/tests/test_global_ns_qualified_deferred_template_call_ret42.cpp
+++ b/tests/test_global_ns_qualified_deferred_template_call_ret42.cpp
@@ -1,0 +1,15 @@
+// Test: global-scope qualified call ::ns::f(t) with dependent argument should
+// defer instantiation (not eagerly bind/fail) during template body parsing.
+namespace ops {
+template<typename T>
+T multiply(T a, T b) { return a * b; }
+}
+
+template<typename T>
+T globalQualifiedMul(T x, T y) {
+return ::ops::multiply(x, y);
+}
+
+int main() {
+return globalQualifiedMul(6, 7);  // 42
+}


### PR DESCRIPTION
## Summary
- preserve definition-context records for qualified non-dependent template-body calls
- add floating-point NTTP identity flow through constexpr evaluation and Itanium mangling
- update the template architecture docs to reflect the completed refactor slices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve floating-point non-type template-argument identity through constexpr evaluation and Itanium mangling.
  * Ensure qualified function-call lookup in template definition contexts preserves definition-context lookup records and correctly defers dependent calls.

* **Tests**
  * Added targeted regression tests for qualified template calls and float/double/long double NTTP specializations.

* **Documentation**
  * Updated audit/progress notes to reflect the latest validation pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1515)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->