### PR TITLE
Preserve dependent member probes in template args

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1609,6 +1609,7 @@ private:
 		std::span<const TemplateParameterNode> target_template_params,
 		InlineVector<TemplateTypeArg, 4>& template_args,
 		const std::vector<ASTNode>* argument_syntax_nodes);
+	StringHandle extractDependentMemberProbeFromCurrentTemplateArg();
 	TemplateTypeArgParsingResult parse_explicit_template_arguments_as_result(TokenDestroyPattern destroy_pattern);	// NEW: Lookahead to check if '<' starts template arguments (Phase 1 of C++20 disambiguation)
 	ConstructorLookaheadResult consume_constructor_or_destructor_prefix(std::string_view class_name);  // Priority 3: Consume ClassName[<...>]::[~] prefix and detect ClassName( pattern (advances token position)
 	ConstructorLookaheadResult lookahead_constructor_or_destructor(std::string_view class_name);	 // Priority 3: Detect ClassName[<...>]::[~]ClassName( pattern with save/restore

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2723,7 +2723,8 @@ ParseResult Parser::parse_template_declaration() {
 					QualifiedIdentifier::fromQualifiedName(template_name, gSymbolTable.get_current_namespace_handle()),
 					template_param_nodes,
 					template_args.toVector(),
-					struct_node);
+					struct_node,
+					std::nullopt);
 			}
 
 			// Reset parsing context flags
@@ -4084,7 +4085,8 @@ ParseResult Parser::parse_template_declaration() {
 				QualifiedIdentifier::fromQualifiedName(template_name, gSymbolTable.get_current_namespace_handle()),
 				template_param_nodes,
 				pattern_args.toVector(),
-				struct_node);
+				struct_node,
+				std::nullopt);
 
 			// Clean up template parameter context before returning
 			clearCurrentTemplateParameters();
@@ -5482,10 +5484,13 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 		// Register pattern under qualified name (MakeUnsigned::List)
 		gTemplateRegistry.registerSpecializationPattern(
-			QualifiedIdentifier{gSymbolTable.get_current_namespace_handle(), qualified_simple_name},
+			QualifiedIdentifier::fromQualifiedName(
+				StringTable::getStringView(qualified_simple_name),
+				gSymbolTable.get_current_namespace_handle()),
 			template_param_nodes,
 			pattern_args.toVector(),
-			template_struct_node);
+			template_struct_node,
+			std::nullopt);
 
 		// Also register pattern under simple name (List) for consistency with primary template
 		// This ensures patterns are found regardless of whether qualified or simple name is used
@@ -5495,7 +5500,8 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				StringTable::getOrInternStringHandle(struct_name)},
 			template_param_nodes,
 			pattern_args.toVector(),
-			template_struct_node);
+			template_struct_node,
+			std::nullopt);
 
 		FLASH_LOG_FORMAT(Parser, Info, "Registered member struct template partial specialization: {} with pattern",
 						 StringTable::getStringView(qualified_pattern_name));

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2719,7 +2719,11 @@ ParseResult Parser::parse_template_declaration() {
 					struct_node);
 			} else {
 				// Partial specialization: register as a pattern for matching
-				gTemplateRegistry.registerSpecializationPattern(template_name, template_param_nodes, template_args.toVector(), struct_node);
+				gTemplateRegistry.registerSpecializationPattern(
+					QualifiedIdentifier::fromQualifiedName(template_name, gSymbolTable.get_current_namespace_handle()),
+					template_param_nodes,
+					template_args.toVector(),
+					struct_node);
 			}
 
 			// Reset parsing context flags
@@ -4076,7 +4080,11 @@ ParseResult Parser::parse_template_declaration() {
 
 			// Register the specialization PATTERN (not exact match)
 			// This allows pattern matching during instantiation
-			gTemplateRegistry.registerSpecializationPattern(template_name, template_param_nodes, pattern_args.toVector(), struct_node);
+			gTemplateRegistry.registerSpecializationPattern(
+				QualifiedIdentifier::fromQualifiedName(template_name, gSymbolTable.get_current_namespace_handle()),
+				template_param_nodes,
+				pattern_args.toVector(),
+				struct_node);
 
 			// Clean up template parameter context before returning
 			clearCurrentTemplateParameters();
@@ -5474,7 +5482,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 		// Register pattern under qualified name (MakeUnsigned::List)
 		gTemplateRegistry.registerSpecializationPattern(
-			StringTable::getStringView(qualified_simple_name),
+			QualifiedIdentifier{gSymbolTable.get_current_namespace_handle(), qualified_simple_name},
 			template_param_nodes,
 			pattern_args.toVector(),
 			template_struct_node);
@@ -5482,7 +5490,9 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		// Also register pattern under simple name (List) for consistency with primary template
 		// This ensures patterns are found regardless of whether qualified or simple name is used
 		gTemplateRegistry.registerSpecializationPattern(
-			struct_name,
+			QualifiedIdentifier{
+				gSymbolTable.get_current_namespace_handle(),
+				StringTable::getOrInternStringHandle(struct_name)},
 			template_param_nodes,
 			pattern_args.toVector(),
 			template_struct_node);

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -931,6 +931,16 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		return std::nullopt;
 	};
 
+	auto canonicalAliasTargetCategory = [](const TemplateAliasNode& alias_node) {
+		const ResolvedAliasTypeInfo resolved_target_type =
+			resolveAliasTypeInfo(alias_node.target_type_node().type_index());
+		TypeCategory target_type = resolved_target_type.typeEnum();
+		if (target_type == TypeCategory::Invalid) {
+			target_type = alias_node.target_type_node().type();
+		}
+		return target_type;
+	};
+
 	auto dependentExpressionValueCategory =
 		[&](const ExpressionNode& expr, std::optional<StringHandle> dependent_name = std::nullopt) {
 			if (dependent_name.has_value()) {
@@ -1190,11 +1200,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 					TemplateDeclarationKind::AliasTemplate);
 				if (alias_opt.has_value()) {
 					const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
-					TypeCategory target_type = alias_node.target_type_node().type();
-					if (!is_struct_type(target_type)) {
+					TypeCategory target_type = canonicalAliasTargetCategory(alias_node);
+					if (target_type == TypeCategory::Void) {
 						auto alias_args_opt = parse_explicit_template_arguments(
 							alias_node.template_parameters(),
-							out_type_nodes);
+							static_cast<std::vector<ASTNode>*>(nullptr));
 						if (alias_args_opt.has_value()) {
 							TemplateTypeArg alias_arg;
 							alias_arg.setType(target_type);
@@ -1984,11 +1994,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 										TemplateDeclarationKind::AliasTemplate);
 									if (alias_opt.has_value()) {
 										const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
-										TypeCategory target_type = alias_node.target_type_node().type();
+										TypeCategory target_type = canonicalAliasTargetCategory(alias_node);
 
-								// If the alias always resolves to a concrete type (like void_t -> void),
-								// use that concrete type instead of marking as dependent
-										if (!is_struct_type(target_type)) {
+										// If the alias always resolves to a concrete type (like void_t -> void),
+										// use that concrete type instead of marking as dependent
+										if (target_type == TypeCategory::Void) {
 											FLASH_LOG(Templates, Debug, "Template alias '", id.name(),
 													  "' resolves to concrete type ", static_cast<int>(target_type));
 											dependent_arg.setType(target_type);

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1170,12 +1170,85 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 	while (true) {
 		// Save position in case type parsing fails
 		SaveHandle arg_saved_pos = save_token_position();
+		StringHandle dependent_member_probe = extractDependentMemberProbeFromCurrentTemplateArg();
 
 		if (peek().is_identifier()) {
 			const Token identifier_token = current_token_;
 			const StringHandle identifier_handle = identifier_token.handle();
 			SaveHandle identifier_saved_pos = save_token_position();
 			advance();
+
+			if (peek() == "<"_tok) {
+				TemplateNameLookupRequest alias_lookup_request =
+					buildTemplateNameLookupRequest(
+						identifier_handle,
+						TemplateNameLookupKind::Ordinary,
+						false);
+				TemplateNameLookupResult alias_lookup =
+					gTemplateRegistry.lookupTemplateName(alias_lookup_request);
+				auto alias_opt = alias_lookup.firstDeclarationOfKind(
+					TemplateDeclarationKind::AliasTemplate);
+				if (alias_opt.has_value()) {
+					const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
+					TypeCategory target_type = alias_node.target_type_node().type();
+					if (!is_struct_type(target_type)) {
+						auto alias_args_opt = parse_explicit_template_arguments(
+							alias_node.template_parameters(),
+							out_type_nodes);
+						if (alias_args_opt.has_value()) {
+							TemplateTypeArg alias_arg;
+							alias_arg.setType(target_type);
+							alias_arg.is_dependent = false;
+							for (const TemplateTypeArg& alias_inner_arg : *alias_args_opt) {
+								if (alias_inner_arg.dependent_name.isValid() &&
+									StringTable::getStringView(alias_inner_arg.dependent_name).find("::") != std::string_view::npos) {
+									alias_arg.dependent_name = alias_inner_arg.dependent_name;
+									break;
+								}
+								if (const TypeInfo* alias_inner_type = tryGetTypeInfo(alias_inner_arg.type_index)) {
+									std::string_view alias_inner_name = StringTable::getStringView(alias_inner_type->name());
+									if (alias_inner_name.find("::") != std::string_view::npos) {
+										alias_arg.dependent_name = StringTable::getOrInternStringHandle(alias_inner_name);
+										break;
+									}
+								}
+							}
+							if (!alias_arg.dependent_name.isValid()) {
+								alias_arg.dependent_name = dependent_member_probe;
+							}
+
+							if (peek() == "..."_tok) {
+								advance();
+								alias_arg.is_pack = true;
+								FLASH_LOG(Templates, Debug, "Marked alias template argument as pack expansion");
+							}
+
+							template_args.push_back(alias_arg);
+							discard_saved_token(identifier_saved_pos);
+							discard_saved_token(arg_saved_pos);
+
+							if (peek() == ">>"_tok) {
+								split_right_shift_token();
+							}
+							if (peek() == ">"_tok) {
+								advance();
+								break;
+							}
+							if (peek() == ","_tok) {
+								advance();
+								continue;
+							}
+
+							FLASH_LOG(Parser, Debug, "parse_explicit_template_arguments unexpected token after alias template argument");
+							restore_token_position(saved_pos);
+							last_failed_template_arg_parse_handle_ = saved_pos;
+							return std::nullopt;
+						}
+					}
+				}
+
+				restore_token_position(identifier_saved_pos);
+			}
 
 			if (peek() == ">>"_tok) {
 				split_right_shift_token();
@@ -2339,6 +2412,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		TemplateTypeArg arg(type_node);
 		arg.is_pack = is_pack_expansion;
 		arg.member_pointer_kind = member_pointer_kind;
+		if (dependent_member_probe.isValid()) {
+			arg.dependent_name = dependent_member_probe;
+		}
 		if (!arg.is_template_template_arg && !arg.is_value) {
 			StringHandle template_name_handle = type_node.token().handle();
 			const TypeInfo* parsed_type_info = type_node.type_index().is_valid()
@@ -3096,6 +3172,74 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 		}
 		++arg_index;
 	}
+}
+
+StringHandle Parser::extractDependentMemberProbeFromCurrentTemplateArg() {
+	int angle_depth = 0;
+	int paren_depth = 0;
+	int bracket_depth = 0;
+	for (size_t lookahead = 0; lookahead < 128; ++lookahead) {
+		Token token = peek_info(lookahead);
+		std::string_view value = token.value();
+		if (token.kind().is_eof()) {
+			return {};
+		}
+		if (value == "<") {
+			++angle_depth;
+		} else if (value == ">") {
+			if (angle_depth == 0 && paren_depth == 0 && bracket_depth == 0) {
+				return {};
+			}
+			if (angle_depth > 0) {
+				--angle_depth;
+			}
+		} else if (value == ">>") {
+			if (angle_depth <= 1 && paren_depth == 0 && bracket_depth == 0) {
+				return {};
+			}
+			angle_depth = angle_depth > 1 ? angle_depth - 2 : 0;
+		} else if (value == "(") {
+			++paren_depth;
+		} else if (value == ")") {
+			if (paren_depth > 0) {
+				--paren_depth;
+			}
+		} else if (value == "[") {
+			++bracket_depth;
+		} else if (value == "]") {
+			if (bracket_depth > 0) {
+				--bracket_depth;
+			}
+		} else if (value == "," && angle_depth == 0 && paren_depth == 0 && bracket_depth == 0) {
+			return {};
+		}
+
+		if (value == "typename") {
+			Token owner_token = peek_info(lookahead + 1);
+			Token scope_token = peek_info(lookahead + 2);
+			Token member_token = peek_info(lookahead + 3);
+			if (owner_token.type() == Token::Type::Identifier &&
+				scope_token.value() == "::" &&
+				member_token.type() == Token::Type::Identifier) {
+				StringHandle owner_handle = owner_token.handle();
+				const auto& current_param_names = currentTemplateParamNames();
+				bool owner_is_template_param = std::any_of(
+					current_param_names.begin(),
+					current_param_names.end(),
+					[owner_handle](StringHandle param_name) {
+						return param_name == owner_handle;
+					});
+				if (owner_is_template_param) {
+					return StringTable::getOrInternStringHandle(
+						StringBuilder()
+							.append(owner_token.value())
+							.append("::"sv)
+							.append(member_token.value()));
+				}
+			}
+		}
+	}
+	return {};
 }
 
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_arguments(

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1700,17 +1700,17 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 					// Fall through to type parsing below
 				} else {
 
-				// Special case: If out_type_nodes is provided AND the expression is a simple identifier,
-				// we should fall through to type parsing so identifiers get properly converted to TypeSpecifierNode.
-				// This is needed for deduction guides where template parameters must be TypeSpecifierNode.
-				// However, complex expressions like is_int<T>::value should still be accepted as dependent expressions.
-				//
-				// ALSO: If we parsed a simple identifier followed by '<', we should fall through to type parsing
-				// because this is likely a template type (e.g., enable_if_t<...>), not a value expression.
-				//
-				// ALSO: If followed by '[', this is an array type declarator - must parse as type
-				//
-				// IMPORTANT: If followed by '...', this is pack expansion, NOT a type - accept as dependent expression
+					// Special case: If out_type_nodes is provided AND the expression is a simple identifier,
+					// we should fall through to type parsing so identifiers get properly converted to TypeSpecifierNode.
+					// This is needed for deduction guides where template parameters must be TypeSpecifierNode.
+					// However, complex expressions like is_int<T>::value should still be accepted as dependent expressions.
+					//
+					// ALSO: If we parsed a simple identifier followed by '<', we should fall through to type parsing
+					// because this is likely a template type (e.g., enable_if_t<...>), not a value expression.
+					//
+					// ALSO: If followed by '[', this is an array type declarator - must parse as type
+					//
+					// IMPORTANT: If followed by '...', this is pack expansion, NOT a type - accept as dependent expression
 					bool is_simple_identifier = std::holds_alternative<IdentifierNode>(expr) ||
 												std::holds_alternative<TemplateParameterReferenceNode>(expr);
 					SimpleTemplateArgKind simple_identifier_kind = classifySimpleTemplateArg(expr);
@@ -1735,28 +1735,28 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 
 					if (!should_try_type_parsing && !peek().is_eof() &&
 						(peek() == ","_tok || peek() == ">"_tok || peek() == ">>"_tok || peek() == "..."_tok)) {
-					// Check if this is actually a concrete type (not a template parameter)
-					// If it's a concrete struct or type alias, we should fall through to type parsing instead
+						// Check if this is actually a concrete type (not a template parameter)
+						// If it's a concrete struct or type alias, we should fall through to type parsing instead
 						bool is_concrete_type = false;
 						if (std::holds_alternative<IdentifierNode>(expr)) {
 							const auto& id = std::get<IdentifierNode>(expr);
 							auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(id.name()));
 							if (type_it != getTypesByNameMap().end()) {
 								const TypeInfo* type_info = type_it->second;
-							// Check if it's a concrete struct (has struct_info_)
-							// OR if it's a type alias that resolves to a concrete type
-							// Type aliases have type_index pointing to the underlying type
+								// Check if it's a concrete struct (has struct_info_)
+								// OR if it's a type alias that resolves to a concrete type
+								// Type aliases have type_index pointing to the underlying type
 								if (type_info->struct_info_ != nullptr) {
 									is_concrete_type = true;
 									FLASH_LOG(Templates, Debug, "Identifier '", id.name(), "' is a concrete struct type, falling through to type parsing");
 								} else if (const TypeInfo* underlying = tryGetTypeInfo(type_info->type_index_)) {
-								// Check if this is a type alias (type_index points to underlying type)
-								// and the underlying type is concrete (not a template parameter)
-								// A type is concrete if:
-								// 1. It has struct_info_ (it's a defined struct/class), OR
-								// 2. It's not Type::UserDefined (i.e., it's a built-in type like int, bool, float)
-								// Template parameters are stored as Type::UserDefined without struct_info_,
-								// so this check correctly excludes them while accepting concrete types.
+									// Check if this is a type alias (type_index points to underlying type)
+									// and the underlying type is concrete (not a template parameter)
+									// A type is concrete if:
+									// 1. It has struct_info_ (it's a defined struct/class), OR
+									// 2. It's not Type::UserDefined (i.e., it's a built-in type like int, bool, float)
+									// Template parameters are stored as Type::UserDefined without struct_info_,
+									// so this check correctly excludes them while accepting concrete types.
 									if (underlying->struct_info_ != nullptr ||
 										underlying->resolvedType() != TypeCategory::UserDefined) {
 									// It's a type alias to a concrete type (struct or built-in)
@@ -1766,20 +1766,20 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								}
 							}
 						} else if (CallInfo::tryFrom(expr).has_value()) {
-						// Call expressions represent a function call expression like test_func<T>()
-						// This is NOT a type - it's a non-type template argument (the result of calling a function)
-						// Previously this code incorrectly treated call expressions with template arguments as a type,
-						// but that was wrong. A function call with template arguments (e.g., test_func<T>()) is still
-						// a function call, not a type. The function returns a value, and that value is used as
-						// the non-type template argument.
-						// DO NOT set is_concrete_type = true here - let it be accepted as a dependent expression.
+							// Call expressions represent a function call expression like test_func<T>()
+							// This is NOT a type - it's a non-type template argument (the result of calling a function)
+							// Previously this code incorrectly treated call expressions with template arguments as a type,
+							// but that was wrong. A function call with template arguments (e.g., test_func<T>()) is still
+							// a function call, not a type. The function returns a value, and that value is used as
+							// the non-type template argument.
+							// DO NOT set is_concrete_type = true here - let it be accepted as a dependent expression.
 							FLASH_LOG(Templates, Debug, "Call expression - treating as function call expression, not a type");
 						} else if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
-						// QualifiedIdentifierNode can represent a namespace-qualified type like ns::Inner
-						// or a template instantiation like ns::Inner<int> (when the template has already been
-						// instantiated during expression parsing).
+							// QualifiedIdentifierNode can represent a namespace-qualified type like ns::Inner
+							// or a template instantiation like ns::Inner<int> (when the template has already been
+							// instantiated during expression parsing).
 							const auto& qual_id = std::get<QualifiedIdentifierNode>(expr);
-						// Build the qualified name and check if it exists in getTypesByNameMap()
+							// Build the qualified name and check if it exists in getTypesByNameMap()
 							std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
 							auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(qualified_name));
 							if (type_it != getTypesByNameMap().end()) {
@@ -1797,14 +1797,14 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							// non-type contexts such as ValueSlot<Owner::value>.
 						}
 
-					// If it's a concrete type, restore and let type parsing handle it
+						// If it's a concrete type, restore and let type parsing handle it
 						if (is_concrete_type) {
 							restore_token_position(arg_saved_pos);
-						// Fall through to type parsing below
+							// Fall through to type parsing below
 						} else {
-						// Check if this is a template parameter that has a type substitution available
-						// This enables variable templates inside function templates to work correctly:
-						// e.g., __is_ratio_v<_R1> where _R1 should be substituted with ratio<1,2>
+							// Check if this is a template parameter that has a type substitution available
+							// This enables variable templates inside function templates to work correctly:
+							// e.g., __is_ratio_v<_R1> where _R1 should be substituted with ratio<1,2>
 							bool substituted_type_param = false;
 							bool substituted_value_param = false;
 							bool finished_parsing = false;  // Track if we consumed '>' and should break
@@ -1817,16 +1817,16 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							}
 
 							if (!param_name_to_check.empty()) {
-							// Check if we have a type substitution for this parameter
+								// Check if we have a type substitution for this parameter
 								for (const auto& subst : template_param_substitutions_) {
 									if (subst.is_type_param && subst.param_name == param_name_to_check) {
-									// Found a type substitution! Use it instead of creating a dependent arg
+										// Found a type substitution! Use it instead of creating a dependent arg
 										FLASH_LOG(Templates, Debug, "Found type substitution for parameter '",
 												  param_name_to_check, "' -> ", subst.substituted_type.toString());
 
 										TemplateTypeArg substituted_arg = subst.substituted_type;
 
-									// Check for pack expansion (...)
+										// Check for pack expansion (...)
 										if (peek() == "..."_tok) {
 											advance(); // consume '...'
 											substituted_arg.is_pack = true;
@@ -1840,7 +1840,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 										discard_saved_token(arg_saved_pos);
 										substituted_type_param = true;
 
-									// Handle next token
+										// Handle next token
 										if (peek() == ">>"_tok) {
 											split_right_shift_token();
 										}
@@ -1891,11 +1891,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							}
 
 							FLASH_LOG(Templates, Debug, "Accepting dependent expression as template argument");
-						// Successfully parsed a dependent expression
-						// Create a dependent template argument
-						// IMPORTANT: Preserve whether this is a type-like placeholder (e.g. T)
-						// or a value-like dependent expression (e.g. Trait<T>::value).
-						// Try to get the type_index for the template parameter so pattern matching can detect reused parameters.
+							// Successfully parsed a dependent expression
+							// Create a dependent template argument
+							// IMPORTANT: Preserve whether this is a type-like placeholder (e.g. T)
+							// or a value-like dependent expression (e.g. Trait<T>::value).
+							// Try to get the type_index for the template parameter so pattern matching can detect reused parameters.
 							TemplateTypeArg dependent_arg;
 							bool is_value_like_dependent_expr =
 								std::holds_alternative<QualifiedIdentifierNode>(expr) ||
@@ -1946,14 +1946,14 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							}
 							dependent_arg.is_dependent = true;
 
-						// Try to get the type_index for template parameter references
-						// For TemplateParameterReferenceNode or IdentifierNode that refers to a template parameter
+							// Try to get the type_index for template parameter references
+							// For TemplateParameterReferenceNode or IdentifierNode that refers to a template parameter
 							if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
 								const auto& tparam_ref = std::get<TemplateParameterReferenceNode>(expr);
 								StringHandle param_name = tparam_ref.param_name();
-						// Store the dependent name for placeholder type generation
+								// Store the dependent name for placeholder type generation
 								dependent_arg.dependent_name = param_name;
-						// Look up the template parameter type in getTypesByNameMap()
+								// Look up the template parameter type in getTypesByNameMap()
 								auto type_it = getTypesByNameMap().find(param_name);
 								if (type_it != getTypesByNameMap().end()) {
 									dependent_arg.type_index = type_it->second->type_index_;
@@ -1962,17 +1962,17 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								}
 							} else if (std::holds_alternative<IdentifierNode>(expr)) {
 								const auto& id = std::get<IdentifierNode>(expr);
-						// Store the dependent name for placeholder type generation
+								// Store the dependent name for placeholder type generation
 								dependent_arg.dependent_name = StringTable::getOrInternStringHandle(id.name());
-						// Check if this identifier is a template parameter by looking it up
+								// Check if this identifier is a template parameter by looking it up
 								auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(id.name()));
 								if (type_it != getTypesByNameMap().end()) {
 									dependent_arg.type_index = type_it->second->type_index_;
 									FLASH_LOG(Templates, Debug, "  Found type_index=", dependent_arg.type_index,
 											  " for identifier '", id.name(), "'");
 								} else {
-							// Check if this identifier is a template alias (like void_t)
-							// Template aliases may resolve to concrete types even when used with dependent arguments
+									// Check if this identifier is a template alias (like void_t)
+									// Template aliases may resolve to concrete types even when used with dependent arguments
 									TemplateNameLookupRequest alias_lookup_request =
 										buildTemplateNameLookupRequest(
 											StringTable::getOrInternStringHandle(id.name()),
@@ -2001,7 +2001,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								dependent_arg.dependent_name = StringTable::getOrInternStringHandle(qual_id.full_name());
 							}
 
-						// Check for pack expansion (...)
+							// Check for pack expansion (...)
 							if (peek() == "..."_tok) {
 								advance(); // consume '...'
 								dependent_arg.is_pack = true;
@@ -2010,17 +2010,17 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 
 							template_args.push_back(dependent_arg);
 
-						// Store the expression node for deferred base class resolution
-						// This is needed so that type trait expressions like __has_trivial_destructor(T)
-						// can be properly substituted and evaluated during template instantiation
+							// Store the expression node for deferred base class resolution
+							// This is needed so that type trait expressions like __has_trivial_destructor(T)
+							// can be properly substituted and evaluated during template instantiation
 							if (out_type_nodes && expr_result.node().has_value()) {
 								out_type_nodes->push_back(*expr_result.node());
 							}
 
 							discard_saved_token(arg_saved_pos);
 
-						// Check for ',' or '>' after the expression (or after pack expansion)
-						// Phase 5: Handle >> token splitting for nested templates
+							// Check for ',' or '>' after the expression (or after pack expansion)
+							// Phase 5: Handle >> token splitting for nested templates
 							if (peek() == ">>"_tok) {
 								split_right_shift_token();
 							}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -3180,46 +3180,51 @@ StringHandle Parser::extractDependentMemberProbeFromCurrentTemplateArg() {
 	int bracket_depth = 0;
 	for (size_t lookahead = 0; lookahead < 128; ++lookahead) {
 		Token token = peek_info(lookahead);
-		std::string_view value = token.value();
-		if (token.kind().is_eof()) {
+		TokenKind kind = token.kind();
+		if (kind.is_eof()) {
 			return {};
 		}
-		if (value == "<") {
+		if (kind == "<"_tok) {
 			++angle_depth;
-		} else if (value == ">") {
+		} else if (kind == ">"_tok) {
 			if (angle_depth == 0 && paren_depth == 0 && bracket_depth == 0) {
 				return {};
 			}
 			if (angle_depth > 0) {
 				--angle_depth;
 			}
-		} else if (value == ">>") {
+		} else if (kind == ">>"_tok) {
 			if (angle_depth <= 1 && paren_depth == 0 && bracket_depth == 0) {
 				return {};
 			}
 			angle_depth = angle_depth > 1 ? angle_depth - 2 : 0;
-		} else if (value == "(") {
+		} else if (kind == "("_tok) {
 			++paren_depth;
-		} else if (value == ")") {
+		} else if (kind == ")"_tok) {
 			if (paren_depth > 0) {
 				--paren_depth;
 			}
-		} else if (value == "[") {
+		} else if (kind == "["_tok) {
 			++bracket_depth;
-		} else if (value == "]") {
+		} else if (kind == "]"_tok) {
 			if (bracket_depth > 0) {
 				--bracket_depth;
 			}
-		} else if (value == "," && angle_depth == 0 && paren_depth == 0 && bracket_depth == 0) {
+		} else if (kind == ","_tok && angle_depth == 0 && paren_depth == 0 && bracket_depth == 0) {
 			return {};
 		}
 
-		if (value == "typename") {
+		if (kind == "typename"_tok) {
 			Token owner_token = peek_info(lookahead + 1);
 			Token scope_token = peek_info(lookahead + 2);
 			Token member_token = peek_info(lookahead + 3);
+			if (owner_token.kind().is_eof() ||
+				scope_token.kind().is_eof() ||
+				member_token.kind().is_eof()) {
+				return {};
+			}
 			if (owner_token.type() == Token::Type::Identifier &&
-				scope_token.value() == "::" &&
+				scope_token.kind() == "::"_tok &&
 				member_token.type() == Token::Type::Identifier) {
 				StringHandle owner_handle = owner_token.handle();
 				const auto& current_param_names = currentTemplateParamNames();

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -3217,15 +3217,12 @@ StringHandle Parser::extractDependentMemberProbeFromCurrentTemplateArg() {
 		if (kind == "typename"_tok) {
 			Token owner_token = peek_info(lookahead + 1);
 			Token scope_token = peek_info(lookahead + 2);
-			Token member_token = peek_info(lookahead + 3);
 			if (owner_token.kind().is_eof() ||
-				scope_token.kind().is_eof() ||
-				member_token.kind().is_eof()) {
+				scope_token.kind().is_eof()) {
 				return {};
 			}
 			if (owner_token.type() == Token::Type::Identifier &&
-				scope_token.kind() == "::"_tok &&
-				member_token.type() == Token::Type::Identifier) {
+				scope_token.kind() == "::"_tok) {
 				StringHandle owner_handle = owner_token.handle();
 				const auto& current_param_names = currentTemplateParamNames();
 				bool owner_is_template_param = std::any_of(
@@ -3235,11 +3232,21 @@ StringHandle Parser::extractDependentMemberProbeFromCurrentTemplateArg() {
 						return param_name == owner_handle;
 					});
 				if (owner_is_template_param) {
-					return StringTable::getOrInternStringHandle(
-						StringBuilder()
-							.append(owner_token.value())
-							.append("::"sv)
-							.append(member_token.value()));
+					InlineVector<StringHandle, 4> components;
+					components.push_back(owner_handle);
+					size_t chain_lookahead = lookahead + 2;
+					while (peek_info(chain_lookahead).kind() == "::"_tok) {
+						Token member_token = peek_info(chain_lookahead + 1);
+						if (member_token.kind().is_eof() ||
+							member_token.type() != Token::Type::Identifier) {
+							break;
+						}
+						components.push_back(member_token.handle());
+						chain_lookahead += 2;
+					}
+					if (components.size() > 1) {
+						return gNamespaceRegistry.buildQualifiedIdentifier(components);
+					}
 				}
 			}
 		}

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -63,14 +63,15 @@ struct OutOfLineNestedClass {
 	InlineVector<TemplateTypeArg, 4> specialization_args; // For full specializations: concrete args (e.g., <int>). Empty for partial specs.
 };
 
-// SFINAE condition for void_t patterns
-// Stores information about dependent member type checks like "typename T::type"
+// SFINAE condition for dependent member type probes.
+// Stores information about dependent member type checks like "typename T::traits::value_type"
 struct SfinaeCondition {
 	size_t template_param_index; // Which template parameter (e.g., 0 for T in has_type<T>)
-	StringHandle member_name; // The member type name to check (e.g., "type")
+	InlineVector<StringHandle, 4> member_chain; // The member type chain to check (e.g., traits::value_type)
 
-	SfinaeCondition() : template_param_index(0), member_name() {}
-	SfinaeCondition(size_t idx, StringHandle name) : template_param_index(idx), member_name(name) {}
+	SfinaeCondition() : template_param_index(0) {}
+	SfinaeCondition(size_t idx, InlineVector<StringHandle, 4> chain)
+		: template_param_index(idx), member_chain(std::move(chain)) {}
 };
 
 // Template specialization pattern - represents a pattern like T&, T*, const T, etc.
@@ -651,23 +652,27 @@ struct TemplatePattern {
 
 				// Check if the concrete type has the required member type
 				if (const TypeInfo* type_info = tryGetTypeInfo(concrete_arg.type_index)) {
+					for (StringHandle member_name : cond.member_chain) {
+						const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_info->type_index_);
+						if (resolved_alias.terminal_type_info != nullptr) {
+							type_info = resolved_alias.terminal_type_info;
+						}
 
-					// Build the qualified member name (e.g., "WithType::type")
-					StringBuilder qualified_name;
-					qualified_name.append(type_info->name());
-					qualified_name.append("::");
-					qualified_name.append(cond.member_name);
-					StringHandle qualified_handle = StringTable::getOrInternStringHandle(qualified_name.commit());
+						StringHandle qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier({
+							type_info->name(),
+							member_name
+						});
 
-					// Check if this member type exists
-					auto type_it = getTypesByNameMap().find(qualified_handle);
-					if (type_it == getTypesByNameMap().end()) {
-						FLASH_LOG(Templates, Debug, "SFINAE condition failed: ",
-								  StringTable::getStringView(qualified_handle), " does not exist");
-						return false; // SFINAE failure - pattern doesn't match
+						auto type_it = getTypesByNameMap().find(qualified_handle);
+						if (type_it == getTypesByNameMap().end()) {
+							FLASH_LOG(Templates, Debug, "SFINAE condition failed: ",
+									  StringTable::getStringView(qualified_handle), " does not exist");
+							return false; // SFINAE failure - pattern doesn't match
+						}
+						type_info = type_it->second;
 					}
 					FLASH_LOG(Templates, Debug, "SFINAE condition passed: ",
-							  StringTable::getStringView(qualified_handle), " exists");
+							  StringTable::getStringView(type_info->name()), " exists");
 				}
 			}
 		}

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -673,7 +673,13 @@ struct TemplatePattern {
 					}
 					FLASH_LOG(Templates, Debug, "SFINAE condition passed: ",
 							  StringTable::getStringView(type_info->name()), " exists");
+				} else {
+					FLASH_LOG(Templates, Debug, "SFINAE condition failed: concrete argument has no member type scope");
+					return false;
 				}
+			} else {
+				FLASH_LOG(Templates, Debug, "SFINAE condition failed: missing concrete argument for checked template parameter");
+				return false;
 			}
 		}
 

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -684,122 +684,6 @@ public:
 		return nullptr;
 	}
 
-	// Register a template specialization pattern (StringHandle overload)
-	void registerSpecializationPattern(StringHandle template_name,
-									   const InlineVector<TemplateParameterNode, 4>& template_params,
-									   std::span<const TemplateTypeArg> pattern_args,
-									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-
-		if (FLASH_LOG_ENABLED(Templates, Debug)) {
-			FLASH_LOG(Templates, Debug, "registerSpecializationPattern: template_name='", StringTable::getStringView(template_name),
-					  "', num_template_params=", template_params.size(), ", num_pattern_args=", pattern_args.size());
-
-			// Debug: log each pattern arg
-			for (size_t i = 0; i < pattern_args.size(); ++i) {
-				const auto& arg = pattern_args[i];
-				std::string_view dep_name_view = arg.dependent_name.isValid() ? StringTable::getStringView(arg.dependent_name) : "";
-				FLASH_LOG(Templates, Debug, "  pattern_arg[", i, "]: base_type=", static_cast<int>(arg.category()),
-						  ", type_index=", arg.type_index, ", is_dependent=", arg.is_dependent,
-						  ", is_value=", arg.is_value, ", dependent_name='", dep_name_view, "'");
-			}
-
-			// Debug: log each template param type
-			for (size_t i = 0; i < template_params.size(); ++i) {
-				FLASH_LOG(Templates, Debug, "  template_param[", i, "]: name=", template_params[i].name());
-			}
-		}
-
-		TemplatePattern pattern;
-		pattern.template_params = template_params;
-		pattern.pattern_args = pattern_args;
-		pattern.specialized_node = specialized_node;
-		pattern.sfinae_condition = sfinae_cond;
-
-		// Auto-detect void_t SFINAE patterns if no explicit condition provided.
-		// Heuristic: patterns with 2 args where first is dependent and second is void
-		// indicate void_t<...> usage. The member name to check is extracted from the
-		// first arg's dependent_name if available, otherwise defaults to "type".
-		if (!sfinae_cond.has_value() && pattern_args.size() == 2) {
-			const auto& first_arg = pattern_args[0];
-			const auto& second_arg = pattern_args[1];
-
-			// Check: first arg is dependent (template param), second arg is void (from void_t expansion)
-			if (first_arg.is_dependent && !second_arg.is_dependent &&
-				second_arg.category() == TypeCategory::Void) {
-				// This looks like a void_t SFINAE pattern.
-				// Try to extract the member name from available information.
-				StringHandle member_name;
-
-				// Check if the first arg's dependent_name contains a qualified name like "T::type"
-				if (first_arg.dependent_name.isValid()) {
-					std::string_view dep_name = StringTable::getStringView(first_arg.dependent_name);
-					size_t scope_pos = dep_name.rfind("::");
-					if (scope_pos != std::string_view::npos && scope_pos + 2 < dep_name.size()) {
-						// Extract the member name after "::"
-						std::string_view extracted_member = dep_name.substr(scope_pos + 2);
-						member_name = StringTable::getOrInternStringHandle(extracted_member);
-						FLASH_LOG(Templates, Debug, "Extracted SFINAE member name '", extracted_member, "' from dependent_name '", dep_name, "'");
-					}
-				}
-
-				// If no member name was extracted, check the type name via type_index
-				if (!member_name.isValid()) {
-					if (const TypeInfo* first_arg_ti = tryGetTypeInfo(first_arg.type_index)) {
-						std::string_view type_name = StringTable::getStringView(first_arg_ti->name());
-						size_t scope_pos = type_name.rfind("::");
-						if (scope_pos != std::string_view::npos && scope_pos + 2 < type_name.size()) {
-							std::string_view extracted_member = type_name.substr(scope_pos + 2);
-							member_name = StringTable::getOrInternStringHandle(extracted_member);
-							FLASH_LOG(Templates, Debug, "Extracted SFINAE member name '", extracted_member, "' from type_name '", type_name, "'");
-						}
-					}
-				}
-
-				// Default to "type" if no member name could be extracted
-				// This is the most common pattern (e.g., void_t<typename T::type>)
-				if (!member_name.isValid()) {
-					member_name = StringTable::getOrInternStringHandle("type");
-					FLASH_LOG(Templates, Debug, "Using default SFINAE member name 'type'");
-				}
-
-				pattern.sfinae_condition = SfinaeCondition(0, member_name);
-				FLASH_LOG(Templates, Debug, "Auto-detected void_t SFINAE pattern: checking for ::",
-						  StringTable::getStringView(member_name), " member");
-			}
-		}
-
-		specialization_patterns_[template_name].push_back(std::move(pattern));
-		const auto& stored_pattern = specialization_patterns_[template_name].back();
-		FLASH_LOG(Templates, Debug, "  Total patterns for '", StringTable::getStringView(template_name), "': ", specialization_patterns_[template_name].size());
-		if (stored_pattern.sfinae_condition.has_value()) {
-			FLASH_LOG(Templates, Debug, "  SFINAE condition set: check param[", stored_pattern.sfinae_condition->template_param_index,
-					  "]::", StringTable::getStringView(stored_pattern.sfinae_condition->member_name));
-		}
-	}
-	void registerSpecializationPattern(StringHandle template_name,
-									   std::span<const TemplateParameterNode> template_params,
-									   std::span<const TemplateTypeArg> pattern_args,
-									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-		InlineVector<TemplateParameterNode, 4> typed_template_params;
-		typed_template_params.reserve(template_params.size());
-		for (const TemplateParameterNode& template_param : template_params) {
-			typed_template_params.push_back(template_param);
-		}
-		registerSpecializationPattern(template_name, typed_template_params, pattern_args, specialized_node, sfinae_cond);
-	}
-
-	// Register a template specialization pattern (string_view overload)
-	void registerSpecializationPattern(std::string_view template_name,
-									   std::span<const TemplateParameterNode> template_params,
-									   std::span<const TemplateTypeArg> pattern_args,
-									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
-		StringHandle key = StringTable::getOrInternStringHandle(template_name);
-		registerSpecializationPattern(key, template_params, pattern_args, specialized_node, sfinae_cond);
-	}
-
 	// Register a template specialization pattern using QualifiedIdentifier.
 	void registerSpecializationPattern(QualifiedIdentifier qi,
 									   std::span<const TemplateParameterNode> template_params,
@@ -807,7 +691,12 @@ public:
 									   ASTNode specialized_node,
 									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
 		forEachQualifiedName(qi, [&](std::string_view name) {
-			registerSpecializationPattern(name, template_params, pattern_args, specialized_node, sfinae_cond);
+			registerSpecializationPatternByName(
+				StringTable::getOrInternStringHandle(name),
+				template_params,
+				pattern_args,
+				specialized_node,
+				sfinae_cond);
 		});
 	}
 
@@ -1026,6 +915,89 @@ public:
 	}
 
 private:
+	// Register a template specialization pattern under an already-normalized registry key.
+	void registerSpecializationPatternByName(StringHandle template_name,
+											 const InlineVector<TemplateParameterNode, 4>& template_params,
+											 std::span<const TemplateTypeArg> pattern_args,
+											 ASTNode specialized_node,
+											 std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+
+		if (FLASH_LOG_ENABLED(Templates, Debug)) {
+			FLASH_LOG(Templates, Debug, "registerSpecializationPattern: template_name='", StringTable::getStringView(template_name),
+					  "', num_template_params=", template_params.size(), ", num_pattern_args=", pattern_args.size());
+
+			// Debug: log each pattern arg
+			for (size_t i = 0; i < pattern_args.size(); ++i) {
+				const auto& arg = pattern_args[i];
+				std::string_view dep_name_view = arg.dependent_name.isValid() ? StringTable::getStringView(arg.dependent_name) : "";
+				FLASH_LOG(Templates, Debug, "  pattern_arg[", i, "]: base_type=", static_cast<int>(arg.category()),
+						  ", type_index=", arg.type_index, ", is_dependent=", arg.is_dependent,
+						  ", is_value=", arg.is_value, ", dependent_name='", dep_name_view, "'");
+			}
+
+			// Debug: log each template param type
+			for (size_t i = 0; i < template_params.size(); ++i) {
+				FLASH_LOG(Templates, Debug, "  template_param[", i, "]: name=", template_params[i].name());
+			}
+		}
+
+		TemplatePattern pattern;
+		pattern.template_params = template_params;
+		pattern.pattern_args = pattern_args;
+		pattern.specialized_node = specialized_node;
+		pattern.sfinae_condition = sfinae_cond;
+
+		// Auto-detect void_t SFINAE patterns if no explicit condition provided.
+		// Patterns like has_member<T, void_t<typename T::value_type>> register as
+		// [T, void], with the second argument preserving the real dependent probe name.
+		if (!sfinae_cond.has_value() && pattern_args.size() == 2) {
+			const auto& second_arg = pattern_args[1];
+
+			// Check: second arg is void from a void_t-like alias expansion.
+			if (!second_arg.is_dependent &&
+				second_arg.category() == TypeCategory::Void) {
+				if (second_arg.dependent_name.isValid()) {
+					std::string_view dep_name = StringTable::getStringView(second_arg.dependent_name);
+					size_t scope_pos = dep_name.rfind("::");
+					if (scope_pos != std::string_view::npos && scope_pos > 0 && scope_pos + 2 < dep_name.size()) {
+						std::string_view owner_name = dep_name.substr(0, scope_pos);
+						std::string_view member_name_view = dep_name.substr(scope_pos + 2);
+						for (size_t i = 0; i < template_params.size(); ++i) {
+							if (StringTable::getStringView(template_params[i].nameHandle()) == owner_name) {
+								StringHandle member_name = StringTable::getOrInternStringHandle(member_name_view);
+								pattern.sfinae_condition = SfinaeCondition(i, member_name);
+								FLASH_LOG(Templates, Debug, "Auto-detected void_t SFINAE pattern: checking param[",
+										  i, "]::", member_name_view, " from dependent_name '", dep_name, "'");
+								break;
+							}
+						}
+					}
+				}
+			}
+		}
+
+		specialization_patterns_[template_name].push_back(std::move(pattern));
+		const auto& stored_pattern = specialization_patterns_[template_name].back();
+		FLASH_LOG(Templates, Debug, "  Total patterns for '", StringTable::getStringView(template_name), "': ", specialization_patterns_[template_name].size());
+		if (stored_pattern.sfinae_condition.has_value()) {
+			FLASH_LOG(Templates, Debug, "  SFINAE condition set: check param[", stored_pattern.sfinae_condition->template_param_index,
+					  "]::", StringTable::getStringView(stored_pattern.sfinae_condition->member_name));
+		}
+	}
+
+	void registerSpecializationPatternByName(StringHandle template_name,
+											 std::span<const TemplateParameterNode> template_params,
+											 std::span<const TemplateTypeArg> pattern_args,
+											 ASTNode specialized_node,
+											 std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+		InlineVector<TemplateParameterNode, 4> typed_template_params;
+		typed_template_params.reserve(template_params.size());
+		for (const TemplateParameterNode& template_param : template_params) {
+			typed_template_params.push_back(template_param);
+		}
+		registerSpecializationPatternByName(template_name, typed_template_params, pattern_args, specialized_node, sfinae_cond);
+	}
+
 	// Register a template specialization under an already-normalized registry key.
 	void registerSpecializationByName(std::string_view template_name, std::span<const TemplateTypeArg> template_args, ASTNode specialized_node) {
 		SpecializationKey key{std::string(template_name), canonicalizeTemplateArgsForExactSpecialization(template_args)};

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -689,7 +689,7 @@ public:
 									   std::span<const TemplateParameterNode> template_params,
 									   std::span<const TemplateTypeArg> pattern_args,
 									   ASTNode specialized_node,
-									   std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+									   std::optional<SfinaeCondition> sfinae_cond) {
 		forEachQualifiedName(qi, [&](std::string_view name) {
 			registerSpecializationPatternByName(
 				StringTable::getOrInternStringHandle(name),
@@ -920,7 +920,7 @@ private:
 											 const InlineVector<TemplateParameterNode, 4>& template_params,
 											 std::span<const TemplateTypeArg> pattern_args,
 											 ASTNode specialized_node,
-											 std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+											 std::optional<SfinaeCondition> sfinae_cond) {
 
 		if (FLASH_LOG_ENABLED(Templates, Debug)) {
 			FLASH_LOG(Templates, Debug, "registerSpecializationPattern: template_name='", StringTable::getStringView(template_name),
@@ -1012,7 +1012,7 @@ private:
 											 std::span<const TemplateParameterNode> template_params,
 											 std::span<const TemplateTypeArg> pattern_args,
 											 ASTNode specialized_node,
-											 std::optional<SfinaeCondition> sfinae_cond = std::nullopt) {
+											 std::optional<SfinaeCondition> sfinae_cond) {
 		InlineVector<TemplateParameterNode, 4> typed_template_params;
 		typed_template_params.reserve(template_params.size());
 		for (const TemplateParameterNode& template_param : template_params) {

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -960,14 +960,27 @@ private:
 					std::string_view dep_name = StringTable::getStringView(second_arg.dependent_name);
 					size_t scope_pos = dep_name.rfind("::");
 					if (scope_pos != std::string_view::npos && scope_pos > 0 && scope_pos + 2 < dep_name.size()) {
-						std::string_view owner_name = dep_name.substr(0, scope_pos);
-						std::string_view member_name_view = dep_name.substr(scope_pos + 2);
+						std::string_view first_component = dep_name.substr(0, dep_name.find("::"));
 						for (size_t i = 0; i < template_params.size(); ++i) {
-							if (StringTable::getStringView(template_params[i].nameHandle()) == owner_name) {
-								StringHandle member_name = StringTable::getOrInternStringHandle(member_name_view);
-								pattern.sfinae_condition = SfinaeCondition(i, member_name);
+							if (StringTable::getStringView(template_params[i].nameHandle()) == first_component) {
+								InlineVector<StringHandle, 4> member_chain;
+								size_t start = first_component.size() + 2;
+								while (start < dep_name.size()) {
+									size_t sep = dep_name.find("::", start);
+									std::string_view component = sep == std::string_view::npos
+										? dep_name.substr(start)
+										: dep_name.substr(start, sep - start);
+									if (!component.empty()) {
+										member_chain.push_back(StringTable::getOrInternStringHandle(component));
+									}
+									if (sep == std::string_view::npos) {
+										break;
+									}
+									start = sep + 2;
+								}
+								pattern.sfinae_condition = SfinaeCondition(i, std::move(member_chain));
 								FLASH_LOG(Templates, Debug, "Auto-detected void_t SFINAE pattern: checking param[",
-										  i, "]::", member_name_view, " from dependent_name '", dep_name, "'");
+										  i, "]::", dep_name.substr(first_component.size() + 2), " from dependent_name '", dep_name, "'");
 								break;
 							}
 						}
@@ -980,8 +993,18 @@ private:
 		const auto& stored_pattern = specialization_patterns_[template_name].back();
 		FLASH_LOG(Templates, Debug, "  Total patterns for '", StringTable::getStringView(template_name), "': ", specialization_patterns_[template_name].size());
 		if (stored_pattern.sfinae_condition.has_value()) {
+			StringBuilder member_chain_builder;
+			bool first_member = true;
+			for (StringHandle member_name : stored_pattern.sfinae_condition->member_chain) {
+				if (!first_member) {
+					member_chain_builder.append("::");
+				}
+				first_member = false;
+				member_chain_builder.append(member_name);
+			}
+			std::string_view member_chain_view = member_chain_builder.commit();
 			FLASH_LOG(Templates, Debug, "  SFINAE condition set: check param[", stored_pattern.sfinae_condition->template_param_index,
-					  "]::", StringTable::getStringView(stored_pattern.sfinae_condition->member_name));
+					  "]::", member_chain_view);
 		}
 	}
 

--- a/tests/test_void_t_nested_member_chain_ret0.cpp
+++ b/tests/test_void_t_nested_member_chain_ret0.cpp
@@ -1,0 +1,38 @@
+template <typename...>
+using void_t = void;
+
+struct false_type {
+	static constexpr bool value = false;
+};
+
+struct true_type {
+	static constexpr bool value = true;
+};
+
+template <typename T, typename = void>
+struct has_nested_value_type : false_type {};
+
+template <typename T>
+struct has_nested_value_type<T, void_t<typename T::traits::value_type>> : true_type {};
+
+struct Traits {
+	using value_type = int;
+};
+
+struct WithNestedValueType {
+	using traits = Traits;
+};
+
+struct WithoutNestedValueType {
+	using traits = int;
+};
+
+int main() {
+	if (!has_nested_value_type<WithNestedValueType>::value) {
+		return 1;
+	}
+	if (has_nested_value_type<WithoutNestedValueType>::value) {
+		return 2;
+	}
+	return 0;
+}

--- a/tests/test_void_t_value_type_ret0.cpp
+++ b/tests/test_void_t_value_type_ret0.cpp
@@ -1,0 +1,34 @@
+template <typename...>
+using void_t = void;
+
+struct false_type {
+	static constexpr bool value = false;
+};
+
+struct true_type {
+	static constexpr bool value = true;
+};
+
+template <typename T, typename = void>
+struct has_value_type : false_type {};
+
+template <typename T>
+struct has_value_type<T, void_t<typename T::value_type>> : true_type {};
+
+struct WithValueType {
+	using value_type = int;
+};
+
+struct WithoutValueType {
+	using type = int;
+};
+
+int main() {
+	if (!has_value_type<WithValueType>::value) {
+		return 1;
+	}
+	if (has_value_type<WithoutValueType>::value) {
+		return 2;
+	}
+	return 0;
+}

--- a/tests/test_void_t_value_type_ret0.cpp
+++ b/tests/test_void_t_value_type_ret0.cpp
@@ -23,12 +23,31 @@ struct WithoutValueType {
 	using type = int;
 };
 
+template <typename T>
+struct TemplateWithValueType {
+	using value_type = T;
+};
+
+template <typename T>
+struct TemplateWithoutValueType {
+	using type = T;
+};
+
 int main() {
 	if (!has_value_type<WithValueType>::value) {
 		return 1;
 	}
 	if (has_value_type<WithoutValueType>::value) {
 		return 2;
+	}
+	if (has_value_type<int>::value) {
+		return 3;
+	}
+	if (!has_value_type<TemplateWithValueType<long long>>::value) {
+		return 4;
+	}
+	if (has_value_type<TemplateWithoutValueType<short>>::value) {
+		return 5;
 	}
 	return 0;
 }


### PR DESCRIPTION
## Summary
- require QualifiedIdentifier for specialization pattern registration and keep raw pattern-key registration private
- preserve dependent member probes such as typename T::value_type when alias template args collapse to void
- remove the non-standard default-to-::type SFINAE fallback and add a void_t value_type regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved template argument parsing to better detect dependent-member expressions, alias-template cases, and pack expansions for more accurate specialization matching.
  * SFINAE checks now validate chains of nested dependent members rather than single names.

* **Refactor**
  * Centralized and simplified template-pattern registration for more consistent and reliable pattern handling.

* **Tests**
  * Added tests validating void_t-based SFINAE for simple and nested member detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1522)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->