### PR TITLE
Make parser require semantic analysis

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -1,0 +1,136 @@
+# 2026-05-16 Sema First-Class Architecture Plan
+
+## Context
+
+The first-stage refactor makes `SemanticAnalysis` exist before `Parser` construction and makes `Parser` hold a non-null semantic dependency directly. This removes the temporary active-sema registration path, but it intentionally does not finish the larger semantic-state cleanup.
+
+The remaining work is to separate:
+
+- always-valid semantic services that parser/template/constexpr code can call at any time
+- post-parse whole-translation-unit normalization work
+- queries whose answer may legitimately be "not known yet"
+
+## Goal
+
+Stop modeling semantic availability as nullable object plumbing. Callers should assume semantic infrastructure exists and should instead branch only on whether a specific semantic fact is available.
+
+## Stage 5: Split Always-Valid Services From Post-Parse Normalization
+
+### 5.1 Define the internal split inside `SemanticAnalysis`
+
+Create explicit internal layers:
+
+- `SemanticAnalysis` as the compilation-lifetime owner/coordinator
+- `ParserSemanticServices` for operations valid during parsing and instantiation
+- `PostParseSemanticNormalizer` for the current `run()` whole-TU sweep
+
+The exact class names can change, but the boundary should be explicit in code.
+
+### 5.2 Move parser-phase operations into the always-valid layer
+
+Candidate operations:
+
+- `normalizePendingSemanticRoots()`
+- `ensureMemberFunctionMaterialized(...)`
+- direct/operator/subscript resolved-call lookup helpers
+- parser/constexpr-facing expression-type queries that are already safe pre-`run()`
+- lazy-member ODR-use marking
+
+These should be callable without implying that whole-TU normalization has already completed.
+
+### 5.3 Make state transitions explicit
+
+Add small, named state queries instead of relying on object lifetime:
+
+- parser attached
+- post-parse normalization started
+- post-parse normalization completed
+
+This should replace implicit assumptions such as "if sema exists, final semantic answers should exist too."
+
+### 5.4 Isolate post-parse-only data flows
+
+Audit side tables and categorize them:
+
+- built incrementally during parsing
+- built during pending-root normalization
+- built only by the whole-TU sweep
+
+Any code reading a table should be able to tell whether an empty lookup means:
+
+- not analyzed yet
+- analyzed and absent
+- deliberately unsupported in that phase
+
+## Stage 6: Make Callers Depend On Semantic Facts, Not Semantic Presence
+
+### 6.1 Remove remaining nullable semantic branches in parser-owned contexts
+
+Target:
+
+- constexpr evaluation contexts
+- template instantiation helpers
+- expression substitution
+- parser-created semantic contexts
+
+Replace `if (sema)` checks with direct semantic calls and allow the called API to return "fact unavailable" where appropriate.
+
+### 6.2 Tighten API contracts
+
+Split APIs into clear categories:
+
+- total operations: always callable, always meaningful
+- partial queries: always callable, may return empty
+- finalized queries: only legal after post-parse normalization
+
+For finalized queries, prefer hard assertions or `InternalError` on misuse instead of quiet fallback logic.
+
+### 6.3 Remove parser/codegen fallback ambiguity gradually
+
+For each family of logic, move from:
+
+- sema if available, otherwise parser/codegen fallback
+
+to:
+
+- semantic service always available
+- semantic query returns a precise answer or explicit "not available yet"
+
+Priority families:
+
+1. constexpr direct-call reuse and lazy-member materialization
+2. overload-resolution argument typing
+3. expression-type queries used by codegen fallback paths
+4. remaining codegen `if (sema_)` branches that should become invariants
+
+### 6.4 End state for codegen
+
+Codegen should treat semantic analysis as mandatory input:
+
+- pass `SemanticAnalysis&` into `AstToIr` constructor
+- remove `setSemanticData(...)`
+- delete optional semantic branches in IR generation
+
+At that point, codegen nullability should be considered a bug.
+
+## Suggested Execution Order
+
+1. Inventory semantic APIs by phase: parser-safe, pending-root-safe, post-parse-only.
+2. Extract parser-safe operations behind a dedicated internal interface/class.
+3. Convert constexpr/template helpers to the parser-safe interface and remove nullable branches there.
+4. Convert `AstToIr` construction to require semantic analysis directly.
+5. Remove legacy parser/codegen fallback paths once invariants are enforced.
+
+## Risks To Watch
+
+- re-entrant normalization loops between parser lazy materialization and semantic normalization
+- callers that currently use empty semantic answers to mean both "not yet analyzed" and "no semantic result"
+- codegen branches that still silently recover through parser state when semantic ownership should be mandatory
+- test helpers that accidentally run post-parse normalization multiple times on the same semantic object without resetting expectations
+
+## Success Criteria
+
+- no parser-owned context needs to ask whether semantic infrastructure exists
+- post-parse normalization is a named phase, not the condition for semantic existence
+- semantic queries communicate availability through their result contract, not through nullable object plumbing
+- codegen requires semantic analysis rather than optionally consuming it

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -389,14 +389,16 @@ int main_impl(int argc, char* argv[]) {
 	// Lexer is allocated on heap so it can be constructed inside the timed block
 	// but outlive it (since Parser stores a reference to it)
 	std::unique_ptr<Lexer> lexer_ptr;
+	std::unique_ptr<SemanticAnalysis> sema;
 	std::unique_ptr<Parser> parser;
 	setTypeTableStatsEnabled(show_perf_stats);
 	{
 		PhaseTimer timer("Lexer Setup", false, &lexer_setup_time);
 		lexer_ptr = std::make_unique<Lexer>(preprocessed_source, file_reader.get_line_map(), file_reader.get_file_paths());
 		lexer_ptr->setMsvcSehKeywords(context.isMsvcMode());
+		sema = std::make_unique<SemanticAnalysis>(context, gSymbolTable);
 		// Allocate Parser on the heap to reduce stack usage - Parser has many large member variables
-		parser = std::make_unique<Parser>(*lexer_ptr, context);
+		parser = std::make_unique<Parser>(*lexer_ptr, context, *sema);
 		parser->setRuntimeStatsEnabled(show_perf_stats);
 		// tests/std/README_STANDARD_HEADERS.md measured ~81,739 saved-token slots
 		// for 4019 preprocessed <limits> lines (~20/line). Cap the heuristic so
@@ -446,11 +448,10 @@ int main_impl(int argc, char* argv[]) {
 	// Semantic analysis pass (post-parse, pre-IR).
 	// The object is kept alive past AstToIr construction so that AstToIr can
 	// consume the semantic annotations (SemanticSlot side table, cast_info_table_).
-	SemanticAnalysis sema(*parser, context, gSymbolTable);
 	{
 		PhaseTimer sema_timer("Semantic Analysis", false, &semantic_analysis_time);
 		try {
-			sema.run();
+			sema->run();
 		} catch (const CompileError& e) {
 			std::string notes = g_parser_instantiation_notes;
 			g_parser_instantiation_notes.clear();
@@ -462,14 +463,14 @@ int main_impl(int argc, char* argv[]) {
 		}
 
 		if (show_perf_stats) {
-			const auto& stats = sema.stats();
+			const auto& stats = sema->stats();
 			FLASH_LOG(General, Info, "Semantic analysis stats:");
 			FLASH_LOG(General, Info, "  Total roots: ", stats.total_roots);
 			FLASH_LOG(General, Info, "  Roots visited: ", stats.roots_visited);
 			FLASH_LOG(General, Info, "  Expressions visited: ", stats.expressions_visited);
 			FLASH_LOG(General, Info, "  Statements visited: ", stats.statements_visited);
 			FLASH_LOG(General, Info, "  Canonical types interned: ", stats.canonical_types_interned);
-			FLASH_LOG(General, Info, "  Unique canonical types: ", sema.typeContext().size());
+			FLASH_LOG(General, Info, "  Unique canonical types: ", sema->typeContext().size());
 			FLASH_LOG(General, Info, "  Slots filled: ", stats.slots_filled);
 			FLASH_LOG(General, Info, "  Cast infos allocated: ", stats.cast_infos_allocated);
 			FLASH_LOG(General, Info, "  Op calls resolved: ", stats.op_calls_resolved);
@@ -477,7 +478,7 @@ int main_impl(int argc, char* argv[]) {
 	}
 
 	AstToIr converter(gSymbolTable, context, *parser);
-	converter.setSemanticData(&sema);
+	converter.setSemanticData(sema.get());
 
 	// Reserve space for IR instructions
 	// Estimate: ~2 instructions per source line (empirical heuristic)

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -467,7 +467,7 @@ class Parser {
 public:
 	static constexpr size_t default_ast_tree_size_ = 256 * 1024;
 
-	explicit Parser(Lexer& lexer, CompileContext& context);
+	explicit Parser(Lexer& lexer, CompileContext& context, SemanticAnalysis& semantic_analysis);
 
 	ParseResult parse() {
 		resetTemplateInstantiationCounters();
@@ -583,8 +583,12 @@ public:
 	bool enqueuePendingSemanticRootIfNeeded(const ASTNode& node) {
 		return enqueuePendingSemanticRoot(node);
 	}
-	void setActiveSemanticAnalysis(SemanticAnalysis* sema);
-	SemanticAnalysis* getActiveSemanticAnalysis() const;
+	SemanticAnalysis& semanticAnalysis() {
+		return semantic_analysis_;
+	}
+	const SemanticAnalysis& semanticAnalysis() const {
+		return semantic_analysis_;
+	}
 	void normalizePendingSemanticRootsIfAvailable();
 	ASTNode get_inner_node(ASTNode node) const {
 		return node;
@@ -640,7 +644,7 @@ private:
 	std::unordered_set<const void*> instantiated_node_keys_;
 	std::vector<ASTNode> pending_semantic_roots_;
 	std::unordered_set<const void*> pending_semantic_root_keys_;
-	SemanticAnalysis* active_sema_ = nullptr;
+	SemanticAnalysis& semantic_analysis_;
 	std::vector<ASTNode> ast_discarded_nodes_;  // Keep discarded nodes alive to prevent memory corruption
 	std::string last_error_;
 

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -627,24 +627,15 @@ void collectLambdaCaptureCandidates(const ASTNode& node,
 	}
 }
 
-Parser::Parser(Lexer& lexer, CompileContext& context)
-	: lexer_(lexer), context_(context), current_token_(lexer_.next_token()) {
+Parser::Parser(Lexer& lexer, CompileContext& context, SemanticAnalysis& semantic_analysis)
+	: lexer_(lexer), context_(context), current_token_(lexer_.next_token()), semantic_analysis_(semantic_analysis) {
+	semantic_analysis_.attachParser(*this);
 	initialize_native_types();
 	ast_nodes_.reserve(default_ast_tree_size_);
 }
 
-void Parser::setActiveSemanticAnalysis(SemanticAnalysis* sema) {
-	active_sema_ = sema;
-}
-
-SemanticAnalysis* Parser::getActiveSemanticAnalysis() const {
-	return active_sema_;
-}
-
 void Parser::normalizePendingSemanticRootsIfAvailable() {
-	if (active_sema_ != nullptr) {
-		active_sema_->normalizePendingSemanticRoots();
-	}
+	semantic_analysis_.normalizePendingSemanticRoots();
 }
 
 int Parser::getStructTypeSizeBits(TypeIndex type_index) const {

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -1024,7 +1024,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 			// since the evaluator works on expression nodes, not initializer lists directly.
 			ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 			eval_ctx.parser = this;
-			eval_ctx.sema = getActiveSemanticAnalysis();
+			eval_ctx.sema = &semanticAnalysis();
 			eval_ctx.storage_duration = ConstExpr::StorageDuration::Global;
 			eval_ctx.is_constinit = is_constinit;
 

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1236,7 +1236,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 							if (width_result.node().has_value()) {
 								ConstExpr::EvaluationContext ctx(gSymbolTable);
 								ctx.parser = this;
-								ctx.sema = getActiveSemanticAnalysis();
+								ctx.sema = &semanticAnalysis();
 								auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 								if (!eval_result.success() || eval_result.as_int() < 0) {
 									return ParseResult::error("Bitfield width must be a non-negative integral constant expression", current_token_);
@@ -1273,7 +1273,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 							for (const auto& dim_expr : anon_array_dimensions) {
 								ConstExpr::EvaluationContext ctx(gSymbolTable);
 								ctx.parser = this;
-								ctx.sema = getActiveSemanticAnalysis();
+								ctx.sema = &semanticAnalysis();
 								auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 								if (eval_result.success() && eval_result.as_int() > 0) {
 									size_t dim_size = static_cast<size_t>(eval_result.as_int());
@@ -1598,7 +1598,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				for (const auto& dim_expr : decl.array_dimensions()) {
 					ConstExpr::EvaluationContext ctx(gSymbolTable);
 					ctx.parser = this;
-					ctx.sema = getActiveSemanticAnalysis();
+					ctx.sema = &semanticAnalysis();
 					auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 					if (eval_result.success() && eval_result.as_int() > 0) {
 						size_t dim_size = static_cast<size_t>(eval_result.as_int());
@@ -1637,7 +1637,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				if (!isDependentTemplateContext()) {
 					ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 					eval_ctx.parser = this;
-					eval_ctx.sema = getActiveSemanticAnalysis();
+					eval_ctx.sema = &semanticAnalysis();
 					eval_ctx.struct_info = struct_info.get();
 					eval_ctx.storage_duration = ConstExpr::StorageDuration::Automatic;
 					auto validation = ConstExpr::Evaluator::evaluate(*init_expr_opt, eval_ctx);
@@ -2022,7 +2022,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 					dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 					ConstExpr::EvaluationContext ctx(gSymbolTable);
 					ctx.parser = this;
-					ctx.sema = getActiveSemanticAnalysis();
+					ctx.sema = &semanticAnalysis();
 					auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
 					if (eval.success())
 						dtor_ref.set_noexcept(eval.as_bool());
@@ -2431,7 +2431,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				if (width_result.node().has_value()) {
 					ConstExpr::EvaluationContext ctx(gSymbolTable);
 					ctx.parser = this;
-					ctx.sema = getActiveSemanticAnalysis();
+					ctx.sema = &semanticAnalysis();
 					auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 					if (!eval_result.success() || eval_result.as_int() < 0) {
 						// Defer evaluation for template non-type parameters
@@ -2584,7 +2584,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 					if (width_result.node().has_value()) {
 						ConstExpr::EvaluationContext ctx(gSymbolTable);
 						ctx.parser = this;
-						ctx.sema = getActiveSemanticAnalysis();
+						ctx.sema = &semanticAnalysis();
 						auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 						if (!eval_result.success() || eval_result.as_int() < 0) {
 							// Defer evaluation for template non-type parameters
@@ -2866,7 +2866,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				ConstExpr::EvaluationContext ctx(gSymbolTable);
 				// Lets constexpr evaluation classify unsubstituted template bounds as dependent.
 				ctx.parser = this;
-				ctx.sema = getActiveSemanticAnalysis();
+				ctx.sema = &semanticAnalysis();
 				auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 				if (!eval_result.success()) {
 					const bool can_defer_dependent_bound =
@@ -3877,7 +3877,7 @@ ParseResult Parser::parse_enum_declaration() {
 				if (!value_extracted) {
 					ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 					eval_ctx.parser = this;
-					eval_ctx.sema = getActiveSemanticAnalysis();
+					eval_ctx.sema = &semanticAnalysis();
 					auto eval_result = ConstExpr::Evaluator::evaluate(*value_node, eval_ctx);
 					if (eval_result.success()) {
 						value = eval_result.as_int();
@@ -4202,7 +4202,7 @@ ParseResult Parser::parse_anonymous_struct_union_members(StructTypeInfo* out_str
 		for (const auto& dim_expr : array_dimensions) {
 			ConstExpr::EvaluationContext ctx(gSymbolTable);
 			ctx.parser = this;
-			ctx.sema = getActiveSemanticAnalysis();
+			ctx.sema = &semanticAnalysis();
 			auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 			if (eval_result.success() && eval_result.as_int() > 0) {
 				size_t dim_size = static_cast<size_t>(eval_result.as_int());

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -367,7 +367,7 @@ ParseResult Parser::parse_static_assert() {
 	// Try to evaluate the constant expression using ConstExprEvaluator
 	ConstExpr::EvaluationContext ctx(gSymbolTable);
 	ctx.parser = this;  // Enable template function instantiation
-	ctx.sema = getActiveSemanticAnalysis();
+	ctx.sema = &semanticAnalysis();
 
 	// Pass struct context for static member lookup in static_assert within struct body
 	if (!struct_parsing_context_stack_.empty()) {

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -531,7 +531,7 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 					if (width_result.node().has_value()) {
 						ConstExpr::EvaluationContext ctx(gSymbolTable);
 						ctx.parser = this;
-						ctx.sema = getActiveSemanticAnalysis();
+						ctx.sema = &semanticAnalysis();
 						auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 						if (!eval_result.success() || eval_result.as_int() < 0) {
 							return ParseResult::error("Bitfield width must be a non-negative integral constant expression", current_token_);
@@ -561,7 +561,7 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 						if (width_result.node().has_value()) {
 							ConstExpr::EvaluationContext ctx(gSymbolTable);
 							ctx.parser = this;
-							ctx.sema = getActiveSemanticAnalysis();
+							ctx.sema = &semanticAnalysis();
 							auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 							if (!eval_result.success() || eval_result.as_int() < 0) {
 								return ParseResult::error("Bitfield width must be a non-negative integral constant expression", current_token_);
@@ -773,7 +773,7 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 						if (!value_extracted) {
 							ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 							eval_ctx.parser = this;
-							eval_ctx.sema = getActiveSemanticAnalysis();
+							eval_ctx.sema = &semanticAnalysis();
 							auto eval_result = ConstExpr::Evaluator::evaluate(*value_node, eval_ctx);
 							if (eval_result.success()) {
 								value = eval_result.as_int();
@@ -1252,7 +1252,7 @@ ParseResult Parser::parse_typedef_declaration() {
 					if (!value_extracted) {
 						ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 						eval_ctx.parser = this;
-						eval_ctx.sema = getActiveSemanticAnalysis();
+						eval_ctx.sema = &semanticAnalysis();
 						auto eval_result = ConstExpr::Evaluator::evaluate(*value_node, eval_ctx);
 						if (eval_result.success()) {
 							value = eval_result.as_int();
@@ -1747,7 +1747,7 @@ ParseResult Parser::parse_typedef_declaration() {
 				if (width_result.node().has_value()) {
 					ConstExpr::EvaluationContext ctx(gSymbolTable);
 					ctx.parser = this;
-					ctx.sema = getActiveSemanticAnalysis();
+					ctx.sema = &semanticAnalysis();
 					auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 					if (!eval_result.success() || eval_result.as_int() < 0) {
 						// Defer evaluation for template non-type parameters
@@ -1790,7 +1790,7 @@ ParseResult Parser::parse_typedef_declaration() {
 					if (width_result.node().has_value()) {
 						ConstExpr::EvaluationContext ctx(gSymbolTable);
 						ctx.parser = this;
-						ctx.sema = getActiveSemanticAnalysis();
+						ctx.sema = &semanticAnalysis();
 						auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 						if (!eval_result.success() || eval_result.as_int() < 0) {
 							// Defer evaluation for template non-type parameters
@@ -2060,7 +2060,7 @@ ParseResult Parser::parse_typedef_declaration() {
 			if (size_result.node().has_value()) {
 				ConstExpr::EvaluationContext ctx(gSymbolTable);
 				ctx.parser = this;
-				ctx.sema = getActiveSemanticAnalysis();
+				ctx.sema = &semanticAnalysis();
 				auto eval_result = ConstExpr::Evaluator::evaluate(*size_result.node(), ctx);
 				if (eval_result.success() && eval_result.as_int() > 0) {
 					array_size = static_cast<size_t>(eval_result.as_int());

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1956,7 +1956,7 @@ ParseResult Parser::parse_static_member_block(
 		for (const auto& dim_expr : decl.array_dimensions()) {
 			ConstExpr::EvaluationContext ctx(gSymbolTable);
 			ctx.parser = this;
-			ctx.sema = getActiveSemanticAnalysis();
+			ctx.sema = &semanticAnalysis();
 			auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 			if (eval_result.success() && eval_result.as_int() > 0) {
 				size_t dim_size = static_cast<size_t>(eval_result.as_int());

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -755,7 +755,7 @@ ParseResult Parser::parse_lambda_expression() {
 			if (noexcept_expr.node().has_value()) {
 				ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 				eval_ctx.parser = this;
-				eval_ctx.sema = getActiveSemanticAnalysis();
+				eval_ctx.sema = &semanticAnalysis();
 				auto eval_result = ConstExpr::Evaluator::evaluate(*noexcept_expr.node(), eval_ctx);
 				if (eval_result.success()) {
 					lambda_is_noexcept = eval_result.as_int() != 0;
@@ -1507,7 +1507,7 @@ ParseResult Parser::parse_if_statement() {
 	if (is_constexpr && has_parameter_packs_ && condition.node().has_value()) {
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		auto eval_result = ConstExpr::Evaluator::evaluate(*condition.node(), eval_ctx);
 		if (eval_result.success()) {
 			bool condition_value = eval_result.as_int() != 0;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2263,7 +2263,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (size_result.node().has_value()) {
 							ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 							eval_ctx.parser = this;
-							eval_ctx.sema = getActiveSemanticAnalysis();
+							eval_ctx.sema = &semanticAnalysis();
 							auto eval_result = ConstExpr::Evaluator::evaluate(*size_result.node(), eval_ctx);
 							if (eval_result.success()) {
 								array_size_val = static_cast<size_t>(eval_result.as_int());
@@ -2311,7 +2311,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								if (size_result.node().has_value()) {
 									ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 									eval_ctx.parser = this;
-									eval_ctx.sema = getActiveSemanticAnalysis();
+									eval_ctx.sema = &semanticAnalysis();
 									auto eval_result = ConstExpr::Evaluator::evaluate(*size_result.node(), eval_ctx);
 									if (eval_result.success()) {
 										array_size_val = static_cast<size_t>(eval_result.as_int());
@@ -2369,7 +2369,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							if (size_result.node().has_value()) {
 								ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 								eval_ctx.parser = this;
-								eval_ctx.sema = getActiveSemanticAnalysis();
+								eval_ctx.sema = &semanticAnalysis();
 								auto eval_result = ConstExpr::Evaluator::evaluate(*size_result.node(), eval_ctx);
 								if (eval_result.success()) {
 									array_size_val = static_cast<size_t>(eval_result.as_int());

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -1076,7 +1076,7 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 		if (arg_result.node().has_value()) {
 			ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 			eval_ctx.parser = this;
-			eval_ctx.sema = getActiveSemanticAnalysis();
+			eval_ctx.sema = &semanticAnalysis();
 			auto eval_result = ConstExpr::Evaluator::evaluate(*arg_result.node(), eval_ctx);
 			if (eval_result.success()) {
 				result = 1;

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -512,7 +512,7 @@ FlashCpp::MemberLeadingSpecifiers Parser::parse_member_leading_specifiers() {
 					// Evaluate the constant expression using ConstExprEvaluator
 					ConstExpr::EvaluationContext ctx(gSymbolTable);
 					ctx.parser = this;  // Enable template function instantiation if needed
-					ctx.sema = getActiveSemanticAnalysis();
+					ctx.sema = &semanticAnalysis();
 
 					auto eval_result = ConstExpr::Evaluator::evaluate(*condition_result.node(), ctx);
 

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1111,7 +1111,7 @@ void Parser::prepareArrayTypeForBraceInitializer(const DeclarationNode& decl_nod
 
 	ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 	eval_ctx.parser = this;
-	eval_ctx.sema = getActiveSemanticAnalysis();
+	eval_ctx.sema = &semanticAnalysis();
 	const auto& decl_dims = decl_node.array_dimensions();
 	if (decl_node.is_unsized_array()) {
 		if (decl_dims.empty()) {

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -93,7 +93,7 @@ ParseResult Parser::parse_bitfield_width(std::optional<size_t>& out_width, std::
 	if (width_result.node().has_value()) {
 		ConstExpr::EvaluationContext ctx(gSymbolTable);
 		ctx.parser = this;
-		ctx.sema = getActiveSemanticAnalysis();
+		ctx.sema = &semanticAnalysis();
 		auto eval_result = ConstExpr::Evaluator::evaluate(*width_result.node(), ctx);
 		if (!eval_result.success() || eval_result.as_int() < 0) {
 			// If caller wants deferred evaluation and the expression is not a plain literal,
@@ -2151,7 +2151,7 @@ ParseResult Parser::parse_template_declaration() {
 								dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 								ConstExpr::EvaluationContext ctx(gSymbolTable);
 								ctx.parser = this;
-								ctx.sema = getActiveSemanticAnalysis();
+								ctx.sema = &semanticAnalysis();
 								auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
 								if (eval.success())
 									dtor_ref.set_noexcept(eval.as_bool());
@@ -3592,7 +3592,7 @@ ParseResult Parser::parse_template_declaration() {
 							dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 							ConstExpr::EvaluationContext ctx(gSymbolTable);
 							ctx.parser = this;
-							ctx.sema = getActiveSemanticAnalysis();
+							ctx.sema = &semanticAnalysis();
 							auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
 							if (eval.success())
 								dtor_ref.set_noexcept(eval.as_bool());
@@ -5228,7 +5228,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 							for (const auto& dim_expr : decl.array_dimensions()) {
 								ConstExpr::EvaluationContext ctx(gSymbolTable);
 								ctx.parser = this;
-								ctx.sema = getActiveSemanticAnalysis();
+								ctx.sema = &semanticAnalysis();
 								auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 								if (eval_result.success() && eval_result.as_int() > 0) {
 									size_t dim_size = static_cast<size_t>(eval_result.as_int());
@@ -5658,7 +5658,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						for (const auto& dim_expr : decl.array_dimensions()) {
 							ConstExpr::EvaluationContext ctx(gSymbolTable);
 							ctx.parser = this;
-							ctx.sema = getActiveSemanticAnalysis();
+							ctx.sema = &semanticAnalysis();
 							auto eval_result = ConstExpr::Evaluator::evaluate(dim_expr, ctx);
 							if (eval_result.success() && eval_result.as_int() > 0) {
 								size_t dim_size = static_cast<size_t>(eval_result.as_int());

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1186,7 +1186,7 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 			ctx.struct_info = struct_ctx.local_struct_info;
 		}
 		ctx.parser = this;
-		ctx.sema = getActiveSemanticAnalysis();
+		ctx.sema = &semanticAnalysis();
 		ctx.is_speculative = true;
 		return ctx;
 	};

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1221,7 +1221,7 @@ static ConstExpr::EvaluationContext makeStaticMemberInitializerEvaluationContext
 	ConstExpr::EvaluationContext eval_ctx(symbol_table);
 	eval_ctx.storage_duration = ConstExpr::StorageDuration::Static;
 	eval_ctx.parser = parser;
-	eval_ctx.sema = parser ? parser->getActiveSemanticAnalysis() : nullptr;
+	eval_ctx.sema = parser ? &parser->semanticAnalysis() : nullptr;
 	eval_ctx.struct_info = struct_info;
 	if (struct_info && struct_info->own_type_index_.has_value()) {
 		eval_ctx.struct_type_index = *struct_info->own_type_index_;
@@ -1904,7 +1904,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		eval_ctx.template_args.assign(args.begin(), args.end());
 		eval_ctx.template_param_names.reserve(params.size());
 		for (const auto& param : params) {
@@ -2344,7 +2344,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		auto eval_result = ConstExpr::Evaluator::evaluate(expr_node, eval_ctx);
 		if (!eval_result.success()) {
 			return false;
@@ -2378,7 +2378,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			*member_decl.bitfield_width_expr, type_sub_map, nontype_sub_map, StringHandle{});
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		auto eval_result = ConstExpr::Evaluator::evaluate(substituted, eval_ctx);
 		if (eval_result.success() && eval_result.as_int() >= 0)
 			return static_cast<size_t>(eval_result.as_int());
@@ -2405,7 +2405,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		}
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		for (const auto& dim_expr : decl.array_dimensions()) {
 			ASTNode substituted = substitute_template_params_in_expression(dim_expr, type_sub_map, nontype_sub_map, StringHandle{});
 			auto eval_result = ConstExpr::Evaluator::evaluate(substituted, eval_ctx);
@@ -4532,7 +4532,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							if (referenced_static_member && referenced_static_member->initializer.has_value()) {
 								ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 								eval_ctx.parser = this;
-								eval_ctx.sema = getActiveSemanticAnalysis();
+								eval_ctx.sema = &semanticAnalysis();
 								eval_ctx.struct_info = instantiated_struct_info;
 								eval_ctx.storage_duration = ConstExpr::StorageDuration::Static;
 								auto eval_result = ConstExpr::Evaluator::evaluate(
@@ -4889,7 +4889,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Evaluate the substituted expression
 				ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 				eval_ctx.parser = this;
-				eval_ctx.sema = getActiveSemanticAnalysis();
+				eval_ctx.sema = &semanticAnalysis();
 				eval_ctx.struct_node = &instantiated_struct_ref;
 
 				auto eval_result = ConstExpr::Evaluator::evaluate(substituted_expr, eval_ctx);
@@ -8860,7 +8860,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_dtor_ref.set_noexcept_expression(substituted_noexcept);
 						ConstExpr::EvaluationContext ctx(gSymbolTable);
 						ctx.parser = this;
-						ctx.sema = getActiveSemanticAnalysis();
+						ctx.sema = &semanticAnalysis();
 						ctx.struct_info = struct_info_ptr;
 						ctx.struct_type_index =
 							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct);
@@ -10166,7 +10166,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Evaluate the substituted expression
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		eval_ctx.struct_node = &instantiated_struct.as<StructDeclarationNode>();
 
 		auto eval_result = ConstExpr::Evaluator::evaluate(substituted_expr, eval_ctx);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -717,7 +717,7 @@ bool Parser::tryAppendDefaultTemplateArg(
 	auto appendEvaluatedNonTypeArg = [&](const ASTNode& expr) -> bool {
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		eval_ctx.template_environment = default_arg_environment;
 		auto eval_sub_map = buildSubstitutionParamMap(default_arg_environment);
 		eval_ctx.template_param_names.assign(
@@ -1734,7 +1734,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		eval_ctx.template_environment.bindings.reserve(param_name_to_arg.size());
 		for (const auto& [deduced_name, deduced_arg] : param_name_to_arg) {
 			TemplateBinding binding;

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -139,7 +139,7 @@ bool Parser::tryAppendMemberDefaultTemplateArg(
 	if (param.kind() == TemplateParameterKind::NonType && substituted_default.is<ExpressionNode>()) {
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 		eval_ctx.parser = this;
-		eval_ctx.sema = getActiveSemanticAnalysis();
+		eval_ctx.sema = &semanticAnalysis();
 		eval_ctx.template_environment = combined_environment;
 		auto eval_sub_map = buildSubstitutionParamMap(combined_environment);
 		eval_ctx.template_param_names.assign(

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -155,7 +155,7 @@ namespace {
 
 	ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 	eval_ctx.parser = &parser;
-	eval_ctx.sema = parser.getActiveSemanticAnalysis();
+	eval_ctx.sema = &parser.semanticAnalysis();
 	eval_ctx.template_environment = buildTemplateEnvironment(
 		std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
 		template_args,
@@ -2251,7 +2251,7 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 
 				ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 				eval_ctx.parser = this;
-				eval_ctx.sema = getActiveSemanticAnalysis();
+				eval_ctx.sema = &semanticAnalysis();
 				auto eval_result = ConstExpr::Evaluator::evaluate(substituted_default, eval_ctx);
 				if (!eval_result.success()) {
 					FLASH_LOG(Templates, Error, "Failed to evaluate non-type default for variable template parameter '",
@@ -3112,7 +3112,7 @@ std::optional<TemplateTypeArg> Parser::evaluateDependentNTTPExpression(
 	// Evaluate the substituted expression using the standard constant expression evaluator
 	ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 	eval_ctx.parser = this;
-	eval_ctx.sema = getActiveSemanticAnalysis();
+	eval_ctx.sema = &semanticAnalysis();
 	eval_ctx.template_environment = buildTemplateEnvironment(
 		template_params,
 		template_args,

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -470,7 +470,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			new_dtor_ref.set_noexcept_expression(substituted_noexcept);
 			ConstExpr::EvaluationContext ctx(gSymbolTable);
 			ctx.parser = this;
-			ctx.sema = getActiveSemanticAnalysis();
+			ctx.sema = &semanticAnalysis();
 			std::optional<TemplateEnvironment> outer_environment;
 			ctx.template_environment = buildLazySubstitutionEnvironment(
 				lazy_info.outer_template_environment_snapshot,
@@ -1206,7 +1206,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 		if (substituted_initializer.has_value() && substituted_initializer->is<ExpressionNode>()) {
 			ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 			eval_ctx.parser = this;
-			eval_ctx.sema = getActiveSemanticAnalysis();
+			eval_ctx.sema = &semanticAnalysis();
 			// Provide struct context so the evaluator prefers same-struct member functions over globals.
 			eval_ctx.struct_info = struct_info;
 			// Provide template args so sizeof(T) etc. resolve correctly.

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1798,7 +1798,7 @@ ASTNode Parser::substituteTemplateParameters(
 		if (if_stmt.is_constexpr()) {
 			ConstExpr::EvaluationContext eval_ctx(gSymbolTable);
 			eval_ctx.parser = this;
-			eval_ctx.sema = getActiveSemanticAnalysis();
+			eval_ctx.sema = &semanticAnalysis();
 			auto eval_result = ConstExpr::Evaluator::evaluate(substituted_condition, eval_ctx);
 			if (eval_result.success()) {
 				bool condition_value = eval_result.as_int() != 0;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1314,11 +1314,9 @@ void logPostParseBoundaryReport(const PostParseBoundaryReport& report) {
 
 // --- SemanticAnalysis ---
 
-SemanticAnalysis::SemanticAnalysis(Parser& parser, CompileContext& context, SymbolTable& symbols)
-	: parser_(parser), context_(context), symbols_(symbols) {
+SemanticAnalysis::SemanticAnalysis(CompileContext& context, SymbolTable& symbols)
+	: context_(context), symbols_(symbols) {
 	(void)context_;
-	previous_active_sema_ = parser_.getActiveSemanticAnalysis();
-	parser_.setActiveSemanticAnalysis(this);
 
 	// Pre-intern the canonical bool type so tryAnnotateContextualBool avoids
 	// repeated interning on every call.
@@ -1328,15 +1326,30 @@ SemanticAnalysis::SemanticAnalysis(Parser& parser, CompileContext& context, Symb
 }
 
 SemanticAnalysis::~SemanticAnalysis() {
-	if (parser_.getActiveSemanticAnalysis() == this) {
-		parser_.setActiveSemanticAnalysis(previous_active_sema_);
+}
+
+void SemanticAnalysis::attachParser(Parser& parser) {
+	parser_ = &parser;
+}
+
+Parser& SemanticAnalysis::parser() {
+	if (parser_ == nullptr) {
+		throw InternalError("SemanticAnalysis parser attachment is missing");
 	}
+	return *parser_;
+}
+
+const Parser& SemanticAnalysis::parser() const {
+	if (parser_ == nullptr) {
+		throw InternalError("SemanticAnalysis parser attachment is missing");
+	}
+	return *parser_;
 }
 
 void SemanticAnalysis::run() {
-	parser_.clearPendingSemanticRoots();
+	parser().clearPendingSemanticRoots();
 
-	const auto& nodes = parser_.get_nodes();
+	const auto& nodes = parser().get_nodes();
 	const size_t initial_root_count = nodes.size();
 	stats_.total_roots = initial_root_count;
 
@@ -1344,7 +1357,7 @@ void SemanticAnalysis::run() {
 	logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(nodes));
 
 	for (size_t root_index = 0; root_index < initial_root_count; ++root_index) {
-		ASTNode node = parser_.get_nodes()[root_index];
+		ASTNode node = parser().get_nodes()[root_index];
 		normalizeTopLevelNode(node);
 	}
 
@@ -1372,7 +1385,7 @@ size_t SemanticAnalysis::normalizePendingSemanticRoots() {
 	size_t normalized_root_count = 0;
 
 	while (true) {
-		std::vector<ASTNode> pending_roots = parser_.takePendingSemanticRoots();
+		std::vector<ASTNode> pending_roots = parser().takePendingSemanticRoots();
 		if (pending_roots.empty()) {
 			break;
 		}
@@ -1888,7 +1901,7 @@ ASTNode SemanticAnalysis::normalizeRangedForLoopDecl(const RangedForStatementNod
 }
 
 void SemanticAnalysis::resolveRemainingAutoReturns() {
-	auto& nodes = const_cast<std::vector<ASTNode>&>(parser_.get_nodes());
+	auto& nodes = const_cast<std::vector<ASTNode>&>(parser().get_nodes());
 	for (auto& node : nodes) {
 		resolveRemainingAutoReturnsInNode(node);
 	}
@@ -1928,7 +1941,7 @@ void SemanticAnalysis::resolveRemainingAutoReturnsInNode(ASTNode& node) {
 				if (auto deduced_type = deducePlaceholderReturnType(func.get_definition().value_or(ASTNode{}), return_type.type());
 					deduced_type.has_value()) {
 					func.decl_node().set_type_node(*deduced_type);
-					parser_.compute_and_set_mangled_name(func, true);
+					parser().compute_and_set_mangled_name(func, true);
 				}
 			}
 		}
@@ -2925,7 +2938,7 @@ void SemanticAnalysis::normalizeStructuredBinding(const StructuredBindingNode& b
 		NamespaceHandle std_namespace;
 	};
 
-	const StructuredBindingTupleProtocolLookup protocol_lookup(parser_, init_type_info->namespaceHandle(), init_type_info->name());
+	const StructuredBindingTupleProtocolLookup protocol_lookup(parser(), init_type_info->namespaceHandle(), init_type_info->name());
 
 	StructuredBindingTupleProtocolLookup::TemplateLookupSet tuple_size_lookup_set = protocol_lookup.resolveTemplateCandidates(
 		protocol_lookup.tuple_size_name,
@@ -3077,7 +3090,7 @@ void SemanticAnalysis::normalizeStructuredBinding(const StructuredBindingNode& b
 		QualifiedIdentifierNode(tuple_size_scope, tuple_size_value_token));
 
 	ConstExpr::EvaluationContext eval_ctx(symbols_);
-	eval_ctx.parser = &parser_;
+	eval_ctx.parser = parser_;
 	eval_ctx.sema = this;
 	auto eval_result = ConstExpr::Evaluator::evaluate(tuple_size_value_expr, eval_ctx);
 	if (!eval_result.success()) {
@@ -4063,7 +4076,7 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 						}
 
 						Parser::AliasTemplateMaterializationResult materialized_type =
-							parser_.materializeTemplateInstantiationForLookup(base_template_name, exact_args);
+							parser().materializeTemplateInstantiationForLookup(base_template_name, exact_args);
 						if (materialized_type.resolved_type_info) {
 							resolved_type_info = materialized_type.resolved_type_info;
 						} else if (!materialized_type.instantiated_name.empty()) {
@@ -4140,7 +4153,7 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 					struct_info = tryGetStructTypeInfo(owner_type_info->registeredTypeIndex());
 				}
 				if (struct_info) {
-					parser_.instantiateLazyStaticMember(struct_info->name, name_handle);
+					parser().instantiateLazyStaticMember(struct_info->name, name_handle);
 					auto [static_member, owner_struct] = struct_info->findStaticMemberRecursive(name_handle);
 					if (static_member && owner_struct) {
 						ResolvedQualifiedIdentifierInfo resolved;
@@ -7025,9 +7038,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		call_info.dependent_unqualified_lookup_record != nullptr &&
 		call_info.dependent_unqualified_lookup_record->has_value()) {
 		std::vector<TypeSpecifierNode> arg_types;
-		if (parser_.tryCollectFunctionCallArgTypes(arguments, arg_types)) {
+		if (parser().tryCollectFunctionCallArgTypes(arguments, arg_types)) {
 			if (std::optional<ASTNode> resolved_target =
-					parser_.resolveDependentUnqualifiedCallAtPointOfInstantiation(
+					parser().resolveDependentUnqualifiedCallAtPointOfInstantiation(
 						**call_info.dependent_unqualified_lookup_record,
 						arguments,
 						arg_types);
@@ -7413,7 +7426,7 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 	// ctor and a compiler-generated implicit one with the same signature.
 	auto resolution = resolve_constructor_overload(*struct_info, arg_types, true);
 	bool template_ctor_ambiguous = false;
-	resolution.selected_overload = parser_.materializeMatchingConstructorTemplate(
+	resolution.selected_overload = parser().materializeMatchingConstructorTemplate(
 		struct_info->getName(),
 		*struct_info,
 		arg_types,
@@ -7521,12 +7534,12 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 		return std::nullopt;
 	}
 
-	auto instantiated = parser_.instantiateLazyMemberIfNeeded(
+	auto instantiated = parser().instantiateLazyMemberIfNeeded(
 		LazyMemberKey::exact(struct_name, function_decl));
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser_.normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRootsIfAvailable();
 	return instantiated;
 }
 
@@ -7537,12 +7550,12 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 		return std::nullopt;
 	}
 
-	auto instantiated = parser_.instantiateLazyMemberIfNeeded(
+	auto instantiated = parser().instantiateLazyMemberIfNeeded(
 		LazyMemberKey::exact(struct_name, ctor_decl));
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser_.normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRootsIfAvailable();
 	return instantiated;
 }
 
@@ -7572,11 +7585,11 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	// when nothing is registered or the entry was already marked instantiated,
 	// so no separate needsInstantiation pre-check is needed.
 	LazyMemberKey query_key = LazyMemberKey::exact(struct_name, member_name, *is_const_member);
-	auto instantiated = parser_.instantiateLazyMemberIfNeeded(query_key);
+	auto instantiated = parser().instantiateLazyMemberIfNeeded(query_key);
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser_.normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRootsIfAvailable();
 	return instantiated;
 }
 
@@ -7625,7 +7638,7 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 						entry.registry_key))) {
 				continue;
 			}
-			auto result = parser_.instantiateLazyMemberIfNeeded(
+			auto result = parser().instantiateLazyMemberIfNeeded(
 				LazyMemberKey::exact(
 					entry.instantiated_owner_name,
 					entry.member_name,
@@ -7633,7 +7646,7 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 					entry.registry_key));
 			if (result.has_value()) {
 				++total_materialized;
-				parser_.normalizePendingSemanticRootsIfAvailable();
+				parser().normalizePendingSemanticRootsIfAvailable();
 				// Same rationale as the AST-walk pass: annotate the freshly-
 				// substituted body so its internal calls route through
 				// `markOdrUsed` and get picked up by the next fixpoint iteration
@@ -7689,7 +7702,7 @@ void SemanticAnalysis::tryAnnotateInitListConstructorArgs(
 
 	auto resolution = resolve_constructor_overload(struct_info, arg_types, true);
 	bool template_ctor_ambiguous = false;
-	resolution.selected_overload = parser_.materializeMatchingConstructorTemplate(
+	resolution.selected_overload = parser().materializeMatchingConstructorTemplate(
 		struct_info.getName(),
 		struct_info,
 		arg_types,

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -51,8 +51,9 @@ struct CallInfo;
 
 class SemanticAnalysis {
 public:
-	SemanticAnalysis(Parser& parser, CompileContext& context, SymbolTable& symbols);
+	SemanticAnalysis(CompileContext& context, SymbolTable& symbols);
 	~SemanticAnalysis();
+	void attachParser(Parser& parser);
 
 	// Main entry point: run the translation-unit semantic pass.
 	// Phase 1 boundary guard: starts with a lightweight walk over the sema-owned
@@ -245,6 +246,9 @@ public:
 	size_t drainLazyMemberRegistry();
 
 private:
+	Parser& parser();
+	const Parser& parser() const;
+
 	// Top-level dispatch
 	void normalizeTopLevelNode(const ASTNode& node);
 
@@ -478,10 +482,9 @@ private:
 										  CanonicalTypeId lhs_type_id = {}, CanonicalTypeId rhs_type_id = {});
 
 	// State
-	Parser& parser_;
+	Parser* parser_ = nullptr;
 	CompileContext& context_;
 	SymbolTable& symbols_;
-	SemanticAnalysis* previous_active_sema_ = nullptr;
 	TypeContext type_context_;
 	CanonicalTypeId bool_type_id_{};	 // Cached canonical type for bool (interned once in constructor).
 	std::vector<ImplicitCastInfo> cast_info_table_;

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -31,10 +31,10 @@
 static CompileContext compile_context;
 static FileTree file_tree;
 
-std::unique_ptr<SemanticAnalysis> runSemanticAnalysisForTest(Parser& parser, CompileContext& context) {
+SemanticAnalysis& runSemanticAnalysisForTest(Parser& parser, CompileContext& context) {
 	FlashCpp::gLazyMemberResolver.clearCache();
-	auto sema = std::make_unique<SemanticAnalysis>(parser, context, gSymbolTable);
-	sema->run();
+	SemanticAnalysis& sema = parser.semanticAnalysis();
+	sema.run();
 	return sema;
 }
 
@@ -69,7 +69,8 @@ void run_test_from_file(const std::string& filename, const std::string& test_nam
 	gTemplateRegistry.clear();
 	gConceptRegistry.clear();  // Clear concept registry
 	Lexer lexer(code, file_reader.get_line_map(), file_reader.get_file_paths());
-	Parser parser(lexer, test_context);
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
 #if WITH_DEBUG_INFO
 	parser.break_at_line_ = break_at_line;
 #endif
@@ -85,9 +86,9 @@ void run_test_from_file(const std::string& filename, const std::string& test_nam
 
 	const auto& ast = parser.get_nodes();
 
-	auto sema = runSemanticAnalysisForTest(parser, test_context);
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
 	AstToIr converter(gSymbolTable, test_context, parser);
-	converter.setSemanticData(sema.get());
+	converter.setSemanticData(&sema);
 	for (auto& node_handle : ast) {
 		converter.visit(node_handle);
 	}
@@ -706,7 +707,8 @@ TEST_SUITE("Parser") {
 			})";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
@@ -758,7 +760,8 @@ TEST_SUITE("Parser") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		gTypeInfo.clear();
 		gNativeTypes.clear();
 		gTypesByName.clear();
@@ -786,7 +789,8 @@ TEST_SUITE("Parser") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		gTypeInfo.clear();
 		gNativeTypes.clear();
 		gTypesByName.clear();
@@ -813,15 +817,16 @@ TEST_SUITE("Code gen") {
             })";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -1140,15 +1145,16 @@ TEST_SUITE("Code gen") {
             })";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -1186,15 +1192,16 @@ TEST_SUITE("Code gen") {
          })";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -1235,15 +1242,16 @@ TEST_SUITE("Code gen"){
          })";
 
 Lexer lexer(code);
-Parser parser(lexer, compile_context);
+SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+Parser parser(lexer, compile_context, parser_sema);
 auto parse_result = parser.parse();
 CHECK(!parse_result.is_error());
 
 const auto& ast = parser.get_nodes();
 
-auto sema = runSemanticAnalysisForTest(parser, compile_context);
+SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 AstToIr converter(gSymbolTable, compile_context, parser);
-converter.setSemanticData(sema.get());
+converter.setSemanticData(&sema);
 for (auto& node_handle : ast) {
 	converter.visit(node_handle);
 }
@@ -1286,15 +1294,16 @@ TEST_SUITE("Code gen"){
          })";
 
 Lexer lexer(code);
-Parser parser(lexer, compile_context);
+SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+Parser parser(lexer, compile_context, parser_sema);
 auto parse_result = parser.parse();
 CHECK(!parse_result.is_error());
 
 const auto& ast = parser.get_nodes();
 
-auto sema = runSemanticAnalysisForTest(parser, compile_context);
+SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 AstToIr converter(gSymbolTable, compile_context, parser);
-converter.setSemanticData(sema.get());
+converter.setSemanticData(&sema);
 for (auto& node_handle : ast) {
 	converter.visit(node_handle);
 }
@@ -1348,15 +1357,16 @@ TEST_CASE("Arithmetic operations and nested function calls") {
 		})";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 
 	const auto& ast = parser.get_nodes();
 
-	auto sema = runSemanticAnalysisForTest(parser, compile_context);
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 	AstToIr converter(gSymbolTable, compile_context, parser);
-	converter.setSemanticData(sema.get());
+	converter.setSemanticData(&sema);
 	for (auto& node_handle : ast) {
 		converter.visit(node_handle);
 	}
@@ -1628,7 +1638,8 @@ TEST_CASE("Parser:FunctionNameIdentifiers") {
 
 		Lexer lexer(code);
 		compile_context.setInputFile("test_function_names.cpp");
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 
 		// Should parse successfully
@@ -1638,9 +1649,9 @@ TEST_CASE("Parser:FunctionNameIdentifiers") {
 			const auto& ast = parser.get_nodes();
 
 			// Convert to IR to verify the string literals are created correctly
-			auto sema = runSemanticAnalysisForTest(parser, compile_context);
+			SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 			AstToIr converter(gSymbolTable, compile_context, parser);
-			converter.setSemanticData(sema.get());
+			converter.setSemanticData(&sema);
 			for (auto& node_handle : ast) {
 				converter.visit(node_handle);
 			}
@@ -1709,7 +1720,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1730,7 +1742,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1749,7 +1762,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1771,7 +1785,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1790,7 +1805,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1810,7 +1826,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1831,7 +1848,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1851,7 +1869,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1871,7 +1890,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1891,7 +1911,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1913,7 +1934,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1941,7 +1963,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1962,7 +1985,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -1983,7 +2007,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -2009,7 +2034,8 @@ TEST_SUITE("= default and = delete special member functions") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 	}
@@ -2027,15 +2053,16 @@ TEST_SUITE("new and delete operators") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -2074,15 +2101,16 @@ TEST_SUITE("new and delete operators") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -2125,15 +2153,16 @@ TEST_SUITE("new and delete operators") {
 		)";
 
 		Lexer lexer(code);
-		Parser parser(lexer, compile_context);
+		SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+		Parser parser(lexer, compile_context, parser_sema);
 		auto parse_result = parser.parse();
 		CHECK(!parse_result.is_error());
 
 		const auto& ast = parser.get_nodes();
 
-		auto sema = runSemanticAnalysisForTest(parser, compile_context);
+		SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
 		AstToIr converter(gSymbolTable, compile_context, parser);
-		converter.setSemanticData(sema.get());
+		converter.setSemanticData(&sema);
 		for (auto& node_handle : ast) {
 			converter.visit(node_handle);
 		}
@@ -2721,13 +2750,14 @@ TEST_CASE("Templates:InheritedStaticStructMemberUsesInstantiatedOwner") {
 	gConceptRegistry.clear();
 
 	Lexer lexer(code, file_reader.get_line_map(), file_reader.get_file_paths());
-	Parser parser(lexer, test_context);
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
 	auto parse_result = parser.parse();
 	REQUIRE(!parse_result.is_error());
 
-	auto sema = runSemanticAnalysisForTest(parser, test_context);
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
 	AstToIr converter(gSymbolTable, test_context, parser);
-	converter.setSemanticData(sema.get());
+	converter.setSemanticData(&sema);
 	for (auto& node_handle : parser.get_nodes()) {
 		converter.visit(node_handle);
 	}
@@ -3059,7 +3089,8 @@ TEST_CASE("Parser:ParameterList:Variadic") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 
@@ -3077,7 +3108,8 @@ TEST_CASE("Parser:MemberFunction:ConstVolatile") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3094,7 +3126,8 @@ TEST_CASE("Parser:MemberFunction:OverrideFinal") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3109,7 +3142,8 @@ TEST_CASE("Parser:Constructor:Defaulted") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3125,7 +3159,8 @@ TEST_CASE("Parser:Destructor:Virtual") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3139,7 +3174,8 @@ TEST_CASE("Parser:Template:MemberFunction") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3156,7 +3192,8 @@ TEST_CASE("Parser:Template:OutOfLine") {
 	)";
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	CHECK(!parse_result.is_error());
 }
@@ -3692,7 +3729,8 @@ TEST_CASE("OverloadResolution:UserDefinedTypeIndex") {
 	gConceptRegistry.clear();
 
 	Lexer lexer(code);
-	Parser parser(lexer, compile_context);
+	SemanticAnalysis parser_sema(compile_context, gSymbolTable);
+	Parser parser(lexer, compile_context, parser_sema);
 	auto parse_result = parser.parse();
 	REQUIRE(!parse_result.is_error());
 


### PR DESCRIPTION
## Summary
- construct semantic analysis before parser construction and make parser require a non-null sema dependency
- remove the temporary active-sema registration path and route parser-owned semantic access through the parser's stored sema
- add a dated docs plan for the stage 5-6 first-class sema architecture cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added architecture planning document outlining semantic analysis system improvements.

* **Refactor**
  * Improved semantic analysis lifecycle management and initialization flow.
  * Enhanced compiler architecture for more reliable code generation with mandatory semantic data dependencies.
  * Strengthened integration between parser and semantic analysis components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->