### PR TITLE
[codex] Add parser perf instrumentation and fix __va_start overload ambiguity

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -32,6 +32,23 @@ definition-time overload sets, consistent with free function template bodies.
 
 ---
 
+## 3) Windows UCRT `va_start` assertion macro still trips expression parsing in `<limits>` include path
+
+- **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` currently stops in
+  `corecrt_wstdio.h:486` at
+  `__vcrt_assert_va_start_is_not_reference<decltype(_Locale)>()` with
+  `Unexpected keyword in expression context`.
+- **Root cause**: Not fully reduced yet, but the failure sits in the UCRT
+  `va_start` assertion macro path and likely involves parsing unevaluated
+  `decltype(...)` inside a macro-expanded comma-expression/cast wrapper.
+- **Affected path**: Windows standard-header include chain for `<limits>` via
+  `<cwchar>` / `<cstdio>` / `stdio.h` / `corecrt_wstdio.h`.
+- **Impact**: Blocks deeper Windows/MSVC `<limits>` parsing and makes local
+  performance analysis on this header a "time to first hard parse error"
+  measurement instead of a full successful compile.
+
+---
+
 ## 4) Pointer-NTTP full specialization dispatch: second lookup produces wrong arg type
 
 - **Symptom**: Given `template <int* P> struct Tag { static int value() { return -1; } };`

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -32,20 +32,20 @@ definition-time overload sets, consistent with free function template bodies.
 
 ---
 
-## 3) Windows UCRT `va_start` assertion macro still trips expression parsing in `<limits>` include path
+## 3) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
 
-- **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` currently stops in
-  `corecrt_wstdio.h:486` at
-  `__vcrt_assert_va_start_is_not_reference<decltype(_Locale)>()` with
-  `Unexpected keyword in expression context`.
-- **Root cause**: Not fully reduced yet, but the failure sits in the UCRT
-  `va_start` assertion macro path and likely involves parsing unevaluated
-  `decltype(...)` inside a macro-expanded comma-expression/cast wrapper.
-- **Affected path**: Windows standard-header include chain for `<limits>` via
-  `<cwchar>` / `<cstdio>` / `stdio.h` / `corecrt_wstdio.h`.
-- **Impact**: Blocks deeper Windows/MSVC `<limits>` parsing and makes local
-  performance analysis on this header a "time to first hard parse error"
-  measurement instead of a full successful compile.
+- **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` now gets past
+  the UCRT `__crt_va_start` wrappers but stops later with
+  `Fatal error: static constexpr member initializer for 'std::_Num_float_base::has_denorm' is not a constant expression: initializer is unresolved`.
+- **Current frontier**: `limits` around the `_Num_base` / `_Num_float_base`
+  `static constexpr float_denorm_style has_denorm = denorm_absent/present;`
+  members.
+- **Root cause**: Not reduced yet. The parser and preprocessor now survive the
+  previous `corecrt_wstdio.h` barrier, so the remaining blocker appears to be
+  constexpr/sema handling for enum-valued `static constexpr` data members in the
+  MSVC STL numeric-limits hierarchy.
+- **Impact**: Windows/MSVC `<limits>` analysis is no longer "time to first UCRT
+  parse failure", but the header still does not complete semantic analysis.
 
 ---
 

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -16,23 +16,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
   constexpr call-evaluation fallback.
 - **Impact**: Blocks portions of libstdc++ headers that rely on variable templates in dependent checks.
 
-## 2) Two-phase lookup for member function template bodies — **FIXED (2026-05-15)**
-
-Two-phase name lookup (C++20 [temp.res]/9) is now applied inside member function template bodies.
-Non-dependent calls inside `template <typename U> T Wrapper<T>::foo(U)` bodies now resolve against
-definition-time overload sets, consistent with free function template bodies.
-
-- **Fixed in**: `src/Parser_Templates_Inst_MemberFunc.cpp` — `instantiate_member_function_template_core`
-  now sets `phase1_cutoff_line_`, `phase1_cutoff_file_idx_`, and
-  `current_template_definition_lookup_context_` before `parse_function_body()`.
-- **Regression guard**: `filterPhase1OrdinaryFunctionOverloads` is no longer called from
-  `lookupMemberFunctionTemplateCandidatesForInstantiation` — member lookup within a class has
-  no phase1 cutoff (all class members are mutually visible).
-- **Regression test**: `tests/test_template_two_phase_member_func_template_ret42.cpp`
-
----
-
-## 3) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
+## 2) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
 
 - **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` now gets past
   the UCRT `__crt_va_start` wrappers but stops later with
@@ -49,7 +33,7 @@ definition-time overload sets, consistent with free function template bodies.
 
 ---
 
-## 4) Pointer-NTTP full specialization dispatch: second lookup produces wrong arg type
+## 3) Pointer-NTTP full specialization dispatch: second lookup produces wrong arg type
 
 - **Symptom**: Given `template <int* P> struct Tag { static int value() { return -1; } };`
   `template <> struct Tag<&ga> { static int value() { return 10; } };`, calling

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -404,32 +404,52 @@ int main_impl(int argc, char* argv[]) {
 		parser->reserveSavedTokenStorage(std::min(source_line_count * SAVED_TOKEN_SLOTS_PER_LINE, SAVED_TOKEN_MAX_RESERVE));
 	}
 	Lexer& lexer = *lexer_ptr;
+	ParseResult parse_result;
+	bool parse_compile_error = false;
+	std::string parse_compile_error_message;
+	std::string parse_compile_error_notes;
 	{
 		PhaseTimer timer("Parsing", false, &parsing_time);
 		// Note: Lexing happens lazily during parsing in this implementation
 		// Template instantiation also happens during parsing
 
-		ParseResult parse_result;
 		try {
 			parse_result = parser->parse();
 		} catch (const CompileError& e) {
 			// Phase 1 violations (e.g. non-dependent name not visible at template definition)
 			// are thrown as CompileError from within template instantiation during parsing.
-			std::string notes = g_parser_instantiation_notes;
+			parse_compile_error = true;
+			parse_compile_error_message = e.what();
+			parse_compile_error_notes = g_parser_instantiation_notes;
 			g_parser_instantiation_notes.clear();
-			FLASH_LOG(Parser, Error, "error: ", e.what(), notes);
-			std::cerr << "error: " << e.what() << notes << std::endl;
-			return 1;
 		}
-
-		if (parse_result.is_error()) {
-			// Print formatted error with file:line:column information and include stack
-			std::string error_msg = parse_result.format_error(lexer.file_paths(), file_reader.get_line_map(), &lexer);
-			FLASH_LOG(Parser, Error, error_msg);
-			// Also print to stderr to ensure error is visible even with minimal logging
-			std::cerr << error_msg << std::endl;
-			return 1;
+	}
+	if (parse_compile_error) {
+		if (show_perf_stats) {
+			parser->printRuntimeStats();
+			printTypeTableStats();
+			StackStringStats::print_stats();
 		}
+		printTimingSummary(preprocessing_time, lexer_setup_time, parsing_time, semantic_analysis_time,
+						   ir_conversion_time, deferred_gen_time, codegen_time, total_start);
+		FLASH_LOG(Parser, Error, "error: ", parse_compile_error_message, parse_compile_error_notes);
+		std::cerr << "error: " << parse_compile_error_message << parse_compile_error_notes << std::endl;
+		return 1;
+	}
+	if (parse_result.is_error()) {
+		if (show_perf_stats) {
+			parser->printRuntimeStats();
+			printTypeTableStats();
+			StackStringStats::print_stats();
+		}
+		printTimingSummary(preprocessing_time, lexer_setup_time, parsing_time, semantic_analysis_time,
+						   ir_conversion_time, deferred_gen_time, codegen_time, total_start);
+		// Print formatted error with file:line:column information and include stack
+		std::string error_msg = parse_result.format_error(lexer.file_paths(), file_reader.get_line_map(), &lexer);
+		FLASH_LOG(Parser, Error, error_msg);
+		// Also print to stderr to ensure error is visible even with minimal logging
+		std::cerr << error_msg << std::endl;
+		return 1;
 	}
 	if (show_perf_stats) {
 		parser->printRuntimeStats();

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -424,7 +424,7 @@ int main_impl(int argc, char* argv[]) {
 			g_parser_instantiation_notes.clear();
 		}
 	}
-	if (parse_compile_error) {
+	if (parse_compile_error || parse_result.is_error()) {
 		if (show_perf_stats) {
 			parser->printRuntimeStats();
 			printTypeTableStats();
@@ -432,18 +432,11 @@ int main_impl(int argc, char* argv[]) {
 		}
 		printTimingSummary(preprocessing_time, lexer_setup_time, parsing_time, semantic_analysis_time,
 						   ir_conversion_time, deferred_gen_time, codegen_time, total_start);
-		FLASH_LOG(Parser, Error, "error: ", parse_compile_error_message, parse_compile_error_notes);
-		std::cerr << "error: " << parse_compile_error_message << parse_compile_error_notes << std::endl;
-		return 1;
-	}
-	if (parse_result.is_error()) {
-		if (show_perf_stats) {
-			parser->printRuntimeStats();
-			printTypeTableStats();
-			StackStringStats::print_stats();
+		if (parse_compile_error) {
+			FLASH_LOG(Parser, Error, "error: ", parse_compile_error_message, parse_compile_error_notes);
+			std::cerr << "error: " << parse_compile_error_message << parse_compile_error_notes << std::endl;
+			return 1;
 		}
-		printTimingSummary(preprocessing_time, lexer_setup_time, parsing_time, semantic_analysis_time,
-						   ir_conversion_time, deferred_gen_time, codegen_time, total_start);
 		// Print formatted error with file:line:column information and include stack
 		std::string error_msg = parse_result.format_error(lexer.file_paths(), file_reader.get_line_map(), &lexer);
 		FLASH_LOG(Parser, Error, error_msg);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -747,6 +747,10 @@ private:
 		size_t active_saves = 0;
 		size_t peak_active_saves = 0;
 		size_t saved_token_slots_peak = 0;
+		size_t saved_token_capacity_peak = 0;
+		size_t saved_token_capacity_growths = 0;
+		size_t saved_token_holes_peak = 0;
+		size_t saved_token_reserved_bytes_peak = 0;
 		size_t restore_ast_nodes_scanned = 0;
 		size_t restore_ast_nodes_preserved = 0;
 		size_t restore_ast_nodes_discarded = 0;

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -722,6 +722,14 @@ void Parser::setRuntimeStatsEnabled(bool enabled) {
 
 void Parser::reserveSavedTokenStorage(size_t saved_token_capacity) {
 	saved_tokens_.reserve(saved_token_capacity);
+#if WITH_PARSER_RUNTIME_STATS
+	if (runtime_stats_enabled_) {
+		runtime_stats_.saved_token_capacity_peak = std::max(runtime_stats_.saved_token_capacity_peak, saved_tokens_.capacity());
+		runtime_stats_.saved_token_reserved_bytes_peak = std::max(
+			runtime_stats_.saved_token_reserved_bytes_peak,
+			saved_tokens_.capacity() * sizeof(std::optional<SavedToken>));
+	}
+#endif
 }
 
 void Parser::printRuntimeStats() const {
@@ -739,6 +747,11 @@ void Parser::printRuntimeStats() const {
 			  ", discard=", stats.discard_count,
 			  ", missing=", stats.missing_restore_count);
 	FLASH_LOG(General, Info, "  Saved-token storage: peak slots=", stats.saved_token_slots_peak,
+			  ", peak capacity=", stats.saved_token_capacity_peak,
+			  ", slot-bytes=", sizeof(std::optional<SavedToken>),
+			  ", peak reserved-bytes=", stats.saved_token_reserved_bytes_peak,
+			  ", capacity growths=", stats.saved_token_capacity_growths,
+			  ", peak holes=", stats.saved_token_holes_peak,
 			  ", peak unreleased saves=", stats.peak_active_saves,
 			  ", unreleased at parse end=", stats.active_saves);
 	FLASH_LOG(General, Info, "  Restore AST cleanup: scanned=", stats.restore_ast_nodes_scanned,
@@ -994,6 +1007,7 @@ Parser::SaveHandle Parser::save_token_position() {
 
 	// Save current parser state (including injected token for >> splitting)
 	TokenPosition lexer_pos = lexer_.save_token_position();
+	size_t capacity_before = saved_tokens_.capacity();
 	if (saved_tokens_.size() <= handle) {
 		saved_tokens_.resize(handle + 1);
 	}
@@ -1004,6 +1018,15 @@ Parser::SaveHandle Parser::save_token_position() {
 		++runtime_stats_.active_saves;
 		runtime_stats_.peak_active_saves = std::max(runtime_stats_.peak_active_saves, runtime_stats_.active_saves);
 		runtime_stats_.saved_token_slots_peak = std::max(runtime_stats_.saved_token_slots_peak, saved_tokens_.size());
+		if (saved_tokens_.capacity() != capacity_before) {
+			++runtime_stats_.saved_token_capacity_growths;
+		}
+		runtime_stats_.saved_token_capacity_peak = std::max(runtime_stats_.saved_token_capacity_peak, saved_tokens_.capacity());
+		runtime_stats_.saved_token_reserved_bytes_peak = std::max(
+			runtime_stats_.saved_token_reserved_bytes_peak,
+			saved_tokens_.capacity() * sizeof(std::optional<SavedToken>));
+		size_t holes = saved_tokens_.size() - runtime_stats_.active_saves;
+		runtime_stats_.saved_token_holes_peak = std::max(runtime_stats_.saved_token_holes_peak, holes);
 		saved_tokens_[handle]->tokens_advanced_at_save_ = runtime_stats_.tokens_advanced;
 		if (!runtime_phase_stack_.empty()) {
 			++runtime_stats_.phase_stats[static_cast<size_t>(runtime_phase_stack_.back().phase)].saves;
@@ -1160,6 +1183,8 @@ void Parser::discard_saved_token(SaveHandle handle) {
 #if WITH_PARSER_RUNTIME_STATS
 		if (runtime_stats_enabled_) {
 			--runtime_stats_.active_saves;
+			size_t holes = saved_tokens_.size() - runtime_stats_.active_saves;
+			runtime_stats_.saved_token_holes_peak = std::max(runtime_stats_.saved_token_holes_peak, holes);
 		}
 #endif
 	}

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -1583,12 +1583,38 @@ void Parser::register_builtin_functions() {
 		gSymbolTable.insert(name, func_decl_node);
 	};
 
+	// Helper lambda to register a variadic builtin with one named parameter.
+	// This is used for intrinsics like __va_start where the second source-level
+	// argument is semantically special and should not compete as a fixed overload
+	// against the platform header declaration `void __va_start(va_list*, ...)`.
+	auto register_variadic_one_param_builtin = [&](std::string_view name, TypeCategory return_type, TypeCategory param1_type) {
+		Token type_token = dummy_token;
+		auto return_type_node = emplace_node<TypeSpecifierNode>(return_type, TypeQualifier::None, 64, type_token, CVQualifier::None);
+
+		Token func_token = dummy_token;
+		func_token = Token(Token::Type::Identifier, name, 0, 0, 0);
+
+		auto decl_node = emplace_node<DeclarationNode>(return_type_node, func_token);
+		auto [func_decl_node, func_decl_ref] = emplace_node_ref<FunctionDeclarationNode>(decl_node.as<DeclarationNode>());
+
+		Token param1_token = dummy_token;
+		auto param1_type_node = emplace_node<TypeSpecifierNode>(param1_type, TypeQualifier::None, 64, param1_token, CVQualifier::None);
+		auto param1_decl = emplace_node<DeclarationNode>(param1_type_node, param1_token);
+		func_decl_ref.add_parameter_node(param1_decl);
+		func_decl_ref.set_linkage(Linkage::C);
+		func_decl_ref.set_is_variadic(true);
+
+		gSymbolTable.insert(name, func_decl_node);
+	};
+
 	// Register variadic argument intrinsics (support both __va_start and __builtin_va_start)
-	// __builtin_va_start(va_list*, last_param) - Clang-style
-	// __va_start(va_list*, last_param) - MSVC-style (legacy)
-	// Both return void
-	register_two_param_builtin("__builtin_va_start", TypeCategory::Void, TypeCategory::UnsignedLongLong, TypeCategory::UnsignedLongLong);
-	register_two_param_builtin("__va_start", TypeCategory::Void, TypeCategory::UnsignedLongLong, TypeCategory::UnsignedLongLong);
+	// __builtin_va_start(ap, last_param) and __va_start(&ap, last_param) both take
+	// two source-level arguments, but the second operand is the variadic anchor and
+	// must not participate in fixed-arity overload ranking. Register them as one
+	// named generic parameter plus ellipsis so a real header declaration like
+	// `void __va_start(va_list*, ...)` cleanly outranks the fallback builtin.
+	register_variadic_one_param_builtin("__builtin_va_start", TypeCategory::Void, TypeCategory::UnsignedLongLong);
+	register_variadic_one_param_builtin("__va_start", TypeCategory::Void, TypeCategory::UnsignedLongLong);
 
 	// __builtin_va_arg(va_list, type) - returns the specified type
 	// For registration purposes, we use int as the return type (will be overridden in codegen)

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -1007,7 +1007,9 @@ Parser::SaveHandle Parser::save_token_position() {
 
 	// Save current parser state (including injected token for >> splitting)
 	TokenPosition lexer_pos = lexer_.save_token_position();
+#if WITH_PARSER_RUNTIME_STATS
 	size_t capacity_before = saved_tokens_.capacity();
+#endif
 	if (saved_tokens_.size() <= handle) {
 		saved_tokens_.resize(handle + 1);
 	}

--- a/tests/test_ucrt_va_start_builtin_overload_ret0.cpp
+++ b/tests/test_ucrt_va_start_builtin_overload_ret0.cpp
@@ -1,0 +1,36 @@
+// Regression: the builtin __va_start fallback must not form an ambiguous
+// overload set with the UCRT-style declaration `void __va_start(va_list*, ...)`.
+// The real-world expansion in corecrt_wstdio.h passes a struct pointer alias as
+// the second argument, so the header declaration should win over the builtin
+// instead of producing an ambiguity.
+
+typedef char* va_list;
+
+struct LocaleTag {
+	int marker;
+};
+
+template <typename T>
+struct __vcrt_va_list_is_reference {
+	enum : bool { __the_value = false };
+};
+
+template <typename T>
+struct __vcrt_assert_va_start_is_not_reference {
+	static_assert(!__vcrt_va_list_is_reference<T>::__the_value, "reference types are invalid");
+};
+
+void __va_start(va_list*, ...);
+
+#define __crt_va_start(ap, x) ((void)(__vcrt_assert_va_start_is_not_reference<decltype(x)>(), ((void)(__va_start(&ap, x)))))
+
+int wrapper(LocaleTag* const locale) {
+	va_list args = 0;
+	__crt_va_start(args, locale);
+	return 0;
+}
+
+int main() {
+	LocaleTag value{42};
+	return wrapper(&value);
+}


### PR DESCRIPTION
## What changed

This PR bundles three related follow-ups from the standard-header timing investigation:

- adds richer parser runtime/perf instrumentation, including parser-failure reporting and saved-token storage metrics
- fixes the Windows/MSVC `__va_start` builtin fallback so it no longer forms an ambiguous overload set with the real UCRT declaration
- removes the now-fixed known-issues entry and updates the remaining `<limits>` issue to the new downstream failure frontier

## Why it changed

The original Windows `<limits>` analysis was stopping too early in `corecrt_wstdio.h` to say much about the real cost of parsing the header stack. The first pass added enough instrumentation to measure where time and storage were going even on parse-failure runs. While using that instrumentation, the parser bug turned out to be a real frontend issue rather than just a profiling limitation.

Root cause of the parser failure:

- FlashCpp pre-registered `__va_start` / `__builtin_va_start` as fixed two-parameter builtins.
- MSVC headers also declare `void __va_start(va_list*, ...)`.
- In the UCRT `__crt_va_start` macro expansion, the header declaration was better on the first argument while the builtin was better on the second, so overload resolution reported an ambiguity.
- After backtracking, that ambiguity surfaced as the misleading `Unexpected keyword in expression context` error at the surrounding `((void)(...))` wrapper.

The fix registers the builtin fallback as one named generic parameter plus ellipsis, which lets the real UCRT declaration outrank it cleanly.

## Impact

- The parser now gets past the previous `corecrt_wstdio.h` blocker on Windows/MSVC STL.
- `tests/std/test_std_limits.cpp --timing --stats` advances to a later semantic/constexpr issue in `std::_Num_float_base::has_denorm`, which is a separate bug.
- The performance instrumentation remains available for future parser investigations.

## Validation

- `./build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1`
- `pwsh tests/run_all_tests.ps1 test_ucrt_va_start_builtin_overload_ret0.cpp`
- `pwsh tests/run_all_tests.ps1 test_va_implementation_ret60.cpp`
- `./x64/Sharded/FlashCppMSVC.exe ./tests/std/test_std_limits.cpp --timing --stats`

## Timing notes

Before the `__va_start` fix, the Windows `<limits>` path stopped in UCRT after roughly:

- preprocessing: ~766 ms median
- parsing: ~112 ms median

After the fix, the same path gets much further and now reaches:

- preprocessing: ~840 ms
- parsing: ~6862 ms
- semantic analysis: ~21 ms

That is expected: the old numbers were time-to-first-hard-error in UCRT, while the new numbers represent real progress deeper into the MSVC STL stack.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated known issues list for Windows/MSVC compatibility.

* **Bug Fixes**
  * Resolved MSVC/Windows parsing issue with numeric limits.
  * Fixed va_start builtin function overload ambiguity.

* **New Features**
  * Enhanced error reporting with improved diagnostics output.

* **Tests**
  * Added regression test for va_start builtin handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->