### PR TITLE
[codex] Finish Stage 5 sema query-state cleanup

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -33,10 +33,18 @@ Further null-pointer elimination in internal helpers:
 - Three helpers in `Parser_Templates_Inst_ClassTemplate.cpp` that forwarded a nullable `Parser*` into `EvaluationContext::sema` now take `Parser&`: the ternary `parser ? &parser->semanticAnalysis() : nullptr` assignment is gone.
 - Four file-static conversion-operator helpers in `SemanticAnalysis.cpp` (`findStructPointerConversionOperator`, `collectAllStructPointerConversionOperators`, `hasAmbiguousPointerConversionOperators`, `structHasConversionOperatorTo`) changed from `SemanticAnalysis*` to `SemanticAnalysis&`, removing all null guards on the sema parameter at those call sites.
 
+### Progress update (2026-05-17)
+
+The Stage 5 structural split is now explicit in code:
+
+- post-parse whole-translation-unit orchestration now lives in a dedicated internal `PostParseSemanticNormalizer` layer instead of being open-coded directly inside `SemanticAnalysis::run()` / `SemanticAnalysis::normalizePendingSemanticRoots()`
+- `SemanticAnalysis` remains the compilation-lifetime owner/coordinator and delegates whole-TU normalization work into that dedicated layer
+- `Parser::normalizePendingSemanticRootsIfAvailable()` now routes through `semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots()` instead of bypassing the parser-safe boundary
+- the remaining Stage 5 work is now narrower: phase-aware side-table/query contracts and additional parser-safe query migration, rather than the high-level owner/normalizer split itself
+
 Remaining Stage 5 work:
 
 - move the rest of the parser/template/constexpr-safe queries behind the parser-safe boundary
-- split the whole-TU `run()` orchestration into a dedicated post-parse normalizer layer
 - audit side tables so "not analyzed yet" and "analyzed and absent" become explicit phase-aware states
 
 ### 5.1 Define the internal split inside `SemanticAnalysis`
@@ -101,6 +109,14 @@ Nullable sema elimination continued in template-instantiation and conversion-ope
 
 - `Parser*` → `Parser&` in `makeStaticMemberInitializerEvaluationContext` and its two callers; the `parser ? &parser->semanticAnalysis() : nullptr` ternary assignment into `EvaluationContext::sema` is eliminated.
 - `SemanticAnalysis*` → `SemanticAnalysis&` in four file-static conversion-operator helpers in `SemanticAnalysis.cpp`; null guards removed.
+
+### Progress update (2026-05-17)
+
+Parser-owned constexpr flows now tighten their semantic contract further:
+
+- dependent-unqualified constexpr call reuse now requires a sema-backed `EvaluationContext` when the context is parser-owned, instead of silently skipping sema reuse on a missing pointer
+- lazy constexpr member materialization now requires sema for parser-owned contexts and no longer falls back to direct parser-side instantiate/normalize bookkeeping
+- `EvaluationContext::sema` itself is still nullable overall because standalone non-parser evaluator callers remain, but the parser/template/member-function paths are now closer to the intended Stage 6 invariant
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -38,11 +38,12 @@ Stage 5 progress so far:
 - the eager `getOverloadResolutionArgType(...)` API remains in place for existing callers, but it now has a sibling query API for phase-aware consumers and tests.
 - parser-safe expression-type queries now also distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` instead of treating a missing semantic slot as the only state signal.
 - expression normalization now records that an expression node was sema-visited even when no semantic type slot was produced, so expression-type queries no longer have to guess phase from slot presence alone.
-- after the remaining code audit, the unresolved nullable/empty lookups are now mostly narrower specialized caches (`identifier` / `qualified-identifier` / member-access / subscript / unary-dereference / structured-binding) that are primarily codegen/finalized consumers rather than the broad parser-safe query families Stage 5 set out to split and phase-harden.
+- subscript-resolution queries now use the same explicit `NotYetAnalyzed` / `AnalyzedAbsent` / `Available` contract, so parser-safe `operator[]` lookups no longer have to infer phase from a missing side-table entry.
+- after the remaining code audit, the unresolved nullable/empty lookups are now mostly narrower specialized caches (`identifier` / `qualified-identifier` / member-access / unary-dereference / structured-binding) that are primarily codegen/finalized consumers rather than the broad parser-safe query families Stage 5 set out to split and phase-harden.
 
 Remaining Stage 5 work:
 
-- Stage 5 core work is effectively complete; any further query-state tightening is now narrower follow-on work on specialized caches and fits better under Stage 6 API-contract/finalized-query hardening
+- Stage 5 core work is complete for the parser-safe services and resolved-call/query families called out above; any further query-state tightening is now narrower follow-on work on specialized finalized/codegen-side caches and fits better under Stage 6 API-contract/finalized-query hardening
 
 ### 5.1 Define the internal split inside `SemanticAnalysis`
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -42,10 +42,18 @@ The Stage 5 structural split is now explicit in code:
 - `Parser::normalizePendingSemanticRootsIfAvailable()` now routes through `semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots()` instead of bypassing the parser-safe boundary
 - the remaining Stage 5 work is now narrower: phase-aware side-table/query contracts and additional parser-safe query migration, rather than the high-level owner/normalizer split itself
 
+### Progress update (2026-05-17, continued)
+
+Resolved-call query state is now phase-aware instead of using bare null as the only contract:
+
+- parser-safe resolved direct-call and `operator()` lookups now have explicit query-state APIs that distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available`
+- sema records when those call-query families were actually examined, so callers no longer have to infer phase from object lifetime or from a missing map entry
+- constexpr direct-call reuse now goes through the explicit direct-call query API, so the parser-safe boundary exercises the new contract directly
+- the remaining Stage 5 side-table work is still broader than call resolution alone: expression-type, overload-argument-type, member-access, and similar tables still need the same phase-aware audit
+
 Remaining Stage 5 work:
 
-- move the rest of the parser/template/constexpr-safe queries behind the parser-safe boundary
-- audit side tables so "not analyzed yet" and "analyzed and absent" become explicit phase-aware states
+- continue the side-table audit so additional families beyond resolved-call lookups distinguish "not analyzed yet" from "analyzed and absent"
 
 ### 5.1 Define the internal split inside `SemanticAnalysis`
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -116,11 +116,12 @@ Parser-owned constexpr flows now tighten their semantic contract further:
 
 - dependent-unqualified constexpr call reuse now requires a sema-backed `EvaluationContext` when the context is parser-owned, instead of silently skipping sema reuse on a missing pointer
 - lazy constexpr member materialization now requires sema for parser-owned contexts and no longer falls back to direct parser-side instantiate/normalize bookkeeping
+- parser-owned `EvaluationContext::normalizePendingSemanticRoots()` now throws on missing sema instead of quietly becoming a no-op
 - `EvaluationContext::sema` itself is still nullable overall because standalone non-parser evaluator callers remain, but the parser/template/member-function paths are now closer to the intended Stage 6 invariant
 
 Remaining Stage 6 work:
 
-- remove the remaining nullable-semantic branches in parser-owned constexpr/template/substitution contexts
+- finish auditing parser-owned constexpr/template/substitution construction sites so `EvaluationContext::sema` can eventually stop being nullable as a field, not just as an enforced parser-owned invariant
 - `EvaluationContext::sema` is still a nullable pointer with a single `if (sema != nullptr)` guard in `normalizePendingSemanticRoots()`; making it non-nullable requires auditing all EvaluationContext creation sites that do not set sema
 - continue replacing parser/codegen fallback ambiguity with explicit "fact unavailable yet" contracts
 - keep tightening finalized-query misuse into hard invariants once the remaining fallback families are retired

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -16,40 +16,26 @@ Stop modeling semantic availability as nullable object plumbing. Callers should 
 
 ## Stage 5: Split Always-Valid Services From Post-Parse Normalization
 
-### Progress update (2026-05-16)
+### Progress update
 
-Initial Stage 5 groundwork is now in place:
+Stage 5 progress so far:
 
 - `SemanticAnalysis` owns an explicit non-virtual `ParserSemanticServices` boundary for parser-safe operations.
 - `SemanticAnalysis` now exposes named lifecycle/state queries for parser attachment and post-parse normalization start/completion.
 - constexpr evaluation and pending-root normalization call sites have started routing through `ParserSemanticServices` instead of reaching straight into the full post-parse owner API.
 - the handoff into `AstToIr` now asserts that post-parse normalization completed before codegen consumes finalized semantic data.
-
-### Progress update (2026-05-16, continued)
-
-Further null-pointer elimination in internal helpers:
-
 - `TemplateEnvironment::semantic_context` was confirmed unused and removed.
-- Three helpers in `Parser_Templates_Inst_ClassTemplate.cpp` that forwarded a nullable `Parser*` into `EvaluationContext::sema` now take `Parser&`: the ternary `parser ? &parser->semanticAnalysis() : nullptr` assignment is gone.
-- Four file-static conversion-operator helpers in `SemanticAnalysis.cpp` (`findStructPointerConversionOperator`, `collectAllStructPointerConversionOperators`, `hasAmbiguousPointerConversionOperators`, `structHasConversionOperatorTo`) changed from `SemanticAnalysis*` to `SemanticAnalysis&`, removing all null guards on the sema parameter at those call sites.
-
-### Progress update (2026-05-17)
-
-The Stage 5 structural split is now explicit in code:
-
-- post-parse whole-translation-unit orchestration now lives in a dedicated internal `PostParseSemanticNormalizer` layer instead of being open-coded directly inside `SemanticAnalysis::run()` / `SemanticAnalysis::normalizePendingSemanticRoots()`
-- `SemanticAnalysis` remains the compilation-lifetime owner/coordinator and delegates whole-TU normalization work into that dedicated layer
-- `Parser::normalizePendingSemanticRootsIfAvailable()` now routes through `semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots()` instead of bypassing the parser-safe boundary
-- the remaining Stage 5 work is now narrower: phase-aware side-table/query contracts and additional parser-safe query migration, rather than the high-level owner/normalizer split itself
-
-### Progress update (2026-05-17, continued)
-
-Resolved-call query state is now phase-aware instead of using bare null as the only contract:
-
-- parser-safe resolved direct-call and `operator()` lookups now have explicit query-state APIs that distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available`
-- sema records when those call-query families were actually examined, so callers no longer have to infer phase from object lifetime or from a missing map entry
-- constexpr direct-call reuse now goes through the explicit direct-call query API, so the parser-safe boundary exercises the new contract directly
-- the remaining Stage 5 side-table work is still broader than call resolution alone: expression-type, overload-argument-type, member-access, and similar tables still need the same phase-aware audit
+- three helpers in `Parser_Templates_Inst_ClassTemplate.cpp` that forwarded a nullable `Parser*` into `EvaluationContext::sema` now take `Parser&`: the ternary `parser ? &parser->semanticAnalysis() : nullptr` assignment is gone.
+- four file-static conversion-operator helpers in `SemanticAnalysis.cpp` (`findStructPointerConversionOperator`, `collectAllStructPointerConversionOperators`, `hasAmbiguousPointerConversionOperators`, `structHasConversionOperatorTo`) changed from `SemanticAnalysis*` to `SemanticAnalysis&`, removing all null guards on the sema parameter at those call sites.
+- post-parse whole-translation-unit orchestration now lives in a dedicated internal `PostParseSemanticNormalizer` layer instead of being open-coded directly inside `SemanticAnalysis::run()` / `SemanticAnalysis::normalizePendingSemanticRoots()`.
+- `SemanticAnalysis` remains the compilation-lifetime owner/coordinator and delegates whole-TU normalization work into that dedicated layer.
+- `Parser::normalizePendingSemanticRootsIfAvailable()` now routes through `semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots()` instead of bypassing the parser-safe boundary.
+- parser-safe resolved direct-call and `operator()` lookups now have explicit query-state APIs that distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available`.
+- sema records when those call-query families were actually examined, so callers no longer have to infer phase from object lifetime or from a missing map entry.
+- constexpr direct-call reuse now goes through the explicit direct-call query API, so the parser-safe boundary exercises the new contract directly.
+- parser-safe overload-argument-type queries now expose `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` instead of making callers guess from a missing cache entry.
+- sema now records when overload-resolution argument typing was actually attempted for an expression node, even when no type could be produced.
+- the eager `getOverloadResolutionArgType(...)` API remains in place for existing callers, but it now has a sibling query API for phase-aware consumers and tests.
 
 Remaining Stage 5 work:
 
@@ -103,29 +89,19 @@ Any code reading a table should be able to tell whether an empty lookup means:
 
 ## Stage 6: Make Callers Depend On Semantic Facts, Not Semantic Presence
 
-### Progress update (2026-05-16)
+### Progress update
 
-Initial Stage 6 codegen invariants are now in place:
+Stage 6 progress so far:
 
 - `AstToIr` now requires `SemanticAnalysis&` at construction time instead of receiving semantic data through a later setter call.
 - the `setSemanticData(...)` plumbing is gone, so codegen cannot accidentally start in a semantic-null state anymore.
 - IR generation helpers now treat semantic analysis as mandatory infrastructure and only branch on whether a particular semantic fact was available.
-
-### Progress update (2026-05-16, continued)
-
-Nullable sema elimination continued in template-instantiation and conversion-operator helpers:
-
 - `Parser*` → `Parser&` in `makeStaticMemberInitializerEvaluationContext` and its two callers; the `parser ? &parser->semanticAnalysis() : nullptr` ternary assignment into `EvaluationContext::sema` is eliminated.
 - `SemanticAnalysis*` → `SemanticAnalysis&` in four file-static conversion-operator helpers in `SemanticAnalysis.cpp`; null guards removed.
-
-### Progress update (2026-05-17)
-
-Parser-owned constexpr flows now tighten their semantic contract further:
-
-- dependent-unqualified constexpr call reuse now requires a sema-backed `EvaluationContext` when the context is parser-owned, instead of silently skipping sema reuse on a missing pointer
-- lazy constexpr member materialization now requires sema for parser-owned contexts and no longer falls back to direct parser-side instantiate/normalize bookkeeping
-- parser-owned `EvaluationContext::normalizePendingSemanticRoots()` now throws on missing sema instead of quietly becoming a no-op
-- `EvaluationContext::sema` itself is still nullable overall because standalone non-parser evaluator callers remain, but the parser/template/member-function paths are now closer to the intended Stage 6 invariant
+- dependent-unqualified constexpr call reuse now requires a sema-backed `EvaluationContext` when the context is parser-owned, instead of silently skipping sema reuse on a missing pointer.
+- lazy constexpr member materialization now requires sema for parser-owned contexts and no longer falls back to direct parser-side instantiate/normalize bookkeeping.
+- parser-owned `EvaluationContext::normalizePendingSemanticRoots()` now throws on missing sema instead of quietly becoming a no-op.
+- `EvaluationContext::sema` itself is still nullable overall because standalone non-parser evaluator callers remain, but the parser/template/member-function paths are now closer to the intended Stage 6 invariant.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -38,10 +38,11 @@ Stage 5 progress so far:
 - the eager `getOverloadResolutionArgType(...)` API remains in place for existing callers, but it now has a sibling query API for phase-aware consumers and tests.
 - parser-safe expression-type queries now also distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` instead of treating a missing semantic slot as the only state signal.
 - expression normalization now records that an expression node was sema-visited even when no semantic type slot was produced, so expression-type queries no longer have to guess phase from slot presence alone.
+- after the remaining code audit, the unresolved nullable/empty lookups are now mostly narrower specialized caches (`identifier` / `qualified-identifier` / member-access / subscript / unary-dereference / structured-binding) that are primarily codegen/finalized consumers rather than the broad parser-safe query families Stage 5 set out to split and phase-harden.
 
 Remaining Stage 5 work:
 
-- core Stage 5 side-table/query audit is in place for resolved-call, overload-argument-type, and expression-type queries; the remaining follow-on audit is narrower and mostly concerns other specialized caches such as member-access related tables
+- Stage 5 core work is effectively complete; any further query-state tightening is now narrower follow-on work on specialized caches and fits better under Stage 6 API-contract/finalized-query hardening
 
 ### 5.1 Define the internal split inside `SemanticAnalysis`
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -36,10 +36,12 @@ Stage 5 progress so far:
 - parser-safe overload-argument-type queries now expose `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` instead of making callers guess from a missing cache entry.
 - sema now records when overload-resolution argument typing was actually attempted for an expression node, even when no type could be produced.
 - the eager `getOverloadResolutionArgType(...)` API remains in place for existing callers, but it now has a sibling query API for phase-aware consumers and tests.
+- parser-safe expression-type queries now also distinguish `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` instead of treating a missing semantic slot as the only state signal.
+- expression normalization now records that an expression node was sema-visited even when no semantic type slot was produced, so expression-type queries no longer have to guess phase from slot presence alone.
 
 Remaining Stage 5 work:
 
-- continue the side-table audit so additional families beyond resolved-call lookups distinguish "not analyzed yet" from "analyzed and absent"
+- core Stage 5 side-table/query audit is in place for resolved-call, overload-argument-type, and expression-type queries; the remaining follow-on audit is narrower and mostly concerns other specialized caches such as member-access related tables
 
 ### 5.1 Define the internal split inside `SemanticAnalysis`
 

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -8,6 +8,15 @@
 
 namespace ConstExpr {
 
+namespace {
+SemanticAnalysis& requireParserOwnedContextSema(const EvaluationContext& context, const char* operation) {
+	if (context.sema == nullptr) {
+		throw InternalError(std::string("ConstExpr ") + operation + " requires a sema-backed EvaluationContext");
+	}
+	return *context.sema;
+}
+} // namespace
+
 void EvaluationContext::normalizePendingSemanticRoots() const {
 	if (sema != nullptr) {
 		sema->parserSemanticServices().normalizePendingSemanticRoots();
@@ -4456,9 +4465,11 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
-		if (context.sema) {
+		if (context.sema != nullptr || context.parser != nullptr) {
 			if (const FunctionDeclarationNode* sema_resolved =
-					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
+					requireParserOwnedContextSema(context, "dependent unqualified call reuse")
+						.parserSemanticServices()
+						.getResolvedDirectCall(&call_expr)) {
 				return evaluate_resolved_function_call(
 					*sema_resolved,
 					call_expr.arguments(),

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -18,6 +18,9 @@ SemanticAnalysis& requireParserOwnedContextSema(const EvaluationContext& context
 } // namespace
 
 void EvaluationContext::normalizePendingSemanticRoots() const {
+	if (parser != nullptr && sema == nullptr) {
+		throw InternalError("ConstExpr normalizePendingSemanticRoots requires sema-backed parser-owned EvaluationContext");
+	}
 	if (sema != nullptr) {
 		sema->parserSemanticServices().normalizePendingSemanticRoots();
 	}
@@ -4465,11 +4468,9 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
-		if (context.sema != nullptr || context.parser != nullptr) {
+		if (context.sema != nullptr) {
 			if (const FunctionDeclarationNode* sema_resolved =
-					requireParserOwnedContextSema(context, "dependent unqualified call reuse")
-						.parserSemanticServices()
-						.getResolvedDirectCall(&call_expr)) {
+					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
 				return evaluate_resolved_function_call(
 					*sema_resolved,
 					call_expr.arguments(),
@@ -4484,6 +4485,7 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		if (!context.parser) {
 			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
 		}
+		(void)requireParserOwnedContextSema(context, "dependent unqualified call reuse");
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!context.parser->tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4469,10 +4469,11 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		if (context.sema != nullptr) {
-			if (const FunctionDeclarationNode* sema_resolved =
-					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
+			ResolvedFunctionQueryResult sema_query =
+				context.sema->parserSemanticServices().getResolvedDirectCallQuery(&call_expr);
+			if (sema_query.hasValue()) {
 				return evaluate_resolved_function_call(
-					*sema_resolved,
+					*sema_query.function,
 					call_expr.arguments(),
 					context,
 					nullptr);

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -9,7 +9,7 @@
 namespace ConstExpr {
 
 namespace {
-SemanticAnalysis& requireParserOwnedContextSema(const EvaluationContext& context, const char* operation) {
+SemanticAnalysis& requireParserOwnedCallContextSema(const EvaluationContext& context, const char* operation) {
 	if (context.sema == nullptr) {
 		throw InternalError(std::string("ConstExpr ") + operation + " requires a sema-backed EvaluationContext");
 	}
@@ -4485,7 +4485,7 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		if (!context.parser) {
 			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
 		}
-		(void)requireParserOwnedContextSema(context, "dependent unqualified call reuse");
+		(void)requireParserOwnedCallContextSema(context, "dependent unqualified call reuse");
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!context.parser->tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1688,10 +1688,11 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		if (context.sema != nullptr) {
-			if (const FunctionDeclarationNode* sema_resolved =
-					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
+			ResolvedFunctionQueryResult sema_query =
+				context.sema->parserSemanticServices().getResolvedDirectCallQuery(&call_expr);
+			if (sema_query.hasValue()) {
 				return evaluate_function_call_with_bindings(
-					*sema_resolved,
+					*sema_query.function,
 					call_expr.arguments(),
 					bindings,
 					context,

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -17,7 +17,7 @@ constexpr size_t kSyntheticTokenColumn = 0;
 constexpr size_t kSyntheticTokenFileIndex = 0;
 constexpr std::string_view kNestedTypeAliasName = "type";
 
-SemanticAnalysis& requireParserOwnedContextSema(const EvaluationContext& context, const char* operation) {
+SemanticAnalysis& requireParserOwnedMemberContextSema(const EvaluationContext& context, const char* operation) {
 	if (context.sema == nullptr) {
 		throw InternalError(std::string("ConstExpr ") + operation + " requires a sema-backed EvaluationContext");
 	}
@@ -1705,7 +1705,7 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		if (!context.parser) {
 			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
 		}
-		(void)requireParserOwnedContextSema(context, "dependent unqualified member call reuse");
+		(void)requireParserOwnedMemberContextSema(context, "dependent unqualified member call reuse");
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!context.parser->tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(
@@ -2932,7 +2932,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 	// sema-owned helper so the evaluator no longer drives the
 	// instantiate/normalize/mark bookkeeping directly.
 	if (context.sema != nullptr || context.parser != nullptr) {
-		(void)requireParserOwnedContextSema(context, "lazy member materialization")
+		(void)requireParserOwnedMemberContextSema(context, "lazy member materialization")
 				  .parserSemanticServices()
 				  .ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
@@ -2952,7 +2952,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 			owner_name = StringTable::getOrInternStringHandle(result.function->parent_struct_name());
 		}
 		if (context.sema != nullptr || context.parser != nullptr) {
-			(void)requireParserOwnedContextSema(context, "lazy member candidate materialization")
+			(void)requireParserOwnedMemberContextSema(context, "lazy member candidate materialization")
 					  .parserSemanticServices()
 					  .ensureMemberFunctionMaterialized(owner_name, *result.function);
 		}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1687,11 +1687,9 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
-		if (context.sema != nullptr || context.parser != nullptr) {
+		if (context.sema != nullptr) {
 			if (const FunctionDeclarationNode* sema_resolved =
-					requireParserOwnedContextSema(context, "dependent unqualified member call reuse")
-						.parserSemanticServices()
-						.getResolvedDirectCall(&call_expr)) {
+					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
 				return evaluate_function_call_with_bindings(
 					*sema_resolved,
 					call_expr.arguments(),
@@ -1707,6 +1705,7 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		if (!context.parser) {
 			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
 		}
+		(void)requireParserOwnedContextSema(context, "dependent unqualified member call reuse");
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!context.parser->tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -17,6 +17,13 @@ constexpr size_t kSyntheticTokenColumn = 0;
 constexpr size_t kSyntheticTokenFileIndex = 0;
 constexpr std::string_view kNestedTypeAliasName = "type";
 
+SemanticAnalysis& requireParserOwnedContextSema(const EvaluationContext& context, const char* operation) {
+	if (context.sema == nullptr) {
+		throw InternalError(std::string("ConstExpr ") + operation + " requires a sema-backed EvaluationContext");
+	}
+	return *context.sema;
+}
+
 TypeSpecifierNode makeArrayTypeSpec(TypeIndex type_index, std::span<const size_t> array_dimensions);
 EvalResult materializeArrayInitializer(
 	TypeIndex type_index,
@@ -1680,9 +1687,11 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
-		if (context.sema) {
+		if (context.sema != nullptr || context.parser != nullptr) {
 			if (const FunctionDeclarationNode* sema_resolved =
-					context.sema->parserSemanticServices().getResolvedDirectCall(&call_expr)) {
+					requireParserOwnedContextSema(context, "dependent unqualified member call reuse")
+						.parserSemanticServices()
+						.getResolvedDirectCall(&call_expr)) {
 				return evaluate_function_call_with_bindings(
 					*sema_resolved,
 					call_expr.arguments(),
@@ -2922,19 +2931,12 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 
 	// Phase 5 Slice D: route lazy member-function materialization through the
 	// sema-owned helper so the evaluator no longer drives the
-	// instantiate/normalize/mark bookkeeping directly. Fall back to the parser
-	// path only when sema is not wired up (e.g., very early speculative
-	// evaluation before a SemanticAnalysis is attached to the context).
-	if (context.sema) {
-		(void)context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(
+	// instantiate/normalize/mark bookkeeping directly.
+	if (context.sema != nullptr || context.parser != nullptr) {
+		(void)requireParserOwnedContextSema(context, "lazy member materialization")
+				  .parserSemanticServices()
+				  .ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
-	} else if (context.parser) {
-		LazyMemberKey member_key = LazyMemberKey::anyConst(
-			context.struct_info->name,
-			function_name_handle);
-		if (context.parser->instantiateLazyMemberIfNeeded(member_key).has_value()) {
-			context.normalizePendingSemanticRoots();
-		}
 	}
 
 	result = find_member_function_candidate(
@@ -2950,14 +2952,10 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 		if (!result.function->parent_struct_name().empty()) {
 			owner_name = StringTable::getOrInternStringHandle(result.function->parent_struct_name());
 		}
-		if (context.sema) {
-			(void)context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(owner_name, *result.function);
-		} else if (context.parser) {
-			if (context.parser->instantiateLazyMemberIfNeeded(
-					LazyMemberKey::exact(owner_name, *result.function))
-					.has_value()) {
-				context.normalizePendingSemanticRoots();
-			}
+		if (context.sema != nullptr || context.parser != nullptr) {
+			(void)requireParserOwnedContextSema(context, "lazy member candidate materialization")
+					  .parserSemanticServices()
+					  .ensureMemberFunctionMaterialized(owner_name, *result.function);
 		}
 		result = find_member_function_candidate(
 			context.struct_info,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -520,7 +520,7 @@ public:
 		return parseResult;
 	}
 
-	const auto& get_nodes() { return ast_nodes_; }
+	const auto& get_nodes() const { return ast_nodes_; }
 	void setRuntimeStatsEnabled(bool enabled);
 	void reserveSavedTokenStorage(size_t saved_token_capacity);
 	void printRuntimeStats() const;

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -635,7 +635,7 @@ Parser::Parser(Lexer& lexer, CompileContext& context, SemanticAnalysis& semantic
 }
 
 void Parser::normalizePendingSemanticRootsIfAvailable() {
-	semantic_analysis_.normalizePendingSemanticRoots();
+	semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots();
 }
 
 int Parser::getStructTypeSizeBits(TypeIndex type_index) const {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1406,6 +1406,10 @@ std::optional<TypeSpecifierNode> ParserSemanticServices::getExpressionType(const
 	return owner_->getExpressionType(node);
 }
 
+TypeSpecifierQueryResult ParserSemanticServices::getOverloadResolutionArgTypeQuery(const ASTNode& arg) const {
+	return owner_->getOverloadResolutionArgTypeQuery(arg);
+}
+
 std::optional<TypeSpecifierNode> ParserSemanticServices::getOverloadResolutionArgType(const ASTNode& arg) const {
 	requireParserSemanticServicesAttachment(*owner_, "getOverloadResolutionArgType");
 	return owner_->getOverloadResolutionArgType(arg);
@@ -3915,24 +3919,57 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::getTernaryResultType(const Te
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::getOverloadResolutionArgType(const ASTNode& arg) {
+	if (TypeSpecifierQueryResult cached = getOverloadResolutionArgTypeQuery(arg); cached.hasValue()) {
+		return cached.type;
+	}
 	if (arg.is<ExpressionNode>()) {
-		const void* key = getExpressionKey(arg);
-		auto it = overload_resolution_arg_types_.find(key);
-		if (it != overload_resolution_arg_types_.end()) {
-			return it->second;
-		}
-
 		if (auto slot_backed_type = getExpressionType(arg); slot_backed_type.has_value()) {
-			overload_resolution_arg_types_.emplace(key, *slot_backed_type);
+			cacheOverloadResolutionArgType(arg, *slot_backed_type);
 			return slot_backed_type;
 		}
 	}
 	auto result = buildOverloadResolutionArgType(arg, nullptr);
-	if (result.has_value() && arg.is<ExpressionNode>()) {
-		const void* key = getExpressionKey(arg);
-		overload_resolution_arg_types_.emplace(key, *result);
+	if (result.has_value()) {
+		cacheOverloadResolutionArgType(arg, *result);
 	}
 	return result;
+}
+
+const void* SemanticAnalysis::getOverloadResolutionArgQueryKey(const ASTNode& arg) const {
+	if (!arg.is<ExpressionNode>()) {
+		return nullptr;
+	}
+	return getExpressionKey(arg);
+}
+
+void SemanticAnalysis::markOverloadResolutionArgQueryAnalyzed(const ASTNode& arg) {
+	if (const void* key = getOverloadResolutionArgQueryKey(arg); key != nullptr) {
+		analyzed_overload_resolution_arg_queries_.insert(key);
+	}
+}
+
+void SemanticAnalysis::cacheOverloadResolutionArgType(const ASTNode& arg, const TypeSpecifierNode& type) {
+	if (const void* key = getOverloadResolutionArgQueryKey(arg); key != nullptr) {
+		overload_resolution_arg_types_[key] = type;
+	}
+}
+
+TypeSpecifierQueryResult SemanticAnalysis::getOverloadResolutionArgTypeQuery(const ASTNode& arg) const {
+	if (!arg.is<ExpressionNode>()) {
+		if (auto type = getExpressionType(arg); type.has_value()) {
+			return {TypeSpecifierQueryResult::State::Available, type};
+		}
+		return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
+	}
+
+	const void* key = getOverloadResolutionArgQueryKey(arg);
+	if (auto it = overload_resolution_arg_types_.find(key); it != overload_resolution_arg_types_.end()) {
+		return {TypeSpecifierQueryResult::State::Available, it->second};
+	}
+	if (analyzed_overload_resolution_arg_queries_.count(key) > 0) {
+		return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
+	}
+	return {TypeSpecifierQueryResult::State::NotYetAnalyzed, std::nullopt};
 }
 
 ValueCategory SemanticAnalysis::inferExpressionValueCategory(const ASTNode& node) {
@@ -5357,6 +5394,8 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 std::optional<TypeSpecifierNode> SemanticAnalysis::buildOverloadResolutionArgType(
 	const ASTNode& arg,
 	CanonicalTypeId* inferred_type_id) {
+	markOverloadResolutionArgQueryAnalyzed(arg);
+
 	auto applyExpressionValueCategory = [this, &arg](TypeSpecifierNode& type) {
 		if (!arg.is<ExpressionNode>()) {
 			return;
@@ -5376,9 +5415,7 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::buildOverloadResolutionArgTyp
 		}
 	};
 	auto storeArgType = [this, &arg](const TypeSpecifierNode& type) {
-		if (arg.is<ExpressionNode>()) {
-			overload_resolution_arg_types_[getExpressionKey(arg)] = type;
-		}
+		cacheOverloadResolutionArgType(arg, type);
 	};
 
 	if (arg.is<ExpressionNode>()) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -3886,6 +3886,34 @@ namespace {
 const void* getExpressionKey(const ASTNode& node) {
 	return static_cast<const void*>(&node.as<ExpressionNode>());
 }
+
+std::optional<TypeSpecifierNode> tryBuildDirectLiteralQueryType(const ASTNode& node) {
+	if (node.is<NumericLiteralNode>()) {
+		const TypeCategory literal_type = node.as<NumericLiteralNode>().type();
+		return TypeSpecifierNode(
+			literal_type,
+			TypeQualifier::None,
+			get_type_size_bits(literal_type),
+			Token{},
+			CVQualifier::None);
+	}
+	if (node.is<BoolLiteralNode>()) {
+		return TypeSpecifierNode(
+			TypeCategory::Bool,
+			TypeQualifier::None,
+			get_type_size_bits(TypeCategory::Bool),
+			Token{},
+			CVQualifier::None);
+	}
+	if (node.is<StringLiteralNode>()) {
+		const int char_size_bits = static_cast<int>(get_type_size_bits(TypeCategory::Char));
+		TypeSpecifierNode type(TypeCategory::Char, TypeQualifier::None, char_size_bits, Token{}, CVQualifier::Const);
+		type.add_pointer_level();
+		type.set_reference_qualifier(ReferenceQualifier::LValueReference);
+		return type;
+	}
+	return std::nullopt;
+}
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNode& node) const {
@@ -3895,6 +3923,9 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNo
 
 TypeSpecifierQueryResult SemanticAnalysis::getExpressionTypeQuery(const ASTNode& node) const {
 	if (!node.is<ExpressionNode>()) {
+		if (auto literal_type = tryBuildDirectLiteralQueryType(node); literal_type.has_value()) {
+			return {TypeSpecifierQueryResult::State::Available, *literal_type};
+		}
 		return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
 	}
 
@@ -3903,11 +3934,9 @@ TypeSpecifierQueryResult SemanticAnalysis::getExpressionTypeQuery(const ASTNode&
 	if (!slot.has_value() || !slot->has_type()) {
 		const ExpressionNode& expr = node.as<ExpressionNode>();
 		if (std::holds_alternative<StringLiteralNode>(expr)) {
-			const int char_size_bits = static_cast<int>(get_type_size_bits(TypeCategory::Char));
-			TypeSpecifierNode type(TypeCategory::Char, TypeQualifier::None, char_size_bits, Token{}, CVQualifier::Const);
-			type.add_pointer_level();
-			type.set_reference_qualifier(ReferenceQualifier::LValueReference);
-			return {TypeSpecifierQueryResult::State::Available, type};
+			if (auto literal_type = tryBuildDirectLiteralQueryType(node); literal_type.has_value()) {
+				return {TypeSpecifierQueryResult::State::Available, *literal_type};
+			}
 		}
 		if (normalized_ast_nodes_.count(key) > 0) {
 			return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
@@ -3977,6 +4006,9 @@ void SemanticAnalysis::cacheOverloadResolutionArgType(const ASTNode& arg, const 
 
 TypeSpecifierQueryResult SemanticAnalysis::getOverloadResolutionArgTypeQuery(const ASTNode& arg) const {
 	if (!arg.is<ExpressionNode>()) {
+		if (auto literal_type = tryBuildDirectLiteralQueryType(arg); literal_type.has_value()) {
+			return {TypeSpecifierQueryResult::State::Available, *literal_type};
+		}
 		if (auto type = getExpressionType(arg); type.has_value()) {
 			return {TypeSpecifierQueryResult::State::Available, type};
 		}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -25,80 +25,6 @@ void requireParserSemanticServicesAttachment(const SemanticAnalysis& sema, const
 	}
 }
 
-class PostParseSemanticNormalizer {
-public:
-	explicit PostParseSemanticNormalizer(SemanticAnalysis& owner)
-		: owner_(owner) {
-	}
-
-	void run() {
-		Parser& attached_parser = owner_.parser();
-		if (owner_.lifecycle_state_ != SemanticAnalysis::LifecycleState::ParserAttached) {
-			throw InternalError("SemanticAnalysis::run() requires attached parser in ParserAttached state");
-		}
-		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationStarted;
-		attached_parser.clearPendingSemanticRoots();
-
-		const auto& nodes = attached_parser.get_nodes();
-		const size_t initial_root_count = nodes.size();
-		owner_.stats_.total_roots = initial_root_count;
-
-		FLASH_LOG(General, Debug, "SemanticAnalysis: starting pass over ", initial_root_count, " top-level nodes");
-		logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(nodes));
-
-		for (size_t root_index = 0; root_index < initial_root_count; ++root_index) {
-			ASTNode node = attached_parser.get_nodes()[root_index];
-			owner_.normalizeTopLevelNode(node);
-		}
-
-		normalizePendingSemanticRoots();
-
-		// Materialize any lazy members sema marked ODR-used before codegen starts.
-		if (owner_.drainLazyMemberRegistry() > 0) {
-			normalizePendingSemanticRoots();
-		}
-
-		owner_.resolveRemainingAutoReturns();
-
-		FLASH_LOG(General, Debug, "SemanticAnalysis: pass complete - ",
-				  owner_.stats_.roots_visited, " roots visited, ",
-				  owner_.stats_.expressions_visited, " expressions, ",
-				  owner_.stats_.statements_visited, " statements, ",
-				  owner_.stats_.canonical_types_interned, " canonical types");
-		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationCompleted;
-	}
-
-	size_t normalizePendingSemanticRoots() {
-		size_t normalized_root_count = 0;
-
-		while (true) {
-			std::vector<ASTNode> pending_roots = owner_.parser().takePendingSemanticRoots();
-			if (pending_roots.empty()) {
-				break;
-			}
-
-			owner_.stats_.total_roots += pending_roots.size();
-			logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(pending_roots));
-
-			for (const ASTNode& pending_root : pending_roots) {
-				if (!pending_root.has_value()) {
-					continue;
-				}
-
-				owner_.normalizeTopLevelNode(pending_root);
-				ASTNode root_handle_for_auto_return_resolution = pending_root;
-				owner_.resolveRemainingAutoReturnsInNode(root_handle_for_auto_return_resolution);
-				++normalized_root_count;
-			}
-		}
-
-		return normalized_root_count;
-	}
-
-private:
-	SemanticAnalysis& owner_;
-};
-
 } // namespace
 
 void applyDeclarationArrayBoundsToTypeSpec(const DeclarationNode& decl, TypeSpecifierNode& type_spec) {
@@ -1390,6 +1316,80 @@ void logPostParseBoundaryReport(const PostParseBoundaryReport& report) {
 	}
 }
 } // namespace
+
+class PostParseSemanticNormalizer {
+public:
+	explicit PostParseSemanticNormalizer(SemanticAnalysis& owner)
+		: owner_(owner) {
+	}
+
+	void run() {
+		Parser& attached_parser = owner_.parser();
+		if (owner_.lifecycle_state_ != SemanticAnalysis::LifecycleState::ParserAttached) {
+			throw InternalError("SemanticAnalysis::run() requires attached parser in ParserAttached state");
+		}
+		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationStarted;
+		attached_parser.clearPendingSemanticRoots();
+
+		const auto& nodes = attached_parser.get_nodes();
+		const size_t initial_root_count = nodes.size();
+		owner_.stats_.total_roots = initial_root_count;
+
+		FLASH_LOG(General, Debug, "SemanticAnalysis: starting pass over ", initial_root_count, " top-level nodes");
+		logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(nodes));
+
+		for (size_t root_index = 0; root_index < initial_root_count; ++root_index) {
+			ASTNode node = attached_parser.get_nodes()[root_index];
+			owner_.normalizeTopLevelNode(node);
+		}
+
+		normalizePendingSemanticRoots();
+
+		// Materialize any lazy members sema marked ODR-used before codegen starts.
+		if (owner_.drainLazyMemberRegistry() > 0) {
+			normalizePendingSemanticRoots();
+		}
+
+		owner_.resolveRemainingAutoReturns();
+
+		FLASH_LOG(General, Debug, "SemanticAnalysis: pass complete - ",
+				  owner_.stats_.roots_visited, " roots visited, ",
+				  owner_.stats_.expressions_visited, " expressions, ",
+				  owner_.stats_.statements_visited, " statements, ",
+				  owner_.stats_.canonical_types_interned, " canonical types");
+		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationCompleted;
+	}
+
+	size_t normalizePendingSemanticRoots() {
+		size_t normalized_root_count = 0;
+
+		while (true) {
+			std::vector<ASTNode> pending_roots = owner_.parser().takePendingSemanticRoots();
+			if (pending_roots.empty()) {
+				break;
+			}
+
+			owner_.stats_.total_roots += pending_roots.size();
+			logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(pending_roots));
+
+			for (const ASTNode& pending_root : pending_roots) {
+				if (!pending_root.has_value()) {
+					continue;
+				}
+
+				owner_.normalizeTopLevelNode(pending_root);
+				ASTNode root_handle_for_auto_return_resolution = pending_root;
+				owner_.resolveRemainingAutoReturnsInNode(root_handle_for_auto_return_resolution);
+				++normalized_root_count;
+			}
+		}
+
+		return normalized_root_count;
+	}
+
+private:
+	SemanticAnalysis& owner_;
+};
 
 // --- SemanticAnalysis ---
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -25,6 +25,80 @@ void requireParserSemanticServicesAttachment(const SemanticAnalysis& sema, const
 	}
 }
 
+class PostParseSemanticNormalizer {
+public:
+	explicit PostParseSemanticNormalizer(SemanticAnalysis& owner)
+		: owner_(owner) {
+	}
+
+	void run() {
+		Parser& attached_parser = owner_.parser();
+		if (owner_.lifecycle_state_ != SemanticAnalysis::LifecycleState::ParserAttached) {
+			throw InternalError("SemanticAnalysis::run() requires attached parser in ParserAttached state");
+		}
+		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationStarted;
+		attached_parser.clearPendingSemanticRoots();
+
+		const auto& nodes = attached_parser.get_nodes();
+		const size_t initial_root_count = nodes.size();
+		owner_.stats_.total_roots = initial_root_count;
+
+		FLASH_LOG(General, Debug, "SemanticAnalysis: starting pass over ", initial_root_count, " top-level nodes");
+		logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(nodes));
+
+		for (size_t root_index = 0; root_index < initial_root_count; ++root_index) {
+			ASTNode node = attached_parser.get_nodes()[root_index];
+			owner_.normalizeTopLevelNode(node);
+		}
+
+		normalizePendingSemanticRoots();
+
+		// Materialize any lazy members sema marked ODR-used before codegen starts.
+		if (owner_.drainLazyMemberRegistry() > 0) {
+			normalizePendingSemanticRoots();
+		}
+
+		owner_.resolveRemainingAutoReturns();
+
+		FLASH_LOG(General, Debug, "SemanticAnalysis: pass complete - ",
+				  owner_.stats_.roots_visited, " roots visited, ",
+				  owner_.stats_.expressions_visited, " expressions, ",
+				  owner_.stats_.statements_visited, " statements, ",
+				  owner_.stats_.canonical_types_interned, " canonical types");
+		owner_.lifecycle_state_ = SemanticAnalysis::LifecycleState::PostParseNormalizationCompleted;
+	}
+
+	size_t normalizePendingSemanticRoots() {
+		size_t normalized_root_count = 0;
+
+		while (true) {
+			std::vector<ASTNode> pending_roots = owner_.parser().takePendingSemanticRoots();
+			if (pending_roots.empty()) {
+				break;
+			}
+
+			owner_.stats_.total_roots += pending_roots.size();
+			logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(pending_roots));
+
+			for (const ASTNode& pending_root : pending_roots) {
+				if (!pending_root.has_value()) {
+					continue;
+				}
+
+				owner_.normalizeTopLevelNode(pending_root);
+				ASTNode root_handle_for_auto_return_resolution = pending_root;
+				owner_.resolveRemainingAutoReturnsInNode(root_handle_for_auto_return_resolution);
+				++normalized_root_count;
+			}
+		}
+
+		return normalized_root_count;
+	}
+
+private:
+	SemanticAnalysis& owner_;
+};
+
 } // namespace
 
 void applyDeclarationArrayBoundsToTypeSpec(const DeclarationNode& decl, TypeSpecifierNode& type_spec) {
@@ -1438,71 +1512,11 @@ const Parser& SemanticAnalysis::parser() const {
 }
 
 void SemanticAnalysis::run() {
-	Parser& attached_parser = parser();
-	if (lifecycle_state_ != LifecycleState::ParserAttached) {
-		throw InternalError("SemanticAnalysis::run() requires attached parser in ParserAttached state");
-	}
-	lifecycle_state_ = LifecycleState::PostParseNormalizationStarted;
-	attached_parser.clearPendingSemanticRoots();
-
-	const auto& nodes = attached_parser.get_nodes();
-	const size_t initial_root_count = nodes.size();
-	stats_.total_roots = initial_root_count;
-
-	FLASH_LOG(General, Debug, "SemanticAnalysis: starting pass over ", initial_root_count, " top-level nodes");
-	logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(nodes));
-
-	for (size_t root_index = 0; root_index < initial_root_count; ++root_index) {
-		ASTNode node = attached_parser.get_nodes()[root_index];
-		normalizeTopLevelNode(node);
-	}
-
-	normalizePendingSemanticRoots();
-
-	// Phase 5 Slice F: materialize every remaining lazy-member registry entry
-	// here, before codegen begins. Any newly-materialized bodies may themselves
-	// introduce further pending sema roots (e.g., nested template usages inside
-	// the freshly-substituted body), so re-drain the pending-root queue after
-	// the registry drain to keep sema output consistent.
-	if (drainLazyMemberRegistry() > 0) {
-		normalizePendingSemanticRoots();
-	}
-
-	resolveRemainingAutoReturns();
-
-	FLASH_LOG(General, Debug, "SemanticAnalysis: pass complete - ",
-			  stats_.roots_visited, " roots visited, ",
-			  stats_.expressions_visited, " expressions, ",
-			  stats_.statements_visited, " statements, ",
-			  stats_.canonical_types_interned, " canonical types");
-	lifecycle_state_ = LifecycleState::PostParseNormalizationCompleted;
+	PostParseSemanticNormalizer(*this).run();
 }
 
 size_t SemanticAnalysis::normalizePendingSemanticRoots() {
-	size_t normalized_root_count = 0;
-
-	while (true) {
-		std::vector<ASTNode> pending_roots = parser().takePendingSemanticRoots();
-		if (pending_roots.empty()) {
-			break;
-		}
-
-		stats_.total_roots += pending_roots.size();
-		logPostParseBoundaryReport(PostParseBoundaryChecker{}.run(pending_roots));
-
-		for (const ASTNode& pending_root : pending_roots) {
-			if (!pending_root.has_value()) {
-				continue;
-			}
-
-			normalizeTopLevelNode(pending_root);
-			ASTNode root_handle_for_auto_return_resolution = pending_root;
-			resolveRemainingAutoReturnsInNode(root_handle_for_auto_return_resolution);
-			++normalized_root_count;
-		}
-	}
-
-	return normalized_root_count;
+	return PostParseSemanticNormalizer(*this).normalizePendingSemanticRoots();
 }
 
 std::vector<ASTNode> SemanticAnalysis::normalizeGenericLambdaParams(

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1435,6 +1435,14 @@ const FunctionDeclarationNode* ParserSemanticServices::getResolvedOpCall(const C
 	return owner_->getResolvedOpCall(key);
 }
 
+ResolvedFunctionQueryResult ParserSemanticServices::getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const {
+	return owner_->getResolvedOpSubscriptQuery(key);
+}
+
+const FunctionDeclarationNode* ParserSemanticServices::getResolvedOpSubscript(const ArraySubscriptNode* key) const {
+	return owner_->getResolvedOpSubscript(key);
+}
+
 ResolvedFunctionQueryResult ParserSemanticServices::getResolvedDirectCallQuery(const void* key) const {
 	return owner_->getResolvedDirectCallQuery(key);
 }
@@ -4153,6 +4161,16 @@ const FunctionDeclarationNode* SemanticAnalysis::getResolvedUnaryDereferenceOper
 	return it != op_unary_deref_table_.end() ? it->second : nullptr;
 }
 
+ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const {
+	if (auto it = op_subscript_table_.find(key); it != op_subscript_table_.end()) {
+		return {ResolvedFunctionQueryResult::State::Available, it->second};
+	}
+	if (analyzed_op_subscript_queries_.count(key) > 0) {
+		return {ResolvedFunctionQueryResult::State::AnalyzedAbsent, nullptr};
+	}
+	return {ResolvedFunctionQueryResult::State::NotYetAnalyzed, nullptr};
+}
+
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedDirectCall(const void* key) const {
 	auto it = resolved_direct_call_table_.find(key);
 	return it != resolved_direct_call_table_.end() ? it->second : nullptr;
@@ -6640,6 +6658,9 @@ void SemanticAnalysis::tryResolveUnaryDereferenceOperator(const UnaryOperatorNod
 }
 
 void SemanticAnalysis::tryResolveSubscriptOperator(const ArraySubscriptNode& subscript_node) {
+	analyzed_op_subscript_queries_.insert(&subscript_node);
+	op_subscript_table_.erase(&subscript_node);
+
 	// Determine whether the array expression has struct type (no pointer, no array dims).
 	const CanonicalTypeId object_type_id = inferExpressionType(subscript_node.array_expr());
 	if (!object_type_id)

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1411,12 +1411,28 @@ std::optional<TypeSpecifierNode> ParserSemanticServices::getOverloadResolutionAr
 	return owner_->getOverloadResolutionArgType(arg);
 }
 
+ResolvedFunctionQueryResult ParserSemanticServices::getResolvedOpCallQuery(const void* key) const {
+	return owner_->getResolvedOpCallQuery(key);
+}
+
+ResolvedFunctionQueryResult ParserSemanticServices::getResolvedOpCallQuery(const CallExprNode* key) const {
+	return owner_->getResolvedOpCallQuery(key);
+}
+
 const FunctionDeclarationNode* ParserSemanticServices::getResolvedOpCall(const void* key) const {
 	return owner_->getResolvedOpCall(key);
 }
 
 const FunctionDeclarationNode* ParserSemanticServices::getResolvedOpCall(const CallExprNode* key) const {
 	return owner_->getResolvedOpCall(key);
+}
+
+ResolvedFunctionQueryResult ParserSemanticServices::getResolvedDirectCallQuery(const void* key) const {
+	return owner_->getResolvedDirectCallQuery(key);
+}
+
+ResolvedFunctionQueryResult ParserSemanticServices::getResolvedDirectCallQuery(const CallExprNode* key) const {
+	return owner_->getResolvedDirectCallQuery(key);
 }
 
 const FunctionDeclarationNode* ParserSemanticServices::getResolvedDirectCall(const void* key) const {
@@ -4059,9 +4075,23 @@ const FunctionDeclarationNode* SemanticAnalysis::getResolvedOpCall(const void* k
 	return it != op_call_table_.end() ? it->second : nullptr;
 }
 
+ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpCallQuery(const void* key) const {
+	if (auto it = op_call_table_.find(key); it != op_call_table_.end()) {
+		return {ResolvedFunctionQueryResult::State::Available, it->second};
+	}
+	if (analyzed_op_call_queries_.count(key) > 0) {
+		return {ResolvedFunctionQueryResult::State::AnalyzedAbsent, nullptr};
+	}
+	return {ResolvedFunctionQueryResult::State::NotYetAnalyzed, nullptr};
+}
+
 const SemanticAnalysis::StructuredBindingPlan* SemanticAnalysis::getStructuredBindingPlan(const StructuredBindingNode* key) const {
 	auto it = structured_binding_plans_.find(key);
 	return it != structured_binding_plans_.end() ? &it->second : nullptr;
+}
+
+ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpCallQuery(const CallExprNode* key) const {
+	return getResolvedOpCallQuery(static_cast<const void*>(key));
 }
 
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedOpCall(const CallExprNode* key) const {
@@ -4078,8 +4108,22 @@ const FunctionDeclarationNode* SemanticAnalysis::getResolvedDirectCall(const voi
 	return it != resolved_direct_call_table_.end() ? it->second : nullptr;
 }
 
+ResolvedFunctionQueryResult SemanticAnalysis::getResolvedDirectCallQuery(const void* key) const {
+	if (auto it = resolved_direct_call_table_.find(key); it != resolved_direct_call_table_.end()) {
+		return {ResolvedFunctionQueryResult::State::Available, it->second};
+	}
+	if (analyzed_direct_call_queries_.count(key) > 0) {
+		return {ResolvedFunctionQueryResult::State::AnalyzedAbsent, nullptr};
+	}
+	return {ResolvedFunctionQueryResult::State::NotYetAnalyzed, nullptr};
+}
+
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedDirectCall(const CallExprNode* key) const {
 	return getResolvedDirectCall(static_cast<const void*>(key));
+}
+
+ResolvedFunctionQueryResult SemanticAnalysis::getResolvedDirectCallQuery(const CallExprNode* key) const {
+	return getResolvedDirectCallQuery(static_cast<const void*>(key));
 }
 
 std::optional<SemanticAnalysis::ResolvedIdentifierMemberInfo> SemanticAnalysis::getResolvedIdentifierMember(const IdentifierNode* key) const {
@@ -6387,6 +6431,8 @@ void SemanticAnalysis::tryAnnotateContextualBool(const ASTNode& expr_node) {
 // --- Callable operator() resolution ---
 
 void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info, const void* call_key) {
+	analyzed_op_call_queries_.insert(call_key);
+
 	if (call_info.has_receiver)
 		return;
 
@@ -7383,6 +7429,8 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 														 const CallInfo& call_info,
 														 const void* call_key,
 														 const char* context_description) {
+	analyzed_direct_call_queries_.insert(call_key);
+
 	const FunctionDeclarationNode* func_decl = resolveCallArgAnnotationTarget(call_info, call_key);
 	if (!func_decl) {
 		for (const ASTNode& arg : *call_info.arguments) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1406,6 +1406,10 @@ std::optional<TypeSpecifierNode> ParserSemanticServices::getExpressionType(const
 	return owner_->getExpressionType(node);
 }
 
+TypeSpecifierQueryResult ParserSemanticServices::getExpressionTypeQuery(const ASTNode& node) const {
+	return owner_->getExpressionTypeQuery(node);
+}
+
 TypeSpecifierQueryResult ParserSemanticServices::getOverloadResolutionArgTypeQuery(const ASTNode& arg) const {
 	return owner_->getOverloadResolutionArgTypeQuery(arg);
 }
@@ -3743,6 +3747,7 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				   expr);
 
 		const void* key = static_cast<const void*>(&expr);
+		normalized_ast_nodes_.insert(key);
 		auto existing_slot = getSlot(key);
 		if (!existing_slot.has_value() || !existing_slot->has_type()) {
 			if (const CanonicalTypeId inferred_type_id = inferExpressionType(node)) {
@@ -3876,8 +3881,13 @@ const void* getExpressionKey(const ASTNode& node) {
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNode& node) const {
+	TypeSpecifierQueryResult query = getExpressionTypeQuery(node);
+	return query.hasValue() ? query.type : std::nullopt;
+}
+
+TypeSpecifierQueryResult SemanticAnalysis::getExpressionTypeQuery(const ASTNode& node) const {
 	if (!node.is<ExpressionNode>()) {
-		return std::nullopt;
+		return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
 	}
 
 	const auto* key = getExpressionKey(node);
@@ -3889,9 +3899,12 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNo
 			TypeSpecifierNode type(TypeCategory::Char, TypeQualifier::None, char_size_bits, Token{}, CVQualifier::Const);
 			type.add_pointer_level();
 			type.set_reference_qualifier(ReferenceQualifier::LValueReference);
-			return type;
+			return {TypeSpecifierQueryResult::State::Available, type};
 		}
-		return std::nullopt;
+		if (normalized_ast_nodes_.count(key) > 0) {
+			return {TypeSpecifierQueryResult::State::AnalyzedAbsent, std::nullopt};
+		}
+		return {TypeSpecifierQueryResult::State::NotYetAnalyzed, std::nullopt};
 	}
 
 	TypeSpecifierNode type = materializeTypeSpecifier(type_context_.get(slot->type_id));
@@ -3907,7 +3920,7 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::getExpressionType(const ASTNo
 		default:
 			throw InternalError("Unexpected semantic value category");
 	}
-	return type;
+	return {TypeSpecifierQueryResult::State::Available, type};
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::getTernaryResultType(const TernaryOperatorNode& ternary_node) const {

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -50,6 +50,21 @@ struct ResolvedFunctionQueryResult {
 	}
 };
 
+struct TypeSpecifierQueryResult {
+	enum class State : uint8_t {
+		NotYetAnalyzed,
+		AnalyzedAbsent,
+		Available,
+	};
+
+	State state = State::NotYetAnalyzed;
+	std::optional<TypeSpecifierNode> type;
+
+	bool hasValue() const {
+		return state == State::Available && type.has_value();
+	}
+};
+
 class ParserSemanticServices final {
 public:
 	ParserSemanticServices() = delete;
@@ -58,6 +73,7 @@ public:
 	size_t normalizePendingSemanticRoots();
 
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
+	TypeSpecifierQueryResult getOverloadResolutionArgTypeQuery(const ASTNode& arg) const;
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg) const;
 
 	ResolvedFunctionQueryResult getResolvedOpCallQuery(const void* key) const;
@@ -144,6 +160,7 @@ public:
 	// Build the type/category view used specifically for overload-resolution arguments.
 	// Unlike getExpressionType(), this preserves overload-sensitive lvalue/xvalue details
 	// such as prvalue member access becoming an xvalue.
+	TypeSpecifierQueryResult getOverloadResolutionArgTypeQuery(const ASTNode& arg) const;
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg);
 
 	enum class StructuredBindingDecompositionKind : uint8_t {
@@ -381,6 +398,9 @@ private:
 	void registerOuterTemplateBindingsInScope(const FunctionDeclarationNode& func);
 	void registerOuterTemplateBindingsInScope(const ConstructorDeclarationNode& ctor);
 	void registerOuterTemplateBindingsInScope(const DestructorDeclarationNode& dtor);
+	const void* getOverloadResolutionArgQueryKey(const ASTNode& arg) const;
+	void markOverloadResolutionArgQueryAnalyzed(const ASTNode& arg);
+	void cacheOverloadResolutionArgType(const ASTNode& arg, const TypeSpecifierNode& type);
 	std::optional<TypeSpecifierNode> buildOverloadResolutionArgType(
 		const ASTNode& arg,
 		CanonicalTypeId* inferred_type_id = nullptr);
@@ -587,6 +607,7 @@ private:
 	std::unordered_map<const IdentifierNode*, ResolvedIdentifierMemberInfo> resolved_identifier_member_table_;
 	std::unordered_map<const QualifiedIdentifierNode*, ResolvedQualifiedIdentifierInfo> resolved_qualified_identifier_table_;
 	std::unordered_map<const void*, TypeSpecifierNode> overload_resolution_arg_types_;
+	std::unordered_set<const void*> analyzed_overload_resolution_arg_queries_;
 	std::unordered_map<const void*, std::vector<CallArgReferenceBindingInfo>> call_ref_bindings_;
 	std::unordered_map<const TernaryOperatorNode*, CanonicalTypeId> ternary_result_types_;
 	std::unordered_map<const StructuredBindingNode*, StructuredBindingPlan> structured_binding_plans_;

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -33,6 +33,7 @@ struct StructTypeInfo;
 struct LambdaInfo;
 struct CallInfo;
 class SemanticAnalysis;
+class PostParseSemanticNormalizer;
 
 class ParserSemanticServices final {
 public:
@@ -289,6 +290,7 @@ public:
 
 private:
 	friend class ParserSemanticServices;
+	friend class PostParseSemanticNormalizer;
 
 	enum class LifecycleState : uint8_t {
 		ParserDetached,

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -81,6 +81,8 @@ public:
 	ResolvedFunctionQueryResult getResolvedOpCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
+	ResolvedFunctionQueryResult getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const;
+	const FunctionDeclarationNode* getResolvedOpSubscript(const ArraySubscriptNode* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const void* key) const;
@@ -222,6 +224,7 @@ public:
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
+	ResolvedFunctionQueryResult getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const;
 	const FunctionDeclarationNode* getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const CallExprNode* key) const;
@@ -614,10 +617,11 @@ private:
 	std::unordered_map<const TernaryOperatorNode*, CanonicalTypeId> ternary_result_types_;
 	std::unordered_map<const StructuredBindingNode*, StructuredBindingPlan> structured_binding_plans_;
 
-	// Side table: ArraySubscriptNode pointer → resolved operator[] declaration.
-	// Populated by tryResolveSubscriptOperator when the subscript object is a struct type.
-	// Empty entry means built-in pointer/array subscript (handled by pointer arithmetic codegen).
+	// Side table: ArraySubscriptNode pointer -> resolved operator[] declaration.
+	// Use getResolvedOpSubscriptQuery(...) when callers must distinguish
+	// "not yet analyzed" from "analyzed and no operator[] overload selected".
 	std::unordered_map<const ArraySubscriptNode*, const FunctionDeclarationNode*> op_subscript_table_;
+	std::unordered_set<const ArraySubscriptNode*> analyzed_op_subscript_queries_;
 
 	// Track which function body ASTNode pointers sema has normalized.
 	// Codegen uses this to skip Phase 15 warnings for functions sema never visited

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -72,6 +72,7 @@ public:
 
 	size_t normalizePendingSemanticRoots();
 
+	TypeSpecifierQueryResult getExpressionTypeQuery(const ASTNode& node) const;
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
 	TypeSpecifierQueryResult getOverloadResolutionArgTypeQuery(const ASTNode& arg) const;
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg) const;
@@ -152,6 +153,7 @@ public:
 	// Look up the semantic slot for an expression node.
 	// Key is the raw pointer to the ExpressionNode (stable, from gChunkedAnyStorage).
 	std::optional<SemanticSlot> getSlot(const void* key) const;
+	TypeSpecifierQueryResult getExpressionTypeQuery(const ASTNode& node) const;
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
 	std::optional<TypeSpecifierNode> getTernaryResultType(const TernaryOperatorNode& ternary_node) const;
 	// Public bridge for codegen/helper paths that need the same canonical type

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -35,6 +35,21 @@ struct CallInfo;
 class SemanticAnalysis;
 class PostParseSemanticNormalizer;
 
+struct ResolvedFunctionQueryResult {
+	enum class State : uint8_t {
+		NotYetAnalyzed,
+		AnalyzedAbsent,
+		Available,
+	};
+
+	State state = State::NotYetAnalyzed;
+	const FunctionDeclarationNode* function = nullptr;
+
+	bool hasValue() const {
+		return state == State::Available && function != nullptr;
+	}
+};
+
 class ParserSemanticServices final {
 public:
 	ParserSemanticServices() = delete;
@@ -45,8 +60,12 @@ public:
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg) const;
 
+	ResolvedFunctionQueryResult getResolvedOpCallQuery(const void* key) const;
+	ResolvedFunctionQueryResult getResolvedOpCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
+	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
+	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const void* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const CallExprNode* key) const;
 
@@ -177,11 +196,16 @@ public:
 	}
 
 	// Look up the pre-resolved callable operator() for a call node.
-	// Returns nullptr when no annotation was stored (non-callable or not yet resolved).
+	// Returns nullptr when no positive annotation was stored. Use the Query variant
+	// when the caller must distinguish "not yet analyzed" from "analyzed and absent".
+	ResolvedFunctionQueryResult getResolvedOpCallQuery(const void* key) const;
+	ResolvedFunctionQueryResult getResolvedOpCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const;
+	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
+	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const void* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const CallExprNode* key) const;
 	struct ResolvedIdentifierMemberInfo {
@@ -557,6 +581,8 @@ private:
 	std::unordered_map<const void*, const FunctionDeclarationNode*> op_call_table_;
 	std::unordered_map<const UnaryOperatorNode*, const FunctionDeclarationNode*> op_unary_deref_table_;
 	std::unordered_map<const void*, const FunctionDeclarationNode*> resolved_direct_call_table_;
+	std::unordered_set<const void*> analyzed_op_call_queries_;
+	std::unordered_set<const void*> analyzed_direct_call_queries_;
 	std::unordered_map<const void*, ResolvedMemberAccessInfo> resolved_member_access_table_;
 	std::unordered_map<const IdentifierNode*, ResolvedIdentifierMemberInfo> resolved_identifier_member_table_;
 	std::unordered_map<const QualifiedIdentifierNode*, ResolvedQualifiedIdentifierInfo> resolved_qualified_identifier_table_;

--- a/tests/FlashCppTest/FlashCppTest.vcxproj
+++ b/tests/FlashCppTest/FlashCppTest.vcxproj
@@ -134,10 +134,6 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\src\AstNodeTypes.cpp" />
-    <ClCompile Include="..\..\src\ChunkedAnyVector.cpp" />
-    <ClCompile Include="..\..\src\CodeViewDebug.cpp" />
-    <ClCompile Include="..\..\src\Parser.cpp" />
     <ClCompile Include="FlashCppTest\FlashCppTest\FlashCppTest.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -79,6 +79,31 @@ static const CallExprNode* findAnyReturnCallExpr(const Parser& parser) {
 	return nullptr;
 }
 
+static const ASTNode* findAnyReturnExpr(const Parser& parser) {
+	for (const ASTNode& node : parser.get_nodes()) {
+		const FunctionDeclarationNode* function = get_function_decl_node(node);
+		if (function == nullptr || !function->get_definition().has_value()) {
+			continue;
+		}
+
+		const ASTNode& definition = *function->get_definition();
+		if (!definition.is<BlockNode>()) {
+			continue;
+		}
+
+		for (const ASTNode& stmt : definition.as<BlockNode>().get_statements()) {
+			if (!stmt.is<ReturnStatementNode>()) {
+				continue;
+			}
+			const auto& return_stmt = stmt.as<ReturnStatementNode>();
+			if (return_stmt.expression().has_value()) {
+				return &*return_stmt.expression();
+			}
+		}
+	}
+	return nullptr;
+}
+
 // Helper function to read test files from Reference directory
 std::string read_test_file(const std::string& filename) {
 	std::ifstream file("tests/" + filename);
@@ -1803,6 +1828,48 @@ TEST_CASE("SemanticAnalysis:ExpressionTypeQueryTracksAnalysisState") {
 	CHECK(after_run.state == TypeSpecifierQueryResult::State::Available);
 	REQUIRE(after_run.type.has_value());
 	CHECK(after_run.type->type() == TypeCategory::Int);
+}
+
+TEST_CASE("SemanticAnalysis:ResolvedSubscriptQueryTracksAnalysisState") {
+	std::string code = R"(
+		struct Buffer {
+			int data[2];
+			int& operator[](int index) { return data[index]; }
+		};
+
+		int main() {
+			Buffer buffer{{3, 7}};
+			return buffer[1];
+		}
+	)";
+
+	Lexer lexer(code);
+	CompileContext test_context;
+	test_context.setInputFile("test_resolved_subscript_query.cpp");
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
+	auto parse_result = parser.parse();
+	CHECK(!parse_result.is_error());
+	if (parse_result.is_error()) {
+		return;
+	}
+
+	const ASTNode* return_expr = findAnyReturnExpr(parser);
+	REQUIRE(return_expr != nullptr);
+	REQUIRE(return_expr->is<ArraySubscriptNode>());
+	const auto& subscript_expr = return_expr->as<ArraySubscriptNode>();
+
+	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
+	ResolvedFunctionQueryResult before_run = parser_services.getResolvedOpSubscriptQuery(&subscript_expr);
+	CHECK(before_run.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed);
+	CHECK(before_run.function == nullptr);
+	CHECK(parser_services.getResolvedOpSubscript(&subscript_expr) == nullptr);
+
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
+	ResolvedFunctionQueryResult after_run = sema.parserSemanticServices().getResolvedOpSubscriptQuery(&subscript_expr);
+	CHECK(after_run.state == ResolvedFunctionQueryResult::State::Available);
+	REQUIRE(after_run.function != nullptr);
+	CHECK(after_run.function->decl_node().identifier_token().value() == "operator[]"sv);
 }
 
 TEST_CASE("Constructor with no parameters") {

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -38,6 +38,39 @@ SemanticAnalysis& runSemanticAnalysisForTest(Parser& parser, CompileContext& con
 	return sema;
 }
 
+static const CallExprNode* findMainReturnCallExpr(const Parser& parser) {
+	for (const ASTNode& node : parser.get_nodes()) {
+		if (!node.is<FunctionDeclarationNode>()) {
+			continue;
+		}
+		const auto& function = node.as<FunctionDeclarationNode>();
+		if (function.decl_node().identifier_token().value() != "main"sv) {
+			continue;
+		}
+		if (!function.get_definition().has_value()) {
+			return nullptr;
+		}
+		const ASTNode& definition = *function.get_definition();
+		if (!definition.is<BlockNode>()) {
+			return nullptr;
+		}
+		const auto& statements = definition.as<BlockNode>().get_statements();
+		if (statements.empty() || !statements[0].is<ReturnStatementNode>()) {
+			return nullptr;
+		}
+		const auto& return_stmt = statements[0].as<ReturnStatementNode>();
+		if (!return_stmt.expression().has_value()) {
+			return nullptr;
+		}
+		const ASTNode& expr = *return_stmt.expression();
+		if (!expr.is<CallExprNode>()) {
+			return nullptr;
+		}
+		return &expr.as<CallExprNode>();
+	}
+	return nullptr;
+}
+
 // Helper function to read test files from Reference directory
 std::string read_test_file(const std::string& filename) {
 	std::ifstream file("tests/" + filename);
@@ -1664,6 +1697,39 @@ TEST_CASE("Parser:FunctionNameIdentifiers") {
 	}
 }
 #endif
+
+TEST_CASE("SemanticAnalysis:ResolvedDirectCallQueryTracksAnalysisState") {
+	std::string code = R"(
+		int foo() { return 7; }
+		int main() { return foo(); }
+	)";
+
+	Lexer lexer(code);
+	CompileContext test_context;
+	test_context.setInputFile("test_resolved_direct_call_query.cpp");
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
+	auto parse_result = parser.parse();
+	CHECK(!parse_result.is_error());
+	if (parse_result.is_error()) {
+		return;
+	}
+
+	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	REQUIRE(call_expr != nullptr);
+
+	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
+	ResolvedFunctionQueryResult before_run = parser_services.getResolvedDirectCallQuery(call_expr);
+	CHECK(before_run.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed);
+	CHECK(before_run.function == nullptr);
+	CHECK(parser_services.getResolvedDirectCall(call_expr) == nullptr);
+
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
+	ResolvedFunctionQueryResult after_run = sema.parserSemanticServices().getResolvedDirectCallQuery(call_expr);
+	CHECK(after_run.state == ResolvedFunctionQueryResult::State::Available);
+	REQUIRE(after_run.function != nullptr);
+	CHECK(after_run.function->decl_node().identifier_token().value() == "foo"sv);
+}
 
 TEST_CASE("Constructor with no parameters") {
 	run_test_from_file("test_constructor_no_params.cpp", "Constructor with no parameters", false);

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -38,35 +38,43 @@ SemanticAnalysis& runSemanticAnalysisForTest(Parser& parser, CompileContext& con
 	return sema;
 }
 
-static const CallExprNode* findMainReturnCallExpr(const Parser& parser) {
-	for (const ASTNode& node : parser.get_nodes()) {
-		if (!node.is<FunctionDeclarationNode>()) {
-			continue;
-		}
-		const auto& function = node.as<FunctionDeclarationNode>();
-		if (function.decl_node().identifier_token().value() != "main"sv) {
-			continue;
-		}
-		if (!function.get_definition().has_value()) {
-			return nullptr;
-		}
-		const ASTNode& definition = *function.get_definition();
-		if (!definition.is<BlockNode>()) {
-			return nullptr;
-		}
-		const auto& statements = definition.as<BlockNode>().get_statements();
-		if (statements.empty() || !statements[0].is<ReturnStatementNode>()) {
-			return nullptr;
-		}
-		const auto& return_stmt = statements[0].as<ReturnStatementNode>();
+static const CallExprNode* findReturnCallExprInNode(const ASTNode& node) {
+	if (node.is<ReturnStatementNode>()) {
+		const auto& return_stmt = node.as<ReturnStatementNode>();
 		if (!return_stmt.expression().has_value()) {
 			return nullptr;
 		}
 		const ASTNode& expr = *return_stmt.expression();
-		if (!expr.is<CallExprNode>()) {
-			return nullptr;
+		if (expr.is<CallExprNode>()) {
+			return &expr.as<CallExprNode>();
 		}
-		return &expr.as<CallExprNode>();
+		return nullptr;
+	}
+
+	if (node.is<BlockNode>()) {
+		for (const ASTNode& stmt : node.as<BlockNode>().get_statements()) {
+			if (const CallExprNode* call_expr = findReturnCallExprInNode(stmt)) {
+				return call_expr;
+			}
+		}
+	}
+
+	return nullptr;
+}
+
+static const CallExprNode* findAnyReturnCallExpr(const Parser& parser) {
+	for (const ASTNode& node : parser.get_nodes()) {
+		const FunctionDeclarationNode* function = get_function_decl_node(node);
+		if (function == nullptr) {
+			continue;
+		}
+		if (!function->get_definition().has_value()) {
+			continue;
+		}
+		const ASTNode& definition = *function->get_definition();
+		if (const CallExprNode* call_expr = findReturnCallExprInNode(definition)) {
+			return call_expr;
+		}
 	}
 	return nullptr;
 }
@@ -1715,7 +1723,7 @@ TEST_CASE("SemanticAnalysis:ResolvedDirectCallQueryTracksAnalysisState") {
 		return;
 	}
 
-	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	const CallExprNode* call_expr = findAnyReturnCallExpr(parser);
 	REQUIRE(call_expr != nullptr);
 
 	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
@@ -1748,7 +1756,7 @@ TEST_CASE("SemanticAnalysis:OverloadResolutionArgTypeQueryTracksAnalysisState") 
 		return;
 	}
 
-	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	const CallExprNode* call_expr = findAnyReturnCallExpr(parser);
 	REQUIRE(call_expr != nullptr);
 	REQUIRE(call_expr->arguments().size() == 1);
 	const ASTNode& arg_expr = call_expr->arguments()[0];
@@ -1782,7 +1790,7 @@ TEST_CASE("SemanticAnalysis:ExpressionTypeQueryTracksAnalysisState") {
 		return;
 	}
 
-	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	const CallExprNode* call_expr = findAnyReturnCallExpr(parser);
 	REQUIRE(call_expr != nullptr);
 
 	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -38,23 +38,19 @@ SemanticAnalysis& runSemanticAnalysisForTest(Parser& parser, CompileContext& con
 	return sema;
 }
 
-static const CallExprNode* findReturnCallExprInNode(const ASTNode& node) {
+static const ASTNode* findReturnExprInNode(const ASTNode& node) {
 	if (node.is<ReturnStatementNode>()) {
 		const auto& return_stmt = node.as<ReturnStatementNode>();
 		if (!return_stmt.expression().has_value()) {
 			return nullptr;
 		}
-		const ASTNode& expr = *return_stmt.expression();
-		if (expr.is<CallExprNode>()) {
-			return &expr.as<CallExprNode>();
-		}
-		return nullptr;
+		return &*return_stmt.expression();
 	}
 
 	if (node.is<BlockNode>()) {
 		for (const ASTNode& stmt : node.as<BlockNode>().get_statements()) {
-			if (const CallExprNode* call_expr = findReturnCallExprInNode(stmt)) {
-				return call_expr;
+			if (const ASTNode* return_expr = findReturnExprInNode(stmt)) {
+				return return_expr;
 			}
 		}
 	}
@@ -62,7 +58,8 @@ static const CallExprNode* findReturnCallExprInNode(const ASTNode& node) {
 	return nullptr;
 }
 
-static const CallExprNode* findAnyReturnCallExpr(const Parser& parser) {
+template <typename Predicate>
+static const ASTNode* findAnyReturnExprNode(const Parser& parser, Predicate&& predicate) {
 	for (const ASTNode& node : parser.get_nodes()) {
 		const FunctionDeclarationNode* function = get_function_decl_node(node);
 		if (function == nullptr) {
@@ -72,36 +69,39 @@ static const CallExprNode* findAnyReturnCallExpr(const Parser& parser) {
 			continue;
 		}
 		const ASTNode& definition = *function->get_definition();
-		if (const CallExprNode* call_expr = findReturnCallExprInNode(definition)) {
-			return call_expr;
+		if (const ASTNode* return_expr = findReturnExprInNode(definition)) {
+			if (predicate(*return_expr)) {
+				return return_expr;
+			}
 		}
 	}
 	return nullptr;
 }
 
-static const ASTNode* findAnyReturnExpr(const Parser& parser) {
-	for (const ASTNode& node : parser.get_nodes()) {
-		const FunctionDeclarationNode* function = get_function_decl_node(node);
-		if (function == nullptr || !function->get_definition().has_value()) {
-			continue;
-		}
-
-		const ASTNode& definition = *function->get_definition();
-		if (!definition.is<BlockNode>()) {
-			continue;
-		}
-
-		for (const ASTNode& stmt : definition.as<BlockNode>().get_statements()) {
-			if (!stmt.is<ReturnStatementNode>()) {
-				continue;
-			}
-			const auto& return_stmt = stmt.as<ReturnStatementNode>();
-			if (return_stmt.expression().has_value()) {
-				return &*return_stmt.expression();
-			}
-		}
+static const CallExprNode* findAnyReturnCallExpr(const Parser& parser) {
+	const ASTNode* return_expr = findAnyReturnExprNode(parser, [](const ASTNode& expr) {
+		return expr.is<ExpressionNode>() && std::holds_alternative<CallExprNode>(expr.as<ExpressionNode>());
+	});
+	if (return_expr == nullptr || !return_expr->is<ExpressionNode>()) {
+		return nullptr;
 	}
-	return nullptr;
+	return std::get_if<CallExprNode>(&return_expr->as<ExpressionNode>());
+}
+
+static const ASTNode* findAnyReturnCallExprNode(const Parser& parser) {
+	return findAnyReturnExprNode(parser, [](const ASTNode& expr) {
+		return expr.is<ExpressionNode>() && std::holds_alternative<CallExprNode>(expr.as<ExpressionNode>());
+	});
+}
+
+static const ArraySubscriptNode* findAnyReturnSubscriptExpr(const Parser& parser) {
+	const ASTNode* return_expr = findAnyReturnExprNode(parser, [](const ASTNode& expr) {
+		return expr.is<ExpressionNode>() && std::holds_alternative<ArraySubscriptNode>(expr.as<ExpressionNode>());
+	});
+	if (return_expr == nullptr || !return_expr->is<ExpressionNode>()) {
+		return nullptr;
+	}
+	return std::get_if<ArraySubscriptNode>(&return_expr->as<ExpressionNode>());
 }
 
 // Helper function to read test files from Reference directory
@@ -1815,16 +1815,18 @@ TEST_CASE("SemanticAnalysis:ExpressionTypeQueryTracksAnalysisState") {
 		return;
 	}
 
+	const ASTNode* return_expr = findAnyReturnCallExprNode(parser);
+	REQUIRE(return_expr != nullptr);
 	const CallExprNode* call_expr = findAnyReturnCallExpr(parser);
 	REQUIRE(call_expr != nullptr);
 
 	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
-	TypeSpecifierQueryResult before_run = parser_services.getExpressionTypeQuery(ASTNode(call_expr));
+	TypeSpecifierQueryResult before_run = parser_services.getExpressionTypeQuery(*return_expr);
 	CHECK(before_run.state == TypeSpecifierQueryResult::State::NotYetAnalyzed);
 	CHECK(!before_run.type.has_value());
 
 	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
-	TypeSpecifierQueryResult after_run = sema.parserSemanticServices().getExpressionTypeQuery(ASTNode(call_expr));
+	TypeSpecifierQueryResult after_run = sema.parserSemanticServices().getExpressionTypeQuery(*return_expr);
 	CHECK(after_run.state == TypeSpecifierQueryResult::State::Available);
 	REQUIRE(after_run.type.has_value());
 	CHECK(after_run.type->type() == TypeCategory::Int);
@@ -1854,19 +1856,17 @@ TEST_CASE("SemanticAnalysis:ResolvedSubscriptQueryTracksAnalysisState") {
 		return;
 	}
 
-	const ASTNode* return_expr = findAnyReturnExpr(parser);
-	REQUIRE(return_expr != nullptr);
-	REQUIRE(return_expr->is<ArraySubscriptNode>());
-	const auto& subscript_expr = return_expr->as<ArraySubscriptNode>();
+	const ArraySubscriptNode* subscript_expr = findAnyReturnSubscriptExpr(parser);
+	REQUIRE(subscript_expr != nullptr);
 
 	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
-	ResolvedFunctionQueryResult before_run = parser_services.getResolvedOpSubscriptQuery(&subscript_expr);
+	ResolvedFunctionQueryResult before_run = parser_services.getResolvedOpSubscriptQuery(subscript_expr);
 	CHECK(before_run.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed);
 	CHECK(before_run.function == nullptr);
-	CHECK(parser_services.getResolvedOpSubscript(&subscript_expr) == nullptr);
+	CHECK(parser_services.getResolvedOpSubscript(subscript_expr) == nullptr);
 
 	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
-	ResolvedFunctionQueryResult after_run = sema.parserSemanticServices().getResolvedOpSubscriptQuery(&subscript_expr);
+	ResolvedFunctionQueryResult after_run = sema.parserSemanticServices().getResolvedOpSubscriptQuery(subscript_expr);
 	CHECK(after_run.state == ResolvedFunctionQueryResult::State::Available);
 	REQUIRE(after_run.function != nullptr);
 	CHECK(after_run.function->decl_node().identifier_token().value() == "operator[]"sv);

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -1645,8 +1645,7 @@ TEST_CASE("Parser:FunctionNameIdentifiers") {
 
 			// Convert to IR to verify the string literals are created correctly
 			SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, compile_context);
-			AstToIr converter(gSymbolTable, compile_context, parser);
-			converter.setSemanticData(&sema);
+			AstToIr converter(gSymbolTable, compile_context, parser, sema);
 			for (auto& node_handle : ast) {
 				converter.visit(node_handle);
 			}

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -1765,6 +1765,38 @@ TEST_CASE("SemanticAnalysis:OverloadResolutionArgTypeQueryTracksAnalysisState") 
 	CHECK(after_run.type->type() == TypeCategory::Int);
 }
 
+TEST_CASE("SemanticAnalysis:ExpressionTypeQueryTracksAnalysisState") {
+	std::string code = R"(
+		int foo() { return 7; }
+		int main() { return foo(); }
+	)";
+
+	Lexer lexer(code);
+	CompileContext test_context;
+	test_context.setInputFile("test_expression_type_query.cpp");
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
+	auto parse_result = parser.parse();
+	CHECK(!parse_result.is_error());
+	if (parse_result.is_error()) {
+		return;
+	}
+
+	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	REQUIRE(call_expr != nullptr);
+
+	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
+	TypeSpecifierQueryResult before_run = parser_services.getExpressionTypeQuery(ASTNode(call_expr));
+	CHECK(before_run.state == TypeSpecifierQueryResult::State::NotYetAnalyzed);
+	CHECK(!before_run.type.has_value());
+
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
+	TypeSpecifierQueryResult after_run = sema.parserSemanticServices().getExpressionTypeQuery(ASTNode(call_expr));
+	CHECK(after_run.state == TypeSpecifierQueryResult::State::Available);
+	REQUIRE(after_run.type.has_value());
+	CHECK(after_run.type->type() == TypeCategory::Int);
+}
+
 TEST_CASE("Constructor with no parameters") {
 	run_test_from_file("test_constructor_no_params.cpp", "Constructor with no parameters", false);
 }

--- a/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
+++ b/tests/FlashCppTest/FlashCppTest/FlashCppTest/FlashCppTest.cpp
@@ -1731,6 +1731,40 @@ TEST_CASE("SemanticAnalysis:ResolvedDirectCallQueryTracksAnalysisState") {
 	CHECK(after_run.function->decl_node().identifier_token().value() == "foo"sv);
 }
 
+TEST_CASE("SemanticAnalysis:OverloadResolutionArgTypeQueryTracksAnalysisState") {
+	std::string code = R"(
+		int bar(int x) { return x; }
+		int main() { return bar(1); }
+	)";
+
+	Lexer lexer(code);
+	CompileContext test_context;
+	test_context.setInputFile("test_overload_resolution_arg_query.cpp");
+	SemanticAnalysis parser_sema(test_context, gSymbolTable);
+	Parser parser(lexer, test_context, parser_sema);
+	auto parse_result = parser.parse();
+	CHECK(!parse_result.is_error());
+	if (parse_result.is_error()) {
+		return;
+	}
+
+	const CallExprNode* call_expr = findMainReturnCallExpr(parser);
+	REQUIRE(call_expr != nullptr);
+	REQUIRE(call_expr->arguments().size() == 1);
+	const ASTNode& arg_expr = call_expr->arguments()[0];
+
+	ParserSemanticServices parser_services = parser.semanticAnalysis().parserSemanticServices();
+	TypeSpecifierQueryResult before_run = parser_services.getOverloadResolutionArgTypeQuery(arg_expr);
+	CHECK(before_run.state == TypeSpecifierQueryResult::State::NotYetAnalyzed);
+	CHECK(!before_run.type.has_value());
+
+	SemanticAnalysis& sema = runSemanticAnalysisForTest(parser, test_context);
+	TypeSpecifierQueryResult after_run = sema.parserSemanticServices().getOverloadResolutionArgTypeQuery(arg_expr);
+	CHECK(after_run.state == TypeSpecifierQueryResult::State::Available);
+	REQUIRE(after_run.type.has_value());
+	CHECK(after_run.type->type() == TypeCategory::Int);
+}
+
 TEST_CASE("Constructor with no parameters") {
 	run_test_from_file("test_constructor_no_params.cpp", "Constructor with no parameters", false);
 }


### PR DESCRIPTION
## Summary
- split post-parse semantic normalization into an explicit internal normalizer layer
- route parser pending-root normalization through `ParserSemanticServices`
- tighten parser-owned constexpr evaluation so dependent call reuse, lazy member materialization, and pending-root normalization require sema-backed contexts
- make the parser-safe semantic query families phase-aware instead of overloading missing entries:
  - resolved direct-call lookups
  - resolved `operator()` lookups
  - resolved `operator[]` lookups
  - overload-resolution argument-type lookups
  - expression-type lookups
- fix the focused sema query-state unit-test helper so it finds returned expressions without assuming a specific top-level function layout
- update the sema-first-class progress document to mark Stage 5 complete for the parser-safe/query-state families and narrow the remaining follow-on work to specialized finalized/codegen-side caches

## Why
This branch finishes the Stage 5 parser-safe split and query-state cleanup.

The semantic infrastructure still exists independently of whole-TU completion, but callers no longer need to treat missing side-table entries as an implicit phase signal for the main parser-owned semantic queries. Instead, those entry points now report explicit `NotYetAnalyzed`, `AnalyzedAbsent`, and `Available` state.

What remains after this PR is narrower Stage 6-style hardening on specialized finalized/codegen-side caches such as identifier/member-access/unary-dereference/structured-binding annotations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured semantic-analysis queries to expose tri-state analysis results and centralized post-parse normalization into a dedicated orchestration layer.
  * Tightened semantic-context invariants for constexpr/member evaluation paths to require parser-owned sema where applicable.

* **Tests**
  * Added AST-scanning helpers and doctest cases to verify query-state transitions for several semantic queries.

* **Documentation**
  * Updated design notes with Stage 5/6 progress and tightened remaining work scope.

* **Chores**
  * Const-correctness and test project build sources cleaned up.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->