### PR TITLE
Continue template-argument infrastructure refactor

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,548 +1,193 @@
 # Template Argument Architecture Audit
 
-**Date:** 2026-05-12
-**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution; inherited dependent-base member-template alias owners now resolve through the shared member-chain concretization path)
+**Date:** 2026-05-12  
+**Last updated:** 2026-05-17
 
-This document describes the current FlashCpp template-argument architecture for
-types, non-type values, template-template arguments, class templates, function
-templates, constructors, member templates, static members, name lookup, qualified
-lookup, ADL, and template argument deduction. It also records the observed
-C++20 conformance gaps.
+This document is the short audit for FlashCpp's template infrastructure. Its
+main purpose is to describe what is still structurally wrong, what the next
+highest-impact work is, and what "good enough" current behavior already exists
+so later refactors do not regress it.
 
 ## Executive summary
 
-The current architecture is pragmatic and has accumulated substantial support
-for common C++20 template cases, but it is not yet a standard-conforming
-template system. The main structural issue is that template argument parsing,
-classification, lookup, substitution, deduction, and instantiation are still
-spread across parser-owned heuristics, global registries, `TypeInfo` side data,
-and late AST rewrites.
+FlashCpp is no longer in the "basic template support" phase. The main
+remaining problem is architectural: template classification, dependent-name
+modeling, two-phase lookup, deduction, and instantiation still cross parser,
+registry, `TypeInfo`, and late substitution layers instead of being owned by
+one semantic pipeline.
 
-C++20 requires template argument interpretation to be driven by declaration
-context, name lookup, dependency, the current instantiation, two-phase lookup,
-deduction rules, constraints, and overload resolution. FlashCpp often decides
-the type/value/template-template category before the target template parameter
-is authoritative, then repairs or reinterprets the argument later. Several
-recent improvements reduce regressions: scalar static-member folding is
-explicit with normalized bytes preferred and bounded recursion; struct member
-function codegen has per-function IR snapshots that roll back only the failing
-member's IR while preserving earlier members; sema constructor annotation is
-advisory and codegen falls through to runtime overload resolution when sema
-omits it; and enum functional casts are now consistently categorized as
-`TypeCategory::Enum` across parser, overload-resolution, and sema type-inference
-layers. These improvements reduce regressions but do not yet provide a fully
-semantic C++20 template pipeline.
+The compiler now handles a broad set of practical C++20 template cases, but it
+is still not standard-conforming as a whole. The largest remaining conformance
+lever is still two-phase lookup and dependent-name ownership, not another broad
+parser cleanup.
 
-## Refactor completion status
+## Current state in one page
 
-The 2026-05-13 template infrastructure refactor completed the planned first
-architecture pass while preserving the behavior described in this audit. The
-2026-05-14 follow-up pass advanced the highest-impact remaining template
-infrastructure tracks. The branch now includes:
+Useful to know before changing anything:
 
-- centralized static `constexpr` member reads through one semantic service;
-- ordered and typed NTTP identity preservation, including exact integral/enum
-  identity and typed `nullptr` identity;
-- shared alias/type-size query infrastructure;
-- parameter-context-driven explicit template argument classification;
-- `TemplateInstantiationContext` plumbing for template lookup and substitution;
-- semantic template lookup requests/records for function templates, member
-  templates, qualified owners/calls, variable templates, alias templates, member
-  probes, and operator/ADL template lookup;
-- conservative template definition lookup records for non-dependent calls and
-  broader two-phase lookup timing;
-- shape-only template deduction viability checks used before body
-  materialization for selected free, explicit free, and member
-  function-template overload paths;
-- dependent qualified-name records for member-type placeholders, current
-  instantiation owners, unknown-specialization owners, and expression
-  qualified-ids;
-- dependent alias-size, nested pack/materialization, and dependent constexpr
-  regression fixes;
-- explicit-template SFINAE repair so explicitly supplied template arguments are
-  substituted before remaining call-argument deduction;
-- typed NTTP identity for integral/enum/`nullptr`, object pointers, references,
-  function pointers, and null member pointers, with unsupported structural-class
-  cases still explicit.
-- qualified non-dependent template-body calls now preserve definition-context
-  lookup records on the call expression, including qualified-name metadata;
-- floating-point NTTP identity now flows through constexpr evaluation and Itanium
-  mangling for standard-shaped floating arguments.
-- remaining low-frequency parser template probes and the constexpr
-  static-initializer template probe now use parser-built semantic lookup
-  requests instead of hardcoded point-of-definition requests.
-- `lookup_inherited_template` and `lookup_inherited_type_alias` now follow the
-  `type_index` on a deferred base (including one alias-chain level) to find a
-  concrete struct and recurse into it rather than always skipping deferred bases.
-- `getTemplateParametersForTypeInfo` in `ConstExprEvaluator_Members.cpp` now
-  uses `makeTemplateNameLookupRequest` when a parser context is available,
-  propagating POI timing and definition-namespace correctly.
-- `ExpressionSubstitutor.cpp` existence-check registry calls are documented as
-  intentionally direct (simple name-presence check, no instantiation context).
-- semantic analysis structured-binding tuple-like lookup now resolves
-  `tuple_size`, `tuple_element`, and `get` through parser-owned semantic
-  template-name lookup (`Parser::lookupTemplateName`) before specialization
-  matching.
-- structured-binding tuple-like specialization matching now uses semantic-lookup
-  candidate ordering first (`tuple_size`, `tuple_element`, `get`) with no
-  synthesized-name fallback.
-- tuple-like mixed member/free `get` protocol precedence now prefers
-  member `e.get<I>()` over free `get<I>(e)` when both are available.
-- fixed root cause of `fallback_names` workaround: `Parser_Templates_Class.cpp`
-  now registers struct specializations via the `QualifiedIdentifier` overload of
-  `registerSpecialization` so they are stored under both simple and fully
-  namespace-qualified names. `std::tuple_size<E>` etc. are now found through
-  normal qualified semantic lookup. The non-standard `fallback_names` mechanism
-  has been removed entirely from `SemanticAnalysis.cpp`.
-- **semantic analyzer unification completed in this slice (2026-05-15):** the
-  remaining sema-layer direct template-name lookup probe in
-  `SemanticAnalysis.cpp` (structured-binding tuple protocol lookup) now routes
-  through the parser-owned semantic lookup interface. A follow-up audit of
-  `SemanticAnalysis.cpp`, `OverloadResolution.h`, and `SemanticTypes.h`
-  confirms no remaining sema-layer direct template-name lookup probes.
-- **`QualifiedTypeMemberAccess::template_arguments` allocation optimized (2026-05-15):**
-  the `unique_ptr<vector<TemplateTypeArg>>` field was replaced with a raw pointer
-  into `gChunkedAnyStorage`, reducing two heap allocations per dependent member
-  chain segment to one and improving cache locality on the hot template
-  substitution path.
-- **dependent unqualified-call POI completion added (2026-05-15):**
-  unresolved dependent unqualified calls now carry first-class
-  `DependentUnqualifiedCallLookupRecord` metadata on `CallExprNode`. Template
-  substitution, semantic call annotation, constexpr evaluation, and lazy static
-  member replay can re-run definition-filtered ordinary lookup plus ADL at the
-  point of instantiation, and lazy static replay now restores definition lookup
-  context while rebuilding initializer AST.
-- **dependent ADL function-template POI completion broadened (2026-05-15):**
-  unresolved dependent unqualified call completion now also attempts
-  ADL-associated namespace-qualified function-template instantiation at POI
-  when ordinary overload sets are empty. Regression
-  `test_template_two_phase_dependent_adl_function_template_poi_ret0.cpp`
-  covers the case.
-- **out-of-line template static-member replay metadata propagation (2026-05-17):**
-  out-of-line static member variable definitions now capture declaration AST at
-  parse time and preserve declaration + initializer-position metadata through
-  registry and concretization paths, so replay-first substitution can stay in
-  two-phase lookup mode instead of dropping to AST-only substitution when
-  metadata transfer was previously incomplete.
-- **two-phase lookup extended to member function template bodies (2026-05-15):**
-  `instantiate_member_function_template_core` in
-  `Parser_Templates_Inst_MemberFunc.cpp` now sets `phase1_cutoff_line_`,
-  `phase1_cutoff_file_idx_`, and `current_template_definition_lookup_context_`
-  before `parse_function_body()`, mirroring the identical setup in the free
-  function template path. Non-dependent calls inside
-  `template <typename U> T Wrapper<T>::foo(U)` bodies now resolve against
-  definition-time overload sets. `filterPhase1OrdinaryFunctionOverloads` was
-  removed from `lookupMemberFunctionTemplateCandidatesForInstantiation` because
-  member-lookup visibility is class-scope (mutual, not cutoff by textual order).
-  Regression `test_template_two_phase_member_func_template_ret42.cpp` covers
-  the non-dependent call case. Full-suite validation: 2361 pass, 184
-  expected-fail, 0 regressions.
-- **dependent unqualified-call POI completion broadened for ordinary-bound calls
-  and template static initializers (2026-05-16):** unqualified dependent calls
-  that already had a definition-time ordinary candidate now also retain
-  `DependentUnqualifiedCallLookupRecord` metadata instead of silently freezing to
-  the provisional callee. Semantic call annotation, constexpr evaluation, and
-  template substitution now prefer POI completion whenever that record exists,
-  and template static-member initializer parsing installs definition-context
-  lookup state before building the initializer AST. Regression
-  `test_template_static_member_initializer_dependent_adl_ret0.cpp` covers the
-  fixed hidden-friend/ADL path.
-- **partial-specialization static-member eager AST paths now replay-first
-  (2026-05-16):** the remaining eager AST-copy paths in
-  `Parser_Templates_Inst_ClassTemplate.cpp`
-  (`pattern_struct.static_members()` and `instantiated_struct_ref` static-member
-  copy) now reparse from saved `initializer_position`/`declaration` with
-  `TemplateInstantiationContext`, `TemplateDefinitionLookupContext`,
-  `ScopedDefinitionLookupContext`, and `parsing_template_depth_ = 1` before
-  falling back to the previous AST substitution behavior. Regression
-  `test_template_partial_spec_static_member_replay_two_phase_lookup_ret0.cpp`
-  covers dependent unqualified call + ADL behavior in a partial specialization.
-- **dependent template-template owner concretization in parser substitution
-  (2026-05-17):** `substitute_template_parameter` in
-  `Parser_Expr_QualLookup.cpp` now remaps dependent-owner names that bind to
-  template-template parameters (e.g. `TemplateOwner`) to their concrete
-  template names before `resolveConcreteInstantiatedMemberChain` runs for
-  dependent/unknown-specialization owner records. This closes a remaining
-  parser-time concretization gap for member chains like
-  `typename TemplateOwner<U>::type`. Regression
-  `dependent_template_template_owner_member_type_ret42.cpp` covers the path.
-- **inherited dependent-base member-template alias lookup unified
-  (2026-05-17):** `resolveBaseClassMemberTypeChain()` in
-  `Parser_Expr_QualLookup.cpp` now resolves alias/class member-template
-  segments through inherited bases instead of requiring the segment to be
-  declared directly on the current owner/pattern/primary owner. The direct
-  parse-time member-template-alias probe in `Parser_TypeSpecifiers.cpp` now
-  uses the same inherited-owner helper. This closes the missing cross-product
-  between dependent-base lookup and deeper member-template segments for base
-  specifiers such as `Mid<T>::template rebind<int>`. Regression
-  `test_template_current_instantiation_inherited_member_template_type_ret0.cpp`
-  covers the fixed path.
+- explicit template arguments are mostly classified by parameter context, not
+  only parser heuristics;
+- main function/member/qualified/alias/operator template lookup paths already
+  use semantic lookup requests/records;
+- selected non-dependent calls in templates already preserve definition-context
+  lookup records;
+- unresolved dependent unqualified calls already preserve POI completion
+  metadata through substitution, sema, constexpr, and lazy-static paths;
+- several static-member instantiation paths now prefer replay-from-source with
+  preserved definition-context lookup rather than AST-only substitution;
+- inherited dependent-base member-template alias owners now resolve through the
+  shared member-chain concretization path for covered base-specifier/member-chain
+  cases such as `Mid<T>::template rebind<int>`;
+- typed NTTP identity is implemented for integral, enum, `nullptr`, object
+  pointer, reference, function pointer, null member pointer, and floating-point
+  cases that already materialize as concrete semantic values;
+- selected free/member function-template overload paths already do
+  signature-only ranking before body materialization.
 
-Validation after all changes passed the Windows sharded build and the full test
-suite (2427 regular tests + 182 expected-fail tests, 0 regressions).
+Validation at this point passed the Windows sharded build and the full suite:
+`2427` regular tests, `182` expected-fail tests, `0` regressions.
 
-The remaining non-conforming areas below are therefore forward-looking
-architecture gaps, not known regressions from the refactor.
+## What is still wrong
 
-## What is left / next
+### 1. Two-phase lookup is still incomplete
 
-The remaining work is not another broad parser cleanup. The next useful passes
-should target the places where FlashCpp still lacks standard-owned semantic
-state. The highest-impact semantic analyzer unification track is now addressed
-in this slice: the last sema-layer direct template-name lookup probe was
-rerouted through the parser-owned interface, and audit now shows no remaining
-sema direct lookup probes. The active architecture tracks are therefore:
+This remains the biggest standards gap.
 
-### Open next steps
+What still needs work:
 
-1. **Broaden POI completion beyond the new unresolved-call record.**
-    Unresolved dependent unqualified calls now carry explicit POI-completion
-    metadata and replay correctly through substitution, sema, constexpr, and
-    lazy-static paths. Definition-time ordinary matches now also keep that POI
-    metadata in the covered unqualified-call paths, including template static
-    member initializers.
-    **New in this slice (2026-05-16):** out-of-line class-template static member
-    initializer replay now captures/restores definition-context lookup metadata
-    and reparses from saved initializer source
-    (`test_template_out_of_line_static_member_two_phase_lookup_ret0.cpp`).
-    **New in this slice (2026-05-16, follow-up):** in-class class-template
-    static-member eager instantiation now also replays from saved initializer
-    source with `TemplateInstantiationContext` and definition-context lookup
-    installed for StructTypeInfo-backed members
-    (`test_template_inclass_static_member_two_phase_lookup_ret0.cpp`).
-    **New in this slice (2026-05-17):** member-template partial-specialization
-    static-member copy paths and full-specialization static-member AST copy now
-    preserve replay metadata (`declaration` + `initializer_position`) during
-    `addStaticMember` transfer, so replay-first substitution can run in those
-    paths as well (`test_member_template_partial_spec_static_member_replay_ret0.cpp`).
-    **New in this slice (2026-05-17, follow-up):** metadata-aware static-member
-    initializer updates now preserve replay metadata (`declaration` +
-    `initializer_position`) when updating already-registered members in primary
-    template copy and lazy materialization paths
-    (`test_template_lazy_static_member_replay_metadata_ret0.cpp`).
-    Remaining gaps are declarations that never record replay metadata at parse
-    time and therefore still need AST-only fallback substitution.
+- remaining current-instantiation and type-alias spellings that do not yet
+  reuse the same owner-correct POI/definition-time path;
+- remaining eager static-member initializer paths that still need AST-only
+  fallback because replay metadata was never captured at parse time;
+- richer dependent-base lookup and deeper member-template/member-type chains;
+- remaining parser-time ADL-sensitive paths outside the already-covered call
+  and static-member flows.
 
-2. **Two-phase lookup expansion (member function template bodies ✅ done).**
-    Definition-context records now cover selected non-dependent calls,
-    unresolved dependent unqualified calls, the main qualified/member/operator
-    template paths, lazy static-member replay, and (new) member function
-    template bodies. Remaining gaps:
-    - **Inherited member templates via `this->template` ✅ done (2026-05-15)**:
-      explicit-arg inherited lookup now falls through base classes and keeps
-      the declaring-owner symbol in lowering/codegen, fixing the previous
-      derived-owner link regressions (`test_inherited_member_template_lookup_ret42.cpp`,
-      `test_inherited_member_template_this_explicit_ret42.cpp`).
-    - Eager static initializers with parser-time reparse paths beyond the now
-      covered direct-call + out-of-line static-member initializer +
-      StructTypeInfo-backed in-class static-member initializer +
-      partial-specialization/member-template static-member copy paths +
-      full-specialization static-member AST copy paths + metadata-aware
-      initializer updates for existing members in primary/lazy update paths.
-    - Remaining current-instantiation / type-alias materialization follow-ons
-      after inherited member-template alias owner recovery. The new shared
-      inherited-owner lookup fixes base-specifier/member-chain concretization,
-      but type-alias spellings such as `typename Derived<T>::template rebind<U>`
-      still need a follow-up pass so alias materialization reuses the same
-      semantic path instead of falling back to placeholder alias copies.
+Concrete follow-up already identified by recent work:
 
-3. **Structural NTTP implementation.**
-   Typed integral/enum/`nullptr`, pointer, reference, function-pointer, and null
-   member-pointer identity exists. The `TemplateArgInfo` roundtrip is now
-   lossless (✅ done: `nttp_kind` + `nttp_entity_name` fields added). Remaining
-   work: add real semantic values for non-null member-pointers, floating-point,
-   and structural class-type NTTPs, and replace the remaining vendor-hash
-   mangling fallback (see `TODO(item-8)` in `NameMangling.h`) where possible.
+- `typename Derived<T>::template rebind<U>`-style alias materialization should
+  reuse the inherited-owner member-template path instead of falling back to
+  placeholder alias copies.
 
-4. **Deduction and constraint pipeline split.**
-   Signature-only candidate ranking now covers selected free, explicit free, and
-   member function-template paths. Continue replacing remaining
-   full-instantiation fallbacks with sema-owned candidate construction,
-   deduction, constraints, partial ordering, and overload ranking.
+### 2. Dependent names are still represented too loosely
 
-5. **Dependent-name and current-instantiation model.**
-   Build on `TypeInfo::DependentQualifiedNameRecord` with richer records for
-   deeper expression/member-template chains, dependent bases,
-   injected-class-name, and alias ordering.
+`TypeInfo::DependentQualifiedNameRecord` now covers useful cases, but the full
+`[temp.dep]` model is still missing.
 
-6. **Constructor fallback hardening.**
-   Current valid test coverage no longer needs codegen-time constructor
-   fallback, but uncovered/invalid paths still use a soft fallback. Keep widening
-   sema coverage until this can become a diagnostic/invariant.
+Still open:
 
-### Highest-impact architecture targets
+- deeper expression/member-template segment chains;
+- plain dependent bases and more unknown-specialization paths;
+- injected-class-name modeling;
+- alias ordering and current-instantiation identity across all qualified-name
+  paths;
+- one canonical equivalence service for dependent unevaluated expressions.
 
-1. **Semantic analyzer unification on semantic lookup records. ✅ ADDRESSED IN THIS SLICE**
-   The remaining sema-layer direct template-name lookup probe
-   (`SemanticAnalysis.cpp` structured-binding tuple protocol helper) now routes
-   through `Parser::lookupTemplateName()`. Audit across
-   `SemanticAnalysis.cpp`, `OverloadResolution.h`, and `SemanticTypes.h`
-   confirms no remaining sema direct template-name lookup probes. Intentional
-   direct calls that are not lookup probes (e.g., pattern-identity checks and
-   no-parser-context fallback paths) remain unchanged.
+### 3. NTTP support is still incomplete
 
-2. **Two-phase lookup and semantic lookup records.**
-    This remains the largest conformance lever. Non-dependent names in templates
-    need definition-context lookup records, while dependent names need explicit
-    point-of-instantiation completion records. This also gives qualified lookup,
-    ADL, static initializers, and member-template calls a shared source of truth.
-     **Progress:** conservative definition-context records now guard
-      non-dependent unqualified function calls, and semantic lookup records now
-      cover the main function/member/qualified/operator template discovery and
-      probe paths with dependent POI/ADL behavior regression-tested. Dependent
-      unqualified POI completion now also instantiates ADL-associated
-      function-template candidates by namespace-qualified names when needed.
-      Out-of-line class-template static member initializer replay now preserves
-      definition-context lookup during instantiation-time reparse. In-class
-      StructTypeInfo-backed eager static-member initialization now also
-      performs replay-first substitution with definition-context lookup before
-      falling back to AST-only substitution.
+Supported identity is much better than before, but C++20 coverage is still not
+complete.
 
-3. **Structural NTTP value model.**
-   The concrete value identity still has C++20 gaps beyond the supported
-   scalar/entity categories. Non-null member-pointer, floating-point, and
-   structural class-type arguments still need typed equivalence and hashing.
-    **Progress:** the value model now distinguishes typed integral/enum,
-    `nullptr`, object pointer, reference, function-pointer, and null
-    member-pointer identities, and explicitly rejects unsupported structural
-    class-type NTTPs instead of manufacturing scalar identities.
-    Remaining: full Itanium encoding for function-pointer, member-pointer NTTPs
-    (see `TODO(item-8)` in `NameMangling.h` ~line 1103).
+Still open:
 
-4. **Deduction and constraint pipeline separation.**
-   Candidate construction, deduction, constraint checking, partial ordering,
-   overload ranking, substitution, and instantiation should keep moving into
-    separate sema-owned phases. **Progress:** overloaded free function
-    templates, explicit free function-template calls, and implicit member
-    function templates can rank signature-only candidates before instantiating
-    the selected body.
+- non-null member-pointer semantic values;
+- structural class-type NTTPs;
+- any remaining floating-point paths that do not yet round-trip through the
+  same semantic identity/mangling flow;
+- replacing remaining conservative function/member-pointer mangling fallbacks
+  such as `TODO(item-8)` in `NameMangling.h`.
 
-5. **Dependent-name and current-instantiation model.**
-   Replace dependent strings/placeholders with first-class entities for current
-   instantiation, unknown specialization, dependent bases, dependent
-   qualified-names, and dependent template-ids. **Progress:** dependent
-   qualified member-type placeholders, current-instantiation owners,
-   unknown-specialization owners, and expression qualified-ids now carry
-   `TypeInfo::DependentQualifiedNameRecord` metadata for the covered paths.
+### 4. Deduction, constraints, and overload resolution are still too coupled to instantiation
 
-## Current architecture snapshot
+Some important overload paths now rank candidates without materializing losing
+bodies, but this is still partial.
 
-- `TemplateTypeArg` carries type, non-type, template-template, and pack
-  arguments across parser, sema, registry, and codegen layers.
-- `NonTypeValueIdentity` preserves typed identity for supported integral, enum,
-  `nullptr`, object-pointer, reference, function-pointer, and null
-  member-pointer NTTPs. Non-null member-pointer, floating-point, and structural
-  class-type NTTPs remain open.
-- `TemplateArgIdentity`, `OrderedTemplateInstantiationIdentity`, and
-  `TemplateInstantiationKey` preserve parameter-order-sensitive specialization
-  identity.
-- `TemplateEnvironment`, `TemplateEnvironmentSnapshot`, and
-  `TemplateInstantiationContext` are the intended substitution and
-  current-instantiation owners, but some legacy paths still reconstruct raw
-  parameter-name and argument vectors.
-- `TypeInfo::TemplateArgInfo` now carries explicit `nttp_kind`
-  (`FlashCpp::NonTypeValueIdentityKind`) and `nttp_entity_name` (`StringHandle`)
-  fields, making the `toTemplateArgInfo` / `toTemplateTypeArg` roundtrip
-  lossless for pointer, reference, and function-pointer NTTPs without any
-  inference from `TypeCategory` or `ref_qualifier`.
-  `NonTypeValueIdentityKind` is defined in `AstNodeTypes_TypeSystem.h` so that
-  `TemplateArgInfo` can use it without pulling in `TemplateTypes.h`.
+Still open:
 
-Parameter-context classification is now in place for the main explicit
-template-id use sites. Remaining classification risk is now concentrated in
-dependent and deep-chain paths rather than low-frequency ordinary probes.
+- more full-instantiation fallback removal;
+- non-deduced contexts and forwarding-reference edge cases;
+- packs in more positions;
+- template-template parameter matching;
+- CTAD and deduction guides;
+- constraint normalization/subsumption and cleaner sema-owned candidate
+  ranking.
 
-All main and low-frequency template lookup paths (function, member, qualified,
-variable, alias, probe, operator, parser/static-initializer, constexpr member
-template parameter resolution) now use parser-built semantic lookup
-requests/records. Deferred-base-class lookup in `lookup_inherited_template` and
-`lookup_inherited_type_alias` now follows the stored `type_index` to a concrete
-struct when available. Remaining dependent-base lookup (plain template-parameter
-bases), hidden-friend ADL at POI, and deeper member-template chains should still
-move behind the same declaration-result and definition-vs-POI timing model.
+### 5. Static-member materialization is still too repair-oriented
 
-Static `constexpr` reads are centralized, invalid non-dependent initializers now
-hard-fail instead of using broad zero-like recovery, and constructor annotation
-coverage is sufficient for current valid tests. The remaining cleanup is to
-turn the constructor/codegen fallback and other compatibility repairs into
-diagnostics or invariants once sema coverage is broad enough.
+Recent work fixed many regressions by preserving replay metadata and using
+definition-context lookup more often, but the model is still not purely sema-
+owned.
 
-Selected free, explicit-free, and member function-template overload paths now
-rank signature-only candidates before materializing bodies. Remaining deduction
-work should focus on moving non-deduced contexts, forwarding references, packs,
-template-template parameters, CTAD/deduction guides, partial ordering, and
-constraint subsumption into sema-owned phases before instantiation.
+Still open:
 
-## Standard-conformance assessment
+- declarations that never capture replay metadata at parse time;
+- remaining eager substitution paths that still need AST-only fallback;
+- final cleanup to make invalid non-dependent cases diagnostics/invariants
+  instead of repair paths.
 
-### Mostly aligned areas
+### 6. Constructor fallback is still intentionally soft
 
-- Template parameters have an explicit type / non-type / template-template kind.
-- Template argument identity now preserves source order.
-- Type arguments carry cv/ref/pointer/array/function-signature metadata.
-- Dependent non-type expressions can preserve AST for later reevaluation.
-- Template environments and snapshots preserve some outer-template state.
-- ADL and hidden-friend infrastructure exists for ordinary calls.
-- Lazy materialization has moved toward sema-owned ODR-use handling in recent
-  work.
-- Static constexpr scalar-member folding is now narrower and more deterministic,
-  preferring normalized bytes and bounded recursive base evaluation.
-- Struct member function codegen uses per-function IR snapshots; a codegen
-  failure in one member rolls back only that member's partial IR, preserving
-  successfully emitted earlier members.
-- Sema constructor annotation is soft: absent annotation triggers a logged
-  warning and a codegen-time overload resolution fallback rather than an
-  internal error, failing hard only if codegen resolution also fails.
-- Enum functional casts are normalized to `TypeCategory::Enum` at parser
-  construction, overload-resolution conversion matching, and sema type-inference
-  layers; `ResolvedQualifiedIdentifierInfo` carries a stored `enum_owner_type_index`
-  for a direct fast-path type inference on enum constants.
+The codegen-time constructor fallback is no longer needed for current valid
+coverage in tested paths, but it still exists for uncovered/invalid cases.
 
-### Non-conforming or structurally risky areas
+Target end state:
 
-#### 1. Template argument kind is often heuristic
+- sema always annotates the valid cases;
+- codegen fallback becomes a diagnostic or invariant, not a compatibility path.
 
-C++20 template argument interpretation is parameter-context sensitive. FlashCpp
-often classifies arguments before the target parameter is available or before
-lookup is authoritative. This affects ambiguous simple identifiers, qualified
-ids, dependent expressions, aliases, variable templates, and static members.
+## Highest-impact next steps
 
-#### 2. Non-type template arguments are too narrow
+In priority order:
 
-C++20 NTTPs include integral values, enumeration values, pointers, references,
-member pointers, `nullptr`, floating-point values, and structural class-type
-values subject to the C++20 structural-type rules. FlashCpp now has typed
-identity for supported integral, enum, `nullptr`, object-pointer, reference,
-function-pointer, and null member-pointer arguments, but the remaining NTTP
-categories are not yet represented as standard semantic values. Until non-null
-member-pointer, floating-point, and structural class values are produced by the
-parser and constexpr evaluator, full C++20 NTTP equivalence and mangling remain
-incomplete.
+1. **Finish the next two-phase lookup slice**
+   - current-instantiation/type-alias follow-ons after inherited member-template
+     alias recovery;
+   - remaining replay-metadata gaps for static-member initialization;
+   - remaining dependent-base/member-chain paths that still bypass the shared
+     semantic lookup model.
 
-#### 3. Dependent names are represented as strings/placeholders
+2. **Continue dependent-name/current-instantiation modeling**
+   - richer dependent-base and unknown-specialization records;
+   - deeper member-template chains;
+   - canonical dependent-expression equivalence.
 
-Many dependent facts are still stored as `dependent_name`, placeholder
-`TypeInfo`, or optional AST. The follow-up work added
-`TypeInfo::DependentQualifiedNameRecord` for important member-type placeholders,
-current-instantiation owners, unknown-specialization owners, and expression
-qualified-ids, but C++20 requires the same semantic distinction across more
-dependent-base, injected-class-name, dependent template-id, and deeper
-expression/member-template segment paths. String identity is not enough to
-implement these rules reliably.
+3. **Complete the remaining NTTP categories**
+   - non-null member-pointers;
+   - structural class-type NTTPs;
+   - remove remaining mangling fallbacks where standard encodings are possible.
 
-Dependent unevaluated expressions also still lack one canonical semantic
-equivalence service. NTTP identity, substitution/materialization, and any other
-site that compares dependent unevaluated expressions need to reuse the same
-C++20 expression-equivalence model rather than carrying local structural checks
-or normalization rules.
+4. **Expand sema-owned deduction/ranking**
+   - keep moving ordinary overload selection away from full-instantiation
+     fallback and toward candidate construction + deduction + constraints +
+     ranking before materialization.
 
-#### 4. Two-phase lookup is incomplete
+## Short completed-state summary
 
-The current system still has paths that reparse and substitute using current
-parser state, global registries, and symbol tables. Conservative
-definition-context records now protect selected non-dependent unqualified
-function calls, but the compiler does not yet have a complete
-point-of-definition ordinary lookup snapshot plus point-of-instantiation
-dependent lookup model. This risks both accepting ill-formed code and rejecting
-valid dependent code outside the covered call paths.
+This section is intentionally compact. It only records the completed work that
+materially changes what future refactors can assume.
 
-#### 5. Qualified lookup is not one authoritative semantic service
+- semantic analyzer unification on parser-owned template-name lookup is done
+  for the previously remaining sema-layer probe paths;
+- semantic lookup records cover the main template lookup paths used by parser
+  and sema;
+- member function template bodies now participate in definition-context lookup;
+- unresolved dependent unqualified calls preserve POI completion metadata;
+- multiple static-member initialization/copy/update paths now preserve replay
+  metadata and definition-context lookup;
+- dependent template-template owner concretization is in place for covered
+  parser substitution paths;
+- inherited dependent-base member-template alias owner lookup is now shared for
+  covered base-specifier/member-chain concretization cases.
 
-Qualified lookup is split across parser type parsing, expression parsing,
-registry lookup, string-based qualified names, namespace registry helpers, and
-member-template reconstruction. C++20 qualified lookup has precise behavior for
-class scopes, base classes, dependent bases, namespaces, injected-class-names,
-using-declarations, and access. These need one semantic lookup engine.
+## Exit criteria for this audit
 
-#### 6. ADL is not uniformly integrated with templates
+This audit can eventually be retired when all of the following are true:
 
-Ordinary call parsing has ADL support, but template fallback, template function
-candidate lookup, dependent calls, hidden friends, and static initializer
-rebinding do not all flow through one call-resolution service. C++20 requires
-function template candidates found by ADL to participate in overload resolution
-and two-phase lookup.
-
-#### 7. Deduction and overload resolution are interleaved with instantiation
-
-C++20 separates candidate construction, template argument deduction, constraint
-checking, viability, partial ordering, overload resolution, substitution, and
-instantiation. FlashCpp now has signature-only ranking for selected overloaded
-free and member function-template paths, but other paths still mix these steps
-while searching the registry and materializing AST.
-
-#### 8. Static member handling is too eager and repair-oriented
-
-Static member initializers are rebound, substituted, instantiated, and
-constant-evaluated inside class-template instantiation. This can work for traits,
-but C++20 requires precise instantiation timing, constant-evaluation context,
-definition availability, and odr-use behavior.
-
-The current recursive and normalized constant paths are still tactical repairs
-in codegen/parser-owned flows rather than a fully sema-owned materialization
-model.
-
-#### 9. Current-instantiation identity is incomplete
-
-Outer bindings and owner reconstruction support many member-template cases, but
-the compiler does not yet maintain an authoritative current-instantiation model
-for all qualified names, nested classes, dependent bases, injected-class-names,
-and member access.
-
-## Conclusion
-
-The current architecture is useful and increasingly capable, but it is not
-standard compliant as a whole. The highest-priority architectural issue is not a
-single parser bug; it is the absence of one semantic template system that owns:
-
-1. declaration lookup and dependency classification;
-2. template parameter and argument matching;
-3. two-phase lookup;
-4. deduction and constraints;
-5. substitution and point-of-instantiation materialization;
-6. constant evaluation under an instantiated semantic context.
-
-## Remaining implementation plan
-
-1. **Unify semantic lookup results**
-   Create one lookup result type used by template candidate discovery, qualified
-   lookup, member lookup, ADL-sensitive call resolution, and constexpr/static
-   initializer paths. Template registries should become indexes behind semantic
-   lookup rather than independent lookup authorities.
-
-2. **Expand definition-vs-POI records**
-   Extend the existing non-dependent function-call records to qualified names,
-   member-template calls, static initializers, dependent bases, unknown
-   specializations, and expression qualified-ids.
-   - **Next:** extend parse-time replay metadata capture into remaining
-     declarations that still only support AST-only fallback substitution.
-
-3. **Complete remaining structural NTTP values**
-   Add parser/constexpr support for non-null member-pointer, floating-point, and
-   structural class-type NTTP values, then wire those categories through
-   identity, hashing, mangling, specialization lookup, and diagnostics. Replace
-   conservative function/member-pointer mangling fallbacks where standard entity
-   encodings are available.
-
-4. **Broaden signature-only deduction/ranking**
-   Move more overload and deduction paths onto shape-only candidate viability so
-   ranking does not instantiate losing bodies. Include constraints,
-   non-deduced contexts, forwarding references, packs, template-template
-   parameters, CTAD, deduction guides, and partial ordering.
-
-5. **Finish dependent-name/current-instantiation modeling**
-   Replace remaining string-like dependent placeholders with records for current
-   instantiation, dependent base members, unknown specializations, injected class
-   names, dependent template-ids, and expression qualified-ids.
-
-6. **Centralize dependent expression equivalence**
-   Introduce one canonical dependent-expression equivalence service and make
-   NTTP identity, template-argument substitution/materialization, and all other
-   dependent unevaluated-expression comparison sites call into it. Identity
-   tracking and evaluation/materialization must not diverge on what counts as
-   the same dependent expression.
-
-7. **Convert repair paths into invariants**
-   Keep the current compatibility fallbacks only where they are still needed for
-   uncovered cases. As sema coverage expands, convert constructor fallback,
-   lookup fallback, and materialization fallback paths into explicit diagnostics
-   or internal invariants.
+- template argument kind is no longer decided by parser heuristics in ambiguous
+  cases;
+- two-phase lookup is covered for non-dependent definition-time binding and
+  dependent POI completion across the main call/member/static paths;
+- NTTP equivalence is complete for the supported C++20 categories;
+- dependent-name/current-instantiation behavior is owned by semantic records
+  instead of string-like placeholders;
+- normal overload ranking no longer materializes losing candidates by default.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-17
+**Last updated:** 2026-05-18
 
 This document is the short audit for FlashCpp's template infrastructure. Its
 main purpose is to describe what is still structurally wrong, what the next
@@ -44,8 +44,12 @@ Useful to know before changing anything:
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
-Validation at this point passed the Windows sharded build and the full suite:
-`2427` regular tests, `182` expected-fail tests, `0` regressions.
+Validation at this point passed the Windows sharded build. The focused
+follow-up regression for inherited member-template alias lookup now passes, and
+the remaining full-suite state is down to one runtime mismatch:
+`2427` regular tests compiled/linked, `2426` runtime pass, `1` runtime
+regression (`test_type_trait_alias_default_nttp_ret0.cpp`), `182`
+expected-fail tests.
 
 ## What is still wrong
 
@@ -65,9 +69,12 @@ What still needs work:
 
 Concrete follow-up already identified by recent work:
 
-- `typename Derived<T>::template rebind<U>`-style alias materialization should
-  reuse the inherited-owner member-template path instead of falling back to
-  placeholder alias copies.
+- alias-selected owners in default-NTTP/qualified-id substitution must now stay
+  attached to the semantic alias result type instead of round-tripping through
+  helper owners such as `Conditional$...::value`;
+- nested alias-target template arguments still need one semantic
+  materialization pass so `IsEmpty<Type>`-style stored template-instantiation
+  arguments become `IsEmpty<Concrete>` before deferred-base trait evaluation.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -142,6 +149,9 @@ In priority order:
 1. **Finish the next two-phase lookup slice**
    - current-instantiation/type-alias follow-up work after inherited member-template
      alias recovery;
+   - complete the remaining alias-owner/default-NTTP path so qualified-id
+     substitution, not constexpr repair logic, owns alias-selected static-member
+     lookup;
    - remaining replay-metadata gaps for static-member initialization;
    - remaining dependent-base/member-chain paths that still bypass the shared
      semantic lookup model.
@@ -177,7 +187,10 @@ materially changes what future refactors can assume.
 - dependent template-template owner concretization is in place for covered
   parser substitution paths;
 - inherited dependent-base member-template alias owner lookup is now shared for
-  covered base-specifier/member-chain concretization cases.
+  covered base-specifier/member-chain concretization cases;
+- alias-template lookup results now expose a canonical semantic owner/result
+  name and the main qualified-id substitution paths prefer that semantic owner
+  over helper instantiated names.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -140,7 +140,7 @@ Target end state:
 In priority order:
 
 1. **Finish the next two-phase lookup slice**
-   - current-instantiation/type-alias follow-ons after inherited member-template
+   - current-instantiation/type-alias follow-up work after inherited member-template
      alias recovery;
    - remaining replay-metadata gaps for static-member initialization;
    - remaining dependent-base/member-chain paths that still bypass the shared

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution)
+**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution; inherited dependent-base member-template alias owners now resolve through the shared member-chain concretization path)
 
 This document describes the current FlashCpp template-argument architecture for
 types, non-type values, template-template arguments, class templates, function
@@ -166,9 +166,20 @@ infrastructure tracks. The branch now includes:
   parser-time concretization gap for member chains like
   `typename TemplateOwner<U>::type`. Regression
   `dependent_template_template_owner_member_type_ret42.cpp` covers the path.
+- **inherited dependent-base member-template alias lookup unified
+  (2026-05-17):** `resolveBaseClassMemberTypeChain()` in
+  `Parser_Expr_QualLookup.cpp` now resolves alias/class member-template
+  segments through inherited bases instead of requiring the segment to be
+  declared directly on the current owner/pattern/primary owner. The direct
+  parse-time member-template-alias probe in `Parser_TypeSpecifiers.cpp` now
+  uses the same inherited-owner helper. This closes the missing cross-product
+  between dependent-base lookup and deeper member-template segments for base
+  specifiers such as `Mid<T>::template rebind<int>`. Regression
+  `test_template_current_instantiation_inherited_member_template_type_ret0.cpp`
+  covers the fixed path.
 
-Validation after all changes passed the Linux sharded build and the full test
-suite (2377 regular tests + 182 expected-fail tests, 0 regressions).
+Validation after all changes passed the Windows sharded build and the full test
+suite (2427 regular tests + 182 expected-fail tests, 0 regressions).
 
 The remaining non-conforming areas below are therefore forward-looking
 architecture gaps, not known regressions from the refactor.
@@ -228,7 +239,12 @@ sema direct lookup probes. The active architecture tracks are therefore:
       partial-specialization/member-template static-member copy paths +
       full-specialization static-member AST copy paths + metadata-aware
       initializer updates for existing members in primary/lazy update paths.
-    - Richer dependent-base lookup and deeper member-template segment chains.
+    - Remaining current-instantiation / type-alias materialization follow-ons
+      after inherited member-template alias owner recovery. The new shared
+      inherited-owner lookup fixes base-specifier/member-chain concretization,
+      but type-alias spellings such as `typename Derived<T>::template rebind<U>`
+      still need a follow-up pass so alias materialization reuses the same
+      semantic path instead of falling back to placeholder alias copies.
 
 3. **Structural NTTP implementation.**
    Typed integral/enum/`nullptr`, pointer, reference, function-pointer, and null

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12
-**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution)
+**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution; inherited dependent-base member-template alias owners now resolve through the shared member-chain concretization path)
 
 This document describes how FlashCpp's template argument architecture can move
 toward C++20 conformance. It is intentionally architectural: it identifies the
@@ -198,9 +198,18 @@ Completed work:
     concretization gap for member chains such as
     `typename TemplateOwner<U>::type`. Regression:
     `dependent_template_template_owner_member_type_ret42.cpp`.
+31. **inherited dependent-base member-template alias owner recovery
+    (2026-05-17):** the shared member-chain concretization path now resolves
+    alias/class member-template segments through inherited bases instead of
+    requiring them to live directly on the current owner, pattern owner, or
+    primary owner. `Parser_TypeSpecifiers.cpp` now reuses that inherited-owner
+    helper for direct member-template-alias probes as well. This fixes base
+    specifiers such as `Mid<T>::template rebind<int>` that previously lost the
+    inherited owner. Regression:
+    `test_template_current_instantiation_inherited_member_template_type_ret0.cpp`.
 
-Latest validation passed the full Linux suite: 2377 pass, 182 expected-fail,
-0 regressions.
+Latest validation passed the full Windows sharded suite: 2427 pass,
+182 expected-fail, 0 regressions.
 
 The remaining target architecture sections are retained as the next conformance
 roadmap, especially deeper dependent-base and segment-chain modeling, ADL
@@ -266,6 +275,11 @@ focused investigations.
       copy paths, richer dependent bases, deeper
       member-template segment chains, and the remaining parser-time ADL-sensitive
       paths.
+    - New narrower follow-up after this slice: current-instantiation/type-alias
+      spellings that preserve member-template alias placeholders
+      (`typename Derived<T>::template rebind<U>`) still need to materialize
+      through the same inherited-owner path instead of falling back to
+      placeholder alias copies during later alias substitution.
 
 3. **Implement remaining structural NTTP values.**
    Typed integral/enum/`nullptr`, object-pointer, reference, function-pointer,
@@ -445,9 +459,12 @@ static-member AST copy paths now preserve replay metadata for replay-first
 substitution (2026-05-17). The next highest-impact work is:
 
 1. **Continue two-phase lookup expansion**: extend definition-context records to
-   dependent-base and unknown-specialization concretization paths, plus any
-   remaining eager-static/parser-time paths that still cannot capture replay
-   metadata at parse time.
+   the remaining current-instantiation/type-alias dependent-base concretization
+   paths, plus any eager-static/parser-time paths that still cannot capture
+   replay metadata at parse time. The inherited member-template alias owner
+   lookup is now shared for base-specifier/member-chain concretization; the
+   next slice should make alias materialization reuse that same path for
+   spellings like `typename Derived<T>::template rebind<U>`.
 
 2. **Structural NTTP completion** (non-null member-pointers, structural class
    types, and replacing `TODO(item-8)` mangling fallback) is the other major

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,640 +1,235 @@
 # Template Argument Standard-Conformance Investigation
 
-**Date:** 2026-05-12
-**Last updated:** 2026-05-17 (out-of-line template static-member concretization now preserves replay metadata through parse/registry/instantiation transfer paths; dependent unqualified call POI metadata/completion added; lazy static-member replay now restores definition lookup context; ADL function-template POI completion broadened; partial-specialization AST static-member eager paths now replay-first; parser substitution now concretizes template-template dependent owners before member-chain resolution; inherited dependent-base member-template alias owners now resolve through the shared member-chain concretization path)
-
-This document describes how FlashCpp's template argument architecture can move
-toward C++20 conformance. It is intentionally architectural: it identifies the
-compiler layers that should own each responsibility and the order in which to
-separate them.
-
-## Baseline behavior to preserve during migration
-
-The current implementation already depends on several behaviors that must be
-preserved through refactoring:
-
-1. expression-lowering fold attempts for static members are scalar-only;
-2. folded reads prefer normalized constant bytes when available;
-3. recursive base-member static-evaluation paths are bounded (depth limit
-   `MAX_RECURSIVE_STATIC_EVAL_DEPTH = 64`);
-4. template static-member normalization applies template-parameter substitution
-   before expression-level substitution;
-5. struct member function codegen takes a per-function IR snapshot before each
-   member; on exception only the failing member's partial IR is rolled back
-   (`InstructionList::truncateTo`), earlier members are preserved;
-6. when sema omits a constructor annotation (`require_sema_resolved_ctor` is
-   set but no annotation is present) codegen logs a warning and falls through to
-   runtime overload resolution, failing hard only if that also finds no match —
-   this fallback must remain until sema coverage is complete;
-7. enum functional casts (`Enum(value)` constructor-call syntax) are
-   categorized as `TypeCategory::Enum`, not `TypeCategory::Struct`, across
-   the parser, overload-resolution conversion matching, and sema type-inference
-   layers; `ResolvedQualifiedIdentifierInfo::enum_owner_type_index` provides a
-   direct fast path for qualified enum-constant type inference;
-8. alias types that resolve to non-struct concrete types participate in codegen
-   size resolution through a TypeInfo-size → TypeSpecifier-size → struct-size
-   fallback chain.
-9. qualified template-body calls preserve definition-context lookup records so
-   template-body lookup can distinguish definition-time and point-of-instantiation
-   resolution boundaries;
-10. floating-point non-type template arguments preserve typed identity through
-    constexpr evaluation and mangling.
-
-These rules are compatibility constraints while migrating ownership to semantic
-lookup, deduction, and instantiation services.
-
-## Completed refactor status
-
-The first-pass refactor described by this investigation has been implemented on
-the template standard-compliance branch. A 2026-05-14 follow-up pass moved more
-of the highest-impact template infrastructure onto standard-shaped semantic
-ownership boundaries while keeping the remaining gaps explicit.
-
-Completed work:
-
-1. centralized static `constexpr` member reads and recursive base-member
-   evaluation policy behind a shared semantic service;
-2. preserved ordered, typed NTTP identities in instantiation keys, including
-   exact integral/enum identity and typed `nullptr` identity;
-3. consolidated alias-aware concrete size queries;
-4. added parameter-context-driven classification for explicit template
-   arguments across function, class, alias, and variable template use sites;
-5. introduced and threaded `TemplateInstantiationContext` through lookup and
-   substitution paths;
-6. extracted shape-only template deduction viability so selected free/member
-   function-template overload paths rank signatures before materializing bodies;
-7. fixed regressions found during full-suite validation in dependent alias size
-   fallback, template-template leftovers, nested pack/materialization, dependent
-   constexpr evaluation, and explicit-template SFINAE deduction;
-8. added conservative definition-context lookup records for non-dependent
-   template-body calls while preserving dependent POI/ADL completion;
-9. added dependent qualified-name records for high-value member-type placeholder
-   paths such as `typename T::type` and
-   `Traits<T>::template rebind<U>::type`;
-10. routed the main function-template, member-template, qualified owner/call,
-    variable-template, alias-template, member probe, and operator/ADL template
-    lookup paths through semantic lookup requests/records;
-11. extended typed NTTP identity beyond integral/enum/`nullptr` to object
-    pointers, references, function pointers, and null member pointers;
-12. expanded signature-only ranking before body materialization to explicit
-    free-function template overloads and fixed explicit overload ranking so
-    losing bodies are not materialized;
-13. extended dependent qualified-name records to current-instantiation owners,
-    unknown-specialization owners, and expression qualified-ids, with stricter
-    missing-`typename` diagnostics for covered unknown-specialization paths.
-14. preserved definition-context records for qualified non-dependent calls and
-    added floating-point NTTP identity flow through constexpr evaluation and
-    Itanium mangling.
-15. moved remaining low-frequency parser template probes and the static-initializer
-    constexpr template probe onto parser-built semantic lookup requests so timing
-    follows definition-vs-POI context instead of hardcoded point-of-definition.
-16. improved deferred-base-class lookup: `lookup_inherited_template` and
-    `lookup_inherited_type_alias` now follow the `type_index` of a deferred base
-    (including one level of alias chain) to find a concrete struct and recurse
-    into it, instead of always skipping deferred bases entirely.
-17. threaded parser context into `getTemplateParametersForTypeInfo` in
-    `ConstExprEvaluator_Members.cpp`; when a parser is available the function
-    uses `makeTemplateNameLookupRequest` (which propagates POI timing and
-    definition-namespace context) instead of the registry convenience wrappers
-    that always use `PointOfDefinition` timing.
-18. documented why `ExpressionSubstitutor.cpp` existence checks keep direct
-    registry calls (simple name-presence check at substitution time, no
-    instantiation-context timing needed).
-19. started semantic-analyzer lookup unification for structured-binding
-    tuple-like protocol resolution: `tuple_size`, `tuple_element`, and `get`
-    now use parser-built semantic template-name lookup requests before
-    specialization matching.
-20. advanced structured-binding specialization matching to semantic-lookup-first
-    ordering for `tuple_size`, `tuple_element`, and `get`.
-21. fixed tuple-like mixed member/free protocol precedence so `e.get<I>()` is
-    selected before free `get<I>(e)` when both are present, matching
-    [dcl.struct.bind]/3 intent.
-22. fixed root cause of `fallback_names` workaround: struct template
-    specializations in `Parser_Templates_Class.cpp` are now registered under
-    both simple and namespace-qualified names (via `QualifiedIdentifier`
-    overload of `registerSpecialization`). This makes `std::tuple_size<E>` and
-    `std::tuple_element<I,E>` findable through normal qualified semantic lookup
-    without any synthesized-name fallback. The non-standard `fallback_names`
-    mechanism was then removed entirely from `SemanticAnalysis.cpp`.
-23. **semantic analyzer unification completed in this slice (2026-05-15):** the
-    remaining sema-layer direct template-name lookup probe in
-    `SemanticAnalysis.cpp` (structured-binding tuple protocol helper) now routes
-    through the parser-owned semantic lookup interface
-    (`Parser::lookupTemplateName`). A follow-up audit of
-    `SemanticAnalysis.cpp`, `OverloadResolution.h`, and `SemanticTypes.h`
-    found no remaining sema-layer direct template-name lookup probes. All
-    surviving direct calls are in documented intentional-direct paths:
-    - pattern-identity checks (`get_instantiation_pattern`, `isPatternStructName`)
-      are not name-lookup probes and are correct as direct calls;
-    - `ConstExprEvaluator_Members.cpp` fallback paths guarded by
-      `if (parser_context == nullptr)` are correct intentional fallbacks;
-    - `ExpressionSubstitutor.cpp` existence-only checks are documented as
-      intentionally direct (no instantiation-context timing needed);
-    - `IrGenerator_*` / `TemplateRegistry_Lazy.h` calls are in codegen or
-      registry-internal layers where `makeTemplateNameLookupRequest` does not apply.
-24. **`QualifiedTypeMemberAccess::template_arguments` optimized (2026-05-15):**
-    replaced `std::unique_ptr<std::vector<TemplateTypeArg>>` with a raw
-    `const std::vector<TemplateTypeArg>*` pointing into `gChunkedAnyStorage`.
-    All four creation sites (`ExpressionSubstitutor.cpp`,
-    `Parser_Expr_QualLookup.cpp` ×2, `Parser_Templates_Inst_ClassTemplate.cpp`)
-    now use `&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(…)`.
-    Copy semantics are a shallow pointer copy (the pointed-to data is immutable
-    after creation and lives for the entire compilation). This reduces two heap
-    allocations per dependent member chain segment to one.
-25. **dependent unqualified-call POI completion added (2026-05-15):**
-    unresolved dependent unqualified calls now carry a first-class
-    `DependentUnqualifiedCallLookupRecord` on `CallExprNode`. Template
-    substitution, semantic call annotation, constexpr evaluation, and lazy
-    static-member replay can re-run definition-filtered ordinary lookup plus
-    ADL at the point of instantiation, and lazy static replay now restores the
-    recorded definition lookup context while rebuilding initializer AST.
-26. **dependent ADL function-template POI completion broadened (2026-05-15):**
-    unresolved dependent unqualified call completion now also attempts
-    ADL-associated namespace-qualified function-template instantiation at POI
-    when ordinary overload sets are empty. Regression
-    `test_template_two_phase_dependent_adl_function_template_poi_ret0.cpp`
-    now covers this path.
-
-27. **two-phase lookup extended to member function template bodies (2026-05-15):**
-    `instantiate_member_function_template_core` in
-    `Parser_Templates_Inst_MemberFunc.cpp` now sets `phase1_cutoff_line_`,
-    `phase1_cutoff_file_idx_`, and `current_template_definition_lookup_context_`
-    before `parse_function_body()`, mirroring the free function template path.
-    `filterPhase1OrdinaryFunctionOverloads` was removed from
-    `lookupMemberFunctionTemplateCandidatesForInstantiation` (member-lookup
-    visibility is class-scope — mutually visible regardless of textual order).
-    Regression `test_template_two_phase_member_func_template_ret42.cpp`.
-    Full-suite validation: 2361 pass, 184 expected-fail, 0 regressions.
-
-28. **dependent unqualified-call POI completion broadened for ordinary-bound
-    calls and template static initializers (2026-05-16):**
-    unqualified dependent calls that already had a definition-time ordinary
-    candidate now also keep `DependentUnqualifiedCallLookupRecord` metadata
-    instead of silently freezing to the provisional callee. Template
-    substitution, semantic call annotation, and constexpr evaluation now prefer
-    POI completion whenever that record exists, and template static-member
-    initializer parsing now installs definition-context lookup state before
-    parsing initializer AST. Regression
-    `test_template_static_member_initializer_dependent_adl_ret0.cpp`. Latest
-    full-suite validation: 2377 pass, 182 expected-fail, 0 regressions.
-
-29. **partial-specialization static-member eager AST paths now replay-first
-     (2026-05-16):** in `Parser_Templates_Inst_ClassTemplate.cpp`, the remaining
-     eager AST-copy paths (`pattern_struct.static_members()` and
-    `instantiated_struct_ref` static-member copy) now first reparse from saved
-    `initializer_position`/`declaration` using
-    `TemplateInstantiationContext` + `TemplateDefinitionLookupContext` under
-    `ScopedDefinitionLookupContext` with `parsing_template_depth_ = 1`, then
-    conservatively fall back to the previous AST substitution behavior.
-     Regression:
-     `test_template_partial_spec_static_member_replay_two_phase_lookup_ret0.cpp`.
-
-30. **dependent template-template owner concretization in parser substitution
-    (2026-05-17):** `substitute_template_parameter` in
-    `Parser_Expr_QualLookup.cpp` now remaps dependent-owner names bound through
-    template-template parameters to their concrete template names before
-    `resolveConcreteInstantiatedMemberChain` runs for
-    dependent/unknown-specialization owner records. This closes a parser-time
-    concretization gap for member chains such as
-    `typename TemplateOwner<U>::type`. Regression:
-    `dependent_template_template_owner_member_type_ret42.cpp`.
-31. **inherited dependent-base member-template alias owner recovery
-    (2026-05-17):** the shared member-chain concretization path now resolves
-    alias/class member-template segments through inherited bases instead of
-    requiring them to live directly on the current owner, pattern owner, or
-    primary owner. `Parser_TypeSpecifiers.cpp` now reuses that inherited-owner
-    helper for direct member-template-alias probes as well. This fixes base
-    specifiers such as `Mid<T>::template rebind<int>` that previously lost the
-    inherited owner. Regression:
-    `test_template_current_instantiation_inherited_member_template_type_ret0.cpp`.
-
-Latest validation passed the full Windows sharded suite: 2427 pass,
-182 expected-fail, 0 regressions.
-
-The remaining target architecture sections are retained as the next conformance
-roadmap, especially deeper dependent-base and segment-chain modeling, ADL
-for dependent calls, and constraint normalization/subsumption.
-
-## What is left / next
-
-The highest-impact semantic analyzer unification track is now addressed in this
-slice. The remaining work is architecture work that should be split into
-focused investigations.
-
-### Open next steps
-
-1. **Broaden POI completion beyond the new unresolved-call record.**
-    Unresolved dependent unqualified calls now carry explicit POI-completion
-    metadata and replay correctly through substitution, sema, constexpr, and
-    lazy-static paths. Covered direct-call paths that already had a
-    definition-time ordinary candidate now also retain this metadata, including
-    template static member initializers.
-    **New in this slice (2026-05-16):** out-of-line class-template static member
-    initializer replay now captures/restores definition-context lookup metadata
-    and reparses from saved initializer source
-    (`test_template_out_of_line_static_member_two_phase_lookup_ret0.cpp`).
-    **New in this slice (2026-05-16, follow-up):** in-class class-template
-    static-member eager substitution now prefers replay from saved initializer
-    source with `TemplateInstantiationContext` and definition-context lookup for
-    StructTypeInfo-backed members
-    (`test_template_inclass_static_member_two_phase_lookup_ret0.cpp`).
-    **New in this slice (2026-05-17):** member-template partial-specialization
-    and full-specialization static-member AST copy paths now preserve replay
-    metadata (`declaration` + `initializer_position`) across `addStaticMember`
-    transfer, extending replay-first substitution coverage
-    (`test_member_template_partial_spec_static_member_replay_ret0.cpp`).
-    **New in this slice (2026-05-17, follow-up):** out-of-line template static
-    member variable definitions now capture declaration AST at parse time and
-    preserve declaration + initializer-position metadata through concretization
-    and update paths, so replay-first substitution remains available on those
-    static members instead of dropping to AST-only substitution when metadata is
-    missing in transfer paths.
-    **New in this slice (2026-05-17, follow-up 2):** metadata-aware static-member
-    initializer updates now preserve replay metadata (`declaration` +
-    `initializer_position`) when updating already-registered members in primary
-    static-member copy and lazy materialization paths
-    (`test_template_lazy_static_member_replay_metadata_ret0.cpp`).
-    Remaining gaps are static-member concretization paths where replay metadata
-    is never captured at parse time, so AST-only fallback substitution must
-    remain.
-
-2. **Broaden two-phase lookup records further (member func template bodies ✅ done).**
-    Definition-context and semantic lookup records now protect selected
-    non-dependent unqualified, unresolved dependent unqualified, qualified,
-    member-template, operator paths, lazy static-member replay, and (new) member
-    function template bodies. Remaining:
-    - **Inherited member templates via `this->template` ✅ done (2026-05-15)**:
-      explicit-arg inherited lookup now walks base classes and preserves the
-      declaring-owner symbol through lowering/codegen, fixing the previous
-      derived-owner link regressions in
-      `test_inherited_member_template_lookup_ret42.cpp` and
-      `test_inherited_member_template_this_explicit_ret42.cpp`.
-    - Eager static initializers beyond the now covered dependent unqualified
-      direct-call + out-of-line static-member initializer + StructTypeInfo-backed
-      in-class static-member replay + partial-specialization AST static-member
-      copy paths, richer dependent bases, deeper
-      member-template segment chains, and the remaining parser-time ADL-sensitive
-      paths.
-    - New narrower follow-up after this slice: current-instantiation/type-alias
-      spellings that preserve member-template alias placeholders
-      (`typename Derived<T>::template rebind<U>`) still need to materialize
-      through the same inherited-owner path instead of falling back to
-      placeholder alias copies during later alias substitution.
-
-3. **Implement remaining structural NTTP values.**
-   Typed integral/enum/`nullptr`, object-pointer, reference, function-pointer,
-   and null member-pointer identity is implemented. Non-null member pointers,
-   floating-point, and structural class-type NTTPs still need standard semantic
-   values. Function-pointer and member-pointer mangling still use a conservative
-   hash fallback (see `TODO(item-8)` in `NameMangling.h` ~line 1103); replace
-   with full Itanium encoding once constexpr evaluation for those categories is
-   implemented.
-
-4. **Expand shape-only deduction and ranking.**
-   Selected overloaded free, explicit free, and member function-template paths
-   can rank signature-only candidates before body materialization. The older
-   full-instantiation fallback remains for unhandled cases; keep moving
-   candidate construction, deduction, constraints, partial ordering, and ranking
-   into sema-owned phases.
-
-5. **Complete dependent-name and current-instantiation modeling.**
-   `TypeInfo::DependentQualifiedNameRecord` covers high-value member-type
-   placeholders, current-instantiation owners, unknown-specialization owners, and
-   expression qualified-id records for practical paths. Full `[temp.dep]` support
-   still needs richer dependent base lookup, deeper member-template segment
-   chains, injected-class-name handling, and alias ordering.
-
-6. **Harden constructor annotation fallback into an invariant.**
-   Current valid coverage no longer needs the fallback in tested cases, but
-   codegen still intentionally keeps a soft fallback for uncovered/invalid
-   paths. Keep widening sema coverage until the fallback can be converted into a
-   hard diagnostic or invariant without losing valid code.
-
-
-### Highest-impact architecture tracks
-
-1. **Semantic analyzer unification on semantic lookup requests. ✅ ADDRESSED IN THIS SLICE**
-   The remaining sema-layer direct template-name lookup probe
-   (`SemanticAnalysis.cpp` structured-binding tuple protocol helper) now routes
-   through `Parser::lookupTemplateName()`. A post-change audit confirms no
-   remaining sema direct template-name lookup probes in
-   `SemanticAnalysis.cpp`, `OverloadResolution.h`, and `SemanticTypes.h`.
-   Intentional direct calls that are not lookup probes stay unchanged.
-
-2. **Two-phase lookup records.**
-   Store definition-context lookup for non-dependent names and defer only
-   dependent lookup to the point of instantiation. This is the highest-impact
-   standard-conformance gap because it affects template bodies, static
-   initializers, dependent calls, ADL, and qualified lookup.
-    The 2026-05-13 follow-up added a conservative definition-context record for
-    non-dependent unqualified function calls. The 2026-05-14 follow-up routed the
-    main function, member, qualified, variable, alias, probe, and operator
-    template lookup paths through semantic lookup requests. Later
-    point-of-instantiation overloads are filtered out where records apply, while
-    dependent calls still complete ADL at POI.
-
-3. **Structural NTTP value identity.**
-   Replace the integral-centric `int64_t` model with typed template-argument
-   equivalence for enums, `nullptr`, pointers/references/member pointers,
-   floating-point values, and structural class-type values.
-    The 2026-05-13 follow-up introduced typed NTTP identity categories and wired
-    equality/hashing/mangling through them for currently supported cases. The
-    2026-05-14 follow-up added concrete identity flow for object pointers,
-    references, function pointers, and null member pointers. Non-null
-    member-pointer, floating-point, and structural class-type NTTPs remain
-    explicit unsupported/placeholder categories until the parser and constant
-    evaluator can produce standard semantic values for them.
-    Full Itanium encoding for function-pointer/member-pointer NTTPs is tracked
-    by `TODO(item-8)` in `NameMangling.h` ~line 1103.
-
-4. **Deduction/constraints split before materialization.**
-   Continue extracting candidate viability, deduction, constraints, partial
-   ordering, and overload ranking so normal selection paths do not instantiate
-   function or class bodies incidentally.
-    The 2026-05-13 follow-up slice routes overloaded free function templates
-    and implicit member function templates through signature-only candidate
-    materialization for overload conversion ranking before instantiating the
-    selected body. The 2026-05-14 follow-up extended this to explicit
-    free-function template overloads and aligned explicit ranking with the
-    non-explicit path. It deliberately keeps the older full-instantiation
-    fallback for cases the shape path cannot rank safely.
-
-5. **First-class dependent-name/current-instantiation model.**
-   Replace string-like placeholders with semantic dependent entities for
-   current instantiation, unknown specialization, dependent bases, dependent
-   qualified names, and dependent template-ids.
-    The 2026-05-13 follow-up slice added a narrow
-    `TypeInfo::DependentQualifiedNameRecord` for dependent member-type
-    placeholders and taught type substitution/member declaration copying to
-    prefer that record for `typename T::type` and dependent member-template
-    chains such as `Traits<T>::template rebind<U>::type`. The 2026-05-14
-    follow-up added current-instantiation owner identity,
-    unknown-specialization owner handling, expression qualified-id records, and
-    stricter missing-`typename` diagnostics for covered paths. It intentionally
-    leaves richer dependent bases, deeper expression/member-template segment
-    chains, injected-class-name handling, and alias ordering as later
-    `[temp.dep]` work.
-
-## Target architecture
-
-Keep moving toward one sema-owned template system:
-
-- semantic lookup results own declaration identity, lookup kind, dependency
-  state, and definition-vs-POI timing;
-- registries act as indexes/caches behind lookup, not independent lookup
-  authorities;
-- dependent names carry records for current instantiation, unknown
-  specialization, dependent bases, dependent template-ids, and dependent
-  expression/member chains;
-- NTTP identity models C++20 template-argument equivalence for every supported
-  category;
-- candidate construction, deduction, constraints, overload ranking,
-  substitution, and materialization are separate phases;
-- static member and constructor handling become sema-owned, with codegen
-  fallbacks converted to diagnostics or invariants as coverage expands.
-
-The old phase plan is intentionally removed from this document. The actionable
-remaining work is the smaller phased delivery list below.
-
-## Suggested regression coverage
-
-### Template argument classification
-
-- Type parameter versus non-type parameter with the same identifier spelling.
-- Qualified type versus qualified static data member.
-- Alias template used as type argument and variable template used as value
-  argument.
-- Dependent `typename T::type` and dependent `T::template rebind<U>`.
-- Current-instantiation members and dependent base members.
-
-### NTTPs
-
-- Exact signedness and width distinctions.
-- Enum NTTPs.
-- `nullptr` NTTPs.
-- Object-pointer, reference, function-pointer, and null member-pointer NTTPs.
-- Non-null member-pointer NTTPs.
-- Floating-point NTTPs.
-- Structural class NTTPs.
-- Dependent NTTP expressions involving `sizeof`, `alignof`, `noexcept`, and
-  static data members. Known failing repro: `Box<sizeof(T)>` and
-  `Box<sizeof(T) + 1>` can collapse during instantiation
-  identity/materialization.
-
-### Lookup and ADL
-
-- Non-dependent unqualified names unaffected by later declarations.
-- Dependent calls that find hidden friends by ADL at instantiation.
-- Qualified lookup through dependent base classes.
-- Namespace aliases, inline namespaces, using-directives, and using-declarations
-  in template definitions and instantiations.
-
-### Deduction
-
-- Non-deduced contexts.
-- Forwarding references.
-- Overload-set arguments.
-- Template-template parameter matching.
-- Packs before, between, and after fixed parameters.
-- CTAD and user-provided deduction guides.
-- Constraint subsumption in overload ordering.
-
-### Static members
-
-- Static constexpr members used as NTTPs inside and outside class templates.
-- Static data member initializers that call hidden friends or member templates.
-- ODR-use-triggered instantiation timing.
-- Dependent initializer failures that should be SFINAE versus hard errors.
-
-## Recommended next step
-
-Inherited member-template lookup is now complete (2026-05-15), dependent
-unqualified POI completion now covers ordinary-bound calls plus template static
-member initializers (2026-05-16), out-of-line class-template static member
-initializer replay preserves definition-context lookup during instantiation
-reparse (2026-05-16), in-class StructTypeInfo-backed static-member eager replay
-preserves definition-context lookup during instantiation substitution (2026-05-16
-follow-up), and member-template partial-specialization + full-specialization
-static-member AST copy paths now preserve replay metadata for replay-first
-substitution (2026-05-17). The next highest-impact work is:
-
-1. **Continue two-phase lookup expansion**: extend definition-context records to
-   the remaining current-instantiation/type-alias dependent-base concretization
-   paths, plus any eager-static/parser-time paths that still cannot capture
-   replay metadata at parse time. The inherited member-template alias owner
-   lookup is now shared for base-specifier/member-chain concretization; the
-   next slice should make alias materialization reuse that same path for
-   spellings like `typename Derived<T>::template rebind<U>`.
-
-2. **Structural NTTP completion** (non-null member-pointers, structural class
-   types, and replacing `TODO(item-8)` mangling fallback) is the other major
-   conformance gap.
-
-3. **Expand sema-owned shape/deduction pipeline coverage** so normal overload
-   viability/ranking paths stop relying on full-instantiation fallback in the
-   remaining unhandled call patterns.
-
-## Implementation plan
-
-### Goal
-
-Converge from parser/codegen repair paths to a sema-owned, declaration-context
-template system while preserving the newly stabilized static `constexpr`
-behavior as compatibility constraints.
-
-### Work plan (remaining phased delivery)
-
-1. **Unify declaration lookup for template names. ✅ COMPLETE**
-   All sema-layer template name lookups now route through semantic lookup requests
-   (`makeTemplateNameLookupRequest`). Registry probes in sema are either
-   post-lookup specialization matching, pattern-identity checks, or documented
-   intentional-direct fallbacks (no parser context available).
-
-2. **Advance two-phase lookup records (member func template bodies ✅)**
-   Persist non-dependent lookup at definition time and defer only dependent
-   completion to instantiation time. Member function template bodies and
-   inherited `this->template` member-template calls now apply the same owner-
-   correct lookup/instantiation path. Static-member replay metadata propagation
-   now also covers member-template partial-specialization and full-specialization
-   AST copy paths, plus metadata-aware update paths for already-registered
-   static members in primary/lazy flows. Remaining: dependent bases, unknown
-   specializations, and ADL-sensitive dependent calls.
-
-3. **Consolidate substitution context ownership**
-   Continue replacing ad-hoc name/vector substitution channels with
-   `TemplateInstantiationContext` as the authoritative owner of scalar
-   bindings, pack bindings, current-instantiation identity, lookup context,
-   constexpr context, and failure policy.
-
-4. **Share one dependent-expression equivalence model**
-   Introduce one canonical semantic equivalence service for dependent
-   unevaluated expressions and route every relevant caller through it:
-   non-type template argument identity, template-argument
-   substitution/materialization, and any other comparison site that currently
-   performs local structural checks. The same C++20 expression-equivalence
-   notion must be reused across identity tracking and later evaluation paths.
-
-5. **Separate deduction from instantiation/materialization**
-   Expand shape-only candidate viability until deduction, constraints, partial
-   ordering, and overload ranking can run without body materialization in normal
-   selection paths. Instantiate only after winner selection.
-
-6. **Expand structural NTTP identity beyond supported scalar cases**
-   Typed integral/enum/`nullptr`, object-pointer, reference, function-pointer,
-   and null member-pointer identities are implemented. Add standard semantic
-   values and equivalence for non-null member-pointer, floating-point, and
-   structural class-type NTTPs, then migrate keys and mangling for those
-   categories. Replace conservative function/member-pointer mangling fallbacks
-   where standard entity encodings are available (tracked in `NameMangling.h`
-   `TODO(item-8)` ~line 1103).
-
-7. **Complete dependent-name/current-instantiation modeling**
-   Build on `DependentQualifiedNameRecord` with semantic records for expression
-   qualified-ids, dependent bases, unknown specialization, injected-class-name,
-   and current-instantiation member lookup.
-
-### Concrete artifacts to implement
-
-1. **Semantic lookup result object. ✅ COMPLETE**
-   `TemplateNameLookupRequest` / `TemplateNameLookupResult` / `TemplateNameLookupCandidate`
-   carry declaration identity, lookup kind (ordinary/qualified/member/ADL),
-   dependency flags, and definition-vs-POI timing metadata. All sema-layer
-   lookups now use these types.
-
-2. **Template-id syntax node plus semantic classification record**
-   Keep parse-time argument syntax unclassified; attach a semantic
-   parameter-matching result that records final kind (type/non-type/template),
-   conversions, defaults, and pack ownership.
-
-3. **TemplateInstantiationContext**
-   Replace ad-hoc maps/vectors with one context object containing scalar
-   bindings, pack bindings, current-instantiation identity, lookup context,
-   constexpr context, and failure policy.
-
-4. **Structural NTTP value representation**
-   Extend the current typed scalar/entity identity into value variants and
-   equivalence/hashing rules for non-null member-pointer, floating-point, and
-   structural class-type NTTPs. Keep object-pointer, reference, function-pointer,
-   and null member-pointer identity in the supported set.
-
-5. **Dependent-name/current-instantiation records**
-   Preserve current-instantiation, dependent base, unknown specialization,
-   dependent qualified-name, and dependent template-id identity without falling
-   back to string-only placeholders.
-
-### Phase gates and dependency order
-
-1. **Gate A (classification)**
-   **Status: closed by the first-pass refactor.** Parameter-context
-   classification is on by default for explicit template-ids in
-   class/function/alias/variable template use sites.
-
-2. **Gate B (lookup unification)**
-   **Status: partial, advanced.** `TemplateInstantiationContext` carries lookup
-   context and non-dependent function calls now preserve a definition-context
-   record, but template candidate discovery is not yet sourced from one
-   authoritative semantic lookup result everywhere.
-
-3. **Gate C (instantiation context)**
-   **Status: partial.** Core paths now thread `TemplateInstantiationContext`,
-   but older substitution and pack expansion paths still reconstruct legacy
-   vectors/maps in places.
-
-4. **Gate D (deduction split)**
-   **Status: partial, advanced.** Shape-only viability now covers selected
-   overloaded free/member function-template paths and should continue expanding
-   until all normal overload viability and deduction run without body
-   materialization.
-
-5. **Gate E (NTTP and two-phase lookup)**
-   **Status: partial, advanced.** Typed NTTP identities and definition-vs-POI
-   lookup are implemented for supported cases, including object pointers,
-   references, function pointers, and null member pointers. Non-null
-   member-pointer, floating-point, and structural class NTTP values remain open,
-   along with full semantic lookup coverage and full dependent-base,
-   injected-class-name, and current-instantiation behavior.
-
-### Exit criteria
-
-- template argument kind is no longer decided by parser heuristics for ambiguous
-  identifiers;
-- static-member constexpr reads use one sema service (no duplicated ad-hoc
-  recursive evaluators in IR paths);
-- selected deduction and overload-ordering paths run without incidental body
-  instantiation;
-- two-phase lookup behavior is test-covered for non-dependent function calls vs
-  dependent POI/ADL calls;
-- NTTP equivalence is type-accurate for supported integral/enum/`nullptr`,
-  object-pointer, reference, function-pointer, and null member-pointer cases,
-  while unsupported structural categories diagnose instead of collapsing to
-  scalar identities.
-
-### Minimum regression suite required before declaring completion
-
-- argument classification ambiguities (`X`, `N`, qualified ids, dependent ids)
-  resolved by parameter kind, not parser heuristics;
-- dependent and non-dependent lookup timing cases that distinguish definition
-  context from POI context;
-- function-template deduction cases for non-deduced contexts, forwarding refs,
-  packs, overload sets, template-template parameters, CTAD, and guides;
-- static-member constexpr cases covering scalar gating, normalized-byte reads,
-  recursive base-member chains, and depth-limit boundary behavior;
-- NTTP identity/equivalence coverage for enum, `nullptr`, object-pointer,
-  reference, function-pointer, null member-pointer, non-null member-pointer,
-  floating-point, and structural class-type arguments;
-- deferred-base NTTP cases proving no category collapse (`unsigned`, `long`,
-  `size_t`, fixed-width types) and stable specialization key selection;
-- static constexpr initializer diagnostics proving no silent zero-initialization
-  for non-constant expressions in non-dependent contexts;
-- namespace-qualified constexpr initializer references (`ns::value`) proving
-  owner resolution does not misclassify namespaces as missing owners;
-- struct with multiple member functions where one fails codegen, verifying that
-  the IR rollback preserves the already-emitted earlier members;
-- enum functional cast overload resolution, verifying `TypeCategory::Enum` is
-  consistently selected over `TypeCategory::Struct` at parser, overload, and
-  sema type-inference layers;
-- qualified enum constant expressions verifying `enum_owner_type_index` fast
-  path produces correct `CanonicalTypeId` without namespace-name-map traversal;
-- sema constructor annotation fallback: a ConstructorCallNode form not yet
-  covered by sema inference should compile successfully through codegen
-  resolution and emit the warning log, not crash.
+**Date:** 2026-05-12  
+**Last updated:** 2026-05-17
+
+This document is the execution plan for moving FlashCpp's template
+infrastructure toward C++20 conformance. It intentionally focuses on remaining
+work. Completed work is kept only when it changes what the next refactor can
+assume.
+
+## Goal
+
+Converge from parser- and registry-owned repair paths to one sema-owned
+template system where:
+
+- declaration lookup owns dependency classification and definition-vs-POI
+  timing;
+- template arguments are classified against the target parameter, not guessed
+  early;
+- dependent names preserve semantic identity instead of string placeholders;
+- NTTP identity models C++20 equivalence for the supported categories;
+- deduction, constraints, ranking, substitution, and materialization are
+  separate phases;
+- static-member and constructor behavior becomes invariant-driven instead of
+  fallback-driven.
+
+## Compatibility constraints to preserve
+
+Refactors must not regress these existing behaviors:
+
+1. scalar-only static-member folding and normalized-byte preference;
+2. bounded recursive static-member evaluation;
+3. template static-member normalization applies template-parameter
+   substitution before expression-level substitution;
+4. per-member IR rollback only rolls back the failing member;
+5. missing sema constructor annotations still fall back to runtime overload
+   resolution until sema coverage is complete;
+6. enum functional casts stay consistently categorized as `TypeCategory::Enum`;
+7. alias-backed non-struct concrete types still resolve size through the
+   existing fallback chain;
+8. qualified template-body calls preserve definition-context lookup metadata;
+9. floating-point NTTP identity continues to round-trip through constexpr and
+   mangling for already-supported cases.
+
+## Current assumptions you can rely on
+
+Future work should assume these are already in place:
+
+- semantic template-name lookup requests/records cover the main parser/sema
+  lookup paths;
+- selected non-dependent template-body calls already preserve definition-time
+  lookup records;
+- unresolved dependent unqualified calls already preserve POI completion
+  metadata through substitution, sema, constexpr, and lazy-static paths;
+- multiple static-member replay/copy/update paths already preserve replay
+  metadata and definition-context lookup;
+- inherited dependent-base member-template alias owners already resolve through
+  the shared member-chain concretization path for covered base-specifier flows;
+- typed NTTP identity already exists for integral, enum, `nullptr`, object
+  pointer, reference, function pointer, null member pointer, and covered
+  floating-point cases;
+- selected free/member function-template overload paths already rank
+  signatures before materializing bodies.
+
+Latest validation passed the Windows sharded suite: `2427` pass,
+`182` expected-fail, `0` regressions.
+
+## Remaining work, in priority order
+
+### 1. Finish the next two-phase lookup slice
+
+This is still the highest-impact track.
+
+Immediate targets:
+
+- current-instantiation and type-alias spellings that still bypass the shared
+  owner-correct lookup/materialization path;
+- remaining declarations and static-member paths that never captured replay
+  metadata at parse time and therefore still require AST-only fallback;
+- remaining dependent-base and deeper member-template/member-type chains;
+- remaining parser-time ADL-sensitive lookup paths outside the already-covered
+  call flows.
+
+Most concrete next subtask:
+
+- make alias materialization for spellings such as
+  `typename Derived<T>::template rebind<U>` reuse the inherited-owner
+  member-template path instead of preserving placeholder alias copies.
+
+### 2. Complete dependent-name and current-instantiation modeling
+
+`DependentQualifiedNameRecord` is a useful base, but it is not a complete
+`[temp.dep]` model.
+
+Still needed:
+
+- richer dependent-base records;
+- more unknown-specialization coverage;
+- deeper expression/member-template chains;
+- injected-class-name handling;
+- consistent current-instantiation identity across qualified-name paths;
+- alias-ordering correctness.
+
+### 3. Centralize dependent-expression equivalence
+
+One canonical semantic equivalence service is still missing.
+
+That service should be used by:
+
+- NTTP identity;
+- substitution/materialization comparisons;
+- any future dependent-expression memoization or lookup keys.
+
+Without this, identity tracking and later evaluation can still diverge.
+
+### 4. Finish NTTP conformance
+
+The main unsupported categories remain:
+
+- non-null member pointers;
+- structural class-type NTTPs;
+- remaining end-to-end floating-point coverage if any paths still rely on local
+  normalization instead of semantic value identity.
+
+Also required:
+
+- replace remaining conservative function/member-pointer mangling fallbacks
+  where full standard encodings are available.
+
+### 5. Expand deduction/constraint separation before materialization
+
+The current shape-only ranking coverage is useful but partial.
+
+Still needed:
+
+- more overload paths off the full-instantiation fallback;
+- non-deduced contexts;
+- forwarding references;
+- more pack shapes;
+- template-template parameter matching;
+- CTAD and deduction guides;
+- stronger constraint normalization/subsumption in ranking.
+
+### 6. Turn fallback-heavy areas into invariants
+
+Two areas still need endgame cleanup:
+
+- constructor annotation fallback;
+- static-member materialization fallbacks that remain only because semantic
+  ownership is still incomplete.
+
+The goal is not to add more fallback code. The goal is to delete it as semantic
+coverage becomes sufficient.
+
+## Recommended implementation order
+
+1. **Two-phase lookup follow-up**
+   - finish current-instantiation/type-alias owner recovery;
+   - extend replay metadata capture into remaining declarations;
+   - remove the next AST-only fallback path.
+
+2. **Dependent-name/current-instantiation expansion**
+   - richer dependent-base and unknown-specialization records;
+   - deeper member-template chains;
+   - owner-correct alias ordering.
+
+3. **Dependent-expression equivalence service**
+   - one reusable semantic identity model for unevaluated dependent
+     expressions.
+
+4. **NTTP completion**
+   - non-null member pointers;
+   - structural class NTTPs;
+   - remaining mangling cleanup.
+
+5. **Deduction/constraint separation**
+   - continue removing full-instantiation fallback from ordinary overload
+     selection.
+
+6. **Invariant cleanup**
+   - constructor fallback;
+   - remaining lookup/materialization repair paths.
+
+## Short artifact list
+
+These are the main architectural pieces still worth building or finishing:
+
+- a fuller sema-owned current-instantiation/dependent-name model;
+- a canonical dependent-expression equivalence service;
+- fuller `TemplateInstantiationContext` ownership in legacy substitution paths;
+- a complete NTTP value representation for the remaining C++20 categories;
+- broader sema-owned candidate construction/deduction/constraint/ranking;
+- final removal of repair-oriented fallback paths.
+
+## Regression focus for future slices
+
+When working on the remaining items, keep adding narrow regressions in these
+areas:
+
+- argument classification ambiguities driven by parameter kind;
+- definition-time vs POI lookup timing;
+- dependent-base and current-instantiation member-template/type chains;
+- NTTP identity for unsupported or partially supported categories;
+- deduction edge cases: non-deduced contexts, forwarding refs, packs,
+  template-template params, CTAD, guides, constraints;
+- static-member replay/ODR-use timing and hidden-friend cases.
+
+## Done, but only as context
+
+This section is intentionally short. It exists only to stop future work from
+re-solving already-solved problems.
+
+- semantic analyzer unification on parser-owned template-name lookup is done
+  for the previously remaining sema-layer probe paths;
+- selected member function template bodies already apply definition-context
+  lookup;
+- dependent unqualified POI completion is already first-class metadata, not an
+  ad hoc retry path;
+- several static-member replay and copy/update paths already preserve metadata;
+- inherited dependent-base member-template alias owner recovery is already in
+  place for covered base-specifier/member-chain cases.
+
+## Exit criteria
+
+This plan is complete when:
+
+- argument kind is always parameter-context-driven for ambiguous template-ids;
+- the main template-body/member/static lookup paths obey definition-vs-POI
+  timing with explicit semantic records;
+- dependent-name/current-instantiation behavior is semantically modeled rather
+  than string-reconstructed;
+- NTTP identity is complete for the supported C++20 categories;
+- ordinary overload selection does not materialize losing candidates by
+  default;
+- remaining repair paths have been converted into diagnostics or invariants.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-17
+**Last updated:** 2026-05-18
 
 This document is the execution plan for moving FlashCpp's template
 infrastructure toward C++20 conformance. It intentionally focuses on remaining
@@ -62,8 +62,10 @@ Future work should assume these are already in place:
 - selected free/member function-template overload paths already rank
   signatures before materializing bodies.
 
-Latest validation passed the Windows sharded suite: `2427` pass,
-`182` expected-fail, `0` regressions.
+Latest validation on Windows sharded build:
+`2427` regular tests compiled/linked, `2426` runtime pass,
+`1` runtime regression (`test_type_trait_alias_default_nttp_ret0.cpp`),
+`182` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -83,9 +85,12 @@ Immediate targets:
 
 Most concrete next subtask:
 
-- make alias materialization for spellings such as
-  `typename Derived<T>::template rebind<U>` reuse the inherited-owner
-  member-template path instead of preserving placeholder alias copies.
+- finish the remaining alias-selected default-NTTP path where qualified-id
+  substitution still reaches a nested stored template-instantiation argument
+  through placeholder state; the inherited-owner `rebind<U>` slice is done, but
+  `ConditionalT<..., IsEmpty<Type>>::value` still needs the nested
+  `IsEmpty<Type>` argument to materialize semantically to `IsEmpty<Concrete>`
+  before deferred-base type-trait evaluation.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -156,6 +161,9 @@ coverage becomes sufficient.
 
 1. **Two-phase lookup follow-up**
    - finish current-instantiation/type-alias owner recovery;
+   - complete alias-selected owner canonicalization in default-NTTP qualified-id
+     substitution so helper owners are not reintroduced after semantic alias
+     resolution;
    - extend replay metadata capture into remaining declarations;
    - remove the next AST-only fallback path.
 
@@ -218,7 +226,10 @@ re-solving already-solved problems.
   ad hoc retry path;
 - several static-member replay and copy/update paths already preserve metadata;
 - inherited dependent-base member-template alias owner recovery is already in
-  place for covered base-specifier/member-chain cases.
+  place for covered base-specifier/member-chain cases;
+- main qualified-id substitution paths now prefer semantic alias owners over
+  helper instantiated names when alias materialization already resolved a
+  concrete `TypeInfo`.
 
 ## Exit criteria
 

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -364,8 +364,12 @@ TypeCreationResult register_type_alias(StringHandle name, const TypeSpecifierNod
 	auto& info = emplaceTypeInfoTracked("register_type_alias", name, type_spec.type_index(), type_spec.size_in_bits());
 	info.registered_type_index_ = alias_idx;
 	info.setNamespaceHandle(ns);
-	info.is_type_alias_ = true;
-	info.setAliasTypeSpecifier(type_spec);
+	update_type_alias_copy(
+		info,
+		type_spec.type_index(),
+		type_spec.size_in_bits(),
+		&type_spec,
+		tryGetTypeInfo(type_spec.type_index()));
 	if (type_spec.category() == TypeCategory::Enum && type_spec.type_index().index() < gTypeInfo.size()) {
 		if (const EnumTypeInfo* enum_info = gTypeInfo[type_spec.type_index().index()].getEnumInfo()) {
 			info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
@@ -459,16 +463,75 @@ TypeInfo& add_instantiated_type(StringHandle name, TypeCategory kind, uint32_t s
 	return type_info;
 }
 
+namespace {
+
+void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
+	alias_type_info.placeholder_kind_ = DependentPlaceholderKind::None;
+	alias_type_info.dependent_qualified_name_.reset();
+	alias_type_info.base_template_ = QualifiedIdentifier{};
+	alias_type_info.template_args_.clear();
+	alias_type_info.instantiation_context_.reset();
+	alias_type_info.is_incomplete_instantiation_ = false;
+}
+
+void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& semantic_source_type_info) {
+	alias_type_info.placeholder_kind_ = semantic_source_type_info.placeholder_kind_;
+	alias_type_info.dependent_qualified_name_ = semantic_source_type_info.dependent_qualified_name_;
+	alias_type_info.base_template_ = semantic_source_type_info.base_template_;
+	alias_type_info.template_args_ = semantic_source_type_info.template_args_;
+	alias_type_info.is_incomplete_instantiation_ = semantic_source_type_info.is_incomplete_instantiation_;
+	if (const TypeInfo::InstantiationContext* instantiation_context =
+			semantic_source_type_info.instantiationContext();
+		instantiation_context != nullptr) {
+		alias_type_info.setInstantiationContext(
+			instantiation_context->param_names,
+			instantiation_context->param_args,
+			instantiation_context->parent);
+	} else {
+		alias_type_info.instantiation_context_.reset();
+	}
+}
+
+} // namespace
+
+void update_type_alias_copy(
+	TypeInfo& alias_type_info,
+	TypeIndex source_type_index,
+	uint32_t size_bits,
+	const TypeSpecifierNode* alias_type_spec,
+	const TypeInfo* semantic_source_type_info) {
+	const uint32_t alias_slot = alias_type_info.registeredTypeIndex().index();
+	alias_type_info.type_index_ = source_type_index;
+	alias_type_info.registered_type_index_ = TypeIndex{alias_slot, TypeCategory::TypeAlias};
+	alias_type_info.fallback_size_bits_ = size_bits;
+	alias_type_info.is_type_alias_ = true;
+	resetTypeAliasSemanticMetadata(alias_type_info);
+	if (semantic_source_type_info != nullptr) {
+		copyTypeAliasSemanticMetadata(alias_type_info, *semantic_source_type_info);
+	}
+	alias_type_info.clearAliasTypeSpecifier();
+	if (alias_type_spec != nullptr) {
+		alias_type_info.setAliasTypeSpecifier(*alias_type_spec);
+	} else if (semantic_source_type_info != nullptr) {
+		if (const TypeSpecifierNode* source_alias_type_spec =
+				semantic_source_type_info->aliasTypeSpecifier();
+			source_alias_type_spec != nullptr) {
+			alias_type_info.setAliasTypeSpecifier(*source_alias_type_spec);
+		}
+	}
+}
+
 TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits) {
 	TypeIndex alias_idx{gTypeInfo.size(), TypeCategory::TypeAlias};
 	auto& type_info = emplaceTypeInfoTracked("add_type_alias_copy", name, source_type_index, size_bits);
 	type_info.registered_type_index_ = alias_idx;
-	type_info.is_type_alias_ = true;
+	update_type_alias_copy(type_info, source_type_index, size_bits, nullptr, nullptr);
 	emplaceTypeNameTracked("add_type_alias_copy", type_info.name(), &type_info);
 	return type_info;
 }
 
 TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits, const TypeSpecifierNode& alias_type_spec) {
+	const TypeInfo* semantic_source_type_info = tryGetTypeInfo(alias_type_spec.type_index());
 	auto& type_info = add_type_alias_copy(name, source_type_index, size_bits);
 	if (!type_info.type_index_.is_valid() && alias_type_spec.type() != TypeCategory::Invalid) {
 		TypeIndex canonical_source = alias_type_spec.type_index();
@@ -481,15 +544,30 @@ TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, ui
 		}
 		type_info.type_index_ = canonical_source;
 	}
-	type_info.setAliasTypeSpecifier(alias_type_spec);
+	update_type_alias_copy(type_info, type_info.type_index_, size_bits, &alias_type_spec, semantic_source_type_info);
+	return type_info;
+}
+
+TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits, const TypeSpecifierNode& alias_type_spec, const TypeInfo& semantic_source_type_info) {
+	auto& type_info = add_type_alias_copy(name, source_type_index, size_bits);
+	if (!type_info.type_index_.is_valid() && alias_type_spec.type() != TypeCategory::Invalid) {
+		TypeIndex canonical_source = alias_type_spec.type_index();
+		if (canonical_source.is_valid()) {
+			canonical_source = canonical_source.withCategory(alias_type_spec.type());
+		} else if (TypeIndex native_type_index = nativeTypeIndex(alias_type_spec.type()); native_type_index.is_valid()) {
+			canonical_source = native_type_index;
+		} else {
+			canonical_source = type_info.registeredTypeIndex().withCategory(alias_type_spec.type());
+		}
+		type_info.type_index_ = canonical_source;
+	}
+	update_type_alias_copy(type_info, type_info.type_index_, size_bits, &alias_type_spec, &semantic_source_type_info);
 	return type_info;
 }
 
 TypeInfo& add_type_alias_copy(StringHandle name, const TypeInfo& source_type_info, uint32_t size_bits) {
-	auto& type_info = add_type_alias_copy(
-		name,
-		source_type_info.registeredTypeIndex().withCategory(source_type_info.typeEnum()),
-		size_bits);
+	auto& type_info = add_type_alias_copy(name, source_type_info.registeredTypeIndex().withCategory(source_type_info.typeEnum()), size_bits);
+	update_type_alias_copy(type_info, type_info.type_index_, size_bits, source_type_info.aliasTypeSpecifier(), &source_type_info);
 	return type_info;
 }
 

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -505,6 +505,18 @@ void update_type_alias_copy(
 	alias_type_info.registered_type_index_ = TypeIndex{alias_slot, TypeCategory::TypeAlias};
 	alias_type_info.fallback_size_bits_ = size_bits;
 	alias_type_info.is_type_alias_ = true;
+	alias_type_info.setEnumInfo(nullptr);
+	const TypeInfo* enum_source_type_info = semantic_source_type_info;
+	if (enum_source_type_info == nullptr &&
+		alias_type_spec != nullptr &&
+		alias_type_spec->type_index().is_valid()) {
+		enum_source_type_info = tryGetTypeInfo(alias_type_spec->type_index());
+	}
+	if (enum_source_type_info != nullptr) {
+		if (const EnumTypeInfo* enum_info = enum_source_type_info->getEnumInfo()) {
+			alias_type_info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
+		}
+	}
 	resetTypeAliasSemanticMetadata(alias_type_info);
 	if (semantic_source_type_info != nullptr) {
 		copyTypeAliasSemanticMetadata(alias_type_info, *semantic_source_type_info);

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1461,7 +1461,9 @@ TypeInfo& add_instantiated_type(StringHandle name, TypeCategory kind, uint32_t s
 // For adding an alias entry that copies type info from another TypeInfo
 TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits);
 TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits, const TypeSpecifierNode& alias_type_spec);
+TypeInfo& add_type_alias_copy(StringHandle name, TypeIndex source_type_index, uint32_t size_bits, const TypeSpecifierNode& alias_type_spec, const TypeInfo& semantic_source_type_info);
 TypeInfo& add_type_alias_copy(StringHandle name, const TypeInfo& source_type_info, uint32_t size_bits);
+void update_type_alias_copy(TypeInfo& alias_type_info, TypeIndex source_type_index, uint32_t size_bits, const TypeSpecifierNode* alias_type_spec, const TypeInfo* semantic_source_type_info);
 
 // For adding an empty/uninitialized TypeInfo entry (caller fills in fields manually)
 TypeCreationResult add_empty_type_entry();

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -708,12 +708,76 @@ ExpressionSubstitutor::MaterializedStoredTemplateArgs ExpressionSubstitutor::mat
 					materialized_arg = rebindDependentTemplateTypeArg(type_subst_it->second, materialized_arg);
 					result.had_substitution = true;
 					substituted = true;
-				} else if (arg_type_info->isDependentPlaceholder()) {
+				} else if (arg_type_info->name().isValid()) {
+					// Alias-target stored template args may carry intermediate
+					// dependent parameter names (e.g. Type -> Head). If direct
+					// param_map_ lookup misses, resolve via the full environment so
+					// deferred trait/default evaluation sees the concrete outer type.
 					if (auto context_binding = resolveContextBinding(arg_type_info->name(), lookup_environment);
 						context_binding.has_value()) {
-					materialized_arg = rebindDependentTemplateTypeArg(*context_binding, materialized_arg);
-					result.had_substitution = true;
-					substituted = true;
+						materialized_arg = rebindDependentTemplateTypeArg(*context_binding, materialized_arg);
+						result.had_substitution = true;
+						substituted = true;
+					}
+				}
+
+				if (!substituted &&
+					arg_type_info->isTemplateInstantiation() &&
+					depth < kMaxDependentMemberTypeResolutionDepth) {
+					MaterializedStoredTemplateArgs nested_materialized_args =
+						materializeStoredTemplateArgs(
+							*arg_type_info,
+							evaluate_dependent_member_values,
+							depth + 1);
+					if (!nested_materialized_args.args.empty() &&
+						!templateArgsStillDependent(nested_materialized_args.args)) {
+						StringHandle qualified_base_template_name =
+							gNamespaceRegistry.buildQualifiedIdentifier(
+								arg_type_info->sourceNamespace(),
+								arg_type_info->baseTemplateName());
+						std::string_view base_template_name =
+							StringTable::getStringView(qualified_base_template_name);
+						if (base_template_name.empty()) {
+							base_template_name =
+								StringTable::getStringView(arg_type_info->baseTemplateName());
+						}
+						if (!base_template_name.empty()) {
+							Parser::AliasTemplateMaterializationResult materialized_nested =
+								parser_.materializeTemplateInstantiationForLookup(
+									base_template_name,
+									nested_materialized_args.args);
+							const TypeInfo* resolved_nested_type =
+								materialized_nested.resolved_type_info;
+							if (resolved_nested_type == nullptr &&
+								qualified_base_template_name != arg_type_info->baseTemplateName()) {
+								materialized_nested =
+									parser_.materializeTemplateInstantiationForLookup(
+										StringTable::getStringView(arg_type_info->baseTemplateName()),
+										nested_materialized_args.args);
+								resolved_nested_type = materialized_nested.resolved_type_info;
+							}
+							if (resolved_nested_type == nullptr) {
+								StringHandle canonical_name_handle =
+									materialized_nested.canonicalNameHandle();
+								if (canonical_name_handle.isValid()) {
+									resolved_nested_type = findTypeByName(canonical_name_handle);
+								}
+							}
+							if (resolved_nested_type != nullptr) {
+								TypeIndex resolved_nested_index =
+									resolved_nested_type->registeredTypeIndex().withCategory(
+										resolved_nested_type->typeEnum());
+								TemplateTypeArg resolved_nested_arg =
+									makeTemplateTypeArgFromResolvedAlias(
+										resolveAliasTypeInfo(resolved_nested_index),
+										resolved_nested_index);
+								materialized_arg = rebindDependentTemplateTypeArg(
+									resolved_nested_arg,
+									materialized_arg);
+								result.had_substitution = true;
+								substituted = true;
+							}
+						}
 					}
 				}
 			}
@@ -2442,6 +2506,10 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 				auto param_it = param_map_.find(arg_type_name);
 				if (param_it != param_map_.end()) {
 					arg = rebindDependentTemplateTypeArg(param_it->second, arg);
+				} else if (auto context_binding =
+							   resolveContextBinding(arg_type_info->name(), environment_);
+						   context_binding.has_value()) {
+					arg = rebindDependentTemplateTypeArg(*context_binding, arg);
 				}
 			}
 		}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -853,13 +853,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 					parser_.materializeTemplateInstantiationForLookup(
 						owner_name,
 						owner_args);
-				if (!materialized_owner.instantiated_name.empty()) {
-					materialized_owner_name = materialized_owner.instantiated_name;
-				} else if (materialized_owner.resolved_type_info != nullptr) {
-					materialized_owner_name =
-						StringTable::getStringView(
-							materialized_owner.resolved_type_info->name());
-				}
+				materialized_owner_name = materialized_owner.canonicalName();
 			}
 			break;
 		}
@@ -938,7 +932,8 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 		parser_.materializeTemplateInstantiationForLookup(
 			base_template_name,
 			concrete_base_args.args);
-	if (materialized_base.instantiated_name.empty()) {
+	std::string_view materialized_base_name = materialized_base.canonicalName();
+	if (materialized_base_name.empty()) {
 		return nullptr;
 	}
 
@@ -948,7 +943,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 	member_chain.push_back(std::move(member_access));
 	const TypeInfo* resolved_type =
 		parser_.resolveBaseClassMemberTypeChain(
-			materialized_base.instantiated_name,
+			materialized_base_name,
 			member_chain);
 	if (resolved_type == nullptr) {
 		return nullptr;
@@ -1933,6 +1928,62 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 
 	// Get the namespace name (e.g., "R1_T")
 	std::string_view ns_name = gNamespaceRegistry.getQualifiedName(qual_id.namespace_handle());
+	constexpr std::string_view kNestedTypeAliasName = "type";
+	auto canonicalizeLookupOwnerForMember =
+		[&](const Parser::AliasTemplateMaterializationResult& materialized_owner,
+			std::string_view member_name) -> std::string_view {
+		std::string_view owner_name = materialized_owner.canonicalName();
+		if (owner_name.empty() || member_name == kNestedTypeAliasName) {
+			return owner_name;
+		}
+
+		const TypeInfo* owner_type_info = materialized_owner.resolved_type_info;
+		if (owner_type_info == nullptr) {
+			owner_type_info = findTypeByName(
+				StringTable::getOrInternStringHandle(owner_name));
+		}
+		if (owner_type_info != nullptr &&
+			owner_type_info->isStruct()) {
+			if (const StructTypeInfo* owner_struct_info =
+					owner_type_info->getStructInfo();
+				owner_struct_info != nullptr) {
+				StringHandle member_handle =
+					StringTable::getOrInternStringHandle(member_name);
+				auto [static_member, owner_struct] =
+					owner_struct_info->findStaticMemberRecursive(member_handle);
+				if (static_member != nullptr || owner_struct != nullptr) {
+					return owner_name;
+				}
+			}
+		}
+
+		StringHandle nested_alias_handle = StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append(owner_name)
+				.append("::")
+				.append(kNestedTypeAliasName)
+				.commit());
+		auto nested_alias_it = getTypesByNameMap().find(nested_alias_handle);
+		if (nested_alias_it == getTypesByNameMap().end() ||
+			nested_alias_it->second == nullptr) {
+			return owner_name;
+		}
+
+		ResolvedAliasTypeInfo resolved_nested_alias = resolveAliasTypeInfo(
+			nested_alias_it->second->registeredTypeIndex().withCategory(
+				nested_alias_it->second->typeEnum()));
+		const TypeInfo* nested_target_info =
+			resolved_nested_alias.terminal_type_info;
+		if (nested_target_info == nullptr &&
+			resolved_nested_alias.type_index.is_valid()) {
+			nested_target_info =
+				tryGetTypeInfo(resolved_nested_alias.type_index);
+		}
+		return nested_target_info != nullptr &&
+				nested_target_info->name().isValid()
+			? StringTable::getStringView(nested_target_info->name())
+			: owner_name;
+	};
 
 	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
 			qual_id.dependentQualifiedName()) {
@@ -1980,13 +2031,8 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 				}
 				Parser::AliasTemplateMaterializationResult materialized_owner =
 					parser_.materializeTemplateInstantiationForLookup(owner_name, owner_args);
-				if (!materialized_owner.instantiated_name.empty()) {
-					materialized_owner_name = materialized_owner.instantiated_name;
-				} else if (materialized_owner.resolved_type_info != nullptr) {
-					materialized_owner_name =
-						StringTable::getStringView(
-							materialized_owner.resolved_type_info->name());
-				} else {
+				materialized_owner_name = materialized_owner.canonicalName();
+				if (materialized_owner_name.empty()) {
 					materialized_owner_name =
 						parser_.get_instantiated_class_name(owner_name, owner_args);
 				}
@@ -2023,9 +2069,8 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 						parser_.materializeTemplateInstantiationForLookup(
 							member_template_name,
 							member_args);
-					if (!materialized_member.instantiated_name.empty()) {
-						materialized_namespace = materialized_member.instantiated_name;
-					} else {
+					materialized_namespace = materialized_member.canonicalName();
+					if (materialized_namespace.empty()) {
 						materialized_namespace =
 							parser_.get_instantiated_class_name(
 								member_template_name,
@@ -2262,10 +2307,12 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 								parser_.materializeTemplateInstantiationForLookup(
 									base_template_name,
 									current_inst_args);
-							if (!materialized_alias_base.instantiated_name.empty()) {
+							std::string_view materialized_alias_base_name =
+								materialized_alias_base.canonicalName();
+							if (!materialized_alias_base_name.empty()) {
 								StringHandle concrete_member_handle = StringTable::getOrInternStringHandle(
 									StringBuilder()
-										.append(materialized_alias_base.instantiated_name)
+										.append(materialized_alias_base_name)
 										.append("::")
 										.append(dependent_member_name)
 										.commit());
@@ -2293,7 +2340,8 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 										concrete_member_handle,
 										resolved_member_index,
 										resolved_type_info->sizeInBits().value,
-										concrete_member_spec);
+										concrete_member_spec,
+										*resolved_type_info);
 									getTypesByNameMap().insert_or_assign(
 										concrete_member_handle,
 										&concrete_member_info);
@@ -2449,7 +2497,9 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 				  "' with ", inst_args.size(), " arguments");
 		Parser::AliasTemplateMaterializationResult materialized_namespace =
 			parser_.materializeTemplateInstantiationForLookup(base_template_name, inst_args);
-		std::string_view instantiated_name = materialized_namespace.instantiated_name;
+		std::string_view instantiated_name = canonicalizeLookupOwnerForMember(
+			materialized_namespace,
+			qual_id.name());
 
 		FLASH_LOG(Templates, Debug, "  Substituted namespace: ", ns_name, " -> ", instantiated_name);
 
@@ -2471,7 +2521,9 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 		FLASH_LOG(Templates, Debug, "  Empty pack expansion for '", base_template_name, "', instantiating with 0 args");
 		Parser::AliasTemplateMaterializationResult materialized_namespace =
 			parser_.materializeTemplateInstantiationForLookup(base_template_name, {});
-		std::string_view instantiated_name = materialized_namespace.instantiated_name;
+		std::string_view instantiated_name = canonicalizeLookupOwnerForMember(
+			materialized_namespace,
+			qual_id.name());
 		if (!instantiated_name.empty()) {
 			FLASH_LOG(Templates, Debug, "  Empty-pack substituted namespace: ", ns_name, " -> ", instantiated_name);
 			StringHandle instantiated_name_handle = StringTable::getOrInternStringHandle(instantiated_name);
@@ -2735,7 +2787,25 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 			}
 		}
 		if (it != param_map_.end()) {
-			const TemplateTypeArg& subst = it->second;
+			TemplateTypeArg subst = it->second;
+			if (!subst.is_value && subst.type_index.is_valid()) {
+				if (const TypeInfo* substituted_type_info = tryGetTypeInfo(subst.type_index);
+					substituted_type_info != nullptr &&
+					!substituted_type_info->isDependentPlaceholder()) {
+					ResolvedAliasTypeInfo resolved_subst_alias = resolveAliasTypeInfo(
+						subst.type_index.withCategory(substituted_type_info->typeEnum()));
+					if (resolved_subst_alias.terminal_type_info != nullptr &&
+						resolved_subst_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
+						substituted_type_info = resolved_subst_alias.terminal_type_info;
+					}
+					if (substituted_type_info->typeEnum() != TypeCategory::Invalid) {
+						subst.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+							substituted_type_info->registeredTypeIndex().withCategory(
+								substituted_type_info->typeEnum()));
+						subst.setCategory(substituted_type_info->typeEnum());
+					}
+				}
+			}
 			FLASH_LOG(Templates, Debug, "  Substituting template parameter: ", token_type_name,
 					  " -> base_type=", (int)subst.typeEnum(), ", type_index=", subst.type_index);
 			if (subst.is_value) {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3370,7 +3370,9 @@ private:	 // Resume private methods
 	// Returns the vector of all template overloads if found, nullptr otherwise
 	// Uses depth limit to prevent infinite recursion in malformed input
 	const std::vector<ASTNode>* lookup_inherited_template(StringHandle struct_name, std::string_view template_name, int depth = 0);
+	// Helper: Build 'owner::member' as an interned handle for member alias/template lookup.
 	StringHandle buildQualifiedMemberNameHandle(StringHandle owner_name, StringHandle member_name) const;
+	// Helper: Resolve direct member-template name on owner/pattern/primary-template fallback.
 	std::string_view lookup_direct_member_template_name(StringHandle owner_name, StringHandle member_name) const;
 	// Helper: Resolve an alias/class member-template segment including inherited bases.
 	// Returns the qualified template name to materialize, or empty when not found.

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3334,6 +3334,8 @@ private:	 // Resume private methods
 	// Returns the vector of all template overloads if found, nullptr otherwise
 	// Uses depth limit to prevent infinite recursion in malformed input
 	const std::vector<ASTNode>* lookup_inherited_template(StringHandle struct_name, std::string_view template_name, int depth = 0);
+	StringHandle buildQualifiedMemberNameHandle(StringHandle owner_name, StringHandle member_name) const;
+	std::string_view lookup_direct_member_template_name(StringHandle owner_name, StringHandle member_name) const;
 	// Helper: Resolve an alias/class member-template segment including inherited bases.
 	// Returns the qualified template name to materialize, or empty when not found.
 	std::string_view lookup_inherited_member_template_name(StringHandle struct_name, StringHandle member_name, int depth);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3334,6 +3334,9 @@ private:	 // Resume private methods
 	// Returns the vector of all template overloads if found, nullptr otherwise
 	// Uses depth limit to prevent infinite recursion in malformed input
 	const std::vector<ASTNode>* lookup_inherited_template(StringHandle struct_name, std::string_view template_name, int depth = 0);
+	// Helper: Resolve an alias/class member-template segment including inherited bases.
+	// Returns the qualified template name to materialize, or empty when not found.
+	std::string_view lookup_inherited_member_template_name(StringHandle struct_name, StringHandle member_name, int depth);
 	// Convenience overload for string_view parameters
 	const std::vector<ASTNode>* lookup_inherited_template(std::string_view struct_name, std::string_view template_name, int depth = 0) {
 		return lookup_inherited_template(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -345,6 +345,26 @@ struct SubstitutionParamMap {
 inline TemplateTypeArg enrichTemplateArgForParameter(
 	const TemplateParameterNode& param,
 	TemplateTypeArg arg) {
+	if (param.kind() == TemplateParameterKind::Type &&
+		!arg.is_value &&
+		arg.type_index.is_valid()) {
+		const TypeInfo* semantic_type_info = tryGetTypeInfo(arg.type_index);
+		if (semantic_type_info != nullptr &&
+			!semantic_type_info->isDependentPlaceholder()) {
+			ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+				arg.type_index.withCategory(semantic_type_info->typeEnum()));
+			if (resolved_alias.terminal_type_info != nullptr &&
+				resolved_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
+				semantic_type_info = resolved_alias.terminal_type_info;
+			}
+			if (semantic_type_info->typeEnum() != TypeCategory::Invalid) {
+				arg.type_index = FlashCpp::canonicalizeTemplateIdentityTypeIndex(
+					semantic_type_info->registeredTypeIndex().withCategory(
+						semantic_type_info->typeEnum()));
+				arg.setCategory(semantic_type_info->typeEnum());
+			}
+		}
+	}
 	if (param.kind() != TemplateParameterKind::Template) {
 		return arg;
 	}
@@ -2846,6 +2866,22 @@ private:
 		std::string_view instantiated_name{};
 		const TypeInfo* resolved_type_info = nullptr;
 		std::optional<ASTNode> instantiated_struct_node{};  // Set when try_instantiate_class_template returns a StructDeclarationNode
+		StringHandle canonicalNameHandle() const {
+			if (resolved_type_info != nullptr &&
+				resolved_type_info->name().isValid()) {
+				return resolved_type_info->name();
+			}
+			if (!instantiated_name.empty()) {
+				return StringTable::getOrInternStringHandle(instantiated_name);
+			}
+			return StringHandle{};
+		}
+		std::string_view canonicalName() const {
+			StringHandle canonical_name = canonicalNameHandle();
+			return canonical_name.isValid()
+				? StringTable::getStringView(canonical_name)
+				: std::string_view{};
+		}
 	};
 	std::string_view get_instantiated_class_name(std::string_view template_name, std::span<const TemplateTypeArg> template_args);	 // NEW: Get mangled name for instantiated class
 	std::string_view instantiate_and_register_base_template(std::string_view& base_class_name, std::span<const TemplateTypeArg> template_args);  // Helper: Instantiate base class template and add to AST
@@ -3359,6 +3395,11 @@ private:	 // Resume private methods
 		Resolved,
 		StillDependent
 	};
+	const TypeInfo* resolveDependentMemberTypeSemantic(
+		const TypeInfo& dependent_type_info,
+		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
+		StringHandle current_owner_type_name);
 	DependentAliasResolutionStatus resolveDependentMemberAlias(
 		ASTNode& type_node,
 		std::span<const TemplateParameterNode> template_params,

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -1222,9 +1222,19 @@ ParseResult Parser::parse_using_directive_or_declaration() {
 		// Check if target name is already registered (avoid duplicates)
 		if (getTypesByNameMap().find(target_type_name) == getTypesByNameMap().end()) {
 			if (existing_type_it != getTypesByNameMap().end()) {
-				// Found existing type - create alias pointing to it
+				// Found existing type - create alias pointing to it.
+				// Use the TypeIndex overload (not the TypeInfo& overload) so we do NOT copy
+				// the source's aliasTypeSpecifier.  If the source is itself an alias (e.g.
+				// "Source::Ptr = int*"), copying its aliasTypeSpecifier would cause
+				// resolveAliasTypeInfo to accumulate pointer/reference depth twice while
+				// walking the chain: once from this new alias and once from the original alias.
+				// By leaving the aliasTypeSpecifier empty we let the chain traversal pick up
+				// all indirection metadata from the original alias exactly once.
 				const TypeInfo* source_type = existing_type_it->second;
-				auto& alias_type_info = add_type_alias_copy(target_type_name, *source_type, source_type->fallback_size_bits_);
+				auto& alias_type_info = add_type_alias_copy(
+					target_type_name,
+					source_type->registeredTypeIndex().withCategory(source_type->typeEnum()),
+					source_type->fallback_size_bits_);
 
 				// If the source type has StructInfo, we don't copy it - we rely on type_index_ to point to it
 				// This is the same pattern used for typedef resolution

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -550,8 +550,27 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 		.append("::")
 		.append(StringTable::getStringView(member_name));
 	std::string_view qualified_name = qualified_name_builder.commit();
+	StringHandle qualified_name_handle = StringTable::getOrInternStringHandle(qualified_name);
 
-	auto direct_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(qualified_name));
+	if (LazyTypeAliasRegistry::getInstance().needsEvaluation(struct_name, member_name)) {
+		if (std::optional<TypeIndex> lazy_alias_type =
+				evaluateLazyTypeAlias(struct_name, member_name);
+			lazy_alias_type.has_value()) {
+			auto direct_register_it = getTypesByNameMap().find(qualified_name_handle);
+			if (direct_register_it == getTypesByNameMap().end()) {
+				uint32_t size_bits = 0;
+				if (const TypeInfo* lazy_type_info = tryGetTypeInfo(*lazy_alias_type)) {
+					SizeInBits lazy_size_bits = lazy_type_info->sizeInBits();
+					if (lazy_size_bits.is_set()) {
+						size_bits = lazy_size_bits.value;
+					}
+				}
+				add_type_alias_copy(qualified_name_handle, *lazy_alias_type, size_bits);
+			}
+		}
+	}
+
+	auto direct_it = getTypesByNameMap().find(qualified_name_handle);
 	if (direct_it != getTypesByNameMap().end()) {
 		FLASH_LOG_FORMAT(Templates, Debug, "Found direct type alias '{}'", qualified_name);
 		return direct_it->second;
@@ -754,6 +773,137 @@ const std::vector<ASTNode>* Parser::lookup_inherited_template(StringHandle struc
 	return nullptr;
 }
 
+std::string_view Parser::lookup_inherited_member_template_name(
+	StringHandle struct_name,
+	StringHandle member_name,
+	int depth) {
+	constexpr int kMaxInheritanceDepth = 100;
+	if (depth > kMaxInheritanceDepth) {
+		FLASH_LOG_FORMAT(
+			Templates,
+			Warning,
+			"lookup_inherited_member_template_name: max depth exceeded for '{}::{}'",
+			StringTable::getStringView(struct_name),
+			StringTable::getStringView(member_name));
+		return {};
+	}
+
+	auto has_registered_member_template = [&](std::string_view qualified_name) {
+		TemplateNameLookupResult lookup_result = gTemplateRegistry.lookupTemplateName(
+			buildTemplateNameLookupRequest(
+				StringTable::getOrInternStringHandle(qualified_name),
+				TemplateNameLookupKind::Qualified,
+				false));
+		return lookup_result.hasAliasTemplate() || lookup_result.hasClassTemplate();
+	};
+	auto build_qualified_member_name = [&](std::string_view owner_name) {
+		return StringBuilder()
+			.append(owner_name)
+			.append("::")
+			.append(StringTable::getStringView(member_name))
+			.commit();
+	};
+	auto try_lookup_direct_member_template_name =
+		[&](StringHandle owner_handle, const TypeInfo* owner_type_info) -> std::string_view {
+		std::string_view owner_name = StringTable::getStringView(owner_handle);
+		std::string_view qualified_member_template_name =
+			build_qualified_member_name(owner_name);
+		if (has_registered_member_template(qualified_member_template_name)) {
+			return qualified_member_template_name;
+		}
+
+		if (owner_type_info != nullptr) {
+			if (auto pattern_name_opt = gTemplateRegistry.get_instantiation_pattern(owner_handle);
+				pattern_name_opt.has_value()) {
+				std::string_view pattern_member_name =
+					StringBuilder()
+						.append(*pattern_name_opt)
+						.append("::")
+						.append(StringTable::getStringView(member_name))
+						.commit();
+				if (has_registered_member_template(pattern_member_name)) {
+					return pattern_member_name;
+				}
+			}
+
+			if (owner_type_info->isTemplateInstantiation()) {
+				std::string_view primary_member_name =
+					StringBuilder()
+						.append(StringTable::getStringView(owner_type_info->baseTemplateName()))
+						.append("::")
+						.append(StringTable::getStringView(member_name))
+						.commit();
+				if (has_registered_member_template(primary_member_name)) {
+					return primary_member_name;
+				}
+			}
+		}
+
+		return {};
+	};
+
+	if (auto direct_it = getTypesByNameMap().find(struct_name);
+		direct_it != getTypesByNameMap().end() &&
+		direct_it->second != nullptr) {
+		if (std::string_view direct_name =
+				try_lookup_direct_member_template_name(struct_name, direct_it->second);
+			!direct_name.empty()) {
+			return direct_name;
+		}
+	}
+
+	auto struct_it = getTypesByNameMap().find(struct_name);
+	if (struct_it == getTypesByNameMap().end()) {
+		return {};
+	}
+
+	const TypeInfo* struct_type_info = struct_it->second;
+	if (struct_type_info == nullptr) {
+		return {};
+	}
+
+	if (!struct_type_info->struct_info_) {
+		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
+			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
+				return lookup_inherited_member_template_name(
+					underlying_type->name(),
+					member_name,
+					depth + 1);
+			}
+		}
+		return {};
+	}
+
+	const StructTypeInfo* struct_info = struct_type_info->struct_info_.get();
+	for (const auto& base_class : struct_info->base_classes) {
+		if (base_class.is_deferred) {
+			const TypeInfo* resolved = tryResolveDeferredBaseToConcreteStruct(base_class);
+			if (resolved != nullptr) {
+				if (std::string_view base_result =
+						lookup_inherited_member_template_name(
+							resolved->name(),
+							member_name,
+							depth + 1);
+					!base_result.empty()) {
+					return base_result;
+				}
+			}
+			continue;
+		}
+
+		if (std::string_view base_result =
+				lookup_inherited_member_template_name(
+					StringTable::getOrInternStringHandle(base_class.name),
+					member_name,
+					depth + 1);
+			!base_result.empty()) {
+			return base_result;
+		}
+	}
+
+	return {};
+}
+
 // Helper: After parsing template arguments for a base class specifier, consume
 // optional ::member type access and ... pack expansion in the correct order.
 // Returns std::nullopt if '::' is found but not followed by an identifier (parse error).
@@ -811,21 +961,42 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 		return findTypeByName(StringTable::getOrInternStringHandle(base_class_name));
 	}
 
-	auto hasRegisteredMemberTemplate = [&](std::string_view qualified_name) {
-		TemplateNameLookupResult lookup_result = gTemplateRegistry.lookupTemplateName(
-			buildTemplateNameLookupRequest(
-				StringTable::getOrInternStringHandle(qualified_name),
-				TemplateNameLookupKind::Qualified,
-				false));
-		return lookup_result.hasAliasTemplate() ||
-			   lookup_result.hasClassTemplate();
-	};
 	auto buildQualifiedMemberName = [](std::string_view owner_name, StringHandle member_name_handle) {
 		return StringBuilder()
 			.append(owner_name)
 			.append("::")
 			.append(StringTable::getStringView(member_name_handle))
 			.commit();
+	};
+	auto normalizeResolvedMemberOwner =
+		[&](const TypeInfo*& type_info, std::string_view& owner_name) {
+		const std::string_view resolved_name =
+			StringTable::getStringView(type_info->name());
+		std::string_view sibling_suffix = resolved_name;
+		if (size_t scope_pos = resolved_name.rfind("::");
+			scope_pos != std::string_view::npos) {
+			if (resolved_name.substr(0, scope_pos) == owner_name) {
+				owner_name = resolved_name;
+				return;
+			}
+			sibling_suffix = resolved_name.substr(scope_pos + 2);
+		}
+
+		StringHandle concrete_sibling_handle = StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append(owner_name)
+				.append("::")
+				.append(sibling_suffix)
+				.commit());
+		auto concrete_sibling_it = getTypesByNameMap().find(concrete_sibling_handle);
+		if (concrete_sibling_it != getTypesByNameMap().end() &&
+			concrete_sibling_it->second != nullptr) {
+			type_info = concrete_sibling_it->second;
+			owner_name = StringTable::getStringView(concrete_sibling_handle);
+			return;
+		}
+
+		owner_name = resolved_name;
 	};
 
 	const TypeInfo* resolved_type = nullptr;
@@ -836,41 +1007,11 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 		std::string_view member_name = StringTable::getStringView(member_access.member_name);
 		if (member_access.has_template_arguments) {
 			std::string_view qualified_member_template_name =
-				buildQualifiedMemberName(current_base_name, member_access.member_name);
-			if (!hasRegisteredMemberTemplate(qualified_member_template_name)) {
-				StringHandle current_base_handle =
-					StringTable::getOrInternStringHandle(current_base_name);
-				auto current_base_it = getTypesByNameMap().find(current_base_handle);
-				if (current_base_it != getTypesByNameMap().end() && current_base_it->second != nullptr) {
-					if (auto pattern_name_opt = gTemplateRegistry.get_instantiation_pattern(current_base_handle);
-						pattern_name_opt.has_value()) {
-						std::string_view pattern_member_name =
-							StringBuilder()
-								.append(*pattern_name_opt)
-								.append("::")
-								.append(member_name)
-								.commit();
-						if (hasRegisteredMemberTemplate(pattern_member_name)) {
-							qualified_member_template_name = pattern_member_name;
-						}
-					}
-
-					if (!hasRegisteredMemberTemplate(qualified_member_template_name) &&
-						current_base_it->second->isTemplateInstantiation()) {
-						std::string_view primary_member_name =
-							StringBuilder()
-								.append(StringTable::getStringView(current_base_it->second->baseTemplateName()))
-								.append("::")
-								.append(member_name)
-								.commit();
-						if (hasRegisteredMemberTemplate(primary_member_name)) {
-							qualified_member_template_name = primary_member_name;
-						}
-					}
-				}
-			}
-
-			if (!hasRegisteredMemberTemplate(qualified_member_template_name)) {
+				lookup_inherited_member_template_name(
+					StringTable::getOrInternStringHandle(current_base_name),
+					member_access.member_name,
+					0);
+			if (qualified_member_template_name.empty()) {
 				return nullptr;
 			}
 
@@ -890,7 +1031,7 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 			if (resolved_type == nullptr) {
 				return nullptr;
 			}
-			current_base_name = StringTable::getStringView(resolved_type->name());
+			normalizeResolvedMemberOwner(resolved_type, current_base_name);
 			continue;
 		}
 
@@ -930,33 +1071,7 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 			}
 		}
 
-		const std::string_view resolved_name =
-			StringTable::getStringView(resolved_type->name());
-		std::string_view sibling_suffix = resolved_name;
-		if (size_t scope_pos = resolved_name.rfind("::");
-			scope_pos != std::string_view::npos) {
-			if (resolved_name.substr(0, scope_pos) == current_base_name) {
-				current_base_name = resolved_name;
-				continue;
-			}
-			sibling_suffix = resolved_name.substr(scope_pos + 2);
-		}
-
-		StringHandle concrete_sibling_handle = StringTable::getOrInternStringHandle(
-			StringBuilder()
-				.append(current_base_name)
-				.append("::")
-				.append(sibling_suffix)
-				.commit());
-		auto concrete_sibling_it = getTypesByNameMap().find(concrete_sibling_handle);
-		if (concrete_sibling_it != getTypesByNameMap().end() &&
-			concrete_sibling_it->second != nullptr) {
-			resolved_type = concrete_sibling_it->second;
-			current_base_name = StringTable::getStringView(concrete_sibling_handle);
-			continue;
-		}
-
-		current_base_name = StringTable::getStringView(resolved_type->name());
+		normalizeResolvedMemberOwner(resolved_type, current_base_name);
 	}
 
 	return resolved_type;

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -556,15 +556,25 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 		if (std::optional<TypeIndex> lazy_alias_type =
 				evaluateLazyTypeAlias(struct_name, member_name);
 			lazy_alias_type.has_value()) {
-			auto direct_register_it = getTypesByNameMap().find(qualified_name_handle);
-			if (direct_register_it == getTypesByNameMap().end()) {
-				uint32_t size_bits = 0;
-				if (const TypeInfo* lazy_type_info = tryGetTypeInfo(*lazy_alias_type)) {
-					SizeInBits lazy_size_bits = lazy_type_info->sizeInBits();
-					if (lazy_size_bits.is_set()) {
-						size_bits = lazy_size_bits.value;
-					}
+			uint32_t size_bits = 0;
+			const TypeInfo* lazy_type_info = tryGetTypeInfo(*lazy_alias_type);
+			if (lazy_type_info != nullptr) {
+				SizeInBits lazy_size_bits = lazy_type_info->sizeInBits();
+				if (lazy_size_bits.is_set()) {
+					size_bits = lazy_size_bits.value;
 				}
+			}
+
+			auto direct_register_it = getTypesByNameMap().find(qualified_name_handle);
+			if (direct_register_it != getTypesByNameMap().end() &&
+				direct_register_it->second != nullptr) {
+				update_type_alias_copy(
+					*direct_register_it->second,
+					*lazy_alias_type,
+					size_bits,
+					nullptr,
+					lazy_type_info);
+			} else {
 				add_type_alias_copy(qualified_name_handle, *lazy_alias_type, size_bits);
 			}
 		}
@@ -821,12 +831,11 @@ std::string_view Parser::lookup_direct_member_template_name(
 	}
 
 	if (owner_type_info->isTemplateInstantiation()) {
-		StringHandle primary_member_name = StringTable::getOrInternStringHandle(
-			StringBuilder()
-				.append(StringTable::getStringView(owner_type_info->baseTemplateName()))
-				.append("::")
-				.append(StringTable::getStringView(member_name))
-				.commit());
+		StringHandle primary_owner_name = gNamespaceRegistry.buildQualifiedIdentifier(
+			owner_type_info->sourceNamespace(),
+			owner_type_info->baseTemplateName());
+		StringHandle primary_member_name =
+			buildQualifiedMemberNameHandle(primary_owner_name, member_name);
 		if (has_registered_member_template(primary_member_name)) {
 			return StringTable::getStringView(primary_member_name);
 		}
@@ -850,9 +859,9 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		return {};
 	}
 
-	if (auto direct_it = getTypesByNameMap().find(struct_name);
-		direct_it != getTypesByNameMap().end() &&
-		direct_it->second != nullptr) {
+	auto struct_it = getTypesByNameMap().find(struct_name);
+	if (struct_it != getTypesByNameMap().end() &&
+		struct_it->second != nullptr) {
 		if (std::string_view direct_name =
 				lookup_direct_member_template_name(struct_name, member_name);
 			!direct_name.empty()) {
@@ -860,7 +869,6 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		}
 	}
 
-	auto struct_it = getTypesByNameMap().find(struct_name);
 	if (struct_it == getTypesByNameMap().end()) {
 		return {};
 	}
@@ -871,6 +879,50 @@ std::string_view Parser::lookup_inherited_member_template_name(
 	}
 
 	if (!struct_type_info->struct_info_) {
+		if (struct_type_info->isTemplateInstantiation()) {
+			StringHandle alias_template_name = gNamespaceRegistry.buildQualifiedIdentifier(
+				struct_type_info->sourceNamespace(),
+				struct_type_info->baseTemplateName());
+			TemplateNameLookupResult alias_template_lookup = gTemplateRegistry.lookupTemplateName(
+				buildTemplateNameLookupRequest(
+					alias_template_name,
+					TemplateNameLookupKind::Qualified,
+					false));
+			if (!alias_template_lookup.hasAliasTemplate()) {
+				alias_template_lookup = gTemplateRegistry.lookupTemplateName(
+					buildTemplateNameLookupRequest(
+						struct_type_info->baseTemplateName(),
+						TemplateNameLookupKind::Ordinary,
+						false));
+			}
+			std::optional<ASTNode> alias_template_entry =
+				alias_template_lookup.firstDeclarationOfKind(TemplateDeclarationKind::AliasTemplate);
+			if (alias_template_entry.has_value() && alias_template_entry->is<TemplateAliasNode>()) {
+				std::vector<TemplateTypeArg> concrete_args;
+				concrete_args.reserve(struct_type_info->templateArgs().size());
+				for (const auto& arg_info : struct_type_info->templateArgs()) {
+					TemplateTypeArg concrete_arg = toTemplateTypeArg(arg_info);
+					concrete_arg.setCategory(arg_info.category());
+					concrete_args.push_back(concrete_arg);
+				}
+
+				if (std::optional<TemplateTypeArg> rebound_arg =
+						tryRebindAliasTargetTemplateArg(
+							alias_template_entry->as<TemplateAliasNode>(),
+							concrete_args);
+					rebound_arg.has_value() &&
+					!rebound_arg->is_value &&
+					rebound_arg->type_index.is_valid()) {
+					if (const TypeInfo* rebound_type = tryGetTypeInfo(rebound_arg->type_index)) {
+						return lookup_inherited_member_template_name(
+							rebound_type->name(),
+							member_name,
+							depth + 1);
+					}
+				}
+			}
+		}
+
 		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
 			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
 				return lookup_inherited_member_template_name(

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -773,6 +773,68 @@ const std::vector<ASTNode>* Parser::lookup_inherited_template(StringHandle struc
 	return nullptr;
 }
 
+StringHandle Parser::buildQualifiedMemberNameHandle(StringHandle owner_name, StringHandle member_name) const {
+	return StringTable::getOrInternStringHandle(
+		StringBuilder()
+			.append(StringTable::getStringView(owner_name))
+			.append("::")
+			.append(StringTable::getStringView(member_name))
+			.commit());
+}
+
+std::string_view Parser::lookup_direct_member_template_name(
+	StringHandle owner_name,
+	StringHandle member_name) const {
+	auto has_registered_member_template = [&](StringHandle qualified_name) {
+		TemplateNameLookupResult lookup_result = gTemplateRegistry.lookupTemplateName(
+			buildTemplateNameLookupRequest(
+				qualified_name,
+				TemplateNameLookupKind::Qualified,
+				false));
+		return lookup_result.hasAliasTemplate() || lookup_result.hasClassTemplate();
+	};
+
+	StringHandle qualified_member_template_name =
+		buildQualifiedMemberNameHandle(owner_name, member_name);
+	if (has_registered_member_template(qualified_member_template_name)) {
+		return StringTable::getStringView(qualified_member_template_name);
+	}
+
+	auto owner_it = getTypesByNameMap().find(owner_name);
+	const TypeInfo* owner_type_info =
+		owner_it != getTypesByNameMap().end() ? owner_it->second : nullptr;
+	if (owner_type_info == nullptr) {
+		return {};
+	}
+
+	if (auto pattern_name_opt = gTemplateRegistry.get_instantiation_pattern(owner_name);
+		pattern_name_opt.has_value()) {
+		StringHandle pattern_member_name = StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append(*pattern_name_opt)
+				.append("::")
+				.append(StringTable::getStringView(member_name))
+				.commit());
+		if (has_registered_member_template(pattern_member_name)) {
+			return StringTable::getStringView(pattern_member_name);
+		}
+	}
+
+	if (owner_type_info->isTemplateInstantiation()) {
+		StringHandle primary_member_name = StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append(StringTable::getStringView(owner_type_info->baseTemplateName()))
+				.append("::")
+				.append(StringTable::getStringView(member_name))
+				.commit());
+		if (has_registered_member_template(primary_member_name)) {
+			return StringTable::getStringView(primary_member_name);
+		}
+	}
+
+	return {};
+}
+
 std::string_view Parser::lookup_inherited_member_template_name(
 	StringHandle struct_name,
 	StringHandle member_name,
@@ -788,65 +850,11 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		return {};
 	}
 
-	auto has_registered_member_template = [&](std::string_view qualified_name) {
-		TemplateNameLookupResult lookup_result = gTemplateRegistry.lookupTemplateName(
-			buildTemplateNameLookupRequest(
-				StringTable::getOrInternStringHandle(qualified_name),
-				TemplateNameLookupKind::Qualified,
-				false));
-		return lookup_result.hasAliasTemplate() || lookup_result.hasClassTemplate();
-	};
-	auto build_qualified_member_name = [&](std::string_view owner_name) {
-		return StringBuilder()
-			.append(owner_name)
-			.append("::")
-			.append(StringTable::getStringView(member_name))
-			.commit();
-	};
-	auto try_lookup_direct_member_template_name =
-		[&](StringHandle owner_handle, const TypeInfo* owner_type_info) -> std::string_view {
-		std::string_view owner_name = StringTable::getStringView(owner_handle);
-		std::string_view qualified_member_template_name =
-			build_qualified_member_name(owner_name);
-		if (has_registered_member_template(qualified_member_template_name)) {
-			return qualified_member_template_name;
-		}
-
-		if (owner_type_info != nullptr) {
-			if (auto pattern_name_opt = gTemplateRegistry.get_instantiation_pattern(owner_handle);
-				pattern_name_opt.has_value()) {
-				std::string_view pattern_member_name =
-					StringBuilder()
-						.append(*pattern_name_opt)
-						.append("::")
-						.append(StringTable::getStringView(member_name))
-						.commit();
-				if (has_registered_member_template(pattern_member_name)) {
-					return pattern_member_name;
-				}
-			}
-
-			if (owner_type_info->isTemplateInstantiation()) {
-				std::string_view primary_member_name =
-					StringBuilder()
-						.append(StringTable::getStringView(owner_type_info->baseTemplateName()))
-						.append("::")
-						.append(StringTable::getStringView(member_name))
-						.commit();
-				if (has_registered_member_template(primary_member_name)) {
-					return primary_member_name;
-				}
-			}
-		}
-
-		return {};
-	};
-
 	if (auto direct_it = getTypesByNameMap().find(struct_name);
 		direct_it != getTypesByNameMap().end() &&
 		direct_it->second != nullptr) {
 		if (std::string_view direct_name =
-				try_lookup_direct_member_template_name(struct_name, direct_it->second);
+				lookup_direct_member_template_name(struct_name, member_name);
 			!direct_name.empty()) {
 			return direct_name;
 		}
@@ -961,13 +969,6 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 		return findTypeByName(StringTable::getOrInternStringHandle(base_class_name));
 	}
 
-	auto buildQualifiedMemberName = [](std::string_view owner_name, StringHandle member_name_handle) {
-		return StringBuilder()
-			.append(owner_name)
-			.append("::")
-			.append(StringTable::getStringView(member_name_handle))
-			.commit();
-	};
 	auto normalizeResolvedMemberOwner =
 		[&](const TypeInfo*& type_info, std::string_view& owner_name) {
 		const std::string_view resolved_name =
@@ -1036,7 +1037,10 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 		}
 
 		StringHandle qualified_member_handle = StringTable::getOrInternStringHandle(
-			buildQualifiedMemberName(current_base_name, member_access.member_name));
+			StringTable::getStringView(
+				buildQualifiedMemberNameHandle(
+					StringTable::getOrInternStringHandle(current_base_name),
+					member_access.member_name)));
 
 		auto alias_it = getTypesByNameMap().find(qualified_member_handle);
 		resolved_type = alias_it != getTypesByNameMap().end() ? alias_it->second : nullptr;

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1020,7 +1020,8 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 				materializeTemplateInstantiationForLookup(
 					qualified_member_template_name,
 					*member_access.template_arguments);
-			if (materialized_member.instantiated_name.empty()) {
+			if (materialized_member.resolved_type_info == nullptr &&
+				materialized_member.instantiated_name.empty()) {
 				return nullptr;
 			}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1739,19 +1739,19 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					auto existing_it = getTypesByNameMap().find(alias_instantiated_handle);
 					if (existing_it != getTypesByNameMap().end() && existing_it->second != nullptr) {
 						alias_info = existing_it->second;
-						const uint32_t alias_slot = alias_info->registeredTypeIndex().index();
-						alias_info->type_index_ = resolved_registered_index;
-						alias_info->registered_type_index_ = TypeIndex{alias_slot, TypeCategory::TypeAlias};
-						alias_info->fallback_size_bits_ = resolved_info->sizeInBits().value;
-						alias_info->is_type_alias_ = true;
-						alias_info->clearAliasTypeSpecifier();
-						alias_info->setAliasTypeSpecifier(alias_type_spec);
+						update_type_alias_copy(
+							*alias_info,
+							resolved_registered_index,
+							resolved_info->sizeInBits().value,
+							&alias_type_spec,
+							resolved_info);
 					} else {
 						alias_info = &add_type_alias_copy(
 							alias_instantiated_handle,
 							resolved_registered_index,
 							resolved_info->sizeInBits().value,
-							alias_type_spec);
+							alias_type_spec,
+							*resolved_info);
 					}
 
 					if (alias_info != nullptr) {
@@ -2468,6 +2468,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									 const auto& args) -> std::optional<TypeSpecifierNode> {
 		if (!type_alias.type_node.is<TypeSpecifierNode>()) {
 			return std::nullopt;
+		}
+
+		if (const TypeInfo* substituted_type_info = tryGetTypeInfo(substituted_type_index);
+			substituted_type_info != nullptr &&
+			substituted_type_info->isDependentMemberType() &&
+			substituted_type_info->hasDependentQualifiedName()) {
+			if (const TypeInfo* resolved_dependent_type =
+					resolveDependentMemberTypeSemantic(
+						*substituted_type_info,
+						params,
+						args,
+						StringHandle{});
+				resolved_dependent_type != nullptr) {
+				substituted_type_index = resolved_dependent_type->registeredTypeIndex();
+				substituted_type = resolved_dependent_type->typeEnum();
+			}
 		}
 
 		ResolvedAliasTypeInfo resolved_alias_target = resolveAliasTypeInfo(substituted_type_index);
@@ -4752,6 +4768,47 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substitution_done:;
 				}
 
+				const TypeInfo* alias_semantic_source =
+					tryGetTypeInfo(TypeIndex{substituted_type_index});
+				std::optional<TypeSpecifierNode> resolved_alias_type_spec_override;
+				{
+					ASTNode resolved_alias_type_node =
+						emplace_node<TypeSpecifierNode>(alias_type_spec);
+					if (resolveDependentMemberAlias(
+							resolved_alias_type_node,
+							template_params,
+							template_args_for_pattern) == DependentAliasResolutionStatus::Resolved) {
+						const TypeSpecifierNode& resolved_alias_type_spec =
+							resolved_alias_type_node.as<TypeSpecifierNode>();
+						substituted_type = resolved_alias_type_spec.type();
+						substituted_type_index = resolved_alias_type_spec.type_index();
+						substituted_size = resolved_alias_type_spec.size_in_bits();
+						alias_semantic_source =
+							tryGetTypeInfo(resolved_alias_type_spec.type_index());
+						resolved_alias_type_spec_override = resolved_alias_type_spec;
+					}
+				}
+				if (const TypeInfo* dependent_alias_target_info =
+						tryGetTypeInfo(TypeIndex{substituted_type_index});
+					dependent_alias_target_info != nullptr &&
+					dependent_alias_target_info->isDependentMemberType() &&
+					dependent_alias_target_info->hasDependentQualifiedName()) {
+					if (const TypeInfo* resolved_dependent_type =
+							resolveDependentMemberTypeSemantic(
+								*dependent_alias_target_info,
+								template_params,
+								template_args_for_pattern,
+								instantiated_name);
+						resolved_dependent_type != nullptr) {
+						substituted_type = resolved_dependent_type->typeEnum();
+						substituted_type_index =
+							resolved_dependent_type->registeredTypeIndex().withCategory(
+								resolved_dependent_type->typeEnum());
+						substituted_size = resolved_dependent_type->sizeInBits().value;
+						alias_semantic_source = resolved_dependent_type;
+					}
+				}
+
 				if (const TypeInfo* concrete_member_info =
 						materializeInstantiatedMemberAliasTarget(
 							alias_type_spec,
@@ -4763,9 +4820,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						concrete_member_info->registeredTypeIndex().withCategory(
 							concrete_member_info->typeEnum());
 					substituted_size = concrete_member_info->sizeInBits().value;
+					alias_semantic_source = concrete_member_info;
 				}
 
-				if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_type_spec.type_index());
+				if (const TypeInfo* alias_target_info = tryGetTypeInfo(TypeIndex{substituted_type_index});
 					alias_target_info != nullptr && alias_target_info->isTemplateInstantiation()) {
 					std::vector<TemplateTypeArg> concrete_alias_args;
 					concrete_alias_args.reserve(alias_target_info->templateArgs().size());
@@ -4812,6 +4870,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									concrete_alias_target->registeredTypeIndex().withCategory(
 										concrete_alias_target->typeEnum());
 								substituted_size = concrete_alias_target->sizeInBits().value;
+								alias_semantic_source = concrete_alias_target;
 							}
 						}
 					}
@@ -4820,14 +4879,25 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern);
-				const TypeSpecifierNode& alias_registration_type_spec = substituted_alias_type_spec.has_value()
-																		   ? substituted_alias_type_spec.value()
-																		   : alias_type_spec;
-				auto& alias_type_info = add_type_alias_copy(
-					qualified_alias_name,
-					TypeIndex{substituted_type_index},
-					substituted_size,
-					alias_registration_type_spec);
+				const TypeSpecifierNode& alias_registration_type_spec =
+					resolved_alias_type_spec_override.has_value()
+						? resolved_alias_type_spec_override.value()
+						: (substituted_alias_type_spec.has_value()
+							   ? substituted_alias_type_spec.value()
+							   : alias_type_spec);
+				auto& alias_type_info =
+					alias_semantic_source != nullptr
+						? add_type_alias_copy(
+							  qualified_alias_name,
+							  TypeIndex{substituted_type_index},
+							  substituted_size,
+							  alias_registration_type_spec,
+							  *alias_semantic_source)
+						: add_type_alias_copy(
+							  qualified_alias_name,
+							  TypeIndex{substituted_type_index},
+							  substituted_size,
+							  alias_registration_type_spec);
 				if (alias_registration_type_spec.is_array()) {
 					std::span<const size_t> alias_array_dimensions = alias_registration_type_spec.array_dimensions();
 					size_t element_size = calculateResolvedMemberSizeAndAlignment(alias_registration_type_spec, substituted_type_index).size;
@@ -8285,6 +8355,47 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 		}
 
+		const TypeInfo* alias_semantic_source =
+			tryGetTypeInfo(TypeIndex{substituted_type_index});
+		std::optional<TypeSpecifierNode> resolved_alias_type_spec_override;
+		{
+			ASTNode resolved_alias_type_node =
+				emplace_node<TypeSpecifierNode>(alias_type_spec);
+			if (resolveDependentMemberAlias(
+					resolved_alias_type_node,
+					template_params,
+					template_args_to_use) == DependentAliasResolutionStatus::Resolved) {
+				const TypeSpecifierNode& resolved_alias_type_spec =
+					resolved_alias_type_node.as<TypeSpecifierNode>();
+				substituted_type = resolved_alias_type_spec.type();
+				substituted_type_index = resolved_alias_type_spec.type_index();
+				substituted_size = resolved_alias_type_spec.size_in_bits();
+				alias_semantic_source =
+					tryGetTypeInfo(resolved_alias_type_spec.type_index());
+				resolved_alias_type_spec_override = resolved_alias_type_spec;
+			}
+		}
+		if (const TypeInfo* dependent_alias_target_info =
+				tryGetTypeInfo(TypeIndex{substituted_type_index});
+			dependent_alias_target_info != nullptr &&
+			dependent_alias_target_info->isDependentMemberType() &&
+			dependent_alias_target_info->hasDependentQualifiedName()) {
+			if (const TypeInfo* resolved_dependent_type =
+					resolveDependentMemberTypeSemantic(
+						*dependent_alias_target_info,
+						template_params,
+						template_args_to_use,
+						instantiated_name);
+				resolved_dependent_type != nullptr) {
+				substituted_type = resolved_dependent_type->typeEnum();
+				substituted_type_index =
+					resolved_dependent_type->registeredTypeIndex().withCategory(
+						resolved_dependent_type->typeEnum());
+				substituted_size = resolved_dependent_type->sizeInBits().value;
+				alias_semantic_source = resolved_dependent_type;
+			}
+		}
+
 		if (const TypeInfo* concrete_member_info =
 				materializeInstantiatedMemberAliasTarget(
 					alias_type_spec,
@@ -8296,6 +8407,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				concrete_member_info->registeredTypeIndex().withCategory(
 					concrete_member_info->typeEnum());
 			substituted_size = concrete_member_info->sizeInBits().value;
+			alias_semantic_source = concrete_member_info;
 		}
 
 		// Ensure size is computed for primitive type aliases that were substituted from template parameters.
@@ -8314,14 +8426,25 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Register the type alias in getTypesByNameMap()
 		std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 			type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_to_use);
-		const TypeSpecifierNode& alias_registration_type_spec = substituted_alias_type_spec.has_value()
-																   ? substituted_alias_type_spec.value()
-																   : alias_type_spec;
-		auto& alias_type_info = add_type_alias_copy(
-			qualified_alias_name,
-			TypeIndex{substituted_type_index},
-			substituted_size,
-			alias_registration_type_spec);
+		const TypeSpecifierNode& alias_registration_type_spec =
+			resolved_alias_type_spec_override.has_value()
+				? resolved_alias_type_spec_override.value()
+				: (substituted_alias_type_spec.has_value()
+					   ? substituted_alias_type_spec.value()
+					   : alias_type_spec);
+		auto& alias_type_info =
+			alias_semantic_source != nullptr
+				? add_type_alias_copy(
+					  qualified_alias_name,
+					  TypeIndex{substituted_type_index},
+					  substituted_size,
+					  alias_registration_type_spec,
+					  *alias_semantic_source)
+				: add_type_alias_copy(
+					  qualified_alias_name,
+					  TypeIndex{substituted_type_index},
+					  substituted_size,
+					  alias_registration_type_spec);
 		if (alias_registration_type_spec.is_array()) {
 			std::span<const size_t> alias_array_dimensions = alias_registration_type_spec.array_dimensions();
 			size_t element_size = calculateResolvedMemberSizeAndAlignment(alias_registration_type_spec, substituted_type_index).size;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2465,7 +2465,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									 TypeIndex substituted_type_index,
 									 TypeCategory substituted_type,
 									 const auto& params,
-									 const auto& args) -> std::optional<TypeSpecifierNode> {
+									 const auto& args,
+									 StringHandle current_owner_type_name) -> std::optional<TypeSpecifierNode> {
 		if (!type_alias.type_node.is<TypeSpecifierNode>()) {
 			return std::nullopt;
 		}
@@ -2479,7 +2480,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						*substituted_type_info,
 						params,
 						args,
-						StringHandle{});
+						current_owner_type_name);
 				resolved_dependent_type != nullptr) {
 				substituted_type_index = resolved_dependent_type->registeredTypeIndex();
 				substituted_type = resolved_dependent_type->typeEnum();
@@ -4878,7 +4879,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
-					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern);
+					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern, instantiated_name);
 				const TypeSpecifierNode& alias_registration_type_spec =
 					resolved_alias_type_spec_override.has_value()
 						? resolved_alias_type_spec_override.value()
@@ -8425,7 +8426,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		// Register the type alias in getTypesByNameMap()
 		std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
-			type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_to_use);
+			type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_to_use, instantiated_name);
 		const TypeSpecifierNode& alias_registration_type_spec =
 			resolved_alias_type_spec_override.has_value()
 				? resolved_alias_type_spec_override.value()

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -1,6 +1,7 @@
 #include "Parser.h"
 #include "AstTraversal.h"
 #include "ConstExprEvaluator.h"
+#include "ExpressionSubstitutor.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
 #include "ParserTemplateClassShared.h"
@@ -257,6 +258,19 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 		return DependentAliasResolutionStatus::Resolved;
 	};
 
+	if (type_info->isDependentMemberType() &&
+		type_info->hasDependentQualifiedName()) {
+		if (const TypeInfo* resolved_dependent_type =
+				resolveDependentMemberTypeSemantic(
+					*type_info,
+					template_params,
+					template_args,
+					StringHandle{});
+			resolved_dependent_type != nullptr) {
+			return emplaceResolvedSpec(resolved_dependent_type);
+		}
+	}
+
 	if (const StructTypeInfo* owner_struct = type_info->getStructInfo();
 		owner_struct && type_name.find("::") == std::string_view::npos) {
 		std::string_view token_name = ts.token().value();
@@ -454,11 +468,29 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 		}
 		return DependentAliasResolutionStatus::StillDependent;
 	}
-
 	auto status = emplaceResolvedSpec(type_it->second);
 	FLASH_LOG(Templates, Debug, "Resolved dependent alias '", type_name, "' to type=", static_cast<int>(type_it->second->typeEnum()),
 			  ", index=", type_it->second->type_index_);
 	return status;
+}
+
+const TypeInfo* Parser::resolveDependentMemberTypeSemantic(
+	const TypeInfo& dependent_type_info,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	StringHandle current_owner_type_name) {
+	if (!dependent_type_info.isDependentMemberType() ||
+		!dependent_type_info.hasDependentQualifiedName()) {
+		return nullptr;
+	}
+
+	SubstitutionParamMap sub_map =
+		buildSubstitutionParamMap(template_params, template_args);
+	ExpressionSubstitutor substitutor(sub_map.param_map, *this, sub_map.param_order);
+	if (current_owner_type_name.isValid()) {
+		substitutor.setCurrentOwnerTypeName(current_owner_type_name);
+	}
+	return substitutor.resolveDependentMemberTypeForSubstitution(dependent_type_info);
 }
 
 static bool hasUsableTemplateFunctionDefinition(const FunctionDeclarationNode& func_decl) {
@@ -2786,6 +2818,17 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 	} else {
 		const TypeSpecifierNode& orig_return_type = orig_decl.type_specifier_node();
 		bool should_reparse = func_decl.has_template_declaration_position();
+		if (!should_reparse) {
+			if (gTemplateRegistry.lookup_alias_template(orig_return_type.token().handle()).has_value()) {
+				should_reparse = true;
+			} else if (const TypeInfo* orig_return_type_info =
+						   tryGetTypeInfo(orig_return_type.type_index());
+					   orig_return_type_info != nullptr &&
+					   (orig_return_type_info->isDependentMemberType() ||
+						orig_return_type_info->isTemplateInstantiation())) {
+				should_reparse = true;
+			}
+		}
 		if (should_reparse) {
 			static thread_local std::unordered_set<std::string_view> trailing_return_in_progress;
 			if (trailing_return_in_progress.count(mangled_name)) {
@@ -2881,6 +2924,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 	resolveDependentMemberAlias(return_type, template_params, template_args);
 	if (return_type.is<TypeSpecifierNode>()) {
 		auto& rt = return_type.as<TypeSpecifierNode>();
+		resolveAliasTemplateInstantiation(rt);
 		apply_resolved_alias_metadata_local(rt);
 		if ((rt.category() == TypeCategory::UserDefined ||
 			 rt.category() == TypeCategory::TypeAlias ||

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1152,6 +1152,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 	auto resolve_builtin_type_info_by_name = [](std::string_view builtin_name) -> const TypeInfo* {
 		constexpr TypeCategory builtin_categories[] = {
 			TypeCategory::Void,
+			TypeCategory::Nullptr,
 			TypeCategory::Bool,
 			TypeCategory::Char,
 			TypeCategory::UnsignedChar,
@@ -1657,7 +1658,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			StringBuilder()
 				.append(materialized_alias_base_name)
 				.append("::")
-				.append(dependent_member_name)
+				.append(dependent_member_path)
 				.commit());
 	auto concrete_member_it = getTypesByNameMap().find(concrete_member_handle);
 	if (concrete_member_it != getTypesByNameMap().end() &&

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -714,6 +714,14 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		alias_entry.has_value() && alias_entry->is<TemplateAliasNode>()) {
 		alias_node = &alias_entry->as<TemplateAliasNode>();
 	}
+	auto alias_preserves_surface_type = [](const ResolvedAliasTypeInfo& resolved_alias) {
+		return resolved_alias.cv_qualifier != CVQualifier::None ||
+			   resolved_alias.pointer_depth != 0 ||
+			   resolved_alias.reference_qualifier != ReferenceQualifier::None ||
+			   resolved_alias.function_signature.has_value() ||
+			   resolved_alias.member_class_name.has_value() ||
+			   !resolved_alias.array_dimensions.empty();
+	};
 	auto tryResolveDirectAliasTarget = [&]() -> bool {
 		if (alias_node == nullptr) {
 			return false;
@@ -729,19 +737,128 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			if (builtin_type_name.empty()) {
 				return false;
 			}
-			result.resolved_type_info = nullptr;
+			TypeIndex native_type_index = nativeTypeIndex(rebound_arg->category());
+			if (native_type_index.is_valid()) {
+				result.resolved_type_info = tryGetTypeInfo(
+					native_type_index.withCategory(rebound_arg->category()));
+			}
+			if (result.resolved_type_info == nullptr) {
+				result.resolved_type_info = findTypeByName(
+					StringTable::getOrInternStringHandle(builtin_type_name));
+			}
 			result.instantiated_name = builtin_type_name;
 			return true;
 		}
 		ResolvedAliasTypeInfo resolved_rebound_alias = resolveAliasTypeInfo(
 			rebound_type_info->registeredTypeIndex().withCategory(
 				rebound_type_info->typeEnum()));
-		if (resolved_rebound_alias.terminal_type_info != nullptr) {
+		if (resolved_rebound_alias.terminal_type_info != nullptr &&
+			!alias_preserves_surface_type(resolved_rebound_alias)) {
 			rebound_type_info = resolved_rebound_alias.terminal_type_info;
 		}
 		result.resolved_type_info = rebound_type_info;
 		result.instantiated_name = StringTable::getStringView(rebound_type_info->name());
 		return true;
+	};
+	auto materializeTemplateArgsForLookup =
+		[&](const TypeInfo& source_type_info) -> std::vector<TemplateTypeArg> {
+		std::vector<TemplateTypeArg> concrete_args =
+			materializeTemplateArgs(
+				source_type_info,
+				alias_node->template_parameters(),
+				template_args);
+		auto recursively_materialize_type_arg =
+			[&](auto&& self,
+				TemplateTypeArg concrete_arg,
+				int depth) -> TemplateTypeArg {
+			constexpr int kMaxRecursiveTemplateArgDepth = 8;
+			if (depth >= kMaxRecursiveTemplateArgDepth ||
+				concrete_arg.is_value ||
+				!concrete_arg.type_index.is_valid()) {
+				return concrete_arg;
+			}
+
+			const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+			if (concrete_type_info == nullptr) {
+				return concrete_arg;
+			}
+
+			ResolvedAliasTypeInfo resolved_arg_alias = resolveAliasTypeInfo(
+				concrete_arg.type_index.withCategory(concrete_type_info->typeEnum()));
+			if (resolved_arg_alias.terminal_type_info != nullptr &&
+				resolved_arg_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
+				concrete_type_info = resolved_arg_alias.terminal_type_info;
+				concrete_arg.type_index =
+					concrete_type_info->registeredTypeIndex().withCategory(
+						concrete_type_info->typeEnum());
+				concrete_arg.setCategory(concrete_type_info->typeEnum());
+			}
+
+			if (!concrete_type_info->isTemplateInstantiation()) {
+				return concrete_arg;
+			}
+
+			std::string_view nested_base_template_name =
+				StringTable::getStringView(concrete_type_info->baseTemplateName());
+			if (nested_base_template_name.empty()) {
+				return concrete_arg;
+			}
+
+			std::vector<TemplateTypeArg> nested_concrete_args =
+				materializeTemplateArgs(
+					*concrete_type_info,
+					alias_node->template_parameters(),
+					template_args);
+			for (TemplateTypeArg& nested_arg : nested_concrete_args) {
+				nested_arg = self(self, std::move(nested_arg), depth + 1);
+			}
+			bool nested_args_still_dependent = false;
+			for (const TemplateTypeArg& nested_arg : nested_concrete_args) {
+				if (nested_arg.is_dependent ||
+					nested_arg.dependent_name.isValid() ||
+					nested_arg.dependent_expr.has_value()) {
+					nested_args_still_dependent = true;
+					break;
+				}
+			}
+			if (nested_args_still_dependent) {
+				return concrete_arg;
+			}
+
+			AliasTemplateMaterializationResult materialized_nested =
+				materializeTemplateInstantiationForLookup(
+					nested_base_template_name,
+					nested_concrete_args);
+			const TypeInfo* resolved_nested_info =
+				materialized_nested.resolved_type_info;
+			if (resolved_nested_info == nullptr) {
+				StringHandle nested_name_handle =
+					materialized_nested.canonicalNameHandle();
+				if (nested_name_handle.isValid()) {
+					resolved_nested_info = findTypeByName(nested_name_handle);
+				}
+			}
+			if (resolved_nested_info == nullptr) {
+				return concrete_arg;
+			}
+
+			concrete_arg.type_index =
+				resolved_nested_info->registeredTypeIndex().withCategory(
+					resolved_nested_info->typeEnum());
+			concrete_arg.setCategory(resolved_nested_info->typeEnum());
+			concrete_arg.is_dependent = false;
+			concrete_arg.dependent_name = {};
+			concrete_arg.dependent_expr = std::nullopt;
+			return concrete_arg;
+		};
+		for (TemplateTypeArg& concrete_arg : concrete_args) {
+			concrete_arg =
+				recursively_materialize_type_arg(
+					recursively_materialize_type_arg,
+					std::move(concrete_arg),
+					0);
+		}
+		return concrete_args;
 	};
 	auto tryMaterializeTemplateAliasTarget = [&]() -> bool {
 		if (alias_node == nullptr) {
@@ -755,10 +872,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		}
 
 		std::vector<TemplateTypeArg> concrete_target_args =
-			materializeTemplateArgs(
-				*target_type_info,
-				alias_node->template_parameters(),
-				template_args);
+			materializeTemplateArgsForLookup(*target_type_info);
 		StringHandle qualified_target_template_name =
 			gNamespaceRegistry.buildQualifiedIdentifier(
 				target_type_info->sourceNamespace(),
@@ -833,10 +947,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target_type.type_index());
 			alias_target_info != nullptr && alias_target_info->isTemplateInstantiation()) {
 			std::vector<TemplateTypeArg> concrete_target_args =
-				materializeTemplateArgs(
-					*alias_target_info,
-					alias_node->template_parameters(),
-					template_args);
+				materializeTemplateArgsForLookup(*alias_target_info);
 			StringHandle qualified_target_template_name =
 				gNamespaceRegistry.buildQualifiedIdentifier(
 					alias_target_info->sourceNamespace(),
@@ -949,7 +1060,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(
 				concrete_member_alias->registeredTypeIndex().withCategory(
 					concrete_member_alias->typeEnum()));
-			if (resolved_member_alias.terminal_type_info != nullptr) {
+			if (resolved_member_alias.terminal_type_info != nullptr &&
+				!alias_preserves_surface_type(resolved_member_alias)) {
 				resolved_member_info = resolved_member_alias.terminal_type_info;
 			}
 			result.resolved_type_info = resolved_member_info;
@@ -990,18 +1102,12 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			if (existing_alias_it != getTypesByNameMap().end() &&
 				existing_alias_it->second != nullptr) {
 				alias_type_info = existing_alias_it->second;
-				const uint32_t aliasIndex = alias_type_info->registeredTypeIndex().index();
-				alias_type_info->type_index_ = alias_target_index;
-				alias_type_info->registered_type_index_ =
-					TypeIndex{aliasIndex, TypeCategory::TypeAlias};
-				alias_type_info->fallback_size_bits_ = resolved_type_info.sizeInBits().value;
-				alias_type_info->is_type_alias_ = true;
-				alias_type_info->is_incomplete_instantiation_ = false;
-				alias_type_info->base_template_ = QualifiedIdentifier{};
-				alias_type_info->template_args_.clear();
-				alias_type_info->instantiation_context_.reset();
-				alias_type_info->clearAliasTypeSpecifier();
-				alias_type_info->setAliasTypeSpecifier(alias_registration_type_spec);
+				update_type_alias_copy(
+					*alias_type_info,
+					alias_target_index,
+					resolved_type_info.sizeInBits().value,
+					&alias_registration_type_spec,
+					&resolved_type_info);
 			}
 			// Only normalize entries that were already created by earlier
 			// parsing/materialization. Creating fresh aliases here changes
@@ -1021,6 +1127,36 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiationForLookup(
 	std::string_view template_name,
 	std::span<const TemplateTypeArg> template_args) {
+	auto resolve_builtin_type_info_by_name = [](std::string_view builtin_name) -> const TypeInfo* {
+		constexpr TypeCategory builtin_categories[] = {
+			TypeCategory::Void,
+			TypeCategory::Bool,
+			TypeCategory::Char,
+			TypeCategory::UnsignedChar,
+			TypeCategory::Short,
+			TypeCategory::UnsignedShort,
+			TypeCategory::Int,
+			TypeCategory::UnsignedInt,
+			TypeCategory::Long,
+			TypeCategory::UnsignedLong,
+			TypeCategory::LongLong,
+			TypeCategory::UnsignedLongLong,
+			TypeCategory::WChar,
+			TypeCategory::Char8,
+			TypeCategory::Char16,
+			TypeCategory::Char32,
+			TypeCategory::Float,
+			TypeCategory::Double,
+			TypeCategory::LongDouble,
+		};
+		for (TypeCategory builtin_category : builtin_categories) {
+			if (getTypeName(builtin_category) == builtin_name) {
+				return findNativeType(builtin_category);
+			}
+		}
+		return nullptr;
+	};
+
 	if (gTemplateRegistry.lookup_alias_template(template_name).has_value()) {
 		AliasTemplateMaterializationResult alias_result =
 			materializeAliasTemplateInstantiation(template_name, template_args);
@@ -1029,6 +1165,10 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 			if (alias_result.resolved_type_info == nullptr) {
 				alias_result.resolved_type_info =
 					findTypeByName(StringTable::getOrInternStringHandle(alias_result.instantiated_name));
+			}
+			if (alias_result.resolved_type_info == nullptr) {
+				alias_result.resolved_type_info =
+					resolve_builtin_type_info_by_name(alias_result.instantiated_name);
 			}
 		}
 		return alias_result;
@@ -1265,32 +1405,61 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		return nullptr;
 	}
 
-	std::string_view original_alias_target_name =
-		StringTable::getStringView(original_alias_target_info->name());
-	size_t member_sep = original_alias_target_name.rfind("::");
-	if (member_sep == std::string_view::npos) {
+	if (original_alias_target_info->isDependentMemberType() &&
+		original_alias_target_info->hasDependentQualifiedName()) {
+		if (const TypeInfo* resolved_dependent_type =
+				resolveDependentMemberTypeSemantic(
+					*original_alias_target_info,
+					template_params,
+					template_args,
+					StringHandle{});
+			resolved_dependent_type != nullptr) {
+			return resolved_dependent_type;
+		}
+	}
+
+	const TypeInfo::DependentQualifiedNameRecord* dependent_name =
+		original_alias_target_info->dependentQualifiedName();
+	if (dependent_name == nullptr ||
+		dependent_name->member_chain.empty()) {
 		return nullptr;
 	}
 
-	std::string_view dependent_base_name =
-		original_alias_target_name.substr(0, member_sep);
-	std::string_view dependent_member_name =
-		original_alias_target_name.substr(member_sep + 2);
-	if (size_t template_pos = dependent_member_name.find('<');
-		template_pos != std::string_view::npos) {
-		dependent_member_name = dependent_member_name.substr(0, template_pos);
+	const TypeInfo* dependent_base_info = nullptr;
+	if (dependent_name->owner_type.is_valid()) {
+		dependent_base_info = tryGetTypeInfo(dependent_name->owner_type);
 	}
-	const TypeInfo* dependent_base_info = findTypeByName(
-		StringTable::getOrInternStringHandle(dependent_base_name));
+	if (dependent_base_info == nullptr && dependent_name->owner_name.isValid()) {
+		dependent_base_info = findTypeByName(dependent_name->owner_name);
+	}
 	if (!dependent_base_info || !dependent_base_info->isTemplateInstantiation()) {
 		return nullptr;
 	}
+	std::string_view dependent_base_name =
+		StringTable::getStringView(dependent_base_info->name());
+	const TypeInfo::DependentQualifiedNameRecord::Member& dependent_member =
+		dependent_name->member_chain.back();
+	std::string_view dependent_member_name =
+		StringTable::getStringView(dependent_member.name);
+	StringBuilder member_path_builder;
+	for (size_t member_index = 0; member_index < dependent_name->member_chain.size();
+		 ++member_index) {
+		if (member_index != 0) {
+			member_path_builder.append("::");
+		}
+		member_path_builder.append(
+			StringTable::getStringView(
+				dependent_name->member_chain[member_index].name));
+	}
+	std::string_view dependent_member_path = member_path_builder.commit();
 
 	TemplateEnvironment inherited_environment;
 	const TemplateEnvironment* inherited_environment_ptr = nullptr;
 	if (const TypeInfo::InstantiationContext* dependent_base_context =
 			dependent_base_info->instantiationContext();
-		dependent_base_context != nullptr) {
+		dependent_base_context != nullptr &&
+		!(dependent_base_info->is_incomplete_instantiation_ &&
+		  dependent_base_info->isTemplateInstantiation())) {
 		inherited_environment = buildTemplateEnvironment(*dependent_base_context);
 		inherited_environment_ptr = &inherited_environment;
 	}
@@ -1300,10 +1469,10 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		inherited_environment_ptr);
 	auto materialize_template_args_with_environment =
 		[&](
-			const TypeInfo& source_type_info) -> InlineVector<TemplateTypeArg, 4> {
-		InlineVector<TemplateTypeArg, 4> concrete_args;
-		concrete_args.reserve(source_type_info.templateArgs().size());
-		for (const TypeInfo::TemplateArgInfo& stored_arg : source_type_info.templateArgs()) {
+			std::span<const TypeInfo::TemplateArgInfo> stored_args) -> InlineVector<TemplateTypeArg, 4> {
+			InlineVector<TemplateTypeArg, 4> concrete_args;
+		concrete_args.reserve(stored_args.size());
+		for (const TypeInfo::TemplateArgInfo& stored_arg : stored_args) {
 			TemplateTypeArg concrete_arg = toTemplateTypeArg(stored_arg);
 			concrete_arg.setCategory(stored_arg.category());
 			bool resolved_from_environment = false;
@@ -1356,13 +1525,28 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		}
 		return concrete_args;
 	};
+	auto materialize_template_args_from_type_info =
+		[&](const TypeInfo& source_type_info) -> InlineVector<TemplateTypeArg, 4> {
+		return materialize_template_args_with_environment(source_type_info.templateArgs());
+	};
+	auto template_args_still_dependent =
+		[](std::span<const TemplateTypeArg> args) -> bool {
+		for (const TemplateTypeArg& arg : args) {
+			if (arg.is_dependent ||
+				arg.dependent_name.isValid() ||
+				arg.dependent_expr.has_value()) {
+				return true;
+			}
+		}
+		return false;
+	};
 
 	StringHandle direct_concrete_member_handle =
 		StringTable::getOrInternStringHandle(
 			StringBuilder()
 				.append(dependent_base_name)
 				.append("::")
-				.append(dependent_member_name)
+				.append(dependent_member_path)
 				.commit());
 	auto direct_concrete_member_it = getTypesByNameMap().find(direct_concrete_member_handle);
 	if (direct_concrete_member_it != getTypesByNameMap().end() &&
@@ -1375,8 +1559,17 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	StringHandle base_template_name_handle = gNamespaceRegistry.buildQualifiedIdentifier(
 		dependent_base_info->sourceNamespace(),
 		dependent_base_info->baseTemplateName());
+	if (dependent_name->owner_name.isValid()) {
+		base_template_name_handle = dependent_name->owner_name;
+	}
 	InlineVector<TemplateTypeArg, 4> concrete_base_args =
-		materialize_template_args_with_environment(*dependent_base_info);
+		!dependent_name->owner_template_arguments.empty()
+			? materialize_template_args_with_environment(
+				  dependent_name->owner_template_arguments)
+			: materialize_template_args_from_type_info(*dependent_base_info);
+	if (template_args_still_dependent(concrete_base_args)) {
+		return nullptr;
+	}
 	AliasTemplateMaterializationResult materialized_alias_base =
 		materializeTemplateInstantiationForLookup(
 			StringTable::getStringView(base_template_name_handle),
@@ -1387,26 +1580,50 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			StringTable::getStringView(dependent_base_info->baseTemplateName()),
 			concrete_base_args);
 	}
-	if (materialized_alias_base.instantiated_name.empty()) {
+	std::string_view materialized_alias_base_name =
+		materialized_alias_base.canonicalName();
+	if (materialized_alias_base_name.empty()) {
 		return nullptr;
 	}
 
 	StringHandle member_alias_handle =
 		StringTable::getOrInternStringHandle(
 			StringBuilder()
-				.append(materialized_alias_base.instantiated_name)
+				.append(materialized_alias_base_name)
 				.append("::")
-				.append(dependent_member_name)
+				.append(dependent_member_path)
 				.commit());
-	if (gTemplateRegistry.lookup_alias_template(member_alias_handle).has_value()) {
+	StringHandle materialized_member_alias_handle = member_alias_handle;
+	if (!gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
+		std::string_view inherited_member_alias_name =
+			lookup_inherited_member_template_name(
+				StringTable::getOrInternStringHandle(materialized_alias_base_name),
+				StringTable::getOrInternStringHandle(dependent_member_name),
+				0);
+		if (!inherited_member_alias_name.empty()) {
+			materialized_member_alias_handle =
+				StringTable::getOrInternStringHandle(inherited_member_alias_name);
+		}
+	}
+	if (gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
 		InlineVector<TemplateTypeArg, 4> concrete_member_template_args;
-		if (original_alias_target_info->isTemplateInstantiation()) {
+		if (dependent_member.has_template_arguments) {
 			concrete_member_template_args =
-				materialize_template_args_with_environment(*original_alias_target_info);
+				materialize_template_args_with_environment(
+					dependent_member.template_arguments);
+			if (template_args_still_dependent(concrete_member_template_args)) {
+				return nullptr;
+			}
+		} else if (original_alias_target_info->isTemplateInstantiation()) {
+			concrete_member_template_args =
+				materialize_template_args_from_type_info(*original_alias_target_info);
+			if (template_args_still_dependent(concrete_member_template_args)) {
+				return nullptr;
+			}
 		}
 		AliasTemplateMaterializationResult materialized_member_alias =
 			materializeAliasTemplateInstantiation(
-				StringTable::getStringView(member_alias_handle),
+				StringTable::getStringView(materialized_member_alias_handle),
 				concrete_member_template_args);
 		if (materialized_member_alias.resolved_type_info != nullptr) {
 			return materialized_member_alias.resolved_type_info;
@@ -1416,7 +1633,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	StringHandle concrete_member_handle =
 		StringTable::getOrInternStringHandle(
 			StringBuilder()
-				.append(materialized_alias_base.instantiated_name)
+				.append(materialized_alias_base_name)
 				.append("::")
 				.append(dependent_member_name)
 				.commit());
@@ -1441,12 +1658,9 @@ bool Parser::resolveAliasTemplateInstantiation(
 		return false;
 	}
 
-	const TypeInfo* resolved_info = materialized_alias.resolved_type_info;
-
-	type_spec.set_type_index(
-		resolved_info->registeredTypeIndex().withCategory(resolved_info->typeEnum()));
-	type_spec.set_category(resolved_info->typeEnum());
-	type_spec.set_size_in_bits(resolved_info->sizeInBits());
+	type_spec = resolveTypeInfoToTypeSpec(
+		*materialized_alias.resolved_type_info,
+		type_spec);
 	return true;
 }
 
@@ -1558,13 +1772,10 @@ std::string_view Parser::instantiate_and_register_base_template(
 								materializeAliasTemplateInstantiation(
 									StringTable::getStringView(member_alias_handle),
 									*member_args);
-							if (!materialized_member.instantiated_name.empty()) {
-								base_class_name = materialized_member.instantiated_name;
-								return materialized_member.instantiated_name;
-							}
-							if (materialized_member.resolved_type_info != nullptr) {
-								base_class_name = StringTable::getStringView(
-									materialized_member.resolved_type_info->name());
+							std::string_view materialized_member_name =
+								materialized_member.canonicalName();
+							if (!materialized_member_name.empty()) {
+								base_class_name = materialized_member_name;
 								return base_class_name;
 							}
 						} else if (const TypeInfo* dependent_base_info =
@@ -2606,6 +2817,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 
 			// Get the type information from the alias
 			const TypeSpecifierNode& alias_type_spec = type_alias.type_node.as<TypeSpecifierNode>();
+			const TypeInfo* alias_semantic_source = tryGetTypeInfo(alias_type_spec.type_index());
 			TypeIndex alias_target_index = alias_type_spec.type_index();
 			int alias_size_bits = alias_type_spec.size_in_bits();
 			TypeSpecifierNode alias_registration_type_spec = alias_type_spec;
@@ -2616,6 +2828,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 					concrete_sibling_alias->registeredTypeIndex().withCategory(
 						concrete_sibling_alias->typeEnum());
 				alias_size_bits = concrete_sibling_alias->sizeInBits().value;
+				alias_semantic_source = concrete_sibling_alias;
 				if (const TypeSpecifierNode* concrete_alias_spec =
 						concrete_sibling_alias->aliasTypeSpecifier()) {
 					alias_registration_type_spec = *concrete_alias_spec;
@@ -2637,6 +2850,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 					concrete_member_info->registeredTypeIndex().withCategory(
 						concrete_member_info->typeEnum());
 				alias_size_bits = concrete_member_info->sizeInBits().value;
+				alias_semantic_source = concrete_member_info;
 				if (const TypeSpecifierNode* concrete_alias_spec =
 						concrete_member_info->aliasTypeSpecifier()) {
 					alias_registration_type_spec = *concrete_alias_spec;
@@ -2653,19 +2867,27 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 			auto existing_it = getTypesByNameMap().find(qualified_alias_name);
 			if (existing_it != getTypesByNameMap().end() && existing_it->second != nullptr) {
 				alias_info = existing_it->second;
-				const uint32_t alias_slot = alias_info->registeredTypeIndex().index();
-				alias_info->type_index_ = alias_target_index;
-				alias_info->registered_type_index_ = TypeIndex{alias_slot, TypeCategory::TypeAlias};
-				alias_info->fallback_size_bits_ = alias_size_bits;
-				alias_info->is_type_alias_ = true;
-				alias_info->clearAliasTypeSpecifier();
-				alias_info->setAliasTypeSpecifier(alias_registration_type_spec);
-			} else {
-				alias_info = &add_type_alias_copy(
-					qualified_alias_name,
+				update_type_alias_copy(
+					*alias_info,
 					alias_target_index,
 					alias_size_bits,
-					alias_registration_type_spec);
+					&alias_registration_type_spec,
+					alias_semantic_source);
+			} else {
+				if (alias_semantic_source != nullptr) {
+					alias_info = &add_type_alias_copy(
+						qualified_alias_name,
+						alias_target_index,
+						alias_size_bits,
+						alias_registration_type_spec,
+						*alias_semantic_source);
+				} else {
+					alias_info = &add_type_alias_copy(
+						qualified_alias_name,
+						alias_target_index,
+						alias_size_bits,
+						alias_registration_type_spec);
+				}
 			}
 			TypeInfo& alias_type_info = *alias_info;
 			if (alias_registration_type_spec.category() == TypeCategory::Enum) {
@@ -2724,7 +2946,8 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 					qualified_nested_name,
 					nested_target_index,
 					original_nested_info->sizeInBits().value,
-					nested_alias_spec);
+					nested_alias_spec,
+					*original_nested_info);
 				getTypesByNameMap().insert_or_assign(
 					qualified_nested_name,
 					&nested_alias_info);
@@ -2739,6 +2962,8 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 						.commit());
 				const TypeSpecifierNode& alias_type_spec =
 					type_alias.type_node.as<TypeSpecifierNode>();
+				const TypeInfo* alias_semantic_source =
+					tryGetTypeInfo(alias_type_spec.type_index());
 				TypeIndex alias_target_index = alias_type_spec.type_index();
 				TypeSpecifierNode alias_registration_type_spec = alias_type_spec;
 				if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target_index);
@@ -2755,11 +2980,19 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 						original_nested_info->sizeInBits());
 				}
 
-				TypeInfo& alias_type_info = add_type_alias_copy(
-					qualified_alias_name,
-					alias_target_index,
-					alias_registration_type_spec.size_in_bits(),
-					alias_registration_type_spec);
+				TypeInfo& alias_type_info =
+					alias_semantic_source != nullptr
+						? add_type_alias_copy(
+							  qualified_alias_name,
+							  alias_target_index,
+							  alias_registration_type_spec.size_in_bits(),
+							  alias_registration_type_spec,
+							  *alias_semantic_source)
+						: add_type_alias_copy(
+							  qualified_alias_name,
+							  alias_target_index,
+							  alias_registration_type_spec.size_in_bits(),
+							  alias_registration_type_spec);
 				getTypesByNameMap().insert_or_assign(
 					qualified_alias_name,
 					&alias_type_info);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -762,11 +762,32 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 	};
 	auto materializeTemplateArgsForLookup =
 		[&](const TypeInfo& source_type_info) -> std::vector<TemplateTypeArg> {
+		// Evaluator for dependent NTTP expressions (e.g. __is_final(Head) -> false).
+		// Uses the Parser's active substitution context so outer bindings like Head->Empty
+		// are visible even when the stored dependent_expr references the original param name.
+		auto eval_nttp = [this](
+			const ASTNode& expr,
+			std::span<const ASTNode> params,
+			std::span<const TemplateTypeArg> args) -> std::optional<TemplateTypeArg> {
+			InlineVector<TemplateParameterNode, 4> typed_params;
+			typed_params.reserve(params.size());
+			for (const ASTNode& param_node : params) {
+				if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+					typed_param != nullptr) {
+					typed_params.push_back(*typed_param);
+				}
+			}
+			return this->evaluateDependentNTTPExpression(
+				expr,
+				std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+				args);
+		};
 		std::vector<TemplateTypeArg> concrete_args =
 			materializeTemplateArgs(
 				source_type_info,
 				alias_node->template_parameters(),
-				template_args);
+				template_args,
+				eval_nttp);
 		auto recursively_materialize_type_arg =
 			[&](auto&& self,
 				TemplateTypeArg concrete_arg,
@@ -808,7 +829,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 				materializeTemplateArgs(
 					*concrete_type_info,
 					alias_node->template_parameters(),
-					template_args);
+					template_args,
+					eval_nttp);
 			for (TemplateTypeArg& nested_arg : nested_concrete_args) {
 				nested_arg = self(self, std::move(nested_arg), depth + 1);
 			}
@@ -1720,7 +1742,24 @@ std::string_view Parser::instantiate_and_register_base_template(
 					materializeTemplateArgs(
 						*alias_target_info,
 						alias_node.template_parameters(),
-						template_args);
+						template_args,
+						[this](
+							const ASTNode& expr,
+							std::span<const ASTNode> params,
+							std::span<const TemplateTypeArg> args) -> std::optional<TemplateTypeArg> {
+							InlineVector<TemplateParameterNode, 4> typed_params;
+							typed_params.reserve(params.size());
+							for (const ASTNode& param_node : params) {
+								if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+									typed_param != nullptr) {
+									typed_params.push_back(*typed_param);
+								}
+							}
+							return this->evaluateDependentNTTPExpression(
+								expr,
+								std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+								args);
+						});
 				StringHandle qualified_target_template_handle =
 					gNamespaceRegistry.buildQualifiedIdentifier(
 						alias_target_info->sourceNamespace(),

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1531,10 +1531,24 @@ ParseResult Parser::parse_type_specifier() {
 						}
 						return buildTypeFromInfo(*instantiated_type_info, type_name_token, false);
 					};
+					auto aliasTemplateArgsStillDependent =
+						[](std::span<const TemplateTypeArg> args) -> bool {
+						for (const TemplateTypeArg& arg : args) {
+							if (arg.is_dependent ||
+								arg.is_pack ||
+								arg.dependent_name.isValid() ||
+								arg.dependent_expr.has_value()) {
+								return true;
+							}
+						}
+						return false;
+					};
+					const bool has_dependent_alias_args =
+						aliasTemplateArgsStillDependent(*template_args);
 
 					// OPTION 1: DEFERRED INSTANTIATION (preferred over string parsing)
 					// Check if this alias uses deferred instantiation (target is a template with unresolved params)
-					if (alias_node.is_deferred()) {
+					if (alias_node.is_deferred() && !has_dependent_alias_args) {
 						FLASH_LOG(Parser, Debug, "Using deferred instantiation for alias '", type_name, "' -> '", alias_node.target_template_name(), "'");
 
 						// Route directly through the alias-specific materialization path
@@ -1577,48 +1591,53 @@ ParseResult Parser::parse_type_specifier() {
 						instantiated_type = makeTypeSpecifierFromTemplateTypeArg(
 							*rebound_arg,
 							Token());
-					} else if (const TypeInfo* concrete_member_info =
-								   materializeInstantiatedMemberAliasTarget(
-									   instantiated_type,
-									   alias_node.template_parameters(),
-									   *template_args);
-							   concrete_member_info != nullptr) {
-						instantiated_type = resolveTypeInfoToTypeSpec(*concrete_member_info, instantiated_type);
-					} else if (const TypeInfo* alias_target_info =
-								   tryGetTypeInfo(instantiated_type.type_index());
-							   alias_target_info != nullptr &&
-							   alias_target_info->isTemplateInstantiation()) {
-						StringHandle qualified_target_template_name =
-							gNamespaceRegistry.buildQualifiedIdentifier(
-								alias_target_info->sourceNamespace(),
-								alias_target_info->baseTemplateName());
-						auto alias_target_entry =
-							gTemplateRegistry.lookup_alias_template(qualified_target_template_name);
-						if (!alias_target_entry.has_value()) {
-							alias_target_entry = gTemplateRegistry.lookup_alias_template(
-								alias_target_info->baseTemplateName());
-						}
-						if (alias_target_entry.has_value()) {
-							std::vector<TemplateTypeArg> concrete_target_args =
-								materializeTemplateArgs(
-									*alias_target_info,
+					} else if (!has_dependent_alias_args) {
+						if (const TypeInfo* concrete_member_info =
+								materializeInstantiatedMemberAliasTarget(
+									instantiated_type,
 									alias_node.template_parameters(),
 									*template_args);
-							AliasTemplateMaterializationResult materialized_target =
-								materializeTemplateInstantiationForLookup(
-									StringTable::getStringView(qualified_target_template_name),
-									concrete_target_args);
-							if (!materialized_target.resolved_type_info &&
-								qualified_target_template_name != alias_target_info->baseTemplateName()) {
-								materialized_target = materializeTemplateInstantiationForLookup(
-									StringTable::getStringView(alias_target_info->baseTemplateName()),
-									concrete_target_args);
+							concrete_member_info != nullptr) {
+							instantiated_type = resolveTypeInfoToTypeSpec(*concrete_member_info, instantiated_type);
+						} else if (const TypeInfo* alias_target_info =
+									   tryGetTypeInfo(instantiated_type.type_index());
+								   alias_target_info != nullptr &&
+								   alias_target_info->isTemplateInstantiation()) {
+							StringHandle qualified_target_template_name =
+								gNamespaceRegistry.buildQualifiedIdentifier(
+									alias_target_info->sourceNamespace(),
+									alias_target_info->baseTemplateName());
+							auto alias_target_entry =
+								gTemplateRegistry.lookup_alias_template(qualified_target_template_name);
+							if (!alias_target_entry.has_value()) {
+								alias_target_entry = gTemplateRegistry.lookup_alias_template(
+									alias_target_info->baseTemplateName());
 							}
-							if (materialized_target.resolved_type_info != nullptr) {
-								instantiated_type = resolveTypeInfoToTypeSpec(
-									*materialized_target.resolved_type_info, instantiated_type);
+							if (alias_target_entry.has_value()) {
+								std::vector<TemplateTypeArg> concrete_target_args =
+									materializeTemplateArgs(
+										*alias_target_info,
+										alias_node.template_parameters(),
+										*template_args);
+								AliasTemplateMaterializationResult materialized_target =
+									materializeTemplateInstantiationForLookup(
+										StringTable::getStringView(qualified_target_template_name),
+										concrete_target_args);
+								if (!materialized_target.resolved_type_info &&
+									qualified_target_template_name != alias_target_info->baseTemplateName()) {
+									materialized_target = materializeTemplateInstantiationForLookup(
+										StringTable::getStringView(alias_target_info->baseTemplateName()),
+										concrete_target_args);
+								}
+								if (materialized_target.resolved_type_info != nullptr) {
+									instantiated_type = resolveTypeInfoToTypeSpec(
+										*materialized_target.resolved_type_info, instantiated_type);
+								}
 							}
 						}
+					}
+					if (has_dependent_alias_args && peek() != "::"_tok) {
+						return ParseResult::success(emplace_node<TypeSpecifierNode>(instantiated_type));
 					}
 
 					if (const TypeInfo* instantiated_type_info =

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1408,17 +1408,10 @@ ParseResult Parser::parse_type_specifier() {
 						}
 					}
 
-					auto buildQualifiedMemberName = [&](std::string_view base_type_name, std::string_view member_name) {
-						return StringBuilder()
-							.append(base_type_name)
-							.append("::")
-							.append(member_name)
-							.commit();
-					};
-
 					auto findOrCreateQualifiedMemberType = [&](std::string_view base_type_name, std::string_view member_name) -> const TypeInfo& {
-						StringHandle qualified_member_handle =
-							StringTable::getOrInternStringHandle(buildQualifiedMemberName(base_type_name, member_name));
+						StringHandle qualified_member_handle = buildQualifiedMemberNameHandle(
+							StringTable::getOrInternStringHandle(base_type_name),
+							StringTable::getOrInternStringHandle(member_name));
 						auto member_type_it = getTypesByNameMap().find(qualified_member_handle);
 						if (member_type_it == getTypesByNameMap().end()) {
 							TypeInfo& placeholder_type = add_empty_type_entry();
@@ -1513,8 +1506,10 @@ ParseResult Parser::parse_type_specifier() {
 								discard_saved_token(scope_pos);
 
 								// Build qualified type name
-								std::string_view qualified_type_name =
-									buildQualifiedMemberName(resolved_instantiated_type_name, member_name);
+								std::string_view qualified_type_name = StringTable::getStringView(
+									buildQualifiedMemberNameHandle(
+										StringTable::getOrInternStringHandle(resolved_instantiated_type_name),
+										member_token.handle()));
 
 								FLASH_LOG(Parser, Debug, "Looking up member type '", qualified_type_name, "' after alias template resolution");
 

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2682,6 +2682,21 @@ ParseResult Parser::parse_type_specifier() {
 							}
 						}
 
+						if (!member_alias_opt.has_value()) {
+							std::string_view inherited_member_alias_name =
+								lookup_inherited_member_template_name(
+									StringTable::getOrInternStringHandle(instantiated_name),
+									StringTable::getOrInternStringHandle(member_name),
+									0);
+							if (!inherited_member_alias_name.empty()) {
+								member_alias_opt =
+									gTemplateRegistry.lookup_alias_template(inherited_member_alias_name);
+								if (member_alias_opt.has_value()) {
+									member_alias_name_str = std::string(inherited_member_alias_name);
+								}
+							}
+						}
+
 						if (member_alias_opt.has_value()) {
 							const TemplateAliasNode& alias_node = member_alias_opt->as<TemplateAliasNode>();
 

--- a/tests/test_nullptr_alias_template_nttp_ret0.cpp
+++ b/tests/test_nullptr_alias_template_nttp_ret0.cpp
@@ -1,0 +1,11 @@
+template <typename T>
+using identity_t = T;
+
+template <identity_t<decltype(nullptr)> Value>
+struct Holder {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return Holder<nullptr>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_alias_enum_payload_ret0.cpp
+++ b/tests/test_template_alias_enum_payload_ret0.cpp
@@ -1,0 +1,17 @@
+template <typename T>
+struct Box {
+	enum class State { Off = 1,
+					   On = 2 };
+
+	using Alias = State;
+	using AliasAgain = Alias;
+
+	static AliasAgain get() {
+		return AliasAgain::On;
+	}
+};
+
+int main() {
+	Box<int>::AliasAgain state = Box<int>::get();
+	return static_cast<int>(state) == 2 ? 0 : 1;
+}

--- a/tests/test_template_current_instantiation_alias_type_spec_ret0.cpp
+++ b/tests/test_template_current_instantiation_alias_type_spec_ret0.cpp
@@ -1,0 +1,16 @@
+template <typename T>
+struct Box {
+	using self_type = Box<T>;
+	using value_type = T;
+	using alias = typename self_type::value_type;
+	using pointer = alias*;
+
+	static pointer make() {
+		return nullptr;
+	}
+};
+
+int main() {
+	Box<int>::pointer value = Box<int>::make();
+	return value == nullptr ? 0 : 1;
+}

--- a/tests/test_template_current_instantiation_inherited_member_template_type_ret0.cpp
+++ b/tests/test_template_current_instantiation_inherited_member_template_type_ret0.cpp
@@ -1,22 +1,19 @@
 template<typename T>
-struct Holder {
-	int value;
-};
-
-template<typename T>
 struct Base {
 	template<typename U>
-	using rebind = Holder<U>;
+	using rebind = U;
 };
 
 template<typename T>
 struct Mid : Base<T> {};
 
 template<typename T>
-struct Derived : Mid<T>::template rebind<int> {
+struct Derived {
+	using value_type = typename Mid<T>::template rebind<int>;
+
 	int run() {
-		this->value = 42;
-		return this->value - 42;
+		value_type value = 42;
+		return value - 42;
 	}
 };
 

--- a/tests/test_template_current_instantiation_inherited_member_template_type_ret0.cpp
+++ b/tests/test_template_current_instantiation_inherited_member_template_type_ret0.cpp
@@ -1,0 +1,26 @@
+template<typename T>
+struct Holder {
+	int value;
+};
+
+template<typename T>
+struct Base {
+	template<typename U>
+	using rebind = Holder<U>;
+};
+
+template<typename T>
+struct Mid : Base<T> {};
+
+template<typename T>
+struct Derived : Mid<T>::template rebind<int> {
+	int run() {
+		this->value = 42;
+		return this->value - 42;
+	}
+};
+
+int main() {
+	Derived<char> value;
+	return value.run();
+}


### PR DESCRIPTION
## Summary
- fix inherited dependent-base member-template alias lookup in shared member-chain concretization
- unify direct qualified member-template owner probing used by the lookup path
- fully materialize nested alias-target template-instantiation arguments before deferred trait/default NTTP evaluation
- ensure dependent NTTP expressions in alias-target materialization are evaluated through the active substitution context
- address review feedback in qualified lookup: refresh lazy alias placeholders, preserve namespace in primary-template fallback, and continue inherited member-template lookup through alias-template owners

## Validation
- `./build_flashcpp.bat`
- `pwsh -File tests/run_all_tests.ps1 test_type_trait_alias_default_nttp_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_member_alias_placeholder_default_nttp_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_member_alias_template_chain_default_nttp_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_alias_chain_partial_default_nttp_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_conditional_alias_partial_default_nttp_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_is_final_builtin_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 test_template_current_instantiation_inherited_member_template_type_ret0.cpp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced long-form architecture audit with a compact status page, prioritized roadmap, and clear exit criteria.
  * Condensed the standard-conformance investigation into a focused goal, remaining-work list, and execution roadmap.

* **Improvements**
  * Improved template-argument canonicalization, dependent-member/type resolution, and inherited member handling.
  * Enhanced type-alias semantic propagation and safer alias registration during instantiation.

* **Tests**
  * Added multiple new tests covering inherited member-template types, alias NTTPs, enum-alias payloads, and alias/type-spec behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->