### PR TITLE
stage6: tighten sema-query contracts in codegen paths (slice 2)

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -123,6 +123,7 @@ Stage 6 progress so far:
 - parser-owned lazy static-member materialization in constexpr/codegen no longer calls `Parser::instantiateLazyStaticMember(...)` directly: `ParserSemanticServices::tryInstantiateLazyStaticMember(...)` now owns that parser-attached entrypoint, and the affected call families in `ConstExprEvaluator_Core.cpp`, `ConstExprEvaluator_Members.cpp`, and `IrGenerator_Visitors_TypeInit.cpp` route through sema services instead of parser plumbing.
 - codegen overload-argument typing in `AstToIr::buildCodegenOverloadResolutionArgType(...)` now consumes `ParserSemanticServices::getOverloadResolutionArgTypeQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies instead of silently collapsing all missing answers into parser fallback behavior.
 - binary-operator overload-argument typing in `IrGenerator_Expr_Operators.cpp` now also consumes the explicit overload-arg query API before parser fallback, so this codegen family no longer depends on nullable sema lookup plumbing.
+- `AstToIr::generateMemberFunctionCallIr(...)` now resolves callable `operator()` receivers through parser-semantic query-state APIs (`getResolvedOpCallQuery` + `getExpressionTypeQuery`), keeping legacy parser fallback for non-normalized/`AnalyzedAbsent` cases while enforcing `NotYetAnalyzed` as an invariant violation in sema-normalized bodies.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -126,6 +126,7 @@ Stage 6 progress so far:
 - `AstToIr::generateMemberFunctionCallIr(...)` now resolves callable `operator()` receivers through parser-semantic query-state APIs (`getResolvedOpCallQuery` + `getExpressionTypeQuery`), keeping legacy parser fallback for non-normalized/`AnalyzedAbsent` cases while enforcing `NotYetAnalyzed` as an invariant violation in sema-normalized bodies.
 - `AstToIr::generateFunctionCallIr(...)` now routes sema-owned direct-call target consumption through `ParserSemanticServices::getResolvedDirectCallQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies (unless sema explicitly recorded the call as unresolved), while preserving legacy parser lookup recovery for non-normalized paths.
 - `AstToIr::getCallExpressionReturnType(...)` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`; sema-normalized bodies hard-fail on `NotYetAnalyzed`, while parser fallback is retained for non-normalized flow and placeholder/invalid type recovery.
+- inline_always single-argument lowering in `AstToIr::generateFunctionCallIr(...)` now queries argument types through `ParserSemanticServices::getExpressionTypeQuery(...)`, hard-fails on `NotYetAnalyzed` in sema-normalized bodies, and keeps parser fallback for unavailable/placeholder/invalid-type recovery.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -124,6 +124,7 @@ Stage 6 progress so far:
 - codegen overload-argument typing in `AstToIr::buildCodegenOverloadResolutionArgType(...)` now consumes `ParserSemanticServices::getOverloadResolutionArgTypeQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies instead of silently collapsing all missing answers into parser fallback behavior.
 - binary-operator overload-argument typing in `IrGenerator_Expr_Operators.cpp` now also consumes the explicit overload-arg query API before parser fallback, so this codegen family no longer depends on nullable sema lookup plumbing.
 - `AstToIr::generateMemberFunctionCallIr(...)` now resolves callable `operator()` receivers through parser-semantic query-state APIs (`getResolvedOpCallQuery` + `getExpressionTypeQuery`), keeping legacy parser fallback for non-normalized/`AnalyzedAbsent` cases while enforcing `NotYetAnalyzed` as an invariant violation in sema-normalized bodies.
+- `AstToIr::generateFunctionCallIr(...)` now routes sema-owned direct-call target consumption through `ParserSemanticServices::getResolvedDirectCallQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies (unless sema explicitly recorded the call as unresolved), while preserving legacy parser lookup recovery for non-normalized paths.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -125,6 +125,7 @@ Stage 6 progress so far:
 - binary-operator overload-argument typing in `IrGenerator_Expr_Operators.cpp` now also consumes the explicit overload-arg query API before parser fallback, so this codegen family no longer depends on nullable sema lookup plumbing.
 - `AstToIr::generateMemberFunctionCallIr(...)` now resolves callable `operator()` receivers through parser-semantic query-state APIs (`getResolvedOpCallQuery` + `getExpressionTypeQuery`), keeping legacy parser fallback for non-normalized/`AnalyzedAbsent` cases while enforcing `NotYetAnalyzed` as an invariant violation in sema-normalized bodies.
 - `AstToIr::generateFunctionCallIr(...)` now routes sema-owned direct-call target consumption through `ParserSemanticServices::getResolvedDirectCallQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies (unless sema explicitly recorded the call as unresolved), while preserving legacy parser lookup recovery for non-normalized paths.
+- `AstToIr::getCallExpressionReturnType(...)` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`; sema-normalized bodies hard-fail on `NotYetAnalyzed`, while parser fallback is retained for non-normalized flow and placeholder/invalid type recovery.
 
 Remaining Stage 6 work:
 

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -403,11 +403,20 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 											: func_name_view;
 	const bool has_synthesized_template_suffix =
 		func_name_view.find('$') != std::string_view::npos;
+	auto sema_services = sema_.parserSemanticServices();
+	const FunctionDeclarationNode* const parser_resolved_direct_target =
+		getParserStoredDirectCallTarget(callExprNode);
+	const ResolvedFunctionQueryResult sema_resolved_direct_query =
+		sema_services.getResolvedDirectCallQuery(sema_call_key);
+	const FunctionDeclarationNode* const sema_resolved_direct_target =
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available
+			? sema_resolved_direct_query.function
+			: nullptr;
 	const FunctionDeclarationNode* const pre_resolved_direct_target = [&]() -> const FunctionDeclarationNode* {
 		const FunctionDeclarationNode* target =
-			getParserStoredDirectCallTarget(callExprNode);
+			parser_resolved_direct_target;
 		if (!target) {
-			target = sema_.getResolvedDirectCall(sema_call_key);
+			target = sema_resolved_direct_target;
 		}
 		return target;
 	}();
@@ -998,7 +1007,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	// instantiated members; only gate pattern-owned member descriptors.
 	if (!matched_func_decl) {
 		const FunctionDeclarationNode* callee_resolved_target =
-			getParserStoredDirectCallTarget(callExprNode);
+			parser_resolved_direct_target;
 		if (callee_resolved_target) {
 			const bool is_pattern_member_target =
 				!callee_resolved_target->parent_struct_name().empty() &&
@@ -1014,7 +1023,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	// direct-call target stored by semantic analysis before attempting any
 	// duplicate symbol-table recovery work in codegen.
 	if (!matched_func_decl) {
-		consumeResolvedDirectCallTarget(sema_.getResolvedDirectCall(sema_call_key), "sema-resolved");
+		consumeResolvedDirectCallTarget(sema_resolved_direct_target, "sema-resolved");
 	}
 
 	// Check if the call expression has a pre-computed mangled name (for namespace-scoped functions)
@@ -1032,6 +1041,13 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	// provide a sema-owned target or mark the call as unresolved.
 	const bool sema_recorded_unresolved_call =
 		sema_.hasUnresolvedCallArgs(sema_call_key);
+	if (!matched_func_decl &&
+		sema_normalized_current_function_ &&
+		!sema_recorded_unresolved_call &&
+		!parser_resolved_direct_target &&
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		throw InternalError("Normalized direct-call query remained NotYetAnalyzed");
+	}
 	const bool allow_lookup_recovery =
 		!sema_normalized_current_function_ || // body not tracked by normalized_bodies_
 		sema_recorded_unresolved_call; // sema recorded a known resolution gap

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -457,10 +457,26 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		auto arg_node = callExprNode.arguments()[0];
 		if (arg_node.is<ExpressionNode>()) {
 			auto getInlineAlwaysArgType = [&]() -> std::optional<TypeSpecifierNode> {
-				if (auto sema_type = sema_.getExpressionType(arg_node); sema_type.has_value()) {
-					return sema_type;
+				TypeSpecifierQueryResult sema_arg_type_query =
+					sema_.parserSemanticServices().getExpressionTypeQuery(arg_node);
+				if (sema_normalized_current_function_ &&
+					sema_arg_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed) {
+					throw InternalError("Normalized inline_always argument type query remained NotYetAnalyzed");
 				}
-				return parser_.get_expression_type(arg_node);
+
+				std::optional<TypeSpecifierNode> sema_arg_type;
+				if (sema_arg_type_query.state == TypeSpecifierQueryResult::State::Available) {
+					sema_arg_type = sema_arg_type_query.type;
+				}
+
+				const bool requires_recovery_fallback =
+					!sema_arg_type.has_value() ||
+					sema_arg_type->type() == TypeCategory::Invalid ||
+					isPlaceholderAutoType(sema_arg_type->type());
+				if (requires_recovery_fallback) {
+					return parser_.get_expression_type(arg_node);
+				}
+				return sema_arg_type;
 			};
 			auto inlineAlwaysTypeMatches = [&](const TypeSpecifierNode& arg_type) {
 				if (!returns_reference) {

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -241,8 +241,13 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 	if (member_func_decl.decl_node().identifier_token().value() == "operator()"sv &&
 		object_node.is<ExpressionNode>()) {
 		std::optional<TypeSpecifierNode> callee_type;
+		auto sema_services = sema_.parserSemanticServices();
+		ResolvedFunctionQueryResult resolved_op_call_query =
+			sema_services.getResolvedOpCallQuery(sema_call_key);
 		const FunctionDeclarationNode* resolved_op_call =
-			sema_.getResolvedOpCall(sema_call_key);
+			resolved_op_call_query.state == ResolvedFunctionQueryResult::State::Available
+				? resolved_op_call_query.function
+				: nullptr;
 		const ExpressionNode& object_expr = object_node.as<ExpressionNode>();
 		const auto* object_ident = std::get_if<IdentifierNode>(&object_expr);
 		auto isInconclusiveCallableType = [](const std::optional<TypeSpecifierNode>& candidate) {
@@ -251,13 +256,19 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					!candidate->is_function_pointer() &&
 					!candidate->has_function_signature());
 		};
-		callee_type = sema_.getExpressionType(object_node);
+		TypeSpecifierQueryResult callee_type_query = sema_services.getExpressionTypeQuery(object_node);
+		if (callee_type_query.state == TypeSpecifierQueryResult::State::Available) {
+			callee_type = callee_type_query.type;
+		}
 		const bool needs_parser_fallback =
 			isInconclusiveCallableType(callee_type) &&
 			!resolved_op_call;
 		if (needs_parser_fallback) {
-			if (sema_normalized_current_function_) {
-				throw InternalError("Normalized callable operator() receiver is missing sema-resolved target/type");
+			const bool sema_query_not_yet_analyzed =
+				resolved_op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed ||
+				callee_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed;
+			if (sema_normalized_current_function_ && sema_query_not_yet_analyzed) {
+				throw InternalError("Normalized callable operator() receiver query remained NotYetAnalyzed");
 			}
 			callee_type = parser_.get_expression_type(object_node);
 		}

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -29,8 +29,23 @@ TempVar AstToIr::emitArrayToPointerDecay(const TypeSpecifierNode& elem_type_spec
 // ============================================================================
 
 std::optional<TypeSpecifierNode> AstToIr::getCallExpressionReturnType(const ASTNode& callNode) const {
-	std::optional<TypeSpecifierNode> result = sema_.getExpressionType(callNode);
-	if ((!result.has_value() || isPlaceholderAutoType(result->type()))) {
+	auto sema_services = sema_.parserSemanticServices();
+	TypeSpecifierQueryResult sema_type_query = sema_services.getExpressionTypeQuery(callNode);
+	if (sema_normalized_current_function_ &&
+		sema_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed) {
+		throw InternalError("Normalized call expression return-type query remained NotYetAnalyzed");
+	}
+
+	std::optional<TypeSpecifierNode> result;
+	if (sema_type_query.state == TypeSpecifierQueryResult::State::Available) {
+		result = sema_type_query.type;
+	}
+
+	const bool requires_recovery_fallback =
+		!result.has_value() ||
+		result->type() == TypeCategory::Invalid ||
+		isPlaceholderAutoType(result->type());
+	if (requires_recovery_fallback) {
 		result = parser_.get_expression_type(callNode);
 	}
 	return result;


### PR DESCRIPTION
## Summary

This PR continues Stage 6 sema-first refactoring by tightening query-state consumption in four critical IR generation paths.

## Changes

1. **Callable operator() receiver resolution** (IrGenerator_Call_Indirect.cpp)
   - Replaced nullable \sema_.getResolvedOpCall()\ with \ParserSemanticServices::getResolvedOpCallQuery()\
   - Added invariant: NotYetAnalyzed in sema-normalized bodies throws InternalError

2. **Direct-call query-state handling** (IrGenerator_Call_Direct.cpp)
   - Centralized parser + sema direct-call targets via \getResolvedDirectCallQuery()\
   - Added NotYetAnalyzed invariant check in sema-normalized paths

3. **Call return-type query in type init** (IrGenerator_Visitors_TypeInit.cpp)
   - Switched \getCallExpressionReturnType()\ to use \getExpressionTypeQuery()\
   - Added NotYetAnalyzed invariant for normalized bodies
   - Preserved fallback for non-normalized and placeholder/invalid recovery

4. **inline_always arg type query handling** (IrGenerator_Call_Direct.cpp)
   - Refactored \getInlineAlwaysArgType\ lambda to use query-state API
   - Added normalized-path invariant checks
   - Preserves fallback for recovery cases

## Testing

All 2427 tests pass (182 expected-fail correct).

Follows from PR #1579 stage6 refactoring work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation describing improvements to compiler semantic analysis.

* **Refactor**
  * Enhanced compiler's internal function call and type resolution mechanisms for improved correctness and error handling during code compilation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1580?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->