### PR TITLE
stage6: tighten remaining codegen query contracts (slice 3)

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -130,6 +130,7 @@ Stage 6 progress so far:
 - `AstToIr::generateMemberFunctionCallIr(...)` now routes member-call receiver struct-type lookup in `resolveStructTypeFromReceiverNode(...)` through `ParserSemanticServices::getExpressionTypeQuery(...)`, treating `NotYetAnalyzed` as an invariant violation in sema-normalized bodies while preserving identifier/static-cast and parser fallback recovery for non-normalized flow.
 - `AstToIr::generateArraySubscriptIr(...)` now consumes `ParserSemanticServices::getResolvedOpSubscriptQuery(...)` before deciding whether `operator[]` dispatch should fall back to builtin array indexing, and sema-normalized bodies now treat `NotYetAnalyzed` subscript-resolution state as an invariant violation instead of quietly skipping to legacy fallback logic.
 - the function-pointer `operator()` branch in `AstToIr::generateFunctionCallIr(...)` now also consumes `ParserSemanticServices::getResolvedOpCallQuery(...)`, so sema-normalized direct-call lowering hard-fails on `NotYetAnalyzed` instead of silently treating an unfinished callable lookup as ordinary fallback flow.
+- ternary common-type fallback in `IrGenerator_Expr_Operators.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for both branch expressions, making sema-normalized ternary lowering fail explicitly on `NotYetAnalyzed` branch-type queries instead of reading nullable sema slots.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -128,6 +128,7 @@ Stage 6 progress so far:
 - `AstToIr::getCallExpressionReturnType(...)` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`; sema-normalized bodies hard-fail on `NotYetAnalyzed`, while parser fallback is retained for non-normalized flow and placeholder/invalid type recovery.
 - inline_always single-argument lowering in `AstToIr::generateFunctionCallIr(...)` now queries argument types through `ParserSemanticServices::getExpressionTypeQuery(...)`, hard-fails on `NotYetAnalyzed` in sema-normalized bodies, and keeps parser fallback for unavailable/placeholder/invalid-type recovery.
 - `AstToIr::generateMemberFunctionCallIr(...)` now routes member-call receiver struct-type lookup in `resolveStructTypeFromReceiverNode(...)` through `ParserSemanticServices::getExpressionTypeQuery(...)`, treating `NotYetAnalyzed` as an invariant violation in sema-normalized bodies while preserving identifier/static-cast and parser fallback recovery for non-normalized flow.
+- `AstToIr::generateArraySubscriptIr(...)` now consumes `ParserSemanticServices::getResolvedOpSubscriptQuery(...)` before deciding whether `operator[]` dispatch should fall back to builtin array indexing, and sema-normalized bodies now treat `NotYetAnalyzed` subscript-resolution state as an invariant violation instead of quietly skipping to legacy fallback logic.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -127,6 +127,7 @@ Stage 6 progress so far:
 - `AstToIr::generateFunctionCallIr(...)` now routes sema-owned direct-call target consumption through `ParserSemanticServices::getResolvedDirectCallQuery(...)` and treats `NotYetAnalyzed` as an invariant violation in sema-normalized bodies (unless sema explicitly recorded the call as unresolved), while preserving legacy parser lookup recovery for non-normalized paths.
 - `AstToIr::getCallExpressionReturnType(...)` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`; sema-normalized bodies hard-fail on `NotYetAnalyzed`, while parser fallback is retained for non-normalized flow and placeholder/invalid type recovery.
 - inline_always single-argument lowering in `AstToIr::generateFunctionCallIr(...)` now queries argument types through `ParserSemanticServices::getExpressionTypeQuery(...)`, hard-fails on `NotYetAnalyzed` in sema-normalized bodies, and keeps parser fallback for unavailable/placeholder/invalid-type recovery.
+- `AstToIr::generateMemberFunctionCallIr(...)` now routes member-call receiver struct-type lookup in `resolveStructTypeFromReceiverNode(...)` through `ParserSemanticServices::getExpressionTypeQuery(...)`, treating `NotYetAnalyzed` as an invariant violation in sema-normalized bodies while preserving identifier/static-cast and parser fallback recovery for non-normalized flow.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -129,6 +129,7 @@ Stage 6 progress so far:
 - inline_always single-argument lowering in `AstToIr::generateFunctionCallIr(...)` now queries argument types through `ParserSemanticServices::getExpressionTypeQuery(...)`, hard-fails on `NotYetAnalyzed` in sema-normalized bodies, and keeps parser fallback for unavailable/placeholder/invalid-type recovery.
 - `AstToIr::generateMemberFunctionCallIr(...)` now routes member-call receiver struct-type lookup in `resolveStructTypeFromReceiverNode(...)` through `ParserSemanticServices::getExpressionTypeQuery(...)`, treating `NotYetAnalyzed` as an invariant violation in sema-normalized bodies while preserving identifier/static-cast and parser fallback recovery for non-normalized flow.
 - `AstToIr::generateArraySubscriptIr(...)` now consumes `ParserSemanticServices::getResolvedOpSubscriptQuery(...)` before deciding whether `operator[]` dispatch should fall back to builtin array indexing, and sema-normalized bodies now treat `NotYetAnalyzed` subscript-resolution state as an invariant violation instead of quietly skipping to legacy fallback logic.
+- the function-pointer `operator()` branch in `AstToIr::generateFunctionCallIr(...)` now also consumes `ParserSemanticServices::getResolvedOpCallQuery(...)`, so sema-normalized direct-call lowering hard-fails on `NotYetAnalyzed` instead of silently treating an unfinished callable lookup as ordinary fallback flow.
 
 Remaining Stage 6 work:
 

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -562,8 +562,12 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 
 	if (func_ptr_decl) {
 		const auto& func_type = func_ptr_decl->type_specifier_node();
+		const ResolvedFunctionQueryResult resolved_operator_call_query =
+			sema_services.getResolvedOpCallQuery(sema_call_key);
 		const FunctionDeclarationNode* resolved_operator_call =
-			sema_.getResolvedOpCall(sema_call_key);
+			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::Available
+				? resolved_operator_call_query.function
+				: nullptr;
 
 		if (resolved_operator_call) {
 			ChunkedVector<ASTNode> member_args;
@@ -579,6 +583,10 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 				std::move(member_args),
 				callExprNode.called_from());
 			return generateMemberFunctionCallIr(member_call, context, sema_call_key);
+		}
+		if (sema_normalized_current_function_ &&
+			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+			throw InternalError("Normalized direct operator() query remained NotYetAnalyzed");
 		}
 
 		// Check if this is a function pointer or a substituted function type carrying

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -420,10 +420,16 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 
 	auto resolveStructTypeFromReceiverNode = [&](const ASTNode& receiver_node) -> std::optional<TypeSpecifierNode> {
 		if (receiver_node.is<ExpressionNode>()) {
-			if (auto sema_type = sema_.getExpressionType(receiver_node); sema_type.has_value()) {
-				if (auto resolved_sema_type = normalizeResolvedStructType(*sema_type); resolved_sema_type.has_value()) {
+			TypeSpecifierQueryResult receiver_type_query =
+				sema_.parserSemanticServices().getExpressionTypeQuery(receiver_node);
+			if (receiver_type_query.state == TypeSpecifierQueryResult::State::Available) {
+				if (auto resolved_sema_type = normalizeResolvedStructType(*receiver_type_query.type); resolved_sema_type.has_value()) {
 					return resolved_sema_type;
 				}
+			}
+			if (sema_normalized_current_function_ &&
+				receiver_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed) {
+				throw InternalError("Normalized member-call receiver type query remained NotYetAnalyzed");
 			}
 
 			const ExpressionNode& receiver_expr = receiver_node.as<ExpressionNode>();

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -1103,8 +1103,23 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 	// Fallback: use sema-backed expression types when no explicit conversion
 	// annotation was recorded for either branch.
 	if (common_cat == TypeCategory::Invalid) {
-		auto true_ts = sema_.getExpressionType(ternaryNode.true_expr());
-		auto false_ts = sema_.getExpressionType(ternaryNode.false_expr());
+		TypeSpecifierQueryResult true_type_query =
+			sema_.parserSemanticServices().getExpressionTypeQuery(ternaryNode.true_expr());
+		TypeSpecifierQueryResult false_type_query =
+			sema_.parserSemanticServices().getExpressionTypeQuery(ternaryNode.false_expr());
+		if (sema_normalized_current_function_ &&
+			(true_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed ||
+			 false_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed)) {
+			throw InternalError("Normalized ternary branch type query remained NotYetAnalyzed");
+		}
+		std::optional<TypeSpecifierNode> true_ts =
+			true_type_query.state == TypeSpecifierQueryResult::State::Available
+				? true_type_query.type
+				: std::nullopt;
+		std::optional<TypeSpecifierNode> false_ts =
+			false_type_query.state == TypeSpecifierQueryResult::State::Available
+				? false_type_query.type
+				: std::nullopt;
 		if (true_ts.has_value() && false_ts.has_value())
 			common_cat = get_common_type(true_ts->category(), false_ts->category());
 	}

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -308,7 +308,10 @@ AstToIr::MultiDimArrayAccess AstToIr::collectMultiDimArrayIndices(const ArraySub
 ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubscriptNode,
 											 ExpressionContext context) {
 	// If sema resolved this subscript to operator[], dispatch to member function call IR.
-	if (const FunctionDeclarationNode* op_subscript = sema_.getResolvedOpSubscript(&arraySubscriptNode)) {
+	ResolvedFunctionQueryResult op_subscript_query =
+		sema_.parserSemanticServices().getResolvedOpSubscriptQuery(&arraySubscriptNode);
+	if (op_subscript_query.state == ResolvedFunctionQueryResult::State::Available) {
+		const FunctionDeclarationNode* op_subscript = op_subscript_query.function;
 		ChunkedVector<ASTNode> args;
 		args.push_back(arraySubscriptNode.index_expr());
 		CallExprNode member_call = makeResolvedMemberCallExpr(
@@ -317,6 +320,10 @@ ExprResult AstToIr::generateArraySubscriptIr(const ArraySubscriptNode& arraySubs
 			std::move(args),
 			arraySubscriptNode.bracket_token());
 		return generateMemberFunctionCallIr(member_call, context);
+	}
+	if (sema_normalized_current_function_ &&
+		op_subscript_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		throw InternalError("Normalized operator[] query remained NotYetAnalyzed");
 	}
 
 	auto makeArrayResult = [](TypeCategory type, int size_bits, IrOperand value, TypeIndex type_index, PointerDepth pointer_depth, ValueStorage storage) -> ExprResult {


### PR DESCRIPTION
## Summary

This PR continues Stage 6 sema-first query-contract tightening in codegen with four focused slices beyond #1580.

## Changes

1. **Member-call receiver typing** (IrGenerator_Call_Indirect.cpp)
   - Switched esolveStructTypeFromReceiverNode(...) to ParserSemanticServices::getExpressionTypeQuery(...)
   - NotYetAnalyzed is now an invariant violation in sema-normalized bodies
   - Preserves identifier/static-cast and parser fallback recovery for non-normalized flow
2. **operator[] dispatch** (IrGenerator_MemberAccess.cpp)
   - Switched array-subscript overload dispatch to getResolvedOpSubscriptQuery(...)
   - Sema-normalized bodies now fail on NotYetAnalyzed instead of silently skipping to builtin indexing fallback
3. **Direct operator() dispatch** (IrGenerator_Call_Direct.cpp)
   - Function-pointer callable dispatch now uses getResolvedOpCallQuery(...)
   -  Sema-normalized direct-call lowering now fails on NotYetAnalyzed query state

4. **Ternary branch typing** (IrGenerator_Expr_Operators.cpp)\n   - Ternary common-type fallback now uses getExpressionTypeQuery(...) for both arms
5. Sema-normalized ternaries now fail explicitly on NotYetAnalyzed branch type queries

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated semantic query handling in code generation to use explicit query-state APIs instead of direct lookups, improving validation of semantic information during compilation.
  * Added explicit error detection for incomplete semantic analysis states in normalized function bodies, ensuring invalid states are caught earlier with informative error messages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1581?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->