### PR TITLE
stage6: tighten remaining parser-owned sema contracts

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -135,6 +135,7 @@ Stage 6 progress so far:
 - generic-lambda argument typing in `IrGenerator_Call_Indirect.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, so sema-normalized member-call lowering fails explicitly on `NotYetAnalyzed` argument-type queries before falling back to the existing symbol/closure/literal deduction helpers.
 - builtin `++`/`--` fallback typing in `IrGenerator_Expr_Conversions.cpp` now also consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, but only hard-fails on `NotYetAnalyzed` where the recovery path actually depends on sema-owned expression typing; identifier/member/dereference pointer-shape recovery still keeps the older parser/declaration-based fallback so Duff's-device-style code continues to lower correctly.
 - parser-owned normalization callers now invoke `Parser::normalizePendingSemanticRoots()` directly; the old `normalizePendingSemanticRootsIfAvailable()` name is gone because parser-attached semantic normalization is no longer an optional capability in these paths.
+- parser-owned constexpr member-function materialization lookup/replay in `ConstExprEvaluator_Members.cpp` now calls `requireParserOwnedSema(...)` directly instead of routing parser-backed contexts through a nullable helper first; standalone sema-only evaluator contexts still keep the explicit nullable fallback.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -133,6 +133,7 @@ Stage 6 progress so far:
 - ternary common-type fallback in `IrGenerator_Expr_Operators.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for both branch expressions, making sema-normalized ternary lowering fail explicitly on `NotYetAnalyzed` branch-type queries instead of reading nullable sema slots.
 - `typeid(expr)` lowering in `IrGenerator_NewDeleteCast.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for the operand's static type/reference query, so sema-normalized bodies hard-fail on `NotYetAnalyzed` instead of silently collapsing incomplete semantic typing into the legacy runtime/type-index fallback path.
 - generic-lambda argument typing in `IrGenerator_Call_Indirect.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, so sema-normalized member-call lowering fails explicitly on `NotYetAnalyzed` argument-type queries before falling back to the existing symbol/closure/literal deduction helpers.
+- builtin `++`/`--` fallback typing in `IrGenerator_Expr_Conversions.cpp` now also consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, but only hard-fails on `NotYetAnalyzed` where the recovery path actually depends on sema-owned expression typing; identifier/member/dereference pointer-shape recovery still keeps the older parser/declaration-based fallback so Duff's-device-style code continues to lower correctly.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -132,6 +132,7 @@ Stage 6 progress so far:
 - the function-pointer `operator()` branch in `AstToIr::generateFunctionCallIr(...)` now also consumes `ParserSemanticServices::getResolvedOpCallQuery(...)`, so sema-normalized direct-call lowering hard-fails on `NotYetAnalyzed` instead of silently treating an unfinished callable lookup as ordinary fallback flow.
 - ternary common-type fallback in `IrGenerator_Expr_Operators.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for both branch expressions, making sema-normalized ternary lowering fail explicitly on `NotYetAnalyzed` branch-type queries instead of reading nullable sema slots.
 - `typeid(expr)` lowering in `IrGenerator_NewDeleteCast.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for the operand's static type/reference query, so sema-normalized bodies hard-fail on `NotYetAnalyzed` instead of silently collapsing incomplete semantic typing into the legacy runtime/type-index fallback path.
+- generic-lambda argument typing in `IrGenerator_Call_Indirect.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, so sema-normalized member-call lowering fails explicitly on `NotYetAnalyzed` argument-type queries before falling back to the existing symbol/closure/literal deduction helpers.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -131,6 +131,7 @@ Stage 6 progress so far:
 - `AstToIr::generateArraySubscriptIr(...)` now consumes `ParserSemanticServices::getResolvedOpSubscriptQuery(...)` before deciding whether `operator[]` dispatch should fall back to builtin array indexing, and sema-normalized bodies now treat `NotYetAnalyzed` subscript-resolution state as an invariant violation instead of quietly skipping to legacy fallback logic.
 - the function-pointer `operator()` branch in `AstToIr::generateFunctionCallIr(...)` now also consumes `ParserSemanticServices::getResolvedOpCallQuery(...)`, so sema-normalized direct-call lowering hard-fails on `NotYetAnalyzed` instead of silently treating an unfinished callable lookup as ordinary fallback flow.
 - ternary common-type fallback in `IrGenerator_Expr_Operators.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for both branch expressions, making sema-normalized ternary lowering fail explicitly on `NotYetAnalyzed` branch-type queries instead of reading nullable sema slots.
+- `typeid(expr)` lowering in `IrGenerator_NewDeleteCast.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for the operand's static type/reference query, so sema-normalized bodies hard-fail on `NotYetAnalyzed` instead of silently collapsing incomplete semantic typing into the legacy runtime/type-index fallback path.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -134,6 +134,7 @@ Stage 6 progress so far:
 - `typeid(expr)` lowering in `IrGenerator_NewDeleteCast.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)` for the operand's static type/reference query, so sema-normalized bodies hard-fail on `NotYetAnalyzed` instead of silently collapsing incomplete semantic typing into the legacy runtime/type-index fallback path.
 - generic-lambda argument typing in `IrGenerator_Call_Indirect.cpp` now consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, so sema-normalized member-call lowering fails explicitly on `NotYetAnalyzed` argument-type queries before falling back to the existing symbol/closure/literal deduction helpers.
 - builtin `++`/`--` fallback typing in `IrGenerator_Expr_Conversions.cpp` now also consumes `ParserSemanticServices::getExpressionTypeQuery(...)`, but only hard-fails on `NotYetAnalyzed` where the recovery path actually depends on sema-owned expression typing; identifier/member/dereference pointer-shape recovery still keeps the older parser/declaration-based fallback so Duff's-device-style code continues to lower correctly.
+- parser-owned normalization callers now invoke `Parser::normalizePendingSemanticRoots()` directly; the old `normalizePendingSemanticRootsIfAvailable()` name is gone because parser-attached semantic normalization is no longer an optional capability in these paths.
 
 Remaining Stage 6 work:
 

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -32,13 +32,6 @@ bool isRecoverablePointerDerefFailure(const EvalResult& result) {
 	}
 	return result.error_message.rfind("Cannot dereference constexpr pointer:", 0) == 0;
 }
-SemanticAnalysis* getSemaForMaterialization(const EvaluationContext& context, const char* operation) {
-	if (context.parser != nullptr) {
-		return &context.requireParserOwnedSema(operation);
-	}
-	return context.sema;
-}
-
 TypeSpecifierNode makeArrayTypeSpec(TypeIndex type_index, std::span<const size_t> array_dimensions);
 EvalResult materializeArrayInitializer(
 	TypeIndex type_index,
@@ -2966,9 +2959,14 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 	// Phase 5 Slice D: route lazy member-function materialization through the
 	// sema-owned helper so the evaluator no longer drives the
 	// instantiate/normalize/mark bookkeeping directly.
-	if (SemanticAnalysis* sema = getSemaForMaterialization(
-			context, kMemberFunctionMaterializationLookupOp); sema != nullptr) {
-		sema->parserSemanticServices().ensureMemberFunctionMaterialized(
+	if (context.parser != nullptr) {
+		context
+			.requireParserOwnedSema(kMemberFunctionMaterializationLookupOp)
+			.parserSemanticServices()
+			.ensureMemberFunctionMaterialized(
+				context.struct_info->name, function_name_handle, std::nullopt);
+	} else if (context.sema != nullptr) {
+		context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
 	}
 
@@ -2985,9 +2983,13 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 		if (!result.function->parent_struct_name().empty()) {
 			owner_name = StringTable::getOrInternStringHandle(result.function->parent_struct_name());
 		}
-		if (SemanticAnalysis* sema = getSemaForMaterialization(
-				context, kMemberFunctionMaterializationReplayOp); sema != nullptr) {
-			sema->parserSemanticServices().ensureMemberFunctionMaterialized(owner_name, *result.function);
+		if (context.parser != nullptr) {
+			context
+				.requireParserOwnedSema(kMemberFunctionMaterializationReplayOp)
+				.parserSemanticServices()
+				.ensureMemberFunctionMaterialized(owner_name, *result.function);
+		} else if (context.sema != nullptr) {
+			context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(owner_name, *result.function);
 		}
 		result = find_member_function_candidate(
 			context.struct_info,

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -2959,14 +2959,15 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 	// Phase 5 Slice D: route lazy member-function materialization through the
 	// sema-owned helper so the evaluator no longer drives the
 	// instantiate/normalize/mark bookkeeping directly.
-	if (context.parser != nullptr) {
-		context
-			.requireParserOwnedSema(kMemberFunctionMaterializationLookupOp)
-			.parserSemanticServices()
-			.ensureMemberFunctionMaterialized(
-				context.struct_info->name, function_name_handle, std::nullopt);
-	} else if (context.sema != nullptr) {
-		context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(
+	auto resolveMaterializationSema = [&](const char* operation) -> SemanticAnalysis* {
+		if (context.parser != nullptr) {
+			return &context.requireParserOwnedSema(operation);
+		}
+		return context.sema;
+	};
+	if (SemanticAnalysis* sema = resolveMaterializationSema(
+			kMemberFunctionMaterializationLookupOp); sema != nullptr) {
+		sema->parserSemanticServices().ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
 	}
 
@@ -2983,13 +2984,9 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 		if (!result.function->parent_struct_name().empty()) {
 			owner_name = StringTable::getOrInternStringHandle(result.function->parent_struct_name());
 		}
-		if (context.parser != nullptr) {
-			context
-				.requireParserOwnedSema(kMemberFunctionMaterializationReplayOp)
-				.parserSemanticServices()
-				.ensureMemberFunctionMaterialized(owner_name, *result.function);
-		} else if (context.sema != nullptr) {
-			context.sema->parserSemanticServices().ensureMemberFunctionMaterialized(owner_name, *result.function);
+		if (SemanticAnalysis* sema = resolveMaterializationSema(
+				kMemberFunctionMaterializationReplayOp); sema != nullptr) {
+			sema->parserSemanticServices().ensureMemberFunctionMaterialized(owner_name, *result.function);
 		}
 		result = find_member_function_candidate(
 			context.struct_info,

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1001,7 +1001,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		return gChunkedAnyStorage.emplace_back<ExpressionNode>(std::move(new_call));
 	};
 	auto normalizePendingSemanticRoots = [&]() {
-		parser_.normalizePendingSemanticRootsIfAvailable();
+		parser_.normalizePendingSemanticRoots();
 	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
 		CallExprNode substituted_call(

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1628,9 +1628,15 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 						if (!argument.is<ExpressionNode>()) {
 							return std::nullopt;
 						}
-						if (auto sema_type = sema_.getExpressionType(argument); sema_type.has_value() &&
-							!isPlaceholderAutoType(sema_type->type())) {
-							return sema_type;
+						TypeSpecifierQueryResult sema_arg_type_query =
+							sema_.parserSemanticServices().getExpressionTypeQuery(argument);
+						if (sema_arg_type_query.state == TypeSpecifierQueryResult::State::Available &&
+							!isPlaceholderAutoType(sema_arg_type_query.type->type())) {
+							return sema_arg_type_query.type;
+						}
+						if (sema_normalized_current_function_ &&
+							sema_arg_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed) {
+							throw InternalError("Normalized generic lambda argument type query remained NotYetAnalyzed");
 						}
 
 						const ExpressionNode& arg_expr = argument.as<ExpressionNode>();

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -2087,12 +2087,38 @@ ExprResult AstToIr::generateBuiltinIncDec(
 	}
 	if (unaryOperatorNode.get_operand().is<ExpressionNode>()) {
 		const ExpressionNode& operandExpr = unaryOperatorNode.get_operand().as<ExpressionNode>();
-		if (operand_pointer_depth == 0) {
-			std::optional<TypeSpecifierNode> operand_type_opt;
-			operand_type_opt = sema_.getExpressionType(unaryOperatorNode.get_operand());
-			if (!operand_type_opt.has_value()) {
-				operand_type_opt = parser_.get_expression_type(unaryOperatorNode.get_operand());
+		auto queryExprTypeWithParserFallback = [&](const ASTNode& node,
+												   bool allow_not_yet_analyzed_recovery,
+												   const char* normalized_not_yet_analyzed_message) -> std::optional<TypeSpecifierNode> {
+			TypeSpecifierQueryResult sema_type_query =
+				sema_.parserSemanticServices().getExpressionTypeQuery(node);
+			std::optional<TypeSpecifierNode> sema_type =
+				sema_type_query.state == TypeSpecifierQueryResult::State::Available
+					? sema_type_query.type
+					: std::nullopt;
+			const bool needs_parser_fallback =
+				!sema_type.has_value() ||
+				sema_type->type() == TypeCategory::Invalid ||
+				isPlaceholderAutoType(sema_type->type());
+			if (!needs_parser_fallback) {
+				return sema_type;
 			}
+			if (sema_normalized_current_function_ &&
+				sema_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed &&
+				!allow_not_yet_analyzed_recovery) {
+				throw InternalError(normalized_not_yet_analyzed_message);
+			}
+			return parser_.get_expression_type(node);
+		};
+		if (operand_pointer_depth == 0) {
+			const bool allow_identifier_or_member_recovery =
+				(operandHandledAsIdentifier && std::holds_alternative<IdentifierNode>(operandExpr)) ||
+				std::holds_alternative<MemberAccessNode>(operandExpr) ||
+				std::holds_alternative<UnaryOperatorNode>(operandExpr);
+			std::optional<TypeSpecifierNode> operand_type_opt = queryExprTypeWithParserFallback(
+				unaryOperatorNode.get_operand(),
+				allow_identifier_or_member_recovery,
+				"Normalized builtin ++/-- operand type query remained NotYetAnalyzed");
 			if (operand_type_opt.has_value()) {
 				applyPointerTypeInfo(*operand_type_opt);
 			}
@@ -2119,10 +2145,10 @@ ExprResult AstToIr::generateBuiltinIncDec(
 				}
 			}
 			if (!object_type_opt.has_value()) {
-				object_type_opt = sema_.getExpressionType(member_access.object());
-			}
-			if (!object_type_opt.has_value()) {
-				object_type_opt = parser_.get_expression_type(member_access.object());
+				object_type_opt = queryExprTypeWithParserFallback(
+					member_access.object(),
+					false,
+					"Normalized builtin ++/-- member object type query remained NotYetAnalyzed");
 			}
 			if (object_type_opt.has_value() &&
 				isIrStructType(toIrType(object_type_opt->type())) &&

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -1112,8 +1112,16 @@ ExprResult AstToIr::generateTypeidIr(const TypeidNode& typeidNode) {
 	} else {
 		const ASTNode& operand_node = typeidNode.operand();
 		const ExpressionNode& operand_expr = operand_node.as<ExpressionNode>();
+		TypeSpecifierQueryResult static_expr_type_query =
+			sema_.parserSemanticServices().getExpressionTypeQuery(operand_node);
 		std::optional<TypeSpecifierNode> static_expr_type =
-			sema_.getExpressionType(operand_node);
+			static_expr_type_query.state == TypeSpecifierQueryResult::State::Available
+				? static_expr_type_query.type
+				: std::nullopt;
+		if (sema_normalized_current_function_ &&
+			static_expr_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed) {
+			throw InternalError("Normalized typeid(expr) operand type query remained NotYetAnalyzed");
+		}
 		auto resolveExprTypeIndex = [&](const ExpressionNode& expr, TypeIndex fallback_type_index) -> TypeIndex {
 			if (fallback_type_index.category() == TypeCategory::Struct && fallback_type_index.is_valid()) {
 				return fallback_type_index;

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -589,7 +589,7 @@ public:
 	const SemanticAnalysis& semanticAnalysis() const {
 		return semantic_analysis_;
 	}
-	void normalizePendingSemanticRootsIfAvailable();
+	void normalizePendingSemanticRoots();
 	ASTNode get_inner_node(ASTNode node) const {
 		return node;
 	}
@@ -2715,7 +2715,7 @@ public:
 	//   2. **Register** - Call registerLateMaterializedTopLevelNode() to:
 	//      - Add the node to ast_nodes_ (so codegen can find it)
 	//      - Enqueue it in pending_semantic_roots_ (so sema can normalize it)
-	//   3. **Normalize** - Call normalizePendingSemanticRootsIfAvailable() to:
+	//   3. **Normalize** - Call normalizePendingSemanticRoots() to:
 	//      - Let SemanticAnalysis process all pending roots
 	//      - Resolve forward declarations, auto types, etc.
 	//
@@ -2725,13 +2725,13 @@ public:
 	//
 	// **Batched Instantiation** (multiple members of same class):
 	//   Call `registerLateMaterializedTopLevelNode(node)` for each member,
-	//   then call `normalizePendingSemanticRootsIfAvailable()` once at the
+	//   then call `normalizePendingSemanticRoots()` once at the
 	//   end. This is more efficient than normalizing after each node.
 	//
 	// **Callers of parser materialization helpers** (from codegen/constexpr):
 	//   If the helper returns a newly-instantiated node but doesn't normalize,
 	//   the caller must call the appropriate normalize function:
-	//   - Parser callers: normalizePendingSemanticRootsIfAvailable()
+	//   - Parser callers: normalizePendingSemanticRoots()
 	//   - AstToIr callers: normalizePendingSemanticRoots()
 	//   - ConstExpr callers: context.normalizePendingSemanticRoots()
 	//
@@ -2767,7 +2767,7 @@ public:
 
 	/// Register a late-materialized AST node for codegen and sema processing.
 	/// Does NOT normalize immediately - use for batched registration.
-	/// After batched registration, call normalizePendingSemanticRootsIfAvailable().
+	/// After batched registration, call normalizePendingSemanticRoots().
 	///
 	/// Idempotent: if `node` has already been registered as a late-materialized
 	/// top-level node (same ASTNode::raw_pointer()), this is a no-op. Multiple
@@ -2810,14 +2810,14 @@ public:
 	/// This is the preferred entry point for single-node instantiation.
 	void registerAndNormalizeLateMaterializedTopLevelNode(const ASTNode& node) {
 		registerLateMaterializedTopLevelNode(node);
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 	}
 
 	/// Register AND normalize a single late-materialized AST node at the front.
 	/// Use for dependencies that must be processed first and immediately visible.
 	void registerAndNormalizeLateMaterializedTopLevelNodeFront(const ASTNode& node) {
 		registerLateMaterializedTopLevelNodeFront(node);
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 	}
 	void registerLateMaterializedOwningStructRoot(StringHandle struct_name) {
 		if (!struct_name.isValid()) {

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -634,7 +634,7 @@ Parser::Parser(Lexer& lexer, CompileContext& context, SemanticAnalysis& semantic
 	ast_nodes_.reserve(default_ast_tree_size_);
 }
 
-void Parser::normalizePendingSemanticRootsIfAvailable() {
+void Parser::normalizePendingSemanticRoots() {
 	semantic_analysis_.parserSemanticServices().normalizePendingSemanticRoots();
 }
 

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -858,7 +858,7 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 		}
 
 		registerLateMaterializedOwningStructRoot(instantiated_struct_name);
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 		return &instantiated_ctor;
 	};
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1025,7 +1025,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 		AliasTemplateMaterializationResult alias_result =
 			materializeAliasTemplateInstantiation(template_name, template_args);
 		if (!alias_result.instantiated_name.empty()) {
-			normalizePendingSemanticRootsIfAvailable();
+			normalizePendingSemanticRoots();
 			if (alias_result.resolved_type_info == nullptr) {
 				alias_result.resolved_type_info =
 					findTypeByName(StringTable::getOrInternStringHandle(alias_result.instantiated_name));
@@ -1039,7 +1039,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeTemplateInstantiat
 	result.instantiated_name =
 		instantiate_and_register_base_template(template_name_to_instantiate, template_args);
 	if (!result.instantiated_name.empty()) {
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 	} else {
 		auto registry_hit = gTemplateRegistry.getInstantiation(
 			StringTable::getOrInternStringHandle(template_name), template_args);
@@ -1251,7 +1251,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberForCanonicalOwner(
 			owner_name,
 			"::",
 			member_name);
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 	}
 	return instantiated;
 }
@@ -3011,7 +3011,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 			registerLateMaterializedTopLevelNode(new_func_node);
 		}
 	}
-	normalizePendingSemanticRootsIfAvailable();
+	normalizePendingSemanticRoots();
 
 	// If no constructor was defined, we should synthesize a default one
 	// For now, mark that we need one and it will be generated in codegen

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -391,7 +391,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		pack_param_info_.resize(saved_ctor_pack_info);
 
 		registerLateMaterializedOwningStructRoot(lazy_info.identity.instantiated_owner_name);
-		normalizePendingSemanticRootsIfAvailable();
+		normalizePendingSemanticRoots();
 
 		auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
 		if (struct_it != getTypesByNameMap().end()) {
@@ -1363,7 +1363,7 @@ bool Parser::instantiateLazyClassToPhase(StringHandle instantiated_name, ClassIn
 		FLASH_LOG(Templates, Debug, "Completed Full phase for: ", instantiated_name);
 	}
 
-	normalizePendingSemanticRootsIfAvailable();
+	normalizePendingSemanticRoots();
 
 	return true;
 }

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1547,7 +1547,7 @@ ParseResult Parser::parse_type_specifier() {
 						AliasTemplateMaterializationResult materialized_alias =
 							materializeAliasTemplateInstantiation(type_name, *template_args);
 						if (!materialized_alias.instantiated_name.empty()) {
-							normalizePendingSemanticRootsIfAvailable();
+							normalizePendingSemanticRoots();
 							if (materialized_alias.resolved_type_info == nullptr) {
 								materialized_alias.resolved_type_info =
 									findTypeByName(StringTable::getOrInternStringHandle(materialized_alias.instantiated_name));

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7805,7 +7805,7 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser().normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRoots();
 	return instantiated;
 }
 
@@ -7821,7 +7821,7 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser().normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRoots();
 	return instantiated;
 }
 
@@ -7855,7 +7855,7 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	if (!instantiated.has_value()) {
 		return std::nullopt;
 	}
-	parser().normalizePendingSemanticRootsIfAvailable();
+	parser().normalizePendingSemanticRoots();
 	return instantiated;
 }
 
@@ -7922,7 +7922,7 @@ size_t SemanticAnalysis::drainLazyMemberRegistry() {
 					entry.registry_key));
 			if (result.has_value()) {
 				++total_materialized;
-				parser().normalizePendingSemanticRootsIfAvailable();
+				parser().normalizePendingSemanticRoots();
 				// Same rationale as the AST-walk pass: annotate the freshly-
 				// substituted body so its internal calls route through
 				// `markOdrUsed` and get picked up by the next fixpoint iteration


### PR DESCRIPTION
## Summary

This PR continues the Stage 6 sema-first cleanup after #1581 by tightening the remaining codegen and parser-owned semantic contracts on top of current `main`.

## Changes

1. **`typeid(expr)` operand typing** (`IrGenerator_NewDeleteCast.cpp`)
   - Switched static operand typing to `ParserSemanticServices::getExpressionTypeQuery(...)`
   - Sema-normalized bodies now hard-fail on `NotYetAnalyzed` instead of silently collapsing to legacy fallback behavior

2. **Generic lambda argument typing** (`IrGenerator_Call_Indirect.cpp`)
   - Switched generic-lambda argument lookup to `getExpressionTypeQuery(...)`
   - Sema-normalized member-call lowering now fails explicitly on `NotYetAnalyzed` before existing symbol/closure/literal fallback helpers

3. **Builtin `++`/`--` fallback typing** (`IrGenerator_Expr_Conversions.cpp`)
   - Switched fallback typing to `getExpressionTypeQuery(...)`
   - Preserved identifier/member/dereference recovery paths so Duff's-device-style code still lowers correctly
   - Only hard-fails on `NotYetAnalyzed` where the recovery path actually depends on sema-owned expression typing

4. **Parser-owned normalization seam** (`Parser.h`, `Parser_Core.cpp`, related callers)
   - Renamed `normalizePendingSemanticRootsIfAvailable()` to `normalizePendingSemanticRoots()`
   - Updated parser-owned callers to reflect that parser-attached semantic normalization is no longer optional in these paths

5. **Constexpr member-function materialization** (`ConstExprEvaluator_Members.cpp`)
   - Parser-backed materialization lookup/replay now calls `requireParserOwnedSema(...)` directly
   - Local sema resolution is deduplicated with a lambda while standalone sema-only evaluator contexts retain the explicit nullable fallback

## Validation

- `./build_flashcpp.bat`
- `pwsh -File tests/run_all_tests.ps1`

All 2427 regular tests pass, and all 182 expected-fail tests still fail as expected.

## Follow-up

The obvious codegen/query-state cleanup is now exhausted; remaining Stage 6 work is broader `EvaluationContext::sema` contract cleanup rather than more localized query swaps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Stage 6 progress update with additional completed work items and clarification of late-materialization lifecycle.

* **Refactor**
  * Standardized parser-aware semantic query usage across type resolution and constexpr flows.
  * Renamed/centralized normalization entry point and made normalization triggers unconditional in several materialization paths.
  * Improved error handling and tightened ordering for template instantiation and member-materialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1583?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->