### PR TITLE
Continue template argument infrastructure refactor

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -38,18 +38,26 @@ Useful to know before changing anything:
 - inherited dependent-base member-template alias owners now resolve through the
   shared member-chain concretization path for covered base-specifier/member-chain
   cases such as `Mid<T>::template rebind<int>`;
+- alias-selected default-NTTP qualified-id owners now canonicalize through a
+  shared owner-materialization primitive instead of local alias/default-NTTP
+  recovery logic in expression substitution;
+- deferred alias/member-chain materialization now recursively concretizes nested
+  alias-target template-instantiation arguments, so stored
+  `IsEmpty<Type>`-style args become `IsEmpty<Concrete>` before deferred-base
+  trait evaluation;
+- current-owner qualified-id substitution now resolves member aliases through the
+  same member-side lookup/materialization path used by current-instantiation
+  member-type lookup, preserving direct dependent-member-target handling and the
+  concrete member-alias cache when a concrete sibling alias must be synthesized;
 - typed NTTP identity is implemented for integral, enum, `nullptr`, object
-  pointer, reference, function pointer, null member pointer, and floating-point
-  cases that already materialize as concrete semantic values;
+  pointer, reference, function pointer, non-null/null member-data pointer, and
+  floating-point cases that already materialize as concrete semantic values;
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
-Validation at this point passed the Windows sharded build. The focused
-follow-up regression for inherited member-template alias lookup now passes, and
-the remaining full-suite state is down to one runtime mismatch:
-`2427` regular tests compiled/linked, `2426` runtime pass, `1` runtime
-regression (`test_type_trait_alias_default_nttp_ret0.cpp`), `182`
-expected-fail tests.
+Validation at this point passed the Windows sharded build and the Windows
+PowerShell test workflow:
+`2437` regular tests compiled/linked/runtime-pass, `182` expected-fail tests.
 
 ## What is still wrong
 
@@ -69,12 +77,11 @@ What still needs work:
 
 Concrete follow-up already identified by recent work:
 
-- alias-selected owners in default-NTTP/qualified-id substitution must now stay
-  attached to the semantic alias result type instead of round-tripping through
-  helper owners such as `Conditional$...::value`;
-- nested alias-target template arguments still need one semantic
-  materialization pass so `IsEmpty<Type>`-style stored template-instantiation
-  arguments become `IsEmpty<Concrete>` before deferred-base trait evaluation.
+- the next concrete follow-up is the remaining dependent-base and unknown-
+  specialization member-chain work plus the declarations that still never
+  capture replay metadata at parse time; deeper current-instantiation/type-alias
+  qualified-id/member chains now reuse the shared semantic lookup path once that
+  metadata exists.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -97,12 +104,13 @@ complete.
 
 Still open:
 
-- non-null member-pointer semantic values;
+- non-null member-function-pointer semantic values;
 - structural class-type NTTPs;
 - any remaining floating-point paths that do not yet round-trip through the
   same semantic identity/mangling flow;
-- replacing remaining conservative function/member-pointer mangling fallbacks
-  such as `TODO(item-8)` in `NameMangling.h`.
+- replacing the remaining conservative function/member-pointer mangling
+  fallbacks in `TODO(item-8)` in `NameMangling.h`; the type side is richer now,
+  but value encoding still intentionally falls back conservatively.
 
 ### 4. Deduction, constraints, and overload resolution are still too coupled to instantiation
 
@@ -148,13 +156,12 @@ In priority order:
 
 1. **Finish the next two-phase lookup slice**
    - current-instantiation/type-alias follow-up work after inherited member-template
-     alias recovery;
-   - complete the remaining alias-owner/default-NTTP path so qualified-id
-     substitution, not constexpr repair logic, owns alias-selected static-member
-     lookup;
+      alias recovery, nested alias-target deferred-base materialization, and the
+      current-owner member-alias qualified-id cleanup is now complete for the
+      deeper covered member-chain cases;
    - remaining replay-metadata gaps for static-member initialization;
    - remaining dependent-base/member-chain paths that still bypass the shared
-     semantic lookup model.
+      semantic lookup model.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
@@ -162,7 +169,7 @@ In priority order:
    - canonical dependent-expression equivalence.
 
 3. **Complete the remaining NTTP categories**
-   - non-null member-pointers;
+   - non-null member-function-pointers;
    - structural class-type NTTPs;
    - remove remaining mangling fallbacks where standard encodings are possible.
 
@@ -190,7 +197,25 @@ materially changes what future refactors can assume.
   covered base-specifier/member-chain concretization cases;
 - alias-template lookup results now expose a canonical semantic owner/result
   name and the main qualified-id substitution paths prefer that semantic owner
-  over helper instantiated names.
+  over helper instantiated names;
+- default-NTTP qualified-id substitution now reuses a shared canonical
+  owner-materialization primitive with parser-side owner lookup materialization
+  instead of bespoke alias/type-index probing in `ExpressionSubstitutor`;
+- current-owner qualified-id member-alias substitution now reuses
+  `resolveBaseClassMemberTypeChain` plus dependent-member materialization helpers
+  instead of the last open-coded local alias repair block in
+  `ExpressionSubstitutor`;
+- deeper current-instantiation/type-alias qualified-id namespace chains now also
+  resolve through that shared member-side path, and replayed qualified-ids now
+  capture current-instantiation metadata early enough that lazy/static replay no
+  longer has to depend on a repair-only fallback for those covered chains;
+- member-pointer NTTPs now preserve declaring-class identity through
+  constexpr/template-arg storage, substitute as `&Class::member` inside template
+  bodies, and distinguish same-name/same-offset members from unrelated classes;
+- member-pointer NTTP mangling now carries richer member-pointer type identity
+  (including the declaring class when recoverable), while value encoding still
+  intentionally falls back conservatively until a full Itanium external-name
+  form is wired for those values.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -56,16 +56,21 @@ Future work should assume these are already in place:
   metadata and definition-context lookup;
 - inherited dependent-base member-template alias owners already resolve through
   the shared member-chain concretization path for covered base-specifier flows;
+- deferred alias/member-chain materialization now recursively concretizes nested
+  alias-target template-instantiation arguments before deferred-base trait
+  evaluation;
+- current-owner qualified-id member aliases now reuse the same member-side
+  lookup/materialization path as nearby current-instantiation member-type
+  resolution, including direct dependent-member-target handling and concrete
+  member-alias cache population when a concrete sibling alias must be materialized;
 - typed NTTP identity already exists for integral, enum, `nullptr`, object
-  pointer, reference, function pointer, null member pointer, and covered
-  floating-point cases;
+  pointer, reference, function pointer, non-null/null member-data pointer, and
+  covered floating-point cases;
 - selected free/member function-template overload paths already rank
   signatures before materializing bodies.
 
 Latest validation on Windows sharded build:
-`2427` regular tests compiled/linked, `2426` runtime pass,
-`1` runtime regression (`test_type_trait_alias_default_nttp_ret0.cpp`),
-`182` expected-fail tests.
+`2437` regular tests compiled/linked/runtime-pass, `182` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -85,12 +90,12 @@ Immediate targets:
 
 Most concrete next subtask:
 
-- finish the remaining alias-selected default-NTTP path where qualified-id
-  substitution still reaches a nested stored template-instantiation argument
-  through placeholder state; the inherited-owner `rebind<U>` slice is done, but
-  `ConditionalT<..., IsEmpty<Type>>::value` still needs the nested
-  `IsEmpty<Type>` argument to materialize semantically to `IsEmpty<Concrete>`
-  before deferred-base type-trait evaluation.
+- finish the remaining dependent-base/unknown-specialization member-chain work
+  and the declarations that still fail to capture replay metadata at parse time;
+  deeper current-instantiation/type-alias qualified-id/member chains now reuse
+  the shared member-side lookup/materialization path, and replayed qualified-id
+  parsing now captures the current-instantiation metadata needed for covered
+  lazy/static flows.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -122,15 +127,17 @@ Without this, identity tracking and later evaluation can still diverge.
 
 The main unsupported categories remain:
 
-- non-null member pointers;
+- non-null member-function pointers;
 - structural class-type NTTPs;
 - remaining end-to-end floating-point coverage if any paths still rely on local
   normalization instead of semantic value identity.
 
 Also required:
 
-- replace remaining conservative function/member-pointer mangling fallbacks
-  where full standard encodings are available.
+- replace the remaining conservative function/member-pointer mangling fallbacks;
+  member-pointer type information is richer now, but value encoding still falls
+  back conservatively until a full standard external-name form is available
+  from current semantic data.
 
 ### 5. Expand deduction/constraint separation before materialization
 
@@ -160,10 +167,11 @@ coverage becomes sufficient.
 ## Recommended implementation order
 
 1. **Two-phase lookup follow-up**
-   - finish current-instantiation/type-alias owner recovery;
-   - complete alias-selected owner canonicalization in default-NTTP qualified-id
-     substitution so helper owners are not reintroduced after semantic alias
-     resolution;
+   - treat the deeper current-instantiation/type-alias member-chain recovery work
+      after the current-owner member-alias qualified-id cleanup as complete for
+      the covered qualified-id/member-side cases;
+   - keep reusing the shared member-side lookup/materialization path in the
+      remaining qualified-id spellings so local repair logic is not reintroduced;
    - extend replay metadata capture into remaining declarations;
    - remove the next AST-only fallback path.
 
@@ -177,7 +185,7 @@ coverage becomes sufficient.
      expressions.
 
 4. **NTTP completion**
-   - non-null member pointers;
+   - non-null member-function pointers;
    - structural class NTTPs;
    - remaining mangling cleanup.
 
@@ -218,6 +226,11 @@ areas:
 This section is intentionally short. It exists only to stop future work from
 re-solving already-solved problems.
 
+- alias-selected default-NTTP qualified-id substitution now canonicalizes the
+  substituted owner through a shared parser/substitutor owner-materialization
+  primitive instead of bespoke alias/default-NTTP recovery in
+  `ExpressionSubstitutor`;
+
 - semantic analyzer unification on parser-owned template-name lookup is done
   for the previously remaining sema-layer probe paths;
 - selected member function template bodies already apply definition-context
@@ -229,7 +242,19 @@ re-solving already-solved problems.
   place for covered base-specifier/member-chain cases;
 - main qualified-id substitution paths now prefer semantic alias owners over
   helper instantiated names when alias materialization already resolved a
-  concrete `TypeInfo`.
+  concrete `TypeInfo`;
+- current-owner member-alias qualified-id substitution now resolves through
+  `resolveBaseClassMemberTypeChain` and dependent-member materialization helpers
+  instead of bespoke local alias repair in `ExpressionSubstitutor`;
+- deeper current-instantiation/type-alias qualified-id namespace chains now go
+  through the same shared member-side path, and replay parsing preserves covered
+  current-instantiation qualified-id metadata early enough for lazy/static
+  substitution to stay semantic instead of falling back to repair;
+- member-data-pointer NTTPs now keep declaring-class identity through
+  constexpr/template-arg round-trips and substitute correctly inside template
+  bodies; mangling now preserves richer member-pointer type identity but still
+  keeps conservative fallback value encoding until a full external-name form is
+  available.
 
 ## Exit criteria
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1020,6 +1020,7 @@ struct TypeInfo {
 		bool is_template_template_arg;  // true if this is a template template argument
 		StringHandle template_name;  // Name of the template for template-template arguments
 		MemberPointerKind member_pointer_kind;  // Distinguish member function vs data pointers
+		StringHandle member_class_name;  // Declaring class for pointer-to-member types
 		// Explicit NTTP identity fields — keep the TemplateTypeArg↔TemplateArgInfo roundtrip
 		// lossless without inferring the kind from TypeCategory or ref_qualifier.
 		// Only meaningful when is_value == true.
@@ -1039,6 +1040,7 @@ struct TypeInfo {
 			  is_array(false),
 			  is_template_template_arg(false),
 			  member_pointer_kind(MemberPointerKind::None),
+			  member_class_name(),
 			  nttp_kind(FlashCpp::NonTypeValueIdentityKind::Integral),
 			  nttp_pointer_offset(0) {}
 
@@ -1059,6 +1061,7 @@ struct TypeInfo {
 			  is_template_template_arg(other.is_template_template_arg),
 			  template_name(other.template_name),
 			  member_pointer_kind(other.member_pointer_kind),
+			  member_class_name(other.member_class_name),
 			  nttp_kind(other.nttp_kind),
 			  nttp_entity_name(other.nttp_entity_name),
 			  nttp_member_name(other.nttp_member_name),
@@ -1084,6 +1087,7 @@ struct TypeInfo {
 				is_template_template_arg = other.is_template_template_arg;
 				template_name = other.template_name;
 				member_pointer_kind = other.member_pointer_kind;
+				member_class_name = other.member_class_name;
 				nttp_kind = other.nttp_kind;
 				nttp_entity_name = other.nttp_entity_name;
 				nttp_member_name = other.nttp_member_name;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -155,6 +155,28 @@ std::vector<size_t> concatenateArrayDimensions(std::vector<size_t> prefix_dimens
 	return prefix_dimensions;
 }
 
+std::vector<QualifiedTypeMemberAccess> buildQualifiedMemberAccessChain(std::string_view qualified_name) {
+	std::vector<QualifiedTypeMemberAccess> member_chain;
+	size_t start = 0;
+	while (start < qualified_name.size()) {
+		size_t separator = qualified_name.find("::", start);
+		std::string_view component = separator == std::string_view::npos
+			? qualified_name.substr(start)
+			: qualified_name.substr(start, separator - start);
+		if (!component.empty()) {
+			QualifiedTypeMemberAccess member_access;
+			member_access.member_name =
+				StringTable::getOrInternStringHandle(component);
+			member_chain.push_back(std::move(member_access));
+		}
+		if (separator == std::string_view::npos) {
+			break;
+		}
+		start = separator + 2;
+	}
+	return member_chain;
+}
+
 void appendArrayDimensions(TypeSpecifierNode& target, std::span<const size_t> prefix_dimensions) {
 	if (prefix_dimensions.empty()) {
 		return;
@@ -863,9 +885,11 @@ bool ExpressionSubstitutor::templateArgsStillDependent(std::span<const TemplateT
 	return false;
 }
 
-const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo& type_info, int depth) {
+ExpressionSubstitutor::MaterializedDependentMemberLookup
+ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_info, int depth) {
+	MaterializedDependentMemberLookup lookup;
 	if (!type_info.isDependentMemberType() || depth >= kMaxDependentMemberTypeResolutionDepth) {
-		return nullptr;
+		return lookup;
 	}
 
 	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
@@ -933,7 +957,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 					InlineVector<TemplateTypeArg, 4> member_args =
 						materializeDependentRecordTemplateArgs(member_record.template_arguments, depth);
 					if (templateArgsStillDependent(member_args)) {
-						return nullptr;
+						return lookup;
 					}
 					member_access.has_template_arguments = true;
 					member_access.template_arguments =
@@ -947,6 +971,27 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 					materialized_owner_name,
 					member_chain);
 			if (resolved_type != nullptr) {
+				if (!dependent_name->member_chain.empty()) {
+					StringBuilder member_path_builder;
+					for (size_t member_index = 0; member_index < dependent_name->member_chain.size();
+						 ++member_index) {
+						if (member_index != 0) {
+							member_path_builder.append("::");
+						}
+						member_path_builder.append(
+							StringTable::getStringView(
+								dependent_name->member_chain[member_index].name));
+					}
+					lookup.materialized_member_handle =
+						StringTable::getOrInternStringHandle(
+							StringBuilder()
+								.append(materialized_owner_name)
+								.append("::")
+								.append(member_path_builder.commit())
+								.commit());
+					lookup.terminal_member_name =
+						dependent_name->member_chain.back().name;
+				}
 				const TypeInfo* next_dependent_type = nullptr;
 				if (const TypeInfo* alias_target =
 						tryGetTypeInfo(resolved_type->type_index_);
@@ -958,9 +1003,15 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 					next_dependent_type = resolved_type;
 				}
 				if (next_dependent_type != nullptr) {
-					return resolveDependentMemberType(*next_dependent_type, depth + 1);
+					MaterializedDependentMemberLookup nested_lookup =
+						lookupMaterializedDependentMember(*next_dependent_type, depth + 1);
+					if (nested_lookup.resolved_type != nullptr) {
+						return nested_lookup;
+					}
+					return lookup;
 				}
-				return resolved_type;
+				lookup.resolved_type = resolved_type;
+				return lookup;
 			}
 		}
 	}
@@ -968,7 +1019,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 	std::string_view type_name = StringTable::getStringView(type_info.name());
 	size_t member_sep = type_name.rfind("::");
 	if (member_sep == std::string_view::npos) {
-		return nullptr;
+		return lookup;
 	}
 
 	std::string_view dependent_base_name = type_name.substr(0, member_sep);
@@ -976,7 +1027,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 	std::string_view dependent_member_name = type_name.substr(member_sep + kScopeResolutionLength);
 	std::string_view base_template_name = extractBaseTemplateName(dependent_base_name);
 	if (base_template_name.empty()) {
-		return nullptr;
+		return lookup;
 	}
 
 	auto dependent_base_it = getTypesByNameMap().find(
@@ -984,7 +1035,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 	if (dependent_base_it == getTypesByNameMap().end() ||
 		dependent_base_it->second == nullptr ||
 		!dependent_base_it->second->isTemplateInstantiation()) {
-		return nullptr;
+		return lookup;
 	}
 
 	MaterializedStoredTemplateArgs concrete_base_args =
@@ -998,7 +1049,7 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 			concrete_base_args.args);
 	std::string_view materialized_base_name = materialized_base.canonicalName();
 	if (materialized_base_name.empty()) {
-		return nullptr;
+		return lookup;
 	}
 
 	QualifiedTypeMemberAccess member_access;
@@ -1010,8 +1061,16 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 			materialized_base_name,
 			member_chain);
 	if (resolved_type == nullptr) {
-		return nullptr;
+		return lookup;
 	}
+	lookup.materialized_member_handle =
+		StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append(materialized_base_name)
+				.append("::")
+				.append(dependent_member_name)
+				.commit());
+	lookup.terminal_member_name = member_access.member_name;
 
 	const TypeInfo* next_dependent_type = nullptr;
 	if (const TypeInfo* alias_target = tryGetTypeInfo(resolved_type->type_index_);
@@ -1021,10 +1080,138 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo
 		next_dependent_type = resolved_type;
 	}
 	if (next_dependent_type != nullptr) {
-		return resolveDependentMemberType(*next_dependent_type, depth + 1);
+		MaterializedDependentMemberLookup nested_lookup =
+			lookupMaterializedDependentMember(*next_dependent_type, depth + 1);
+		if (nested_lookup.resolved_type != nullptr) {
+			return nested_lookup;
+		}
+		return lookup;
 	}
 
-	return resolved_type;
+	lookup.resolved_type = resolved_type;
+	return lookup;
+}
+
+const TypeInfo* ExpressionSubstitutor::resolveMaterializedMemberAliasLookup(
+	const MaterializedDependentMemberLookup& lookup) {
+	if (lookup.resolved_type == nullptr) {
+		return nullptr;
+	}
+	if (!lookup.materialized_member_handle.isValid()) {
+		return lookup.resolved_type;
+	}
+
+	auto concrete_member_it = getTypesByNameMap().find(lookup.materialized_member_handle);
+	if (concrete_member_it != getTypesByNameMap().end() &&
+		concrete_member_it->second != nullptr) {
+		return concrete_member_it->second;
+	}
+
+	if (!lookup.terminal_member_name.isValid() ||
+		StringTable::getStringView(lookup.resolved_type->name()) !=
+			StringTable::getStringView(lookup.terminal_member_name)) {
+		return lookup.resolved_type;
+	}
+
+	TypeIndex resolved_member_index =
+		lookup.resolved_type->registeredTypeIndex().withCategory(
+			lookup.resolved_type->typeEnum());
+	TypeSpecifierNode concrete_member_spec(
+		resolved_member_index,
+		lookup.resolved_type->sizeInBits(),
+		Token(),
+		CVQualifier::None,
+		ReferenceQualifier::None);
+	if (const TypeSpecifierNode* existing_alias_spec =
+			lookup.resolved_type->aliasTypeSpecifier()) {
+		concrete_member_spec = *existing_alias_spec;
+	}
+	TypeInfo& concrete_member_info = add_type_alias_copy(
+		lookup.materialized_member_handle,
+		resolved_member_index,
+		lookup.resolved_type->sizeInBits().value,
+		concrete_member_spec,
+		*lookup.resolved_type);
+	getTypesByNameMap().insert_or_assign(
+		lookup.materialized_member_handle,
+		&concrete_member_info);
+	return &concrete_member_info;
+}
+
+const TypeInfo* ExpressionSubstitutor::resolveQualifiedMemberNamespaceChain(
+	std::string_view owner_name,
+	std::span<QualifiedTypeMemberAccess> member_chain) {
+	if (owner_name.empty()) {
+		return nullptr;
+	}
+
+	const TypeInfo* resolved_member =
+		parser_.resolveBaseClassMemberTypeChain(owner_name, member_chain);
+	if (resolved_member == nullptr) {
+		return nullptr;
+	}
+
+	bool had_dependent_member_lookup = false;
+	if (const TypeInfo* alias_target = tryGetTypeInfo(resolved_member->type_index_);
+		alias_target != nullptr &&
+		alias_target != resolved_member &&
+		alias_target->isDependentMemberType()) {
+		had_dependent_member_lookup = true;
+		MaterializedDependentMemberLookup lookup =
+			lookupMaterializedDependentMember(
+				*alias_target,
+				kInitialDependentMemberTypeResolutionDepth);
+		if (const TypeInfo* materialized_member =
+				resolveMaterializedMemberAliasLookup(lookup);
+			materialized_member != nullptr) {
+			return materialized_member;
+		}
+	}
+	if (resolved_member->isDependentMemberType()) {
+		had_dependent_member_lookup = true;
+		MaterializedDependentMemberLookup lookup =
+			lookupMaterializedDependentMember(
+				*resolved_member,
+				kInitialDependentMemberTypeResolutionDepth);
+		if (const TypeInfo* materialized_member =
+				resolveMaterializedMemberAliasLookup(lookup);
+			materialized_member != nullptr) {
+			return materialized_member;
+		}
+	}
+
+	ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+		resolved_member->registeredTypeIndex().withCategory(
+			resolved_member->typeEnum()));
+	const TypeInfo* resolved_type_info = resolved_alias.terminal_type_info;
+	if (resolved_type_info == nullptr && resolved_alias.type_index.is_valid()) {
+		resolved_type_info = tryGetTypeInfo(resolved_alias.type_index);
+	}
+	if (resolved_type_info != nullptr &&
+		!resolved_type_info->isDependentMemberType()) {
+		return resolved_type_info;
+	}
+	return had_dependent_member_lookup ? nullptr : resolved_member;
+}
+
+const TypeInfo* ExpressionSubstitutor::resolveCurrentOwnerQualifiedNamespaceMember(
+	StringHandle member_name_handle) {
+	if (!current_owner_type_name_.isValid() || !member_name_handle.isValid()) {
+		return nullptr;
+	}
+
+	std::vector<QualifiedTypeMemberAccess> member_chain =
+		buildQualifiedMemberAccessChain(
+			StringTable::getStringView(member_name_handle));
+	if (member_chain.empty()) {
+		return nullptr;
+	}
+	std::string_view owner_name = StringTable::getStringView(current_owner_type_name_);
+	return resolveQualifiedMemberNamespaceChain(owner_name, member_chain);
+}
+
+const TypeInfo* ExpressionSubstitutor::resolveDependentMemberType(const TypeInfo& type_info, int depth) {
+	return lookupMaterializedDependentMember(type_info, depth).resolved_type;
 }
 
 const TypeInfo* ExpressionSubstitutor::resolveDependentMemberTypeForSubstitution(const TypeInfo& type_info) {
@@ -2107,47 +2294,46 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 
 		if (!materialized_owner_name.empty() && !dependent_name->member_chain.empty()) {
 			std::string_view materialized_namespace = materialized_owner_name;
-			for (size_t member_index = 0;
-				 member_index + 1 < dependent_name->member_chain.size();
-				 ++member_index) {
-				const auto& member_record = dependent_name->member_chain[member_index];
-				std::string_view member_name =
-					StringTable::getStringView(member_record.name);
-				if (member_record.has_template_arguments) {
-					InlineVector<TemplateTypeArg, 4> member_args =
-						materializeDependentRecordTemplateArgs(
-							member_record.template_arguments,
-							kInitialDependentMemberTypeResolutionDepth);
-					if (templateArgsStillDependent(member_args)) {
-						ExpressionNode& deferred_expr =
-							gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
-						return ASTNode(&deferred_expr);
+			if (dependent_name->member_chain.size() > 1) {
+				std::vector<QualifiedTypeMemberAccess> namespace_member_chain;
+				namespace_member_chain.reserve(
+					dependent_name->member_chain.size() - 1);
+				for (size_t member_index = 0;
+					 member_index + 1 < dependent_name->member_chain.size();
+					 ++member_index) {
+					const auto& member_record =
+						dependent_name->member_chain[member_index];
+					QualifiedTypeMemberAccess member_access;
+					member_access.member_name = member_record.name;
+					if (member_record.has_template_arguments) {
+						InlineVector<TemplateTypeArg, 4> member_args =
+							materializeDependentRecordTemplateArgs(
+								member_record.template_arguments,
+								kInitialDependentMemberTypeResolutionDepth);
+						if (templateArgsStillDependent(member_args)) {
+							ExpressionNode& deferred_expr =
+								gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
+							return ASTNode(&deferred_expr);
+						}
+						member_access.has_template_arguments = true;
+						member_access.template_arguments =
+							&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(
+								member_args.toVector());
 					}
-					std::string_view member_template_name =
-						StringBuilder()
-							.append(materialized_namespace)
-							.append("::")
-							.append(member_name)
-							.commit();
-					Parser::AliasTemplateMaterializationResult materialized_member =
-						parser_.materializeTemplateInstantiationForLookup(
-							member_template_name,
-							member_args);
-					materialized_namespace = materialized_member.canonicalName();
-					if (materialized_namespace.empty()) {
-						materialized_namespace =
-							parser_.get_instantiated_class_name(
-								member_template_name,
-								member_args);
-					}
-				} else {
-					materialized_namespace =
-						StringBuilder()
-							.append(materialized_namespace)
-							.append("::")
-							.append(member_name)
-							.commit();
+					namespace_member_chain.push_back(std::move(member_access));
 				}
+				const TypeInfo* resolved_namespace =
+					resolveQualifiedMemberNamespaceChain(
+						materialized_owner_name,
+						namespace_member_chain);
+				if (resolved_namespace == nullptr ||
+					!resolved_namespace->name().isValid()) {
+					ExpressionNode& deferred_expr =
+						gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
+					return ASTNode(&deferred_expr);
+				}
+				materialized_namespace =
+					StringTable::getStringView(resolved_namespace->name());
 			}
 
 			const auto& final_member = dependent_name->member_chain.back();
@@ -2265,46 +2451,14 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 			// and the constexpr evaluator quite correctly diagnoses it as undefined.
 			// This order ensures qualified-id expressions like A::value resolve through
 			// alias chains to the concrete struct/class owner type.
-			// Resolution order:
-			// 1) resolved alias terminal TypeInfo
-			// 2) resolved alias TypeIndex lookup
-			// 3) original TypeIndex lookup
-			const auto resolve_concrete_owner_type_info = [&](const TemplateTypeArg& type_arg) -> const TypeInfo* {
-				if (!type_arg.type_index.is_valid()) {
-					return nullptr;
-				}
-				ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
-					type_arg.type_index.withCategory(type_arg.typeEnum()));
-				if (resolved_alias.terminal_type_info != nullptr) {
-					return resolved_alias.terminal_type_info;
-				}
-				if (resolved_alias.type_index.is_valid()) {
-					if (const TypeInfo* resolved_info = tryGetTypeInfo(resolved_alias.type_index)) {
-						return resolved_info;
-					}
-				}
-				return tryGetTypeInfo(type_arg.type_index);
-			};
-			const TypeInfo* type_info = resolve_concrete_owner_type_info(concrete_type);
+			Parser::AliasTemplateMaterializationResult canonical_owner =
+				parser_.materializeCanonicalOwnerTypeForLookup(concrete_type);
+			const TypeInfo* type_info = canonical_owner.resolved_type_info;
 			if (type_info != nullptr && (type_info->isStruct() || type_info->getStructInfo() != nullptr)) {
-				StringHandle type_name_handle = type_info->name();
-
-				if (type_info->isTemplateInstantiation()) {
-					std::string_view base_name = StringTable::getStringView(type_info->baseTemplateName());
-					FLASH_LOG(Templates, Debug, "  Concrete type is template instantiation: base='", base_name, "'");
-					if (!base_name.empty()) {
-						std::vector<TemplateTypeArg> concrete_inst_args;
-						for (const auto& stored_arg : type_info->templateArgs()) {
-							concrete_inst_args.push_back(toTemplateTypeArg(stored_arg));
-						}
-						Parser::AliasTemplateMaterializationResult materialized_type =
-							parser_.materializeTemplateInstantiationForLookup(base_name, concrete_inst_args);
-						if (!materialized_type.instantiated_name.empty()) {
-							type_name_handle = StringTable::getOrInternStringHandle(
-								materialized_type.instantiated_name);
-						}
-					}
-				}
+				StringHandle type_name_handle =
+					canonical_owner.canonicalNameHandle().isValid()
+						? canonical_owner.canonicalNameHandle()
+						: type_info->name();
 
 				// Create a new QualifiedIdentifierNode with the concrete struct as namespace
 				NamespaceHandle new_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
@@ -2336,120 +2490,22 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 	}
 
 	if (current_owner_type_name_.isValid() && !ns_name.empty()) {
-		StringHandle qualified_alias_handle = StringTable::getOrInternStringHandle(
-			StringBuilder()
-				.append(current_owner_type_name_)
-				.append("::")
-				.append(ns_name)
-				.commit());
-		auto alias_it = getTypesByNameMap().find(qualified_alias_handle);
-		if (alias_it != getTypesByNameMap().end() && alias_it->second != nullptr) {
-			const TypeInfo* alias_info = alias_it->second;
-			ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
-				alias_info->registeredTypeIndex().withCategory(alias_info->typeEnum()));
-			const TypeInfo* resolved_type_info = resolved_alias.terminal_type_info;
-			if (!resolved_type_info && resolved_alias.type_index.is_valid()) {
-				resolved_type_info = tryGetTypeInfo(resolved_alias.type_index);
-			}
-			if (resolved_type_info != nullptr) {
-				StringHandle resolved_name_handle = resolved_type_info->name();
-				std::string_view materialization_target_name =
-					StringTable::getStringView(resolved_name_handle);
-				if (const TypeInfo* direct_alias_target_info =
-						tryGetTypeInfo(alias_info->type_index_)) {
-					// Phase 4: use explicit placeholder flag instead of string heuristic
-					if (direct_alias_target_info->isDependentMemberType()) {
-						materialization_target_name =
-							StringTable::getStringView(direct_alias_target_info->name());
-					}
-				}
-				size_t member_sep = materialization_target_name.rfind("::");
-				if (member_sep != std::string_view::npos) {
-					std::string_view dependent_base_name =
-						materialization_target_name.substr(0, member_sep);
-					std::string_view dependent_member_name =
-						materialization_target_name.substr(member_sep + 2);
-					std::string_view base_template_name = extractBaseTemplateName(dependent_base_name);
-					if (!base_template_name.empty()) {
-						std::vector<TemplateTypeArg> current_inst_args =
-							collectCurrentBoundTemplateArgs("ExpressionSubstitutor::substituteQualifiedIdentifier");
-						StringHandle dependent_base_handle =
-							StringTable::getOrInternStringHandle(dependent_base_name);
-						auto dependent_base_it = getTypesByNameMap().find(dependent_base_handle);
-						if (dependent_base_it != getTypesByNameMap().end() &&
-							dependent_base_it->second != nullptr &&
-							dependent_base_it->second->isTemplateInstantiation()) {
-							MaterializedStoredTemplateArgs concrete_base_args =
-								materializeStoredTemplateArgs(
-									*dependent_base_it->second,
-									/*evaluate_dependent_member_values=*/true,
-									kInitialDependentMemberTypeResolutionDepth);
-							if (!concrete_base_args.args.empty()) {
-								current_inst_args = std::move(concrete_base_args.args);
-							}
-						}
-						if (!current_inst_args.empty()) {
-							Parser::AliasTemplateMaterializationResult materialized_alias_base =
-								parser_.materializeTemplateInstantiationForLookup(
-									base_template_name,
-									current_inst_args);
-							std::string_view materialized_alias_base_name =
-								materialized_alias_base.canonicalName();
-							if (!materialized_alias_base_name.empty()) {
-								StringHandle concrete_member_handle = StringTable::getOrInternStringHandle(
-									StringBuilder()
-										.append(materialized_alias_base_name)
-										.append("::")
-										.append(dependent_member_name)
-										.commit());
-								auto concrete_member_it = getTypesByNameMap().find(concrete_member_handle);
-								if (concrete_member_it != getTypesByNameMap().end() &&
-									concrete_member_it->second != nullptr) {
-									resolved_type_info = concrete_member_it->second;
-									resolved_name_handle = concrete_member_it->second->name();
-								} else if (StringTable::getStringView(resolved_name_handle) ==
-										   dependent_member_name) {
-									TypeIndex resolved_member_index =
-										resolved_type_info->registeredTypeIndex().withCategory(
-											resolved_type_info->typeEnum());
-									TypeSpecifierNode concrete_member_spec(
-										resolved_member_index,
-										resolved_type_info->sizeInBits(),
-										Token(),
-										CVQualifier::None,
-										ReferenceQualifier::None);
-									if (const TypeSpecifierNode* existing_alias_spec =
-											resolved_type_info->aliasTypeSpecifier()) {
-										concrete_member_spec = *existing_alias_spec;
-									}
-									TypeInfo& concrete_member_info = add_type_alias_copy(
-										concrete_member_handle,
-										resolved_member_index,
-										resolved_type_info->sizeInBits().value,
-										concrete_member_spec,
-										*resolved_type_info);
-									getTypesByNameMap().insert_or_assign(
-										concrete_member_handle,
-										&concrete_member_info);
-									resolved_type_info = &concrete_member_info;
-									resolved_name_handle = concrete_member_info.name();
-								}
-							}
-						}
-					}
-				}
-				NamespaceHandle new_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
-					NamespaceRegistry::GLOBAL_NAMESPACE,
-					resolved_name_handle);
-				QualifiedIdentifierNode& new_qual_id = gChunkedAnyStorage.emplace_back<QualifiedIdentifierNode>(
-					new_ns_handle,
-					qual_id.identifier_token());
-				FLASH_LOG(Templates, Debug, "  Resolved struct-local alias namespace '", ns_name,
-						  "' -> ", StringTable::getStringView(resolved_name_handle),
-						  " in owner ", StringTable::getStringView(current_owner_type_name_));
-				ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_qual_id);
-				return ASTNode(&new_expr);
-			}
+		if (const TypeInfo* resolved_member_info =
+				resolveCurrentOwnerQualifiedNamespaceMember(
+					StringTable::getOrInternStringHandle(ns_name));
+			resolved_member_info != nullptr) {
+			StringHandle resolved_name_handle = resolved_member_info->name();
+			NamespaceHandle new_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+				NamespaceRegistry::GLOBAL_NAMESPACE,
+				resolved_name_handle);
+			QualifiedIdentifierNode& new_qual_id = gChunkedAnyStorage.emplace_back<QualifiedIdentifierNode>(
+				new_ns_handle,
+				qual_id.identifier_token());
+			FLASH_LOG(Templates, Debug, "  Resolved struct-local alias namespace '", ns_name,
+					  "' -> ", StringTable::getStringView(resolved_name_handle),
+					  " in owner ", StringTable::getStringView(current_owner_type_name_));
+			ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_qual_id);
+			return ASTNode(&new_expr);
 		}
 	}
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -157,22 +157,14 @@ std::vector<size_t> concatenateArrayDimensions(std::vector<size_t> prefix_dimens
 
 std::vector<QualifiedTypeMemberAccess> buildQualifiedMemberAccessChain(std::string_view qualified_name) {
 	std::vector<QualifiedTypeMemberAccess> member_chain;
-	size_t start = 0;
-	while (start < qualified_name.size()) {
-		size_t separator = qualified_name.find("::", start);
-		std::string_view component = separator == std::string_view::npos
-			? qualified_name.substr(start)
-			: qualified_name.substr(start, separator - start);
-		if (!component.empty()) {
-			QualifiedTypeMemberAccess member_access;
-			member_access.member_name =
-				StringTable::getOrInternStringHandle(component);
-			member_chain.push_back(std::move(member_access));
+	for (std::string_view component : splitQualifiedNamespace(qualified_name)) {
+		if (component.empty()) {
+			continue;
 		}
-		if (separator == std::string_view::npos) {
-			break;
-		}
-		start = separator + 2;
+		QualifiedTypeMemberAccess member_access;
+		member_access.member_name =
+			StringTable::getOrInternStringHandle(component);
+		member_chain.push_back(std::move(member_access));
 	}
 	return member_chain;
 }
@@ -972,23 +964,16 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 					member_chain);
 			if (resolved_type != nullptr) {
 				if (!dependent_name->member_chain.empty()) {
-					StringBuilder member_path_builder;
-					for (size_t member_index = 0; member_index < dependent_name->member_chain.size();
-						 ++member_index) {
-						if (member_index != 0) {
-							member_path_builder.append("::");
-						}
-						member_path_builder.append(
-							StringTable::getStringView(
-								dependent_name->member_chain[member_index].name));
+					StringBuilder full_path_builder;
+					full_path_builder.append(materialized_owner_name);
+					for (const auto& member_record : dependent_name->member_chain) {
+						full_path_builder.append("::");
+						full_path_builder.append(
+							StringTable::getStringView(member_record.name));
 					}
 					lookup.materialized_member_handle =
 						StringTable::getOrInternStringHandle(
-							StringBuilder()
-								.append(materialized_owner_name)
-								.append("::")
-								.append(member_path_builder.commit())
-								.commit());
+							full_path_builder.commit());
 					lookup.terminal_member_name =
 						dependent_name->member_chain.back().name;
 				}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -155,7 +155,7 @@ std::vector<size_t> concatenateArrayDimensions(std::vector<size_t> prefix_dimens
 	return prefix_dimensions;
 }
 
-std::vector<QualifiedTypeMemberAccess> buildQualifiedMemberAccessChain(std::string_view qualified_name) {
+static std::vector<QualifiedTypeMemberAccess> buildQualifiedMemberAccessChain(std::string_view qualified_name) {
 	std::vector<QualifiedTypeMemberAccess> member_chain;
 	for (std::string_view component : splitQualifiedNamespace(qualified_name)) {
 		if (component.empty()) {
@@ -1093,8 +1093,7 @@ const TypeInfo* ExpressionSubstitutor::resolveMaterializedMemberAliasLookup(
 	}
 
 	if (!lookup.terminal_member_name.isValid() ||
-		StringTable::getStringView(lookup.resolved_type->name()) !=
-			StringTable::getStringView(lookup.terminal_member_name)) {
+		lookup.resolved_type->name() != lookup.terminal_member_name) {
 		return lookup.resolved_type;
 	}
 

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -4,6 +4,7 @@
 #include "TemplateEnvironment.h"
 #include "TemplateRegistry.h"
 #include <unordered_map>
+#include <optional>
 #include <string_view>
 #include <vector>
 
@@ -108,6 +109,11 @@ private:
 		std::vector<TemplateTypeArg> args;
 		bool had_substitution = false;
 	};
+	struct MaterializedDependentMemberLookup {
+		const TypeInfo* resolved_type = nullptr;
+		StringHandle materialized_member_handle{};
+		StringHandle terminal_member_name{};
+	};
 
 	// Handlers for different expression types
 	ASTNode substituteConstructorCall(const ConstructorCallNode& ctor);
@@ -144,6 +150,16 @@ private:
 		std::span<const TypeInfo::TemplateArgInfo> stored_args,
 		int depth);
 	bool templateArgsStillDependent(std::span<const TemplateTypeArg> args) const;
+	MaterializedDependentMemberLookup lookupMaterializedDependentMember(
+		const TypeInfo& type_info,
+		int depth);
+	const TypeInfo* resolveMaterializedMemberAliasLookup(
+		const MaterializedDependentMemberLookup& lookup);
+	const TypeInfo* resolveQualifiedMemberNamespaceChain(
+		std::string_view owner_name,
+		std::span<QualifiedTypeMemberAccess> member_chain);
+	const TypeInfo* resolveCurrentOwnerQualifiedNamespaceMember(
+		StringHandle member_name_handle);
 	const TypeInfo* resolveDependentMemberType(const TypeInfo& type_info, int depth);
 	void rebuildEnvironmentFromCurrentBindings();
 

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -189,6 +189,9 @@ inline std::string generateItaniumEncodedTypeName(std::string_view qualified_nam
 	return std::string(builder.commit());
 }
 
+template <typename OutputType>
+inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& type_node, bool is_function_parameter);
+
 // Helper to append CV-qualifier code (A/B/C/D) to output
 inline void appendCVQualifier(auto& output, CVQualifier cv) {
 	if (cv == CVQualifier::None) {
@@ -282,6 +285,9 @@ inline TemplateTypeArg normalizeTemplateTypeArgForMangling(TemplateTypeArg arg) 
 		if (!arg.function_signature.has_value() && alias_info.function_signature.has_value()) {
 			arg.function_signature = alias_info.function_signature;
 		}
+		if (!arg.member_class_name.isValid() && alias_info.member_class_name.has_value()) {
+			arg.member_class_name = *alias_info.member_class_name;
+		}
 	}
 
 	if ((category_out_of_range || arg.category() == TypeCategory::Invalid) && arg.type_index.is_valid()) {
@@ -291,6 +297,100 @@ inline TemplateTypeArg normalizeTemplateTypeArgForMangling(TemplateTypeArg arg) 
 	}
 
 	return arg;
+}
+
+inline const StructMember* tryResolveMemberObjectPointerMemberRecursive(
+	const StructTypeInfo* struct_info,
+	StringHandle member_name) {
+	if (struct_info == nullptr) {
+		return nullptr;
+	}
+	for (const StructMember& member : struct_info->members) {
+		if (member.name == member_name) {
+			return &member;
+		}
+	}
+	for (const BaseClassSpecifier& base : struct_info->base_classes) {
+		const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
+		if (base_type_info == nullptr || base_type_info->getStructInfo() == nullptr) {
+			continue;
+		}
+		if (const StructMember* resolved = tryResolveMemberObjectPointerMemberRecursive(
+				base_type_info->getStructInfo(),
+				member_name)) {
+			return resolved;
+		}
+	}
+	return nullptr;
+}
+
+inline const StructMember* tryResolveMemberObjectPointerMember(const FlashCpp::NonTypeValueIdentity& identity) {
+	if (!identity.member_class_name.isValid() || !identity.member_name.isValid()) {
+		return nullptr;
+	}
+	auto type_it = getTypesByNameMap().find(identity.member_class_name);
+	if (type_it == getTypesByNameMap().end() || type_it->second == nullptr) {
+		return nullptr;
+	}
+	const StructTypeInfo* struct_info = type_it->second->getStructInfo();
+	return tryResolveMemberObjectPointerMemberRecursive(struct_info, identity.member_name);
+}
+
+template <typename OutputType>
+inline void appendItaniumVendorExtendedTypeCode(
+	OutputType& output,
+	std::string_view prefix,
+	size_t hash_value) {
+	const std::string encoded_name = std::string(prefix) + std::to_string(hash_value);
+	output += 'u';
+	output += std::to_string(encoded_name.size());
+	output += encoded_name;
+}
+
+template <typename OutputType>
+inline bool appendItaniumMemberPointerTypeCode(
+	OutputType& output,
+	const FlashCpp::NonTypeValueIdentity& identity) {
+	if (!identity.member_class_name.isValid()) {
+		return false;
+	}
+	output += 'M';
+	appendItaniumQualifiedTypeName(output, StringTable::getStringView(identity.member_class_name));
+	if (identity.valueTypeCategory() == TypeCategory::MemberObjectPointer) {
+		const StructMember* member = tryResolveMemberObjectPointerMember(identity);
+		if (member == nullptr) {
+			return false;
+		}
+		TypeSpecifierNode member_type(member->type_index, TypeQualifier::None, 0, Token{}, CVQualifier::None);
+		member_type.add_pointer_levels(member->pointer_depth);
+		member_type.set_reference_qualifier(member->reference_qualifier);
+		if (member->is_array) {
+			member_type.set_array_dimensions(member->array_dimensions);
+		}
+		if (member->function_signature.has_value()) {
+			member_type.set_function_signature(*member->function_signature);
+		}
+		appendItaniumTypeCode(output, member_type, false);
+		return true;
+	}
+	if (identity.valueTypeCategory() == TypeCategory::MemberFunctionPointer &&
+		identity.function_signature.has_value()) {
+		output += 'F';
+		const FunctionSignature& sig = *identity.function_signature;
+		TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
+		appendItaniumTypeCode(output, ret_spec, false);
+		if (sig.parameter_type_indices.empty()) {
+			output += 'v';
+		} else {
+			for (const TypeIndex& pt : sig.parameter_type_indices) {
+				TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);
+				appendItaniumTypeCode(output, param_spec, false);
+			}
+		}
+		output += 'E';
+		return true;
+	}
+	return false;
 }
 
 // Generate MSVC type code for mangling
@@ -1060,6 +1160,17 @@ inline void appendItaniumTypeTemplateArgs(
 			case TypeCategory::Nullptr:
 				output += "Dn";
 				break;
+			case TypeCategory::MemberObjectPointer:
+			case TypeCategory::MemberFunctionPointer:
+				if (!appendItaniumMemberPointerTypeCode(output, identity)) {
+					appendItaniumVendorExtendedTypeCode(
+						output,
+						identity.valueTypeCategory() == TypeCategory::MemberFunctionPointer
+							? "flash_mfp_"
+							: "flash_mop_",
+						identity.hash());
+				}
+				break;
 			case TypeCategory::Struct:
 			case TypeCategory::UserDefined:
 			case TypeCategory::TypeAlias:
@@ -1102,9 +1213,9 @@ inline void appendItaniumTypeTemplateArgs(
 				identity.kind == FlashCpp::NonTypeValueIdentityKind::Reference) {
 				// TODO(item-8): Encode FunctionPointer with full Itanium function-signature
 				// mangling (XadL_Z<mangled-function>EE) once function-pointer NTTP evaluation
-				// is implemented. MemberPointer encoding (Xad<member-external-name>EE) likewise
-				// requires constexpr member-pointer evaluation. Until then use a vendor-extended
-				// hash to ensure uniqueness.
+				// is implemented. MemberPointer value encoding still lacks a complete Itanium
+				// external-name form for the covered semantic data, so keep the conservative
+				// vendor-extended hash fallback until that wiring exists.
 				const size_t identity_hash = identity.hash();
 				output += "u";
 				if (identity.kind == FlashCpp::NonTypeValueIdentityKind::FunctionPointer) {

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -760,7 +760,7 @@ inline void populateSubstitutionsFromClassContext(
 // Append Itanium-style type encoding for basic types
 // Reference: https://itanium-cxx-abi.github.io/cxx-abi/abi.html#mangling-type
 template <typename OutputType>
-inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& type_node, bool is_function_parameter = false) {
+inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& type_node, bool is_function_parameter) {
 	TypeSpecifierNode parameter_adjusted_type =
 		is_function_parameter ? type_node.adjusted_function_parameter_type() : type_node;
 	TypeSpecifierNode normalized_type = normalizeTypeSpecifierForMangling(parameter_adjusted_type);
@@ -920,14 +920,14 @@ inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& t
 				// cv_qualifier_ and other fields from emitting garbage into the mangled name.
 				// Resolve TypeAlias TypeIndex values to their underlying concrete type first.
 			TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-			appendItaniumTypeCode(output, ret_spec);
+			appendItaniumTypeCode(output, ret_spec, false);
 				// Encode parameter types
 			if (sig.parameter_type_indices.empty()) {
 				output += 'v';  // void parameter list
 			} else {
 				for (const TypeIndex& pt : sig.parameter_type_indices) {
 					TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);	 // explicit ctor: see above
-					appendItaniumTypeCode(output, param_spec);
+					appendItaniumTypeCode(output, param_spec, false);
 				}
 			}
 		} else {
@@ -1334,13 +1334,13 @@ inline void appendItaniumTypeTemplateArgs(
 				if (arg.function_signature.has_value()) {
 					const auto& sig = *arg.function_signature;
 					TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-					appendItaniumTypeCode(output, ret_spec);
+					appendItaniumTypeCode(output, ret_spec, false);
 					if (sig.parameter_type_indices.empty()) {
 						output += 'v';
 					} else {
 						for (const TypeIndex& pt : sig.parameter_type_indices) {
 							TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-							appendItaniumTypeCode(output, param_spec);
+							appendItaniumTypeCode(output, param_spec, false);
 						}
 					}
 				} else {
@@ -1357,13 +1357,13 @@ inline void appendItaniumTypeTemplateArgs(
 				if (arg.function_signature.has_value()) {
 					const auto& sig = *arg.function_signature;
 					TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-					appendItaniumTypeCode(output, ret_spec);
+					appendItaniumTypeCode(output, ret_spec, false);
 					if (sig.parameter_type_indices.empty()) {
 						output += 'v';
 					} else {
 						for (const TypeIndex& pt : sig.parameter_type_indices) {
 							TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-							appendItaniumTypeCode(output, param_spec);
+							appendItaniumTypeCode(output, param_spec, false);
 						}
 					}
 				} else {

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -348,6 +348,26 @@ inline void appendItaniumVendorExtendedTypeCode(
 }
 
 template <typename OutputType>
+inline void appendItaniumMemberFunctionQualifiers(
+	OutputType& output,
+	const FunctionSignature& sig) {
+	if (sig.is_const) {
+		output += 'K';
+	}
+	if (sig.is_volatile) {
+		output += 'V';
+	}
+	if (sig.function_reference_qualifier == ReferenceQualifier::LValueReference) {
+		output += 'R';
+	} else if (sig.function_reference_qualifier == ReferenceQualifier::RValueReference) {
+		output += 'O';
+	}
+	if (sig.is_noexcept) {
+		output += "Do";
+	}
+}
+
+template <typename OutputType>
 inline bool appendItaniumMemberPointerTypeCode(
 	OutputType& output,
 	const FlashCpp::NonTypeValueIdentity& identity) {
@@ -387,6 +407,7 @@ inline bool appendItaniumMemberPointerTypeCode(
 				appendItaniumTypeCode(output, param_spec, false);
 			}
 		}
+		appendItaniumMemberFunctionQualifiers(output, sig);
 		output += 'E';
 		return true;
 	}
@@ -1366,6 +1387,7 @@ inline void appendItaniumTypeTemplateArgs(
 							appendItaniumTypeCode(output, param_spec, false);
 						}
 					}
+					appendItaniumMemberFunctionQualifiers(output, sig);
 				} else {
 					throw InternalError("Itanium name mangling: MemberFunctionPointer template arg missing function signature");
 				}

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2888,6 +2888,11 @@ private:
 	AliasTemplateMaterializationResult materializeTemplateInstantiationForLookup(
 		std::string_view template_name,
 		std::span<const TemplateTypeArg> template_args);
+	AliasTemplateMaterializationResult materializeCanonicalOwnerTypeForLookup(
+		const TypeInfo& owner_type_info,
+		std::span<const TemplateTypeArg> owner_template_args);
+	AliasTemplateMaterializationResult materializeCanonicalOwnerTypeForLookup(
+		const TemplateTypeArg& owner_type_arg);
 	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(
 		std::string_view owner_name);
 	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4038,6 +4038,56 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						owner_template_arg_infos = owner_type_it->second->templateArgs();
 					}
 				}
+				if (!owner_is_dependent) {
+					std::string_view current_owner_name;
+					if (!member_function_context_stack_.empty()) {
+						const auto& member_ctx = member_function_context_stack_.back();
+						current_owner_name =
+							StringTable::getStringView(member_ctx.struct_name);
+						owner_type_index = member_ctx.struct_type_index;
+					} else if (!struct_parsing_context_stack_.empty()) {
+						const auto& struct_ctx = struct_parsing_context_stack_.back();
+						current_owner_name = struct_ctx.struct_name;
+						auto current_owner_it = getTypesByNameMap().find(
+							StringTable::getOrInternStringHandle(current_owner_name));
+						if (current_owner_it != getTypesByNameMap().end() &&
+							current_owner_it->second != nullptr) {
+							owner_type_index =
+								current_owner_it->second->registeredTypeIndex();
+						}
+					}
+					if (!current_owner_name.empty()) {
+						std::vector<QualifiedTypeMemberAccess> namespace_member_chain;
+						namespace_member_chain.reserve(namespaces.size());
+						for (const auto& namespace_part : namespaces) {
+							QualifiedTypeMemberAccess member_access;
+							member_access.member_name =
+								StringTable::getOrInternStringHandle(
+									namespace_part.c_str());
+							namespace_member_chain.push_back(std::move(member_access));
+						}
+						if (resolveBaseClassMemberTypeChain(
+								current_owner_name,
+								namespace_member_chain) != nullptr) {
+							std::vector<StringHandle> dependent_member_names;
+							dependent_member_names.reserve(namespaces.size() + 1);
+							for (const auto& namespace_part : namespaces) {
+								dependent_member_names.push_back(
+									StringTable::getOrInternStringHandle(
+										namespace_part.c_str()));
+							}
+							dependent_member_names.push_back(final_identifier.handle());
+							qual_id.setDependentQualifiedName(
+								makeExpressionDependentQualifiedNameRecord(
+									StringTable::getOrInternStringHandle(
+										current_owner_name),
+									owner_type_index,
+									TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation,
+									{},
+									dependent_member_names));
+						}
+					}
+				}
 				if (owner_is_dependent) {
 					std::vector<StringHandle> dependent_member_names;
 					dependent_member_names.reserve(namespaces.size());
@@ -6260,6 +6310,50 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								FLASH_LOG(Templates, Debug, "Substituted FunctionPointer NTTP '", param_name,
 										  "' with &", entity_name_view);
 								return true;
+							}
+							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
+								identity.member_name.isValid() &&
+								identity.member_class_name.isValid()) {
+								InlineVector<StringHandle, 4> owner_components;
+								std::string_view owner_name_view = StringTable::getStringView(identity.member_class_name);
+								size_t owner_start = 0;
+								while (owner_start < owner_name_view.size()) {
+									size_t owner_end = owner_name_view.find("::", owner_start);
+									if (owner_end == std::string_view::npos) {
+										owner_end = owner_name_view.size();
+									}
+									owner_components.push_back(StringTable::getOrInternStringHandle(
+										owner_name_view.substr(owner_start, owner_end - owner_start)));
+									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
+								}
+								NamespaceHandle owner_scope = owner_components.empty()
+									? NamespaceRegistry::GLOBAL_NAMESPACE
+									: gNamespaceRegistry.getOrCreatePath(
+										NamespaceRegistry::GLOBAL_NAMESPACE,
+										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
+									std::string_view member_name_view = StringTable::getStringView(identity.member_name);
+									Token member_token(Token::Type::Identifier, member_name_view,
+											   identifier_token.line(), identifier_token.column(),
+											   identifier_token.file_index());
+									Token amp_token(Token::Type::Operator, "&"sv,
+											identifier_token.line(), identifier_token.column(),
+											identifier_token.file_index());
+									ASTNode qualified_member = emplace_node<ExpressionNode>(
+										QualifiedIdentifierNode(owner_scope, member_token));
+									result = emplace_node<ExpressionNode>(
+										UnaryOperatorNode(amp_token, qualified_member, true));
+									FLASH_LOG(
+										Templates,
+										Debug,
+										"Substituted MemberPointer NTTP '",
+										param_name,
+										"' with &",
+										StringTable::getStringView(identity.member_class_name),
+										"::",
+										member_name_view);
+									return true;
+								}
 							}
 						}
 						// Substitute with actual value

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -3120,23 +3120,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							concrete_owner_name = StringTable::getStringView(
 								materialized_owner.resolved_type_info->name());
 						}
-						NamespaceHandle full_ns_handle = NamespaceRegistry::GLOBAL_NAMESPACE;
-						size_t component_start = 0;
-						while (component_start < concrete_owner_name.size()) {
-							size_t component_end = concrete_owner_name.find("::", component_start);
-							std::string_view component = component_end == std::string_view::npos
-								? concrete_owner_name.substr(component_start)
-								: concrete_owner_name.substr(component_start, component_end - component_start);
-							if (!component.empty()) {
-								full_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
-									full_ns_handle,
-									StringTable::getOrInternStringHandle(component));
-							}
-							if (component_end == std::string_view::npos) {
-								break;
-							}
-							component_start = component_end + 2;
-						}
+						std::vector<std::string_view> owner_components =
+							splitQualifiedNamespace(concrete_owner_name);
+						NamespaceHandle full_ns_handle = owner_components.empty()
+							? NamespaceRegistry::GLOBAL_NAMESPACE
+							: gNamespaceRegistry.getOrCreatePath(
+								NamespaceRegistry::GLOBAL_NAMESPACE,
+								std::span<const std::string_view>(
+									owner_components.data(),
+									owner_components.size()));
 
 						// Parse the :: and the member name
 						advance(); // consume ::
@@ -6314,23 +6306,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
 								identity.member_name.isValid() &&
 								identity.member_class_name.isValid()) {
-								InlineVector<StringHandle, 4> owner_components;
-								std::string_view owner_name_view = StringTable::getStringView(identity.member_class_name);
-								size_t owner_start = 0;
-								while (owner_start < owner_name_view.size()) {
-									size_t owner_end = owner_name_view.find("::", owner_start);
-									if (owner_end == std::string_view::npos) {
-										owner_end = owner_name_view.size();
-									}
-									owner_components.push_back(StringTable::getOrInternStringHandle(
-										owner_name_view.substr(owner_start, owner_end - owner_start)));
-									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
-								}
+								std::vector<std::string_view> owner_components =
+									splitQualifiedNamespace(
+										StringTable::getStringView(identity.member_class_name));
 								NamespaceHandle owner_scope = owner_components.empty()
 									? NamespaceRegistry::GLOBAL_NAMESPACE
 									: gNamespaceRegistry.getOrCreatePath(
 										NamespaceRegistry::GLOBAL_NAMESPACE,
-										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+										std::span<const std::string_view>(
+											owner_components.data(),
+											owner_components.size()));
 								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
 									std::string_view member_name_view = StringTable::getStringView(identity.member_name);
 									Token member_token(Token::Type::Identifier, member_name_view,

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1024,6 +1024,27 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 	auto makeConstantValueFromCategory = [&](int64_t value, TypeCategory category) {
 		return makeConstantValue(value, category, TypeIndex{});
 	};
+	auto inferMemberPointerClassNameFromNode =
+		[&](const ASTNode& node, const auto& self) -> StringHandle {
+		if (!node.is<ExpressionNode>()) {
+			return {};
+		}
+		const ExpressionNode& expr_variant = node.as<ExpressionNode>();
+		if (const auto* unary = std::get_if<UnaryOperatorNode>(&expr_variant)) {
+			if (unary->op() == "&") {
+				return self(unary->get_operand(), self);
+			}
+			return {};
+		}
+		if (const auto* qualified_id = std::get_if<QualifiedIdentifierNode>(&expr_variant)) {
+			std::string_view qualified_scope =
+				gNamespaceRegistry.getQualifiedName(qualified_id->namespace_handle());
+			if (!qualified_scope.empty()) {
+				return StringTable::getOrInternStringHandle(qualified_scope);
+			}
+		}
+		return {};
+	};
 	auto makeConstantValueFromEvalResult = [&](const ConstExpr::EvalResult& eval_result) {
 		TypeCategory category = TypeCategory::Int;
 		TypeIndex type_index{};
@@ -1049,10 +1070,18 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 				eval_result.pointer_offset);
 		} else if (eval_result.member_pointer_member.isValid() || eval_result.is_null_member_pointer) {
 			if (eval_result.member_pointer_member.isValid()) {
+				StringHandle member_class_name{};
+				if (eval_result.exact_type.has_value() && eval_result.exact_type->has_member_class()) {
+					member_class_name = eval_result.exact_type->member_class_name();
+				}
+				if (!member_class_name.isValid()) {
+					member_class_name = inferMemberPointerClassNameFromNode(expr_node, inferMemberPointerClassNameFromNode);
+				}
 				value.identity = FlashCpp::NonTypeValueIdentity::makeMemberPointer(
 					value.type_index,
 					eval_result.member_pointer_member,
-					eval_result.as_int());
+					eval_result.as_int(),
+					member_class_name);
 			} else {
 				// Null member pointer: emit a Nullptr-typed Integral identity (value=0)
 				// so that classifyExplicitTemplateArgumentsAgainstParameters handles it

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3592,7 +3592,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									return tryMaterializeDeferredBaseTypeArg(
 										type_spec,
 										template_params,
-										template_args,
+										template_args_for_member_copy,
 										[&](std::string_view concrete_base_template_name, std::span<const TemplateTypeArg> concrete_base_args) {
 											std::vector<TemplateTypeArg> mutable_concrete_base_args(
 												concrete_base_args.begin(),

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -594,14 +594,18 @@ static std::optional<bool> functionDeclarationsMatchAfterTemplateSubstitution(
 // template's substitution maps are available.
 // Returns std::nullopt when any pack expansion or concrete member argument cannot be resolved.
 // The substitution maps only need to remain valid for the duration of this call.
+// `materialize_type_arg` must accept `const TypeSpecifierNode&` and return an
+// optionally more concrete `TemplateTypeArg` for nested template-instantiation
+// arguments that need full deferred-base materialization.
 // `substitute_expression` must accept `const ASTNode&` and return a substituted `ASTNode`.
 // `evaluate_constant_expression` must accept `const ASTNode&` and return
 // `std::optional<Parser::ConstantValue>` for non-type template arguments.
-template <typename SubstituteExpressionFn, typename EvaluateConstantExpressionFn>
+template <typename MaterializeTypeArgFn, typename SubstituteExpressionFn, typename EvaluateConstantExpressionFn>
 static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBaseMemberTypeChain(
 	std::span<const QualifiedTypeMemberAccess> member_type_chain,
 	const TemplateArgSubstitutionMap& name_substitution_map,
 	const TemplateArgPackSubstitutionMap& pack_substitution_map,
+	MaterializeTypeArgFn&& materialize_type_arg,
 	SubstituteExpressionFn&& substitute_expression,
 	EvaluateConstantExpressionFn&& evaluate_constant_expression) {
 	std::vector<QualifiedTypeMemberAccess> resolved_member_chain;
@@ -658,6 +662,14 @@ static std::optional<std::vector<QualifiedTypeMemberAccess>> resolveDeferredBase
 						resolved_type_arg.has_value()) {
 						resolved_args.push_back(*resolved_type_arg);
 						member_arg_resolved = true;
+					}
+					if (!member_arg_resolved) {
+						if (std::optional<TemplateTypeArg> materialized_type_arg =
+								materialize_type_arg(ts);
+							materialized_type_arg.has_value()) {
+							resolved_args.push_back(*materialized_type_arg);
+							member_arg_resolved = true;
+						}
 					}
 					if (!member_arg_resolved) {
 						resolved_args.emplace_back(ts);
@@ -3576,6 +3588,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								deferred_base.member_type_chain,
 								spec_subst_map,
 								spec_pack_subst_map,
+								[&](const TypeSpecifierNode& type_spec) {
+									return tryMaterializeDeferredBaseTypeArg(
+										type_spec,
+										template_params,
+										template_args,
+										[&](std::string_view concrete_base_template_name, std::span<const TemplateTypeArg> concrete_base_args) {
+											std::vector<TemplateTypeArg> mutable_concrete_base_args(
+												concrete_base_args.begin(),
+												concrete_base_args.end());
+											return instantiateAndResolveBaseName(
+												concrete_base_template_name,
+												mutable_concrete_base_args,
+												true);
+										});
+								},
 								[&](const ASTNode& node) {
 									return substituteTemplateParameters(node, template_params, template_args);
 								},
@@ -6874,6 +6901,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						deferred_base.member_type_chain,
 						subst_map,
 						pack_substitution_map,
+						[&](const TypeSpecifierNode& type_spec) {
+							return tryMaterializeDeferredBaseTypeArg(
+								type_spec,
+								template_params,
+								template_args_to_use,
+								[this](std::string_view concrete_base_template_name, std::span<const TemplateTypeArg> concrete_base_args) {
+									return instantiate_and_register_base_template(concrete_base_template_name, concrete_base_args);
+								});
+						},
 						[&](const ASTNode& node) {
 							return member_template_arg_substitutor.substitute(node);
 						},

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -201,7 +201,7 @@ namespace {
 		TemplateTypeArg concrete_arg,
 		MaterializeArgsFn&& materialize_args,
 		MaterializeLookupFn&& materialize_lookup,
-		int depth = 0) {
+		int depth) {
 		constexpr int kMaxRecursiveTemplateArgDepth = 8;
 		if (depth >= kMaxRecursiveTemplateArgDepth ||
 			concrete_arg.is_value ||
@@ -255,10 +255,21 @@ namespace {
 		if (resolved_arg_alias.terminal_type_info != nullptr &&
 			resolved_arg_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
 			concrete_type_info = resolved_arg_alias.terminal_type_info;
-			concrete_arg.type_index =
+			TemplateTypeArg resolved_alias_arg = makeTemplateTypeArgFromResolvedAlias(
+				resolved_arg_alias,
 				concrete_type_info->registeredTypeIndex().withCategory(
-					concrete_type_info->typeEnum());
-			concrete_arg.setCategory(concrete_type_info->typeEnum());
+					concrete_type_info->typeEnum()));
+			concrete_arg.type_index = resolved_alias_arg.type_index;
+			concrete_arg.setCategory(resolved_alias_arg.typeEnum());
+			concrete_arg.pointer_depth = resolved_alias_arg.pointer_depth;
+			concrete_arg.ref_qualifier = resolved_alias_arg.ref_qualifier;
+			concrete_arg.cv_qualifier = resolved_alias_arg.cv_qualifier;
+			concrete_arg.is_array = resolved_alias_arg.is_array;
+			concrete_arg.array_dimensions = std::move(resolved_alias_arg.array_dimensions);
+			concrete_arg.function_signature = resolved_alias_arg.function_signature;
+			if (resolved_arg_alias.member_class_name.has_value()) {
+				concrete_arg.member_class_name = *resolved_arg_alias.member_class_name;
+			}
 			concrete_arg.is_dependent = false;
 			concrete_arg.dependent_name = {};
 			concrete_arg.dependent_expr = std::nullopt;
@@ -487,7 +498,8 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 						substitution_environment,
 						std::move(concrete_arg),
 						materialize_args,
-						materialize_lookup);
+						materialize_lookup,
+						0);
 				}
 				if (!StringTable::getStringView(arg_type_info->baseTemplateName()).empty()) {
 					AliasTemplateMaterializationResult materialized_type =
@@ -978,7 +990,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 				substitution_environment,
 				std::move(concrete_arg),
 				materialize_args,
-				materialize_lookup);
+				materialize_lookup,
+				0);
 		}
 		return concrete_args;
 	};
@@ -1378,6 +1391,20 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 		result.instantiated_name =
 			StringTable::getStringView(canonical_owner_type_info->name());
 	}
+	auto canonical_owner_template_names = [&]() {
+		StringHandle qualified_base_template_handle =
+			gNamespaceRegistry.buildQualifiedIdentifier(
+				canonical_owner_type_info->sourceNamespace(),
+				canonical_owner_type_info->baseTemplateName());
+		std::string_view qualified_base_template_name =
+			StringTable::getStringView(qualified_base_template_handle);
+		std::string_view base_template_name =
+			StringTable::getStringView(canonical_owner_type_info->baseTemplateName());
+		return std::tuple<StringHandle, std::string_view, std::string_view>(
+			qualified_base_template_handle,
+			qualified_base_template_name,
+			base_template_name);
+	};
 
 	auto try_materialize_exact_owner =
 		[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) -> bool {
@@ -1395,18 +1422,32 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 			return false;
 		}
 
-		std::string_view base_template_name =
-			StringTable::getStringView(canonical_owner_type_info->baseTemplateName());
-		if (base_template_name.empty()) {
+		auto [qualified_base_template_handle, qualified_base_template_name, base_template_name] =
+			canonical_owner_template_names();
+		if (qualified_base_template_name.empty() && base_template_name.empty()) {
 			return false;
 		}
 
-		AliasTemplateMaterializationResult canonical_owner =
-			materializeTemplateInstantiationForLookup(
-				base_template_name,
-				std::span<const TemplateTypeArg>(
-					concrete_template_args.data(),
-					concrete_template_args.size()));
+		AliasTemplateMaterializationResult canonical_owner;
+		if (!qualified_base_template_name.empty()) {
+			canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					qualified_base_template_name,
+					std::span<const TemplateTypeArg>(
+						concrete_template_args.data(),
+						concrete_template_args.size()));
+		}
+		if ((canonical_owner.instantiated_name.empty() &&
+			 canonical_owner.resolved_type_info == nullptr) &&
+			!base_template_name.empty() &&
+			qualified_base_template_handle != canonical_owner_type_info->baseTemplateName()) {
+			canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					base_template_name,
+					std::span<const TemplateTypeArg>(
+						concrete_template_args.data(),
+						concrete_template_args.size()));
+		}
 		if (canonical_owner.instantiated_name.empty() &&
 			canonical_owner.resolved_type_info == nullptr) {
 			return false;
@@ -1447,14 +1488,27 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 		return result;
 	}
 
-	const std::string_view base_template_name =
-		StringTable::getStringView(canonical_owner_type_info->baseTemplateName());
+	auto [qualified_base_template_handle, qualified_base_template_name, base_template_name] =
+		canonical_owner_template_names();
 	if (!owner_template_args.empty() &&
-		can_materialize_owner_template(base_template_name)) {
-		AliasTemplateMaterializationResult canonical_owner =
-			materializeTemplateInstantiationForLookup(
-				base_template_name,
-				owner_template_args);
+		(can_materialize_owner_template(qualified_base_template_name) ||
+		 can_materialize_owner_template(base_template_name))) {
+		AliasTemplateMaterializationResult canonical_owner;
+		if (can_materialize_owner_template(qualified_base_template_name)) {
+			canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					qualified_base_template_name,
+					owner_template_args);
+		}
+		if ((canonical_owner.instantiated_name.empty() &&
+			 canonical_owner.resolved_type_info == nullptr) &&
+			can_materialize_owner_template(base_template_name) &&
+			qualified_base_template_handle != canonical_owner_type_info->baseTemplateName()) {
+			canonical_owner =
+				materializeTemplateInstantiationForLookup(
+					base_template_name,
+					owner_template_args);
+		}
 		if (!canonical_owner.instantiated_name.empty() ||
 			canonical_owner.resolved_type_info != nullptr) {
 			return canonical_owner;

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -36,11 +36,16 @@ TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_
 		if (!value_type_index.is_valid()) {
 			value_type_index = nativeTypeIndex(TypeCategory::MemberObjectPointer);
 		}
+		StringHandle member_class_name{};
+		if (eval_result.exact_type.has_value() && eval_result.exact_type->has_member_class()) {
+			member_class_name = eval_result.exact_type->member_class_name();
+		}
 		return TemplateTypeArg::makeValueIdentity(
 			FlashCpp::NonTypeValueIdentity::makeMemberPointer(
 				value_type_index,
 				eval_result.member_pointer_member,
-				eval_result.as_int()));
+				eval_result.as_int(),
+				member_class_name));
 	}
 	if (const auto* bool_value = std::get_if<bool>(&eval_result.value)) {
 		return TemplateTypeArg(*bool_value ? 1LL : 0LL, TypeCategory::Bool);
@@ -174,6 +179,136 @@ namespace {
 	return templateTypeArgFromEvalResult(eval_result);
 }
 
+	bool templateArgsStillNeedAliasLookupMaterialization(std::span<const TemplateTypeArg> template_args) {
+		for (const TemplateTypeArg& arg : template_args) {
+			if (arg.is_dependent ||
+				arg.dependent_name.isValid() ||
+				arg.dependent_expr.has_value()) {
+				return true;
+			}
+			if (!arg.is_value &&
+				arg.type_index.is_valid() &&
+				typeIndexContainsDependentPlaceholder(arg.type_index)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	template <typename MaterializeArgsFn, typename MaterializeLookupFn>
+	TemplateTypeArg recursivelyMaterializeAliasLookupTemplateArg(
+		const TemplateEnvironment& substitution_environment,
+		TemplateTypeArg concrete_arg,
+		MaterializeArgsFn&& materialize_args,
+		MaterializeLookupFn&& materialize_lookup,
+		int depth = 0) {
+		constexpr int kMaxRecursiveTemplateArgDepth = 8;
+		if (depth >= kMaxRecursiveTemplateArgDepth ||
+			concrete_arg.is_value ||
+			!concrete_arg.type_index.is_valid()) {
+			return concrete_arg;
+		}
+
+		auto tryRebindByName = [&](StringHandle dependent_name) -> bool {
+			if (!dependent_name.isValid()) {
+				return false;
+			}
+			if (std::optional<TemplateTypeArg> rebound =
+					resolveContextBinding(
+						dependent_name,
+						substitution_environment);
+				rebound.has_value()) {
+				concrete_arg = !rebound->is_value
+					? rebindDependentTemplateTypeArg(*rebound, concrete_arg)
+					: *rebound;
+				return true;
+			}
+			return false;
+		};
+
+		if (concrete_arg.is_dependent &&
+			concrete_arg.dependent_name.isValid()) {
+			(void)tryRebindByName(concrete_arg.dependent_name);
+			if (concrete_arg.is_value || !concrete_arg.type_index.is_valid()) {
+				return concrete_arg;
+			}
+		}
+
+		const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+		if (concrete_type_info == nullptr) {
+			return concrete_arg;
+		}
+
+		if (concrete_type_info->name().isValid() &&
+			tryRebindByName(concrete_type_info->name())) {
+			if (concrete_arg.is_value || !concrete_arg.type_index.is_valid()) {
+				return concrete_arg;
+			}
+			concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
+			if (concrete_type_info == nullptr) {
+				return concrete_arg;
+			}
+		}
+
+		ResolvedAliasTypeInfo resolved_arg_alias = resolveAliasTypeInfo(
+			concrete_arg.type_index.withCategory(concrete_type_info->typeEnum()));
+		if (resolved_arg_alias.terminal_type_info != nullptr &&
+			resolved_arg_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
+			concrete_type_info = resolved_arg_alias.terminal_type_info;
+			concrete_arg.type_index =
+				concrete_type_info->registeredTypeIndex().withCategory(
+					concrete_type_info->typeEnum());
+			concrete_arg.setCategory(concrete_type_info->typeEnum());
+			concrete_arg.is_dependent = false;
+			concrete_arg.dependent_name = {};
+			concrete_arg.dependent_expr = std::nullopt;
+		}
+
+		if (!concrete_type_info->isTemplateInstantiation()) {
+			return concrete_arg;
+		}
+
+		std::vector<TemplateTypeArg> nested_concrete_args =
+			materialize_args(*concrete_type_info);
+		for (TemplateTypeArg& nested_arg : nested_concrete_args) {
+			nested_arg = recursivelyMaterializeAliasLookupTemplateArg(
+				substitution_environment,
+				std::move(nested_arg),
+				materialize_args,
+				materialize_lookup,
+				depth + 1);
+		}
+		if (templateArgsStillNeedAliasLookupMaterialization(nested_concrete_args)) {
+			return concrete_arg;
+		}
+
+		auto materialized_nested =
+			materialize_lookup(*concrete_type_info, nested_concrete_args);
+		const TypeInfo* resolved_nested_info = materialized_nested.resolved_type_info;
+		if (resolved_nested_info == nullptr) {
+			StringHandle canonical_name_handle =
+				materialized_nested.canonicalNameHandle();
+			if (canonical_name_handle.isValid()) {
+				resolved_nested_info = findTypeByName(canonical_name_handle);
+			}
+		}
+		if (resolved_nested_info == nullptr) {
+			return concrete_arg;
+		}
+
+		TypeIndex resolved_nested_index =
+			resolved_nested_info->registeredTypeIndex().withCategory(
+				resolved_nested_info->typeEnum());
+		TemplateTypeArg resolved_nested_arg =
+			makeTemplateTypeArgFromResolvedAlias(
+				resolveAliasTypeInfo(resolved_nested_index),
+				resolved_nested_index);
+		resolved_nested_arg.is_pack = concrete_arg.is_pack;
+		return rebindDependentTemplateTypeArg(
+			resolved_nested_arg,
+			concrete_arg);
+	}
+
 }  // namespace
 
 ASTNode Parser::substituteNonTypeDefaultExpression(
@@ -290,57 +425,73 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg_type.type_index());
 				arg_type_info != nullptr &&
 				arg_type_info->isTemplateInstantiation()) {
-				std::vector<TemplateTypeArg> concrete_instantiation_args = materializeTemplateArgs(
-					*arg_type_info,
-					template_parameters,
-					template_args);
 				TemplateEnvironment substitution_environment = buildTemplateEnvironment(
 					std::span<const TemplateParameterNode>(
 						template_parameters.data(),
 						template_parameters.size()),
 					template_args,
 					nullptr);
-				for (TemplateTypeArg& concrete_arg : concrete_instantiation_args) {
-					if (concrete_arg.is_value) {
-						continue;
-					}
-					if (concrete_arg.is_dependent &&
-						concrete_arg.dependent_name.isValid()) {
-						if (std::optional<TemplateTypeArg> rebound =
-								resolveContextBinding(
-									concrete_arg.dependent_name,
-									substitution_environment);
-							rebound.has_value()) {
-							concrete_arg = !rebound->is_value
-								? rebindDependentTemplateTypeArg(*rebound, concrete_arg)
-								: *rebound;
-							continue;
+				auto eval_nttp = [this](
+					const ASTNode& expr,
+					std::span<const ASTNode> params,
+					std::span<const TemplateTypeArg> args) -> std::optional<TemplateTypeArg> {
+					InlineVector<TemplateParameterNode, 4> typed_params;
+					typed_params.reserve(params.size());
+					for (const ASTNode& param_node : params) {
+						if (const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(param_node);
+							typed_param != nullptr) {
+							typed_params.push_back(*typed_param);
 						}
 					}
-					if (!concrete_arg.type_index.is_valid()) {
-						continue;
-					}
-					const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
-					if (concrete_type_info == nullptr || !concrete_type_info->name().isValid()) {
-						continue;
-					}
-					if (std::optional<TemplateTypeArg> rebound =
-							resolveContextBinding(
-								concrete_type_info->name(),
-								substitution_environment);
-						rebound.has_value()) {
-						concrete_arg = !rebound->is_value
-							? rebindDependentTemplateTypeArg(*rebound, concrete_arg)
-							: *rebound;
-					}
+					return this->evaluateDependentNTTPExpression(
+						expr,
+						std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
+						args);
+				};
+				auto materialize_args = [&](const TypeInfo& source_type_info) {
+					return materializeTemplateArgs(
+						source_type_info,
+						template_parameters,
+						template_args,
+						eval_nttp);
+				};
+				auto materialize_lookup =
+					[this](const TypeInfo& source_type_info, std::span<const TemplateTypeArg> concrete_instantiation_args) {
+						StringHandle qualified_base_template_name =
+							gNamespaceRegistry.buildQualifiedIdentifier(
+								source_type_info.sourceNamespace(),
+								source_type_info.baseTemplateName());
+						std::string_view base_template_name =
+							StringTable::getStringView(qualified_base_template_name);
+						AliasTemplateMaterializationResult materialized_type;
+						if (!base_template_name.empty()) {
+							materialized_type =
+								materializeTemplateInstantiationForLookup(
+									base_template_name,
+									concrete_instantiation_args);
+						}
+						if ((materialized_type.resolved_type_info == nullptr &&
+							 materialized_type.instantiated_name.empty()) &&
+							qualified_base_template_name != source_type_info.baseTemplateName()) {
+							materialized_type =
+								materializeTemplateInstantiationForLookup(
+									StringTable::getStringView(source_type_info.baseTemplateName()),
+									concrete_instantiation_args);
+						}
+						return materialized_type;
+					};
+				std::vector<TemplateTypeArg> concrete_instantiation_args =
+					materialize_args(*arg_type_info);
+				for (TemplateTypeArg& concrete_arg : concrete_instantiation_args) {
+					concrete_arg = recursivelyMaterializeAliasLookupTemplateArg(
+						substitution_environment,
+						std::move(concrete_arg),
+						materialize_args,
+						materialize_lookup);
 				}
-				std::string_view base_template_name =
-					StringTable::getStringView(arg_type_info->baseTemplateName());
-				if (!base_template_name.empty()) {
+				if (!StringTable::getStringView(arg_type_info->baseTemplateName()).empty()) {
 					AliasTemplateMaterializationResult materialized_type =
-						materializeTemplateInstantiationForLookup(
-							base_template_name,
-							concrete_instantiation_args);
+						materialize_lookup(*arg_type_info, concrete_instantiation_args);
 					const TypeInfo* resolved_type_info = materialized_type.resolved_type_info;
 					if (resolved_type_info == nullptr &&
 						!materialized_type.instantiated_name.empty()) {
@@ -782,103 +933,52 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 				std::span<const TemplateParameterNode>(typed_params.data(), typed_params.size()),
 				args);
 		};
-		std::vector<TemplateTypeArg> concrete_args =
-			materializeTemplateArgs(
-				source_type_info,
+		auto materialize_args = [&](const TypeInfo& nested_source_type_info) {
+			return materializeTemplateArgs(
+				nested_source_type_info,
 				alias_node->template_parameters(),
 				template_args,
 				eval_nttp);
-		auto recursively_materialize_type_arg =
-			[&](auto&& self,
-				TemplateTypeArg concrete_arg,
-				int depth) -> TemplateTypeArg {
-			constexpr int kMaxRecursiveTemplateArgDepth = 8;
-			if (depth >= kMaxRecursiveTemplateArgDepth ||
-				concrete_arg.is_value ||
-				!concrete_arg.type_index.is_valid()) {
-				return concrete_arg;
-			}
-
-			const TypeInfo* concrete_type_info = tryGetTypeInfo(concrete_arg.type_index);
-			if (concrete_type_info == nullptr) {
-				return concrete_arg;
-			}
-
-			ResolvedAliasTypeInfo resolved_arg_alias = resolveAliasTypeInfo(
-				concrete_arg.type_index.withCategory(concrete_type_info->typeEnum()));
-			if (resolved_arg_alias.terminal_type_info != nullptr &&
-				resolved_arg_alias.terminal_type_info->typeEnum() != TypeCategory::Invalid) {
-				concrete_type_info = resolved_arg_alias.terminal_type_info;
-				concrete_arg.type_index =
-					concrete_type_info->registeredTypeIndex().withCategory(
-						concrete_type_info->typeEnum());
-				concrete_arg.setCategory(concrete_type_info->typeEnum());
-			}
-
-			if (!concrete_type_info->isTemplateInstantiation()) {
-				return concrete_arg;
-			}
-
-			std::string_view nested_base_template_name =
-				StringTable::getStringView(concrete_type_info->baseTemplateName());
-			if (nested_base_template_name.empty()) {
-				return concrete_arg;
-			}
-
-			std::vector<TemplateTypeArg> nested_concrete_args =
-				materializeTemplateArgs(
-					*concrete_type_info,
-					alias_node->template_parameters(),
-					template_args,
-					eval_nttp);
-			for (TemplateTypeArg& nested_arg : nested_concrete_args) {
-				nested_arg = self(self, std::move(nested_arg), depth + 1);
-			}
-			bool nested_args_still_dependent = false;
-			for (const TemplateTypeArg& nested_arg : nested_concrete_args) {
-				if (nested_arg.is_dependent ||
-					nested_arg.dependent_name.isValid() ||
-					nested_arg.dependent_expr.has_value()) {
-					nested_args_still_dependent = true;
-					break;
-				}
-			}
-			if (nested_args_still_dependent) {
-				return concrete_arg;
-			}
-
-			AliasTemplateMaterializationResult materialized_nested =
-				materializeTemplateInstantiationForLookup(
-					nested_base_template_name,
-					nested_concrete_args);
-			const TypeInfo* resolved_nested_info =
-				materialized_nested.resolved_type_info;
-			if (resolved_nested_info == nullptr) {
-				StringHandle nested_name_handle =
-					materialized_nested.canonicalNameHandle();
-				if (nested_name_handle.isValid()) {
-					resolved_nested_info = findTypeByName(nested_name_handle);
-				}
-			}
-			if (resolved_nested_info == nullptr) {
-				return concrete_arg;
-			}
-
-			concrete_arg.type_index =
-				resolved_nested_info->registeredTypeIndex().withCategory(
-					resolved_nested_info->typeEnum());
-			concrete_arg.setCategory(resolved_nested_info->typeEnum());
-			concrete_arg.is_dependent = false;
-			concrete_arg.dependent_name = {};
-			concrete_arg.dependent_expr = std::nullopt;
-			return concrete_arg;
 		};
+		std::vector<TemplateTypeArg> concrete_args =
+			materialize_args(source_type_info);
+		TemplateEnvironment substitution_environment = buildTemplateEnvironment(
+			std::span<const TemplateParameterNode>(
+				alias_node->template_parameters().data(),
+				alias_node->template_parameters().size()),
+			template_args,
+			nullptr);
+		auto materialize_lookup =
+			[this](const TypeInfo& nested_type_info, std::span<const TemplateTypeArg> nested_concrete_args) {
+				StringHandle qualified_base_template_name =
+					gNamespaceRegistry.buildQualifiedIdentifier(
+						nested_type_info.sourceNamespace(),
+						nested_type_info.baseTemplateName());
+				std::string_view base_template_name =
+					StringTable::getStringView(qualified_base_template_name);
+				AliasTemplateMaterializationResult materialized_nested;
+				if (!base_template_name.empty()) {
+					materialized_nested =
+						materializeTemplateInstantiationForLookup(
+							base_template_name,
+							nested_concrete_args);
+				}
+				if ((materialized_nested.resolved_type_info == nullptr &&
+					 materialized_nested.instantiated_name.empty()) &&
+					qualified_base_template_name != nested_type_info.baseTemplateName()) {
+					materialized_nested =
+						materializeTemplateInstantiationForLookup(
+							StringTable::getStringView(nested_type_info.baseTemplateName()),
+							nested_concrete_args);
+				}
+				return materialized_nested;
+			};
 		for (TemplateTypeArg& concrete_arg : concrete_args) {
-			concrete_arg =
-				recursively_materialize_type_arg(
-					recursively_materialize_type_arg,
-					std::move(concrete_arg),
-					0);
+			concrete_arg = recursivelyMaterializeAliasLookupTemplateArg(
+				substitution_environment,
+				std::move(concrete_arg),
+				materialize_args,
+				materialize_lookup);
 		}
 		return concrete_args;
 	};
@@ -1231,6 +1331,166 @@ Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedO
 		std::span<const TemplateTypeArg>{});
 }
 
+Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerTypeForLookup(
+	const TypeInfo& owner_type_info,
+	std::span<const TemplateTypeArg> owner_template_args) {
+	AliasTemplateMaterializationResult result;
+	result.instantiated_name = StringTable::getStringView(owner_type_info.name());
+	result.resolved_type_info = &owner_type_info;
+
+	const auto can_materialize_owner_template =
+		[&](std::string_view candidate_name) {
+		if (candidate_name.empty()) {
+			return false;
+		}
+		if (gTemplateRegistry.lookup_alias_template(candidate_name).has_value()) {
+			return true;
+		}
+		if (auto template_entry = gTemplateRegistry.lookupTemplate(candidate_name);
+			template_entry.has_value() &&
+			template_entry->is<TemplateClassDeclarationNode>()) {
+			return true;
+		}
+		return false;
+	};
+
+	const TypeInfo* canonical_owner_type_info = &owner_type_info;
+	ResolvedAliasTypeInfo resolved_owner_alias = resolveAliasTypeInfo(
+		owner_type_info.registeredTypeIndex().withCategory(owner_type_info.typeEnum()));
+	if (resolved_owner_alias.terminal_type_info != nullptr &&
+		(resolved_owner_alias.terminal_type_info->isTemplateInstantiation() ||
+		 resolved_owner_alias.terminal_type_info->isStruct() ||
+		 resolved_owner_alias.terminal_type_info->getStructInfo() != nullptr)) {
+		canonical_owner_type_info = resolved_owner_alias.terminal_type_info;
+	} else if (resolved_owner_alias.type_index.is_valid()) {
+		if (const TypeInfo* resolved_owner_index_info =
+				tryGetTypeInfo(resolved_owner_alias.type_index);
+			resolved_owner_index_info != nullptr &&
+			(resolved_owner_index_info->isTemplateInstantiation() ||
+			 resolved_owner_index_info->isStruct() ||
+			 resolved_owner_index_info->getStructInfo() != nullptr)) {
+			canonical_owner_type_info = resolved_owner_index_info;
+		}
+	}
+
+	result.resolved_type_info = canonical_owner_type_info;
+	if (canonical_owner_type_info->name().isValid()) {
+		result.instantiated_name =
+			StringTable::getStringView(canonical_owner_type_info->name());
+	}
+
+	auto try_materialize_exact_owner =
+		[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) -> bool {
+		std::vector<TemplateTypeArg> concrete_template_args;
+		concrete_template_args.reserve(stored_args.size());
+		for (const auto& stored_arg : stored_args) {
+			TemplateTypeArg concrete_arg = toTemplateTypeArg(stored_arg);
+			concrete_arg.setCategory(stored_arg.category());
+			if (concrete_arg.is_dependent || stored_arg.dependent_name.isValid()) {
+				return false;
+			}
+			concrete_template_args.push_back(std::move(concrete_arg));
+		}
+		if (concrete_template_args.empty() && !stored_args.empty()) {
+			return false;
+		}
+
+		std::string_view base_template_name =
+			StringTable::getStringView(canonical_owner_type_info->baseTemplateName());
+		if (base_template_name.empty()) {
+			return false;
+		}
+
+		AliasTemplateMaterializationResult canonical_owner =
+			materializeTemplateInstantiationForLookup(
+				base_template_name,
+				std::span<const TemplateTypeArg>(
+					concrete_template_args.data(),
+					concrete_template_args.size()));
+		if (canonical_owner.instantiated_name.empty() &&
+			canonical_owner.resolved_type_info == nullptr) {
+			return false;
+		}
+
+		if (!canonical_owner.instantiated_name.empty()) {
+			result.instantiated_name = canonical_owner.instantiated_name;
+		}
+		if (canonical_owner.resolved_type_info != nullptr) {
+			result.resolved_type_info = canonical_owner.resolved_type_info;
+		}
+		return true;
+	};
+
+	if (!canonical_owner_type_info->isTemplateInstantiation()) {
+		if (!owner_template_args.empty() &&
+			can_materialize_owner_template(result.instantiated_name)) {
+			AliasTemplateMaterializationResult materialized_owner =
+				materializeTemplateInstantiationForLookup(
+					result.instantiated_name,
+					owner_template_args);
+			if (!materialized_owner.instantiated_name.empty() ||
+				materialized_owner.resolved_type_info != nullptr) {
+				return materialized_owner;
+			}
+		}
+		return result;
+	}
+
+	if (try_materialize_exact_owner(canonical_owner_type_info->templateArgs())) {
+		return result;
+	}
+
+	if (canonical_owner_type_info->hasInstantiationContext() &&
+		canonical_owner_type_info->instantiationContext() != nullptr &&
+		try_materialize_exact_owner(
+			canonical_owner_type_info->instantiationContext()->param_args)) {
+		return result;
+	}
+
+	const std::string_view base_template_name =
+		StringTable::getStringView(canonical_owner_type_info->baseTemplateName());
+	if (!owner_template_args.empty() &&
+		can_materialize_owner_template(base_template_name)) {
+		AliasTemplateMaterializationResult canonical_owner =
+			materializeTemplateInstantiationForLookup(
+				base_template_name,
+				owner_template_args);
+		if (!canonical_owner.instantiated_name.empty() ||
+			canonical_owner.resolved_type_info != nullptr) {
+			return canonical_owner;
+		}
+	}
+
+	return result;
+}
+
+Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerTypeForLookup(
+	const TemplateTypeArg& owner_type_arg) {
+	AliasTemplateMaterializationResult result;
+	if (!owner_type_arg.type_index.is_valid()) {
+		return result;
+	}
+
+	const TypeInfo* owner_type_info = nullptr;
+	ResolvedAliasTypeInfo resolved_owner_alias = resolveAliasTypeInfo(
+		owner_type_arg.type_index.withCategory(owner_type_arg.typeEnum()));
+	if (resolved_owner_alias.terminal_type_info != nullptr) {
+		owner_type_info = resolved_owner_alias.terminal_type_info;
+	} else if (resolved_owner_alias.type_index.is_valid()) {
+		owner_type_info = tryGetTypeInfo(resolved_owner_alias.type_index);
+	}
+	if (owner_type_info == nullptr) {
+		owner_type_info = tryGetTypeInfo(owner_type_arg.type_index);
+	}
+	if (owner_type_info == nullptr) {
+		return result;
+	}
+
+	return materializeCanonicalOwnerTypeForLookup(
+		*owner_type_info,
+		std::span<const TemplateTypeArg>{});
+}
+
 Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedOwnerForLookup(
 	std::string_view owner_name,
 	std::span<const TemplateTypeArg> owner_template_args) {
@@ -1259,108 +1519,9 @@ Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedO
 	const StringHandle owner_name_handle = StringTable::getOrInternStringHandle(owner_name);
 	if (const TypeInfo* initial_owner_type_info = findTypeByName(owner_name_handle);
 		initial_owner_type_info != nullptr) {
-		const TypeInfo* owner_type_info = initial_owner_type_info;
-		result.resolved_type_info = owner_type_info;
-		if (!owner_type_info->isTemplateInstantiation()) {
-			ResolvedAliasTypeInfo resolved_owner_alias = resolveAliasTypeInfo(
-				owner_type_info->registeredTypeIndex().withCategory(owner_type_info->typeEnum()));
-			if (resolved_owner_alias.terminal_type_info != nullptr &&
-				resolved_owner_alias.terminal_type_info != owner_type_info &&
-				resolved_owner_alias.terminal_type_info->isTemplateInstantiation()) {
-				owner_type_info = resolved_owner_alias.terminal_type_info;
-				result.resolved_type_info = owner_type_info;
-			}
-		}
-		if (!owner_type_info->isTemplateInstantiation()) {
-			if (!owner_template_args.empty() &&
-				can_materialize_owner_template(owner_name)) {
-				AliasTemplateMaterializationResult materialized_owner =
-					materializeTemplateInstantiationForLookup(owner_name, owner_template_args);
-				if (!materialized_owner.instantiated_name.empty() ||
-					materialized_owner.resolved_type_info != nullptr) {
-					return materialized_owner;
-				}
-			}
-			return result;
-		}
-
-		const std::string_view base_template_name =
-			StringTable::getStringView(owner_type_info->baseTemplateName());
-		if (base_template_name.empty()) {
-			return result;
-		}
-
-		std::vector<TemplateTypeArg> concrete_template_args;
-		concrete_template_args.reserve(owner_type_info->templateArgs().size());
-		bool has_dependent_template_arg = false;
-		for (const auto& stored_arg : owner_type_info->templateArgs()) {
-			TemplateTypeArg concrete_arg = toTemplateTypeArg(stored_arg);
-			concrete_arg.setCategory(stored_arg.category());
-			if (concrete_arg.is_dependent || stored_arg.dependent_name.isValid()) {
-				has_dependent_template_arg = true;
-				break;
-			}
-			concrete_template_args.push_back(concrete_arg);
-		}
-		if (!has_dependent_template_arg) {
-			AliasTemplateMaterializationResult canonical_owner =
-				materializeTemplateInstantiationForLookup(
-					base_template_name,
-					std::span<const TemplateTypeArg>(
-						concrete_template_args.data(),
-						concrete_template_args.size()));
-			if (!canonical_owner.instantiated_name.empty()) {
-				result.instantiated_name = canonical_owner.instantiated_name;
-			}
-			if (canonical_owner.resolved_type_info != nullptr) {
-				result.resolved_type_info = canonical_owner.resolved_type_info;
-			}
-			return result;
-		}
-
-		if (has_dependent_template_arg &&
-			owner_type_info->hasInstantiationContext() &&
-			owner_type_info->instantiationContext() != nullptr) {
-			concrete_template_args.clear();
-			has_dependent_template_arg = false;
-			for (const auto& context_arg : owner_type_info->instantiationContext()->param_args) {
-				TemplateTypeArg concrete_arg = toTemplateTypeArg(context_arg);
-				concrete_arg.setCategory(context_arg.category());
-				if (concrete_arg.is_dependent || context_arg.dependent_name.isValid()) {
-					has_dependent_template_arg = true;
-					break;
-				}
-				concrete_template_args.push_back(concrete_arg);
-			}
-			if (!has_dependent_template_arg) {
-				AliasTemplateMaterializationResult canonical_owner =
-					materializeTemplateInstantiationForLookup(
-						base_template_name,
-						std::span<const TemplateTypeArg>(
-							concrete_template_args.data(),
-							concrete_template_args.size()));
-				if (!canonical_owner.instantiated_name.empty()) {
-					result.instantiated_name = canonical_owner.instantiated_name;
-				}
-				if (canonical_owner.resolved_type_info != nullptr) {
-					result.resolved_type_info = canonical_owner.resolved_type_info;
-				}
-				return result;
-			}
-		}
-
-		if (!owner_template_args.empty() &&
-			can_materialize_owner_template(base_template_name)) {
-			AliasTemplateMaterializationResult canonical_owner =
-				materializeTemplateInstantiationForLookup(
-					base_template_name,
-					owner_template_args);
-			if (!canonical_owner.instantiated_name.empty() ||
-				canonical_owner.resolved_type_info != nullptr) {
-				return canonical_owner;
-			}
-		}
-		return result;
+		return materializeCanonicalOwnerTypeForLookup(
+			*initial_owner_type_info,
+			owner_template_args);
 	}
 
 	if (!owner_template_args.empty()) {

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -3252,6 +3252,14 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 					expr_node)) {
 			if (auto const_value = try_evaluate_constant_expression(expr_node)) {
 				FlashCpp::NonTypeValueIdentity identity = const_value->identity;
+				if (!identity.member_class_name.isValid() &&
+					existing_arg.member_class_name.isValid()) {
+					identity.member_class_name = existing_arg.member_class_name;
+				}
+				if (!identity.function_signature.has_value() &&
+					existing_arg.function_signature.has_value()) {
+					identity.function_signature = existing_arg.function_signature;
+				}
 				TypeIndex declared_type_index = param.has_type()
 					? param.type_specifier_node().type_index().withCategory(param.type_specifier_node().type())
 					: TypeIndex{};
@@ -3273,6 +3281,14 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 						}
 					} else if (declared_category == TypeCategory::MemberObjectPointer ||
 							   declared_category == TypeCategory::MemberFunctionPointer) {
+						if (!identity.member_class_name.isValid() &&
+							param.type_specifier_node().has_member_class()) {
+							identity.member_class_name = param.type_specifier_node().member_class_name();
+						}
+						if (!identity.function_signature.has_value() &&
+							param.type_specifier_node().has_function_signature()) {
+							identity.function_signature = param.type_specifier_node().function_signature();
+						}
 						if (identity.kind == FlashCpp::NonTypeValueIdentityKind::Nullptr) {
 							identity.kind = FlashCpp::NonTypeValueIdentityKind::MemberPointer;
 						}

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -530,6 +530,48 @@ ASTNode Parser::substituteTemplateParameters(
 								substituted_template_param_ref = true;
 								return;
 							}
+							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
+								arg.typed_value_identity.member_name.isValid() &&
+								arg.valueIdentity().member_class_name.isValid()) {
+								InlineVector<StringHandle, 4> owner_components;
+								std::string_view owner_name_view =
+									StringTable::getStringView(arg.valueIdentity().member_class_name);
+								size_t owner_start = 0;
+								while (owner_start < owner_name_view.size()) {
+									size_t owner_end = owner_name_view.find("::", owner_start);
+									if (owner_end == std::string_view::npos) {
+										owner_end = owner_name_view.size();
+									}
+									owner_components.push_back(StringTable::getOrInternStringHandle(
+										owner_name_view.substr(owner_start, owner_end - owner_start)));
+									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
+								}
+								NamespaceHandle owner_scope = owner_components.empty()
+									? NamespaceRegistry::GLOBAL_NAMESPACE
+									: gNamespaceRegistry.getOrCreatePath(
+										NamespaceRegistry::GLOBAL_NAMESPACE,
+										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
+									Token member_token(
+										Token::Type::Identifier,
+										StringTable::getStringView(arg.typed_value_identity.member_name),
+										tparam_ref.token().line(),
+										tparam_ref.token().column(),
+										tparam_ref.token().file_index());
+									Token amp_token(
+										Token::Type::Operator,
+										"&"sv,
+										tparam_ref.token().line(),
+										tparam_ref.token().column(),
+										tparam_ref.token().file_index());
+									ASTNode qualified_member = emplace_node<ExpressionNode>(
+										QualifiedIdentifierNode(owner_scope, member_token));
+									substituted_node = emplace_node<ExpressionNode>(
+										UnaryOperatorNode(amp_token, qualified_member, true));
+									substituted_template_param_ref = true;
+									return;
+								}
+							}
 						}
 						TypeCategory value_type = arg.typeEnum();
 						int size_bits = get_type_size_bits(value_type);
@@ -584,6 +626,43 @@ ASTNode Parser::substituteTemplateParameters(
 								substituted_node = emplace_node<ExpressionNode>(UnaryOperatorNode(amp_token, entity_id, true));
 								substituted_identifier = true;
 								return;
+							}
+							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
+								arg.typed_value_identity.member_name.isValid() &&
+								arg.valueIdentity().member_class_name.isValid()) {
+								InlineVector<StringHandle, 4> owner_components;
+								std::string_view owner_name_view =
+									StringTable::getStringView(arg.valueIdentity().member_class_name);
+								size_t owner_start = 0;
+								while (owner_start < owner_name_view.size()) {
+									size_t owner_end = owner_name_view.find("::", owner_start);
+									if (owner_end == std::string_view::npos) {
+										owner_end = owner_name_view.size();
+									}
+									owner_components.push_back(StringTable::getOrInternStringHandle(
+										owner_name_view.substr(owner_start, owner_end - owner_start)));
+									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
+								}
+								NamespaceHandle owner_scope = owner_components.empty()
+									? NamespaceRegistry::GLOBAL_NAMESPACE
+									: gNamespaceRegistry.getOrCreatePath(
+										NamespaceRegistry::GLOBAL_NAMESPACE,
+										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
+									Token member_token(
+										Token::Type::Identifier,
+										StringTable::getStringView(arg.typed_value_identity.member_name),
+										0,
+										0,
+										0);
+									Token amp_token(Token::Type::Operator, "&"sv, 0, 0, 0);
+									ASTNode qualified_member = emplace_node<ExpressionNode>(
+										QualifiedIdentifierNode(owner_scope, member_token));
+									substituted_node = emplace_node<ExpressionNode>(
+										UnaryOperatorNode(amp_token, qualified_member, true));
+									substituted_identifier = true;
+									return;
+								}
 							}
 						}
 						TypeCategory value_type = arg.typeEnum();

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -533,24 +533,17 @@ ASTNode Parser::substituteTemplateParameters(
 							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
 								arg.typed_value_identity.member_name.isValid() &&
 								arg.valueIdentity().member_class_name.isValid()) {
-								InlineVector<StringHandle, 4> owner_components;
-								std::string_view owner_name_view =
-									StringTable::getStringView(arg.valueIdentity().member_class_name);
-								size_t owner_start = 0;
-								while (owner_start < owner_name_view.size()) {
-									size_t owner_end = owner_name_view.find("::", owner_start);
-									if (owner_end == std::string_view::npos) {
-										owner_end = owner_name_view.size();
-									}
-									owner_components.push_back(StringTable::getOrInternStringHandle(
-										owner_name_view.substr(owner_start, owner_end - owner_start)));
-									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
-								}
+								std::vector<std::string_view> owner_components =
+									splitQualifiedNamespace(
+										StringTable::getStringView(
+											arg.valueIdentity().member_class_name));
 								NamespaceHandle owner_scope = owner_components.empty()
 									? NamespaceRegistry::GLOBAL_NAMESPACE
 									: gNamespaceRegistry.getOrCreatePath(
 										NamespaceRegistry::GLOBAL_NAMESPACE,
-										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+										std::span<const std::string_view>(
+											owner_components.data(),
+											owner_components.size()));
 								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
 									Token member_token(
 										Token::Type::Identifier,
@@ -630,24 +623,17 @@ ASTNode Parser::substituteTemplateParameters(
 							if (kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer &&
 								arg.typed_value_identity.member_name.isValid() &&
 								arg.valueIdentity().member_class_name.isValid()) {
-								InlineVector<StringHandle, 4> owner_components;
-								std::string_view owner_name_view =
-									StringTable::getStringView(arg.valueIdentity().member_class_name);
-								size_t owner_start = 0;
-								while (owner_start < owner_name_view.size()) {
-									size_t owner_end = owner_name_view.find("::", owner_start);
-									if (owner_end == std::string_view::npos) {
-										owner_end = owner_name_view.size();
-									}
-									owner_components.push_back(StringTable::getOrInternStringHandle(
-										owner_name_view.substr(owner_start, owner_end - owner_start)));
-									owner_start = owner_end == owner_name_view.size() ? owner_end : owner_end + 2;
-								}
+								std::vector<std::string_view> owner_components =
+									splitQualifiedNamespace(
+										StringTable::getStringView(
+											arg.valueIdentity().member_class_name));
 								NamespaceHandle owner_scope = owner_components.empty()
 									? NamespaceRegistry::GLOBAL_NAMESPACE
 									: gNamespaceRegistry.getOrCreatePath(
 										NamespaceRegistry::GLOBAL_NAMESPACE,
-										std::span<const StringHandle>(owner_components.data(), owner_components.size()));
+										std::span<const std::string_view>(
+											owner_components.data(),
+											owner_components.size()));
 								if (owner_scope.isValid() && !owner_scope.isGlobal()) {
 									Token member_token(
 										Token::Type::Identifier,

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -15,6 +15,20 @@ struct NamedPackBinding {
 	std::optional<std::vector<TemplateTypeArg>> template_args;
 };
 
+std::string buildMemberPointerOwnerReconstructionErrorMessage(
+	const TemplateTypeArg& arg,
+	std::string_view stage) {
+	return std::string(
+		StringBuilder()
+			.append("Failed to reconstruct member-pointer owner during ")
+			.append(stage)
+			.append(" substitution for ")
+			.append(StringTable::getStringView(arg.valueIdentity().member_class_name))
+			.append("::")
+			.append(StringTable::getStringView(arg.typed_value_identity.member_name))
+			.commit());
+}
+
 size_t getSubstitutedTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {
 	if (arg.pointer_depth > 0 ||
 		arg.category() == TypeCategory::FunctionPointer ||
@@ -476,6 +490,23 @@ ASTNode Parser::substituteTemplateParameters(
 			CallMetadataCopyOptions{});
 		return substituteWithExpressionSubstitutor(ASTNode(&substituted_call));
 	};
+	auto substituteTernaryOperator = [&](const TernaryOperatorNode& ternary, bool wrap_in_expression) -> ASTNode {
+		ASTNode substituted_condition = substituteTemplateParameters(ternary.condition(), template_params, template_args);
+		ASTNode substituted_true = substituteTemplateParameters(ternary.true_expr(), template_params, template_args);
+		ASTNode substituted_false = substituteTemplateParameters(ternary.false_expr(), template_params, template_args);
+		if (wrap_in_expression) {
+			return emplace_node<ExpressionNode>(TernaryOperatorNode(
+				substituted_condition,
+				substituted_true,
+				substituted_false,
+				ternary.get_token()));
+		}
+		return emplace_node<TernaryOperatorNode>(
+			substituted_condition,
+			substituted_true,
+			substituted_false,
+			ternary.get_token());
+	};
 
 	// Handle different node types
 	if (node.is<ExpressionNode>()) {
@@ -564,6 +595,7 @@ ASTNode Parser::substituteTemplateParameters(
 									substituted_template_param_ref = true;
 									return;
 								}
+								throw InternalError(buildMemberPointerOwnerReconstructionErrorMessage(arg, "template"));
 							}
 						}
 						TypeCategory value_type = arg.typeEnum();
@@ -649,6 +681,7 @@ ASTNode Parser::substituteTemplateParameters(
 									substituted_identifier = true;
 									return;
 								}
+								throw InternalError(buildMemberPointerOwnerReconstructionErrorMessage(arg, "identifier"));
 							}
 						}
 						TypeCategory value_type = arg.typeEnum();
@@ -755,6 +788,8 @@ ASTNode Parser::substituteTemplateParameters(
 			BinaryOperatorNode substituted_binop(bin_op.get_token(), substituted_left, substituted_right);
 			annotateConcreteBinaryOperatorOverload(substituted_binop);
 			return emplace_node<ExpressionNode>(substituted_binop);
+		} else if (const auto* ternary_operator = std::get_if<TernaryOperatorNode>(&expr)) {
+			return substituteTernaryOperator(*ternary_operator, true);
 		} else if (std::holds_alternative<QualifiedIdentifierNode>(expr)) {
 			return substituteWithExpressionSubstitutor(node);
 		} else if (const auto* unary_operator = std::get_if<UnaryOperatorNode>(&expr)) {
@@ -1458,6 +1493,9 @@ ASTNode Parser::substituteTemplateParameters(
 		BinaryOperatorNode substituted_binop(bin_op.get_token(), substituted_left, substituted_right);
 		annotateConcreteBinaryOperatorOverload(substituted_binop);
 		return emplace_node<BinaryOperatorNode>(substituted_binop);
+
+	} else if (node.is<TernaryOperatorNode>()) {
+		return substituteTernaryOperator(node.as<TernaryOperatorNode>(), false);
 
 	} else if (node.is<PointerToMemberAccessNode>()) {
 		const PointerToMemberAccessNode& member_access = node.as<PointerToMemberAccessNode>();

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -44,6 +44,7 @@ TypeInfo::TemplateArgInfo toTemplateArgInfo(const TemplateTypeArg& arg) {
 	info.is_template_template_arg = arg.is_template_template_arg;
 	info.template_name = arg.template_name_handle;
 	info.member_pointer_kind = arg.member_pointer_kind;
+	info.member_class_name = arg.member_class_name;
 	// Default: store the integer value. For pointer/reference/function-pointer NTTPs with
 	// a named entity, also preserve the explicit identity kind and entity name in the
 	// dedicated fields so the roundtrip through toTemplateTypeArg is lossless.
@@ -56,6 +57,9 @@ TypeInfo::TemplateArgInfo toTemplateArgInfo(const TemplateTypeArg& arg) {
 		}
 		if (id.member_name.isValid()) {
 			info.nttp_member_name = id.member_name;
+		}
+		if (id.member_class_name.isValid()) {
+			info.member_class_name = id.member_class_name;
 		}
 		info.nttp_pointer_offset = id.kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer
 			? id.value
@@ -82,6 +86,7 @@ TemplateTypeArg toTemplateTypeArg(const TypeInfo::TemplateArgInfo& arg) {
 	ta.is_template_template_arg = arg.is_template_template_arg;
 	ta.template_name_handle = arg.template_name;
 	ta.member_pointer_kind = arg.member_pointer_kind;
+	ta.member_class_name = arg.member_class_name;
 	if (arg.is_value) {
 		const bool has_explicit_nttp_identity =
 			arg.nttp_kind != FlashCpp::NonTypeValueIdentityKind::Integral ||
@@ -113,7 +118,11 @@ TemplateTypeArg toTemplateTypeArg(const TypeInfo::TemplateArgInfo& arg) {
 				}
 				break;
 			case FlashCpp::NonTypeValueIdentityKind::MemberPointer:
-				ta.setValueIdentity(FlashCpp::NonTypeValueIdentity::makeMemberPointer(arg.type_index, arg.nttp_member_name, arg.nttp_pointer_offset));
+				ta.setValueIdentity(FlashCpp::NonTypeValueIdentity::makeMemberPointer(
+					arg.type_index,
+					arg.nttp_member_name,
+					arg.nttp_pointer_offset,
+					arg.member_class_name));
 				break;
 			case FlashCpp::NonTypeValueIdentityKind::Nullptr:
 				ta.setValueIdentity(FlashCpp::NonTypeValueIdentity::makeNullptr(arg.type_index));

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -166,6 +166,7 @@ struct TemplateTypeArg {
 	bool is_array;
 	std::vector<size_t> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
 	MemberPointerKind member_pointer_kind;
+	StringHandle member_class_name;
 
 	// For non-type template parameters
 	bool is_value;  // true if this represents a value instead of a type
@@ -218,7 +219,16 @@ struct TemplateTypeArg {
 	// when building instantiation keys, hashes, or mangled names for non-type arguments.
 	FlashCpp::NonTypeValueIdentity valueIdentity() const {
 		if (is_value && has_typed_value_identity) {
-			return typed_value_identity;
+			FlashCpp::NonTypeValueIdentity identity = typed_value_identity;
+			if (identity.kind == FlashCpp::NonTypeValueIdentityKind::MemberPointer) {
+				if (!identity.member_class_name.isValid() && member_class_name.isValid()) {
+					identity.member_class_name = member_class_name;
+				}
+				if (!identity.function_signature.has_value() && function_signature.has_value()) {
+					identity.function_signature = function_signature;
+				}
+			}
+			return identity;
 		}
 		if (is_dependent) {
 			return FlashCpp::NonTypeValueIdentity::makeDependentExpression(dependent_expr, dependent_name, value, type_index);
@@ -235,6 +245,12 @@ struct TemplateTypeArg {
 		is_dependent = identity.is_dependent;
 		dependent_name = identity.dependent_name;
 		dependent_expr = identity.dependent_expression;
+		if (identity.member_class_name.isValid()) {
+			member_class_name = identity.member_class_name;
+		}
+		if (identity.function_signature.has_value()) {
+			function_signature = identity.function_signature;
+		}
 	}
 
 	// Builds a TypeIndex with category directly.
@@ -243,10 +259,10 @@ struct TemplateTypeArg {
 	}
 
 	TemplateTypeArg()
-		: type_index(TypeIndex{}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), dependent_name(), is_template_template_arg(false), template_name_handle() {}
+		: type_index(TypeIndex{}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), member_class_name(), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), dependent_name(), is_template_template_arg(false), template_name_handle() {}
 
 	explicit TemplateTypeArg(const TypeSpecifierNode& type_spec)
-		: type_index(makeTypeIndex(type_spec.type_index().withCategory(type_spec.type()))), ref_qualifier(type_spec.reference_qualifier()), pointer_depth(type_spec.pointer_depth()), pointer_cv_qualifiers(), cv_qualifier(type_spec.cv_qualifier()), is_array(type_spec.is_array()), array_dimensions(type_spec.array_dimensions().begin(), type_spec.array_dimensions().end()), member_pointer_kind(MemberPointerKind::None), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle(), function_signature(type_spec.has_function_signature() ? std::optional(type_spec.function_signature()) : std::nullopt) {
+		: type_index(makeTypeIndex(type_spec.type_index().withCategory(type_spec.type()))), ref_qualifier(type_spec.reference_qualifier()), pointer_depth(type_spec.pointer_depth()), pointer_cv_qualifiers(), cv_qualifier(type_spec.cv_qualifier()), is_array(type_spec.is_array()), array_dimensions(type_spec.array_dimensions().begin(), type_spec.array_dimensions().end()), member_pointer_kind(MemberPointerKind::None), member_class_name(type_spec.has_member_class() ? type_spec.member_class_name() : StringHandle{}), is_value(false), value(0), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle(), function_signature(type_spec.has_function_signature() ? std::optional(type_spec.function_signature()) : std::nullopt) {
 		for (const auto& level : type_spec.pointer_levels()) {
 			pointer_cv_qualifiers.push_back(level.cv_qualifier);
 		}
@@ -287,11 +303,11 @@ struct TemplateTypeArg {
 
 	// Constructor for non-type template parameters (default int type)
 	explicit TemplateTypeArg(int64_t val)
-		: type_index(nativeTypeIndex(TypeCategory::Int)), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
+		: type_index(nativeTypeIndex(TypeCategory::Int)), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), member_class_name(), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
 
 	// Constructor for non-type template parameters with explicit type
 	TemplateTypeArg(int64_t val, TypeCategory category)
-		: type_index(TypeIndex{0, category}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
+		: type_index(TypeIndex{0, category}), ref_qualifier(ReferenceQualifier::None), pointer_depth(0), pointer_cv_qualifiers(), cv_qualifier(CVQualifier::None), is_array(false), array_dimensions(), member_pointer_kind(MemberPointerKind::None), member_class_name(), is_value(true), value(val), has_typed_value_identity(false), typed_value_identity(), is_pack(false), is_dependent(false), is_template_template_arg(false), template_name_handle() {}
 
 	// Factory methods
 	static TemplateTypeArg makeType(TypeIndex idx) {
@@ -375,6 +391,10 @@ struct TemplateTypeArg {
 			h ^= std::hash<size_t>{}(dim) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		}
 		h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(member_pointer_kind)) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		h ^= std::hash<bool>{}(member_class_name.isValid()) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		if (member_class_name.isValid()) {
+			h ^= std::hash<StringHandle>{}(member_class_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
 		h ^= std::hash<bool>{}(is_value) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		if (is_value) {
 			h ^= valueIdentity().hash() + 0x9e3779b9 + (h << 6) + (h >> 2);
@@ -420,6 +440,7 @@ struct TemplateTypeArg {
 			  is_array == other.is_array &&
 			  array_dimensions == other.array_dimensions &&
 			  member_pointer_kind == other.member_pointer_kind &&
+			  member_class_name == other.member_class_name &&
 			  is_value == other.is_value &&
 			  is_dependent == other.is_dependent &&
 			  // dependent_name only contributes when the arg is still dependent.

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -211,9 +211,11 @@ struct NonTypeValueIdentity {
 	TypeIndex value_type_index = nativeTypeIndex(TypeCategory::Int);  // The full type identity of the value
 	StringHandle entity_name{};     // Named object/function for pointer/reference/function-pointer identities
 	StringHandle member_name{};     // Class member for pointer-to-member identities
+	StringHandle member_class_name{}; // Declaring class for pointer-to-member identities
 	int64_t pointer_offset = 0;     // Array-element offset for object pointer identities
 	StringHandle dependent_name{};  // Name when dependent (e.g., "N" for template<int N>)
 	std::optional<ASTNode> dependent_expression{}; // Structural dependent expression identity when no single name represents the argument
+	std::optional<FunctionSignature> function_signature{}; // Member/function pointer type identity when available
 	bool is_dependent = false;      // True if this is a dependent (not yet substituted) value
 
 	TypeCategory valueTypeCategory() const {
@@ -294,11 +296,20 @@ struct NonTypeValueIdentity {
 	}
 
 	static NonTypeValueIdentity makeMemberPointer(TypeIndex type_index, StringHandle target_member, int64_t offset) {
+		return makeMemberPointer(type_index, target_member, offset, {});
+	}
+
+	static NonTypeValueIdentity makeMemberPointer(
+		TypeIndex type_index,
+		StringHandle target_member,
+		int64_t offset,
+		StringHandle declaring_class) {
 		NonTypeValueIdentity id;
 		id.kind = NonTypeValueIdentityKind::MemberPointer;
 		id.value = offset;
 		id.value_type_index = type_index;
 		id.member_name = target_member;
+		id.member_class_name = declaring_class;
 		id.is_dependent = false;
 		id.dependent_name = {};
 		return id;
@@ -411,6 +422,10 @@ struct NonTypeValueIdentity {
 				return true;
 			}
 			return member_name == other.member_name &&
+				   member_class_name == other.member_class_name &&
+				   function_signature.has_value() == other.function_signature.has_value() &&
+				   (!function_signature.has_value() ||
+					equalFunctionSignatureIdentity(*function_signature, *other.function_signature)) &&
 				   value == other.value;
 		}
 		return false;
@@ -439,8 +454,14 @@ struct NonTypeValueIdentity {
 		} else if (kind == NonTypeValueIdentityKind::MemberPointer) {
 			h ^= std::hash<uint8_t>{}(0x5a) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		}
+		if (member_class_name.isValid()) {
+			h ^= std::hash<StringHandle>{}(member_class_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
 		if (kind == NonTypeValueIdentityKind::ObjectPointer) {
 			h ^= std::hash<int64_t>{}(pointer_offset) + 0x9e3779b9 + (h << 6) + (h >> 2);
+		}
+		if (function_signature.has_value()) {
+			h ^= hashFunctionSignatureIdentity(*function_signature) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		}
 		h ^= hashValueTypeIdentity(value_type_index) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		return h;
@@ -481,6 +502,10 @@ struct NonTypeValueIdentity {
 		}
 		if (member_name.isValid()) {
 			std::string result = "&";
+			if (member_class_name.isValid()) {
+				result += StringTable::getStringView(member_class_name);
+				result += "::";
+			}
 			result += StringTable::getStringView(member_name);
 			return result;
 		}

--- a/tests/test_alias_selected_default_nttp_owner_canonicalization_ret0.cpp
+++ b/tests/test_alias_selected_default_nttp_owner_canonicalization_ret0.cpp
@@ -1,0 +1,41 @@
+template<bool B>
+struct Select;
+
+template<>
+struct Select<true> {
+	template<class T, class F>
+	using type = T;
+};
+
+template<>
+struct Select<false> {
+	template<class T, class F>
+	using type = F;
+};
+
+template<bool B, class T, class F>
+using SelectT = typename Select<B>::template type<T, F>;
+
+struct TrueChoice {
+	static constexpr bool value = true;
+};
+
+struct FalseChoice {
+	static constexpr bool value = false;
+};
+
+template<class T>
+using SelectedValueOwner = SelectT<__is_empty(T), TrueChoice, FalseChoice>;
+
+template<class T, bool Empty = SelectedValueOwner<T>::value>
+struct UsesAliasDefault {
+	static constexpr bool value = Empty;
+};
+
+struct NonEmpty {
+	int value;
+};
+
+int main() {
+	return UsesAliasDefault<NonEmpty>::value ? 1 : 0;
+}

--- a/tests/test_member_pointer_nttp_body_substitution_ret0.cpp
+++ b/tests/test_member_pointer_nttp_body_substitution_ret0.cpp
@@ -1,0 +1,16 @@
+struct S {
+	int x;
+	int y;
+};
+
+template <int S::* P>
+int read(const S& s) {
+	return s.*P;
+}
+
+int main() {
+	S s{};
+	s.x = 5;
+	s.y = 37;
+	return read<&S::y>(s) - 37;
+}

--- a/tests/test_member_pointer_nttp_identity_ret0.cpp
+++ b/tests/test_member_pointer_nttp_identity_ret0.cpp
@@ -1,0 +1,27 @@
+struct A {
+	int value;
+};
+
+struct B {
+	int value;
+};
+
+template <auto P>
+struct member_pointer_tag {
+	static constexpr int value = 0;
+};
+
+template <>
+struct member_pointer_tag<&A::value> {
+	static constexpr int value = 1;
+};
+
+template <>
+struct member_pointer_tag<&B::value> {
+	static constexpr int value = 2;
+};
+
+int main() {
+	return member_pointer_tag<&A::value>::value * 10 +
+		member_pointer_tag<&B::value>::value - 12;
+}

--- a/tests/test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp
+++ b/tests/test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp
@@ -1,0 +1,22 @@
+template <typename T>
+struct Box {
+	struct Deep {
+		static constexpr int value = 42;
+	};
+
+	struct Mid {
+		using inner = Deep;
+	};
+
+	using self_type = Box<T>;
+	using alias_mid = typename self_type::Mid;
+	using alias_inner = typename alias_mid::inner;
+
+	static int run() {
+		return alias_mid::inner::value - alias_inner::value;
+	}
+};
+
+int main() {
+	return Box<int>::run();
+}

--- a/tests/test_template_current_instantiation_alias_qualified_member_ret0.cpp
+++ b/tests/test_template_current_instantiation_alias_qualified_member_ret0.cpp
@@ -1,0 +1,17 @@
+template <typename T>
+struct Box {
+	struct Nested {
+		static constexpr int value = 42;
+	};
+
+	using self_type = Box<T>;
+	using alias_inner = typename self_type::Nested;
+
+	static int run() {
+		return alias_inner::value - 42;
+	}
+};
+
+int main() {
+	return Box<int>::run();
+}

--- a/tests/test_template_lazy_static_current_instantiation_alias_chain_ret0.cpp
+++ b/tests/test_template_lazy_static_current_instantiation_alias_chain_ret0.cpp
@@ -1,0 +1,19 @@
+template <typename T>
+struct Box {
+	struct Deep {
+		static constexpr int value = 42;
+	};
+
+	struct Mid {
+		using inner = Deep;
+	};
+
+	using self_type = Box<T>;
+	using alias_mid = typename self_type::Mid;
+
+	inline static int value = alias_mid::inner::value;
+};
+
+int main() {
+	return Box<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_type_trait_alias_default_nttp_ret0.cpp
+++ b/tests/test_type_trait_alias_default_nttp_ret0.cpp
@@ -24,7 +24,10 @@ struct IsEmpty : ConditionalT<__is_empty(Type), TrueType, FalseType> {
 };
 
 template<typename Type>
-using EmptyNotFinal = ConditionalT<__is_final(Type), FalseType, IsEmpty<Type>>;
+using EmptyAlias = IsEmpty<Type>;
+
+template<typename Type>
+using EmptyNotFinal = ConditionalT<__is_final(Type), FalseType, EmptyAlias<Type>>;
 
 template<unsigned long Index, typename Head, bool = EmptyNotFinal<Head>::value>
 struct HeadBase {


### PR DESCRIPTION
## Summary
- preserve member-pointer NTTP identity and substitute member-pointer NTTPs back into template bodies
- unify alias/current-instantiation owner materialization and extend deeper current-instantiation/type-alias qualified member-chain resolution
- capture current-instantiation replay metadata for covered lazy/static flows, add focused regression tests, and update the template-argument refactor docs with the next remaining seams

## Validation
- .\build_flashcpp.bat
- pwsh -File tests\run_all_tests.ps1 tests\test_member_pointer_nttp_body_substitution_ret0.cpp tests\test_member_pointer_nttp_identity_ret0.cpp tests\test_alias_selected_default_nttp_owner_canonicalization_ret0.cpp tests\test_template_current_instantiation_alias_qualified_member_ret0.cpp tests\test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp tests\test_template_lazy_static_current_instantiation_alias_chain_ret0.cpp tests\test_type_trait_alias_default_nttp_ret0.cpp tests\std\test_conditional_member_alias_default_nttp_ret0.cpp
- pwsh -File tests\run_all_tests.ps1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated template-argument architecture audit and investigation plan to reflect recent progress, revised validation results, and narrowed remaining conformance gaps.

* **Bug Fixes**
  * Improved member-pointer NTTP identity handling and round-trip preservation across parsing, substitution, mangling, and storage.
  * Enhanced alias/member-chain materialization and dependent-member resolution for deeper qualified-member cases.

* **Tests**
  * Added multiple tests exercising member-pointer NTTPs, alias chains, and qualified dependent-member access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->