### PR TITLE
stage6: require parser-owned sema in dependent POI reuse

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -147,7 +147,7 @@ Stage 6 progress so far:
 - constexpr `sizeof(array[index])` now falls back through `global_symbols` before expression-type decay, so inferred global arrays keep the correct element size during codegen folding, and `sizeof(S{0})` on a struct prvalue now stays locked in as a passing regression test instead of an expected failure; the regression now also covers mixed-layout and templated prvalue cases.
 - `EvaluationContext` now also has explicit parser-owned and sema-only constructors, and both the shared helpers and the remaining parser-owned call sites now use those constructors directly instead of constructing a raw context and attaching semantic ownership afterward. The final array-bounds parser helper now also takes `Parser&` instead of a dishonest `const Parser&`, because its constexpr evaluation can instantiate templates and normalize pending semantic roots.
 - dependent-unqualified call POI resolution in both `ConstExprEvaluator_Core.cpp` and `ConstExprEvaluator_Members.cpp` now requires parser-owned sema via `requireParserOwnedSema(...)` directly instead of first probing `context.parser` with ad-hoc null checks.
-- parser-gated constexpr template instantiation in `ConstExprEvaluator_Core.cpp` now also routes parser access through `requireParserOwnedSema(...)` once parser context exists, instead of dereferencing `context.parser` directly after nullable guards.
+- parser-gated constexpr template instantiation in `ConstExprEvaluator_Core.cpp` now routes parser access through `requireParserOwnedSema(...)` directly; the old parser-null guard/error branch in `tryEvaluateAsVariableTemplate(...)` was removed.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -147,6 +147,7 @@ Stage 6 progress so far:
 - constexpr `sizeof(array[index])` now falls back through `global_symbols` before expression-type decay, so inferred global arrays keep the correct element size during codegen folding, and `sizeof(S{0})` on a struct prvalue now stays locked in as a passing regression test instead of an expected failure; the regression now also covers mixed-layout and templated prvalue cases.
 - `EvaluationContext` now also has explicit parser-owned and sema-only constructors, and both the shared helpers and the remaining parser-owned call sites now use those constructors directly instead of constructing a raw context and attaching semantic ownership afterward. The final array-bounds parser helper now also takes `Parser&` instead of a dishonest `const Parser&`, because its constexpr evaluation can instantiate templates and normalize pending semantic roots.
 - dependent-unqualified call POI resolution in both `ConstExprEvaluator_Core.cpp` and `ConstExprEvaluator_Members.cpp` now requires parser-owned sema via `requireParserOwnedSema(...)` directly instead of first probing `context.parser` with ad-hoc null checks.
+- parser-gated constexpr template instantiation in `ConstExprEvaluator_Core.cpp` now also routes parser access through `requireParserOwnedSema(...)` once parser context exists, instead of dereferencing `context.parser` directly after nullable guards.
 
 Remaining Stage 6 work:
 

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -146,6 +146,7 @@ Stage 6 progress so far:
 - `EvaluationContext::normalizePendingSemanticRoots()` now requires parser-attached semantic analysis instead of silently no-oping on a null sema, parser-attached member-function materialization now requires parser-attached sema explicitly, and the old nullable `resolveMaterializationSema(...)` seam is gone.
 - constexpr `sizeof(array[index])` now falls back through `global_symbols` before expression-type decay, so inferred global arrays keep the correct element size during codegen folding, and `sizeof(S{0})` on a struct prvalue now stays locked in as a passing regression test instead of an expected failure; the regression now also covers mixed-layout and templated prvalue cases.
 - `EvaluationContext` now also has explicit parser-owned and sema-only constructors, and both the shared helpers and the remaining parser-owned call sites now use those constructors directly instead of constructing a raw context and attaching semantic ownership afterward. The final array-bounds parser helper now also takes `Parser&` instead of a dishonest `const Parser&`, because its constexpr evaluation can instantiate templates and normalize pending semantic roots.
+- dependent-unqualified call POI resolution in both `ConstExprEvaluator_Core.cpp` and `ConstExprEvaluator_Members.cpp` now requires parser-owned sema via `requireParserOwnedSema(...)` directly instead of first probing `context.parser` with ad-hoc null checks.
 
 Remaining Stage 6 work:
 

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4400,6 +4400,7 @@ EvalResult Evaluator::tryEvaluateAsVariableTemplate(std::string_view func_name, 
 	if (!context.parser) {
 		return EvalResult::error("No parser available for variable template instantiation");
 	}
+	(void)context.requireParserOwnedSema("variable template instantiation");
 	Parser& parser = *context.parser;
 
 	if (!call_expr.has_template_arguments()) {
@@ -4785,7 +4786,9 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 
 		// No pre-instantiated version found - try to instantiate on-demand if parser is available
 		if (context.parser) {
-			std::optional<ASTNode> instantiated_opt = context.parser->tryInstantiateTemplateFromCallArguments(
+			(void)context.requireParserOwnedSema("template call argument instantiation");
+			Parser& parser = *context.parser;
+			std::optional<ASTNode> instantiated_opt = parser.tryInstantiateTemplateFromCallArguments(
 				qualified_name,
 				func_name,
 				arguments);

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4397,9 +4397,6 @@ EvalResult Evaluator::evaluate_builtin_function(std::string_view func_name, cons
 
 
 EvalResult Evaluator::tryEvaluateAsVariableTemplate(std::string_view func_name, const CallExprNode& call_expr, EvaluationContext& context) {
-	if (!context.parser) {
-		return EvalResult::error("No parser available for variable template instantiation");
-	}
 	(void)context.requireParserOwnedSema("variable template instantiation");
 	Parser& parser = *context.parser;
 

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4516,19 +4516,15 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 	}
 
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
-		// POI resolution requires the parser.  If context.parser is null here it
-		// means the evaluator was invoked without a parser in a context where a
-		// dependent-unqualified call survived template instantiation, which is a
-		// compiler bug.
-		if (!context.parser) {
-			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
-		}
+		// POI resolution requires parser-owned context. Missing parser/sema is a
+		// contract violation and must hard-fail.
+		SemanticAnalysis& sema_ref =
+			context.requireParserOwnedSema("dependent unqualified call POI resolution");
 		Parser& parser = *context.parser;
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		ResolvedFunctionQueryResult sema_query =
-			context
-				.requireParserOwnedSema("dependent unqualified call reuse")
+			sema_ref
 				.parserSemanticServices()
 				.getResolvedDirectCallQuery(&call_expr);
 		if (sema_query.hasValue()) {

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1696,19 +1696,15 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 	}
 
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
-		// POI resolution requires the parser.  If context.parser is null here it
-		// means the evaluator was invoked without a parser in a context where a
-		// dependent-unqualified call survived template instantiation, which is a
-		// compiler bug.
-		if (!context.parser) {
-			throw InternalError("Parser required for dependent unqualified call POI resolution but is null");
-		}
+		// POI resolution requires parser-owned context. Missing parser/sema is a
+		// contract violation and must hard-fail.
+		SemanticAnalysis& sema_ref =
+			context.requireParserOwnedSema("dependent unqualified member call POI resolution");
 		Parser& parser = *context.parser;
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		ResolvedFunctionQueryResult sema_query =
-			context
-				.requireParserOwnedSema("dependent unqualified member call reuse")
+			sema_ref
 				.parserSemanticServices()
 				.getResolvedDirectCallQuery(&call_expr);
 		if (sema_query.hasValue()) {


### PR DESCRIPTION
## Summary
- remove ad-hoc parser-null probing from parser-required dependent unqualified POI reuse
- require parser-owned sema via equireParserOwnedSema(...) before parser dereference in Core and Members
- update Stage 6 progress doc with this completed tightening slice

## Validation
- .\build_flashcpp.bat
- pwsh -File tests\run_all_tests.ps1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated development plan with Stage 6 progress on standardizing parser-owned semantic analysis access.

* **Refactor**
  * Strengthened constexpr evaluation paths to consistently require parser-owned semantic analysis for template instantiation and dependent-call/member resolution, replacing ad-hoc null checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->