### PR TITLE
Preserve call-shaped member-template replay

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -80,13 +80,13 @@ Concrete follow-up already identified by recent work:
 - the explicit-template unknown-specialization owner-record gap is now narrower:
   replayed deferred qualified-call records keep the instantiated placeholder
   `owner_type`, so declaration-time replay is no longer forced to recover that
-  identity from the raw owner spelling alone. Deferred non-call qualified
-  expressions now also keep member-template segment arguments such as
-  `Traits<T>::template Box<T>::value` instead of dropping the `Box<T>` segment
+  identity from the raw owner spelling alone. Deferred non-call and call-shaped
+  qualified expressions now also keep member-template segment arguments such as
+  `Traits<T>::template Box<T>::value` and
+  `Traits<T>::template Box<T>::get()` instead of dropping the `Box<T>` segment
   at parse time. The next concrete follow-up is the remaining dependent-base and
-  unknown-specialization member-chain work, especially call-shaped deeper
-  member-template chains and the declarations that still never capture replay
-  metadata at parse time.
+  unknown-specialization member-chain work in declarations that still never
+  capture replay metadata at parse time.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -95,7 +95,8 @@ Concrete follow-up already identified by recent work:
 
 Still open:
 
-- deeper expression/member-template segment chains;
+- broader expression/member-template segment chains outside the covered lazy
+  static initializer paths;
 - plain dependent bases and more unknown-specialization paths;
 - injected-class-name modeling;
 - alias ordering and current-instantiation identity across all qualified-name
@@ -164,13 +165,15 @@ In priority order:
       alias recovery, nested alias-target deferred-base materialization, and the
       current-owner member-alias qualified-id cleanup is now complete for the
       deeper covered member-chain cases;
-   - remaining replay-metadata gaps for static-member initialization;
+   - remaining replay-metadata gaps for static-member initialization outside
+      the covered member-template call/non-call chains;
    - remaining dependent-base/member-chain paths that still bypass the shared
       semantic lookup model.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
-   - deeper member-template chains;
+   - broader member-template chains outside the covered current lazy-static
+     cases;
    - canonical dependent-expression equivalence.
 
 3. **Complete the remaining NTTP categories**

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -77,11 +77,16 @@ What still needs work:
 
 Concrete follow-up already identified by recent work:
 
-- the next concrete follow-up is the remaining dependent-base and unknown-
-  specialization member-chain work plus the declarations that still never
-  capture replay metadata at parse time; deeper current-instantiation/type-alias
-  qualified-id/member chains now reuse the shared semantic lookup path once that
-  metadata exists.
+- the explicit-template unknown-specialization owner-record gap is now narrower:
+  replayed deferred qualified-call records keep the instantiated placeholder
+  `owner_type`, so declaration-time replay is no longer forced to recover that
+  identity from the raw owner spelling alone. Deferred non-call qualified
+  expressions now also keep member-template segment arguments such as
+  `Traits<T>::template Box<T>::value` instead of dropping the `Box<T>` segment
+  at parse time. The next concrete follow-up is the remaining dependent-base and
+  unknown-specialization member-chain work, especially call-shaped deeper
+  member-template chains and the declarations that still never capture replay
+  metadata at parse time.
 
 ### 2. Dependent names are still represented too loosely
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -91,11 +91,17 @@ Immediate targets:
 Most concrete next subtask:
 
 - finish the remaining dependent-base/unknown-specialization member-chain work
-  and the declarations that still fail to capture replay metadata at parse time;
-  deeper current-instantiation/type-alias qualified-id/member chains now reuse
-  the shared member-side lookup/materialization path, and replayed qualified-id
-  parsing now captures the current-instantiation metadata needed for covered
-  lazy/static flows.
+  after the latest replay-metadata improvement: deferred explicit-template
+  qualified-call records now preserve the instantiated placeholder `owner_type`
+  instead of dropping it at parse time. Deferred non-call qualified expressions
+  now also preserve deeper member-template segment arguments such as
+  `Traits<T>::template Box<T>::value`. The next concrete gap is still the
+  remaining call-shaped member-template/member-chain cases and the declarations
+  that never capture replay metadata in the first place; current-
+  instantiation/type-alias qualified-id/member chains already reuse the shared
+  member-side lookup/materialization path, and covered replayed qualified-id
+  parsing now preserves both current-instantiation and explicit-template owner
+  identity plus non-call member-template segment metadata.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2971,6 +2971,16 @@ public:
 	bool has_dependent_unqualified_lookup_record() const {
 		return dependent_unqualified_lookup_record_.has_value();
 	}
+	void set_dependent_qualified_lookup_record(
+		const TypeInfo::DependentQualifiedNameRecord& record) {
+		dependent_qualified_lookup_record_ = record;
+	}
+	const std::optional<TypeInfo::DependentQualifiedNameRecord>& dependent_qualified_lookup_record() const {
+		return dependent_qualified_lookup_record_;
+	}
+	bool has_dependent_qualified_lookup_record() const {
+		return dependent_qualified_lookup_record_.has_value();
+	}
 
 private:
 	CalleeDescriptor callee_;
@@ -2982,6 +2992,7 @@ private:
 	std::vector<ASTNode> template_arguments_;  // Explicit template arguments
 	std::optional<FunctionCallDefinitionLookupRecord> definition_lookup_record_;
 	std::optional<DependentUnqualifiedCallLookupRecord> dependent_unqualified_lookup_record_;
+	std::optional<TypeInfo::DependentQualifiedNameRecord> dependent_qualified_lookup_record_;
 };
 
 // Constructor call node - represents constructor calls like T(args)

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -49,6 +49,7 @@ struct CallInfo {
 	std::span<const ASTNode> template_arguments;
 	const std::optional<FunctionCallDefinitionLookupRecord>* definition_lookup_record;
 	const std::optional<DependentUnqualifiedCallLookupRecord>* dependent_unqualified_lookup_record;
+	const std::optional<TypeInfo::DependentQualifiedNameRecord>* dependent_qualified_lookup_record;
 	bool is_indirect;
 
 	// --- Factory helpers ---------------------------------------------------
@@ -67,6 +68,8 @@ struct CallInfo {
 		info.definition_lookup_record = &node.definition_lookup_record();
 		info.dependent_unqualified_lookup_record =
 			&node.dependent_unqualified_lookup_record();
+		info.dependent_qualified_lookup_record =
+			&node.dependent_qualified_lookup_record();
 		info.is_indirect           = node.callee().is_indirect();
 		return info;
 	}
@@ -86,6 +89,7 @@ struct CallMetadataCopyOptions {
 	bool copy_template_arguments = true;
 	bool copy_definition_lookup_record = true;
 	bool copy_dependent_unqualified_lookup_record = true;
+	bool copy_dependent_qualified_lookup_record = true;
 };
 
 template <typename CallNodeT>
@@ -118,6 +122,12 @@ inline void copyCallMetadataFromInfo(
 		source.dependent_unqualified_lookup_record->has_value()) {
 		target.set_dependent_unqualified_lookup_record(
 			**source.dependent_unqualified_lookup_record);
+	}
+	if (options.copy_dependent_qualified_lookup_record &&
+		source.dependent_qualified_lookup_record != nullptr &&
+		source.dependent_qualified_lookup_record->has_value()) {
+		target.set_dependent_qualified_lookup_record(
+			**source.dependent_qualified_lookup_record);
 	}
 }
 
@@ -265,6 +275,20 @@ inline void setCallDependentUnqualifiedLookupRecord(
 	CallExprNode& call_expr,
 	const DependentUnqualifiedCallLookupRecord& record) {
 	call_expr.set_dependent_unqualified_lookup_record(record);
+}
+
+inline void setCallDependentQualifiedLookupRecord(
+	ExpressionNode& expr,
+	const TypeInfo::DependentQualifiedNameRecord& record) {
+	if (auto* call_expr = std::get_if<CallExprNode>(&expr)) {
+		call_expr->set_dependent_qualified_lookup_record(record);
+	}
+}
+
+inline void setCallDependentQualifiedLookupRecord(
+	CallExprNode& call_expr,
+	const TypeInfo::DependentQualifiedNameRecord& record) {
+	call_expr.set_dependent_qualified_lookup_record(record);
 }
 
 inline void setCallTemplateArguments(CallExprNode& call_expr, std::vector<ASTNode>&& template_args) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2214,9 +2214,9 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 
 					std::optional<ASTNode> instantiated_member =
 						parser_.instantiateLazyMemberForCanonicalOwner(
-						materialized_owner_name,
-						member_name,
-						std::span<const TemplateTypeArg>{});
+							materialized_owner_name,
+							member_name,
+							std::span<const TemplateTypeArg>{});
 					if (instantiated_member.has_value() &&
 						instantiated_member->is<FunctionDeclarationNode>()) {
 						target_func =

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2163,11 +2163,11 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 										qualified_owner_name,
 										member_args);
 							} else {
-								StringHandle chained_owner_handle =
+								const StringHandle chained_owner_lookup_handle =
 									StringTable::getOrInternStringHandle(
 										chained_owner_name);
 								auto chained_owner_it =
-									getTypesByNameMap().find(chained_owner_handle);
+									getTypesByNameMap().find(chained_owner_lookup_handle);
 								if (chained_owner_it == getTypesByNameMap().end() ||
 									chained_owner_it->second == nullptr) {
 									std::string_view instantiated_owner_name =

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -478,7 +478,11 @@ std::vector<TemplateTypeArg> ExpressionSubstitutor::collectCurrentBoundTemplateA
 		size_t scalar_bindings_consumed = 0;
 		size_t pack_bindings_consumed = 0;
 		bound_args.reserve(param_map_.size());
+		std::unordered_set<std::string_view> consumed_ordered_names;
 		for (std::string_view param_name : template_param_order_) {
+			if (!consumed_ordered_names.insert(param_name).second) {
+				continue;
+			}
 			auto scalar_it = param_map_.find(param_name);
 			auto pack_it = pack_map_.find(StringTable::getOrInternStringHandle(param_name));
 			if (scalar_it != param_map_.end() && pack_it != pack_map_.end()) {
@@ -1220,6 +1224,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	FLASH_LOG(Templates, Debug, "ExpressionSubstitutor: Processing function call");
 	FLASH_LOG(Templates, Debug, "  has_mangled_name: ", call.has_mangled_name());
 	FLASH_LOG(Templates, Debug, "  has_template_arguments: ", call.has_template_arguments());
+	FLASH_LOG(Templates, Debug, "  has_dependent_qualified_lookup_record: ", call.has_dependent_qualified_lookup_record());
 
 	const DeclarationNode& decl_node = call.callee().declaration();
 	std::string_view func_name = call.called_from().value();
@@ -1861,9 +1866,468 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		return materializeSubstitutedUnresolvedCall(std::move(substituted_args));
 	}
 
+	if (call.has_dependent_qualified_lookup_record()) {
+		const TypeInfo::DependentQualifiedNameRecord& dependent_record =
+			*call.dependent_qualified_lookup_record();
+		if (dependent_record.member_chain.size() == 1) {
+			Token synthetic_member_token(
+				Token::Type::Identifier,
+				StringTable::getStringView(dependent_record.member_chain.back().name),
+				call.called_from().line(),
+				call.called_from().column(),
+				call.called_from().file_index());
+			QualifiedIdentifierNode synthetic_qual_id(
+				NamespaceRegistry::GLOBAL_NAMESPACE,
+				synthetic_member_token);
+			synthetic_qual_id.setDependentQualifiedName(dependent_record);
+			ASTNode substituted_callee_node =
+				substituteQualifiedIdentifier(synthetic_qual_id);
+			if (substituted_callee_node.is<ExpressionNode>()) {
+				const ExpressionNode& substituted_callee_expr =
+					substituted_callee_node.as<ExpressionNode>();
+				if (const auto* resolved_qual_id =
+						std::get_if<QualifiedIdentifierNode>(
+							&substituted_callee_expr);
+					resolved_qual_id != nullptr &&
+					!resolved_qual_id->hasDependentQualifiedName()) {
+					const std::string_view resolved_owner_name =
+						gNamespaceRegistry.getQualifiedName(
+							resolved_qual_id->namespace_handle());
+					const std::string_view resolved_member_name =
+						resolved_qual_id->name();
+					if (!resolved_owner_name.empty()) {
+						ChunkedVector<ASTNode> substituted_args;
+						for (size_t i = 0; i < call.arguments().size(); ++i) {
+							substituted_args.push_back(substitute(call.arguments()[i]));
+						}
+
+						const FunctionDeclarationNode* target_func = nullptr;
+						std::string_view mutable_resolved_owner_name =
+							resolved_owner_name;
+						if (std::optional<ASTNode> instantiated_member =
+								parser_.instantiateLazyMemberForCanonicalOwner(
+									mutable_resolved_owner_name,
+									resolved_member_name,
+									std::span<const TemplateTypeArg>{});
+							instantiated_member.has_value() &&
+							instantiated_member->is<FunctionDeclarationNode>()) {
+							target_func = &instantiated_member->as<FunctionDeclarationNode>();
+						}
+						if (target_func == nullptr) {
+							auto qualified_symbol =
+								gSymbolTable.lookup_qualified(
+									resolved_qual_id->namespace_handle(),
+									resolved_member_name);
+							if (qualified_symbol.has_value()) {
+								target_func = get_function_decl_node(*qualified_symbol);
+							}
+						}
+						if (target_func != nullptr) {
+							Token called_from_token(
+								Token::Type::Identifier,
+								StringBuilder()
+									.append(resolved_owner_name)
+									.append("::")
+									.append(resolved_member_name)
+									.commit(),
+								call.called_from().line(),
+								call.called_from().column(),
+								call.called_from().file_index());
+							ExpressionNode& new_expr = emplaceDirectCallExpr(
+								target_func->decl_node(),
+								target_func,
+								std::move(substituted_args),
+								called_from_token);
+							copyMetadataToExpr(new_expr);
+							setCallQualifiedName(
+								new_expr,
+								StringBuilder()
+									.append(resolved_owner_name)
+									.append("::")
+									.append(resolved_member_name)
+									.commit());
+							if (target_func->has_mangled_name()) {
+								setCallMangledName(new_expr, target_func->mangled_name());
+							}
+							return ASTNode(&new_expr);
+						}
+					}
+				}
+			}
+		}
+		auto materializeRecordArgs =
+			[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) {
+			std::vector<TemplateTypeArg> materialized_args;
+			materialized_args.reserve(stored_args.size());
+			for (const TypeInfo::TemplateArgInfo& stored_arg : stored_args) {
+				TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
+				if (arg.dependent_name.isValid()) {
+					auto param_it =
+						param_map_.find(StringTable::getStringView(arg.dependent_name));
+					if (param_it != param_map_.end()) {
+						arg = rebindDependentTemplateTypeArg(param_it->second, arg);
+					}
+				}
+				materialized_args.push_back(std::move(arg));
+			}
+			return materialized_args;
+		};
+		auto areTemplateArgsConcrete = [&](std::span<const TemplateTypeArg> args) {
+			for (const TemplateTypeArg& arg : args) {
+				if (arg.is_dependent) {
+					return false;
+				}
+				if (arg.is_value || !arg.type_index.is_valid()) {
+					continue;
+				}
+				const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index);
+				if (arg_type_info &&
+					(arg_type_info->is_incomplete_instantiation_ ||
+					 (arg_type_info->isTemplateInstantiation() &&
+					  arg_type_info->getStructInfo() == nullptr))) {
+					return false;
+				}
+			}
+			return true;
+		};
+
+		std::string_view materialized_owner_name;
+		std::string_view recorded_owner_name =
+			StringTable::getStringView(dependent_record.owner_name);
+		switch (dependent_record.owner_kind) {
+		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
+			if (dependent_record.owner_type.is_valid()) {
+				if (const TypeInfo* owner_type_info =
+						tryGetTypeInfo(dependent_record.owner_type)) {
+					materialized_owner_name =
+						StringTable::getStringView(owner_type_info->name());
+				}
+			}
+			break;
+		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
+			if (dependent_record.owner_template_arguments.empty()) {
+				auto owner_param_it = param_map_.find(recorded_owner_name);
+				if (owner_param_it != param_map_.end()) {
+					if (const TypeInfo* owner_type_info =
+							tryGetTypeInfo(owner_param_it->second.type_index)) {
+						materialized_owner_name =
+							StringTable::getStringView(owner_type_info->name());
+					}
+				}
+				break;
+			}
+			[[fallthrough]];
+		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation:
+		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization: {
+			std::vector<TemplateTypeArg> owner_args =
+				materializeRecordArgs(dependent_record.owner_template_arguments);
+			if (areTemplateArgsConcrete(owner_args)) {
+				Parser::AliasTemplateMaterializationResult canonical_owner =
+					parser_.resolveCanonicalInstantiatedOwnerForLookup(
+						recorded_owner_name,
+						std::span<const TemplateTypeArg>(
+							owner_args.data(),
+							owner_args.size()));
+				if (!canonical_owner.instantiated_name.empty()) {
+					materialized_owner_name = canonical_owner.instantiated_name;
+				} else if (canonical_owner.resolved_type_info != nullptr) {
+					materialized_owner_name =
+						StringTable::getStringView(canonical_owner.resolved_type_info->name());
+				}
+			}
+			break;
+		}
+		}
+
+		if (!materialized_owner_name.empty() &&
+			!dependent_record.member_chain.empty()) {
+			const std::string_view materialized_record_owner_name =
+				materialized_owner_name;
+			std::string_view member_name =
+				StringTable::getStringView(
+					dependent_record.member_chain.back().name);
+			std::vector<QualifiedTypeMemberAccess> owner_member_chain;
+			owner_member_chain.reserve(
+				dependent_record.member_chain.size() > 0
+					? dependent_record.member_chain.size() - 1
+					: 0);
+			bool owner_chain_concrete = true;
+			for (size_t i = 0; i + 1 < dependent_record.member_chain.size(); ++i) {
+				const auto& member_record = dependent_record.member_chain[i];
+				QualifiedTypeMemberAccess member_access;
+				member_access.member_name = member_record.name;
+				if (member_record.has_template_arguments) {
+					std::vector<TemplateTypeArg> member_args =
+						materializeRecordArgs(member_record.template_arguments);
+					if (!areTemplateArgsConcrete(member_args)) {
+						owner_chain_concrete = false;
+						break;
+					}
+					member_access.has_template_arguments = true;
+					member_access.template_arguments =
+						&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(
+							std::move(member_args));
+				}
+				owner_member_chain.push_back(std::move(member_access));
+			}
+
+			if (owner_chain_concrete) {
+				if (!owner_member_chain.empty()) {
+					std::string_view chained_owner_name = materialized_owner_name;
+					bool owner_chain_materialized = true;
+					for (size_t i = 0; i + 1 < dependent_record.member_chain.size(); ++i) {
+						const auto& member_record = dependent_record.member_chain[i];
+						const std::string_view member_name_for_owner =
+							StringTable::getStringView(member_record.name);
+						if (member_record.has_template_arguments) {
+							std::vector<TemplateTypeArg> member_args =
+								materializeRecordArgs(member_record.template_arguments);
+							if (!areTemplateArgsConcrete(member_args)) {
+								owner_chain_materialized = false;
+								break;
+							}
+							const StringHandle chained_owner_handle =
+								StringTable::getOrInternStringHandle(chained_owner_name);
+							const StringHandle member_name_handle =
+								StringTable::getOrInternStringHandle(member_name_for_owner);
+							std::string_view qualified_owner_name;
+							if (i == 0 &&
+								!recorded_owner_name.empty()) {
+								std::string_view pattern_owner_name =
+									StringBuilder()
+										.append(recorded_owner_name)
+										.append("::")
+										.append(member_name_for_owner)
+										.commit();
+								if (gTemplateRegistry.lookupTemplate(pattern_owner_name).has_value()) {
+									qualified_owner_name = pattern_owner_name;
+								}
+							}
+							if (qualified_owner_name.empty()) {
+								qualified_owner_name =
+									parser_.lookup_inherited_member_template_name(
+										chained_owner_handle,
+										member_name_handle,
+										0);
+							}
+							if (qualified_owner_name.empty()) {
+								qualified_owner_name =
+									StringBuilder()
+										.append(chained_owner_name)
+										.append("::")
+										.append(member_name_for_owner)
+										.commit();
+							}
+							if (auto owner_it = getTypesByNameMap().find(chained_owner_handle);
+								owner_it != getTypesByNameMap().end() &&
+								owner_it->second != nullptr &&
+								owner_it->second->hasInstantiationContext()) {
+								const TypeInfo::InstantiationContext* parent_context =
+									owner_it->second->instantiationContext();
+								OuterTemplateBinding outer_binding;
+								for (size_t binding_i = 0;
+									 binding_i < parent_context->param_names.size() &&
+									 binding_i < parent_context->param_args.size();
+									 ++binding_i) {
+									outer_binding.param_names.push_back(
+										parent_context->param_names[binding_i]);
+									outer_binding.param_args.push_back(
+										toTemplateTypeArg(parent_context->param_args[binding_i]));
+								}
+								if (!outer_binding.param_names.empty()) {
+									gTemplateRegistry.registerOuterTemplateBinding(
+										StringTable::getOrInternStringHandle(qualified_owner_name),
+										std::move(outer_binding));
+								}
+							}
+							if (std::optional<ASTNode> instantiated_member_template =
+									parser_.try_instantiate_class_template(
+										qualified_owner_name,
+										member_args,
+										false);
+								instantiated_member_template.has_value() &&
+								instantiated_member_template->is<StructDeclarationNode>()) {
+								parser_.registerAndNormalizeLateMaterializedTopLevelNode(
+									*instantiated_member_template);
+							}
+							Parser::AliasTemplateMaterializationResult materialized_member_owner =
+								parser_.resolveCanonicalInstantiatedOwnerForLookup(
+									qualified_owner_name,
+									std::span<const TemplateTypeArg>(
+										member_args.data(),
+										member_args.size()));
+							chained_owner_name = materialized_member_owner.canonicalName();
+							if (chained_owner_name.empty()) {
+								chained_owner_name =
+									parser_.get_instantiated_class_name(
+										qualified_owner_name,
+										member_args);
+							} else {
+								StringHandle chained_owner_handle =
+									StringTable::getOrInternStringHandle(
+										chained_owner_name);
+								auto chained_owner_it =
+									getTypesByNameMap().find(chained_owner_handle);
+								if (chained_owner_it == getTypesByNameMap().end() ||
+									chained_owner_it->second == nullptr) {
+									std::string_view instantiated_owner_name =
+										parser_.get_instantiated_class_name(
+											qualified_owner_name,
+											member_args);
+									if (!instantiated_owner_name.empty()) {
+										chained_owner_name = instantiated_owner_name;
+									}
+								}
+							}
+							if (chained_owner_name.empty()) {
+								owner_chain_materialized = false;
+								break;
+							}
+							continue;
+						}
+						if (const TypeInfo* resolved_owner =
+								parser_.resolveBaseClassMemberTypeChain(
+									chained_owner_name,
+									std::span<QualifiedTypeMemberAccess>(
+										&owner_member_chain[i],
+										1))) {
+							chained_owner_name =
+								StringTable::getStringView(resolved_owner->name());
+						} else {
+							owner_chain_materialized = false;
+							break;
+						}
+					}
+					if (owner_chain_materialized) {
+						materialized_owner_name = chained_owner_name;
+					} else {
+						materialized_owner_name = {};
+					}
+				}
+
+				if (!materialized_owner_name.empty()) {
+					ChunkedVector<ASTNode> substituted_args;
+					for (size_t i = 0; i < call.arguments().size(); ++i) {
+						substituted_args.push_back(substitute(call.arguments()[i]));
+					}
+					const FunctionDeclarationNode* target_func = nullptr;
+
+					std::optional<ASTNode> instantiated_member =
+						parser_.instantiateLazyMemberForCanonicalOwner(
+						materialized_owner_name,
+						member_name,
+						std::span<const TemplateTypeArg>{});
+					if (instantiated_member.has_value() &&
+						instantiated_member->is<FunctionDeclarationNode>()) {
+						target_func =
+							&instantiated_member->as<FunctionDeclarationNode>();
+					}
+					parser_.instantiateLazyClassToPhase(
+						StringTable::getOrInternStringHandle(materialized_owner_name),
+						ClassInstantiationPhase::Full);
+
+					const FunctionDeclarationNode* resolved_struct_member = nullptr;
+					StringHandle owner_handle =
+						StringTable::getOrInternStringHandle(materialized_owner_name);
+					StringHandle member_handle =
+						StringTable::getOrInternStringHandle(member_name);
+					auto owner_it = getTypesByNameMap().find(owner_handle);
+					if (owner_it != getTypesByNameMap().end() &&
+						owner_it->second != nullptr) {
+						if (const StructTypeInfo* struct_info =
+								owner_it->second->getStructInfo()) {
+							auto member_result =
+								struct_info->findMemberFunctionRecursive(member_handle);
+							if (member_result.first != nullptr &&
+								member_result.first->function_decl.is<FunctionDeclarationNode>()) {
+								resolved_struct_member =
+									&member_result.first->function_decl.as<FunctionDeclarationNode>();
+							}
+						}
+					}
+					if (target_func == nullptr) {
+						target_func = resolved_struct_member;
+					}
+					if (target_func == nullptr) {
+						std::vector<ASTNode> member_candidates =
+							gSymbolTable.lookup_all(member_name);
+						for (const ASTNode& candidate_node : member_candidates) {
+							const FunctionDeclarationNode* candidate_func =
+								get_function_decl_node(candidate_node);
+							if (candidate_func == nullptr) {
+								continue;
+							}
+							const std::string_view parent_name =
+								candidate_func->parent_struct_name();
+							if (parent_name == materialized_owner_name ||
+								(!parent_name.empty() &&
+								 parent_name.ends_with(materialized_owner_name))) {
+								target_func = candidate_func;
+								break;
+							}
+						}
+					}
+					if (target_func == nullptr &&
+						!materialized_record_owner_name.empty() &&
+						materialized_owner_name != materialized_record_owner_name) {
+						std::string_view qualified_owner_name =
+							StringBuilder()
+								.append(materialized_record_owner_name)
+								.append("::")
+								.append(materialized_owner_name)
+								.commit();
+						std::string_view mutable_qualified_owner_name =
+							qualified_owner_name;
+						if (std::optional<ASTNode> qualified_instantiated_member =
+								parser_.instantiateLazyMemberForCanonicalOwner(
+									mutable_qualified_owner_name,
+									member_name,
+									std::span<const TemplateTypeArg>{});
+							qualified_instantiated_member.has_value() &&
+							qualified_instantiated_member->is<FunctionDeclarationNode>()) {
+							target_func =
+								&qualified_instantiated_member->as<FunctionDeclarationNode>();
+							materialized_owner_name = mutable_qualified_owner_name;
+						}
+					}
+
+					if (target_func != nullptr) {
+						Token called_from_token(
+							Token::Type::Identifier,
+							StringBuilder()
+								.append(materialized_owner_name)
+								.append("::")
+								.append(member_name)
+								.commit(),
+							call.called_from().line(),
+							call.called_from().column(),
+							call.called_from().file_index());
+						ExpressionNode& new_expr = emplaceDirectCallExpr(
+							target_func->decl_node(),
+							target_func,
+							std::move(substituted_args),
+							called_from_token);
+						copyMetadataToExpr(new_expr);
+						setCallQualifiedName(
+							new_expr,
+							StringBuilder()
+								.append(materialized_owner_name)
+								.append("::")
+								.append(member_name)
+								.commit());
+						if (target_func->has_mangled_name()) {
+							setCallMangledName(new_expr, target_func->mangled_name());
+						}
+						return ASTNode(&new_expr);
+					}
+				}
+			}
+		}
+	}
+
 	// If not a template function call or instantiation failed, check for qualified owners
 	// that became concrete during substitution and need canonical owner identity rebound.
-	size_t scope_pos = func_name.find("::");
+	size_t scope_pos = func_name.rfind("::");
 	if (scope_pos != std::string_view::npos) {
 		std::string_view owner_name = func_name.substr(0, scope_pos);
 		std::string_view member_name = func_name.substr(scope_pos + 2);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5851,6 +5851,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								return buildTTPQualifiedIdentifier(ttp_name_view);
 							}
 
+							const bool materialized_owner_names_current_instantiation =
+								tryResolveCurrentInstantiationTemplateOwner(
+									template_name,
+									*explicit_template_args).has_value();
 							AliasTemplateMaterializationResult materialized_owner =
 								materializePrimaryTemplateOwnerForLookup(
 									template_name,
@@ -5930,7 +5934,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										member_segment.has_template_keyword = has_template_keyword;
 										advance(); // consume member name
 										std::vector<ASTNode> member_template_arg_nodes;
-										if (has_template_keyword && peek() == "<"_tok) {
+										if ((has_template_keyword ||
+											 materialized_owner_names_current_instantiation) &&
+											peek() == "<"_tok) {
 											auto member_template_args =
 												parse_explicit_template_arguments(
 													&member_template_arg_nodes);
@@ -5988,7 +5994,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										makeExpressionDependentQualifiedNameRecord(
 											StringTable::getOrInternStringHandle(qualified_template_name),
 											lookupRecordedDependentOwnerType(dependent_owner_handle),
-											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+											materialized_owner_names_current_instantiation
+												? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
+												: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 											toTemplateArgInfoList(*explicit_template_args),
 											dependent_member_segments));
 									if (has_deferred_member_call) {
@@ -6073,7 +6081,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									member_segment.has_template_keyword = has_template_keyword;
 									advance(); // consume member name
 									std::vector<ASTNode> member_template_arg_nodes;
-									if (has_template_keyword && peek() == "<"_tok) {
+									if ((has_template_keyword ||
+										 materialized_owner_names_current_instantiation) &&
+										peek() == "<"_tok) {
 										auto member_template_args =
 											parse_explicit_template_arguments(&member_template_arg_nodes);
 										if (!member_template_args.has_value()) {
@@ -6132,7 +6142,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											StringTable::getOrInternStringHandle(template_name),
 											lookupRecordedDependentOwnerType(
 												StringTable::getOrInternStringHandle(instantiated_name)),
-											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+											materialized_owner_names_current_instantiation
+												? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
+												: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 											toTemplateArgInfoList(*explicit_template_args),
 											deferred_member_segments));
 									if (has_deferred_member_call) {
@@ -7071,6 +7083,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return buildTTPQualifiedIdentifier(ttp_name_view);
 					}
 
+					const bool materialized_owner_names_current_instantiation =
+						tryResolveCurrentInstantiationTemplateOwner(
+							identifier_token.value(),
+							*explicit_template_args).has_value();
 					Parser::AliasTemplateMaterializationResult materialized_owner =
 						materializePrimaryTemplateOwnerForLookup(
 							identifier_token.value(),
@@ -7144,7 +7160,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								member_segment.has_template_keyword = has_template_keyword;
 								advance(); // consume member name
 								std::vector<ASTNode> member_template_arg_nodes;
-								if (has_template_keyword && peek() == "<"_tok) {
+								if ((has_template_keyword ||
+									 materialized_owner_names_current_instantiation) &&
+									peek() == "<"_tok) {
 									auto member_template_args =
 										parse_explicit_template_arguments(
 											&member_template_arg_nodes);
@@ -7202,7 +7220,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								makeExpressionDependentQualifiedNameRecord(
 									StringTable::getOrInternStringHandle(qualified_template_name),
 									lookupRecordedDependentOwnerType(dependent_owner_handle),
-									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+									materialized_owner_names_current_instantiation
+										? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
+										: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 									toTemplateArgInfoList(*explicit_template_args),
 									dependent_member_segments));
 							if (has_deferred_member_call) {
@@ -7285,7 +7305,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							member_segment.has_template_keyword = has_template_keyword;
 							advance(); // consume member name
 							std::vector<ASTNode> member_template_arg_nodes;
-							if (has_template_keyword && peek() == "<"_tok) {
+							if ((has_template_keyword ||
+								 materialized_owner_names_current_instantiation) &&
+								peek() == "<"_tok) {
 								auto member_template_args =
 									parse_explicit_template_arguments(&member_template_arg_nodes);
 								if (!member_template_args.has_value()) {
@@ -7344,7 +7366,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									StringTable::getOrInternStringHandle(identifier_token.value()),
 									lookupRecordedDependentOwnerType(
 										StringTable::getOrInternStringHandle(instantiated_class_name)),
-									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+									materialized_owner_names_current_instantiation
+										? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
+										: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 									toTemplateArgInfoList(*explicit_template_args),
 									deferred_member_segments));
 							if (has_deferred_member_call) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -26,6 +26,12 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 		});
 }
 
+struct ExpressionDependentMemberSegmentInfo {
+	StringHandle name;
+	bool has_template_keyword = false;
+	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> template_args;
+};
+
 TypeInfo::DependentQualifiedNameRecord makeExpressionDependentQualifiedNameRecord(
 	StringHandle owner_name,
 	TypeIndex owner_type,
@@ -45,6 +51,43 @@ TypeInfo::DependentQualifiedNameRecord makeExpressionDependentQualifiedNameRecor
 		record.member_chain.push_back(std::move(member));
 	}
 	return record;
+}
+
+TypeInfo::DependentQualifiedNameRecord makeExpressionDependentQualifiedNameRecord(
+	StringHandle owner_name,
+	TypeIndex owner_type,
+	TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
+	InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments,
+	std::span<const ExpressionDependentMemberSegmentInfo> member_segments) {
+	TypeInfo::DependentQualifiedNameRecord record;
+	record.owner_kind = owner_kind;
+	record.owner_name = owner_name;
+	record.owner_type = owner_type;
+	record.owner_template_arguments = std::move(owner_template_arguments);
+	record.names_current_instantiation =
+		owner_kind == TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation;
+	for (const ExpressionDependentMemberSegmentInfo& segment_info : member_segments) {
+		TypeInfo::DependentQualifiedNameRecord::Member member;
+		member.name = segment_info.name;
+		member.has_template_keyword = segment_info.has_template_keyword;
+		if (segment_info.template_args.has_value()) {
+			member.template_arguments = *segment_info.template_args;
+			member.has_template_arguments = true;
+		}
+		record.member_chain.push_back(std::move(member));
+	}
+	return record;
+}
+
+TypeIndex lookupRecordedDependentOwnerType(StringHandle owner_handle) {
+	if (!owner_handle.isValid()) {
+		return {};
+	}
+	auto owner_it = getTypesByNameMap().find(owner_handle);
+	if (owner_it == getTypesByNameMap().end() || owner_it->second == nullptr) {
+		return {};
+	}
+	return owner_it->second->registeredTypeIndex();
 }
 
 bool isEligibleDefinitionLookupCall(
@@ -5788,9 +5831,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										NamespaceRegistry::GLOBAL_NAMESPACE,
 										dependent_owner_handle);
 									Token final_identifier{};
-									std::vector<StringHandle> dependent_member_names;
+									std::vector<ExpressionDependentMemberSegmentInfo> dependent_member_segments;
 									while (peek() == "::"_tok) {
 										advance(); // consume ::
+										const bool has_template_keyword = peek() == "template"_tok;
 										if (peek() == "template"_tok) {
 											advance(); // consume 'template' keyword
 										}
@@ -5798,12 +5842,26 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											return ParseResult::error("Expected identifier after '::'", peek_info());
 										}
 										final_identifier = peek_info();
-										dependent_member_names.push_back(final_identifier.handle());
+										ExpressionDependentMemberSegmentInfo member_segment;
+										member_segment.name = final_identifier.handle();
+										member_segment.has_template_keyword = has_template_keyword;
 										advance(); // consume member name
-										// Skip template arguments on member if present (e.g., ::member<T>)
-										if (peek() == "<"_tok) {
-											skip_template_arguments();
+										if (has_template_keyword && peek() == "<"_tok) {
+											std::vector<ASTNode> member_template_arg_nodes;
+											auto member_template_args =
+												parse_explicit_template_arguments(
+													&member_template_arg_nodes);
+											if (!member_template_args.has_value()) {
+												return ParseResult::error(
+													"Failed to parse dependent member template arguments",
+													final_identifier);
+											}
+											member_segment.template_args =
+												toTemplateArgInfoList(
+													*member_template_args);
 										}
+										dependent_member_segments.push_back(
+											std::move(member_segment));
 										// Skip function call arguments if present (e.g., ::member(a, b))
 										if (peek() == "("_tok) {
 											skip_balanced_parens();
@@ -5824,10 +5882,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									dependent_qual_id.setDependentQualifiedName(
 										makeExpressionDependentQualifiedNameRecord(
 											StringTable::getOrInternStringHandle(qualified_template_name),
-											TypeIndex{},
+											lookupRecordedDependentOwnerType(dependent_owner_handle),
 											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 											toTemplateArgInfoList(*explicit_template_args),
-											dependent_member_names));
+											dependent_member_segments));
 									result = emplace_node<ExpressionNode>(dependent_qual_id);
 									return ParseResult::success(*result);
 								}
@@ -5839,6 +5897,73 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 							// Parse qualified identifier after template, using the instantiated name
 							// We need to collect the :: path ourselves since we have the instantiated name
+							if (parsing_template_depth_ > 0 && peek() == "::"_tok) {
+								SaveHandle deferred_member_chain_start = save_token_position();
+								NamespaceHandle deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+									NamespaceRegistry::GLOBAL_NAMESPACE,
+									StringTable::getOrInternStringHandle(instantiated_name));
+								Token deferred_final_identifier{};
+								std::vector<ExpressionDependentMemberSegmentInfo> deferred_member_segments;
+								bool has_deferred_member_template_segment = false;
+								bool deferred_member_chain_valid = true;
+								while (peek() == "::"_tok) {
+									advance(); // consume ::
+									const bool has_template_keyword = peek() == "template"_tok;
+									if (has_template_keyword) {
+										advance(); // consume 'template'
+									}
+									if (!peek().is_identifier()) {
+										deferred_member_chain_valid = false;
+										break;
+									}
+									deferred_final_identifier = peek_info();
+									ExpressionDependentMemberSegmentInfo member_segment;
+									member_segment.name = deferred_final_identifier.handle();
+									member_segment.has_template_keyword = has_template_keyword;
+									advance(); // consume member name
+									if (has_template_keyword && peek() == "<"_tok) {
+										auto member_template_args = parse_explicit_template_arguments();
+										if (!member_template_args.has_value()) {
+											deferred_member_chain_valid = false;
+											break;
+										}
+										member_segment.template_args =
+											toTemplateArgInfoList(*member_template_args);
+										has_deferred_member_template_segment =
+											has_deferred_member_template_segment ||
+											has_template_keyword ||
+											explicitTemplateArgsRequireDeferredInstantiation(
+												*member_template_args);
+									}
+									deferred_member_segments.push_back(std::move(member_segment));
+									if (peek() == "::"_tok) {
+										deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+											deferred_ns_handle,
+											deferred_final_identifier.handle());
+									}
+								}
+								if (deferred_member_chain_valid &&
+									has_deferred_member_template_segment &&
+									deferred_final_identifier.type() == Token::Type::Identifier &&
+									peek() != "("_tok) {
+									QualifiedIdentifierNode dependent_qual_id(
+										deferred_ns_handle,
+										deferred_final_identifier);
+									dependent_qual_id.setDependentQualifiedName(
+										makeExpressionDependentQualifiedNameRecord(
+											StringTable::getOrInternStringHandle(template_name),
+											lookupRecordedDependentOwnerType(
+												StringTable::getOrInternStringHandle(instantiated_name)),
+											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+											toTemplateArgInfoList(*explicit_template_args),
+											deferred_member_segments));
+									result = emplace_node<ExpressionNode>(dependent_qual_id);
+									pending_explicit_template_args_.reset();
+									return ParseResult::success(*result);
+								}
+								restore_token_position(deferred_member_chain_start);
+							}
+
 							std::vector<StringType<32>> namespaces;
 							Token final_identifier = identifier_token;
 
@@ -6779,9 +6904,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								NamespaceRegistry::GLOBAL_NAMESPACE,
 								dependent_owner_handle);
 							Token final_identifier{};
-							std::vector<StringHandle> dependent_member_names;
+							std::vector<ExpressionDependentMemberSegmentInfo> dependent_member_segments;
 							while (peek() == "::"_tok) {
 								advance(); // consume ::
+								const bool has_template_keyword = peek() == "template"_tok;
 								if (peek() == "template"_tok) {
 									advance(); // consume 'template' keyword
 								}
@@ -6789,12 +6915,26 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									return ParseResult::error("Expected identifier after '::'", peek_info());
 								}
 								final_identifier = peek_info();
-								dependent_member_names.push_back(final_identifier.handle());
+								ExpressionDependentMemberSegmentInfo member_segment;
+								member_segment.name = final_identifier.handle();
+								member_segment.has_template_keyword = has_template_keyword;
 								advance(); // consume member name
-								// Skip template arguments on member if present
-								if (peek() == "<"_tok) {
-									skip_template_arguments();
+								if (has_template_keyword && peek() == "<"_tok) {
+									std::vector<ASTNode> member_template_arg_nodes;
+									auto member_template_args =
+										parse_explicit_template_arguments(
+											&member_template_arg_nodes);
+									if (!member_template_args.has_value()) {
+										return ParseResult::error(
+											"Failed to parse dependent member template arguments",
+											final_identifier);
+									}
+									member_segment.template_args =
+										toTemplateArgInfoList(
+											*member_template_args);
 								}
+								dependent_member_segments.push_back(
+									std::move(member_segment));
 								// Skip function call arguments if present
 								if (peek() == "("_tok) {
 									skip_balanced_parens();
@@ -6815,10 +6955,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							dependent_qual_id.setDependentQualifiedName(
 								makeExpressionDependentQualifiedNameRecord(
 									StringTable::getOrInternStringHandle(qualified_template_name),
-									TypeIndex{},
+									lookupRecordedDependentOwnerType(dependent_owner_handle),
 									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 									toTemplateArgInfoList(*explicit_template_args),
-									dependent_member_names));
+									dependent_member_segments));
 							result = emplace_node<ExpressionNode>(dependent_qual_id);
 							return ParseResult::success(*result);
 						}
@@ -6828,6 +6968,72 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 
 					// Create a token with the instantiated name to pass to parse_qualified_identifier_after_template
+					if (parsing_template_depth_ > 0 && peek() == "::"_tok) {
+						SaveHandle deferred_member_chain_start = save_token_position();
+						NamespaceHandle deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+							NamespaceRegistry::GLOBAL_NAMESPACE,
+							StringTable::getOrInternStringHandle(instantiated_class_name));
+						Token deferred_final_identifier{};
+						std::vector<ExpressionDependentMemberSegmentInfo> deferred_member_segments;
+						bool has_deferred_member_template_segment = false;
+						bool deferred_member_chain_valid = true;
+						while (peek() == "::"_tok) {
+							advance(); // consume ::
+							const bool has_template_keyword = peek() == "template"_tok;
+							if (has_template_keyword) {
+								advance(); // consume 'template'
+							}
+							if (!peek().is_identifier()) {
+								deferred_member_chain_valid = false;
+								break;
+							}
+							deferred_final_identifier = peek_info();
+							ExpressionDependentMemberSegmentInfo member_segment;
+							member_segment.name = deferred_final_identifier.handle();
+							member_segment.has_template_keyword = has_template_keyword;
+							advance(); // consume member name
+							if (has_template_keyword && peek() == "<"_tok) {
+								auto member_template_args = parse_explicit_template_arguments();
+								if (!member_template_args.has_value()) {
+									deferred_member_chain_valid = false;
+									break;
+								}
+								member_segment.template_args =
+									toTemplateArgInfoList(*member_template_args);
+								has_deferred_member_template_segment =
+									has_deferred_member_template_segment ||
+									has_template_keyword ||
+									explicitTemplateArgsRequireDeferredInstantiation(
+										*member_template_args);
+							}
+							deferred_member_segments.push_back(std::move(member_segment));
+							if (peek() == "::"_tok) {
+								deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
+									deferred_ns_handle,
+									deferred_final_identifier.handle());
+							}
+						}
+						if (deferred_member_chain_valid &&
+							has_deferred_member_template_segment &&
+							deferred_final_identifier.type() == Token::Type::Identifier &&
+							peek() != "("_tok) {
+							QualifiedIdentifierNode dependent_qual_id(
+								deferred_ns_handle,
+								deferred_final_identifier);
+							dependent_qual_id.setDependentQualifiedName(
+								makeExpressionDependentQualifiedNameRecord(
+									StringTable::getOrInternStringHandle(identifier_token.value()),
+									lookupRecordedDependentOwnerType(
+										StringTable::getOrInternStringHandle(instantiated_class_name)),
+									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+									toTemplateArgInfoList(*explicit_template_args),
+									deferred_member_segments));
+							result = emplace_node<ExpressionNode>(dependent_qual_id);
+							return ParseResult::success(*result);
+						}
+						restore_token_position(deferred_member_chain_start);
+					}
+
 					Token instantiated_token(Token::Type::Identifier, instantiated_class_name,
 											 identifier_token.line(), identifier_token.column(), identifier_token.file_index());
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -8,6 +8,8 @@
 #include "TypeTraitEvaluator.h"
 
 #include <algorithm>
+#include <charconv>
+#include <type_traits>
 
 std::optional<TypedNumeric> get_numeric_literal_type(std::string_view text);
 
@@ -88,6 +90,83 @@ TypeIndex lookupRecordedDependentOwnerType(StringHandle owner_handle) {
 		return {};
 	}
 	return owner_it->second->registeredTypeIndex();
+}
+
+void appendDependentTemplateArgSpelling(
+	StringBuilder& builder,
+	const TypeInfo::TemplateArgInfo& template_arg) {
+	if (template_arg.is_template_template_arg) {
+		if (template_arg.template_name.isValid()) {
+			builder.append(StringTable::getStringView(template_arg.template_name));
+		} else {
+			builder.append("template");
+		}
+		return;
+	}
+	if (template_arg.dependent_name.isValid()) {
+		builder.append(StringTable::getStringView(template_arg.dependent_name));
+		return;
+	}
+	if (template_arg.is_value) {
+		std::visit(
+			[&](const auto& value) {
+				using ValueType = std::decay_t<decltype(value)>;
+				if constexpr (std::is_same_v<ValueType, int64_t>) {
+					builder.append(value);
+				} else if constexpr (std::is_same_v<ValueType, double>) {
+					char buffer[64];
+					auto [end_ptr, err] = std::to_chars(
+						std::begin(buffer),
+						std::end(buffer),
+						value);
+					if (err == std::errc{}) {
+						builder.append(std::string_view(
+							buffer,
+							static_cast<size_t>(end_ptr - buffer)));
+					}
+				} else if constexpr (std::is_same_v<ValueType, StringHandle>) {
+					if (value.isValid()) {
+						builder.append(StringTable::getStringView(value));
+					} else {
+						builder.append("0");
+					}
+				}
+			},
+			template_arg.value);
+		return;
+	}
+	if (template_arg.type_index.is_valid()) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(template_arg.type_index)) {
+			builder.append(StringTable::getStringView(type_info->name()));
+			return;
+		}
+	}
+	builder.append("auto");
+}
+
+std::string_view buildDependentQualifiedCallName(
+	std::string_view owner_name,
+	std::span<const ExpressionDependentMemberSegmentInfo> member_segments) {
+	StringBuilder qualified_name_builder;
+	qualified_name_builder.append(owner_name);
+	for (const ExpressionDependentMemberSegmentInfo& member_segment : member_segments) {
+		qualified_name_builder.append("::");
+		qualified_name_builder.append(StringTable::getStringView(member_segment.name));
+		if (member_segment.template_args.has_value() &&
+			!member_segment.template_args->empty()) {
+			qualified_name_builder.append("<");
+			bool is_first = true;
+			for (const TypeInfo::TemplateArgInfo& template_arg : *member_segment.template_args) {
+				if (!is_first) {
+					qualified_name_builder.append(", ");
+				}
+				appendDependentTemplateArgSpelling(qualified_name_builder, template_arg);
+				is_first = false;
+			}
+			qualified_name_builder.append(">");
+		}
+	}
+	return qualified_name_builder.commit();
 }
 
 bool isEligibleDefinitionLookupCall(
@@ -5832,6 +5911,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										dependent_owner_handle);
 									Token final_identifier{};
 									std::vector<ExpressionDependentMemberSegmentInfo> dependent_member_segments;
+									bool has_deferred_member_call = false;
+									Token deferred_member_call_token{};
+									ChunkedVector<ASTNode> deferred_member_call_args;
+									std::vector<ASTNode> deferred_member_call_template_arg_nodes;
 									while (peek() == "::"_tok) {
 										advance(); // consume ::
 										const bool has_template_keyword = peek() == "template"_tok;
@@ -5846,8 +5929,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										member_segment.name = final_identifier.handle();
 										member_segment.has_template_keyword = has_template_keyword;
 										advance(); // consume member name
+										std::vector<ASTNode> member_template_arg_nodes;
 										if (has_template_keyword && peek() == "<"_tok) {
-											std::vector<ASTNode> member_template_arg_nodes;
 											auto member_template_args =
 												parse_explicit_template_arguments(
 													&member_template_arg_nodes);
@@ -5862,9 +5945,31 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										}
 										dependent_member_segments.push_back(
 											std::move(member_segment));
-										// Skip function call arguments if present (e.g., ::member(a, b))
 										if (peek() == "("_tok) {
-											skip_balanced_parens();
+											advance(); // consume '('
+											auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+												.handle_pack_expansion = true,
+												.collect_types = true,
+												.expand_simple_packs = false});
+											if (!args_result.success) {
+												return ParseResult::error(
+													args_result.error_message,
+													args_result.error_token.value_or(current_token_));
+											}
+											if (!consume(")"_tok)) {
+												return ParseResult::error(
+													"Expected ')' after function call arguments",
+													current_token_);
+											}
+											if (peek() != "::"_tok) {
+												has_deferred_member_call = true;
+												deferred_member_call_token = final_identifier;
+												deferred_member_call_args = std::move(args_result.args);
+												if (!member_template_arg_nodes.empty()) {
+													deferred_member_call_template_arg_nodes =
+														std::move(member_template_arg_nodes);
+												}
+											}
 										}
 										if (peek() == "::"_tok) {
 											ns_handle = gNamespaceRegistry.getOrCreateNamespace(
@@ -5886,7 +5991,49 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 											toTemplateArgInfoList(*explicit_template_args),
 											dependent_member_segments));
-									result = emplace_node<ExpressionNode>(dependent_qual_id);
+									if (has_deferred_member_call) {
+										auto type_node = emplace_node<TypeSpecifierNode>(
+											TypeIndex{}.withCategory(TypeCategory::Auto),
+											0,
+											deferred_member_call_token,
+											CVQualifier::None,
+											ReferenceQualifier::None);
+										auto placeholder_decl =
+											emplace_node<DeclarationNode>(
+												type_node,
+												deferred_member_call_token);
+										std::string_view deferred_qualified_call_name =
+											buildDependentQualifiedCallName(
+												StringTable::getStringView(dependent_owner_handle),
+												dependent_member_segments);
+										Token deferred_call_token(
+											Token::Type::Identifier,
+											deferred_qualified_call_name,
+											deferred_member_call_token.line(),
+											deferred_member_call_token.column(),
+											deferred_member_call_token.file_index());
+										result = emplace_node<ExpressionNode>(
+											makeDirectCallExpr(
+												placeholder_decl.as<DeclarationNode>(),
+												std::move(deferred_member_call_args),
+												deferred_call_token));
+										setCallQualifiedName(
+											result->as<ExpressionNode>(),
+											deferred_qualified_call_name);
+										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+												dependent_qual_id.dependentQualifiedName()) {
+											setCallDependentQualifiedLookupRecord(
+												result->as<ExpressionNode>(),
+												*dependent_record);
+										}
+										if (!deferred_member_call_template_arg_nodes.empty()) {
+											setCallTemplateArguments(
+												result->as<ExpressionNode>(),
+												std::move(deferred_member_call_template_arg_nodes));
+										}
+									} else {
+										result = emplace_node<ExpressionNode>(dependent_qual_id);
+									}
 									return ParseResult::success(*result);
 								}
 								pending_explicit_template_args_.reset();
@@ -5905,6 +6052,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								Token deferred_final_identifier{};
 								std::vector<ExpressionDependentMemberSegmentInfo> deferred_member_segments;
 								bool has_deferred_member_template_segment = false;
+								bool has_deferred_member_call = false;
+								Token deferred_member_call_token{};
+								ChunkedVector<ASTNode> deferred_member_call_args;
+								std::vector<ASTNode> deferred_member_call_template_arg_nodes;
 								bool deferred_member_chain_valid = true;
 								while (peek() == "::"_tok) {
 									advance(); // consume ::
@@ -5921,8 +6072,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									member_segment.name = deferred_final_identifier.handle();
 									member_segment.has_template_keyword = has_template_keyword;
 									advance(); // consume member name
+									std::vector<ASTNode> member_template_arg_nodes;
 									if (has_template_keyword && peek() == "<"_tok) {
-										auto member_template_args = parse_explicit_template_arguments();
+										auto member_template_args =
+											parse_explicit_template_arguments(&member_template_arg_nodes);
 										if (!member_template_args.has_value()) {
 											deferred_member_chain_valid = false;
 											break;
@@ -5935,6 +6088,32 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											explicitTemplateArgsRequireDeferredInstantiation(
 												*member_template_args);
 									}
+									if (peek() == "("_tok) {
+										advance(); // consume '('
+										auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+											.handle_pack_expansion = true,
+											.collect_types = true,
+											.expand_simple_packs = false});
+										if (!args_result.success) {
+											return ParseResult::error(
+												args_result.error_message,
+												args_result.error_token.value_or(current_token_));
+										}
+										if (!consume(")"_tok)) {
+											return ParseResult::error(
+												"Expected ')' after function call arguments",
+												current_token_);
+										}
+										if (peek() != "::"_tok) {
+											has_deferred_member_call = true;
+											deferred_member_call_token = deferred_final_identifier;
+											deferred_member_call_args = std::move(args_result.args);
+											if (!member_template_arg_nodes.empty()) {
+												deferred_member_call_template_arg_nodes =
+													std::move(member_template_arg_nodes);
+											}
+										}
+									}
 									deferred_member_segments.push_back(std::move(member_segment));
 									if (peek() == "::"_tok) {
 										deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
@@ -5944,8 +6123,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								}
 								if (deferred_member_chain_valid &&
 									has_deferred_member_template_segment &&
-									deferred_final_identifier.type() == Token::Type::Identifier &&
-									peek() != "("_tok) {
+									deferred_final_identifier.type() == Token::Type::Identifier) {
 									QualifiedIdentifierNode dependent_qual_id(
 										deferred_ns_handle,
 										deferred_final_identifier);
@@ -5957,7 +6135,49 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 											toTemplateArgInfoList(*explicit_template_args),
 											deferred_member_segments));
-									result = emplace_node<ExpressionNode>(dependent_qual_id);
+									if (has_deferred_member_call) {
+										auto type_node = emplace_node<TypeSpecifierNode>(
+											TypeIndex{}.withCategory(TypeCategory::Auto),
+											0,
+											deferred_member_call_token,
+											CVQualifier::None,
+											ReferenceQualifier::None);
+										auto placeholder_decl =
+											emplace_node<DeclarationNode>(
+												type_node,
+												deferred_member_call_token);
+										std::string_view deferred_qualified_call_name =
+											buildDependentQualifiedCallName(
+												instantiated_name,
+												deferred_member_segments);
+										Token deferred_call_token(
+											Token::Type::Identifier,
+											deferred_qualified_call_name,
+											deferred_member_call_token.line(),
+											deferred_member_call_token.column(),
+											deferred_member_call_token.file_index());
+										result = emplace_node<ExpressionNode>(
+											makeDirectCallExpr(
+												placeholder_decl.as<DeclarationNode>(),
+												std::move(deferred_member_call_args),
+												deferred_call_token));
+										setCallQualifiedName(
+											result->as<ExpressionNode>(),
+											deferred_qualified_call_name);
+										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+												dependent_qual_id.dependentQualifiedName()) {
+											setCallDependentQualifiedLookupRecord(
+												result->as<ExpressionNode>(),
+												*dependent_record);
+										}
+										if (!deferred_member_call_template_arg_nodes.empty()) {
+											setCallTemplateArguments(
+												result->as<ExpressionNode>(),
+												std::move(deferred_member_call_template_arg_nodes));
+										}
+									} else {
+										result = emplace_node<ExpressionNode>(dependent_qual_id);
+									}
 									pending_explicit_template_args_.reset();
 									return ParseResult::success(*result);
 								}
@@ -6468,7 +6688,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 						// Substitute with actual value
 						StringBuilder value_str;
-						value_str.append(subst.value);  // Directly append int64_t without std::to_string()
+						value_str.append(subst.value);
 						std::string_view value_view = value_str.commit();
 						Token num_token(Token::Type::Literal, value_view,
 										identifier_token.line(), identifier_token.column(),
@@ -6905,6 +7125,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								dependent_owner_handle);
 							Token final_identifier{};
 							std::vector<ExpressionDependentMemberSegmentInfo> dependent_member_segments;
+							bool has_deferred_member_call = false;
+							Token deferred_member_call_token{};
+							ChunkedVector<ASTNode> deferred_member_call_args;
+							std::vector<ASTNode> deferred_member_call_template_arg_nodes;
 							while (peek() == "::"_tok) {
 								advance(); // consume ::
 								const bool has_template_keyword = peek() == "template"_tok;
@@ -6919,8 +7143,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								member_segment.name = final_identifier.handle();
 								member_segment.has_template_keyword = has_template_keyword;
 								advance(); // consume member name
+								std::vector<ASTNode> member_template_arg_nodes;
 								if (has_template_keyword && peek() == "<"_tok) {
-									std::vector<ASTNode> member_template_arg_nodes;
 									auto member_template_args =
 										parse_explicit_template_arguments(
 											&member_template_arg_nodes);
@@ -6935,9 +7159,31 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								}
 								dependent_member_segments.push_back(
 									std::move(member_segment));
-								// Skip function call arguments if present
 								if (peek() == "("_tok) {
-									skip_balanced_parens();
+									advance(); // consume '('
+									auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+										.handle_pack_expansion = true,
+										.collect_types = true,
+										.expand_simple_packs = false});
+									if (!args_result.success) {
+										return ParseResult::error(
+											args_result.error_message,
+											args_result.error_token.value_or(current_token_));
+									}
+									if (!consume(")"_tok)) {
+										return ParseResult::error(
+											"Expected ')' after function call arguments",
+											current_token_);
+									}
+									if (peek() != "::"_tok) {
+										has_deferred_member_call = true;
+										deferred_member_call_token = final_identifier;
+										deferred_member_call_args = std::move(args_result.args);
+										if (!member_template_arg_nodes.empty()) {
+											deferred_member_call_template_arg_nodes =
+												std::move(member_template_arg_nodes);
+										}
+									}
 								}
 								if (peek() == "::"_tok) {
 									ns_handle = gNamespaceRegistry.getOrCreateNamespace(
@@ -6959,7 +7205,49 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 									toTemplateArgInfoList(*explicit_template_args),
 									dependent_member_segments));
-							result = emplace_node<ExpressionNode>(dependent_qual_id);
+							if (has_deferred_member_call) {
+								auto type_node = emplace_node<TypeSpecifierNode>(
+									TypeIndex{}.withCategory(TypeCategory::Auto),
+									0,
+									deferred_member_call_token,
+									CVQualifier::None,
+									ReferenceQualifier::None);
+								auto placeholder_decl =
+									emplace_node<DeclarationNode>(
+										type_node,
+										deferred_member_call_token);
+								std::string_view deferred_qualified_call_name =
+									buildDependentQualifiedCallName(
+										StringTable::getStringView(dependent_owner_handle),
+										dependent_member_segments);
+								Token deferred_call_token(
+									Token::Type::Identifier,
+									deferred_qualified_call_name,
+									deferred_member_call_token.line(),
+									deferred_member_call_token.column(),
+									deferred_member_call_token.file_index());
+								result = emplace_node<ExpressionNode>(
+									makeDirectCallExpr(
+										placeholder_decl.as<DeclarationNode>(),
+										std::move(deferred_member_call_args),
+										deferred_call_token));
+								setCallQualifiedName(
+									result->as<ExpressionNode>(),
+									deferred_qualified_call_name);
+								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+										dependent_qual_id.dependentQualifiedName()) {
+									setCallDependentQualifiedLookupRecord(
+										result->as<ExpressionNode>(),
+										*dependent_record);
+								}
+								if (!deferred_member_call_template_arg_nodes.empty()) {
+									setCallTemplateArguments(
+										result->as<ExpressionNode>(),
+										std::move(deferred_member_call_template_arg_nodes));
+								}
+							} else {
+								result = emplace_node<ExpressionNode>(dependent_qual_id);
+							}
 							return ParseResult::success(*result);
 						}
 						return ParseResult::error(
@@ -6976,6 +7264,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						Token deferred_final_identifier{};
 						std::vector<ExpressionDependentMemberSegmentInfo> deferred_member_segments;
 						bool has_deferred_member_template_segment = false;
+						bool has_deferred_member_call = false;
+						Token deferred_member_call_token{};
+						ChunkedVector<ASTNode> deferred_member_call_args;
+						std::vector<ASTNode> deferred_member_call_template_arg_nodes;
 						bool deferred_member_chain_valid = true;
 						while (peek() == "::"_tok) {
 							advance(); // consume ::
@@ -6992,8 +7284,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							member_segment.name = deferred_final_identifier.handle();
 							member_segment.has_template_keyword = has_template_keyword;
 							advance(); // consume member name
+							std::vector<ASTNode> member_template_arg_nodes;
 							if (has_template_keyword && peek() == "<"_tok) {
-								auto member_template_args = parse_explicit_template_arguments();
+								auto member_template_args =
+									parse_explicit_template_arguments(&member_template_arg_nodes);
 								if (!member_template_args.has_value()) {
 									deferred_member_chain_valid = false;
 									break;
@@ -7006,6 +7300,32 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									explicitTemplateArgsRequireDeferredInstantiation(
 										*member_template_args);
 							}
+							if (peek() == "("_tok) {
+								advance(); // consume '('
+								auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+									.handle_pack_expansion = true,
+									.collect_types = true,
+									.expand_simple_packs = false});
+								if (!args_result.success) {
+									return ParseResult::error(
+										args_result.error_message,
+										args_result.error_token.value_or(current_token_));
+								}
+								if (!consume(")"_tok)) {
+									return ParseResult::error(
+										"Expected ')' after function call arguments",
+										current_token_);
+								}
+								if (peek() != "::"_tok) {
+									has_deferred_member_call = true;
+									deferred_member_call_token = deferred_final_identifier;
+									deferred_member_call_args = std::move(args_result.args);
+									if (!member_template_arg_nodes.empty()) {
+										deferred_member_call_template_arg_nodes =
+											std::move(member_template_arg_nodes);
+									}
+								}
+							}
 							deferred_member_segments.push_back(std::move(member_segment));
 							if (peek() == "::"_tok) {
 								deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
@@ -7015,8 +7335,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 						if (deferred_member_chain_valid &&
 							has_deferred_member_template_segment &&
-							deferred_final_identifier.type() == Token::Type::Identifier &&
-							peek() != "("_tok) {
+							deferred_final_identifier.type() == Token::Type::Identifier) {
 							QualifiedIdentifierNode dependent_qual_id(
 								deferred_ns_handle,
 								deferred_final_identifier);
@@ -7028,7 +7347,49 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
 									toTemplateArgInfoList(*explicit_template_args),
 									deferred_member_segments));
-							result = emplace_node<ExpressionNode>(dependent_qual_id);
+							if (has_deferred_member_call) {
+								auto type_node = emplace_node<TypeSpecifierNode>(
+									TypeIndex{}.withCategory(TypeCategory::Auto),
+									0,
+									deferred_member_call_token,
+									CVQualifier::None,
+									ReferenceQualifier::None);
+								auto placeholder_decl =
+									emplace_node<DeclarationNode>(
+										type_node,
+										deferred_member_call_token);
+								std::string_view deferred_qualified_call_name =
+									buildDependentQualifiedCallName(
+										instantiated_class_name,
+										deferred_member_segments);
+								Token deferred_call_token(
+									Token::Type::Identifier,
+									deferred_qualified_call_name,
+									deferred_member_call_token.line(),
+									deferred_member_call_token.column(),
+									deferred_member_call_token.file_index());
+								result = emplace_node<ExpressionNode>(
+									makeDirectCallExpr(
+										placeholder_decl.as<DeclarationNode>(),
+										std::move(deferred_member_call_args),
+										deferred_call_token));
+								setCallQualifiedName(
+									result->as<ExpressionNode>(),
+									deferred_qualified_call_name);
+								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+										dependent_qual_id.dependentQualifiedName()) {
+									setCallDependentQualifiedLookupRecord(
+										result->as<ExpressionNode>(),
+										*dependent_record);
+								}
+								if (!deferred_member_call_template_arg_nodes.empty()) {
+									setCallTemplateArguments(
+										result->as<ExpressionNode>(),
+										std::move(deferred_member_call_template_arg_nodes));
+								}
+							} else {
+								result = emplace_node<ExpressionNode>(dependent_qual_id);
+							}
 							return ParseResult::success(*result);
 						}
 						restore_token_position(deferred_member_chain_start);

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5196,10 +5196,63 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					}
 
 					// Check if this is a static member function (has '(')
-					// Static member functions in member template structs should be skipped for now
-					// (they will be instantiated when the template is used)
 					if (peek() == "("_tok) {
-						skip_member_declaration_to_semicolon();
+						FunctionDeclarationNode* parsed_func_decl = nullptr;
+						DeclarationNode* parsed_decl_node = nullptr;
+						auto parsed_member_result = parse_member_function_declarator_result(
+							type_and_name_result,
+							parsed_func_decl,
+							parsed_decl_node);
+						if (parsed_member_result.is_error()) {
+							return parsed_member_result;
+						}
+
+						DeclarationNode& decl_node = *parsed_decl_node;
+						FunctionDeclarationNode& func_decl = *parsed_func_decl;
+						auto [member_func_node, member_func_ref] =
+							emplace_node_ref<FunctionDeclarationNode>(decl_node, qualified_pattern_name);
+						for (const auto& param : func_decl.parameter_nodes()) {
+							member_func_ref.add_parameter_node(param);
+						}
+						member_func_ref.set_is_static(true);
+						if (is_constexpr) {
+							member_func_ref.set_is_constexpr(true);
+						}
+
+						FlashCpp::MemberQualifiers member_quals;
+						FlashCpp::FunctionSpecifiers func_specs;
+						auto specs_result = parse_function_trailing_specifiers(
+							member_quals,
+							func_specs,
+							member_func_ref.parameter_nodes());
+						if (specs_result.is_error()) {
+							return specs_result;
+						}
+						auto trailing_return_result = parse_member_trailing_return_type(member_func_ref);
+						if (trailing_return_result.is_error()) {
+							return trailing_return_result;
+						}
+						if (func_specs.is_noexcept) {
+							member_func_ref.set_noexcept(true);
+							if (func_specs.noexcept_expr) {
+								member_func_ref.set_noexcept_expression(*func_specs.noexcept_expr);
+							}
+						}
+						if (peek() == "{"_tok) {
+							SaveHandle body_start = save_token_position();
+							member_func_ref.set_template_body_position(body_start);
+							skip_balanced_braces();
+						} else if (peek() == ";"_tok) {
+							advance();
+						}
+						member_struct_ref.add_member_function(
+							member_func_node,
+							current_access,
+							func_specs.is_virtual,
+							func_specs.is_pure_virtual(),
+							func_specs.is_override,
+							func_specs.is_final,
+							member_quals.cv_qualifier);
 						continue;
 					}
 
@@ -5610,9 +5663,63 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				}
 
 				// Check if this is a static member function (has '(')
-				// Static member functions in member template structs should be skipped for now
 				if (peek() == "("_tok) {
-					skip_member_declaration_to_semicolon();
+					FunctionDeclarationNode* parsed_func_decl = nullptr;
+					DeclarationNode* parsed_decl_node = nullptr;
+					auto parsed_member_result = parse_member_function_declarator_result(
+						type_and_name_result,
+						parsed_func_decl,
+						parsed_decl_node);
+					if (parsed_member_result.is_error()) {
+						return parsed_member_result;
+					}
+
+					DeclarationNode& decl_node = *parsed_decl_node;
+					FunctionDeclarationNode& func_decl = *parsed_func_decl;
+					auto [member_func_node, member_func_ref] =
+						emplace_node_ref<FunctionDeclarationNode>(decl_node, qualified_name);
+					for (const auto& param : func_decl.parameter_nodes()) {
+						member_func_ref.add_parameter_node(param);
+					}
+					member_func_ref.set_is_static(true);
+					if (is_static_constexpr) {
+						member_func_ref.set_is_constexpr(true);
+					}
+
+					FlashCpp::MemberQualifiers member_quals;
+					FlashCpp::FunctionSpecifiers func_specs;
+					auto specs_result = parse_function_trailing_specifiers(
+						member_quals,
+						func_specs,
+						member_func_ref.parameter_nodes());
+					if (specs_result.is_error()) {
+						return specs_result;
+					}
+					auto trailing_return_result = parse_member_trailing_return_type(member_func_ref);
+					if (trailing_return_result.is_error()) {
+						return trailing_return_result;
+					}
+					if (func_specs.is_noexcept) {
+						member_func_ref.set_noexcept(true);
+						if (func_specs.noexcept_expr) {
+							member_func_ref.set_noexcept_expression(*func_specs.noexcept_expr);
+						}
+					}
+					if (peek() == "{"_tok) {
+						SaveHandle body_start = save_token_position();
+						member_func_ref.set_template_body_position(body_start);
+						skip_balanced_braces();
+					} else if (peek() == ";"_tok) {
+						advance();
+					}
+					member_struct_ref.add_member_function(
+						member_func_node,
+						current_access,
+						func_specs.is_virtual,
+						func_specs.is_pure_virtual(),
+						func_specs.is_override,
+						func_specs.is_final,
+						member_quals.cv_qualifier);
 					continue;
 				}
 
@@ -5899,7 +6006,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 	// Also register with simple name for lookups within the parent struct
 	gTemplateRegistry.registerTemplate(struct_name_token.handle(), template_struct_node);
 
-	FLASH_LOG_FORMAT(Parser, Info, "Registered member struct template: {}", StringTable::getStringView(qualified_name));
+		FLASH_LOG_FORMAT(Parser, Info, "Registered member struct template: {}", StringTable::getStringView(qualified_name));
 
 	// template_scope automatically cleans up template parameters when it goes out of scope
 

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -4768,6 +4768,38 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 			advance();
 		}
 	};
+	auto skipStaticMemberTemplateFunctionTail =
+		[&](FunctionDeclarationNode& member_func_ref) -> ParseResult {
+		if (peek() == "requires"_tok) {
+			skip_trailing_requires_clause();
+		}
+		if (peek() == "try"_tok || peek() == "{"_tok) {
+			SaveHandle body_start = save_token_position();
+			member_func_ref.set_template_body_position(body_start);
+			if (peek() == "try"_tok) {
+				skip_function_body();
+			} else {
+				skip_balanced_braces();
+			}
+			return ParseResult::success();
+		}
+		if (peek() == "="_tok) {
+			advance();
+			if (peek() != "default"_tok && peek() != "delete"_tok) {
+				return ParseResult::error("Expected default or delete after '=' in static member function declaration", current_token_);
+			}
+			advance();
+			if (!consume(";"_tok)) {
+				return ParseResult::error("Expected ';' after static member function declaration", current_token_);
+			}
+			return ParseResult::success();
+		}
+		if (peek() == ";"_tok) {
+			advance();
+			return ParseResult::success();
+		}
+		return ParseResult::error("Expected static member function body, requires-clause, '= default', '= delete', or ';'", current_token_);
+	};
 
 	auto skipMemberStructTemplateConstructor = [&]() {
 		if (peek() == "("_tok) {
@@ -5214,6 +5246,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						for (const auto& param : func_decl.parameter_nodes()) {
 							member_func_ref.add_parameter_node(param);
 						}
+						member_func_ref.set_is_variadic(func_decl.is_variadic());
 						member_func_ref.set_is_static(true);
 						if (is_constexpr) {
 							member_func_ref.set_is_constexpr(true);
@@ -5238,12 +5271,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 								member_func_ref.set_noexcept_expression(*func_specs.noexcept_expr);
 							}
 						}
-						if (peek() == "{"_tok) {
-							SaveHandle body_start = save_token_position();
-							member_func_ref.set_template_body_position(body_start);
-							skip_balanced_braces();
-						} else if (peek() == ";"_tok) {
-							advance();
+						ParseResult tail_result =
+							skipStaticMemberTemplateFunctionTail(member_func_ref);
+						if (tail_result.is_error()) {
+							return tail_result;
 						}
 						member_struct_ref.add_member_function(
 							member_func_node,
@@ -5681,6 +5712,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					for (const auto& param : func_decl.parameter_nodes()) {
 						member_func_ref.add_parameter_node(param);
 					}
+					member_func_ref.set_is_variadic(func_decl.is_variadic());
 					member_func_ref.set_is_static(true);
 					if (is_static_constexpr) {
 						member_func_ref.set_is_constexpr(true);
@@ -5705,12 +5737,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 							member_func_ref.set_noexcept_expression(*func_specs.noexcept_expr);
 						}
 					}
-					if (peek() == "{"_tok) {
-						SaveHandle body_start = save_token_position();
-						member_func_ref.set_template_body_position(body_start);
-						skip_balanced_braces();
-					} else if (peek() == ";"_tok) {
-						advance();
+					ParseResult tail_result =
+						skipStaticMemberTemplateFunctionTail(member_func_ref);
+					if (tail_result.is_error()) {
+						return tail_result;
 					}
 					member_struct_ref.add_member_function(
 						member_func_node,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7542,11 +7542,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Qualified ids like T::value can also be template-parameter dependent.
 			if (std::holds_alternative<QualifiedIdentifierNode>(expr))
 				return true;
-			if (const auto* call = std::get_if<CallExprNode>(&expr)) {
-				if (call->has_dependent_qualified_lookup_record() ||
-					call->dependent_unqualified_lookup_record().has_value()) {
-					return true;
-				}
+			if (RebindStaticMemberAst::visitASTUntil(*initializer, [](const ASTNode& node) {
+					if (!node.is<CallExprNode>()) {
+						return false;
+					}
+					const CallExprNode& call = node.as<CallExprNode>();
+					return call.has_dependent_qualified_lookup_record() ||
+						   call.dependent_unqualified_lookup_record().has_value();
+				})) {
+				return true;
 			}
 
 			return false;
@@ -8717,8 +8721,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	std::vector<StructMemberFunctionDecl> effective_member_functions;
+	bool effective_has_constructor = false;
 	for (const StructMemberFunctionDecl& member_function : class_decl.member_functions()) {
 		effective_member_functions.push_back(member_function);
+		effective_has_constructor = effective_has_constructor || member_function.is_constructor;
 	}
 	if (effective_member_functions.empty() &&
 		template_struct_info != nullptr &&
@@ -8738,6 +8744,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			member_function_decl.cv_qualifier = member_function.cv_qualifier;
 			member_function_decl.is_noexcept = member_function.is_noexcept;
 			effective_member_functions.push_back(member_function_decl);
+			effective_has_constructor = effective_has_constructor || member_function_decl.is_constructor;
 		}
 	}
 
@@ -10779,15 +10786,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Check if the template class has any constructors
 	// If not, mark that we need to generate a default one for the instantiation
-	bool has_constructor = false;
-	for (const auto& mem_func : class_decl.member_functions()) {
-		if (mem_func.is_constructor) {
-			has_constructor = true;
-			break;
-		}
-	}
-	struct_info_ptr->needs_default_constructor = !has_constructor;
-	FLASH_LOG(Templates, Debug, "Instantiated struct ", instantiated_name, " has_constructor=", has_constructor,
+	struct_info_ptr->needs_default_constructor = !effective_has_constructor;
+	FLASH_LOG(Templates, Debug, "Instantiated struct ", instantiated_name, " has_constructor=", effective_has_constructor,
 			  ", needs_default_constructor=", struct_info_ptr->needs_default_constructor);
 
 	// Propagate deleted constructor flags from the template pattern to the instantiated struct.

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7542,6 +7542,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Qualified ids like T::value can also be template-parameter dependent.
 			if (std::holds_alternative<QualifiedIdentifierNode>(expr))
 				return true;
+			if (const auto* call = std::get_if<CallExprNode>(&expr)) {
+				if (call->has_dependent_qualified_lookup_record() ||
+					call->dependent_unqualified_lookup_record().has_value()) {
+					return true;
+				}
+			}
 
 			return false;
 		};
@@ -8710,13 +8716,38 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		instantiated_struct_ref.add_nested_class(nested_class_node);
 	}
 
+	std::vector<StructMemberFunctionDecl> effective_member_functions;
+	for (const StructMemberFunctionDecl& member_function : class_decl.member_functions()) {
+		effective_member_functions.push_back(member_function);
+	}
+	if (effective_member_functions.empty() &&
+		template_struct_info != nullptr &&
+		!template_struct_info->member_functions.empty()) {
+		effective_member_functions.reserve(template_struct_info->member_functions.size());
+		for (const StructMemberFunction& member_function : template_struct_info->member_functions) {
+			StructMemberFunctionDecl member_function_decl(
+				member_function.function_decl,
+				member_function.access,
+				member_function.is_constructor,
+				member_function.is_destructor,
+				member_function.operator_kind);
+			member_function_decl.is_virtual = member_function.is_virtual;
+			member_function_decl.is_pure_virtual = member_function.is_pure_virtual;
+			member_function_decl.is_override = member_function.is_override;
+			member_function_decl.is_final = member_function.is_final;
+			member_function_decl.cv_qualifier = member_function.cv_qualifier;
+			member_function_decl.is_noexcept = member_function.is_noexcept;
+			effective_member_functions.push_back(member_function_decl);
+		}
+	}
+
 	// Log lazy instantiation status (already determined earlier in the function)
 	if (is_implicit_instantiation) {
 		FLASH_LOG(Templates, Debug, "Using LAZY instantiation for ", instantiated_name, " - registering ",
-				  class_decl.member_functions().size(), " member functions for on-demand instantiation");
+				  effective_member_functions.size(), " member functions for on-demand instantiation");
 	} else if (force_eager) {
 		FLASH_LOG(Templates, Debug, "Using EAGER instantiation for ", instantiated_name, " (forced by explicit instantiation) - instantiating ",
-				  class_decl.member_functions().size(), " member functions immediately");
+				  effective_member_functions.size(), " member functions immediately");
 	}
 
 	// Slice 3: map from original template member node (by raw pointer) to the instantiated stub node.
@@ -8781,7 +8812,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	};
 
 	// Copy member functions from the template
-	for (const StructMemberFunctionDecl& mem_func : class_decl.member_functions()) {
+	for (const StructMemberFunctionDecl& mem_func : effective_member_functions) {
 
 		if (mem_func.function_declaration.is<FunctionDeclarationNode>()) {
 			const FunctionDeclarationNode& func_decl = mem_func.function_declaration.as<FunctionDeclarationNode>();

--- a/tests/test_template_current_instantiation_member_template_call_without_keyword_ret0.cpp
+++ b/tests/test_template_current_instantiation_member_template_call_without_keyword_ret0.cpp
@@ -1,0 +1,15 @@
+template <typename T>
+struct Current {
+	template <typename U>
+	struct Box {
+		static constexpr int get() {
+			return sizeof(U) == sizeof(int) ? 42 : 7;
+		}
+	};
+
+	inline static int value = Current<T>::Box<T>::get();
+};
+
+int main() {
+	return Current<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_member_template_call_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_member_template_call_ret0.cpp
@@ -1,0 +1,18 @@
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		static constexpr int get() {
+			return sizeof(U) == sizeof(T) ? 42 : 7;
+		}
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value = Traits<T>::template Box<T>::get();
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_member_template_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_member_template_ret0.cpp
@@ -1,0 +1,16 @@
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		static constexpr int value = sizeof(U) == sizeof(T) ? 42 : 7;
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value = Traits<T>::template Box<T>::value;
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_member_template_wrapped_call_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_member_template_wrapped_call_ret0.cpp
@@ -1,0 +1,18 @@
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		static constexpr int get() {
+			return sizeof(U) == sizeof(T) ? 42 : 7;
+		}
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value = static_cast<int>(Traits<T>::template Box<T>::get());
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_owner_metadata_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_owner_metadata_ret0.cpp
@@ -1,0 +1,15 @@
+template <typename T>
+struct Base {
+	static int get() {
+		return sizeof(T) == sizeof(int) ? 42 : 7;
+	}
+};
+
+template <typename T>
+struct UseBase {
+	inline static int value = Base<T>::get();
+};
+
+int main() {
+	return UseBase<int>::value == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- preserve dependent-qualified replay metadata for deferred call-shaped member-template chains
- materialize nested unknown-specialization member-template owners before rebinding static calls
- keep static member functions in member struct templates so lazy instantiation can resolve constexpr calls
- document the completed call-shaped slice and add a focused regression

## Validation
- `./build_flashcpp.bat`
- `pwsh -File tests/run_all_tests.ps1` (2442 regular, 181 expected-fail)

## Next tasks from the architecture document
1. Close remaining replay-metadata gaps for static-member initialization outside the now-covered member-template call/non-call chains.
2. Continue dependent-base/member-chain paths that still bypass the shared semantic lookup model.
3. Broaden dependent-base and unknown-specialization records for uncovered member-template segment chains.
4. Add canonical dependent-expression equivalence support before widening into injected-class-name and broader current-instantiation identity work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined template-argument architecture audit with narrower remaining gaps and clearer, more precise next steps for replay/metadata coverage.

* **Bug Fixes**
  * Improved handling of dependent qualified/member-template expressions to preserve owner and template-argument metadata during parsing, replay, and instantiation.
  * More reliable parsing and instantiation for static member function and lazy-static initialization scenarios.

* **Tests**
  * Added multiple tests validating lazy-static initialization and member-template call/owner metadata behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->