### PR TITLE
Refresh template known issues and regressions

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -33,49 +33,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 3) Pointer-NTTP full specialization dispatch: second lookup produces wrong arg type
-
-- **Symptom**: Given `template <int* P> struct Tag { static int value() { return -1; } };`
-  `template <> struct Tag<&ga> { static int value() { return 10; } };`, calling
-  `Tag<&ga>::value()` in `main()` returns `-1` (invokes the primary template) instead of `10`.
-  The specialization IS correctly instantiated and both symbols appear in the object file.
-
-- **Root cause (confirmed via debug instrumentation)**:
-  There are two distinct lookup paths for `Tag<&ga>`:
-  1. During parsing of `template <> struct Tag<&ga>`: `&ga` is evaluated to
-     `ObjectPointer(nativeTypeIndex(Int), "ga", 0)` → `SpecializationKey` hash matches →
-     `lookupExactSpecialization` returns the spec node ✓
-  2. During parsing of `Tag<&ga>::value()` in `main()`: `&ga` evaluates to a plain
-     `TemplateTypeArg(0, Int)` (value=0, `has_typed_value_identity=false`) → different hash →
-     `lookupExactSpecialization` returns `nullopt` → generic template is instantiated with
-     mangled name `Tag$00000a1837ced158` instead of `Tag$00a3b7d5a86c5df9` → `main` calls
-     the wrong symbol.
-
-  The second path fails to produce an `ObjectPointer` identity for the `&ga` argument. This
-  is likely because the expression-side template-argument classification in `main` context
-  either calls `parse_explicit_template_arguments()` without template params (skipping
-  `classifyExplicitTemplateArgumentsAgainstParameters`), or `try_evaluate_constant_expression`
-  returns an `EvalResult` without `pointer_to_var` set in that path, causing fallback to
-  `TemplateTypeArg::makeValue(0, Int)`.
-
-- **Affected paths**:
-  - `src/Parser_Expr_PrimaryExpr.cpp` — second call to `parse_explicit_template_arguments` /
-    `materializePrimaryTemplateOwnerForLookup` (line ~1461)
-  - `src/Parser_Templates_Params.cpp` — `makeValueArgForSyntax` / `classifyExplicitTemplateArgumentsAgainstParameters`
-  - `src/TemplateRegistry_Registry.h` — `lookupExactSpecialization`
-  - `src/Parser_Templates_Function.cpp` — `makeConstantValueFromEvalResult` (creates `ObjectPointer`)
-
-- **Recommended fix**: Ensure that wherever `Tag<&ga>` template args are parsed for the member
-  access / function call context, the path goes through `parse_explicit_template_arguments(primary_template_params)`
-  (with template params provided) and `classifyExplicitTemplateArgumentsAgainstParameters` is
-  called so `&ga` is evaluated with the declared `int*` type, giving `pointer_to_var.isValid()=true`
-  and thus `ObjectPointer` identity via `makeConstantValueFromEvalResult`.
-
-- **Impact**: All pointer-NTTP full specializations where the specialization adds/changes member
-  functions are silently not dispatched to; the generic template is called instead.
-
-- **Regression test (pending)**: `tests/test_nttp_ptr_specialization_ret0.cpp`
-
+## 3) Out-of-line template member signature validation is too literal
 
 - **Symptom**: Parser warnings like `Parameter 1 type mismatch in out-of-line template member ...` remain for
   valid declarations/definitions that differ only by dependent spelling/aliases.
@@ -86,7 +44,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 5) `tests/std/test_std_ratio.cpp` — no `.o` output and residual diagnostic noise
+## 4) `tests/std/test_std_ratio.cpp` — no `.o` output and residual diagnostic noise
 
 **Status**: Crash (SIGSEGV/exit 139) fixed. Two root-cause bugs were fixed:
 
@@ -95,22 +53,14 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 2. **Explicit template type args ignored** for zero-param function template calls in
    the constexpr evaluator (`ConstExprEvaluator_Core.cpp`).
 
+**Current frontier**: The previous `__ratio_less_impl` / remove-cv alias
+instantiation stop is fixed. The first hard blocker has moved later to
+`__ratio_add_impl` default-NTTP evaluation, currently surfacing as unresolved
+`ratio_less$...::value` during constant evaluation.
+
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
-### 5a) `std::__is_complete_or_unbounded` instantiation always fails
-
-- **Symptom**: Many `[ERROR][Templates] All 2 template overload(s) failed for '__is_complete_or_unbounded'`
-  during parsing of `<ratio>` and its dependencies.
-- **Root cause**: `constexpr true_type __is_complete_or_unbounded(__type_identity<_Tp>)` is a function
-  template with a non-type default template parameter (`size_t = sizeof(_Tp)`). FlashCpp does not
-  yet support template argument deduction from a class-template-specialization argument
-  (`__type_identity<_Tp>` → deduce `_Tp`) combined with a defaulted non-type parameter that
-  depends on the deduced type.
-- **Affected path**: `Parser_Templates_Inst_Deduction.cpp` — `tryInstantiateTemplateFromCallArguments`.
-- **Impact**: Non-fatal during parsing (expressions remain dependent), but prevents correct
-  constexpr evaluation of `static_assert` checks inside `<type_traits>` and `<ratio>`.
-
-### 5b) `std::__are_both_ratios` parse-time instantiation failure (expected noise)
+### 4a) `std::__are_both_ratios` parse-time instantiation failure (expected noise)
 
 - **Symptom**: `[WARN][Parser] Parsed template arguments but instantiation failed for 'std::__are_both_ratios'`
   followed by `[ERROR][Templates] All 1 template overload(s) failed for '__are_both_ratios'` — appears
@@ -118,12 +68,12 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 - **Root cause**: The parser speculatively tries to instantiate `__are_both_ratios<_R1, _R2>` at
   template-body parse time, when `_R1` and `_R2` are still dependent type parameters.
   `try_instantiate_template_explicit` has an early-out for dependent args (correct behaviour).
-  The errors are non-fatal and the constexpr evaluator path correctly handles them via
-  the explicit-type-args fix (Bug 2 above), but `__is_complete_or_unbounded` failure (5a above)
-  prevents full `static_assert` evaluation.
+  The errors are non-fatal and the constexpr evaluator path correctly handles
+  them via the explicit-type-args fix above; the current hard stop is later
+  default-NTTP/value propagation in ratio arithmetic.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 5c) Residual substitution cycle in `ExpressionSubstitutor` for partially-dependent `ratio` instances
+### 4b) Residual substitution cycle/default-NTTP value loss in partially-dependent `ratio` instances
 
 - **Symptom**: Repeated DEBUG log lines cycling between `_R1::num` and `__static_abs$xxx::value`
   lookups during depth=2 `ratio` template processing.

--- a/tests/test_nttp_ptr_specialization_ret0.cpp
+++ b/tests/test_nttp_ptr_specialization_ret0.cpp
@@ -1,0 +1,27 @@
+int ga = 1;
+int gb = 2;
+
+template <int* P>
+struct Tag {
+	static int value() {
+		return -1;
+	}
+};
+
+template <>
+struct Tag<&ga> {
+	static int value() {
+		return 10;
+	}
+};
+
+template <>
+struct Tag<&gb> {
+	static int value() {
+		return 20;
+	}
+};
+
+int main() {
+	return Tag<&ga>::value() == 10 && Tag<&gb>::value() == 20 ? 0 : 1;
+}

--- a/tests/test_template_dependent_base_member_template_static_value_ret0.cpp
+++ b/tests/test_template_dependent_base_member_template_static_value_ret0.cpp
@@ -1,0 +1,16 @@
+template <typename T>
+struct Base {
+	template <typename U>
+	struct Inner {
+		static constexpr int value = sizeof(T) + sizeof(U);
+	};
+};
+
+template <typename T>
+struct Derived : Base<T> {
+	static constexpr int value = Derived<T>::template Inner<int>::value;
+};
+
+int main() {
+	return Derived<char>::value == 5 ? 0 : 1;
+}

--- a/tests/test_template_out_of_line_alias_signature_ret0.cpp
+++ b/tests/test_template_out_of_line_alias_signature_ret0.cpp
@@ -1,0 +1,16 @@
+template <typename T>
+struct Box {
+	using value_type = T;
+
+	int set(value_type v);
+};
+
+template <typename T>
+int Box<T>::set(T v) {
+	return static_cast<int>(v);
+}
+
+int main() {
+	Box<int> box;
+	return box.set(42) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- remove stale pointer-NTTP dispatch known issue now fixed on latest main
- update the <ratio> known-issue frontier to the current __ratio_add_impl/default-NTTP blocker
- add regression coverage for pointer-NTTP specialization dispatch, dependent-base member-template static values, and out-of-line alias signature matching

## Validation
- .\build_flashcpp.bat
- git --no-pager diff --check
- pwsh -File tests\run_all_tests.ps1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated known issues documentation with refined tracking of template resolution and pointer non-type template parameter specialization behavior.

* **Tests**
  * Added test coverage for pointer non-type template parameter specialization, dependent base member template access, and out-of-line template member function signature validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->