### PR TITLE
Fix alias-aware out-of-line signature validation

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -6,17 +6,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 1) Variable-template template-id fallback still treated as callable in dependent static_assert
-
-- **Symptom**: During `<string_view>` instantiation, expressions such as `is_same_v<...>` can fail with  
-  `Identifier is not a function or callable object: is_same_v`.
-- **Root cause**: When variable-template instantiation fails in dependent contexts, the evaluator still falls
-  back to call-expression semantics instead of preserving a dependent value-template expression.
-- **Affected path**: `ExpressionSubstitutor::substituteFunctionCallImpl` / variable-template instantiation +
-  constexpr call-evaluation fallback.
-- **Impact**: Blocks portions of libstdc++ headers that rely on variable templates in dependent checks.
-
-## 2) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
+## 1) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
 
 - **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` now gets past
   the UCRT `__crt_va_start` wrappers but stops later with
@@ -33,18 +23,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 3) Out-of-line template member signature validation is too literal
-
-- **Symptom**: Parser warnings like `Parameter 1 type mismatch in out-of-line template member ...` remain for
-  valid declarations/definitions that differ only by dependent spelling/aliases.
-- **Root cause**: `validate_signature_match` compares low-level type fields (`type_index`, category, pointer/ref)
-  too rigidly for dependent contexts and does not use a more canonicalized/dependent-aware type equivalence.
-- **Affected path**: `Parser::validate_signature_match`, invoked from out-of-line template member parsing.
-- **Impact**: Noisy diagnostics and increased risk of picking/validating against suboptimal overload candidates.
-
----
-
-## 4) `tests/std/test_std_ratio.cpp` — no `.o` output and residual diagnostic noise
+## 2) `tests/std/test_std_ratio.cpp` — no `.o` output and residual diagnostic noise
 
 **Status**: Crash (SIGSEGV/exit 139) fixed. Two root-cause bugs were fixed:
 
@@ -60,7 +39,7 @@ instantiation stop is fixed. The first hard blocker has moved later to
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
-### 4a) `std::__are_both_ratios` parse-time instantiation failure (expected noise)
+### 2a) `std::__are_both_ratios` parse-time instantiation failure (expected noise)
 
 - **Symptom**: `[WARN][Parser] Parsed template arguments but instantiation failed for 'std::__are_both_ratios'`
   followed by `[ERROR][Templates] All 1 template overload(s) failed for '__are_both_ratios'` — appears
@@ -73,7 +52,7 @@ instantiation stop is fixed. The first hard blocker has moved later to
   default-NTTP/value propagation in ratio arithmetic.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 4b) Residual substitution cycle/default-NTTP value loss in partially-dependent `ratio` instances
+### 2b) Residual substitution cycle/default-NTTP value loss in partially-dependent `ratio` instances
 
 - **Symptom**: Repeated DEBUG log lines cycling between `_R1::num` and `__static_abs$xxx::value`
   lookups during depth=2 `ratio` template processing.

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1884,43 +1884,69 @@ inline bool TypeSpecifierNode::matches_signature(const TypeSpecifierNode& other)
 	const TypeSpecifierNode self = adjusted_function_parameter_type();
 	const TypeSpecifierNode other_adjusted = other.adjusted_function_parameter_type();
 
-	// Check basic type
-	if (self.type_index_.category() != other_adjusted.type_index_.category()) {
-		// Be lenient for typedef/alias cases, but do not collapse distinct semantic
-		// types such as enum vs int just because they share a runtime size.
-		TypeCategory resolved_type = resolve_type_alias(self.type_index_);
-		TypeCategory other_resolved_type = resolve_type_alias(other_adjusted.type_index_);
-		if (resolved_type != other_resolved_type) {
+	struct EffectiveSignatureType {
+		TypeIndex type_index{};
+		TypeCategory category = TypeCategory::Invalid;
+		size_t pointer_depth = 0;
+		CVQualifier cv_qualifier = CVQualifier::None;
+		ReferenceQualifier reference_qualifier = ReferenceQualifier::None;
+		std::string_view token_value;
+	};
+
+	auto makeEffectiveSignatureType = [](const TypeSpecifierNode& type_spec) {
+		EffectiveSignatureType effective;
+		const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_spec.type_index_);
+		effective.type_index = resolved_alias.type_index.is_valid()
+			? resolved_alias.type_index.withCategory(resolved_alias.typeEnum())
+			: type_spec.type_index_.withCategory(type_spec.type_index_.category());
+		effective.category = effective.type_index.category();
+		if (effective.category == TypeCategory::Invalid) {
+			effective.category = type_spec.type_index_.category();
+		}
+		effective.pointer_depth = type_spec.pointer_levels_.size() + resolved_alias.pointer_depth;
+		effective.cv_qualifier = type_spec.cv_qualifier_ | resolved_alias.cv_qualifier;
+		effective.reference_qualifier = type_spec.reference_qualifier_ != ReferenceQualifier::None
+			? type_spec.reference_qualifier_
+			: resolved_alias.reference_qualifier;
+		effective.token_value = type_spec.token_.value();
+		return effective;
+	};
+
+	const EffectiveSignatureType self_effective = makeEffectiveSignatureType(self);
+	const EffectiveSignatureType other_effective = makeEffectiveSignatureType(other_adjusted);
+
+	if (self_effective.category != other_effective.category) {
+		return false;
+	}
+	if (needs_type_index(self_effective.category)) {
+		if (self_effective.type_index.is_valid() && other_effective.type_index.is_valid() &&
+			self_effective.type_index != other_effective.type_index) {
 			return false;
 		}
-	}
-
-	// Check type index for user-defined types
-	if (is_struct_type(self.type_index_.category())) {
-		if (self.type_index_ != other_adjusted.type_index_) {
-			// Be lenient for dependent/alias types: treat as match when the identifier tokens are the same
-			if (self.token_.value() != other_adjusted.token_.value()) {
-				return false;
-			}
+		if ((!self_effective.type_index.is_valid() || !other_effective.type_index.is_valid()) &&
+			self_effective.token_value != other_effective.token_value) {
+			return false;
 		}
 	}
 
 	// For function signature matching, top-level CV qualifiers on value types are ignored.
 	// CV qualifiers below the top level still matter for pointers/references.
 	const bool has_indirection =
-		!self.pointer_levels_.empty() || self.reference_qualifier_ != ReferenceQualifier::None;
-	if (has_indirection && self.cv_qualifier_ != other_adjusted.cv_qualifier_) {
+		self_effective.pointer_depth != 0 || self_effective.reference_qualifier != ReferenceQualifier::None;
+	if (has_indirection && self_effective.cv_qualifier != other_effective.cv_qualifier) {
 		return false;
 	}
 
 	// Check reference qualifiers
-	if (self.reference_qualifier_ != other_adjusted.reference_qualifier_)
+	if (self_effective.reference_qualifier != other_effective.reference_qualifier)
 		return false;
 
 	// Check pointer depth and qualifiers at each level
-	if (self.pointer_levels_.size() != other_adjusted.pointer_levels_.size())
+	if (self_effective.pointer_depth != other_effective.pointer_depth)
 		return false;
-	for (size_t i = 0; i < self.pointer_levels_.size(); ++i) {
+	const size_t shared_explicit_pointer_depth =
+		std::min(self.pointer_levels_.size(), other_adjusted.pointer_levels_.size());
+	for (size_t i = 0; i < shared_explicit_pointer_depth; ++i) {
 		if (self.pointer_levels_[i].cv_qualifier != other_adjusted.pointer_levels_[i].cv_qualifier)
 			return false;
 	}

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -505,39 +505,9 @@ FlashCpp::SignatureValidationResult Parser::validate_signature_match(
 													"Unable to extract parameter type information");
 		}
 
-		// Compare basic type properties (ignore top-level cv-qualifiers on parameters - they don't affect signature)
-		if (def_type->type() != decl_type->type() ||
-			def_type->type_index() != decl_type->type_index() ||
-			def_type->pointer_depth() != decl_type->pointer_depth() ||
-			def_type->is_reference() != decl_type->is_reference()) {
+		if (!decl_type->matches_signature(*def_type)) {
 			std::string msg = "Parameter " + std::to_string(i + 1) + " type mismatch";
 			return SignatureValidationResult::error(SignatureMismatch::ParameterType, i + 1, std::move(msg));
-		}
-
-		// For pointers, compare cv-qualifiers on pointed-to type (int* vs const int*)
-		if (def_type->pointer_depth() > 0) {
-			if (def_type->cv_qualifier() != decl_type->cv_qualifier()) {
-				std::string msg = "Parameter " + std::to_string(i + 1) + " pointer cv-qualifier mismatch";
-				return SignatureValidationResult::error(SignatureMismatch::ParameterCVQualifier, i + 1, std::move(msg));
-			}
-
-			// cv-qualifiers on pointer levels also matter: int* const vs int*
-			const auto& def_levels = def_type->pointer_levels();
-			const auto& decl_levels = decl_type->pointer_levels();
-			for (size_t p = 0; p < def_levels.size(); ++p) {
-				if (def_levels[p].cv_qualifier != decl_levels[p].cv_qualifier) {
-					std::string msg = "Parameter " + std::to_string(i + 1) + " pointer level cv-qualifier mismatch";
-					return SignatureValidationResult::error(SignatureMismatch::ParameterPointerLevel, i + 1, std::move(msg));
-				}
-			}
-		}
-
-		// For references, compare cv-qualifiers on the base type (const T& vs T&)
-		if (def_type->is_reference()) {
-			if (def_type->cv_qualifier() != decl_type->cv_qualifier()) {
-				std::string msg = "Parameter " + std::to_string(i + 1) + " reference cv-qualifier mismatch";
-				return SignatureValidationResult::error(SignatureMismatch::ParameterCVQualifier, i + 1, std::move(msg));
-			}
 		}
 	}
 
@@ -547,10 +517,7 @@ FlashCpp::SignatureValidationResult Parser::validate_signature_match(
 	const TypeSpecifierNode& decl_return_type = decl_decl.type_specifier_node();
 	const TypeSpecifierNode& def_return_type = def_decl.type_specifier_node();
 
-	if (def_return_type.type() != decl_return_type.type() ||
-		def_return_type.type_index() != decl_return_type.type_index() ||
-		def_return_type.pointer_depth() != decl_return_type.pointer_depth() ||
-		def_return_type.is_reference() != decl_return_type.is_reference()) {
+	if (!decl_return_type.matches_signature(def_return_type)) {
 		return SignatureValidationResult::error(SignatureMismatch::ReturnType, 0, "Return type mismatch");
 	}
 

--- a/tests/std/test_std_type_traits_is_integral_any_of_ret0.cpp
+++ b/tests/std/test_std_type_traits_is_integral_any_of_ret0.cpp
@@ -1,7 +1,6 @@
-// Expected failure: distilled MSVC <type_traits> std::is_integral pattern.
+// Distilled MSVC <type_traits> std::is_integral pattern.
 // A variable-template partial specialization feeds another variable template,
 // then that value is used as a non-type template argument in a base class.
-// FlashCpp currently evaluates is_integral<int>::value as false.
 
 template <class, class>
 constexpr bool is_same_v = false;

--- a/tests/test_out_of_line_member_alias_signature_ret0.cpp
+++ b/tests/test_out_of_line_member_alias_signature_ret0.cpp
@@ -1,0 +1,50 @@
+struct Box {
+	using Value = int;
+	using Pointer = int*;
+
+	int set(Value value);
+	Value get();
+	int read(Pointer value);
+};
+
+int Box::set(int value) {
+	return value;
+}
+
+int Box::get() {
+	return 7;
+}
+
+int Box::read(int* value) {
+	return *value;
+}
+
+struct Payload {
+	int value;
+};
+
+struct UsesPayload {
+	using Alias = Payload;
+
+	int extract(Alias payload);
+};
+
+int UsesPayload::extract(Payload payload) {
+	return payload.value;
+}
+
+int main() {
+	Box box;
+	int value = 5;
+	if (box.set(42) != 42) {
+		return 1;
+	}
+	if (box.get() != 7) {
+		return 2;
+	}
+	if (box.read(&value) != 5) {
+		return 3;
+	}
+	UsesPayload uses_payload;
+	return uses_payload.extract(Payload{9}) == 9 ? 0 : 4;
+}

--- a/tests/test_out_of_line_member_alias_signature_ret0.cpp
+++ b/tests/test_out_of_line_member_alias_signature_ret0.cpp
@@ -4,7 +4,9 @@ struct Box {
 
 	int set(Value value);
 	Value get();
+	int get_reverse();
 	int read(Pointer value);
+	int read_reverse(int* value);
 };
 
 int Box::set(int value) {
@@ -15,8 +17,16 @@ int Box::get() {
 	return 7;
 }
 
+Box::Value Box::get_reverse() {
+	return 8;
+}
+
 int Box::read(int* value) {
 	return *value;
+}
+
+int Box::read_reverse(Box::Pointer value) {
+	return *value + 1;
 }
 
 struct Payload {
@@ -27,10 +37,20 @@ struct UsesPayload {
 	using Alias = Payload;
 
 	int extract(Alias payload);
+	int extract_reverse(Payload payload);
+	Alias make();
 };
 
 int UsesPayload::extract(Payload payload) {
 	return payload.value;
+}
+
+int UsesPayload::extract_reverse(UsesPayload::Alias payload) {
+	return payload.value + 1;
+}
+
+UsesPayload::Alias UsesPayload::make() {
+	return Payload{11};
 }
 
 int main() {
@@ -45,6 +65,18 @@ int main() {
 	if (box.read(&value) != 5) {
 		return 3;
 	}
+	if (box.get_reverse() != 8) {
+		return 4;
+	}
+	if (box.read_reverse(&value) != 6) {
+		return 5;
+	}
 	UsesPayload uses_payload;
-	return uses_payload.extract(Payload{9}) == 9 ? 0 : 4;
+	if (uses_payload.extract(Payload{9}) != 9) {
+		return 6;
+	}
+	if (uses_payload.extract_reverse(Payload{9}) != 10) {
+		return 7;
+	}
+	return uses_payload.make().value == 11 ? 0 : 8;
 }


### PR DESCRIPTION
## Summary
- fix out-of-line member signature validation so aliases compare through the canonical `TypeSpecifierNode::matches_signature` path instead of literal type-index checks
- add regression coverage for parameter aliases, return aliases, pointer aliases, and struct aliases in out-of-line definitions
- convert the stale variable-template expected-fail into passing coverage and remove fixed KNOWN_ISSUES entries

## Validation
- uild_flashcpp.bat`
- `git --no-pager diff --check origin/main...HEAD`
- `pwsh -File tests\run_all_tests.ps1` (2448 regular, 181 expected-fail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated and reorganized known issues documentation with revised priority ordering and classifications.

* **Bug Fixes**
  * Enhanced type signature validation for improved accuracy in function parameter and return type matching.

* **Tests**
  * Added comprehensive test coverage for type trait evaluation patterns.
  * Expanded test coverage for out-of-line member function implementations with nested type aliases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->