### PR TITLE
Preserve default NTTP parameter type

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -469,6 +469,9 @@ inline std::vector<std::string_view> buildTemplateParamNames(
 // Declared here (not in TemplateRegistry_Types.h) to avoid a dependency on
 // ConstExprEvaluator.h from the template-registry header.
 TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_result);
+TemplateTypeArg templateTypeArgFromEvalResult(
+	const ConstExpr::EvalResult& eval_result,
+	const TypeSpecifierNode& target_type);
 
 // Thread-local instantiation backtrace.  Unlike current_instantiation_ctx_ (which is RAII
 // and clears during stack unwinding), this string persists through exception propagation

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -759,7 +759,21 @@ bool Parser::tryAppendDefaultTemplateArg(
 			}
 			return false;
 		}
-		template_args.push_back(templateTypeArgFromEvalResult(eval_result));
+		if (param.has_type()) {
+			ASTNode substituted_type_node = substituteTemplateParameters(
+				ASTNode::emplace_node<TypeSpecifierNode>(param.type_specifier_node()),
+				template_params,
+				std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
+			if (substituted_type_node.is<TypeSpecifierNode>()) {
+				template_args.push_back(templateTypeArgFromEvalResult(
+					eval_result,
+					substituted_type_node.as<TypeSpecifierNode>()));
+			} else {
+				template_args.push_back(templateTypeArgFromEvalResult(eval_result));
+			}
+		} else {
+			template_args.push_back(templateTypeArgFromEvalResult(eval_result));
+		}
 		default_arg_environment = buildTemplateEnvironment(
 			template_params,
 			std::span<const TemplateTypeArg>(template_args.data(), template_args.size()),

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -62,6 +62,81 @@ TemplateTypeArg templateTypeArgFromEvalResult(const ConstExpr::EvalResult& eval_
 	return TemplateTypeArg(eval_result.as_int());
 }
 
+static int64_t convertIntegralTemplateValueToType(int64_t value, TypeCategory target_category) {
+	switch (target_category) {
+	case TypeCategory::Bool:
+		return value != 0 ? 1 : 0;
+	case TypeCategory::Char:
+		return static_cast<int64_t>(static_cast<char>(value));
+	case TypeCategory::UnsignedChar:
+		return static_cast<int64_t>(static_cast<unsigned char>(value));
+	case TypeCategory::WChar:
+		return static_cast<int64_t>(static_cast<wchar_t>(value));
+	case TypeCategory::Char8:
+		return static_cast<int64_t>(static_cast<char8_t>(value));
+	case TypeCategory::Char16:
+		return static_cast<int64_t>(static_cast<char16_t>(value));
+	case TypeCategory::Char32:
+		return static_cast<int64_t>(static_cast<char32_t>(value));
+	case TypeCategory::Short:
+		return static_cast<int64_t>(static_cast<short>(value));
+	case TypeCategory::UnsignedShort:
+		return static_cast<int64_t>(static_cast<unsigned short>(value));
+	case TypeCategory::Int:
+		return static_cast<int64_t>(static_cast<int>(value));
+	case TypeCategory::UnsignedInt:
+		return static_cast<int64_t>(static_cast<unsigned int>(value));
+	case TypeCategory::Long:
+		return static_cast<int64_t>(static_cast<long>(value));
+	case TypeCategory::UnsignedLong:
+		return static_cast<int64_t>(static_cast<unsigned long>(value));
+	case TypeCategory::LongLong:
+		return static_cast<int64_t>(static_cast<long long>(value));
+	case TypeCategory::UnsignedLongLong:
+		return static_cast<int64_t>(static_cast<unsigned long long>(value));
+	default:
+		return value;
+	}
+}
+
+TemplateTypeArg templateTypeArgFromEvalResult(
+	const ConstExpr::EvalResult& eval_result,
+	const TypeSpecifierNode& target_type) {
+	TemplateTypeArg arg = templateTypeArgFromEvalResult(eval_result);
+	if (!arg.is_value || arg.has_typed_value_identity) {
+		return arg;
+	}
+
+	const TypeCategory target_category = target_type.type();
+	if (target_category == TypeCategory::Invalid ||
+		isPlaceholderAutoType(target_category) ||
+		target_type.pointer_depth() != 0 ||
+		target_type.reference_qualifier() != ReferenceQualifier::None ||
+		target_type.has_function_signature() ||
+		target_type.has_member_class()) {
+		return arg;
+	}
+	if (!isIntegralType(target_category) && target_category != TypeCategory::Enum) {
+		return arg;
+	}
+
+	TypeIndex target_type_index = target_type.type_index().withCategory(target_type.type());
+	if (!target_type_index.is_valid() && is_builtin_type(target_type.type())) {
+		target_type_index = nativeTypeIndex(target_type.type());
+	}
+	if (target_category == TypeCategory::Enum && !target_type_index.is_valid()) {
+		return arg;
+	}
+	if (!target_type_index.is_valid()) {
+		target_type_index = TypeIndex{0, target_category};
+	}
+	if (isIntegralType(target_category)) {
+		arg.value = convertIntegralTemplateValueToType(arg.value, target_category);
+	}
+	arg.type_index = TemplateTypeArg::makeTypeIndex(target_type_index);
+	return arg;
+}
+
 namespace {
 
 	InlineVector<TemplateParameterNode, 4> getTargetTemplateParameters(StringHandle target_template_name) {
@@ -143,6 +218,24 @@ namespace {
 	return substitutor.substitute(default_node);
 }
 
+	std::optional<TypeSpecifierNode> substituteNonTypeParameterTypeImpl(
+		Parser& parser,
+		const TemplateParameterNode& param,
+		const InlineVector<TemplateParameterNode, 4>& template_params,
+		std::span<const TemplateTypeArg> template_args) {
+	if (param.kind() != TemplateParameterKind::NonType || !param.has_type()) {
+		return std::nullopt;
+	}
+	ASTNode substituted_type_node = parser.substituteTemplateParameters(
+		ASTNode::emplace_node<TypeSpecifierNode>(param.type_specifier_node()),
+		template_params,
+		template_args);
+	if (!substituted_type_node.is<TypeSpecifierNode>()) {
+		return std::nullopt;
+	}
+	return substituted_type_node.as<TypeSpecifierNode>();
+}
+
 	std::optional<TemplateTypeArg> substituteAndEvaluateNonTypeDefaultImpl(
 		Parser& parser,
 		const ASTNode& default_node,
@@ -175,6 +268,18 @@ namespace {
 	}
 
 	FLASH_LOG(Templates, Debug, "substituteAndEvaluateNonTypeDefaultImpl: succeeded");
+	if (template_args.size() < template_params.size()) {
+		const TemplateParameterNode& param = template_params[template_args.size()];
+		if (std::optional<TypeSpecifierNode> target_type =
+				substituteNonTypeParameterTypeImpl(
+					parser,
+					param,
+					template_params,
+					template_args);
+			target_type.has_value()) {
+			return templateTypeArgFromEvalResult(eval_result, *target_type);
+		}
+	}
 	return templateTypeArgFromEvalResult(eval_result);
 }
 
@@ -2721,6 +2826,18 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(std::string_vie
 					return std::nullopt;
 				}
 
+				if (!param.has_type()) {
+					return templateTypeArgFromEvalResult(eval_result);
+				}
+				if (std::optional<TypeSpecifierNode> target_type =
+						substituteNonTypeParameterTypeImpl(
+							*this,
+							param,
+							template_params,
+							bound_args_inline);
+					target_type.has_value()) {
+					return templateTypeArgFromEvalResult(eval_result, *target_type);
+				}
 				return templateTypeArgFromEvalResult(eval_result);
 			}
 

--- a/tests/test_nttp_default_param_type_identity_ret0.cpp
+++ b/tests/test_nttp_default_param_type_identity_ret0.cpp
@@ -1,0 +1,43 @@
+template <class T, T V>
+struct Tag {
+	static constexpr int value = 0;
+};
+
+template <>
+struct Tag<short, static_cast<short>(1)> {
+	static constexpr int value = 42;
+};
+
+template <class T, T V = 1>
+struct Use : Tag<T, V> {
+};
+
+template <class T, T V = static_cast<T>(1)>
+struct UseCast : Tag<T, V> {
+};
+
+template <class T, T V = -1>
+struct SignedDefault {
+	static constexpr int value = V;
+};
+
+template <class T, T V = 255>
+struct UnsignedDefault {
+	static constexpr int value = V;
+};
+
+int main() {
+	if (Use<short>::value != 42) {
+		return 1;
+	}
+	if (UseCast<short>::value != 42) {
+		return 2;
+	}
+	if (SignedDefault<signed char>::value != -1) {
+		return 3;
+	}
+	if (UnsignedDefault<unsigned char>::value != 255) {
+		return 4;
+	}
+	return Use<int>::value == 0 ? 0 : 5;
+}

--- a/tests/test_nttp_default_param_type_identity_ret0.cpp
+++ b/tests/test_nttp_default_param_type_identity_ret0.cpp
@@ -26,6 +26,26 @@ struct UnsignedDefault {
 	static constexpr int value = V;
 };
 
+template <class T, T V = true>
+struct BoolDefault {
+	static constexpr int value = V ? 100 : 0;
+};
+
+template <class T, T V = 'A'>
+struct CharDefault {
+	static constexpr int value = V;
+};
+
+template <class T, T V = 1L>
+struct LongDefault {
+	static constexpr long long value = V;
+};
+
+template <class T, T V = 1LL>
+struct LongLongDefault {
+	static constexpr long long value = V;
+};
+
 int main() {
 	if (Use<short>::value != 42) {
 		return 1;
@@ -39,5 +59,17 @@ int main() {
 	if (UnsignedDefault<unsigned char>::value != 255) {
 		return 4;
 	}
-	return Use<int>::value == 0 ? 0 : 5;
+	if (BoolDefault<bool>::value != 100) {
+		return 5;
+	}
+	if (CharDefault<char>::value != 'A') {
+		return 6;
+	}
+	if (LongDefault<long>::value != 1L) {
+		return 7;
+	}
+	if (LongLongDefault<long long>::value != 1LL) {
+		return 8;
+	}
+	return Use<int>::value == 0 ? 0 : 9;
 }


### PR DESCRIPTION
## Summary
- Preserve substituted declared types when materializing default non-type template arguments.
- Apply target-type materialization in the shared default evaluator, deduction fallback, and variable-template default path.
- Add a regression for `template<class T, T V = 1>` preserving `T=short`, plus signed/unsigned integral conversion coverage.

## Validation
- clang++ -std=c++20 -fsyntax-only tests\test_nttp_default_param_type_identity_ret0.cpp
- .\build_flashcpp.bat
- pwsh -File tests\run_all_tests.ps1 test_nttp_default_param_type_identity_ret0.cpp test_template_dependent_base_member_template_static_value_ret0.cpp test_nttp_ptr_specialization_ret0.cpp
- git --no-pager diff --check origin/main...HEAD
- pwsh -File tests\run_all_tests.ps1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-type template parameters now correctly convert evaluated values to their declared target types (bool/char/signed/unsigned/integral) during deduction and default-materialization.

* **Refactor**
  * Improved template-parameter handling to more accurately track and apply declared type information during instantiation.

* **Tests**
  * Added comprehensive tests exercising default NTTP behavior and specialization across various integer, boolean, and character types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->