### PR TITLE
stage6: tighten remaining sema query-state invariants

### DIFF
--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -158,13 +158,13 @@ Stage 6 progress so far:
 - normalized codegen now hardens several remaining fallback families: `IrGenerator_NewDeleteCast.cpp` rejects `typeid(expr)` when sema-normalized codegen still lacks an operand type, `IrGenerator_Visitors_Decl.cpp` now requires sema to annotate user-declared constructor calls instead of warning and recomputing, and `IrGenerator_Expr_Operators.cpp` no longer recomputes recorded operator-overload failures in sema-normalized bodies.
 - builtin `++/--` codegen in `IrGenerator_Expr_Conversions.cpp` now treats nested-unary operand type queries as finalized in sema-normalized bodies; identifier/member recovery remains temporarily allowed after this pass exposed an existing normalized gap in `test_duffs_device_ret20.cpp`.
 - base-constructor materialization in `IrGenerator_Visitors_TypeInit.cpp` now goes through `sema_.ensureMemberFunctionMaterialized(...)` instead of calling `parser_.instantiateLazyMemberIfNeeded(...)` directly from codegen.
+- switch `case`/`default` bodies now flow through `SemanticAnalysis::normalizeStatement(...)` just like the rest of function bodies, closing the missing sema-owned normalization seam that left Duff's-device expressions (`*dst++`, `*src++`, `--n`) at `NotYetAnalyzed` inside sema-normalized codegen. With that feature in place, builtin `++/--` codegen no longer needs the temporary identifier/member query-state recovery in normalized bodies.
 
 Remaining Stage 6 work:
 
 - `EvaluationContext` still has a raw symbol-table constructor for any future genuinely mode-delayed construction, but the last live parser-owned construct-then-attach path is now gone
 - decide whether to retire the remaining pointer/boolean query adapters (`getResolvedDirectCall(...)`, `getResolvedOpCall(...)`, `resolveOrGetMemberAccess(...)`) now that query-result forms are in active use across the hot paths
 - tighten the remaining codegen recovery seam in `AstToIr::getCallExpressionReturnType(...)`, which still falls back to `parser_.get_expression_type(...)` after a sema query reports an unusable result
-- revisit builtin `++/--` identifier/member operand recovery once sema guarantees those operand-type annotations in all sema-normalized bodies
 - struct-without-conversion-operator codegen fallback removed; sema return-conversion is now fully enforced for struct returns ✅
 - `parser_` in `AstToIr` is now `Parser&` — no more defensive null guards in codegen ✅
 - codegen-side `EvaluationContext` construction is now further centralised via `makeEvalContext`, and the converted call sites carry parser + sema by construction

--- a/docs/2026-05-16-sema-first-class-plan.md
+++ b/docs/2026-05-16-sema-first-class-plan.md
@@ -154,12 +154,17 @@ Stage 6 progress so far:
 - Audit (branch `copilot/sema-next-7`): re-verified Slice A–D contracts in `ConstExprEvaluator_Core.cpp`, `ConstExprEvaluator_Members.cpp`, `IrGenerator_Call_Indirect.cpp`, `IrGenerator_Stmt_Control.cpp`, and `ExpressionSubstitutor.cpp`; behavior already matched contract requirements, so no additional functional code edits were needed in this pass.
 - parser-gated constexpr template instantiation in `ConstExprEvaluator_Core.cpp` now routes parser access through `requireParserOwnedSema(...)` directly; the old parser-null guard/error branch in `tryEvaluateAsVariableTemplate(...)` was removed.
 - template-function constexpr fallback instantiation in `ConstExprEvaluator_Core.cpp` now also requires parser-owned sema unconditionally before parser use, removing the remaining `if (context.parser)` gate in that parser-required instantiation path.
+- remaining constexpr expression-type lookups in `ConstExprEvaluator_Core.cpp` and `ConstExprEvaluator_Members.cpp` now route through the shared `Evaluator::tryQueryExpressionType(...)` helper, which prefers sema query state and only falls back to parser expression typing when needed; direct parser lookups for constructor-argument typing, array constness checks, nested member base typing, pointer-to-member access typing, and initializer exact-type capture are gone.
+- normalized codegen now hardens several remaining fallback families: `IrGenerator_NewDeleteCast.cpp` rejects `typeid(expr)` when sema-normalized codegen still lacks an operand type, `IrGenerator_Visitors_Decl.cpp` now requires sema to annotate user-declared constructor calls instead of warning and recomputing, and `IrGenerator_Expr_Operators.cpp` no longer recomputes recorded operator-overload failures in sema-normalized bodies.
+- builtin `++/--` codegen in `IrGenerator_Expr_Conversions.cpp` now treats nested-unary operand type queries as finalized in sema-normalized bodies; identifier/member recovery remains temporarily allowed after this pass exposed an existing normalized gap in `test_duffs_device_ret20.cpp`.
+- base-constructor materialization in `IrGenerator_Visitors_TypeInit.cpp` now goes through `sema_.ensureMemberFunctionMaterialized(...)` instead of calling `parser_.instantiateLazyMemberIfNeeded(...)` directly from codegen.
 
 Remaining Stage 6 work:
 
 - `EvaluationContext` still has a raw symbol-table constructor for any future genuinely mode-delayed construction, but the last live parser-owned construct-then-attach path is now gone
-- continue replacing parser/codegen fallback ambiguity with explicit "fact unavailable yet" contracts
-- keep tightening finalized-query misuse into hard invariants once the remaining fallback families are retired
+- decide whether to retire the remaining pointer/boolean query adapters (`getResolvedDirectCall(...)`, `getResolvedOpCall(...)`, `resolveOrGetMemberAccess(...)`) now that query-result forms are in active use across the hot paths
+- tighten the remaining codegen recovery seam in `AstToIr::getCallExpressionReturnType(...)`, which still falls back to `parser_.get_expression_type(...)` after a sema query reports an unusable result
+- revisit builtin `++/--` identifier/member operand recovery once sema guarantees those operand-type annotations in all sema-normalized bodies
 - struct-without-conversion-operator codegen fallback removed; sema return-conversion is now fully enforced for struct returns ✅
 - `parser_` in `AstToIr` is now `Parser&` — no more defensive null guards in codegen ✅
 - codegen-side `EvaluationContext` construction is now further centralised via `makeEvalContext`, and the converted call sites carry parser + sema by construction

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -528,6 +528,9 @@ public:
 	static EvalResult evaluate_member_function_call(const CallExprNode& call_expr, EvaluationContext& context);
 	static EvalResult evaluate_array_subscript(const ArraySubscriptNode& subscript, EvaluationContext& context);
 	static EvalResult evaluate_type_trait(const TypeTraitExprNode& trait_expr);
+	static std::optional<TypeSpecifierNode> tryQueryExpressionType(
+		const ASTNode& expr,
+		EvaluationContext& context);
 
 	static const StructTypeInfo* get_struct_info_from_type(const TypeSpecifierNode& type_spec);
 	static EvalResult evaluate_nested_member_access(
@@ -1026,7 +1029,7 @@ private:
 		std::span<const size_t> array_dimensions);
 
 	// Try to obtain the source expression's type from an already-evaluated
-	// result (exact_type) or by asking the parser for the AST node's type.
+	// result (exact_type) or via the shared sema-first AST type query helper.
 	static std::optional<TypeSpecifierNode> tryGetExpressionType(
 		const EvalResult& result,
 		const ASTNode& expr,

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4518,7 +4518,6 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		// contract violation and must hard-fail.
 		SemanticAnalysis& sema_ref =
 			context.requireParserOwnedSema("dependent unqualified call POI resolution");
-		Parser& parser = *context.parser;
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		auto sema_services = sema_ref.parserSemanticServices();
@@ -4543,6 +4542,8 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		case ResolvedFunctionQueryResult::State::AnalyzedAbsent:
 			break;
 		}
+		// Sema query was absent or not yet analyzed — fall back to parser POI lookup.
+		Parser& parser = *context.parser;
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!parser.tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -378,8 +378,8 @@ std::optional<TypeSpecifierNode> tryGetConstexprPointerToMemberAccessType(
 	const PointerToMemberAccessNode& member_access,
 	EvaluationContext& context) {
 	auto object_type_opt = tryGetConstexprBoundExpressionType(member_access.object(), context);
-	if (!object_type_opt.has_value() && context.parser) {
-		object_type_opt = context.parser->get_expression_type(member_access.object());
+	if (!object_type_opt.has_value()) {
+		object_type_opt = Evaluator::tryQueryExpressionType(member_access.object(), context);
 	}
 	if (!object_type_opt.has_value()) {
 		return std::nullopt;
@@ -442,8 +442,8 @@ std::optional<TypeSpecifierNode> tryGetConstexprBoundExpressionType(const ASTNod
 
 	const ExpressionNode& expr = expr_node.as<ExpressionNode>();
 	auto tryParserFallbackForType = [&](std::optional<TypeSpecifierNode> type_opt, const ASTNode& fallback_expr) {
-		if (!type_opt.has_value() && context.parser) {
-			type_opt = context.parser->get_expression_type(fallback_expr);
+		if (!type_opt.has_value()) {
+			type_opt = Evaluator::tryQueryExpressionType(fallback_expr, context);
 		}
 		return type_opt;
 	};
@@ -581,10 +581,7 @@ std::optional<TypeSpecifierNode> tryGetConstexprExpressionTypeForTypeTraits(cons
 	if (auto expr_type_opt = tryGetConstexprBoundExpressionType(expr_node, context); expr_type_opt.has_value()) {
 		return expr_type_opt;
 	}
-	if (context.parser) {
-		return context.parser->get_expression_type(expr_node);
-	}
-	return std::nullopt;
+	return Evaluator::tryQueryExpressionType(expr_node, context);
 }
 
 void maybe_set_exact_type(EvalResult& result, const TypeSpecifierNode& type_spec) {
@@ -602,11 +599,7 @@ void maybe_set_exact_type_from_declaration(EvalResult& result, const Declaration
 }
 
 void maybe_set_exact_type_from_initializer(EvalResult& result, const ASTNode& initializer, EvaluationContext& context) {
-	if (!context.parser) {
-		return;
-	}
-
-	auto init_type = context.parser->get_expression_type(initializer);
+	auto init_type = Evaluator::tryQueryExpressionType(initializer, context);
 	if (init_type.has_value()) {
 		maybe_set_exact_type(result, *init_type);
 	}
@@ -2521,7 +2514,23 @@ std::optional<TypeSpecifierNode> Evaluator::tryGetExpressionType(
 	if (result.exact_type.has_value()) {
 		return result.exact_type;
 	}
-	if (context.parser) {
+	return tryQueryExpressionType(expr, context);
+}
+
+std::optional<TypeSpecifierNode> Evaluator::tryQueryExpressionType(
+	const ASTNode& expr,
+	EvaluationContext& context) {
+	if (context.sema != nullptr) {
+		TypeSpecifierQueryResult sema_type_query =
+			context.sema->parserSemanticServices().getExpressionTypeQuery(expr);
+		if (sema_type_query.state == TypeSpecifierQueryResult::State::Available &&
+			sema_type_query.type.has_value() &&
+			sema_type_query.type->type() != TypeCategory::Invalid &&
+			!isPlaceholderAutoType(sema_type_query.type->type())) {
+			return sema_type_query.type;
+		}
+	}
+	if (context.parser != nullptr) {
 		return context.parser->get_expression_type(expr);
 	}
 	return std::nullopt;

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1108,10 +1108,8 @@ const ConstructorDeclarationNode* Evaluator::find_matching_constructor(
 	arg_types.reserve(arguments.size());
 	bool has_all_arg_types = true;
 	for (const auto& argument : arguments) {
-		std::optional<TypeSpecifierNode> arg_type_opt;
-		if (context.parser) {
-			arg_type_opt = context.parser->get_expression_type(argument);
-		}
+		std::optional<TypeSpecifierNode> arg_type_opt =
+			Evaluator::tryQueryExpressionType(argument, context);
 
 		if (!arg_type_opt.has_value() && argument.is<ExpressionNode>()) {
 			const ExpressionNode& expr = argument.as<ExpressionNode>();
@@ -2153,8 +2151,8 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_array_subscript(
 					}
 				}
 			}
-			if (!object_is_const && context.parser) {
-				auto expr_type = context.parser->get_expression_type(array_expr);
+			if (!object_is_const) {
+				auto expr_type = Evaluator::tryQueryExpressionType(array_expr, context);
 				object_is_const = expr_type.has_value() &&
 					expr_type->cv_qualifier() == CVQualifier::Const;
 			}
@@ -6390,10 +6388,9 @@ EvalResult Evaluator::evaluate_nested_member_access(
 				return final_member_it->second;
 			}
 			if (intermediate_result.object_member_bindings.empty() &&
-				!intermediate_result.object_type_index.is_valid() &&
-				context.parser) {
+				!intermediate_result.object_type_index.is_valid()) {
 				TypeIndex base_type_index;
-				if (auto parsed_type_opt = context.parser->get_expression_type(base_obj_expr); parsed_type_opt.has_value()) {
+				if (auto parsed_type_opt = Evaluator::tryQueryExpressionType(base_obj_expr, context); parsed_type_opt.has_value()) {
 					base_type_index = parsed_type_opt->type_index();
 				}
 				if (base_type_index.is_valid()) {
@@ -6468,8 +6465,8 @@ EvalResult Evaluator::evaluate_nested_member_access(
 					base_type_index = base_type_opt->type_index();
 				}
 			}
-			if (!base_type_index.is_valid() && context.parser) {
-				if (auto parsed_type_opt = context.parser->get_expression_type(base_obj_expr); parsed_type_opt.has_value()) {
+			if (!base_type_index.is_valid()) {
+				if (auto parsed_type_opt = Evaluator::tryQueryExpressionType(base_obj_expr, context); parsed_type_opt.has_value()) {
 					base_type_index = parsed_type_opt->type_index();
 				}
 			}
@@ -8912,8 +8909,8 @@ EvalResult Evaluator::evaluate_array_subscript(const ArraySubscriptNode& subscri
 					}
 				}
 			}
-			if (!object_is_const && context.parser) {
-				auto expr_type = context.parser->get_expression_type(array_expr);
+			if (!object_is_const) {
+				auto expr_type = Evaluator::tryQueryExpressionType(array_expr, context);
 				object_is_const = expr_type.has_value() &&
 					expr_type->cv_qualifier() == CVQualifier::Const;
 			}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1700,7 +1700,6 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		// contract violation and must hard-fail.
 		SemanticAnalysis& sema_ref =
 			context.requireParserOwnedSema("dependent unqualified member call POI resolution");
-		Parser& parser = *context.parser;
 		// The sema pass may have already resolved this call during annotation.
 		// Consume that pre-resolved result directly instead of re-running POI lookup.
 		auto sema_services = sema_ref.parserSemanticServices();
@@ -1726,6 +1725,8 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		case ResolvedFunctionQueryResult::State::AnalyzedAbsent:
 			break;
 		}
+		// Sema query was absent or not yet analyzed — fall back to parser POI lookup.
+		Parser& parser = *context.parser;
 		std::vector<TypeSpecifierNode> arg_types;
 		if (!parser.tryCollectFunctionCallArgTypes(call_expr.arguments(), arg_types)) {
 			return EvalResult::error(

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -2113,8 +2113,7 @@ ExprResult AstToIr::generateBuiltinIncDec(
 		if (operand_pointer_depth == 0) {
 			const bool allow_identifier_or_member_recovery =
 				(operandHandledAsIdentifier && std::holds_alternative<IdentifierNode>(operandExpr)) ||
-				std::holds_alternative<MemberAccessNode>(operandExpr) ||
-				std::holds_alternative<UnaryOperatorNode>(operandExpr);
+				std::holds_alternative<MemberAccessNode>(operandExpr);
 			std::optional<TypeSpecifierNode> operand_type_opt = queryExprTypeWithParserFallback(
 				unaryOperatorNode.get_operand(),
 				allow_identifier_or_member_recovery,

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -2111,12 +2111,9 @@ ExprResult AstToIr::generateBuiltinIncDec(
 			return parser_.get_expression_type(node);
 		};
 		if (operand_pointer_depth == 0) {
-			const bool allow_identifier_or_member_recovery =
-				(operandHandledAsIdentifier && std::holds_alternative<IdentifierNode>(operandExpr)) ||
-				std::holds_alternative<MemberAccessNode>(operandExpr);
 			std::optional<TypeSpecifierNode> operand_type_opt = queryExprTypeWithParserFallback(
 				unaryOperatorNode.get_operand(),
-				allow_identifier_or_member_recovery,
+				false,
 				"Normalized builtin ++/-- operand type query remained NotYetAnalyzed");
 			if (operand_type_opt.has_value()) {
 				applyPointerTypeInfo(*operand_type_opt);

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -2234,7 +2234,10 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 		// Check for operator overload (member function or free function)
 		OperatorOverloadResult overload_result;
 		bool can_recompute_recorded_failure =
-			(binaryOperatorNode.has_ambiguous_operator_overload() || binaryOperatorNode.has_no_match_operator_overload()) && recorded_overload_still_relevant && (lhs_has_user_defined_identity || rhs_has_user_defined_identity);
+			!sema_normalized_current_function_ &&
+			(binaryOperatorNode.has_ambiguous_operator_overload() || binaryOperatorNode.has_no_match_operator_overload()) &&
+			recorded_overload_still_relevant &&
+			(lhs_has_user_defined_identity || rhs_has_user_defined_identity);
 
 		if (binaryOperatorNode.has_ambiguous_operator_overload() && !can_recompute_recorded_failure) {
 			overload_result = OperatorOverloadResult::ambiguous();

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -3727,15 +3727,25 @@ bool AstToIr::isVariableReference(std::string_view var_name) const {
 bool AstToIr::resolveMemberAccessType(const MemberAccessNode& member_access,
 									  const StructTypeInfo*& out_struct_info,
 									  const StructMember*& out_member) const {
-	if (sema_.resolveOrGetMemberAccess(member_access, out_struct_info, out_member)) {
+	const ResolvedMemberAccessQueryResult member_access_query = sema_.getResolvedMemberAccessQuery(&member_access);
+	if (member_access_query.hasValue()) {
+		out_struct_info = member_access_query.owner_struct_info;
+		out_member = member_access_query.member;
 		return true;
 	}
-	if (sema_normalized_current_function_) {
+	if (sema_normalized_current_function_ &&
+		member_access_query.state == ResolvedMemberAccessQueryResult::State::NotYetAnalyzed) {
 		throw InternalError(std::string(StringBuilder()
 			.append("Missing sema-owned member access resolution in sema-normalized body for member '")
 			.append(member_access.member_name())
 			.append("'")
 			.commit()));
+	}
+	if (!sema_normalized_current_function_ &&
+		member_access_query.state == ResolvedMemberAccessQueryResult::State::NotYetAnalyzed) {
+		if (sema_.resolveOrGetMemberAccess(member_access, out_struct_info, out_member)) {
+			return true;
+		}
 	}
 
 	// Get the base object expression

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -3741,6 +3741,9 @@ bool AstToIr::resolveMemberAccessType(const MemberAccessNode& member_access,
 			.append("'")
 			.commit()));
 	}
+	if (sema_normalized_current_function_) {
+		return false;
+	}
 	if (!sema_normalized_current_function_ &&
 		member_access_query.state == ResolvedMemberAccessQueryResult::State::NotYetAnalyzed) {
 		if (sema_.resolveOrGetMemberAccess(member_access, out_struct_info, out_member)) {

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -1250,6 +1250,10 @@ ExprResult AstToIr::generateTypeidIr(const TypeidNode& typeidNode) {
 			return makeExprResult(nativeTypeIndex(TypeCategory::Void), SizeInBits{64}, IrOperand{result_temp}, PointerDepth{}, ValueStorage::ContainsData);
 		}
 
+		if (sema_normalized_current_function_) {
+			throw InternalError("Normalized typeid(expr) is missing a sema-owned operand type");
+		}
+
 			// Fallback when semantic typing is unavailable.
 			// Extract IrValue from expression result
 		std::variant<StringHandle, TempVar> operand_value;

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -3396,11 +3396,11 @@ ExprResult AstToIr::generateConstructorCallIr(const ConstructorCallNode& constru
 			}
 			matching_ctor = nullptr;
 		} else if (require_sema_resolved_ctor) {
-			// Sema ran but did not annotate the resolved constructor.  Log a
-			// diagnostic and fall through to codegen-time overload resolution
-			// below; only fail hard if that also finds nothing.
-			FLASH_LOG(Codegen, Warning, "Sema did not annotate constructor for '",
-					  struct_info->name, "' - falling back to codegen-time resolution");
+			throw InternalError(std::string(StringBuilder()
+				.append("Sema-normalized constructor call is missing a resolved constructor for '")
+				.append(StringTable::getStringView(struct_info->name))
+				.append("'")
+				.commit()));
 		}
 		if (!matching_ctor) {
 			std::vector<TypeSpecifierNode> arg_types;

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2023,10 +2023,8 @@ void AstToIr::generateTrivialDefaultConstructors() {
 					const StructTypeInfo* base_struct_info = base_type_it->second->getStructInfo();
 					if (base_struct_info && base_struct_info->hasConstructor()) {
 						// If the base class has a lazy (unmaterialized) default constructor,
-						// materialize it via the parser before emitting the ConstructorCallOp.
-						// This constructor path still uses the parser entry point because it
-						// predates the sema-owned helper and remains coupled to parser-side
-						// lazy instantiation bookkeeping.
+						// materialize it through sema before emitting the ConstructorCallOp
+						// so codegen does not drive parser-side lazy bookkeeping directly.
 						const StructMemberFunction* base_default_ctor = base_struct_info->findDefaultConstructor();
 						if (base_default_ctor &&
 							base_default_ctor->function_decl.is<ConstructorDeclarationNode>() &&
@@ -2035,9 +2033,7 @@ void AstToIr::generateTrivialDefaultConstructors() {
 							const auto& ctor_decl = base_default_ctor->function_decl.as<ConstructorDeclarationNode>();
 							StringHandle ctor_name = ctor_decl.name();
 							if (base_name.isValid() && ctor_name.isValid()) {
-								LazyMemberKey key = LazyMemberKey::exact(base_name, ctor_decl);
-								parser_.instantiateLazyMemberIfNeeded(key);
-								normalizePendingSemanticRoots();
+								sema_.ensureMemberFunctionMaterialized(base_name, ctor_decl);
 							}
 						}
 						ConstructorCallOp call_op;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -3607,6 +3607,7 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 			} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
 				normalizeExpression(e.object(), ctx);
 				const void* member_access_key = static_cast<const void*>(&e);
+				analyzed_member_access_queries_.insert(member_access_key);
 				ResolvedMemberAccessInfo member_info;
 				if (tryResolveMemberAccessInfo(e, member_info)) {
 					resolved_member_access_table_[member_access_key] = member_info;
@@ -3633,7 +3634,11 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				}
 			} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
 				tryResolveSubscriptOperator(e);
-				if (!getResolvedOpSubscript(&e)) {
+				const ResolvedFunctionQueryResult op_subscript_query = getResolvedOpSubscriptQuery(&e);
+				if (op_subscript_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+					throw InternalError("Array subscript query remained NotYetAnalyzed after tryResolveSubscriptOperator");
+				}
+				if (!op_subscript_query.hasValue()) {
 					const std::optional<CanonicalTypeId> pointer_conversion_target_type_id =
 						normalizeBuiltinSubscriptOperands(e);
 					const CanonicalTypeId array_type_id = inferExpressionType(e.array_expr());
@@ -3647,7 +3652,8 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				// If sema resolved this subscript to operator[], annotate the index
 				// argument against the operator's parameter type using the shared
 				// single-argument annotation helper.
-				if (const FunctionDeclarationNode* op = getResolvedOpSubscript(&e)) {
+				if (op_subscript_query.hasValue()) {
+					const FunctionDeclarationNode* op = op_subscript_query.function;
 					const auto& params = op->parameter_nodes();
 					if (!params.empty() && params[0].is<DeclarationNode>()) {
 						const ASTNode param_type_node = params[0].as<DeclarationNode>().type_node();
@@ -4163,10 +4169,16 @@ ValueCategory SemanticAnalysis::inferExpressionValueCategory(const ASTNode& node
 		} else if constexpr (std::is_same_v<T, CallExprNode>) {
 			const FunctionDeclarationNode* func_decl = getParserStoredDirectCallTarget(inner);
 			if (!func_decl) {
-				func_decl = getResolvedDirectCall(&inner);
+				const ResolvedFunctionQueryResult direct_call_query = getResolvedDirectCallQuery(&inner);
+				if (direct_call_query.hasValue()) {
+					func_decl = direct_call_query.function;
+				}
 			}
 			if (!func_decl) {
-				func_decl = getResolvedOpCall(&inner);
+				const ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(&inner);
+				if (op_call_query.hasValue()) {
+					func_decl = op_call_query.function;
+				}
 			}
 			if (func_decl) {
 				if (auto category = getReferenceQualifiedValueCategory(func_decl->decl_node().type_node());
@@ -4195,8 +4207,8 @@ ValueCategory SemanticAnalysis::inferExpressionValueCategory(const ASTNode& node
 }
 
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedOpCall(const void* key) const {
-	auto it = op_call_table_.find(key);
-	return it != op_call_table_.end() ? it->second : nullptr;
+	const ResolvedFunctionQueryResult query = getResolvedOpCallQuery(key);
+	return query.hasValue() ? query.function : nullptr;
 }
 
 ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpCallQuery(const void* key) const {
@@ -4238,8 +4250,8 @@ ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpSubscriptQuery(const 
 }
 
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedDirectCall(const void* key) const {
-	auto it = resolved_direct_call_table_.find(key);
-	return it != resolved_direct_call_table_.end() ? it->second : nullptr;
+	const ResolvedFunctionQueryResult query = getResolvedDirectCallQuery(key);
+	return query.hasValue() ? query.function : nullptr;
 }
 
 ResolvedFunctionQueryResult SemanticAnalysis::getResolvedDirectCallQuery(const void* key) const {
@@ -4279,28 +4291,64 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 bool SemanticAnalysis::resolveOrGetMemberAccess(const MemberAccessNode& key,
 												const StructTypeInfo*& out_struct_info,
 												const StructMember*& out_member) {
+	ResolvedMemberAccessQueryResult query = getResolvedMemberAccessQuery(&key);
+	if (query.hasValue()) {
+		out_struct_info = query.owner_struct_info;
+		out_member = query.member;
+		return true;
+	}
+	if (query.state == ResolvedMemberAccessQueryResult::State::AnalyzedAbsent) {
+		return false;
+	}
+
 	const void* cache_key = static_cast<const void*>(&key);
-	auto it = resolved_member_access_table_.find(cache_key);
-	if (it == resolved_member_access_table_.end()) {
-		ResolvedMemberAccessInfo member_info;
-		if (!tryResolveMemberAccessInfo(key, member_info)) {
-			return false;
-		}
-		it = resolved_member_access_table_.emplace(cache_key, member_info).first;
+	analyzed_member_access_queries_.insert(cache_key);
+	ResolvedMemberAccessInfo member_info;
+	if (!tryResolveMemberAccessInfo(key, member_info)) {
+		resolved_member_access_table_.erase(cache_key);
+		return false;
+	}
+	resolved_member_access_table_[cache_key] = member_info;
+
+	query = getResolvedMemberAccessQuery(&key);
+	if (!query.hasValue()) {
+		throw InternalError("Resolved member-access cache entry did not yield an available query result");
 	}
 
-	const TypeInfo* owner_type_info = tryGetTypeInfo(it->second.owner_type_index);
-	const StructTypeInfo* owner_struct_info = owner_type_info ? owner_type_info->getStructInfo() : nullptr;
-	if (!owner_struct_info) {
-		throw InternalError("Resolved member access owner type no longer names a struct");
-	}
-	if (it->second.member_index >= owner_struct_info->members.size()) {
-		throw InternalError("Resolved member access index out of bounds");
-	}
-
-	out_struct_info = owner_struct_info;
-	out_member = &owner_struct_info->members[it->second.member_index];
+	out_struct_info = query.owner_struct_info;
+	out_member = query.member;
 	return true;
+}
+
+ResolvedMemberAccessQueryResult SemanticAnalysis::getResolvedMemberAccessQuery(const MemberAccessNode* key) const {
+	if (key == nullptr) {
+		return {ResolvedMemberAccessQueryResult::State::NotYetAnalyzed, nullptr, nullptr};
+	}
+
+	const void* cache_key = static_cast<const void*>(key);
+	if (auto it = resolved_member_access_table_.find(cache_key); it != resolved_member_access_table_.end()) {
+		const TypeInfo* owner_type_info = tryGetTypeInfo(it->second.owner_type_index);
+		const StructTypeInfo* owner_struct_info = owner_type_info ? owner_type_info->getStructInfo() : nullptr;
+		if (!owner_struct_info) {
+			throw InternalError("Resolved member access owner type no longer names a struct");
+		}
+		if (it->second.member_index >= owner_struct_info->members.size()) {
+			throw InternalError("Resolved member access index out of bounds");
+		}
+		return {
+			ResolvedMemberAccessQueryResult::State::Available,
+			owner_struct_info,
+			&owner_struct_info->members[it->second.member_index]};
+	}
+
+	if (analyzed_member_access_queries_.count(cache_key) > 0) {
+		return {ResolvedMemberAccessQueryResult::State::AnalyzedAbsent, nullptr, nullptr};
+	}
+	return {ResolvedMemberAccessQueryResult::State::NotYetAnalyzed, nullptr, nullptr};
+}
+
+ResolvedMemberAccessQueryResult SemanticAnalysis::getResolvedMemberAccessQuery(const MemberAccessNode& key) const {
+	return getResolvedMemberAccessQuery(&key);
 }
 
 const SemanticAnalysis::MemberContext* SemanticAnalysis::getCurrentMemberContext() const {
@@ -4851,19 +4899,30 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 				// Phase 6: parser_.get_expression_type fallback removed.
 				// Sema now resolves data members, static members, and member
 				// functions entirely through its own type infrastructure.
+				const ResolvedMemberAccessQueryResult member_access_query = getResolvedMemberAccessQuery(&e);
 				const auto object_info = resolveMemberAccessObjectInfo(e);
 				if (!object_info.has_value()) {
 					return {};
 				}
 
-				// Try data member resolution first via the existing path.
-				ResolvedMemberAccessInfo member_info;
-				if (tryResolveMemberAccessInfo(e, member_info)) {
-					const TypeInfo* owner_type_info = tryGetTypeInfo(member_info.owner_type_index);
-					const StructTypeInfo* owner_struct_info = owner_type_info ? owner_type_info->getStructInfo() : nullptr;
-					if (owner_struct_info && member_info.member_index < owner_struct_info->members.size()) {
-						return type_context_.intern(canonicalTypeDescFromStructMember(
-							owner_struct_info->members[member_info.member_index], object_info->object_desc.base_cv));
+				// Prefer sema query-state payload in finalized/normalized-sensitive
+				// paths so callers can distinguish absent from not-yet-analyzed.
+				if (member_access_query.hasValue()) {
+					return type_context_.intern(canonicalTypeDescFromStructMember(
+						*member_access_query.member, object_info->object_desc.base_cv));
+				}
+
+				// Fallback for pre-analysis flows where this path may run before
+				// expression normalization has visited the MemberAccessNode.
+				if (member_access_query.state == ResolvedMemberAccessQueryResult::State::NotYetAnalyzed) {
+					ResolvedMemberAccessInfo member_info;
+					if (tryResolveMemberAccessInfo(e, member_info)) {
+						const TypeInfo* owner_type_info = tryGetTypeInfo(member_info.owner_type_index);
+						const StructTypeInfo* owner_struct_info = owner_type_info ? owner_type_info->getStructInfo() : nullptr;
+						if (owner_struct_info && member_info.member_index < owner_struct_info->members.size()) {
+							return type_context_.intern(canonicalTypeDescFromStructMember(
+								owner_struct_info->members[member_info.member_index], object_info->object_desc.base_cv));
+						}
 					}
 				}
 
@@ -4912,7 +4971,9 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 				return type_context_.intern(result_desc);
 			} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
 				// If sema resolved this subscript to operator[], return the operator[]'s return type.
-				if (const FunctionDeclarationNode* op_subscript = getResolvedOpSubscript(&e)) {
+				const ResolvedFunctionQueryResult op_subscript_query = getResolvedOpSubscriptQuery(&e);
+				if (op_subscript_query.hasValue()) {
+					const FunctionDeclarationNode* op_subscript = op_subscript_query.function;
 					const ASTNode& ret_type_node = op_subscript->decl_node().type_node();
 					if (ret_type_node.is<TypeSpecifierNode>())
 						return canonicalizeType(ret_type_node.as<TypeSpecifierNode>());
@@ -5423,18 +5484,22 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 					return {};
 				};
 
-				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(getResolvedOpCall(&e))) {
+				ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(&e);
+				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(op_call_query.hasValue() ? op_call_query.function : nullptr)) {
 					return resolved_type_id;
 				}
-				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(getResolvedDirectCall(&e))) {
+				ResolvedFunctionQueryResult direct_call_query = getResolvedDirectCallQuery(&e);
+				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(direct_call_query.hasValue() ? direct_call_query.function : nullptr)) {
 					return resolved_type_id;
 				}
 
 				tryResolveCallableOperator(e);
-				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(getResolvedOpCall(&e))) {
+				op_call_query = getResolvedOpCallQuery(&e);
+				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(op_call_query.hasValue() ? op_call_query.function : nullptr)) {
 					return resolved_type_id;
 				}
-				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(getResolvedDirectCall(&e))) {
+				direct_call_query = getResolvedDirectCallQuery(&e);
+				if (const CanonicalTypeId resolved_type_id = inferCallReturnType(direct_call_query.hasValue() ? direct_call_query.function : nullptr)) {
 					return resolved_type_id;
 				}
 
@@ -7317,10 +7382,12 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 
-	const FunctionDeclarationNode* func_decl = getResolvedOpCall(call_key);
-	if (!func_decl) {
+	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
+	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
+	if (!func_decl && op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 		tryResolveCallableOperatorImpl(call_info, call_key);
-		func_decl = getResolvedOpCall(call_key);
+		op_call_query = getResolvedOpCallQuery(call_key);
+		func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
 	}
 	if (func_decl)
 		return func_decl;
@@ -7583,7 +7650,8 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 	// codegen-side fallbacks. See `tryMaterializeLazyCallTarget` for details.
 	func_decl = tryMaterializeLazyCallTarget(func_decl, call_info);
 
-	const FunctionDeclarationNode* resolved_op_call = getResolvedOpCall(call_key);
+	const ResolvedFunctionQueryResult resolved_op_call_query = getResolvedOpCallQuery(call_key);
+	const FunctionDeclarationNode* resolved_op_call = resolved_op_call_query.hasValue() ? resolved_op_call_query.function : nullptr;
 	const bool cache_as_direct_call =
 		!resolved_op_call &&
 		(!call_info.has_receiver ||

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2838,6 +2838,19 @@ void SemanticAnalysis::normalizeStatement(const ASTNode& node, const SemanticCon
 		if (has_condition_decl) {
 			popScope();
 		}
+	} else if (node.is<CaseLabelNode>()) {
+		const auto& case_node = node.as<CaseLabelNode>();
+		if (case_node.get_case_value().is<ExpressionNode>()) {
+			normalizeExpression(case_node.get_case_value(), ctx);
+		}
+		if (case_node.has_statement()) {
+			normalizeStatement(*case_node.get_statement(), ctx);
+		}
+	} else if (node.is<DefaultLabelNode>()) {
+		const auto& default_node = node.as<DefaultLabelNode>();
+		if (default_node.has_statement()) {
+			normalizeStatement(*default_node.get_statement(), ctx);
+		}
 	} else if (node.is<RangedForStatementNode>()) {
 		const auto& stmt = node.as<RangedForStatementNode>();
 		pushScope();

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -3619,14 +3619,9 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				tryAnnotateConstructorCallArgConversions(e);
 			} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
 				normalizeExpression(e.object(), ctx);
-				const void* member_access_key = static_cast<const void*>(&e);
-				analyzed_member_access_queries_.insert(member_access_key);
-				ResolvedMemberAccessInfo member_info;
-				if (tryResolveMemberAccessInfo(e, member_info)) {
-					resolved_member_access_table_[member_access_key] = member_info;
-				} else {
-					resolved_member_access_table_.erase(member_access_key);
-				}
+				const StructTypeInfo* resolved_owner_struct = nullptr;
+				const StructMember* resolved_member = nullptr;
+				resolveOrGetMemberAccess(e, resolved_owner_struct, resolved_member);
 			} else if constexpr (std::is_same_v<T, PointerToMemberAccessNode>) {
 				normalizeExpression(e.object(), ctx);
 				normalizeExpression(e.member_pointer(), ctx);
@@ -4928,14 +4923,11 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 				// Fallback for pre-analysis flows where this path may run before
 				// expression normalization has visited the MemberAccessNode.
 				if (member_access_query.state == ResolvedMemberAccessQueryResult::State::NotYetAnalyzed) {
-					ResolvedMemberAccessInfo member_info;
-					if (tryResolveMemberAccessInfo(e, member_info)) {
-						const TypeInfo* owner_type_info = tryGetTypeInfo(member_info.owner_type_index);
-						const StructTypeInfo* owner_struct_info = owner_type_info ? owner_type_info->getStructInfo() : nullptr;
-						if (owner_struct_info && member_info.member_index < owner_struct_info->members.size()) {
-							return type_context_.intern(canonicalTypeDescFromStructMember(
-								owner_struct_info->members[member_info.member_index], object_info->object_desc.base_cv));
-						}
+					const StructTypeInfo* owner_struct_info = nullptr;
+					const StructMember* member = nullptr;
+					if (resolveOrGetMemberAccess(e, owner_struct_info, member)) {
+						return type_context_.intern(canonicalTypeDescFromStructMember(
+							*member, object_info->object_desc.base_cv));
 					}
 				}
 

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -50,6 +50,24 @@ struct ResolvedFunctionQueryResult {
 	}
 };
 
+struct ResolvedMemberAccessQueryResult {
+	enum class State : uint8_t {
+		NotYetAnalyzed,
+		AnalyzedAbsent,
+		Available,
+	};
+
+	State state = State::NotYetAnalyzed;
+	const StructTypeInfo* owner_struct_info = nullptr;
+	const StructMember* member = nullptr;
+
+	bool hasValue() const {
+		return state == State::Available &&
+			owner_struct_info != nullptr &&
+			member != nullptr;
+	}
+};
+
 struct TypeSpecifierQueryResult {
 	enum class State : uint8_t {
 		NotYetAnalyzed,
@@ -274,6 +292,8 @@ public:
 	};
 	std::optional<ResolvedIdentifierMemberInfo> getResolvedIdentifierMember(const IdentifierNode* key) const;
 	std::optional<ResolvedQualifiedIdentifierInfo> getResolvedQualifiedIdentifier(const QualifiedIdentifierNode* key) const;
+	ResolvedMemberAccessQueryResult getResolvedMemberAccessQuery(const MemberAccessNode* key) const;
+	ResolvedMemberAccessQueryResult getResolvedMemberAccessQuery(const MemberAccessNode& key) const;
 	bool resolveOrGetMemberAccess(const MemberAccessNode& key,
 								  const StructTypeInfo*& out_struct_info,
 								  const StructMember*& out_member);
@@ -622,6 +642,7 @@ private:
 	std::unordered_set<const void*> analyzed_op_call_queries_;
 	std::unordered_set<const void*> analyzed_direct_call_queries_;
 	std::unordered_map<const void*, ResolvedMemberAccessInfo> resolved_member_access_table_;
+	std::unordered_set<const void*> analyzed_member_access_queries_;
 	std::unordered_map<const IdentifierNode*, ResolvedIdentifierMemberInfo> resolved_identifier_member_table_;
 	std::unordered_map<const QualifiedIdentifierNode*, ResolvedQualifiedIdentifierInfo> resolved_qualified_identifier_table_;
 	std::unordered_map<const void*, TypeSpecifierNode> overload_resolution_arg_types_;


### PR DESCRIPTION
## Summary
- add sema-owned query-state tracking for member access and subscript resolution, including cached member-access query results in sema and codegen
- route remaining constexpr expression-type lookups through a shared sema-first helper and harden normalized codegen for typeid(expr), constructor resolution, operator overload reuse, and base-constructor materialization
- normalize switch case/default label bodies so Duff's-device expressions participate in sema-owned query-state tracking instead of relying on codegen recovery

## Validation
- .\\build_flashcpp.bat
- pwsh -File tests\\run_all_tests.ps1