### PR TITLE
Advance ratio template argument handling

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -51,7 +51,7 @@ conversion for `test_std_ratio.cpp`.
   `try_instantiate_template_explicit` has an early-out for dependent args (correct behaviour).
   The errors are non-fatal and the constexpr evaluator path correctly handles
   them via the explicit-type-args fix above; the current hard stop is later
-  default-NTTP/value propagation in ratio arithmetic.
+  IR conversion for `<ratio>` helpers after constexpr ratio comparison succeeds.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
 ### 2b) Residual ratio IR conversion failures

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -33,9 +33,10 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
    the constexpr evaluator (`ConstExprEvaluator_Core.cpp`).
 
 **Current frontier**: The previous `__ratio_less_impl` / remove-cv alias
-instantiation stop is fixed. The first hard blocker has moved later to
-`__ratio_add_impl` default-NTTP evaluation, currently surfacing as unresolved
-`ratio_less$...::value` during constant evaluation.
+instantiation stop, default-NTTP declared-type materialization issue, MSVC
+`type_traits` dependent member-template argument parse failure, and deferred-base
+call-expression invariant are fixed. The first hard blocker currently reaches
+the `std::ratio_less<third, half>` assertion in `test_std_ratio.cpp`.
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
@@ -52,21 +53,17 @@ instantiation stop is fixed. The first hard blocker has moved later to
   default-NTTP/value propagation in ratio arithmetic.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 2b) Residual substitution cycle/default-NTTP value loss in partially-dependent `ratio` instances
+### 2b) Residual ratio comparison value propagation
 
-- **Symptom**: Repeated DEBUG log lines cycling between `_R1::num` and `__static_abs$xxx::value`
-  lookups during depth=2 `ratio` template processing.
-- **Root cause**: When `__ratio_multiply<ratio<N1,D1>, ratio<N2,D2>>::type` is computed, intermediate
-  partially-substituted `ratio<expr, expr>` instances store their `num`/`den` as still-dependent
-  expressions pointing to `__static_abs` helper types. Those helpers in turn store the original
-  `_R1::num`/`_R2::num` as their template arg. The two cycle guards (keyed on TypeInfo* and
-  qualified-id key) detect each individual back-edge but the two-node cycle
-  (`"_R1::num"` ↔ `"__static_abs$xxx::value"`) uses distinct keys, so substitution terminates
-  by returning raw/unresolved args rather than resolved numeric values.
-- **Affected path**: `ExpressionSubstitutor::substituteQualifiedIdentifier` /
-  `materializeStoredTemplateArgs` for intermediate instantiation contexts.
-- **Impact**: `ratio<N,D>::num` and `::den` remain as unresolved dependent expressions in
-  `__ratio_multiply` results; `ratio_equal`, `ratio_less`, etc. cannot be evaluated.
-  This prevents `.o` output for `tests/std/test_std_ratio.cpp` (codegen requires resolved types).
-- **Fix direction**: Track the full two-node cycle by keying both nodes together, or resolve
-  numeric NTTP values eagerly when concrete integer template args are available.
+- **Symptom**: `tests/std/test_std_ratio.cpp` now parses the MSVC `type_traits`
+  helpers and reaches `static_assert(std::ratio_less<third, half>::value)`,
+  where the assertion fails.
+- **Root cause**: Still under investigation. The remaining hard stop is now in
+  ratio comparison value propagation after the dependent member-template
+  argument parsing and deferred-base call-expression blockers are cleared.
+- **Affected path**: ratio comparison constexpr/value propagation for
+  `std::ratio_less` over concrete `ratio<N,D>` instances.
+- **Impact**: `tests/std/test_std_ratio.cpp` still does not produce `.o` output.
+- **Fix direction**: Reproduce the smallest `ratio_less<ratio<1,3>, ratio<1,2>>`
+  value-propagation failure, then fix the remaining concrete ratio comparison
+  evaluation path without reintroducing local parser recovery.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -34,9 +34,10 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 **Current frontier**: The previous `__ratio_less_impl` / remove-cv alias
 instantiation stop, default-NTTP declared-type materialization issue, MSVC
-`type_traits` dependent member-template argument parse failure, and deferred-base
-call-expression invariant are fixed. The first hard blocker currently reaches
-the `std::ratio_less<third, half>` assertion in `test_std_ratio.cpp`.
+`type_traits` dependent member-template argument parse failure, deferred-base
+call-expression invariant, and `std::ratio_less<third, half>` constexpr
+comparison failure are fixed. The first hard blocker currently reaches IR
+conversion for `test_std_ratio.cpp`.
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
@@ -53,17 +54,18 @@ the `std::ratio_less<third, half>` assertion in `test_std_ratio.cpp`.
   default-NTTP/value propagation in ratio arithmetic.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 2b) Residual ratio comparison value propagation
+### 2b) Residual ratio IR conversion failures
 
 - **Symptom**: `tests/std/test_std_ratio.cpp` now parses the MSVC `type_traits`
-  helpers and reaches `static_assert(std::ratio_less<third, half>::value)`,
-  where the assertion fails.
+  helpers and passes `static_assert(std::ratio_less<third, half>::value)`, then
+  fails during IR conversion with missed scalar conversion diagnostics such as
+  `wchar_t -> int`, `char -> int`, and `unsigned long long -> long long`.
 - **Root cause**: Still under investigation. The remaining hard stop is now in
-  ratio comparison value propagation after the dependent member-template
-  argument parsing and deferred-base call-expression blockers are cleared.
-- **Affected path**: ratio comparison constexpr/value propagation for
-  `std::ratio_less` over concrete `ratio<N,D>` instances.
+  IR conversion after the ratio comparison constexpr/value propagation path is
+  evaluable.
+- **Affected path**: IR conversion for standard-header helper functions and
+  namespace-scope initializers reached while compiling `<ratio>`.
 - **Impact**: `tests/std/test_std_ratio.cpp` still does not produce `.o` output.
-- **Fix direction**: Reproduce the smallest `ratio_less<ratio<1,3>, ratio<1,2>>`
-  value-propagation failure, then fix the remaining concrete ratio comparison
-  evaluation path without reintroducing local parser recovery.
+- **Fix direction**: Minimize the new conversion diagnostics from the generated
+  standard-header surface, then fix the missing sema-to-IR scalar conversion
+  handoff without adding local `<ratio>` special cases.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -61,7 +61,7 @@ Useful to know before changing anything:
 
 Validation at this point passed the Windows sharded build and the Windows
 PowerShell test workflow:
-`2450` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2453` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## What is still wrong
 
@@ -93,7 +93,8 @@ Concrete follow-up already identified by recent work:
   cases. The next concrete follow-up is either the remaining dependent-base and
   unknown-specialization member-chain work in declarations that still never
   capture replay metadata at parse time, or the current `<ratio>` blocker where
-  parsing now reaches the older `std::ratio_less` value-propagation frontier.
+  parsing and `std::ratio_less` constexpr comparison now progress to later IR
+  conversion failures.
 
 ### 2. Dependent names are still represented too loosely
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-18
+**Last updated:** 2026-05-19
 
 This document is the short audit for FlashCpp's template infrastructure. Its
 main purpose is to describe what is still structurally wrong, what the next
@@ -52,12 +52,16 @@ Useful to know before changing anything:
 - typed NTTP identity is implemented for integral, enum, `nullptr`, object
   pointer, reference, function pointer, non-null/null member-data pointer, and
   floating-point cases that already materialize as concrete semantic values;
+- default non-type template arguments now materialize with their substituted
+  declared parameter type for covered scalar/enum cases, so
+  `template<class T, T V = 1>` preserves `T=short` instead of storing `V` as
+  `int`;
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
 Validation at this point passed the Windows sharded build and the Windows
 PowerShell test workflow:
-`2437` regular tests compiled/linked/runtime-pass, `182` expected-fail tests.
+`2450` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## What is still wrong
 
@@ -84,9 +88,12 @@ Concrete follow-up already identified by recent work:
   qualified expressions now also keep member-template segment arguments such as
   `Traits<T>::template Box<T>::value` and
   `Traits<T>::template Box<T>::get()` instead of dropping the `Box<T>` segment
-  at parse time. The next concrete follow-up is the remaining dependent-base and
+  at parse time.
+- default NTTP declared-type materialization is now covered for scalar/enum
+  cases. The next concrete follow-up is either the remaining dependent-base and
   unknown-specialization member-chain work in declarations that still never
-  capture replay metadata at parse time.
+  capture replay metadata at parse time, or the current `<ratio>` blocker where
+  parsing now reaches the older `std::ratio_less` value-propagation frontier.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -223,7 +230,10 @@ materially changes what future refactors can assume.
 - member-pointer NTTP mangling now carries richer member-pointer type identity
   (including the declaring class when recoverable), while value encoding still
   intentionally falls back conservatively until a full Itanium external-name
-  form is wired for those values.
+  form is wired for those values;
+- default NTTP values now use the substituted declared parameter type when
+  materialized through the shared default-evaluation paths, preserving identity
+  for cases like `template<class T, T V = 1>` instantiated as `T=short`.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-18
+**Last updated:** 2026-05-19
 
 This document is the execution plan for moving FlashCpp's template
 infrastructure toward C++20 conformance. It intentionally focuses on remaining
@@ -66,11 +66,14 @@ Future work should assume these are already in place:
 - typed NTTP identity already exists for integral, enum, `nullptr`, object
   pointer, reference, function pointer, non-null/null member-data pointer, and
   covered floating-point cases;
+- default NTTP values use the substituted declared parameter type in the shared
+  default-evaluation paths for covered scalar/enum cases, so
+  `template<class T, T V = 1>` preserves the `T` identity after substitution;
 - selected free/member function-template overload paths already rank
   signatures before materializing bodies.
 
 Latest validation on Windows sharded build:
-`2437` regular tests compiled/linked/runtime-pass, `182` expected-fail tests.
+`2450` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -95,13 +98,14 @@ Most concrete next subtask:
   qualified-call records now preserve the instantiated placeholder `owner_type`
   instead of dropping it at parse time. Deferred non-call qualified expressions
   now also preserve deeper member-template segment arguments such as
-  `Traits<T>::template Box<T>::value`. The next concrete gap is still the
-  remaining call-shaped member-template/member-chain cases and the declarations
-  that never capture replay metadata in the first place; current-
-  instantiation/type-alias qualified-id/member chains already reuse the shared
-  member-side lookup/materialization path, and covered replayed qualified-id
-  parsing now preserves both current-instantiation and explicit-template owner
-  identity plus non-call member-template segment metadata.
+  `Traits<T>::template Box<T>::value`, and call-shaped expressions preserve
+  `Traits<T>::template Box<T>::get()`. The next concrete gap is the remaining
+  declarations that never capture replay metadata in the first place, plus
+  dependent-base/unknown-specialization member-chain cases outside the covered
+  replayed static-initializer flows. The current `<ratio>` blocker is also a
+  useful bounded target because parsing now reaches the older `std::ratio_less`
+  value-propagation frontier rather than stopping in the fixed default NTTP
+  declared-type materialization or dependent member-template argument paths.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -73,7 +73,7 @@ Future work should assume these are already in place:
   signatures before materializing bodies.
 
 Latest validation on Windows sharded build:
-`2450` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2453` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -103,9 +103,10 @@ Most concrete next subtask:
   declarations that never capture replay metadata in the first place, plus
   dependent-base/unknown-specialization member-chain cases outside the covered
   replayed static-initializer flows. The current `<ratio>` blocker is also a
-  useful bounded target because parsing now reaches the older `std::ratio_less`
-  value-propagation frontier rather than stopping in the fixed default NTTP
-  declared-type materialization or dependent member-template argument paths.
+  useful bounded target because parsing and `std::ratio_less` constexpr
+  comparison now progress to later IR conversion failures rather than stopping
+  in the fixed default NTTP declared-type materialization or dependent
+  member-template argument paths.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -701,8 +701,12 @@ private:
 
 	// Internal evaluation methods for different node types
 	static EvalResult evaluate_numeric_literal(const NumericLiteralNode& literal);
-	static EvalResult evaluate_binary_operator(const ASTNode& lhs_node, const ASTNode& rhs_node,
-											   std::string_view op, EvaluationContext& context);
+	static EvalResult evaluate_binary_operator(const BinaryOperatorNode& binary_operator, EvaluationContext& context);
+	static std::optional<EvalResult> try_evaluate_constexpr_member_binary_operator(
+		const BinaryOperatorNode& binary_operator,
+		const EvalResult& lhs_result,
+		const EvalResult& rhs_result,
+		EvaluationContext& context);
 	static EvalResult evaluate_unary_operator(const ASTNode& operand_node, std::string_view op,
 											  EvaluationContext& context);
 	// Dereference a constexpr pointer: look up the named variable in the symbol table and evaluate it.

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -1189,8 +1189,10 @@ EvalResult Evaluator::evaluate_binary_operator(const BinaryOperatorNode& binary_
 	const ASTNode& lhs_node = binary_operator.get_lhs();
 	const ASTNode& rhs_node = binary_operator.get_rhs();
 	const std::string_view op = binary_operator.op();
-	// Eagerly evaluate LHS first. For built-in &&/|| outside speculative mode we may
-	// still short-circuit, but overloaded logical operators must evaluate both operands.
+	// Evaluate LHS first so built-in &&/|| can still short-circuit in non-speculative
+	// mode. In speculative mode we avoid early short-circuit to keep both operands
+	// visible to template-argument disambiguation, and overloaded operator&&/operator||
+	// must always evaluate both operands.
 	auto lhs_result = evaluate(lhs_node, context);
 	if (!lhs_result.success()) {
 		return lhs_result;

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -1189,33 +1189,27 @@ EvalResult Evaluator::evaluate_binary_operator(const BinaryOperatorNode& binary_
 	const ASTNode& lhs_node = binary_operator.get_lhs();
 	const ASTNode& rhs_node = binary_operator.get_rhs();
 	const std::string_view op = binary_operator.op();
-	// Short-circuit && and || per C++ semantics when not in speculative mode.
-	// In speculative mode (template-argument disambiguation), both sides are evaluated
-	// eagerly so that a truthy LHS of `||` does not give a false-positive constant-
-	// expression result that would confuse the `<` disambiguation heuristic.
-	if (!context.is_speculative && (op == "&&" || op == "||")) {
-		auto lhs_result = evaluate(lhs_node, context);
-		if (!lhs_result.success())
-			return lhs_result;
-		const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
-		if (op == "&&" && !lhs_bool)
-			return EvalResult::from_bool(false);
-		if (op == "||" && lhs_bool)
-			return EvalResult::from_bool(true);
-		auto rhs_result = evaluate(rhs_node, context);
-		if (!rhs_result.success())
-			return rhs_result;
-		const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
-		return EvalResult::from_bool(rhs_bool);
-	}
-
-	// Eagerly evaluate both sides (required in speculative mode, or for non-logical ops)
+	// Eagerly evaluate LHS first. For built-in &&/|| outside speculative mode we may
+	// still short-circuit, but overloaded logical operators must evaluate both operands.
 	auto lhs_result = evaluate(lhs_node, context);
-	auto rhs_result = evaluate(rhs_node, context);
-
 	if (!lhs_result.success()) {
 		return lhs_result;
 	}
+
+	if (!context.is_speculative && (op == "&&" || op == "||")) {
+		const bool lhs_has_overloaded_logical =
+			binary_operator.has_resolved_operator_overload() ||
+			lhs_result.object_type_index.is_valid();
+		if (!lhs_has_overloaded_logical) {
+			const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+			if (op == "&&" && !lhs_bool)
+				return EvalResult::from_bool(false);
+			if (op == "||" && lhs_bool)
+				return EvalResult::from_bool(true);
+		}
+	}
+
+	auto rhs_result = evaluate(rhs_node, context);
 	if (!rhs_result.success()) {
 		return rhs_result;
 	}
@@ -1223,6 +1217,11 @@ EvalResult Evaluator::evaluate_binary_operator(const BinaryOperatorNode& binary_
 	if (auto member_operator_result =
 			try_evaluate_constexpr_member_binary_operator(binary_operator, lhs_result, rhs_result, context)) {
 		return *member_operator_result;
+	}
+	if (op == "&&" || op == "||") {
+		const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+		const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
+		return EvalResult::from_bool(op == "&&" ? (lhs_bool && rhs_bool) : (lhs_bool || rhs_bool));
 	}
 
 	return apply_binary_op(lhs_result, rhs_result, op, &context);

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -924,7 +924,7 @@ EvalResult Evaluator::evaluate(const ASTNode& expr_node, EvaluationContext& cont
 
 	// For BinaryOperatorNode, we need to check if it's in the variant
 	if (const auto* bin_op = std::get_if<BinaryOperatorNode>(&expr)) {
-		return evaluate_binary_operator(bin_op->get_lhs(), bin_op->get_rhs(), bin_op->op(), context);
+		return evaluate_binary_operator(*bin_op, context);
 	}
 
 	// For UnaryOperatorNode
@@ -1185,8 +1185,10 @@ EvalResult Evaluator::evaluate_numeric_literal(const NumericLiteralNode& literal
 	return EvalResult::error("Unknown numeric literal type");
 }
 
-EvalResult Evaluator::evaluate_binary_operator(const ASTNode& lhs_node, const ASTNode& rhs_node,
-											   std::string_view op, EvaluationContext& context) {
+EvalResult Evaluator::evaluate_binary_operator(const BinaryOperatorNode& binary_operator, EvaluationContext& context) {
+	const ASTNode& lhs_node = binary_operator.get_lhs();
+	const ASTNode& rhs_node = binary_operator.get_rhs();
+	const std::string_view op = binary_operator.op();
 	// Short-circuit && and || per C++ semantics when not in speculative mode.
 	// In speculative mode (template-argument disambiguation), both sides are evaluated
 	// eagerly so that a truthy LHS of `||` does not give a false-positive constant-
@@ -1218,7 +1220,55 @@ EvalResult Evaluator::evaluate_binary_operator(const ASTNode& lhs_node, const AS
 		return rhs_result;
 	}
 
+	if (auto member_operator_result =
+			try_evaluate_constexpr_member_binary_operator(binary_operator, lhs_result, rhs_result, context)) {
+		return *member_operator_result;
+	}
+
 	return apply_binary_op(lhs_result, rhs_result, op, &context);
+}
+
+std::optional<EvalResult> Evaluator::try_evaluate_constexpr_member_binary_operator(
+	const BinaryOperatorNode& binary_operator,
+	const EvalResult& lhs_result,
+	const EvalResult& rhs_result,
+	EvaluationContext& context) {
+	if (lhs_result.object_type_index.is_valid()) {
+		const TypeInfo* type_info = tryGetTypeInfo(lhs_result.object_type_index);
+		const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
+		if (struct_info) {
+			const FunctionDeclarationNode* function = nullptr;
+			if (binary_operator.has_resolved_member_operator_overload()) {
+				const StructMemberFunction* member_overload = binary_operator.resolved_member_operator_overload();
+				if (member_overload && member_overload->function_decl.is<FunctionDeclarationNode>()) {
+					function = &member_overload->function_decl.as<FunctionDeclarationNode>();
+				}
+			} else {
+				StringBuilder operator_name_builder;
+				operator_name_builder.append("operator").append(overloadableOperatorToString(binary_operator.operator_kind()));
+				StringHandle operator_name = StringTable::getOrInternStringHandle(operator_name_builder.commit());
+				ResolvedMemberFunctionCandidate candidate =
+					findConstexprOperatorOverload(struct_info, operator_name, 1, context);
+				if (candidate.ambiguous) {
+					return EvalResult::error("Ambiguous binary operator overload in constant expression");
+				}
+				function = candidate.function;
+			}
+			if (function) {
+				return invokeConstexprMemberFunction(
+					*function,
+					lhs_result.object_member_bindings,
+					lhs_result.object_type_index,
+					type_info,
+					struct_info,
+					{rhs_result},
+					context,
+					"binary operator body is not a block",
+					"binary operator did not return a value");
+			}
+		}
+	}
+	return std::nullopt;
 }
 
 EvalResult Evaluator::evaluate_unary_operator(const ASTNode& operand_node, std::string_view op,

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -3591,36 +3591,35 @@ EvalResult Evaluator::evaluate_expression_with_bindings(
 		}
 
 		// Regular binary operators (non-assignment)
-		// Short-circuit && and || per C++ semantics: evaluate LHS first, skip RHS
-		// when the result is already determined.  This is critical for guard patterns
-		// like `p && *p` where the RHS must not be evaluated when LHS is falsy.
-		if (op == "&&" || op == "||") {
-			auto lhs_result = evaluate_expression_with_bindings(bin_op.get_lhs(), bindings, context);
-			if (!lhs_result.success())
-				return lhs_result;
-			const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
-			if (op == "&&" && !lhs_bool)
-				return EvalResult::from_bool(false);
-			if (op == "||" && lhs_bool)
-				return EvalResult::from_bool(true);
-			auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);
-			if (!rhs_result.success())
-				return rhs_result;
-			const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
-			return EvalResult::from_bool(rhs_bool);
-		}
-
 		auto lhs_result = evaluate_expression_with_bindings(bin_op.get_lhs(), bindings, context);
-		auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);
-
 		if (!lhs_result.success())
 			return lhs_result;
+
+		if (op == "&&" || op == "||") {
+			const bool lhs_has_overloaded_logical =
+				bin_op.has_resolved_operator_overload() ||
+				lhs_result.object_type_index.is_valid();
+			if (!lhs_has_overloaded_logical) {
+				const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+				if (op == "&&" && !lhs_bool)
+					return EvalResult::from_bool(false);
+				if (op == "||" && lhs_bool)
+					return EvalResult::from_bool(true);
+			}
+		}
+
+		auto rhs_result = evaluate_expression_with_bindings(bin_op.get_rhs(), bindings, context);
 		if (!rhs_result.success())
 			return rhs_result;
 
 		if (auto member_operator_result =
 				try_evaluate_constexpr_member_binary_operator(bin_op, lhs_result, rhs_result, context)) {
 			return *member_operator_result;
+		}
+		if (op == "&&" || op == "||") {
+			const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+			const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
+			return EvalResult::from_bool(op == "&&" ? (lhs_bool && rhs_bool) : (lhs_bool || rhs_bool));
 		}
 
 		return apply_binary_op(lhs_result, rhs_result, bin_op.op(), &context, &bindings);
@@ -3893,30 +3892,36 @@ EvalResult Evaluator::evaluate_expression_with_bindings_dispatch(
 		const auto& bin_op = std::get<BinaryOperatorNode>(expr);
 		std::string_view op = bin_op.op();
 
-		// Short-circuit && and || per C++ semantics (see mutable-bindings path above).
-		if (op == "&&" || op == "||") {
-			auto lhs_result = recursive_eval(bin_op.get_lhs(), bindings, context);
-			if (!lhs_result.success())
-				return lhs_result;
-			const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
-			if (op == "&&" && !lhs_bool)
-				return EvalResult::from_bool(false);
-			if (op == "||" && lhs_bool)
-				return EvalResult::from_bool(true);
-			auto rhs_result = recursive_eval(bin_op.get_rhs(), bindings, context);
-			if (!rhs_result.success())
-				return rhs_result;
-			const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
-			return EvalResult::from_bool(rhs_bool);
-		}
-
 		auto lhs_result = recursive_eval(bin_op.get_lhs(), bindings, context);
-		auto rhs_result = recursive_eval(bin_op.get_rhs(), bindings, context);
-
 		if (!lhs_result.success())
 			return lhs_result;
+
+		if (op == "&&" || op == "||") {
+			const bool lhs_has_overloaded_logical =
+				bin_op.has_resolved_operator_overload() ||
+				lhs_result.object_type_index.is_valid();
+			if (!lhs_has_overloaded_logical) {
+				const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+				if (op == "&&" && !lhs_bool)
+					return EvalResult::from_bool(false);
+				if (op == "||" && lhs_bool)
+					return EvalResult::from_bool(true);
+			}
+		}
+
+		auto rhs_result = recursive_eval(bin_op.get_rhs(), bindings, context);
 		if (!rhs_result.success())
 			return rhs_result;
+
+		if (auto member_operator_result =
+				try_evaluate_constexpr_member_binary_operator(bin_op, lhs_result, rhs_result, context)) {
+			return *member_operator_result;
+		}
+		if (op == "&&" || op == "||") {
+			const bool lhs_bool = lhs_result.pointer_to_var.isValid() ? true : lhs_result.as_bool();
+			const bool rhs_bool = rhs_result.pointer_to_var.isValid() ? true : rhs_result.as_bool();
+			return EvalResult::from_bool(op == "&&" ? (lhs_bool && rhs_bool) : (lhs_bool || rhs_bool));
+		}
 
 		return apply_binary_op(lhs_result, rhs_result, bin_op.op(), &context, &bindings);
 	}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -3618,6 +3618,11 @@ EvalResult Evaluator::evaluate_expression_with_bindings(
 		if (!rhs_result.success())
 			return rhs_result;
 
+		if (auto member_operator_result =
+				try_evaluate_constexpr_member_binary_operator(bin_op, lhs_result, rhs_result, context)) {
+			return *member_operator_result;
+		}
+
 		return apply_binary_op(lhs_result, rhs_result, bin_op.op(), &context, &bindings);
 	}
 
@@ -5258,6 +5263,15 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 				if (type_info && type_info->isStruct()) {
 					struct_info = type_info->getStructInfo();
 					resolved_type_info = type_info;
+				} else if (type_info) {
+					if (const EnumTypeInfo* enum_info = type_info->getEnumInfo()) {
+						if (auto enum_result = tryEvaluateEnumConstant(
+								*enum_info,
+								type_info->type_index_,
+								qualified_id.nameHandle())) {
+							return *enum_result;
+						}
+					}
 				}
 			}
 

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1119,6 +1119,7 @@ private:
 	// Add parsing depth counter to detect infinite loops
 	// This is incremented/decremented in critical parsing functions
 	size_t parsing_depth_ = 0;
+	bool parsing_alias_type_id_ = false;
 	static constexpr size_t MAX_PARSING_DEPTH = 500;	 // Reasonable limit for nested parsing
 	std::vector<std::string_view> template_param_names_;	 // Template parameter names in current scope
 

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -834,6 +834,8 @@ ParseResult Parser::parse_using_directive_or_declaration() {
 			SaveHandle alias_target_start = save_token_position();
 
 			// Try to parse as a type specifier (for type aliases like: using value_type = T;)
+			FlashCpp::ScopedState alias_type_id_guard(parsing_alias_type_id_);
+			parsing_alias_type_id_ = true;
 			ParseResult type_result = parse_type_specifier();
 			if (!type_result.is_error()) {
 				// Parse any pointer/reference modifiers after the type

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -271,6 +271,8 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 		advance(); // consume '='
 
 		// Parse the type
+		FlashCpp::ScopedState alias_type_id_guard(parsing_alias_type_id_);
+		parsing_alias_type_id_ = true;
 		auto type_result = parse_type_specifier();
 		if (type_result.is_error()) {
 			return type_result;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -873,6 +873,8 @@ ParseResult Parser::parse_template_declaration() {
 		auto target_type_start_pos = save_token_position();
 
 		// Parse the target type
+		FlashCpp::ScopedState alias_type_id_guard(parsing_alias_type_id_);
+		parsing_alias_type_id_ = true;
 		ParseResult type_result = parse_type_specifier();
 		if (type_result.is_error()) {
 			return type_result;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -6804,6 +6804,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								}
 							}
 
+							ExpressionSubstitutor substitutor(subst_map, *this, template_param_order);
+							ASTNode substituted_node = substitutor.substitute(arg_info.node);
+							if (auto value = try_evaluate_constant_expression(substituted_node)) {
+								FLASH_LOG_FORMAT(Templates, Debug, "Evaluated substituted deferred base call to value {}", value->value);
+								resolved_args.push_back(makeEvaluatedDeferredBaseValueArg(*value));
+								continue;
+							}
+
 							throw InternalError("Deferred base arguments should be resolved by specialized handlers");
 						} else if (std::holds_alternative<BinaryOperatorNode>(expr) || std::holds_alternative<TernaryOperatorNode>(expr)) {
 							// Handle binary/ternary operator expressions like: R1<T>::num < R2<T>::num

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1509,6 +1509,30 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 			}
 
 			if (peek() == ">"_tok || peek() == ","_tok) {
+				if (parsing_alias_type_id_ &&
+					(gTemplateRegistry.lookup_alias_template(identifier_handle).has_value() ||
+					 gTemplateRegistry.lookupTemplate(identifier_handle).has_value() ||
+					 gTemplateRegistry.isClassTemplate(identifier_handle) ||
+					 (currentTemplateParamKind(identifier_handle).has_value() &&
+					  *currentTemplateParamKind(identifier_handle) == TemplateParameterKind::Template))) {
+					TemplateTypeArg template_arg = TemplateTypeArg::makeTemplate(identifier_handle);
+					template_arg.is_pack = is_pack_expansion;
+					template_args.push_back(template_arg);
+					if (out_type_nodes) {
+						out_type_nodes->push_back(ASTNode::emplace_node<ExpressionNode>(IdentifierNode(identifier_token)));
+					}
+					discard_saved_token(identifier_saved_pos);
+					discard_saved_token(arg_saved_pos);
+
+					if (peek() == ">"_tok) {
+						advance();
+						break;
+					}
+
+					advance();
+					continue;
+				}
+
 				auto [simple_identifier_kind, prebuilt_arg] = classifySimpleTemplateArgName(identifier_handle);
 				if (simple_identifier_kind == SimpleTemplateArgKind::ValueLike) {
 					// Use the concrete arg returned by the classify call (avoids a second loop over

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -561,8 +561,12 @@ ParseResult Parser::parse_type_specifier() {
 
 	auto diagnoseMissingTypenameForDependentOwner =
 		[&](TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
-			const Token& diagnostic_token) -> std::optional<ParseResult> {
-		if (saw_typename_keyword || !dependentQualifiedOwnerNeedsTypename(owner_kind)) {
+			const Token& diagnostic_token,
+			bool allow_member_template_type_id) -> std::optional<ParseResult> {
+		if (saw_typename_keyword ||
+			parsing_alias_type_id_ ||
+			allow_member_template_type_id ||
+			!dependentQualifiedOwnerNeedsTypename(owner_kind)) {
 			return std::nullopt;
 		}
 		StringBuilder message_builder;
@@ -1235,7 +1239,8 @@ ParseResult Parser::parse_type_specifier() {
 				if (is_dependent_qualified_type) {
 					if (auto typename_error = diagnoseMissingTypenameForDependentOwner(
 							TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
-							last_qualified_token);
+							last_qualified_token,
+							false);
 						typename_error.has_value()) {
 						return *typename_error;
 					}
@@ -2258,7 +2263,8 @@ ParseResult Parser::parse_type_specifier() {
 						if (auto typename_error =
 								diagnoseMissingTypenameForDependentOwner(
 									owner_kind,
-									type_name_token);
+									type_name_token,
+									had_template_keyword && dependent_member_template_args.has_value());
 							typename_error.has_value()) {
 							return *typename_error;
 						}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2264,7 +2264,9 @@ ParseResult Parser::parse_type_specifier() {
 								diagnoseMissingTypenameForDependentOwner(
 									owner_kind,
 									type_name_token,
-									had_template_keyword && dependent_member_template_args.has_value());
+									parsing_alias_type_id_ &&
+										had_template_keyword &&
+										dependent_member_template_args.has_value());
 							typename_error.has_value()) {
 							return *typename_error;
 						}

--- a/tests/test_constexpr_member_operator_less_ret0.cpp
+++ b/tests/test_constexpr_member_operator_less_ret0.cpp
@@ -1,0 +1,21 @@
+struct Big {
+	unsigned long long upper;
+	unsigned long long lower;
+
+	constexpr bool operator<(Big rhs) const {
+		if (upper != rhs.upper) {
+			return upper < rhs.upper;
+		}
+		return lower < rhs.lower;
+	}
+};
+
+constexpr Big makeBig(unsigned long long value) {
+	return {0, value};
+}
+
+static_assert(makeBig(2) < makeBig(3));
+
+int main() {
+	return 0;
+}

--- a/tests/test_constexpr_ratio_like_member_operator_ret0.cpp
+++ b/tests/test_constexpr_ratio_like_member_operator_ret0.cpp
@@ -1,0 +1,70 @@
+struct Big {
+	unsigned long long upper;
+	unsigned long long lower;
+
+	constexpr bool operator<(Big rhs) const {
+		if (upper != rhs.upper) {
+			return upper < rhs.upper;
+		}
+		return lower < rhs.lower;
+	}
+};
+
+constexpr Big bigMultiply(unsigned long long left, unsigned long long right) {
+	const unsigned long long leftLow = left & 0xFFFFFFFFULL;
+	const unsigned long long leftHigh = left >> 32;
+	const unsigned long long rightLow = right & 0xFFFFFFFFULL;
+	const unsigned long long rightHigh = right >> 32;
+
+	const unsigned long long productLow = leftLow * rightLow;
+	const unsigned long long productMiddle1 = leftHigh * rightLow;
+	const unsigned long long productMiddle2 = leftLow * rightHigh;
+	const unsigned long long productHigh = leftHigh * rightHigh;
+
+	const unsigned long long carry = ((productLow >> 32) + (productMiddle1 & 0xFFFFFFFFULL) + (productMiddle2 & 0xFFFFFFFFULL)) >> 32;
+
+	return {productHigh + (productMiddle1 >> 32) + (productMiddle2 >> 32) + carry, productLow + (productMiddle1 << 32) + (productMiddle2 << 32)};
+}
+
+constexpr bool ratioLess(long long nx1, long long dx1, long long nx2, long long dx2) {
+	if (nx1 >= 0 && nx2 >= 0) {
+		return bigMultiply(static_cast<unsigned long long>(nx1), static_cast<unsigned long long>(dx2))
+			< bigMultiply(static_cast<unsigned long long>(nx2), static_cast<unsigned long long>(dx1));
+	}
+	return nx1 < nx2;
+}
+
+constexpr bool lessWithParams(unsigned long long lhs, unsigned long long rhs) {
+	return lhs < rhs;
+}
+
+constexpr bool nonNegative(long long lhs, long long rhs) {
+	return lhs >= 0 && rhs >= 0;
+}
+
+constexpr bool castLess(long long lhs, long long rhs) {
+	return static_cast<unsigned long long>(lhs) < static_cast<unsigned long long>(rhs);
+}
+
+constexpr bool castBigLess(long long lhs, long long rhs) {
+	return bigMultiply(1, static_cast<unsigned long long>(lhs)) < bigMultiply(1, static_cast<unsigned long long>(rhs));
+}
+
+constexpr bool crossBigLess(long long nx1, long long dx1, long long nx2, long long dx2) {
+	return bigMultiply(static_cast<unsigned long long>(nx1), static_cast<unsigned long long>(dx2))
+		< bigMultiply(static_cast<unsigned long long>(nx2), static_cast<unsigned long long>(dx1));
+}
+
+static_assert(bigMultiply(1, 2).lower == 2);
+static_assert(bigMultiply(1, 3).lower == 3);
+static_assert(bigMultiply(1, 2) < bigMultiply(1, 3));
+static_assert(lessWithParams(2, 3));
+static_assert(nonNegative(1, 1));
+static_assert(castLess(2, 3));
+static_assert(castBigLess(2, 3));
+static_assert(crossBigLess(1, 3, 1, 2));
+static_assert(ratioLess(1, 3, 1, 2));
+
+int main() {
+	return 0;
+}

--- a/tests/test_constexpr_ratio_like_member_operator_ret0.cpp
+++ b/tests/test_constexpr_ratio_like_member_operator_ret0.cpp
@@ -64,6 +64,10 @@ static_assert(castLess(2, 3));
 static_assert(castBigLess(2, 3));
 static_assert(crossBigLess(1, 3, 1, 2));
 static_assert(ratioLess(1, 3, 1, 2));
+static_assert(castLess(static_cast<char>(2), static_cast<wchar_t>(3)));
+static_assert(crossBigLess(
+	static_cast<unsigned short>(1), static_cast<unsigned short>(3),
+	static_cast<unsigned int>(1), static_cast<unsigned int>(2)));
 
 int main() {
 	return 0;

--- a/tests/test_static_constexpr_enum_class_member_ret0.cpp
+++ b/tests/test_static_constexpr_enum_class_member_ret0.cpp
@@ -1,0 +1,14 @@
+enum class Strategy {
+	Functor,
+	Member
+};
+
+struct Invoker {
+	static constexpr Strategy strategy = Strategy::Member;
+};
+
+static_assert(Invoker::strategy == Strategy::Member);
+
+int main() {
+	return 0;
+}

--- a/tests/test_template_template_alias_argument_ret0.cpp
+++ b/tests/test_template_template_alias_argument_ret0.cpp
@@ -1,0 +1,19 @@
+template <bool>
+struct Select;
+
+template <>
+struct Select<true> {
+	template <template <class> class Function, class Type>
+	using Apply = typename Function<Type>::type;
+};
+
+template <class Type>
+struct Wrap {
+	using type = Type;
+};
+
+using Result = typename Select<true>::template Apply<Wrap, int>;
+
+int main() {
+	return 0;
+}


### PR DESCRIPTION
## Summary
- parse bare alias/function/class template names as template-template arguments in alias type-id contexts, including member aliases
- keep missing-`typename` recovery scoped to alias type-ids while preserving expected diagnostics elsewhere
- evaluate substituted deferred-base call arguments and constexpr member binary operators, including bound function-body expressions
- add reducers for alias template-template arguments, constexpr member `operator<`, ratio-like 128-bit comparison, and enum-class static constexpr members
- update template-argument docs and known `<ratio>` frontier

## Validation
- `clang++ -std=c++20 -fsyntax-only tests\test_constexpr_member_operator_less_ret0.cpp tests\test_constexpr_ratio_like_member_operator_ret0.cpp tests\test_static_constexpr_enum_class_member_ret0.cpp`
- `pwsh -File tests\run_all_tests.ps1 test_constexpr_member_operator_less_ret0.cpp test_constexpr_ratio_like_member_operator_ret0.cpp test_static_constexpr_enum_class_member_ret0.cpp test_std_ratio.cpp` (new reducers pass; `test_std_ratio.cpp` now reaches later IR conversion failures)
- `git --no-pager diff --check origin/main...HEAD`
- `pwsh -File tests\run_all_tests.ps1` (2453 regular, 181 expected-fail)

## Current frontier
`tests/std/test_std_ratio.cpp` now passes the former dependent member-template parser blocker and `std::ratio_less<third, half>` constexpr assertion. The next blocker is later IR conversion for standard-header helper code, with missed scalar conversion diagnostics such as `wchar_t -> int`, `char -> int`, and `unsigned long long -> long long`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated known issues with latest test progress and IR conversion status
  * Refreshed template conformance documentation with current test counts

* **New Features**
  * Added support for constexpr evaluation of member binary operators
  * Enhanced template alias parsing for improved argument resolution
  * Improved enum-type constant expression evaluation

* **Tests**
  * Added new tests for constexpr member operators and advanced comparisons
  * Added tests for static constexpr enum class members and template-template alias arguments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GregorGullwi/FlashCpp/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->