### PR TITLE
Fix ratio pointer/null and CRT linkage frontiers

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -23,23 +23,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 2) `tests/std/test_std_ratio.cpp` — now reaches a link-time `__security_cookie` conflict
-
-**Status**: Crash (SIGSEGV/exit 139) fixed. Two root-cause bugs were fixed:
-
-1. **Infinite mutual recursion** between `materializeStoredTemplateArgs` and
-   `substituteQualifiedIdentifier` (cycle guards added in `ExpressionSubstitutor`).
-2. **Explicit template type args ignored** for zero-param function template calls in
-   the constexpr evaluator (`ConstExprEvaluator_Core.cpp`).
-
-**Current frontier**: The previous `__ratio_less_impl` / remove-cv alias
-instantiation stop, default-NTTP declared-type materialization issue, MSVC
-`type_traits` dependent member-template argument parse failure, deferred-base
-call-expression invariant, `std::ratio_less<third, half>` constexpr
-comparison failure, the later pointer/null IR-conversion failures in
-`wcsnlen_s` / `strnlen_s`, and the link-time unresolved CRT helper symbols are
-fixed. On current `main`, `test_std_ratio.cpp` now compiles and links further
-before stopping on a multiply defined `__security_cookie`.
+## 2) `tests/std/test_std_ratio.cpp` — link-time `__security_cookie` conflict
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
@@ -49,11 +33,10 @@ before stopping on a multiply defined `__security_cookie`.
   `[ERROR][Templates] [depth=1]: All 2 template overload(s) failed for 'swap'`,
   the same error for `std::swap`, and
   `[ERROR][Templates] [depth=1]: All 1 template overload(s) failed for '_Hash_representation'`
-  before the later IR-conversion failure.
+  before the later link failure.
 - **Root cause**: still under investigation. These diagnostics appear during
-  standard-header template processing after the earlier dependent member-template
-  parse failure was fixed, but they are not the first fatal stop in the
-  compilation.
+  standard-header template processing, but they are not the first fatal stop in
+  the compilation.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
 ### 2b) Link-time `__security_cookie` multiple-definition conflict
@@ -61,10 +44,8 @@ before stopping on a multiply defined `__security_cookie`.
 - **Symptom**: `tests/std/test_std_ratio.cpp` now compiles successfully but
   fails to link with `LIBCMT.lib(gs_cookie.obj) : error LNK2005:
   __security_cookie already defined`.
-- **Root cause**: Still under investigation. After fixing the imported-CRT
-  naming issue (preserving `extern "C"` over `_ACRTIMP`/`dllimport` in parser
-  linkage precedence), the next remaining blocker is that FlashCpp's output now
-  collides with the CRT-provided GS cookie symbol.
+- **Root cause**: Still under investigation. FlashCpp's output now collides
+  with the CRT-provided GS cookie symbol.
 - **Affected path**: Link stage for the object generated from `<ratio>` and the
   headers it pulls in.
 - **Impact**: `tests/std/test_std_ratio.cpp` still does not produce a runnable

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -23,7 +23,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 2) `tests/std/test_std_ratio.cpp` — now reaches link-time unresolved CRT symbols
+## 2) `tests/std/test_std_ratio.cpp` — now reaches a link-time `__security_cookie` conflict
 
 **Status**: Crash (SIGSEGV/exit 139) fixed. Two root-cause bugs were fixed:
 
@@ -36,10 +36,10 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 instantiation stop, default-NTTP declared-type materialization issue, MSVC
 `type_traits` dependent member-template argument parse failure, deferred-base
 call-expression invariant, `std::ratio_less<third, half>` constexpr
-comparison failure, and the later pointer/null IR-conversion failures in
-`wcsnlen_s` / `strnlen_s` are fixed. On current `main`, `test_std_ratio.cpp`
-now compiles through IR generation and instead stops at link time on unresolved
-CRT helper symbols.
+comparison failure, the later pointer/null IR-conversion failures in
+`wcsnlen_s` / `strnlen_s`, and the link-time unresolved CRT helper symbols are
+fixed. On current `main`, `test_std_ratio.cpp` now compiles and links further
+before stopping on a multiply defined `__security_cookie`.
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
@@ -56,19 +56,19 @@ CRT helper symbols.
   compilation.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 2b) Link-time unresolved CRT/UCRT helper symbols
+### 2b) Link-time `__security_cookie` multiple-definition conflict
 
 - **Symptom**: `tests/std/test_std_ratio.cpp` now compiles successfully but
-  fails to link with unresolved externals such as `wcstok`, `wcspbrk`,
-  `strnlen`, and `strpbrk`.
-- **Root cause**: Still under investigation. The remaining blocker has moved
-  beyond sema/IR conversion and now appears to be missing runtime or import
-  coverage for CRT/UCRT helpers referenced by the instantiated standard-library
-  surface.
+  fails to link with `LIBCMT.lib(gs_cookie.obj) : error LNK2005:
+  __security_cookie already defined`.
+- **Root cause**: Still under investigation. After fixing the imported-CRT
+  naming issue (preserving `extern "C"` over `_ACRTIMP`/`dllimport` in parser
+  linkage precedence), the next remaining blocker is that FlashCpp's output now
+  collides with the CRT-provided GS cookie symbol.
 - **Affected path**: Link stage for the object generated from `<ratio>` and the
   headers it pulls in.
 - **Impact**: `tests/std/test_std_ratio.cpp` still does not produce a runnable
   executable, even though it now compiles.
-- **Fix direction**: Audit the unresolved functions to determine whether
-  FlashCpp should emit/import them differently or whether the Windows link step
-  is currently missing required CRT coverage for these overloads/vararg forms.
+- **Fix direction**: Audit where FlashCpp synthesizes or exports the GS cookie
+  runtime state and make it coexist with the CRT-provided definition instead of
+  emitting a second strong symbol.

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -23,7 +23,7 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 2) `tests/std/test_std_ratio.cpp` — no `.o` output and residual diagnostic noise
+## 2) `tests/std/test_std_ratio.cpp` — now reaches link-time unresolved CRT symbols
 
 **Status**: Crash (SIGSEGV/exit 139) fixed. Two root-cause bugs were fixed:
 
@@ -35,37 +35,40 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 **Current frontier**: The previous `__ratio_less_impl` / remove-cv alias
 instantiation stop, default-NTTP declared-type materialization issue, MSVC
 `type_traits` dependent member-template argument parse failure, deferred-base
-call-expression invariant, and `std::ratio_less<third, half>` constexpr
-comparison failure are fixed. The first hard blocker currently reaches IR
-conversion for `test_std_ratio.cpp`.
+call-expression invariant, `std::ratio_less<third, half>` constexpr
+comparison failure, and the later pointer/null IR-conversion failures in
+`wcsnlen_s` / `strnlen_s` are fixed. On current `main`, `test_std_ratio.cpp`
+now compiles through IR generation and instead stops at link time on unresolved
+CRT helper symbols.
 
 **Remaining blockers** (non-crashing, but prevent `.o` output):
 
-### 2a) `std::__are_both_ratios` parse-time instantiation failure (expected noise)
+### 2a) Standard-library template-instantiation noise during `<ratio>` compile
 
-- **Symptom**: `[WARN][Parser] Parsed template arguments but instantiation failed for 'std::__are_both_ratios'`
-  followed by `[ERROR][Templates] All 1 template overload(s) failed for '__are_both_ratios'` — appears
-  4 times during `__ratio_multiply`/`ratio_equal` template body parsing.
-- **Root cause**: The parser speculatively tries to instantiate `__are_both_ratios<_R1, _R2>` at
-  template-body parse time, when `_R1` and `_R2` are still dependent type parameters.
-  `try_instantiate_template_explicit` has an early-out for dependent args (correct behaviour).
-  The errors are non-fatal and the constexpr evaluator path correctly handles
-  them via the explicit-type-args fix above; the current hard stop is later
-  IR conversion for `<ratio>` helpers after constexpr ratio comparison succeeds.
+- **Symptom**: compiling `tests/std/test_std_ratio.cpp` now emits
+  `[ERROR][Templates] [depth=1]: All 2 template overload(s) failed for 'swap'`,
+  the same error for `std::swap`, and
+  `[ERROR][Templates] [depth=1]: All 1 template overload(s) failed for '_Hash_representation'`
+  before the later IR-conversion failure.
+- **Root cause**: still under investigation. These diagnostics appear during
+  standard-header template processing after the earlier dependent member-template
+  parse failure was fixed, but they are not the first fatal stop in the
+  compilation.
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
-### 2b) Residual ratio IR conversion failures
+### 2b) Link-time unresolved CRT/UCRT helper symbols
 
-- **Symptom**: `tests/std/test_std_ratio.cpp` now parses the MSVC `type_traits`
-  helpers and passes `static_assert(std::ratio_less<third, half>::value)`, then
-  fails during IR conversion with missed scalar conversion diagnostics such as
-  `wchar_t -> int`, `char -> int`, and `unsigned long long -> long long`.
-- **Root cause**: Still under investigation. The remaining hard stop is now in
-  IR conversion after the ratio comparison constexpr/value propagation path is
-  evaluable.
-- **Affected path**: IR conversion for standard-header helper functions and
-  namespace-scope initializers reached while compiling `<ratio>`.
-- **Impact**: `tests/std/test_std_ratio.cpp` still does not produce `.o` output.
-- **Fix direction**: Minimize the new conversion diagnostics from the generated
-  standard-header surface, then fix the missing sema-to-IR scalar conversion
-  handoff without adding local `<ratio>` special cases.
+- **Symptom**: `tests/std/test_std_ratio.cpp` now compiles successfully but
+  fails to link with unresolved externals such as `wcstok`, `wcspbrk`,
+  `strnlen`, and `strpbrk`.
+- **Root cause**: Still under investigation. The remaining blocker has moved
+  beyond sema/IR conversion and now appears to be missing runtime or import
+  coverage for CRT/UCRT helpers referenced by the instantiated standard-library
+  surface.
+- **Affected path**: Link stage for the object generated from `<ratio>` and the
+  headers it pulls in.
+- **Impact**: `tests/std/test_std_ratio.cpp` still does not produce a runnable
+  executable, even though it now compiles.
+- **Fix direction**: Audit the unresolved functions to determine whether
+  FlashCpp should emit/import them differently or whether the Windows link step
+  is currently missing required CRT coverage for these overloads/vararg forms.

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1186,6 +1186,9 @@ private:
 	static bool shouldPreferExpressionReturnType(
 		const TypeSpecifierNode& expr_type,
 		const TypeSpecifierNode& decl_type);
+	static bool isNullPointerConstantExpr(
+		const ExprResult& expr_result,
+		const ASTNode& node);
 
 	/// Emit a Dereference IR instruction and return the result TempVar holding the loaded value.
 	TempVar emitDereference(TypeCategory pointee_type, int pointer_size_bits, int pointer_depth, IrValue pointer_value, Token token = Token());

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -2906,6 +2906,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 	// Try to get pointer depth for pointer arithmetic
 	int lhs_pointer_depth = 0;
 	const TypeSpecifierNode* lhs_type_node = nullptr;
+	std::optional<TypeSpecifierNode> lhs_fallback_type_node;
 	if (binaryOperatorNode.get_lhs().is<ExpressionNode>()) {
 		const ExpressionNode& lhs_expr = binaryOperatorNode.get_lhs().as<ExpressionNode>();
 		if (std::holds_alternative<IdentifierNode>(lhs_expr)) {
@@ -2939,10 +2940,18 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 	if (lhs_pointer_depth == 0) {
 		lhs_pointer_depth = lhsExprResult.pointer_depth.value;
 	}
+	if (lhs_pointer_depth == 0) {
+		TypeSpecifierQueryResult lhs_type_query = sema_.parserSemanticServices().getExpressionTypeQuery(binaryOperatorNode.get_lhs());
+		if (lhs_type_query.state == TypeSpecifierQueryResult::State::Available &&
+			lhs_type_query.type.has_value()) {
+			lhs_pointer_depth = static_cast<int>(lhs_type_query.type->pointer_depth());
+		}
+	}
 
 	// Try to get pointer depth and type node for RHS as well (for ptr - ptr and int + ptr)
 	int rhs_pointer_depth = 0;
 	const TypeSpecifierNode* rhs_type_node = nullptr;
+	std::optional<TypeSpecifierNode> rhs_fallback_type_node;
 	if (binaryOperatorNode.get_rhs().is<ExpressionNode>()) {
 		const ExpressionNode& rhs_expr = binaryOperatorNode.get_rhs().as<ExpressionNode>();
 		if (std::holds_alternative<IdentifierNode>(rhs_expr)) {
@@ -2965,6 +2974,79 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 	if (rhs_pointer_depth == 0) {
 		rhs_pointer_depth = rhsExprResult.pointer_depth.value;
 	}
+	if (rhs_pointer_depth == 0) {
+		TypeSpecifierQueryResult rhs_type_query = sema_.parserSemanticServices().getExpressionTypeQuery(binaryOperatorNode.get_rhs());
+		if (rhs_type_query.state == TypeSpecifierQueryResult::State::Available &&
+			rhs_type_query.type.has_value()) {
+			rhs_pointer_depth = static_cast<int>(rhs_type_query.type->pointer_depth());
+		}
+	}
+	if (auto binary_type_specs = tryGetBinaryOperatorTypeSpecs(); binary_type_specs.has_value()) {
+		if (lhs_pointer_depth == 0 && binary_type_specs->first.pointer_depth() > 0) {
+			lhs_fallback_type_node = binary_type_specs->first;
+			lhs_pointer_depth = static_cast<int>(lhs_fallback_type_node->pointer_depth());
+			if (!lhs_type_node) {
+				lhs_type_node = &*lhs_fallback_type_node;
+			}
+		}
+		if (rhs_pointer_depth == 0 && binary_type_specs->second.pointer_depth() > 0) {
+			rhs_fallback_type_node = binary_type_specs->second;
+			rhs_pointer_depth = static_cast<int>(rhs_fallback_type_node->pointer_depth());
+			if (!rhs_type_node) {
+				rhs_type_node = &*rhs_fallback_type_node;
+			}
+		}
+	}
+
+	auto isNullPointerConstantExpr = [&](const ExprResult& expr_result, const ASTNode& node) {
+		if (expr_result.category() == TypeCategory::Nullptr) {
+			return true;
+		}
+		if (const auto* ull_value = std::get_if<unsigned long long>(&expr_result.value)) {
+			return *ull_value == 0;
+		}
+		if (const auto* int_value = std::get_if<int>(&expr_result.value)) {
+			return *int_value == 0;
+		}
+		if (node.is<ExpressionNode>()) {
+			if (const auto* identifier = std::get_if<IdentifierNode>(&node.as<ExpressionNode>())) {
+				return identifier->name() == "nullptr";
+			}
+		}
+		return false;
+	};
+	auto makeNullPointerExpr = [&](const ExprResult& pointer_expr, int pointer_depth) {
+		TypeIndex pointer_type_index = pointer_expr.type_index;
+		if (!pointer_type_index.is_valid()) {
+			pointer_type_index = nativeTypeIndex(pointer_expr.category());
+		}
+		return makeExprResult(
+			pointer_type_index,
+			SizeInBits{64},
+			IrOperand{0ULL},
+			PointerDepth{pointer_depth > 0 ? pointer_depth : 1},
+			ValueStorage::ContainsData);
+	};
+
+	if (op == "==" || op == "!=") {
+		const bool lhs_is_null_pointer_constant = isNullPointerConstantExpr(lhsExprResult, binaryOperatorNode.get_lhs());
+		const bool rhs_is_null_pointer_constant = isNullPointerConstantExpr(rhsExprResult, binaryOperatorNode.get_rhs());
+		if (lhs_pointer_depth > 0 && rhs_is_null_pointer_constant) {
+			rhsExprResult = makeNullPointerExpr(lhsExprResult, lhs_pointer_depth);
+			rhs_pointer_depth = lhs_pointer_depth;
+			rhsSize = rhsExprResult.size_in_bits.value;
+			rhsCat = rhsExprResult.category();
+		} else if (rhs_pointer_depth > 0 && lhs_is_null_pointer_constant) {
+			lhsExprResult = makeNullPointerExpr(rhsExprResult, rhs_pointer_depth);
+			lhs_pointer_depth = rhs_pointer_depth;
+			lhsSize = lhsExprResult.size_in_bits.value;
+			lhsCat = lhsExprResult.category();
+		}
+	}
+	const bool is_pointer_comparison =
+		(op == "==" || op == "!=" || op == "<" || op == "<=" || op == ">" || op == ">=") &&
+		lhs_pointer_depth > 0 &&
+		rhs_pointer_depth > 0;
 
 	// Special handling for pointer subtraction (ptr - ptr)
 	// Result is ptrdiff_t (number of elements between pointers)
@@ -3316,7 +3398,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 	// Phase 15: generate conversions — prefer sema annotations; log warning on fallback.
 	// Reuse tryGlobalSemaConv (defined above) which performs sema slot lookup, struct-type
 	// guard, expected-target verification, enum type mismatch handling, and conversion.
-	if (lhsCat != commonType) {
+	if (!is_pointer_comparison && lhsCat != commonType) {
 		if (!tryGlobalSemaConv(lhsExprResult, binaryOperatorNode.get_lhs(), commonType)) {
 			if (sema_normalized_current_function_ && is_standard_arithmetic_type(lhsCat) && is_standard_arithmetic_type(commonType))
 				throw InternalError(std::string(StringBuilder()
@@ -3342,7 +3424,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 				rhsExprResult = generateTypeConversion(rhsExprResult, rhsCat, promoted_rhs, binaryOperatorNode.get_token());
 			}
 		}
-	} else if (rhsCat != commonType) {
+	} else if (!is_pointer_comparison && rhsCat != commonType) {
 		if (!tryGlobalSemaConv(rhsExprResult, binaryOperatorNode.get_rhs(), commonType)) {
 			if (sema_normalized_current_function_ && is_standard_arithmetic_type(rhsCat) && is_standard_arithmetic_type(commonType))
 				throw InternalError(std::string(StringBuilder()

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -2998,23 +2998,6 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 		}
 	}
 
-	auto isNullPointerConstantExpr = [&](const ExprResult& expr_result, const ASTNode& node) {
-		if (expr_result.category() == TypeCategory::Nullptr) {
-			return true;
-		}
-		if (const auto* ull_value = std::get_if<unsigned long long>(&expr_result.value)) {
-			return *ull_value == 0;
-		}
-		if (const auto* int_value = std::get_if<int>(&expr_result.value)) {
-			return *int_value == 0;
-		}
-		if (node.is<ExpressionNode>()) {
-			if (const auto* identifier = std::get_if<IdentifierNode>(&node.as<ExpressionNode>())) {
-				return identifier->name() == "nullptr";
-			}
-		}
-		return false;
-	};
 	auto makeNullPointerExpr = [&](const ExprResult& pointer_expr, int pointer_depth) {
 		TypeIndex pointer_type_index = pointer_expr.type_index;
 		if (!pointer_type_index.is_valid()) {
@@ -3029,8 +3012,8 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 	};
 
 	if (op == "==" || op == "!=") {
-		const bool lhs_is_null_pointer_constant = isNullPointerConstantExpr(lhsExprResult, binaryOperatorNode.get_lhs());
-		const bool rhs_is_null_pointer_constant = isNullPointerConstantExpr(rhsExprResult, binaryOperatorNode.get_rhs());
+		const bool lhs_is_null_pointer_constant = AstToIr::isNullPointerConstantExpr(lhsExprResult, binaryOperatorNode.get_lhs());
+		const bool rhs_is_null_pointer_constant = AstToIr::isNullPointerConstantExpr(rhsExprResult, binaryOperatorNode.get_rhs());
 		if (lhs_pointer_depth > 0 && rhs_is_null_pointer_constant) {
 			rhsExprResult = makeNullPointerExpr(lhsExprResult, lhs_pointer_depth);
 			rhs_pointer_depth = lhs_pointer_depth;

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -253,6 +253,23 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 			bool return_requires_ctor_resolution = false;
 			bool return_ctor_no_match = false;
 			std::string_view return_ctor_target_name;
+			auto isNullPointerConstantExpr = [&](const ExprResult& expr_result, const ASTNode& node) {
+				if (expr_result.category() == TypeCategory::Nullptr) {
+					return true;
+				}
+				if (const auto* ull_value = std::get_if<unsigned long long>(&expr_result.value)) {
+					return *ull_value == 0;
+				}
+				if (const auto* int_value = std::get_if<int>(&expr_result.value)) {
+					return *int_value == 0;
+				}
+				if (node.is<ExpressionNode>()) {
+					if (const auto* identifier = std::get_if<IdentifierNode>(&node.as<ExpressionNode>())) {
+						return identifier->name() == "nullptr";
+					}
+				}
+				return false;
+			};
 
 			// Check whether the semantic pass has already computed a cast annotation.
 			// When present for a non-struct conversion, apply it and skip the local policy.
@@ -312,6 +329,20 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 						}
 					}
 				}
+			}
+			if (!sema_applied_conversion &&
+				currentFunctionReturnsPointer() &&
+				isNullPointerConstantExpr(operands, *expr_opt)) {
+				operands = makeExprResult(
+					return_type_index,
+					SizeInBits{return_size},
+					IrOperand{0ULL},
+					PointerDepth{1},
+					ValueStorage::ContainsData);
+				expr_type = return_type;
+				expr_category = return_category;
+				expr_size = return_size;
+				sema_applied_conversion = true;
 			}
 			if (expr_opt->is<ExpressionNode>()) {
 				const void* key = static_cast<const void*>(&expr_opt->as<ExpressionNode>());

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -2,6 +2,24 @@
 #include "IrGenerator.h"
 #include "SemanticAnalysis.h"
 
+bool AstToIr::isNullPointerConstantExpr(const ExprResult& expr_result, const ASTNode& node) {
+	if (expr_result.category() == TypeCategory::Nullptr) {
+		return true;
+	}
+	if (const auto* ull_value = std::get_if<unsigned long long>(&expr_result.value)) {
+		return *ull_value == 0;
+	}
+	if (const auto* int_value = std::get_if<int>(&expr_result.value)) {
+		return *int_value == 0;
+	}
+	if (node.is<ExpressionNode>()) {
+		if (const auto* identifier = std::get_if<IdentifierNode>(&node.as<ExpressionNode>())) {
+			return identifier->name() == "nullptr";
+		}
+	}
+	return false;
+}
+
 void AstToIr::visitNamespaceDeclarationNode(const NamespaceDeclarationNode& node) {
 	// Namespace declarations themselves don't generate IR - they just provide scope
 	// Track the current namespace for proper name mangling
@@ -253,24 +271,6 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 			bool return_requires_ctor_resolution = false;
 			bool return_ctor_no_match = false;
 			std::string_view return_ctor_target_name;
-			auto isNullPointerConstantExpr = [&](const ExprResult& expr_result, const ASTNode& node) {
-				if (expr_result.category() == TypeCategory::Nullptr) {
-					return true;
-				}
-				if (const auto* ull_value = std::get_if<unsigned long long>(&expr_result.value)) {
-					return *ull_value == 0;
-				}
-				if (const auto* int_value = std::get_if<int>(&expr_result.value)) {
-					return *int_value == 0;
-				}
-				if (node.is<ExpressionNode>()) {
-					if (const auto* identifier = std::get_if<IdentifierNode>(&node.as<ExpressionNode>())) {
-						return identifier->name() == "nullptr";
-					}
-				}
-				return false;
-			};
-
 			// Check whether the semantic pass has already computed a cast annotation.
 			// When present for a non-struct conversion, apply it and skip the local policy.
 			// When present as UserDefined, the source is a struct with a conversion operator.
@@ -332,7 +332,7 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 			}
 			if (!sema_applied_conversion &&
 				currentFunctionReturnsPointer() &&
-				isNullPointerConstantExpr(operands, *expr_opt)) {
+				AstToIr::isNullPointerConstantExpr(operands, *expr_opt)) {
 				operands = makeExprResult(
 					return_type_index,
 					SizeInBits{return_size},

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -473,7 +473,8 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 
 		// Apply attributes
 		func_ref.set_calling_convention(attr_info.calling_convention);
-		if (attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) {
+		if ((attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) &&
+			func_ref.linkage() == Linkage::None) {
 			func_ref.set_linkage(attr_info.linkage);
 		}
 		func_ref.set_is_constexpr(is_constexpr);
@@ -662,7 +663,8 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		// Apply attribute linkage if present (calling convention already set in parse_function_declaration)
 		if (auto func_node_ptr = function_definition_result.node()) {
 			FunctionDeclarationNode& func_node = func_node_ptr->as<FunctionDeclarationNode>();
-			if (attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) {
+			if ((attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) &&
+				func_node.linkage() == Linkage::None) {
 				func_node.set_linkage(attr_info.linkage);
 			}
 			func_node.set_is_constexpr(is_constexpr);

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -1008,10 +1008,10 @@ ParseResult Parser::create_function_from_header(
 	func_ref.set_calling_convention(header.storage.calling_convention);
 
 	// Set linkage
-	if (header.storage.linkage != Linkage::None) {
-		func_ref.set_linkage(header.storage.linkage);
-	} else if (current_linkage_ != Linkage::None) {
+	if (current_linkage_ != Linkage::None) {
 		func_ref.set_linkage(current_linkage_);
+	} else if (header.storage.linkage != Linkage::None) {
+		func_ref.set_linkage(header.storage.linkage);
 	} else {
 		// Check if there's a forward declaration with linkage and inherit it
 		// Use lookup_all to check all overloads in case there are multiple

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -780,7 +780,8 @@ ParseResult Parser::parse_variable_declaration() {
 				// Successfully parsed as function
 				if (auto func_node_ptr = function_result.node()) {
 					FunctionDeclarationNode& func_node = func_node_ptr->as<FunctionDeclarationNode>();
-					if (attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) {
+					if ((attr_info.linkage == Linkage::DllImport || attr_info.linkage == Linkage::DllExport) &&
+						func_node.linkage() == Linkage::None) {
 						func_node.set_linkage(attr_info.linkage);
 					}
 					func_node.set_is_constexpr(is_constexpr);

--- a/tests/test_pointer_null_wrappers_ret0.cpp
+++ b/tests/test_pointer_null_wrappers_ret0.cpp
@@ -1,0 +1,34 @@
+const wchar_t* findWideChar(const wchar_t* text, wchar_t needle, unsigned long long count) {
+	for (; 0 < count; ++text, --count) {
+		if (*text == needle) {
+			return text;
+		}
+	}
+
+	return 0;
+}
+
+unsigned long long safeStrnlen(const char* text, unsigned long long count) {
+	return text == 0 ? 0 : count;
+}
+
+int main() {
+	const wchar_t wide_text[] = {L'a', L'b', 0};
+	const wchar_t* found = findWideChar(wide_text, L'b', 2);
+	const wchar_t* missing = findWideChar(wide_text, L'z', 2);
+
+	if (found == 0 || *found != L'b') {
+		return 1;
+	}
+	if (missing != 0) {
+		return 2;
+	}
+	if (safeStrnlen(0, 9) != 0) {
+		return 3;
+	}
+	if (safeStrnlen("abc", 3) != 3) {
+		return 4;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- fix pointer/null comparison lowering in IR so `pointer == 0` and pointer-returning `return 0;` stay on the pointer path instead of tripping arithmetic-conversion fallbacks
- add `tests/test_pointer_null_wrappers_ret0.cpp` to cover the reduced `strnlen_s`/`wmemchr` style wrappers behind the ratio frontier
- preserve `extern "C"` over `_ACRTIMP`/`dllimport` precedence so imported CRT declarations keep C naming and `tests/std/test_std_ratio.cpp` no longer fails on bogus unresolved `wcstok`/`wcspbrk`/`strnlen`/`strpbrk` symbols
- update `KNOWN_ISSUES.md` to reflect the new explicit `tests/std/test_std_ratio.cpp` frontier (`__security_cookie` multiple definition)

## Validation
- `./build_flashcpp.bat`
- `pwsh -File tests/run_all_tests.ps1`
- `pwsh -File tests/run_all_tests.ps1 test_pointer_null_wrappers_ret0.cpp`
- `pwsh -File tests/run_all_tests.ps1 tests/std/test_std_ratio.cpp` *(still fails, now at `__security_cookie` multiple definition)*