### PR TITLE
[codex] Handle dependent qualified default NTTP member chains

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -75,11 +75,22 @@ Useful to know before changing anything:
 - member alias-template declarations now preserve deferred member suffixes and
   enclosing class-template bindings for covered non-template intermediate member
   chains such as `Provider<T>::Node::template Apply<U>`;
+- template-parameter default arguments now route dependent owner template-ids
+  such as `Provider<T>::Node::template Apply<T>::value` through the same
+  deferred qualified-member-chain parser used in template bodies, instead of
+  falling through to the generic postfix `::` parser and stopping before
+  semantic substitution/evaluation;
+- direct member-template lookup on fully qualified instantiated nested owners
+  now retries shortened nested-owner spellings, so declarations that materialize
+  owners like `Outer<int>::Inner::template Apply<int>` can find member-template
+  registrations stored under nested names such as `Inner::Apply`;
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
 Validation at this point passed the Linux sharded build and ELF test workflow:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+Latest Windows/MSVC full-suite validation for this slice:
+`2476` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## What is still wrong
 
@@ -117,13 +128,13 @@ Concrete follow-up already identified by recent work:
   materialization. Member alias-template chains with covered non-template
   intermediate members and enclosing class-template bindings now preserve enough
   metadata for declarations such as `Provider<T>::Node::template Apply<U>`.
-  The next concrete follow-up is the remaining dependent-base and
-  unknown-specialization member-chain work in declarations that still do not
-  preserve enough metadata, especially chains that combine non-template
-  intermediates with deeper dependent bases, value/static member lookups, or
-  member-alias targets outside the newly covered alias-template materialization
-  path, plus the current `<ratio>` blocker where parsing and `std::ratio_less`
-  constexpr comparison now progress to later IR conversion/link failures.
+  The next concrete follow-up is now narrower: the parser-side declaration stop
+  for dependent owner template-ids in default NTTPs is covered, including
+  direct member-template and nested alias chains ending in `::value`. The
+  remaining `<ratio>`-class blocker is the later deferred-base/member-chain
+  materialization gap where instantiated owners like `ratio_less<...>` still
+  miss inherited base/member attachment in some libstdc++ flows, leaving
+  `::value` unresolved even after parsing/substitution carry the full chain.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -286,6 +297,11 @@ materially changes what future refactors can assume.
   register instantiated/nested aliases with recovered outer class-template
   bindings, covering non-template intermediate member chains such as
   `Provider<T>::Node::template Apply<U>`.
+- template-parameter default arguments now preserve dependent qualified
+  member-template chains ending in static-member lookups, covering focused
+  declaration-time shapes such as `Provider<T>::Node::template Apply<T>::value`
+  and `Provider<T>::Node::type::value` instead of rejecting them in the postfix
+  parser before default evaluation.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -98,12 +98,19 @@ Future work should assume these are already in place:
   merge recovered outer class-template bindings while materializing covered
   non-template intermediate member chains such as
   `Provider<T>::Node::template Apply<U>`.
+- template-parameter default arguments now reuse the deferred qualified-member
+  chain parser for dependent owner template-ids, so declaration-time defaults
+  like `Provider<T>::Node::template Apply<T>::value` and
+  `Provider<T>::Node::type::value` no longer stop in the generic postfix `::`
+  path before semantic substitution/evaluation.
 
 Latest validation on Linux sharded build:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 Targeted validation for the latest member alias-template non-template
 intermediate chain slice passed the focused ELF regressions after
 `make sharded CXX=clang++`.
+Latest Windows/MSVC full-suite validation for this slice:
+`2476` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -135,16 +142,19 @@ Most concrete next subtask:
   outer owner bindings for the covered initializer/constexpr paths.
   `this->template` member-function-template calls through dependent bases now
   work for focused inline class-template body cases, including multilevel base
-  chains. The next concrete gap is declarations outside the covered replay
-  flows, plus deeper dependent-base/member-chain shapes that still do not carry
-  enough semantic metadata. The current `<ratio>` blocker remains a useful
-  bounded target because parsing and `std::ratio_less` constexpr comparison now
-  progress to later IR conversion/link failures rather than stopping in the
-  fixed default NTTP declared-type materialization, dependent member-template
-  argument paths, covered member alias-template target materialization path,
-  alias-template `sizeof...` NTTP target arguments, covered variable-template
-  initializer replay paths, covered member variable-template chain recovery, or
-  covered dependent-base `this->template` member-function-template lookup.
+  chains. The next concrete gap is now after the newly covered declaration-time
+  parser stop for dependent owner template-ids in default NTTPs. The current
+  `<ratio>` blocker remains a useful bounded target, but the remaining failure
+  is later: deferred base/member-chain materialization can still leave
+  instantiated owners like `ratio_less<...>` without the inherited/member
+  metadata needed for final `::value` lookup on some libstdc++ paths.
+  Parsing/substitution now progress past the fixed default-NTTP declared-type
+  materialization, dependent member-template argument paths, covered member
+  alias-template target materialization path, alias-template `sizeof...` NTTP
+  target arguments, covered variable-template initializer replay paths, covered
+  member variable-template chain recovery, covered dependent-base
+  `this->template` member-function-template lookup, and the newly covered
+  default-NTTP member-chain parser path.
   Covered deferred alias member-template suffix chains in declarations and base
   specifiers now work as well, and covered member alias-template declarations
   now preserve non-template intermediate member segments plus enclosing
@@ -228,9 +238,13 @@ coverage becomes sufficient.
       the covered qualified-id/member-side cases;
    - keep reusing the shared member-side lookup/materialization path in the
       remaining qualified-id spellings so local repair logic is not reintroduced;
-   - extend replay metadata capture into remaining declarations outside the
-     covered static-member and variable-template initializer paths;
-   - remove the next AST-only fallback path.
+   - treat dependent owner template-ids in template-parameter defaults as
+     covered for the focused member-template and nested-alias `::value` cases;
+   - extend owner-correct replay/materialization into the remaining declaration
+     and deferred-base paths outside the covered static-member,
+     variable-template initializer, and default-NTTP parser flows;
+   - remove the next AST-only/deferred-base fallback path, with libstdc++
+     `<ratio>` still the best bounded target.
 
 2. **Dependent-name/current-instantiation expansion**
    - richer dependent-base and unknown-specialization records;
@@ -327,6 +341,12 @@ re-solving already-solved problems.
   covered alias/base-specifier materialization walks each segment through
   owner-aware lookup so `Owner<T>::template Box<U>::template Rebind<T>` is not
   rejected or truncated at parse time.
+- dependent owner template-ids in template-parameter defaults now reuse the
+  deferred qualified-member parser instead of the generic postfix `::` path, so
+  focused declaration-time chains like
+  `Provider<T>::Node::template Apply<T>::value` and
+  `Provider<T>::Node::type::value` reach substitution/evaluation as semantic
+  qualified names instead of stopping at parse time.
 
 ## Exit criteria
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5986,16 +5986,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									{},
 									*explicit_template_args);
 							std::string_view instantiated_name = materialized_owner.instantiated_name;
-							// Detect dependent args up front (used both for the retry path and the skip/error path).
-							bool any_dependent = false;
-							if (parsing_template_depth_ > 0) {
-								for (const auto& arg : *explicit_template_args) {
-									if (arg.is_dependent || arg.is_pack) {
-										any_dependent = true;
-										break;
-									}
-								}
-							}
+							// Template parameter defaults also need the deferred qualified-member path
+							// when the owner template-id is dependent.
+							const bool any_dependent =
+								explicitTemplateArgsRequireDeferredInstantiation(
+									*explicit_template_args);
 							if (instantiated_name.empty()) {
 								// If materialization still failed, apply the original dependent args
 								// skip and defer strategy for genuinely un-instantiable expressions.
@@ -6184,7 +6179,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 							// Parse qualified identifier after template, using the instantiated name
 							// We need to collect the :: path ourselves since we have the instantiated name
-							if (parsing_template_depth_ > 0 && peek() == "::"_tok) {
+							if (any_dependent && peek() == "::"_tok) {
 								SaveHandle deferred_member_chain_start = save_token_position();
 								NamespaceHandle deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
 									NamespaceRegistry::GLOBAL_NAMESPACE,
@@ -7260,18 +7255,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							{},
 							*explicit_template_args);
 					std::string_view instantiated_class_name = materialized_owner.instantiated_name;
+					const bool any_dependent =
+						explicitTemplateArgsRequireDeferredInstantiation(
+							*explicit_template_args);
 					if (instantiated_class_name.empty()) {
 						// In a template body, the template arguments may be dependent on
 						// enclosing template parameters. Defer the entire qualified call.
-						bool any_dependent = false;
-						if (parsing_template_depth_ > 0) {
-							for (const auto& arg : *explicit_template_args) {
-								if (arg.is_dependent || arg.is_pack) {
-									any_dependent = true;
-									break;
-								}
-							}
-						}
 						if (any_dependent) {
 							QualifiedIdentifier dependent_owner_template =
 								QualifiedIdentifier::fromQualifiedName(
@@ -7450,7 +7439,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					}
 
 					// Create a token with the instantiated name to pass to parse_qualified_identifier_after_template
-					if (parsing_template_depth_ > 0 && peek() == "::"_tok) {
+					if (any_dependent && peek() == "::"_tok) {
 						SaveHandle deferred_member_chain_start = save_token_position();
 						NamespaceHandle deferred_ns_handle = gNamespaceRegistry.getOrCreateNamespace(
 							NamespaceRegistry::GLOBAL_NAMESPACE,

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -810,6 +810,19 @@ std::string_view Parser::lookup_direct_member_template_name(
 		return StringTable::getStringView(qualified_member_template_name);
 	}
 
+	std::string_view owner_name_view = StringTable::getStringView(owner_name);
+	for (size_t scope_pos = owner_name_view.find("::");
+		 scope_pos != std::string_view::npos;
+		 scope_pos = owner_name_view.find("::", scope_pos + 2)) {
+		StringHandle nested_owner_handle = StringTable::getOrInternStringHandle(
+			owner_name_view.substr(scope_pos + 2));
+		StringHandle nested_member_template_name =
+			buildQualifiedMemberNameHandle(nested_owner_handle, member_name);
+		if (has_registered_member_template(nested_member_template_name)) {
+			return StringTable::getStringView(nested_member_template_name);
+		}
+	}
+
 	auto owner_it = getTypesByNameMap().find(owner_name);
 	const TypeInfo* owner_type_info =
 		owner_it != getTypesByNameMap().end() ? owner_it->second : nullptr;

--- a/tests/test_dependent_member_alias_chain_default_nttp_value_ret0.cpp
+++ b/tests/test_dependent_member_alias_chain_default_nttp_value_ret0.cpp
@@ -1,0 +1,43 @@
+struct true_type {
+	static constexpr bool value = true;
+};
+
+struct false_type {
+	static constexpr bool value = false;
+};
+
+template <bool Select>
+struct chooser;
+
+template <>
+struct chooser<true> {
+	using type = true_type;
+};
+
+template <>
+struct chooser<false> {
+	using type = false_type;
+};
+
+template <typename T>
+struct provider_with_alias {
+	template <typename U>
+	struct node {
+		using type = typename chooser<(sizeof(T) == sizeof(U))>::type;
+	};
+};
+
+template <typename T,
+		  bool = provider_with_alias<T>::template node<T>::type::value>
+struct alias_probe {
+	static constexpr int value = 7;
+};
+
+template <typename T>
+struct alias_probe<T, false> {
+	static constexpr int value = 1;
+};
+
+int main() {
+	return alias_probe<int>::value == 7 ? 0 : 1;
+}

--- a/tests/test_dependent_member_chain_default_nttp_value_ret0.cpp
+++ b/tests/test_dependent_member_chain_default_nttp_value_ret0.cpp
@@ -1,0 +1,23 @@
+template <typename T>
+struct provider {
+	struct node {
+		template <typename U>
+		struct apply {
+			static constexpr bool value = sizeof(T) == sizeof(U);
+		};
+	};
+};
+
+template <typename T, bool = provider<T>::node::template apply<T>::value>
+struct probe {
+	static constexpr int value = 7;
+};
+
+template <typename T>
+struct probe<T, false> {
+	static constexpr int value = 1;
+};
+
+int main() {
+	return probe<int>::value == 7 ? 0 : 1;
+}

--- a/tests/test_ratio_add_default_member_value_ret0.cpp
+++ b/tests/test_ratio_add_default_member_value_ret0.cpp
@@ -1,0 +1,33 @@
+template <long long Num, long long Den = 1>
+struct ratio {
+	static constexpr long long num = Num;
+	static constexpr long long den = Den;
+};
+
+template <typename R1, typename R2,
+		  bool = (R1::num == 0 || R2::num == 0),
+		  bool = false>
+struct ratio_less_impl {
+	static constexpr bool value = (R1::num * R2::den) < (R2::num * R1::den);
+};
+
+template <typename R1, typename R2>
+struct ratio_less {
+	static constexpr bool value = ratio_less_impl<R1, R2>::value;
+};
+
+template <typename R1, typename R2, bool = ratio_less<R1, R2>::value>
+struct ratio_add_impl {
+	static constexpr int value = 1;
+};
+
+template <typename R1, typename R2>
+struct ratio_add_impl<R1, R2, true> {
+	static constexpr int value = 7;
+};
+
+int main() {
+	using half = ratio<1, 2>;
+	using third = ratio<1, 3>;
+	return ratio_add_impl<third, half>::value == 7 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- keep dependent owner template-ids in default non-type template arguments on the deferred qualified-member-chain parser path
- add nested-owner member-template lookup fallback for fully qualified instantiated owners
- add focused regressions for direct member-template chains, nested alias chains, and ratio-style default NTTP member-value evaluation

## Why
Default NTTP expressions like `Provider<T>::Node::template Apply<T>::value` were falling through the generic postfix `::` parser path in declaration context. That stopped parsing before substitution/evaluation and left a standards-conformance gap in the template infrastructure.

## Impact
Declaration-time dependent qualified member chains in template parameter defaults now reach semantic substitution and constant evaluation instead of failing during parsing. This extends the two-phase lookup/template-argument refactor coverage to a high-impact remaining declaration path.

