### PR TITLE
Fix canonical owner lookup for ratio default NTTPs

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -80,6 +80,11 @@ Useful to know before changing anything:
   deferred qualified-member-chain parser used in template bodies, instead of
   falling through to the generic postfix `::` parser and stopping before
   semantic substitution/evaluation;
+- lookup-time owner materialization for concrete template instantiations now
+  canonicalizes through the shared owner helper before qualified member-chain
+  resolution, so ratio-like inherited `::type::value` chains can find inherited
+  static members during default-NTTP evaluation without reopening deferred-base
+  attachment fallback paths;
 - direct member-template lookup on fully qualified instantiated nested owners
   now retries shortened nested-owner spellings, so declarations that materialize
   owners like `Outer<int>::Inner::template Apply<int>` can find member-template
@@ -89,8 +94,12 @@ Useful to know before changing anything:
 
 Validation at this point passed the Linux sharded build and ELF test workflow:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Latest Windows/MSVC full-suite validation for this slice:
-`2476` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+Focused Windows/MSVC validation for this slice passed the new ratio-owner
+regression plus nearby ratio/dependent-member regressions. Latest Windows/MSVC
+full-suite validation after adding that regression:
+`2476` regular tests compiled/linked/runtime-pass, `1` unrelated regular test
+link-fail (`template_template_with_member_ret0.cpp`), `181` expected-fail
+tests.
 
 ## What is still wrong
 
@@ -128,13 +137,14 @@ Concrete follow-up already identified by recent work:
   materialization. Member alias-template chains with covered non-template
   intermediate members and enclosing class-template bindings now preserve enough
   metadata for declarations such as `Provider<T>::Node::template Apply<U>`.
-  The next concrete follow-up is now narrower: the parser-side declaration stop
-  for dependent owner template-ids in default NTTPs is covered, including
-  direct member-template and nested alias chains ending in `::value`. The
-  remaining `<ratio>`-class blocker is the later deferred-base/member-chain
-  materialization gap where instantiated owners like `ratio_less<...>` still
-  miss inherited base/member attachment in some libstdc++ flows, leaving
-  `::value` unresolved even after parsing/substitution carry the full chain.
+  The parser-side declaration stop for dependent owner template-ids in default
+  NTTPs is now covered, including direct member-template and nested alias chains
+  ending in `::value`, and the later lookup-time `<ratio>` owner gap is now
+  covered by canonical owner materialization before inherited member-chain
+  lookup. The next concrete follow-up is therefore narrower again: extend that
+  owner-correct lookup path to deeper dependent-base/unknown-specialization
+  chains, especially when intermediate `::value` or other static-member hops
+  appear between type/member-alias segments.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -210,16 +220,20 @@ In priority order:
 
 1. **Finish the next two-phase lookup slice**
    - current-instantiation/type-alias follow-up work after inherited member-template
-      alias recovery, nested alias-target deferred-base materialization, and the
-      current-owner member-alias qualified-id cleanup is now complete for the
-      deeper covered member-chain cases;
+       alias recovery, nested alias-target deferred-base materialization, and the
+       current-owner member-alias qualified-id cleanup is now complete for the
+       deeper covered member-chain cases;
+   - lookup-time canonical owner materialization now covers the focused
+      ratio-style inherited `::type::value` default-NTTP path without mutating
+      deferred-base attachment;
    - dependent-base `this->template` member-function-template calls are covered
-      for focused inline class-template body cases, including multilevel
-      dependent-base chains;
+     for focused inline class-template body cases, including multilevel
+     dependent-base chains;
    - remaining replay-metadata gaps outside the covered static-member and
-      variable-template initializer paths;
+     variable-template initializer paths;
    - remaining dependent-base/member-chain paths that still bypass the shared
-      semantic lookup model.
+      semantic lookup model, especially deeper unknown-specialization/value-hop
+      chains.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
@@ -302,6 +316,10 @@ materially changes what future refactors can assume.
   declaration-time shapes such as `Provider<T>::Node::template Apply<T>::value`
   and `Provider<T>::Node::type::value` instead of rejecting them in the postfix
   parser before default evaluation.
+- lookup-time concrete owner resolution now routes through
+  `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
+  resolution, covering ratio-style inherited `::type` then default-NTTP
+  `::value` flows without adding a new deferred-base or constexpr fallback.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -103,14 +103,23 @@ Future work should assume these are already in place:
   like `Provider<T>::Node::template Apply<T>::value` and
   `Provider<T>::Node::type::value` no longer stop in the generic postfix `::`
   path before semantic substitution/evaluation.
+- lookup-time owner materialization for concrete template instantiations now
+  reuses the shared canonical owner helper before inherited member-chain
+  resolution, covering ratio-style inherited `::type::value` lookup during
+  default-NTTP evaluation without perturbing deferred-base attachment.
 
 Latest validation on Linux sharded build:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 Targeted validation for the latest member alias-template non-template
 intermediate chain slice passed the focused ELF regressions after
 `make sharded CXX=clang++`.
-Latest Windows/MSVC full-suite validation for this slice:
-`2476` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+Focused Windows/MSVC validation for this slice passed
+`test_ratio_inherited_type_default_nttp_value_ret0.cpp` plus nearby ratio and
+dependent-member regressions. Latest Windows/MSVC full-suite validation after
+adding that regression:
+`2476` regular tests compiled/linked/runtime-pass, `1` unrelated regular test
+link-fail (`template_template_with_member_ret0.cpp`), `181` expected-fail
+tests.
 
 ## Remaining work, in priority order
 
@@ -142,13 +151,12 @@ Most concrete next subtask:
   outer owner bindings for the covered initializer/constexpr paths.
   `this->template` member-function-template calls through dependent bases now
   work for focused inline class-template body cases, including multilevel base
-  chains. The next concrete gap is now after the newly covered declaration-time
-  parser stop for dependent owner template-ids in default NTTPs. The current
-  `<ratio>` blocker remains a useful bounded target, but the remaining failure
-  is later: deferred base/member-chain materialization can still leave
-  instantiated owners like `ratio_less<...>` without the inherited/member
-  metadata needed for final `::value` lookup on some libstdc++ paths.
-  Parsing/substitution now progress past the fixed default-NTTP declared-type
+  chains. The newly covered declaration-time parser stop for dependent owner
+  template-ids in default NTTPs is now joined by lookup-time canonical owner
+  materialization for the focused `<ratio>` inherited `::type::value` path, so
+  parsing/substitution/evaluation no longer lose that chain when concrete owner
+  lookup runs. Parsing/substitution now progress past the fixed default-NTTP
+  declared-type materialization, the lookup-time ratio owner gap,
   materialization, dependent member-template argument paths, covered member
   alias-template target materialization path, alias-template `sizeof...` NTTP
   target arguments, covered variable-template initializer replay paths, covered
@@ -159,9 +167,11 @@ Most concrete next subtask:
   specifiers now work as well, and covered member alias-template declarations
   now preserve non-template intermediate member segments plus enclosing
   class-template bindings for cases like `Provider<T>::Node::template Apply<U>`.
-  The next bounded alias-chain step is expanding that owner-correct path to
-  deeper dependent-base/unknown-specialization chains, especially when value or
-  static member lookups appear between type/member-alias segments.
+  The next bounded follow-up is expanding that owner-correct path to deeper
+  dependent-base/unknown-specialization chains, especially when value or static
+  member lookups appear between type/member-alias segments. Separate from this
+  slice, current Windows full-suite validation still exposes an unrelated link
+  failure in `template_template_with_member_ret0.cpp`.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -239,12 +249,14 @@ coverage becomes sufficient.
    - keep reusing the shared member-side lookup/materialization path in the
       remaining qualified-id spellings so local repair logic is not reintroduced;
    - treat dependent owner template-ids in template-parameter defaults as
-     covered for the focused member-template and nested-alias `::value` cases;
+      covered for the focused member-template and nested-alias `::value` cases;
+   - treat lookup-time canonical owner materialization as covered for the
+      focused ratio-style inherited `::type::value` default-NTTP path;
    - extend owner-correct replay/materialization into the remaining declaration
-     and deferred-base paths outside the covered static-member,
-     variable-template initializer, and default-NTTP parser flows;
-   - remove the next AST-only/deferred-base fallback path, with libstdc++
-     `<ratio>` still the best bounded target.
+      and deferred-base paths outside the covered static-member,
+      variable-template initializer, and default-NTTP parser flows;
+   - remove the next AST-only/deferred-base fallback path, with the next bounded
+      target now deeper dependent-base/unknown-specialization value-hop chains.
 
 2. **Dependent-name/current-instantiation expansion**
    - richer dependent-base and unknown-specialization records;
@@ -347,6 +359,10 @@ re-solving already-solved problems.
   `Provider<T>::Node::template Apply<T>::value` and
   `Provider<T>::Node::type::value` reach substitution/evaluation as semantic
   qualified names instead of stopping at parse time.
+- lookup-time concrete owner resolution now routes through
+  `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
+  resolution, covering ratio-style inherited `::type` followed by default-NTTP
+  `::value` use without introducing another fallback path.
 
 ## Exit criteria
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1619,12 +1619,10 @@ TypeIndex Parser::substitute_template_parameter(
 
 		AliasTemplateMaterializationResult materialized_base =
 			resolveCanonicalInstantiatedOwnerForLookup(base_template_name, concrete_args);
-		if (materialized_base.instantiated_name.empty() &&
-			materialized_base.resolved_type_info == nullptr) {
-			return nullptr;
-		}
-		if (materialized_base.instantiated_name.empty() &&
-			materialized_base.resolved_type_info != nullptr) {
+		if (materialized_base.instantiated_name.empty()) {
+			if (materialized_base.resolved_type_info == nullptr) {
+				return nullptr;
+			}
 			materialized_base.instantiated_name =
 				StringTable::getStringView(materialized_base.resolved_type_info->name());
 		}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1618,12 +1618,22 @@ TypeIndex Parser::substitute_template_parameter(
 		}
 
 		AliasTemplateMaterializationResult materialized_base =
-			materializeTemplateInstantiationForLookup(base_template_name, concrete_args);
-		if (materialized_base.instantiated_name.empty()) {
+			resolveCanonicalInstantiatedOwnerForLookup(base_template_name, concrete_args);
+		if (materialized_base.instantiated_name.empty() &&
+			materialized_base.resolved_type_info == nullptr) {
 			return nullptr;
 		}
+		if (materialized_base.instantiated_name.empty() &&
+			materialized_base.resolved_type_info != nullptr) {
+			materialized_base.instantiated_name =
+				StringTable::getStringView(materialized_base.resolved_type_info->name());
+		}
 		if (member_chain.empty()) {
-			return materialized_base.resolved_type_info;
+			if (materialized_base.resolved_type_info != nullptr) {
+				return materialized_base.resolved_type_info;
+			}
+			return findTypeByName(
+				StringTable::getOrInternStringHandle(materialized_base.instantiated_name));
 		}
 		if (const TypeInfo* qualified_member_type = lookupTypeInfoByName(
 				StringBuilder()

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -3397,12 +3397,25 @@ void Parser::classifyExplicitTemplateArgumentsAgainstParameters(
 		if (!name.isValid()) {
 			return std::nullopt;
 		}
+		// Concrete templates (alias, class, or registered): not dependent.
 		if (gTemplateRegistry.lookup_alias_template(name).has_value() ||
 			gTemplateRegistry.lookupTemplate(name).has_value() ||
-			gTemplateRegistry.isClassTemplate(name) ||
-			(currentTemplateParamKind(name).has_value() &&
-			 *currentTemplateParamKind(name) == TemplateParameterKind::Template)) {
+			gTemplateRegistry.isClassTemplate(name)) {
 			return TemplateTypeArg::makeTemplate(name);
+		}
+		// Template template parameter: the name is a bound parameter, not a concrete
+		// template.  Mark the arg as dependent so that try_instantiate_class_template
+		// creates only a dependent placeholder (instead of a premature instantiation).
+		// The dependent_name is required so that the arg round-trips correctly through
+		// toTemplateArgInfo / toTemplateTypeArg and is recognized as dependent by
+		// try_materialize_exact_owner, allowing the correct concrete substitution to
+		// happen later during lazy instantiation of the enclosing template.
+		if (currentTemplateParamKind(name).has_value() &&
+			*currentTemplateParamKind(name) == TemplateParameterKind::Template) {
+			TemplateTypeArg arg = TemplateTypeArg::makeTemplate(name);
+			arg.is_dependent = true;
+			arg.dependent_name = name;
+			return arg;
 		}
 		return std::nullopt;
 	};

--- a/tests/test_ratio_inherited_type_default_nttp_value_ret0.cpp
+++ b/tests/test_ratio_inherited_type_default_nttp_value_ret0.cpp
@@ -1,0 +1,45 @@
+template <typename T, T V>
+struct integral_constant {
+	static constexpr T value = V;
+	using type = integral_constant;
+};
+
+template <int N>
+struct static_sign : integral_constant<int, (N < 0) ? -1 : 1> {};
+
+template <int N>
+struct static_abs : integral_constant<int, N * static_sign<N>::value> {};
+
+template <int Num, int Den = 1>
+struct ratio {
+	static constexpr int num = Num * static_sign<Den>::value;
+	static constexpr int den = static_abs<Den>::value;
+};
+
+template <typename R>
+struct ratio_sum_base : integral_constant<int, R::num + R::den> {};
+
+template <typename R>
+struct ratio_sum : ratio_sum_base<R>::type {};
+
+template <typename R>
+struct ratio_sum_chain : ratio_sum<R>::type {};
+
+template <typename R, int = ratio_sum_chain<R>::value>
+struct ratio_probe {
+	static constexpr int value = 1;
+};
+
+template <typename R>
+struct ratio_probe<R, 3> {
+	static constexpr int value = 7;
+};
+
+int main() {
+	using half = ratio<1, 2>;
+
+	static_assert(ratio_sum<half>::value == 3);
+	static_assert(ratio_sum_chain<half>::value == 3);
+
+	return ratio_probe<half>::value == 7 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- route lookup-time concrete owner materialization through the shared canonical owner helper before inherited member-chain resolution
- add a focused ratio regression covering inherited `::type` followed by default-NTTP `::value`
- update the template-argument audit and investigation docs with the completed slice and next bounded follow-up