### PR TITLE
Add shared owner-correct prefix materialization for deeper dependent qualified chains

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -89,17 +89,22 @@ Useful to know before changing anything:
   now retries shortened nested-owner spellings, so declarations that materialize
   owners like `Outer<int>::Inner::template Apply<int>` can find member-template
   registrations stored under nested names such as `Inner::Apply`;
+- dependent qualified-id and call substitution now share owner-correct prefix
+  materialization for covered unknown-specialization and dependent-base chains,
+  so general expression/lazy-static paths such as
+  `Traits<T>::template Box<T>::type::value`,
+  `Traits<T>::template Box<T>::type::get()`, and
+  `Derived<T>::template Inner<int>::type::value` stay concrete through the
+  intermediate `type` alias instead of stalling after the member-template hop;
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
 Validation at this point passed the Linux sharded build and ELF test workflow:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Focused Windows/MSVC validation for this slice passed the new ratio-owner
-regression plus nearby ratio/dependent-member regressions. Latest Windows/MSVC
-full-suite validation after adding that regression:
-`2476` regular tests compiled/linked/runtime-pass, `1` unrelated regular test
-link-fail (`template_template_with_member_ret0.cpp`), `181` expected-fail
-tests.
+Focused Windows/MSVC validation for this slice passed the new deeper
+dependent-chain regressions plus the nearby ratio/dependent-member regressions.
+Latest Windows/MSVC full-suite validation after this slice:
+`2481` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## What is still wrong
 
@@ -141,10 +146,13 @@ Concrete follow-up already identified by recent work:
   NTTPs is now covered, including direct member-template and nested alias chains
   ending in `::value`, and the later lookup-time `<ratio>` owner gap is now
   covered by canonical owner materialization before inherited member-chain
-  lookup. The next concrete follow-up is therefore narrower again: extend that
-  owner-correct lookup path to deeper dependent-base/unknown-specialization
-  chains, especially when intermediate `::value` or other static-member hops
-  appear between type/member-alias segments.
+  lookup. General expression/lazy-static substitution now also reuses a shared
+  owner-correct prefix-chain materialization path for the focused
+  unknown-specialization and dependent-base `member-template -> type/alias ->
+  value/call` cases. The next concrete follow-up is therefore narrower again:
+  extend that same owner-correct replay/materialization path into the remaining
+  declaration/static-member paths that still never captured enough metadata to
+  avoid AST-only fallback.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -226,14 +234,19 @@ In priority order:
    - lookup-time canonical owner materialization now covers the focused
       ratio-style inherited `::type::value` default-NTTP path without mutating
       deferred-base attachment;
+   - general expression/lazy-static substitution now covers the focused
+     deeper dependent-base and unknown-specialization
+     `member-template -> type/alias -> value/call` chains via a shared
+     owner-correct prefix materialization path reused by qualified-id and call
+     substitution;
    - dependent-base `this->template` member-function-template calls are covered
      for focused inline class-template body cases, including multilevel
      dependent-base chains;
    - remaining replay-metadata gaps outside the covered static-member and
      variable-template initializer paths;
-   - remaining dependent-base/member-chain paths that still bypass the shared
-      semantic lookup model, especially deeper unknown-specialization/value-hop
-      chains.
+   - remaining declaration/static-member/deferred-base paths that still bypass
+     the shared semantic lookup model and therefore fall back to AST-only
+     repair.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
@@ -320,6 +333,10 @@ materially changes what future refactors can assume.
   `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
   resolution, covering ratio-style inherited `::type` then default-NTTP
   `::value` flows without adding a new deferred-base or constexpr fallback.
+- dependent qualified-id and qualified-call substitution now share owner-
+  correct prefix-chain materialization for the covered general
+  expression/lazy-static cases where a member-template hop produces an
+  intermediate type/alias before the final static member or member call.
 
 ## Exit criteria for this audit
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -107,19 +107,23 @@ Future work should assume these are already in place:
   reuses the shared canonical owner helper before inherited member-chain
   resolution, covering ratio-style inherited `::type::value` lookup during
   default-NTTP evaluation without perturbing deferred-base attachment.
+- dependent qualified-id and qualified-call substitution now share owner-
+  correct prefix-chain materialization for the focused general
+  expression/lazy-static cases where a member-template hop produces an
+  intermediate type/alias before a final static value or call, covering shapes
+  such as `Traits<T>::template Box<T>::type::value`,
+  `Traits<T>::template Box<T>::type::get()`, and
+  `Derived<T>::template Inner<int>::type::value`.
 
 Latest validation on Linux sharded build:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 Targeted validation for the latest member alias-template non-template
 intermediate chain slice passed the focused ELF regressions after
 `make sharded CXX=clang++`.
-Focused Windows/MSVC validation for this slice passed
-`test_ratio_inherited_type_default_nttp_value_ret0.cpp` plus nearby ratio and
-dependent-member regressions. Latest Windows/MSVC full-suite validation after
-adding that regression:
-`2476` regular tests compiled/linked/runtime-pass, `1` unrelated regular test
-link-fail (`template_template_with_member_ret0.cpp`), `181` expected-fail
-tests.
+Focused Windows/MSVC validation for this slice passed the new deeper
+dependent-chain regressions plus nearby ratio and dependent-member regressions.
+Latest Windows/MSVC full-suite validation after this slice:
+`2481` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -139,8 +143,8 @@ Immediate targets:
 
 Most concrete next subtask:
 
-- finish the remaining dependent-base/unknown-specialization member-chain work
-  after the latest replay-metadata improvements: deferred explicit-template
+- finish the remaining declaration/static-member two-phase lookup work after the
+  latest replay-metadata improvements: deferred explicit-template
   qualified-call records now preserve the instantiated placeholder `owner_type`
   instead of dropping it at parse time, and variable-template initializers now
   capture replay metadata for covered namespace/member declarations. Deferred
@@ -167,11 +171,13 @@ Most concrete next subtask:
   specifiers now work as well, and covered member alias-template declarations
   now preserve non-template intermediate member segments plus enclosing
   class-template bindings for cases like `Provider<T>::Node::template Apply<U>`.
-  The next bounded follow-up is expanding that owner-correct path to deeper
-  dependent-base/unknown-specialization chains, especially when value or static
-  member lookups appear between type/member-alias segments. Separate from this
-  slice, current Windows full-suite validation still exposes an unrelated link
-  failure in `template_template_with_member_ret0.cpp`.
+  General expression/lazy-static substitution now also covers the focused
+  deeper dependent-base/unknown-specialization
+  `member-template -> type/alias -> value/call` chains via a shared owner-
+  correct prefix materialization path reused by qualified-id and call
+  substitution. The next bounded follow-up is therefore the remaining
+  declaration/static-member/deferred-base paths that still never captured enough
+  metadata to stay on that semantic path and still require AST-only fallback.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -252,11 +258,15 @@ coverage becomes sufficient.
       covered for the focused member-template and nested-alias `::value` cases;
    - treat lookup-time canonical owner materialization as covered for the
       focused ratio-style inherited `::type::value` default-NTTP path;
-   - extend owner-correct replay/materialization into the remaining declaration
-      and deferred-base paths outside the covered static-member,
-      variable-template initializer, and default-NTTP parser flows;
+   - treat general expression/lazy-static deeper dependent-base and
+     unknown-specialization `member-template -> type/alias -> value/call`
+     chains as covered for the focused qualified-id and call-substitution
+     paths;
+   - extend owner-correct replay/materialization into the remaining
+     declaration, static-member, and deferred-base paths outside the covered
+     variable-template initializer and default-NTTP parser flows;
    - remove the next AST-only/deferred-base fallback path, with the next bounded
-      target now deeper dependent-base/unknown-specialization value-hop chains.
+     target now the remaining declaration/static-member replay gaps.
 
 2. **Dependent-name/current-instantiation expansion**
    - richer dependent-base and unknown-specialization records;
@@ -363,6 +373,10 @@ re-solving already-solved problems.
   `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
   resolution, covering ratio-style inherited `::type` followed by default-NTTP
   `::value` use without introducing another fallback path.
+- dependent qualified-id and qualified-call substitution now share owner-
+  correct prefix-chain materialization for the covered general
+  expression/lazy-static chains where a member-template hop feeds an
+  intermediate type/alias before the final static member or member call.
 
 ## Exit criteria
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -951,6 +951,247 @@ InlineVector<TemplateTypeArg, 4> ExpressionSubstitutor::materializeDependentReco
 	return materialized_args;
 }
 
+Parser::AliasTemplateMaterializationResult
+ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
+	const TypeInfo::DependentQualifiedNameRecord& dependent_name,
+	int depth,
+	bool prefer_current_owner_type_name) {
+	Parser::AliasTemplateMaterializationResult materialized_owner;
+	std::string_view owner_name =
+		StringTable::getStringView(dependent_name.owner_name);
+	auto assign_owner_type =
+		[&](const TypeInfo* owner_type_info) {
+		if (owner_type_info == nullptr) {
+			return;
+		}
+		materialized_owner.resolved_type_info = owner_type_info;
+		if (owner_type_info->name().isValid()) {
+			materialized_owner.instantiated_name =
+				StringTable::getStringView(owner_type_info->name());
+		}
+	};
+
+	switch (dependent_name.owner_kind) {
+	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
+		if (prefer_current_owner_type_name &&
+			current_owner_type_name_.isValid()) {
+			materialized_owner.instantiated_name =
+				StringTable::getStringView(current_owner_type_name_);
+			materialized_owner.resolved_type_info =
+				findTypeByName(current_owner_type_name_);
+			break;
+		}
+		if (dependent_name.owner_type.is_valid()) {
+			assign_owner_type(tryGetTypeInfo(dependent_name.owner_type));
+		}
+		break;
+	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
+		if (dependent_name.owner_template_arguments.empty()) {
+			if (auto owner_subst_it = param_map_.find(owner_name);
+				owner_subst_it != param_map_.end()) {
+				if (const TypeInfo* owner_type_info =
+						tryGetTypeInfo(owner_subst_it->second.type_index)) {
+					materialized_owner =
+						parser_.materializeCanonicalOwnerTypeForLookup(*owner_type_info, {});
+					if (materialized_owner.instantiated_name.empty() &&
+						materialized_owner.resolved_type_info == nullptr) {
+						assign_owner_type(owner_type_info);
+					}
+				}
+			}
+			break;
+		}
+		[[fallthrough]];
+	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation:
+	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization: {
+		InlineVector<TemplateTypeArg, 4> owner_args =
+			materializeDependentRecordTemplateArgs(
+				dependent_name.owner_template_arguments,
+				depth);
+		if (owner_args.empty() && !dependent_name.owner_template_arguments.empty()) {
+			break;
+		}
+		if (templateArgsStillDependent(owner_args)) {
+			break;
+		}
+		if (auto owner_template_subst_it = param_map_.find(owner_name);
+			owner_template_subst_it != param_map_.end() &&
+			owner_template_subst_it->second.is_template_template_arg &&
+			owner_template_subst_it->second.template_name_handle.isValid()) {
+			owner_name = StringTable::getStringView(
+				owner_template_subst_it->second.template_name_handle);
+		}
+		materialized_owner =
+			parser_.resolveCanonicalInstantiatedOwnerForLookup(
+				owner_name,
+				std::span<const TemplateTypeArg>(
+					owner_args.data(),
+					owner_args.size()));
+		if (materialized_owner.instantiated_name.empty() &&
+			materialized_owner.resolved_type_info == nullptr &&
+			!owner_args.empty()) {
+			materialized_owner.instantiated_name =
+				parser_.get_instantiated_class_name(owner_name, owner_args);
+			if (!materialized_owner.instantiated_name.empty()) {
+				materialized_owner.resolved_type_info = findTypeByName(
+					StringTable::getOrInternStringHandle(
+						materialized_owner.instantiated_name));
+			}
+		}
+		break;
+	}
+	}
+
+	return materialized_owner;
+}
+
+ExpressionSubstitutor::MaterializedQualifiedLookupOwner
+ExpressionSubstitutor::materializeDependentQualifiedMemberPrefixOwner(
+	StringHandle owner_name_handle,
+	std::string_view recorded_owner_name,
+	std::span<const TypeInfo::DependentQualifiedNameRecord::Member> prefix_chain,
+	int depth) {
+	MaterializedQualifiedLookupOwner result;
+	if (!owner_name_handle.isValid()) {
+		return result;
+	}
+
+	result.owner_name = owner_name_handle;
+	result.owner_type = findTypeByName(owner_name_handle);
+
+	for (size_t i = 0; i < prefix_chain.size(); ++i) {
+		const auto& member_record = prefix_chain[i];
+		std::string_view chained_owner_name =
+			StringTable::getStringView(result.owner_name);
+		if (chained_owner_name.empty()) {
+			result = {};
+			return result;
+		}
+
+		if (member_record.has_template_arguments) {
+			InlineVector<TemplateTypeArg, 4> member_args =
+				materializeDependentRecordTemplateArgs(
+					member_record.template_arguments,
+					depth);
+			if (templateArgsStillDependent(member_args)) {
+				result = {};
+				return result;
+			}
+
+			std::string_view member_name =
+				StringTable::getStringView(member_record.name);
+			std::string_view qualified_owner_name;
+			if (i == 0 &&
+				!recorded_owner_name.empty()) {
+				std::string_view pattern_owner_name =
+					StringBuilder()
+						.append(recorded_owner_name)
+						.append("::")
+						.append(member_name)
+						.commit();
+				if (gTemplateRegistry.lookupTemplate(pattern_owner_name).has_value()) {
+					qualified_owner_name = pattern_owner_name;
+				}
+			}
+			if (qualified_owner_name.empty()) {
+				qualified_owner_name =
+					parser_.lookup_inherited_member_template_name(
+						result.owner_name,
+						member_record.name,
+						0);
+			}
+			if (qualified_owner_name.empty()) {
+				qualified_owner_name =
+					StringBuilder()
+						.append(chained_owner_name)
+						.append("::")
+						.append(member_name)
+						.commit();
+			}
+
+			if (result.owner_type != nullptr &&
+				result.owner_type->hasInstantiationContext()) {
+				const TypeInfo::InstantiationContext* parent_context =
+					result.owner_type->instantiationContext();
+				OuterTemplateBinding outer_binding;
+				for (size_t binding_i = 0;
+					 parent_context != nullptr &&
+					 binding_i < parent_context->param_names.size() &&
+					 binding_i < parent_context->param_args.size();
+					 ++binding_i) {
+					outer_binding.param_names.push_back(
+						parent_context->param_names[binding_i]);
+					outer_binding.param_args.push_back(
+						toTemplateTypeArg(parent_context->param_args[binding_i]));
+				}
+				if (!outer_binding.param_names.empty()) {
+					gTemplateRegistry.registerOuterTemplateBinding(
+						StringTable::getOrInternStringHandle(qualified_owner_name),
+						std::move(outer_binding));
+				}
+			}
+
+			if (std::optional<ASTNode> instantiated_member_template =
+					parser_.try_instantiate_class_template(
+						qualified_owner_name,
+						member_args,
+						false);
+				instantiated_member_template.has_value() &&
+				instantiated_member_template->is<StructDeclarationNode>()) {
+				parser_.registerAndNormalizeLateMaterializedTopLevelNode(
+					*instantiated_member_template);
+			}
+
+			Parser::AliasTemplateMaterializationResult materialized_member_owner =
+				parser_.resolveCanonicalInstantiatedOwnerForLookup(
+					qualified_owner_name,
+					std::span<const TemplateTypeArg>(
+						member_args.data(),
+						member_args.size()));
+			StringHandle next_owner_handle =
+				materialized_member_owner.canonicalNameHandle();
+			if (!next_owner_handle.isValid()) {
+				std::string_view instantiated_owner_name =
+					parser_.get_instantiated_class_name(
+						qualified_owner_name,
+						member_args);
+				if (!instantiated_owner_name.empty()) {
+					next_owner_handle =
+						StringTable::getOrInternStringHandle(instantiated_owner_name);
+				}
+			}
+			if (!next_owner_handle.isValid()) {
+				result = {};
+				return result;
+			}
+
+			result.owner_name = next_owner_handle;
+			result.owner_type = materialized_member_owner.resolved_type_info;
+			if (result.owner_type == nullptr) {
+				result.owner_type = findTypeByName(next_owner_handle);
+			}
+			continue;
+		}
+
+		QualifiedTypeMemberAccess member_access;
+		member_access.member_name = member_record.name;
+		const TypeInfo* resolved_owner =
+			resolveQualifiedMemberNamespaceChain(
+				chained_owner_name,
+				std::span<QualifiedTypeMemberAccess>(&member_access, 1));
+		if (resolved_owner == nullptr ||
+			!resolved_owner->name().isValid()) {
+			result = {};
+			return result;
+		}
+
+		result.owner_type = resolved_owner;
+		result.owner_name = resolved_owner->name();
+	}
+
+	return result;
+}
+
 bool ExpressionSubstitutor::templateArgsStillDependent(std::span<const TemplateTypeArg> args) const {
 	for (const TemplateTypeArg& arg : args) {
 		if (arg.is_dependent) {
@@ -980,59 +1221,13 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 
 	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
 			type_info.dependentQualifiedName()) {
-		std::string_view owner_name =
-			StringTable::getStringView(dependent_name->owner_name);
-		std::string_view materialized_owner_name;
-		switch (dependent_name->owner_kind) {
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
-			if (current_owner_type_name_.isValid()) {
-				materialized_owner_name =
-					StringTable::getStringView(current_owner_type_name_);
-				break;
-			}
-			if (dependent_name->owner_type.is_valid()) {
-				if (const TypeInfo* owner_type_info =
-						tryGetTypeInfo(dependent_name->owner_type)) {
-					materialized_owner_name =
-						StringTable::getStringView(owner_type_info->name());
-				}
-			}
-			break;
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
-			if (dependent_name->owner_template_arguments.empty()) {
-				if (auto owner_subst_it = param_map_.find(owner_name);
-					owner_subst_it != param_map_.end()) {
-					const TypeInfo* owner_type_info =
-						tryGetTypeInfo(owner_subst_it->second.type_index);
-					if (owner_type_info != nullptr) {
-						materialized_owner_name =
-							StringTable::getStringView(owner_type_info->name());
-					}
-				}
-				break;
-			}
-			[[fallthrough]];
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation:
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization: {
-			InlineVector<TemplateTypeArg, 4> owner_args =
-				materializeDependentRecordTemplateArgs(dependent_name->owner_template_arguments, depth);
-			if (!owner_args.empty() && !templateArgsStillDependent(owner_args)) {
-				if (auto owner_template_subst_it = param_map_.find(owner_name);
-					owner_template_subst_it != param_map_.end() &&
-					owner_template_subst_it->second.is_template_template_arg) {
-					owner_name = StringTable::getStringView(
-						owner_template_subst_it->second.template_name_handle);
-				}
-				Parser::AliasTemplateMaterializationResult materialized_owner =
-					parser_.materializeTemplateInstantiationForLookup(
-						owner_name,
-						owner_args);
-				materialized_owner_name = materialized_owner.canonicalName();
-			}
-			break;
-		}
-		}
-
+		Parser::AliasTemplateMaterializationResult materialized_owner =
+			materializeDependentQualifiedRecordOwner(
+				*dependent_name,
+				depth,
+				/*prefer_current_owner_type_name=*/true);
+		std::string_view materialized_owner_name =
+			materialized_owner.canonicalName();
 		if (!materialized_owner_name.empty()) {
 			std::vector<QualifiedTypeMemberAccess> member_chain;
 			member_chain.reserve(dependent_name->member_chain.size());
@@ -2062,89 +2257,15 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 			}
 		}
-		auto materializeRecordArgs =
-			[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) {
-			std::vector<TemplateTypeArg> materialized_args;
-			materialized_args.reserve(stored_args.size());
-			for (const TypeInfo::TemplateArgInfo& stored_arg : stored_args) {
-				TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
-				if (arg.dependent_name.isValid()) {
-					auto param_it =
-						param_map_.find(StringTable::getStringView(arg.dependent_name));
-					if (param_it != param_map_.end()) {
-						arg = rebindDependentTemplateTypeArg(param_it->second, arg);
-					}
-				}
-				materialized_args.push_back(std::move(arg));
-			}
-			return materialized_args;
-		};
-		auto areTemplateArgsConcrete = [&](std::span<const TemplateTypeArg> args) {
-			for (const TemplateTypeArg& arg : args) {
-				if (arg.is_dependent) {
-					return false;
-				}
-				if (arg.is_value || !arg.type_index.is_valid()) {
-					continue;
-				}
-				const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index);
-				if (arg_type_info &&
-					(arg_type_info->is_incomplete_instantiation_ ||
-					 (arg_type_info->isTemplateInstantiation() &&
-					  arg_type_info->getStructInfo() == nullptr))) {
-					return false;
-				}
-			}
-			return true;
-		};
-
-		std::string_view materialized_owner_name;
-		std::string_view recorded_owner_name =
+		const std::string_view recorded_owner_name =
 			StringTable::getStringView(dependent_record.owner_name);
-		switch (dependent_record.owner_kind) {
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
-			if (dependent_record.owner_type.is_valid()) {
-				if (const TypeInfo* owner_type_info =
-						tryGetTypeInfo(dependent_record.owner_type)) {
-					materialized_owner_name =
-						StringTable::getStringView(owner_type_info->name());
-				}
-			}
-			break;
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
-			if (dependent_record.owner_template_arguments.empty()) {
-				auto owner_param_it = param_map_.find(recorded_owner_name);
-				if (owner_param_it != param_map_.end()) {
-					if (const TypeInfo* owner_type_info =
-							tryGetTypeInfo(owner_param_it->second.type_index)) {
-						materialized_owner_name =
-							StringTable::getStringView(owner_type_info->name());
-					}
-				}
-				break;
-			}
-			[[fallthrough]];
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation:
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization: {
-			std::vector<TemplateTypeArg> owner_args =
-				materializeRecordArgs(dependent_record.owner_template_arguments);
-			if (areTemplateArgsConcrete(owner_args)) {
-				Parser::AliasTemplateMaterializationResult canonical_owner =
-					parser_.resolveCanonicalInstantiatedOwnerForLookup(
-						recorded_owner_name,
-						std::span<const TemplateTypeArg>(
-							owner_args.data(),
-							owner_args.size()));
-				if (!canonical_owner.instantiated_name.empty()) {
-					materialized_owner_name = canonical_owner.instantiated_name;
-				} else if (canonical_owner.resolved_type_info != nullptr) {
-					materialized_owner_name =
-						StringTable::getStringView(canonical_owner.resolved_type_info->name());
-				}
-			}
-			break;
-		}
-		}
+		Parser::AliasTemplateMaterializationResult materialized_owner =
+			materializeDependentQualifiedRecordOwner(
+				dependent_record,
+				kInitialDependentMemberTypeResolutionDepth,
+				/*prefer_current_owner_type_name=*/false);
+		std::string_view materialized_owner_name =
+			materialized_owner.canonicalName();
 
 		if (!materialized_owner_name.empty() &&
 			!dependent_record.member_chain.empty()) {
@@ -2153,166 +2274,22 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			std::string_view member_name =
 				StringTable::getStringView(
 					dependent_record.member_chain.back().name);
-			std::vector<QualifiedTypeMemberAccess> owner_member_chain;
-			owner_member_chain.reserve(
-				dependent_record.member_chain.size() > 0
-					? dependent_record.member_chain.size() - 1
-					: 0);
-			bool owner_chain_concrete = true;
-			for (size_t i = 0; i + 1 < dependent_record.member_chain.size(); ++i) {
-				const auto& member_record = dependent_record.member_chain[i];
-				QualifiedTypeMemberAccess member_access;
-				member_access.member_name = member_record.name;
-				if (member_record.has_template_arguments) {
-					std::vector<TemplateTypeArg> member_args =
-						materializeRecordArgs(member_record.template_arguments);
-					if (!areTemplateArgsConcrete(member_args)) {
-						owner_chain_concrete = false;
-						break;
-					}
-					member_access.has_template_arguments = true;
-					member_access.template_arguments =
-						&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(
-							std::move(member_args));
-				}
-				owner_member_chain.push_back(std::move(member_access));
+			if (dependent_record.member_chain.size() > 1) {
+				MaterializedQualifiedLookupOwner materialized_prefix_owner =
+					materializeDependentQualifiedMemberPrefixOwner(
+						StringTable::getOrInternStringHandle(materialized_owner_name),
+						recorded_owner_name,
+						std::span<const TypeInfo::DependentQualifiedNameRecord::Member>(
+							dependent_record.member_chain.data(),
+							dependent_record.member_chain.size() - 1),
+						kInitialDependentMemberTypeResolutionDepth);
+				materialized_owner_name =
+					materialized_prefix_owner.owner_name.isValid()
+						? StringTable::getStringView(materialized_prefix_owner.owner_name)
+						: std::string_view{};
 			}
 
-			if (owner_chain_concrete) {
-				if (!owner_member_chain.empty()) {
-					std::string_view chained_owner_name = materialized_owner_name;
-					bool owner_chain_materialized = true;
-					for (size_t i = 0; i + 1 < dependent_record.member_chain.size(); ++i) {
-						const auto& member_record = dependent_record.member_chain[i];
-						const std::string_view member_name_for_owner =
-							StringTable::getStringView(member_record.name);
-						if (member_record.has_template_arguments) {
-							std::vector<TemplateTypeArg> member_args =
-								materializeRecordArgs(member_record.template_arguments);
-							if (!areTemplateArgsConcrete(member_args)) {
-								owner_chain_materialized = false;
-								break;
-							}
-							const StringHandle chained_owner_handle =
-								StringTable::getOrInternStringHandle(chained_owner_name);
-							const StringHandle member_name_handle =
-								StringTable::getOrInternStringHandle(member_name_for_owner);
-							std::string_view qualified_owner_name;
-							if (i == 0 &&
-								!recorded_owner_name.empty()) {
-								std::string_view pattern_owner_name =
-									StringBuilder()
-										.append(recorded_owner_name)
-										.append("::")
-										.append(member_name_for_owner)
-										.commit();
-								if (gTemplateRegistry.lookupTemplate(pattern_owner_name).has_value()) {
-									qualified_owner_name = pattern_owner_name;
-								}
-							}
-							if (qualified_owner_name.empty()) {
-								qualified_owner_name =
-									parser_.lookup_inherited_member_template_name(
-										chained_owner_handle,
-										member_name_handle,
-										0);
-							}
-							if (qualified_owner_name.empty()) {
-								qualified_owner_name =
-									StringBuilder()
-										.append(chained_owner_name)
-										.append("::")
-										.append(member_name_for_owner)
-										.commit();
-							}
-							if (auto owner_it = getTypesByNameMap().find(chained_owner_handle);
-								owner_it != getTypesByNameMap().end() &&
-								owner_it->second != nullptr &&
-								owner_it->second->hasInstantiationContext()) {
-								const TypeInfo::InstantiationContext* parent_context =
-									owner_it->second->instantiationContext();
-								OuterTemplateBinding outer_binding;
-								for (size_t binding_i = 0;
-									 binding_i < parent_context->param_names.size() &&
-									 binding_i < parent_context->param_args.size();
-									 ++binding_i) {
-									outer_binding.param_names.push_back(
-										parent_context->param_names[binding_i]);
-									outer_binding.param_args.push_back(
-										toTemplateTypeArg(parent_context->param_args[binding_i]));
-								}
-								if (!outer_binding.param_names.empty()) {
-									gTemplateRegistry.registerOuterTemplateBinding(
-										StringTable::getOrInternStringHandle(qualified_owner_name),
-										std::move(outer_binding));
-								}
-							}
-							if (std::optional<ASTNode> instantiated_member_template =
-									parser_.try_instantiate_class_template(
-										qualified_owner_name,
-										member_args,
-										false);
-								instantiated_member_template.has_value() &&
-								instantiated_member_template->is<StructDeclarationNode>()) {
-								parser_.registerAndNormalizeLateMaterializedTopLevelNode(
-									*instantiated_member_template);
-							}
-							Parser::AliasTemplateMaterializationResult materialized_member_owner =
-								parser_.resolveCanonicalInstantiatedOwnerForLookup(
-									qualified_owner_name,
-									std::span<const TemplateTypeArg>(
-										member_args.data(),
-										member_args.size()));
-							chained_owner_name = materialized_member_owner.canonicalName();
-							if (chained_owner_name.empty()) {
-								chained_owner_name =
-									parser_.get_instantiated_class_name(
-										qualified_owner_name,
-										member_args);
-							} else {
-								const StringHandle chained_owner_lookup_handle =
-									StringTable::getOrInternStringHandle(
-										chained_owner_name);
-								auto chained_owner_it =
-									getTypesByNameMap().find(chained_owner_lookup_handle);
-								if (chained_owner_it == getTypesByNameMap().end() ||
-									chained_owner_it->second == nullptr) {
-									std::string_view instantiated_owner_name =
-										parser_.get_instantiated_class_name(
-											qualified_owner_name,
-											member_args);
-									if (!instantiated_owner_name.empty()) {
-										chained_owner_name = instantiated_owner_name;
-									}
-								}
-							}
-							if (chained_owner_name.empty()) {
-								owner_chain_materialized = false;
-								break;
-							}
-							continue;
-						}
-						if (const TypeInfo* resolved_owner =
-								parser_.resolveBaseClassMemberTypeChain(
-									chained_owner_name,
-									std::span<QualifiedTypeMemberAccess>(
-										&owner_member_chain[i],
-										1))) {
-							chained_owner_name =
-								StringTable::getStringView(resolved_owner->name());
-						} else {
-							owner_chain_materialized = false;
-							break;
-						}
-					}
-					if (owner_chain_materialized) {
-						materialized_owner_name = chained_owner_name;
-					} else {
-						materialized_owner_name = {};
-					}
-				}
-
-				if (!materialized_owner_name.empty()) {
+			if (!materialized_owner_name.empty()) {
 					ChunkedVector<ASTNode> substituted_args;
 					for (size_t i = 0; i < call.arguments().size(); ++i) {
 						substituted_args.push_back(substitute(call.arguments()[i]));
@@ -2430,7 +2407,6 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 			}
 		}
-	}
 
 	// If not a template function call or instantiation failed, check for qualified owners
 	// that became concrete during substitution and need canonical owner identity rebound.
@@ -2821,102 +2797,34 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 
 	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
 			qual_id.dependentQualifiedName()) {
-		std::string_view owner_name =
+		const std::string_view recorded_owner_name =
 			StringTable::getStringView(dependent_name->owner_name);
-		std::string_view materialized_owner_name;
-		switch (dependent_name->owner_kind) {
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
-			if (current_owner_type_name_.isValid()) {
-				materialized_owner_name =
-					StringTable::getStringView(current_owner_type_name_);
-			} else if (dependent_name->owner_type.is_valid()) {
-				if (const TypeInfo* owner_type_info =
-						tryGetTypeInfo(dependent_name->owner_type)) {
-					materialized_owner_name =
-						StringTable::getStringView(owner_type_info->name());
-				}
-			}
-			break;
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
-			if (dependent_name->owner_template_arguments.empty()) {
-				if (auto owner_subst_it = param_map_.find(owner_name);
-					owner_subst_it != param_map_.end()) {
-					if (const TypeInfo* owner_type_info =
-							tryGetTypeInfo(owner_subst_it->second.type_index)) {
-						materialized_owner_name =
-							StringTable::getStringView(owner_type_info->name());
-					}
-				}
-				break;
-			}
-			[[fallthrough]];
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation:
-		case TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization: {
-			InlineVector<TemplateTypeArg, 4> owner_args =
-				materializeDependentRecordTemplateArgs(
-					dependent_name->owner_template_arguments,
-					kInitialDependentMemberTypeResolutionDepth);
-			if (!owner_args.empty() && !templateArgsStillDependent(owner_args)) {
-				if (auto owner_template_subst_it = param_map_.find(owner_name);
-					owner_template_subst_it != param_map_.end() &&
-					owner_template_subst_it->second.is_template_template_arg) {
-					owner_name = StringTable::getStringView(
-						owner_template_subst_it->second.template_name_handle);
-				}
-				Parser::AliasTemplateMaterializationResult materialized_owner =
-					parser_.materializeTemplateInstantiationForLookup(owner_name, owner_args);
-				materialized_owner_name = materialized_owner.canonicalName();
-				if (materialized_owner_name.empty()) {
-					materialized_owner_name =
-						parser_.get_instantiated_class_name(owner_name, owner_args);
-				}
-			}
-			break;
-		}
-		}
+		Parser::AliasTemplateMaterializationResult materialized_owner =
+			materializeDependentQualifiedRecordOwner(
+				*dependent_name,
+				kInitialDependentMemberTypeResolutionDepth,
+				/*prefer_current_owner_type_name=*/true);
+		std::string_view materialized_owner_name =
+			materialized_owner.canonicalName();
 
 		if (!materialized_owner_name.empty() && !dependent_name->member_chain.empty()) {
 			std::string_view materialized_namespace = materialized_owner_name;
 			if (dependent_name->member_chain.size() > 1) {
-				std::vector<QualifiedTypeMemberAccess> namespace_member_chain;
-				namespace_member_chain.reserve(
-					dependent_name->member_chain.size() - 1);
-				for (size_t member_index = 0;
-					 member_index + 1 < dependent_name->member_chain.size();
-					 ++member_index) {
-					const auto& member_record =
-						dependent_name->member_chain[member_index];
-					QualifiedTypeMemberAccess member_access;
-					member_access.member_name = member_record.name;
-					if (member_record.has_template_arguments) {
-						InlineVector<TemplateTypeArg, 4> member_args =
-							materializeDependentRecordTemplateArgs(
-								member_record.template_arguments,
-								kInitialDependentMemberTypeResolutionDepth);
-						if (templateArgsStillDependent(member_args)) {
-							ExpressionNode& deferred_expr =
-								gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
-							return ASTNode(&deferred_expr);
-						}
-						member_access.has_template_arguments = true;
-						member_access.template_arguments =
-							&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(
-								member_args.toVector());
-					}
-					namespace_member_chain.push_back(std::move(member_access));
-				}
-				const TypeInfo* resolved_namespace =
-					resolveQualifiedMemberNamespaceChain(
-						materialized_owner_name,
-						namespace_member_chain);
-				if (resolved_namespace == nullptr ||
-					!resolved_namespace->name().isValid()) {
+				MaterializedQualifiedLookupOwner resolved_namespace =
+					materializeDependentQualifiedMemberPrefixOwner(
+						StringTable::getOrInternStringHandle(materialized_owner_name),
+						recorded_owner_name,
+						std::span<const TypeInfo::DependentQualifiedNameRecord::Member>(
+							dependent_name->member_chain.data(),
+							dependent_name->member_chain.size() - 1),
+						kInitialDependentMemberTypeResolutionDepth);
+				if (!resolved_namespace.owner_name.isValid()) {
 					ExpressionNode& deferred_expr =
 						gChunkedAnyStorage.emplace_back<ExpressionNode>(qual_id);
 					return ASTNode(&deferred_expr);
 				}
 				materialized_namespace =
-					StringTable::getStringView(resolved_namespace->name());
+					StringTable::getStringView(resolved_namespace.owner_name);
 			}
 
 			const auto& final_member = dependent_name->member_chain.back();

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1058,6 +1058,15 @@ ExpressionSubstitutor::materializeDependentQualifiedMemberPrefixOwner(
 
 	result.owner_name = owner_name_handle;
 	result.owner_type = findTypeByName(owner_name_handle);
+	StringHandle recorded_owner_name_handle;
+	if (!recorded_owner_name.empty()) {
+		recorded_owner_name_handle =
+			StringTable::getOrInternStringHandle(recorded_owner_name);
+	}
+	result.outer_binding = parser_.buildAccumulatedOuterTemplateBinding(
+		result.owner_type,
+		nullptr,
+		recorded_owner_name_handle);
 
 	for (size_t i = 0; i < prefix_chain.size(); ++i) {
 		const auto& member_record = prefix_chain[i];
@@ -1109,26 +1118,15 @@ ExpressionSubstitutor::materializeDependentQualifiedMemberPrefixOwner(
 						.commit();
 			}
 
-			if (result.owner_type != nullptr &&
-				result.owner_type->hasInstantiationContext()) {
-				const TypeInfo::InstantiationContext* parent_context =
-					result.owner_type->instantiationContext();
-				OuterTemplateBinding outer_binding;
-				for (size_t binding_i = 0;
-					 parent_context != nullptr &&
-					 binding_i < parent_context->param_names.size() &&
-					 binding_i < parent_context->param_args.size();
-					 ++binding_i) {
-					outer_binding.param_names.push_back(
-						parent_context->param_names[binding_i]);
-					outer_binding.param_args.push_back(
-						toTemplateTypeArg(parent_context->param_args[binding_i]));
-				}
-				if (!outer_binding.param_names.empty()) {
-					gTemplateRegistry.registerOuterTemplateBinding(
-						StringTable::getOrInternStringHandle(qualified_owner_name),
-						std::move(outer_binding));
-				}
+			OuterTemplateBinding outer_binding =
+				parser_.buildAccumulatedOuterTemplateBinding(
+					result.owner_type,
+					&result.outer_binding,
+					StringHandle{});
+			if (!outer_binding.param_names.empty()) {
+				gTemplateRegistry.registerOuterTemplateBinding(
+					StringTable::getOrInternStringHandle(qualified_owner_name),
+					std::move(outer_binding));
 			}
 
 			if (std::optional<ASTNode> instantiated_member_template =
@@ -1170,6 +1168,11 @@ ExpressionSubstitutor::materializeDependentQualifiedMemberPrefixOwner(
 			if (result.owner_type == nullptr) {
 				result.owner_type = findTypeByName(next_owner_handle);
 			}
+			result.outer_binding =
+				parser_.buildAccumulatedOuterTemplateBinding(
+					result.owner_type,
+					&result.outer_binding,
+					StringHandle{});
 			continue;
 		}
 

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -115,6 +115,10 @@ private:
 		StringHandle materialized_member_handle{};
 		StringHandle terminal_member_name{};
 	};
+	struct MaterializedQualifiedLookupOwner {
+		const TypeInfo* owner_type = nullptr;
+		StringHandle owner_name{};
+	};
 
 	// Handlers for different expression types
 	ASTNode substituteConstructorCall(const ConstructorCallNode& ctor);
@@ -151,6 +155,15 @@ private:
 		std::span<const TypeInfo::TemplateArgInfo> stored_args,
 		int depth);
 	bool templateArgsStillDependent(std::span<const TemplateTypeArg> args) const;
+	Parser::AliasTemplateMaterializationResult materializeDependentQualifiedRecordOwner(
+		const TypeInfo::DependentQualifiedNameRecord& dependent_name,
+		int depth,
+		bool prefer_current_owner_type_name);
+	MaterializedQualifiedLookupOwner materializeDependentQualifiedMemberPrefixOwner(
+		StringHandle owner_name,
+		std::string_view recorded_owner_name,
+		std::span<const TypeInfo::DependentQualifiedNameRecord::Member> prefix_chain,
+		int depth);
 	MaterializedDependentMemberLookup lookupMaterializedDependentMember(
 		const TypeInfo& type_info,
 		int depth);

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -118,6 +118,7 @@ private:
 	struct MaterializedQualifiedLookupOwner {
 		const TypeInfo* owner_type = nullptr;
 		StringHandle owner_name{};
+		OuterTemplateBinding outer_binding;
 	};
 
 	// Handlers for different expression types

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2875,6 +2875,10 @@ private:
 	AliasTemplateMaterializationResult resolveCanonicalInstantiatedOwnerForLookup(
 		std::string_view owner_name,
 		std::span<const TemplateTypeArg> owner_template_args);
+	OuterTemplateBinding buildAccumulatedOuterTemplateBinding(
+		const TypeInfo* owner_type_info,
+		const OuterTemplateBinding* inherited_binding,
+		StringHandle fallback_binding_lookup_name);
 	std::optional<ASTNode> instantiateLazyMemberForCanonicalOwner(
 		std::string_view& owner_name,
 		std::string_view member_name,

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2112,6 +2112,83 @@ Parser::AliasTemplateMaterializationResult Parser::resolveCanonicalInstantiatedO
 	return result;
 }
 
+OuterTemplateBinding Parser::buildAccumulatedOuterTemplateBinding(
+	const TypeInfo* owner_type_info,
+	const OuterTemplateBinding* inherited_binding,
+	StringHandle fallback_binding_lookup_name) {
+	OuterTemplateBinding binding;
+	auto overlay_binding =
+		[&](StringHandle param_name, const TemplateTypeArg& param_arg) {
+		for (size_t i = 0; i < binding.param_names.size();) {
+			if (binding.param_names[i] == param_name) {
+				binding.param_names.erase(binding.param_names.begin() + i);
+				binding.param_args.erase(binding.param_args.begin() + i);
+				continue;
+			}
+			++i;
+		}
+		binding.param_names.push_back(param_name);
+		binding.param_args.push_back(param_arg);
+	};
+	auto overlay_existing_binding =
+		[&](const OuterTemplateBinding* existing_binding) {
+		if (existing_binding == nullptr) {
+			return;
+		}
+		for (size_t i = 0;
+			 i < existing_binding->param_names.size() &&
+			 i < existing_binding->param_args.size();
+			 ++i) {
+			overlay_binding(
+				existing_binding->param_names[i],
+				existing_binding->param_args[i]);
+		}
+	};
+
+	StringHandle owner_base_binding_handle;
+	if (owner_type_info != nullptr &&
+		owner_type_info->sourceNamespace().isValid() &&
+		owner_type_info->baseTemplateName().isValid()) {
+		owner_base_binding_handle =
+			gNamespaceRegistry.buildQualifiedIdentifier(
+				owner_type_info->sourceNamespace(),
+				owner_type_info->baseTemplateName());
+	}
+
+	if (inherited_binding != nullptr) {
+		overlay_existing_binding(inherited_binding);
+	} else {
+		if (owner_base_binding_handle.isValid()) {
+			overlay_existing_binding(
+				gTemplateRegistry.getOuterTemplateBinding(
+					StringTable::getStringView(owner_base_binding_handle)));
+		}
+		if (fallback_binding_lookup_name.isValid() &&
+			fallback_binding_lookup_name != owner_base_binding_handle) {
+			overlay_existing_binding(
+				gTemplateRegistry.getOuterTemplateBinding(
+					StringTable::getStringView(fallback_binding_lookup_name)));
+		}
+	}
+
+	if (owner_type_info != nullptr &&
+		owner_type_info->hasInstantiationContext()) {
+		const TypeInfo::InstantiationContext* instantiation_context =
+			owner_type_info->instantiationContext();
+		for (size_t i = 0;
+			 instantiation_context != nullptr &&
+			 i < instantiation_context->param_names.size() &&
+			 i < instantiation_context->param_args.size();
+			 ++i) {
+			overlay_binding(
+				instantiation_context->param_names[i],
+				toTemplateTypeArg(instantiation_context->param_args[i]));
+		}
+	}
+
+	return binding;
+}
+
 std::optional<ASTNode> Parser::instantiateLazyMemberForCanonicalOwner(
 	std::string_view& owner_name,
 	std::string_view member_name,

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2528,14 +2528,12 @@ ParseResult Parser::parse_type_specifier() {
 								return ParseResult::error("Failed to parse template arguments for member class template", type_name_token);
 							}
 
-							if (parent_type_it != getTypesByNameMap().end() &&
-								parent_type_it->second->hasInstantiationContext()) {
-								const TypeInfo::InstantiationContext* parent_context = parent_type_it->second->instantiationContext();
-								OuterTemplateBinding outer_binding;
-								for (size_t i = 0; i < parent_context->param_names.size() && i < parent_context->param_args.size(); ++i) {
-									outer_binding.param_names.push_back(parent_context->param_names[i]);
-									outer_binding.param_args.push_back(toTemplateTypeArg(parent_context->param_args[i]));
-								}
+							if (parent_type_it != getTypesByNameMap().end()) {
+								OuterTemplateBinding outer_binding =
+									buildAccumulatedOuterTemplateBinding(
+										parent_type_it->second,
+										nullptr,
+										StringHandle{});
 								if (!outer_binding.param_names.empty()) {
 									gTemplateRegistry.registerOuterTemplateBinding(member_template_name_handle, std::move(outer_binding));
 								}
@@ -2606,31 +2604,11 @@ ParseResult Parser::parse_type_specifier() {
 								// must also pull in whatever outer binding was used for the chain parent.
 								StringHandle chain_template_handle = StringTable::getOrInternStringHandle(chain_template_name);
 								{
-									OuterTemplateBinding chain_outer_binding;
-									// First: carry over any outer binding that was used when the chain parent was instantiated
-									if (const OuterTemplateBinding* ancestor_binding = gTemplateRegistry.getOuterTemplateBinding(
-											StringTable::getStringView(chain_full_base_handle))) {
-										for (size_t i = 0; i < ancestor_binding->param_names.size() && i < ancestor_binding->param_args.size(); ++i) {
-											chain_outer_binding.param_names.push_back(ancestor_binding->param_names[i]);
-											chain_outer_binding.param_args.push_back(ancestor_binding->param_args[i]);
-										}
-									}
-									// Second: add the chain parent's own template params
-									if (chain_parent_it->second->hasInstantiationContext()) {
-										const TypeInfo::InstantiationContext* chain_ctx = chain_parent_it->second->instantiationContext();
-										for (size_t i = 0; i < chain_ctx->param_names.size() && i < chain_ctx->param_args.size(); ++i) {
-											for (size_t existing_i = 0; existing_i < chain_outer_binding.param_names.size();) {
-												if (chain_outer_binding.param_names[existing_i] == chain_ctx->param_names[i]) {
-													chain_outer_binding.param_names.erase(chain_outer_binding.param_names.begin() + existing_i);
-													chain_outer_binding.param_args.erase(chain_outer_binding.param_args.begin() + existing_i);
-													continue;
-												}
-												++existing_i;
-											}
-											chain_outer_binding.param_names.push_back(chain_ctx->param_names[i]);
-											chain_outer_binding.param_args.push_back(toTemplateTypeArg(chain_ctx->param_args[i]));
-										}
-									}
+									OuterTemplateBinding chain_outer_binding =
+										buildAccumulatedOuterTemplateBinding(
+											chain_parent_it->second,
+											nullptr,
+											chain_full_base_handle);
 									if (!chain_outer_binding.param_names.empty()) {
 										gTemplateRegistry.registerOuterTemplateBinding(chain_template_handle, std::move(chain_outer_binding));
 									}

--- a/tests/test_template_dependent_base_member_template_type_value_ret0.cpp
+++ b/tests/test_template_dependent_base_member_template_type_value_ret0.cpp
@@ -1,0 +1,37 @@
+struct true_type {
+	static constexpr int value = 42;
+};
+
+struct false_type {
+	static constexpr int value = 7;
+};
+
+template <bool Select>
+struct chooser;
+
+template <>
+struct chooser<true> {
+	using type = true_type;
+};
+
+template <>
+struct chooser<false> {
+	using type = false_type;
+};
+
+template <typename T>
+struct Base {
+	template <typename U>
+	struct Inner {
+		using type = typename chooser<(sizeof(T) == sizeof(U))>::type;
+	};
+};
+
+template <typename T>
+struct Derived : Base<T> {
+	static constexpr int value = Derived<T>::template Inner<int>::type::value;
+};
+
+int main() {
+	return Derived<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_member_template_type_call_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_member_template_type_call_ret0.cpp
@@ -1,0 +1,41 @@
+struct true_type {
+	static constexpr int get() {
+		return 42;
+	}
+};
+
+struct false_type {
+	static constexpr int get() {
+		return 7;
+	}
+};
+
+template <bool Select>
+struct chooser;
+
+template <>
+struct chooser<true> {
+	using type = true_type;
+};
+
+template <>
+struct chooser<false> {
+	using type = false_type;
+};
+
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		using type = typename chooser<(sizeof(U) == sizeof(T))>::type;
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value = Traits<T>::template Box<T>::type::get();
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_member_template_type_value_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_member_template_type_value_ret0.cpp
@@ -1,0 +1,37 @@
+struct true_type {
+	static constexpr int value = 42;
+};
+
+struct false_type {
+	static constexpr int value = 7;
+};
+
+template <bool Select>
+struct chooser;
+
+template <>
+struct chooser<true> {
+	using type = true_type;
+};
+
+template <>
+struct chooser<false> {
+	using type = false_type;
+};
+
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		using type = typename chooser<(sizeof(U) == sizeof(T))>::type;
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value = Traits<T>::template Box<T>::type::value;
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}

--- a/tests/test_template_lazy_static_unknown_specialization_multilevel_member_template_value_ret0.cpp
+++ b/tests/test_template_lazy_static_unknown_specialization_multilevel_member_template_value_ret0.cpp
@@ -1,0 +1,45 @@
+struct true_type {
+	static constexpr int value = 42;
+};
+
+struct false_type {
+	static constexpr int value = 7;
+};
+
+template <bool Select>
+struct chooser;
+
+template <>
+struct chooser<true> {
+	using type = true_type;
+};
+
+template <>
+struct chooser<false> {
+	using type = false_type;
+};
+
+template <typename T>
+struct Traits {
+	template <typename U>
+	struct Box {
+		template <typename V>
+		struct Selector {
+			using type =
+				typename chooser<
+					(sizeof(T) == sizeof(int)) &&
+					(sizeof(U) == 1) &&
+					(sizeof(V) == 8)>::type;
+		};
+	};
+};
+
+template <typename T>
+struct Holder {
+	inline static int value =
+		Traits<T>::template Box<char>::template Selector<long long>::type::value;
+};
+
+int main() {
+	return Holder<int>::value == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Description
Add shared owner-correct prefix materialization for deeper dependent qualified member chains.

Implements the highest-impact bounded template infrastructure slice: deeper dependent-base and unknown-specialization member chains in general expression/lazy-static substitution paths.

## Problem
The dependent qualified-id substitution path (for static member access like `T::type::value`) only materializes the root owner and uses namespace-chain lookup for segments. In contrast, the dependent qualified-call path (for static member functions like `T::type::get()`) uses a stronger per-hop owner materialization with canonical resolution and inherited-member-template retries. This inconsistency causes failures on deeper chains that pass through member-templates to intermediate types/aliases.

## Solution
Extracted shared owner-materialization helpers that model the call-path's stronger per-hop logic:
- `materializeDependentQualifiedRecordOwner`: materializes root owner with canonical resolution, respecting current-instantiation preference
- `materializeDependentQualifiedMemberPrefixOwner`: materializes full member prefix chain with per-hop resolution for both template-arg hops (via `try_instantiate_class_template`) and non-template hops (via `resolveBaseClassMemberTypeChain`)

Both qualified-id and qualified-call substitution paths now use these helpers, preserving the stronger per-hop logic while maintaining existing CurrentInstantiation semantics differences.

## Changes
- **src/ExpressionSubstitutor.h**: Added MaterializedQualifiedLookupOwner struct and two private helper declarations
- **src/ExpressionSubstitutor.cpp**: 
  - Implemented `materializeDependentQualifiedRecordOwner` with canonical resolution
  - Implemented `materializeDependentQualifiedMemberPrefixOwner` with per-hop prefix chain materialization
  - Refactored `lookupMaterializedDependentMember` to use new owner helper
  - Rewired dependent qualified-call substitution to use prefix helper
  - Rewired qualified-id substitution to use prefix helper

- **tests/**: Added 3 focused regressions covering target shapes:
  - `test_template_lazy_static_unknown_specialization_member_template_type_value_ret0.cpp`: Unknown-specialization type-alias-to-value shape
  - `test_template_lazy_static_unknown_specialization_member_template_type_call_ret0.cpp`: Unknown-specialization type-alias-to-call shape
  - `test_template_dependent_base_member_template_type_value_ret0.cpp`: Dependent-base shape

- **docs/**: Updated architecture audit and standard-conformance documents with completed work and refined next steps

## Technical Details
- Preserves stronger call-path per-hop materialization (canonical resolution + inherited-member template retries) instead of namespace-chain-only qual-id path
- Maintains CurrentInstantiation semantics differences via `prefer_current_owner_type_name` parameter
- Call-only fallback logic (lookup_all, parent_name.ends_with, qualified_owner_name retry) kept separate to avoid leaking call-specific concerns
- Handles deferred expressions: zeros result if prefix args remain dependent after materialization

## Validation
- **Targeted regressions**: 7/7 pass (compile, link, runtime)
- **Full Windows suite**: 2481 regular tests pass + 181 expected-fail = 100% success

## Next Steps
Remaining work per updated architecture audit:
1. Declaration/static-member paths that never captured materialization metadata
2. Deferred-base paths requiring replay of witness/metadata
3. Static member template instantiation ordering refinement

See docs/2026-05-12-template-argument-architecture-audit.md for detailed roadmap.