### PR TITLE
[codex] Fix dependent member variable-template chain recovery

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -74,26 +74,3 @@ before stopping on a multiply defined `__security_cookie`.
   emitting a second strong symbol.
 
 ---
-
-## 4) Sema does not annotate implicit conversions for non-standard-arithmetic binary operands
-
-- **Symptom**: Binary expressions where one or both operands are non-standard-arithmetic
-  types (unscoped enums, pointer types, function pointer types, user-defined types) fall
-  back to `generateTypeConversion` in the codegen layer instead of being annotated by sema.
-- **Root cause**: `SemanticAnalysis::normalizeBinaryOperator` (called during sema pass)
-  annotates implicit arithmetic conversions for standard arithmetic types (int, float, etc.)
-  but does not emit conversion annotations for:
-    - Unscoped enum → underlying integer type (e.g. `Status::OK == 1`)
-    - Static local / global variable pointer → value type conversions
-    - Function pointer nullptr comparisons
-- **Affected path**: `IrGenerator_Expr_Operators.cpp` Phase 15 LHS/RHS conversion block
-  in the sema-normalized binary-operator conversion logic; the existing `InternalError` guard fires only for sema-normalized +
-  both standard-arithmetic mismatches; the `generateTypeConversion` fallback handles the rest.
-- **Impact**: The fallback produces correct code today, but prevents the codegen layer from
-  being a strict "no-implicit-conversion" consumer of sema output.
-- **Fix direction**: Extend `normalizeBinaryOperator` (or a dedicated sema pass) to emit
-  `TypeConversionAnnotation` nodes for unscoped-enum-to-int and other non-arithmetic
-  implicit conversions; then promote the `generateTypeConversion` fallback at line 3394 to
-  an `InternalError`.
-
----

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -75,18 +75,25 @@ before stopping on a multiply defined `__security_cookie`.
 
 ---
 
-## 3) Dependent qualified member variable-template chains are not fully recovered
+## 4) Sema does not annotate implicit conversions for non-standard-arithmetic binary operands
 
-- **Symptom**: A variable-template initializer such as
-  `Outer<T>::template member<U>` can still lower to an unresolved qualified
-  identifier when the member is itself a variable template and the owner is a
-  dependent class-template instantiation.
-- **Root cause**: Replay reparses the initializer under the definition context,
-  but the later expression substitution path does not always recover concrete
-  explicit template arguments for qualified member variable-template calls.
-- **Affected path**: `Parser::try_instantiate_variable_template` initializer
-  replay followed by `ExpressionSubstitutor` handling of unresolved qualified
-  member variable-template calls.
-- **Impact**: The new replay infrastructure covers namespace variable templates
-  and member-template function chains, but fully dependent member variable-template
-  chains need a follow-up instantiation recovery pass.
+- **Symptom**: Binary expressions where one or both operands are non-standard-arithmetic
+  types (unscoped enums, pointer types, function pointer types, user-defined types) fall
+  back to `generateTypeConversion` in the codegen layer instead of being annotated by sema.
+- **Root cause**: `SemanticAnalysis::normalizeBinaryOperator` (called during sema pass)
+  annotates implicit arithmetic conversions for standard arithmetic types (int, float, etc.)
+  but does not emit conversion annotations for:
+    - Unscoped enum → underlying integer type (e.g. `Status::OK == 1`)
+    - Static local / global variable pointer → value type conversions
+    - Function pointer nullptr comparisons
+- **Affected path**: `IrGenerator_Expr_Operators.cpp` Phase 15 LHS/RHS conversion block
+  in the sema-normalized binary-operator conversion logic; the existing `InternalError` guard fires only for sema-normalized +
+  both standard-arithmetic mismatches; the `generateTypeConversion` fallback handles the rest.
+- **Impact**: The fallback produces correct code today, but prevents the codegen layer from
+  being a strict "no-implicit-conversion" consumer of sema output.
+- **Fix direction**: Extend `normalizeBinaryOperator` (or a dedicated sema pass) to emit
+  `TypeConversionAnnotation` nodes for unscoped-enum-to-int and other non-arithmetic
+  implicit conversions; then promote the `generateTypeConversion` fallback at line 3394 to
+  an `InternalError`.
+
+---

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -5147,42 +5147,55 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 		return EvalResult::error("Cannot evaluate qualified identifier: no symbol table provided");
 	}
 
-	auto collectQualifiedVariableTemplateArgs =
-		[&](const TypeInfo* lookup_owner_type) -> std::vector<TemplateTypeArg> {
+	struct QualifiedVariableTemplateArgsResult {
 		std::vector<TemplateTypeArg> template_args;
+		std::optional<EvalResult> error;
+		bool has_template_args = false;
+	};
+
+	auto collectQualifiedVariableTemplateArgs =
+		[&](const TypeInfo* lookup_owner_type) -> QualifiedVariableTemplateArgsResult {
+		QualifiedVariableTemplateArgsResult result;
 		if (qualified_id.has_template_arguments()) {
-			template_args.reserve(qualified_id.template_arguments().size());
+			result.has_template_args = true;
+			result.template_args.reserve(qualified_id.template_arguments().size());
 			for (const ASTNode& arg_node : qualified_id.template_arguments()) {
 				if (arg_node.is<TypeSpecifierNode>()) {
-					template_args.emplace_back(arg_node.as<TypeSpecifierNode>());
+					result.template_args.emplace_back(arg_node.as<TypeSpecifierNode>());
 					continue;
 				}
 				if (!arg_node.is<ExpressionNode>()) {
-					return {};
+					result.error = EvalResult::error(
+						"Unsupported template argument type for qualified variable template");
+					return result;
 				}
 
 				EvalResult arg_val = evaluate(arg_node, context);
 				if (!arg_val.success()) {
-					return {};
+					result.error = EvalResult::error(
+						"Failed to evaluate non-type template argument: " +
+						arg_val.error_message);
+					return result;
 				}
-				template_args.push_back(templateTypeArgFromEvalResult(arg_val));
+				result.template_args.push_back(templateTypeArgFromEvalResult(arg_val));
 			}
-			return template_args;
+			return result;
 		}
 
 		const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 			qualified_id.dependentQualifiedName();
 		if (dependent_record == nullptr ||
 			dependent_record->member_chain.empty()) {
-			return {};
+			return result;
 		}
 
 		const auto& final_member = dependent_record->member_chain.back();
 		if (!final_member.has_template_arguments) {
-			return {};
+			return result;
 		}
 
-		template_args.reserve(final_member.template_arguments.size());
+		result.has_template_args = true;
+		result.template_args.reserve(final_member.template_arguments.size());
 		for (const TypeInfo::TemplateArgInfo& stored_arg : final_member.template_arguments) {
 			TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
 			if (std::optional<TemplateTypeArg> rebound_arg =
@@ -5197,13 +5210,16 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 			if (arg.is_value && arg.dependent_expr.has_value()) {
 				EvalResult arg_val = evaluate(*arg.dependent_expr, context);
 				if (!arg_val.success()) {
-					return {};
+					result.error = EvalResult::error(
+						"Failed to evaluate non-type template argument: " +
+						arg_val.error_message);
+					return result;
 				}
 				arg = templateTypeArgFromEvalResult(arg_val);
 			}
-			template_args.push_back(std::move(arg));
+			result.template_args.push_back(std::move(arg));
 		}
-		return template_args;
+		return result;
 	};
 
 	auto tryInstantiateQualifiedMemberVariableTemplate =
@@ -5212,11 +5228,17 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 			return std::nullopt;
 		}
 
-		std::vector<TemplateTypeArg> template_args =
+		QualifiedVariableTemplateArgsResult template_arg_result =
 			collectQualifiedVariableTemplateArgs(lookup_owner_type);
-		if (template_args.empty()) {
+		if (template_arg_result.error.has_value()) {
+			return *template_arg_result.error;
+		}
+		if (!template_arg_result.has_template_args ||
+			template_arg_result.template_args.empty()) {
 			return std::nullopt;
 		}
+		std::vector<TemplateTypeArg>& template_args =
+			template_arg_result.template_args;
 
 		Parser& parser = *context.parser;
 		StringHandle owner_handle{};
@@ -5236,26 +5258,28 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 				}
 			}
 		}
-		if (!owner_handle.isValid()) {
-			return std::nullopt;
+		std::string_view variable_template_lookup_name;
+		std::optional<OuterTemplateBinding> explicit_outer_binding;
+		if (owner_handle.isValid()) {
+			variable_template_lookup_name =
+				parser.lookup_inherited_member_variable_template_name(
+					owner_handle,
+					qualified_id.nameHandle(),
+					0);
+			if (variable_template_lookup_name.empty()) {
+				StringBuilder qualified_name_builder;
+				variable_template_lookup_name = qualified_name_builder
+					.append(StringTable::getStringView(owner_handle))
+					.append("::")
+					.append(qualified_id.name())
+					.commit();
+			}
+			explicit_outer_binding =
+				parser.buildOuterBindingForOwner(owner_handle);
+		} else {
+			variable_template_lookup_name = qualified_id.name();
 		}
 
-		std::string_view variable_template_lookup_name =
-			parser.lookup_inherited_member_variable_template_name(
-				owner_handle,
-				qualified_id.nameHandle(),
-				0);
-		if (variable_template_lookup_name.empty()) {
-			StringBuilder qualified_name_builder;
-			variable_template_lookup_name = qualified_name_builder
-				.append(StringTable::getStringView(owner_handle))
-				.append("::")
-				.append(qualified_id.name())
-				.commit();
-		}
-
-		std::optional<OuterTemplateBinding> explicit_outer_binding =
-			parser.buildOuterBindingForOwner(owner_handle);
 		std::optional<ASTNode> instantiated_var =
 			parser.try_instantiate_variable_template(
 				variable_template_lookup_name,

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -5147,11 +5147,10 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 		return EvalResult::error("Cannot evaluate qualified identifier: no symbol table provided");
 	}
 
-	// Try to look up the qualified name
-	auto symbol_opt = context.symbols->lookup_qualified(qualified_id.qualifiedIdentifier());
-	if (!symbol_opt.has_value()) {
-		if (qualified_id.has_template_arguments() && context.parser != nullptr) {
-			std::vector<TemplateTypeArg> template_args;
+	auto collectQualifiedVariableTemplateArgs =
+		[&](const TypeInfo* lookup_owner_type) -> std::vector<TemplateTypeArg> {
+		std::vector<TemplateTypeArg> template_args;
+		if (qualified_id.has_template_arguments()) {
 			template_args.reserve(qualified_id.template_arguments().size());
 			for (const ASTNode& arg_node : qualified_id.template_arguments()) {
 				if (arg_node.is<TypeSpecifierNode>()) {
@@ -5159,84 +5158,142 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 					continue;
 				}
 				if (!arg_node.is<ExpressionNode>()) {
-					return EvalResult::error(
-						"Unsupported template argument type for qualified variable template");
+					return {};
 				}
 
 				EvalResult arg_val = evaluate(arg_node, context);
 				if (!arg_val.success()) {
-					return EvalResult::error(
-						"Failed to evaluate non-type template argument: " +
-						arg_val.error_message);
+					return {};
 				}
-
-				TypeCategory arg_type = TypeCategory::Int;
-				if (std::holds_alternative<bool>(arg_val.value)) {
-					arg_type = TypeCategory::Bool;
-				} else if (arg_val.is_uint()) {
-					arg_type = TypeCategory::UnsignedLongLong;
-				}
-				template_args.emplace_back(arg_val.as_int(), arg_type);
+				template_args.push_back(templateTypeArgFromEvalResult(arg_val));
 			}
-			if (!template_args.empty()) {
-				Parser& parser = *context.parser;
-				std::string_view scope_name =
-					gNamespaceRegistry.getQualifiedName(qualified_id.namespace_handle());
-				std::string_view qualified_lookup_name = qualified_id.name();
-				StringBuilder qualified_name_builder;
-				if (!scope_name.empty()) {
-					qualified_lookup_name = qualified_name_builder
-						.append(scope_name)
-						.append("::")
-						.append(qualified_id.name())
-						.commit();
-				}
-				std::string_view variable_template_lookup_name =
-					qualified_lookup_name;
-				std::optional<OuterTemplateBinding> explicit_outer_binding;
-				if (!scope_name.empty()) {
-					std::string_view member_variable_template_name =
-						parser.lookup_inherited_member_variable_template_name(
-							StringTable::getOrInternStringHandle(scope_name),
-							StringTable::getOrInternStringHandle(qualified_id.name()),
-							0);
-					if (!member_variable_template_name.empty()) {
-						variable_template_lookup_name =
-							member_variable_template_name;
-					}
-					explicit_outer_binding =
-						parser.buildOuterBindingForOwner(
-							StringTable::getOrInternStringHandle(scope_name));
-				}
+			return template_args;
+		}
 
-				auto instantiated_var =
-					parser.try_instantiate_variable_template(
-						variable_template_lookup_name,
-						template_args,
-						explicit_outer_binding.has_value()
-							? &*explicit_outer_binding
-							: nullptr);
-				context.normalizePendingSemanticRoots();
-				if (!instantiated_var.has_value() &&
-					variable_template_lookup_name != qualified_id.name()) {
-					instantiated_var =
-						parser.try_instantiate_variable_template(
-							qualified_id.name(),
-							template_args,
-							explicit_outer_binding.has_value()
-								? &*explicit_outer_binding
-								: nullptr);
-					context.normalizePendingSemanticRoots();
+		const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+			qualified_id.dependentQualifiedName();
+		if (dependent_record == nullptr ||
+			dependent_record->member_chain.empty()) {
+			return {};
+		}
+
+		const auto& final_member = dependent_record->member_chain.back();
+		if (!final_member.has_template_arguments) {
+			return {};
+		}
+
+		template_args.reserve(final_member.template_arguments.size());
+		for (const TypeInfo::TemplateArgInfo& stored_arg : final_member.template_arguments) {
+			TemplateTypeArg arg = toTemplateTypeArg(stored_arg);
+			if (std::optional<TemplateTypeArg> rebound_arg =
+					trySubstituteDependentTemplateArgForLookup(
+						arg,
+						context,
+						lookup_owner_type,
+						0);
+				rebound_arg.has_value()) {
+				arg = std::move(*rebound_arg);
+			}
+			if (arg.is_value && arg.dependent_expr.has_value()) {
+				EvalResult arg_val = evaluate(*arg.dependent_expr, context);
+				if (!arg_val.success()) {
+					return {};
 				}
-				if (instantiated_var.has_value() &&
-					instantiated_var->is<VariableDeclarationNode>()) {
-					const auto& var_decl =
-						instantiated_var->as<VariableDeclarationNode>();
-					if (var_decl.initializer().has_value()) {
-						return evaluate(var_decl.initializer().value(), context);
+				arg = templateTypeArgFromEvalResult(arg_val);
+			}
+			template_args.push_back(std::move(arg));
+		}
+		return template_args;
+	};
+
+	auto tryInstantiateQualifiedMemberVariableTemplate =
+		[&](const TypeInfo* lookup_owner_type) -> std::optional<EvalResult> {
+		if (context.parser == nullptr) {
+			return std::nullopt;
+		}
+
+		std::vector<TemplateTypeArg> template_args =
+			collectQualifiedVariableTemplateArgs(lookup_owner_type);
+		if (template_args.empty()) {
+			return std::nullopt;
+		}
+
+		Parser& parser = *context.parser;
+		StringHandle owner_handle{};
+		if (lookup_owner_type != nullptr && lookup_owner_type->name().isValid()) {
+			owner_handle = lookup_owner_type->name();
+		} else {
+			NamespaceHandle ns_handle = qualified_id.namespace_handle();
+			if (!ns_handle.isGlobal()) {
+				owner_handle = gNamespaceRegistry.getQualifiedNameHandle(ns_handle);
+				if (!owner_handle.isValid()) {
+					std::string_view owner_name =
+						gNamespaceRegistry.getQualifiedName(ns_handle);
+					if (!owner_name.empty()) {
+						owner_handle =
+							StringTable::getOrInternStringHandle(owner_name);
 					}
 				}
 			}
+		}
+		if (!owner_handle.isValid()) {
+			return std::nullopt;
+		}
+
+		std::string_view variable_template_lookup_name =
+			parser.lookup_inherited_member_variable_template_name(
+				owner_handle,
+				qualified_id.nameHandle(),
+				0);
+		if (variable_template_lookup_name.empty()) {
+			StringBuilder qualified_name_builder;
+			variable_template_lookup_name = qualified_name_builder
+				.append(StringTable::getStringView(owner_handle))
+				.append("::")
+				.append(qualified_id.name())
+				.commit();
+		}
+
+		std::optional<OuterTemplateBinding> explicit_outer_binding =
+			parser.buildOuterBindingForOwner(owner_handle);
+		std::optional<ASTNode> instantiated_var =
+			parser.try_instantiate_variable_template(
+				variable_template_lookup_name,
+				template_args,
+				explicit_outer_binding.has_value()
+					? &*explicit_outer_binding
+					: nullptr);
+		context.normalizePendingSemanticRoots();
+		if (!instantiated_var.has_value() &&
+			variable_template_lookup_name != qualified_id.name()) {
+			instantiated_var =
+				parser.try_instantiate_variable_template(
+					qualified_id.name(),
+					template_args,
+					explicit_outer_binding.has_value()
+						? &*explicit_outer_binding
+						: nullptr);
+			context.normalizePendingSemanticRoots();
+		}
+		if (!instantiated_var.has_value() ||
+			!instantiated_var->is<VariableDeclarationNode>()) {
+			return std::nullopt;
+		}
+
+		const auto& var_decl = instantiated_var->as<VariableDeclarationNode>();
+		if (!var_decl.initializer().has_value()) {
+			return std::nullopt;
+		}
+		return evaluate(var_decl.initializer().value(), context);
+	};
+
+	// Try to look up the qualified name
+	auto symbol_opt = context.symbols->lookup_qualified(qualified_id.qualifiedIdentifier());
+	if (!symbol_opt.has_value()) {
+		if (std::optional<EvalResult> variable_template_value =
+				tryInstantiateQualifiedMemberVariableTemplate(nullptr);
+			variable_template_value.has_value()) {
+			return *variable_template_value;
 		}
 
 		// PHASE 3 FIX: If not found in symbol table, try looking up as struct static member
@@ -5541,6 +5598,19 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 				// patterns like `template<> struct trait<int> { static constexpr V value = ...; };`
 				// override the primary template's inherited member regardless of which
 				// alias-shaped argument reached the original template-instantiation cache.
+				if (!static_member) {
+					if (std::optional<EvalResult> variable_template_value =
+							tryInstantiateQualifiedMemberVariableTemplate(
+								resolved_type_info != nullptr
+									? resolved_type_info
+									: struct_type_it != getTypesByNameMap().end()
+										? struct_type_it->second
+										: nullptr);
+						variable_template_value.has_value()) {
+						return *variable_template_value;
+					}
+				}
+
 				if (!static_member) {
 					if (auto exact_value = evaluate_specialization_static_member(member_handle)) {
 						FLASH_LOG(ConstExpr, Debug, "Evaluated static member from exact specialization AST");

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2868,6 +2868,7 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 				gChunkedAnyStorage.emplace_back<QualifiedIdentifierNode>(
 					new_ns_handle,
 					final_token);
+			bool preserved_dependent_member_template_record = false;
 			if (final_member.has_template_arguments) {
 				InlineVector<TemplateTypeArg, 4> final_member_args =
 					materializeDependentRecordTemplateArgs(
@@ -2892,6 +2893,9 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 				if (!explicit_template_arg_nodes.empty()) {
 					new_qual_id.set_template_arguments(
 						std::move(explicit_template_arg_nodes));
+				} else {
+					new_qual_id.setDependentQualifiedName(*dependent_name);
+					preserved_dependent_member_template_record = true;
 				}
 			} else if (qual_id.has_template_arguments()) {
 				std::vector<ASTNode> explicit_template_arg_nodes =
@@ -2903,7 +2907,10 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 			}
 			FLASH_LOG(Templates, Debug, "  Record-substituted qualified-id: ",
 					  qual_id.full_name(), " -> ", materialized_namespace, "::",
-					  final_member_name);
+					  final_member_name,
+					  preserved_dependent_member_template_record
+						  ? " (preserved deferred member-template record)"
+						  : "");
 			ExpressionNode& new_expr =
 				gChunkedAnyStorage.emplace_back<ExpressionNode>(new_qual_id);
 			return ASTNode(&new_expr);

--- a/tests/test_var_template_replay_member_variable_template_chain_ret0.cpp
+++ b/tests/test_var_template_replay_member_variable_template_chain_ret0.cpp
@@ -1,0 +1,44 @@
+template <typename T>
+struct direct_owner {
+	template <typename U>
+	static constexpr int value = sizeof(T) + sizeof(U);
+};
+
+template <typename T>
+constexpr int direct_value_v = direct_owner<T>::template value<T>;
+
+template <typename T>
+struct nested_owner {
+	struct inner {
+		template <typename U>
+		static constexpr int value = sizeof(T) + sizeof(U);
+	};
+};
+
+template <typename T>
+constexpr int nested_value_v = nested_owner<T>::inner::template value<T>;
+
+template <typename T>
+struct base_owner {
+	template <typename U>
+	static constexpr int value = sizeof(T) + sizeof(U);
+};
+
+template <typename T>
+struct derived_owner : base_owner<T> {};
+
+template <typename T>
+constexpr int inherited_value_v = derived_owner<T>::template value<T>;
+
+int main() {
+	static_assert(
+		direct_value_v<int> == 8,
+		"direct member variable-template replay preserves explicit template arguments");
+	static_assert(
+		nested_value_v<int> == 8,
+		"nested qualified member variable-template replay preserves explicit template arguments");
+	static_assert(
+		inherited_value_v<int> == 8,
+		"inherited qualified member variable-template replay preserves explicit template arguments");
+	return direct_value_v<int> + nested_value_v<int> + inherited_value_v<int> - 24;
+}


### PR DESCRIPTION
## What changed

- fixed dependent qualified member variable-template chain recovery during replay/substitution
- added regression coverage for direct, nested, and inherited member variable-template chains
- removed the now-resolved `KNOWN_ISSUES.md` entry for this bug, while preserving the upstream post-rebase cleanup

## Why

Variable-template initializers like dependent qualified member variable-template chains could survive replay as qualified identifiers without enough recovered template-argument information to instantiate the member variable template later. That left constexpr evaluation with unresolved qualified identifiers instead of concrete instantiated members.

## Root cause

- `ExpressionSubstitutor` could materialize the owner portion of a dependent qualified-id but still end up without explicit template-argument AST nodes for the final member variable-template hop.
- `ConstExprEvaluator` only instantiated qualified member variable templates from those explicit AST nodes, so recovered chains could still fail as undefined qualified identifiers.

## Impact

This makes direct, nested, and inherited dependent member variable-template chains evaluate correctly in replayed variable-template initializers.
