### PR TITLE
[codex] Preserve static member replay definition context

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -60,6 +60,11 @@ Useful to know before changing anything:
   replay positions and definition lookup contexts, and variable-template
   instantiation prefers replay-first initializer materialization before the
   compatibility AST-substitution fallback;
+- in-class static-member declarations now preserve initializer definition
+  lookup context alongside replay positions on both AST and instantiated
+  static-member carriers, and covered nested/member-template static-member
+  instantiation now reuses replay-first substitution instead of AST-only
+  substitution;
 - qualified member variable-template chains now use owner-aware lookup through
   instantiated owners and dependent bases, preserving recovered outer class
   template bindings for cases such as `Derived<T>::template member_v<T>`;
@@ -104,7 +109,7 @@ Validation at this point passed the Linux sharded build and ELF test workflow:
 Focused Windows/MSVC validation for this slice passed the new deeper
 dependent-chain regressions plus the nearby ratio/dependent-member regressions.
 Latest Windows/MSVC full-suite validation after this slice:
-`2481` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2487` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## What is still wrong
 
@@ -116,8 +121,9 @@ What still needs work:
 
 - remaining current-instantiation and type-alias spellings that do not yet
   reuse the same owner-correct POI/definition-time path;
-- remaining eager static-member initializer paths that still need AST-only
-  fallback because replay metadata was never captured at parse time;
+- remaining declaration/static-member paths outside the newly covered in-class
+  and nested static-member replay flows that still need AST-only fallback
+  because replay metadata was never captured at parse time;
 - richer dependent-base lookup and deeper member-template/member-type chains;
 - remaining parser-time ADL-sensitive paths outside the already-covered call
   and static-member flows.
@@ -134,6 +140,10 @@ Concrete follow-up already identified by recent work:
   at parse time.
 - default NTTP declared-type materialization and variable-template initializer
   replay metadata are now covered for the targeted scalar/member-chain cases.
+  In-class static members now preserve definition lookup context on the stored
+  static-member carriers as well, and covered nested/member-template static-
+  member instantiation now reuses replay-first substitution with outer/inner
+  template bindings instead of immediate AST-only substitution.
   Qualified member variable-template chains through dependent bases are now
   covered for the focused initializer/constexpr paths, and dependent-base
   `this->template` member-function-template calls are covered for the focused
@@ -244,9 +254,10 @@ In priority order:
      dependent-base chains;
    - remaining replay-metadata gaps outside the covered static-member and
      variable-template initializer paths;
-   - remaining declaration/static-member/deferred-base paths that still bypass
-     the shared semantic lookup model and therefore fall back to AST-only
-     repair.
+- remaining declaration/static-member/deferred-base paths that still bypass
+  the shared semantic lookup model and therefore fall back to AST-only
+  repair, with the next bounded target now the still-uncovered replay users
+  outside the new in-class/nested static-member metadata path.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
@@ -309,6 +320,11 @@ materially changes what future refactors can assume.
   context for namespace and member variable templates, with replay-first
   instantiation covering definition-time lookup and dependent member-template
   call chains before the older AST-substitution fallback is used.
+- static-member declarations now store definition lookup context alongside
+  replay positions on both AST and instantiated static-member carriers, and
+  covered nested/member-template static-member instantiation reuses that stored
+  metadata for replay-first substitution before falling back to AST
+  substitution.
 - qualified member variable-template chains now resolve through inherited
   owner-aware member variable-template lookup, and member variable-template
   instantiation folds recovered outer class-template bindings into initializer

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -84,6 +84,10 @@ Future work should assume these are already in place:
   positions and definition lookup contexts; instantiation uses replay-first
   materialization for covered initializer expressions before falling back to
   stored AST substitution.
+- in-class static-member declarations now preserve replay positions and
+  definition lookup contexts on both AST and instantiated static-member
+  carriers, and covered nested/member-template static-member instantiation now
+  reuses replay-first substitution instead of direct AST-only substitution.
 - qualified member variable-template chains through instantiated owners and
   dependent bases now recover the canonical member variable-template owner and
   outer class-template bindings for covered constexpr/initializer flows.
@@ -123,7 +127,7 @@ intermediate chain slice passed the focused ELF regressions after
 Focused Windows/MSVC validation for this slice passed the new deeper
 dependent-chain regressions plus nearby ratio and dependent-member regressions.
 Latest Windows/MSVC full-suite validation after this slice:
-`2481` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2487` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 
 ## Remaining work, in priority order
 
@@ -135,7 +139,8 @@ Immediate targets:
 
 - current-instantiation and type-alias spellings that still bypass the shared
   owner-correct lookup/materialization path;
-- remaining declarations and static-member paths that never captured replay
+- remaining declarations and static-member paths outside the newly covered
+  in-class/nested static-member replay flows that never captured replay
   metadata at parse time and therefore still require AST-only fallback;
 - remaining dependent-base and deeper member-template/member-type chains;
 - remaining parser-time ADL-sensitive lookup paths outside the already-covered
@@ -166,7 +171,11 @@ Most concrete next subtask:
   target arguments, covered variable-template initializer replay paths, covered
   member variable-template chain recovery, covered dependent-base
   `this->template` member-function-template lookup, and the newly covered
-  default-NTTP member-chain parser path.
+  default-NTTP member-chain parser path. In-class static members now also keep
+  definition lookup context on stored AST/instantiated static-member carriers,
+  and covered nested/member-template static-member instantiation reuses
+  replay-first substitution with outer/inner template bindings instead of
+  immediate AST-only substitution.
   Covered deferred alias member-template suffix chains in declarations and base
   specifiers now work as well, and covered member alias-template declarations
   now preserve non-template intermediate member segments plus enclosing
@@ -178,6 +187,9 @@ Most concrete next subtask:
   substitution. The next bounded follow-up is therefore the remaining
   declaration/static-member/deferred-base paths that still never captured enough
   metadata to stay on that semantic path and still require AST-only fallback.
+  The next bounded follow-up is therefore the remaining replay users outside the
+  new in-class/nested static-member metadata path, plus broader coverage for
+  out-of-line static-member replay combined with deeper dependent owner chains.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -264,7 +276,8 @@ coverage becomes sufficient.
      paths;
    - extend owner-correct replay/materialization into the remaining
      declaration, static-member, and deferred-base paths outside the covered
-     variable-template initializer and default-NTTP parser flows;
+     variable-template initializer, in-class/nested static-member replay, and
+     default-NTTP parser flows;
    - remove the next AST-only/deferred-base fallback path, with the next bounded
      target now the remaining declaration/static-member replay gaps.
 
@@ -351,6 +364,10 @@ re-solving already-solved problems.
 - variable-template initializer replay is now available for namespace and member
   variable templates, covering definition-time lookup and dependent
   member-template call chains.
+- static-member replay metadata now includes definition lookup context on both
+  AST and instantiated static-member carriers, covering the focused nested
+  member-template static-member replay paths where outer/inner template
+  bindings and definition-time ordinary lookup must survive instantiation.
 - qualified member variable-template chain recovery now covers direct,
   dependent-owner, and inherited dependent-base cases such as
   `Derived<T>::template member_v<T>` by resolving the owner-aware member

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -493,6 +493,25 @@ struct StructTypeInfo {
 		static_members.back().is_constexpr = is_constexpr;
 	}
 
+	void addStaticMember(StringHandle member_name, TypeIndex type_index, size_t size, size_t member_alignment,
+						 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
+						 ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
+						 std::optional<ASTNode> declaration,
+						 std::optional<SaveHandle> initializer_position,
+						 const TemplateDefinitionLookupContext& initializer_definition_lookup_context,
+						 bool is_constexpr) {
+		static_members.push_back(StructStaticMember(member_name, type_index, size, member_alignment, access, initializer, cv_qual, ref_qual, ptr_depth));
+		if (declaration.has_value()) {
+			static_members.back().setDeclaration(*declaration);
+		}
+		if (initializer_position.has_value()) {
+			static_members.back().setInitializerPosition(*initializer_position);
+		}
+		static_members.back().setInitializerDefinitionLookupContext(initializer_definition_lookup_context);
+		static_members.back().setArrayInfo(is_array, array_dimensions);
+		static_members.back().is_constexpr = is_constexpr;
+	}
+
 	// Update an existing static member's initializer (used for lazy instantiation)
 	// Returns true if the member was found and updated, false otherwise
 	// Note: Uses linear search through static_members vector. This is acceptable because:
@@ -524,6 +543,30 @@ struct StructTypeInfo {
 				if (initializer_position.has_value()) {
 					static_member.setInitializerPosition(*initializer_position);
 				}
+				static_member.normalized_init.reset();
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool updateStaticMemberInitializerWithMetadata(StringHandle member_name,
+												   std::optional<ASTNode> initializer,
+												   std::optional<ASTNode> declaration,
+												   std::optional<SaveHandle> initializer_position,
+												   const TemplateDefinitionLookupContext& initializer_definition_lookup_context) {
+		for (auto& static_member : static_members) {
+			if (static_member.name == member_name) {
+				static_member.initializer = initializer;
+				// Metadata is optional because some update paths only have initializer AST
+				// while replay-capable paths also carry declaration/save-handle state.
+				if (declaration.has_value()) {
+					static_member.setDeclaration(*declaration);
+				}
+				if (initializer_position.has_value()) {
+					static_member.setInitializerPosition(*initializer_position);
+				}
+				static_member.setInitializerDefinitionLookupContext(initializer_definition_lookup_context);
 				static_member.normalized_init.reset();
 				return true;
 			}
@@ -2839,22 +2882,6 @@ private:
 // ============================================================================
 // Unified call-expression node (consolidation plan step 1)
 // ============================================================================
-
-// Definition-context lookup state used by the first two-phase lookup record.
-// This is intentionally small: it snapshots the lexical point and namespace in
-// which a template definition was parsed.  Consumers may re-run ordinary lookup
-// and ADL against the current symbol table only after filtering candidates to
-// declarations whose source token was visible at this definition point.
-struct TemplateDefinitionLookupContext {
-	size_t definition_line = 0;
-	size_t definition_file_index = SIZE_MAX;
-	NamespaceHandle definition_namespace{};
-	StringHandle current_instantiation_name{};
-
-	bool is_valid() const {
-		return definition_line != 0 && definition_file_index != SIZE_MAX;
-	}
-};
 
 // Per-call semantic record for non-dependent function calls whose lookup was
 // completed in the template definition context.  The callee pointer follows the

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1033,6 +1033,7 @@ struct StaticMemberDecl {
 	int pointer_depth = 0;		   // Pointer indirection level (e.g., int* = 1, int** = 2)
 	bool is_constexpr = false;
 	std::optional<SaveHandle> initializer_position; // Saved lexer position at '=' or '{' for lazy replay
+	TemplateDefinitionLookupContext initializer_definition_lookup_context;
 
 	// Returns the legacy Type enum derived from the embedded TypeCategory.
 	TypeCategory memberType() const { return type_index.category(); }
@@ -1061,6 +1062,11 @@ struct StaticMemberDecl {
 	bool hasInitializerPosition() const { return initializer_position.has_value(); }
 	SaveHandle initializerPosition() const { return *initializer_position; }
 	void setInitializerPosition(SaveHandle pos) { initializer_position = pos; }
+	bool hasInitializerDefinitionLookupContext() const { return initializer_definition_lookup_context.is_valid(); }
+	const TemplateDefinitionLookupContext& initializerDefinitionLookupContext() const { return initializer_definition_lookup_context; }
+	void setInitializerDefinitionLookupContext(const TemplateDefinitionLookupContext& context) {
+		initializer_definition_lookup_context = context;
+	}
 	void setIsConstexpr(bool value) { is_constexpr = value; }
 };
 
@@ -1207,14 +1213,27 @@ public:
 						   std::optional<ASTNode> declaration,
 						   std::optional<SaveHandle> initializer_position, bool is_constexpr) {
 		addStaticMemberImpl(name, std::move(declaration), type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth,
-							is_array, array_dimensions, initializer_position, is_constexpr);
+							is_array, array_dimensions, initializer_position, TemplateDefinitionLookupContext{}, is_constexpr);
+	}
+
+	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
+						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
+						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
+						   std::optional<ASTNode> declaration,
+						   std::optional<SaveHandle> initializer_position,
+						   const TemplateDefinitionLookupContext& initializer_definition_lookup_context,
+						   bool is_constexpr) {
+		addStaticMemberImpl(name, std::move(declaration), type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth,
+							is_array, array_dimensions, initializer_position, initializer_definition_lookup_context, is_constexpr);
 	}
 
 private:
 	void addStaticMemberImpl(StringHandle name, std::optional<ASTNode> declaration, TypeIndex type_index, size_t size, size_t alignment,
 							 AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 							 ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
-							 std::optional<SaveHandle> initializer_position, bool is_constexpr) {
+							 std::optional<SaveHandle> initializer_position,
+							 const TemplateDefinitionLookupContext& initializer_definition_lookup_context,
+							 bool is_constexpr) {
 		static_members_.emplace_back(name, type_index, size, alignment, access, initializer, cv_qual, ref_qual, ptr_depth);
 		if (declaration.has_value()) {
 			static_members_.back().setDeclaration(std::move(*declaration));
@@ -1223,6 +1242,7 @@ private:
 		if (initializer_position.has_value()) {
 			static_members_.back().setInitializerPosition(*initializer_position);
 		}
+		static_members_.back().setInitializerDefinitionLookupContext(initializer_definition_lookup_context);
 		static_members_.back().setIsConstexpr(is_constexpr);
 	}
 

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1207,7 +1207,7 @@ public:
 	}
 
 	// Static member support (for template/partial specialization AST storage)
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
+	void addStaticMember(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
 						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
 						   std::optional<ASTNode> declaration,
@@ -1216,7 +1216,7 @@ public:
 							is_array, array_dimensions, initializer_position, TemplateDefinitionLookupContext{}, is_constexpr);
 	}
 
-	void add_static_member(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
+	void addStaticMember(StringHandle name, TypeIndex type_index, size_t size, size_t alignment,
 						   AccessSpecifier access, std::optional<ASTNode> initializer, CVQualifier cv_qual,
 						   ReferenceQualifier ref_qual, int ptr_depth, bool is_array, std::span<const size_t> array_dimensions,
 						   std::optional<ASTNode> declaration,

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -19,6 +19,48 @@ enum class CVQualifier : uint8_t {
 	Volatile = 1 << 1,
 	ConstVolatile = Const | Volatile
 };
+
+struct SourceLocation {
+	size_t line = 0;
+	size_t column = 0;
+	size_t file_index = SIZE_MAX;
+
+	static SourceLocation fromToken(const Token& token) {
+		return SourceLocation{
+			token.line(),
+			token.column(),
+			token.file_index()};
+	}
+
+	static SourceLocation fromParts(size_t line_value, size_t column_value, size_t file_index_value) {
+		return SourceLocation{
+			line_value,
+			column_value,
+			file_index_value};
+	}
+
+	bool is_valid() const {
+		return line != 0 && file_index != SIZE_MAX;
+	}
+};
+
+// Definition-context lookup state used by two-phase lookup records.
+// This snapshots the lexical point and namespace in which a template
+// definition was parsed, so later replay/substitution can filter ordinary
+// lookup to declarations visible at that definition point.
+struct TemplateDefinitionLookupContext {
+	SourceLocation definition_location{};
+	NamespaceHandle definition_namespace{};
+	StringHandle current_instantiation_name{};
+
+	bool is_valid() const {
+		return definition_location.is_valid();
+	}
+
+	const SourceLocation& definitionLocation() const { return definition_location; }
+	void setDefinitionLocation(SourceLocation location) { definition_location = location; }
+	void setDefinitionToken(const Token& token) { definition_location = SourceLocation::fromToken(token); }
+};
 inline CVQualifier operator|(CVQualifier a, CVQualifier b) {
 	return static_cast<CVQualifier>(static_cast<uint8_t>(a) | static_cast<uint8_t>(b));
 }
@@ -1278,6 +1320,7 @@ struct StructStaticMember {
 	std::optional<ASTNode> declaration; // Original declaration AST for replay-based substitution
 	std::optional<ASTNode> initializer;	// Optional initializer expression
 	std::optional<SaveHandle> initializer_position; // Saved lexer position at '=' or '{' for replay
+	TemplateDefinitionLookupContext initializer_definition_lookup_context;
 	CVQualifier cv_qualifier = CVQualifier::None;  // CV qualifiers (const, volatile)
 	ReferenceQualifier reference_qualifier = ReferenceQualifier::None;  // None, LValueReference (&), or RValueReference (&&)
 	bool is_array = false;
@@ -1319,6 +1362,11 @@ struct StructStaticMember {
 	bool hasInitializerPosition() const { return initializer_position.has_value(); }
 	SaveHandle initializerPosition() const { return *initializer_position; }
 	void setInitializerPosition(SaveHandle pos) { initializer_position = pos; }
+	bool hasInitializerDefinitionLookupContext() const { return initializer_definition_lookup_context.is_valid(); }
+	const TemplateDefinitionLookupContext& initializerDefinitionLookupContext() const { return initializer_definition_lookup_context; }
+	void setInitializerDefinitionLookupContext(const TemplateDefinitionLookupContext& context) {
+		initializer_definition_lookup_context = context;
+	}
 
 	StringHandle getName() const {
 		return name;

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3476,14 +3476,16 @@ private:	 // Resume private methods
 	void filterPhase1OrdinaryFunctionOverloads(std::vector<ASTNode>& overloads) {
 		const TemplateDefinitionLookupContext* definition_context =
 			current_template_definition_lookup_context_;
+		const SourceLocation cutoff_location =
+			definition_context != nullptr && definition_context->is_valid()
+			? definition_context->definitionLocation()
+			: SourceLocation::fromParts(phase1_cutoff_line_, 0, phase1_cutoff_file_idx_);
 		const size_t cutoff_line =
-			definition_context != nullptr && definition_context->is_valid()
-			? definition_context->definition_line
-			: phase1_cutoff_line_;
+			cutoff_location.line;
 		const size_t cutoff_file_idx =
-			definition_context != nullptr && definition_context->is_valid()
-			? definition_context->definition_file_index
-			: phase1_cutoff_file_idx_;
+			cutoff_location.file_index;
+		const size_t cutoff_column =
+			cutoff_location.column;
 		if (cutoff_line == 0) {
 			return;
 		}
@@ -3493,9 +3495,14 @@ private:	 // Resume private methods
 			}
 			size_t decl_src_line = lexer_.getSourceLine(decl_tok.line());
 			size_t cutoff_src_line = lexer_.getSourceLine(cutoff_line);
-			return (decl_src_line > 0 && cutoff_src_line > 0)
-				? decl_src_line > cutoff_src_line
-				: decl_tok.line() > cutoff_line;
+			if (decl_src_line > 0 && cutoff_src_line > 0) {
+				if (decl_src_line != cutoff_src_line) {
+					return decl_src_line > cutoff_src_line;
+				}
+			} else if (decl_tok.line() != cutoff_line) {
+				return decl_tok.line() > cutoff_line;
+			}
+			return cutoff_column != 0 && decl_tok.column() > cutoff_column;
 		};
 		overloads.erase(
 			std::remove_if(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1602,9 +1602,17 @@ private:
 	ParseResult parse_member_template_alias(StructDeclarationNode& struct_node, AccessSpecifier access);	 // NEW: Parse member template aliases
 	ParseResult parse_member_struct_template(StructDeclarationNode& struct_node, AccessSpecifier access);  // NEW: Parse member struct/class templates
 	ParseResult parse_member_variable_template(StructDeclarationNode& struct_node, AccessSpecifier access);	// NEW: Parse member variable templates
+	TemplateDefinitionLookupContext buildDefinitionLookupContextFromToken(
+		const Token& definition_token,
+		StringHandle current_instantiation_name) const;
 	TemplateDefinitionLookupContext buildVariableTemplateInitializerDefinitionLookupContext(
 		const Token& variable_name_token,
 		StringHandle current_instantiation_name) const;
+	TemplateDefinitionLookupContext ensureReplayDefinitionLookupContext(
+		TemplateDefinitionLookupContext definition_lookup_context,
+		const Token& fallback_definition_token,
+		NamespaceHandle fallback_definition_namespace,
+		StringHandle fallback_current_instantiation_name) const;
 	ParseResult parse_member_template_or_function(StructDeclarationNode& struct_node, AccessSpecifier access);  // Helper: Detect and parse member template alias or function
 	StringHandle getStructQualifiedNameForRegistration(const StructDeclarationNode& struct_node) const;
 	ParseResult parse_bitfield_width(std::optional<size_t>& out_width, std::optional<ASTNode>* out_expr = nullptr);	// Helper: Parse ': <const-expr>' for bitfields

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1507,10 +1507,8 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			const TemplateDefinitionLookupContext* initializer_definition_lookup_context =
 				current_template_definition_lookup_context_;
 			if (needs_template_initializer_lookup_context) {
-				static_member_definition_lookup_context.definition_line =
-					decl.identifier_token().line();
-				static_member_definition_lookup_context.definition_file_index =
-					decl.identifier_token().file_index();
+				static_member_definition_lookup_context.setDefinitionToken(
+					decl.identifier_token());
 				static_member_definition_lookup_context.definition_namespace =
 					gSymbolTable.get_current_namespace_handle();
 				static_member_definition_lookup_context.current_instantiation_name =
@@ -1649,6 +1647,9 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				array_dimensions,
 				type_and_name_result.node(),  // declaration AST for lazy re-parse
 				initializer_position,         // saved lexer position for lazy re-parse
+				initializer_definition_lookup_context != nullptr
+					? *initializer_definition_lookup_context
+					: TemplateDefinitionLookupContext{},
 				is_static_constexpr);
 
 			continue;

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1507,12 +1507,10 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			const TemplateDefinitionLookupContext* initializer_definition_lookup_context =
 				current_template_definition_lookup_context_;
 			if (needs_template_initializer_lookup_context) {
-				static_member_definition_lookup_context.setDefinitionToken(
-					decl.identifier_token());
-				static_member_definition_lookup_context.definition_namespace =
-					gSymbolTable.get_current_namespace_handle();
-				static_member_definition_lookup_context.current_instantiation_name =
-					qualified_struct_name;
+				static_member_definition_lookup_context =
+					buildDefinitionLookupContextFromToken(
+						decl.identifier_token(),
+						qualified_struct_name);
 				if (static_member_definition_lookup_context.is_valid()) {
 					initializer_definition_lookup_context =
 						&static_member_definition_lookup_context;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5232,11 +5232,32 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					// Check for initialization (e.g., = sizeof(T))
 					std::optional<ASTNode> init_expr_opt;
 					std::optional<SaveHandle> initializer_position;
+					TemplateDefinitionLookupContext static_member_definition_lookup_context;
+					const TemplateDefinitionLookupContext* initializer_definition_lookup_context =
+						current_template_definition_lookup_context_;
+					if ((initializer_definition_lookup_context == nullptr ||
+						 !initializer_definition_lookup_context->is_valid()) &&
+						type_and_name_result.node().has_value()) {
+						const DeclarationNode& decl = type_and_name_result.node()->as<DeclarationNode>();
+						static_member_definition_lookup_context.setDefinitionToken(
+							decl.identifier_token());
+						static_member_definition_lookup_context.definition_namespace =
+							gSymbolTable.get_current_namespace_handle();
+						static_member_definition_lookup_context.current_instantiation_name =
+							qualified_pattern_name;
+						if (static_member_definition_lookup_context.is_valid()) {
+							initializer_definition_lookup_context =
+								&static_member_definition_lookup_context;
+						}
+					}
 					if (peek() == "="_tok) {
 						initializer_position = save_token_position();
 						advance(); // consume '='
 
 						// Parse the initializer expression
+						ScopedDefinitionLookupContext ctx_scope(
+							current_template_definition_lookup_context_,
+							initializer_definition_lookup_context);
 						auto init_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 						if (init_result.is_error()) {
 							return init_result;
@@ -5359,6 +5380,9 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 							array_dimensions,
 							/* declaration */ *type_and_name_result.node(),
 							initializer_position,
+							initializer_definition_lookup_context != nullptr
+								? *initializer_definition_lookup_context
+								: TemplateDefinitionLookupContext{},
 							is_constexpr);
 					}
 					continue;
@@ -5775,11 +5799,32 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				// Check for initialization (e.g., = sizeof(T))
 				std::optional<ASTNode> init_expr_opt;
 				std::optional<SaveHandle> initializer_position;
+				TemplateDefinitionLookupContext static_member_definition_lookup_context;
+				const TemplateDefinitionLookupContext* initializer_definition_lookup_context =
+					current_template_definition_lookup_context_;
+				if ((initializer_definition_lookup_context == nullptr ||
+					 !initializer_definition_lookup_context->is_valid()) &&
+					type_and_name_result.node().has_value()) {
+					const DeclarationNode& decl = type_and_name_result.node()->as<DeclarationNode>();
+					static_member_definition_lookup_context.setDefinitionToken(
+						decl.identifier_token());
+					static_member_definition_lookup_context.definition_namespace =
+						gSymbolTable.get_current_namespace_handle();
+					static_member_definition_lookup_context.current_instantiation_name =
+						qualified_name;
+					if (static_member_definition_lookup_context.is_valid()) {
+						initializer_definition_lookup_context =
+							&static_member_definition_lookup_context;
+					}
+				}
 				if (peek() == "="_tok) {
 					initializer_position = save_token_position();
 					advance(); // consume '='
 
 					// Parse the initializer expression
+					ScopedDefinitionLookupContext ctx_scope(
+						current_template_definition_lookup_context_,
+						initializer_definition_lookup_context);
 					auto init_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 					if (init_result.is_error()) {
 						return init_result;
@@ -5836,6 +5881,9 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						array_dimensions,
 						/* declaration */ *type_and_name_result.node(),
 						initializer_position,
+						initializer_definition_lookup_context != nullptr
+							? *initializer_definition_lookup_context
+							: TemplateDefinitionLookupContext{},
 						is_static_constexpr);
 				}
 				continue;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -43,7 +43,7 @@ void addUnscopedEnumEnumeratorsAsStaticMembers(
 		const TypeIndex enum_type_index = enum_decl.type_index();
 		std::optional<ASTNode> initializer = enumerator.value();
 
-		struct_ref.add_static_member(
+		struct_ref.addStaticMember(
 			enumerator_name,
 			enum_type_index,
 			enum_size,
@@ -5239,12 +5239,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						 !initializer_definition_lookup_context->is_valid()) &&
 						type_and_name_result.node().has_value()) {
 						const DeclarationNode& decl = type_and_name_result.node()->as<DeclarationNode>();
-						static_member_definition_lookup_context.setDefinitionToken(
-							decl.identifier_token());
-						static_member_definition_lookup_context.definition_namespace =
-							gSymbolTable.get_current_namespace_handle();
-						static_member_definition_lookup_context.current_instantiation_name =
-							qualified_pattern_name;
+						static_member_definition_lookup_context =
+							buildDefinitionLookupContextFromToken(
+								decl.identifier_token(),
+								qualified_pattern_name);
 						if (static_member_definition_lookup_context.is_valid()) {
 							initializer_definition_lookup_context =
 								&static_member_definition_lookup_context;
@@ -5366,7 +5364,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 
 						// Add to struct's static members
 						StringHandle static_member_name_handle = decl.identifier_token().handle();
-						member_struct_ref.add_static_member(
+						member_struct_ref.addStaticMember(
 							static_member_name_handle,
 							type_spec.type_index(),
 							static_member_size,
@@ -5806,12 +5804,10 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					 !initializer_definition_lookup_context->is_valid()) &&
 					type_and_name_result.node().has_value()) {
 					const DeclarationNode& decl = type_and_name_result.node()->as<DeclarationNode>();
-					static_member_definition_lookup_context.setDefinitionToken(
-						decl.identifier_token());
-					static_member_definition_lookup_context.definition_namespace =
-						gSymbolTable.get_current_namespace_handle();
-					static_member_definition_lookup_context.current_instantiation_name =
-						qualified_name;
+					static_member_definition_lookup_context =
+						buildDefinitionLookupContextFromToken(
+							decl.identifier_token(),
+							qualified_name);
 					if (static_member_definition_lookup_context.is_valid()) {
 						initializer_definition_lookup_context =
 							&static_member_definition_lookup_context;
@@ -5867,7 +5863,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 						}
 					}
 
-					member_struct_ref.add_static_member(
+					member_struct_ref.addStaticMember(
 						decl.identifier_token().handle(),
 						type_spec.type_index(),
 						static_member_size,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4406,15 +4406,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									currentTemplateSubstitutionFailurePolicy());
 
 							TemplateDefinitionLookupContext definition_lookup_context =
-								static_member.initializerDefinitionLookupContext();
-							if (!definition_lookup_context.is_valid()) {
-								definition_lookup_context.setDefinitionToken(
-									declaration->identifier_token());
-								definition_lookup_context.definition_namespace =
-									spec_decl_ns;
-							}
-							definition_lookup_context.current_instantiation_name =
-								instantiated_name;
+								ensureReplayDefinitionLookupContext(
+									static_member.initializerDefinitionLookupContext(),
+									declaration->identifier_token(),
+									spec_decl_ns,
+									instantiated_name);
 							substitution_context.definition_lookup_context =
 								definition_lookup_context.is_valid()
 									? &definition_lookup_context
@@ -5018,7 +5014,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											 effective_pattern_template_args))
 									   : std::nullopt;
 						});
-				instantiated_struct_ref.add_static_member(
+				instantiated_struct_ref.addStaticMember(
 					static_member.name,
 					substituted_type_index,
 					substituted_size,
@@ -7412,15 +7408,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				currentTemplateSubstitutionFailurePolicy());
 
 		TemplateDefinitionLookupContext definition_lookup_context =
-			static_member.initializerDefinitionLookupContext();
-		if (!definition_lookup_context.is_valid()) {
-			definition_lookup_context.setDefinitionToken(
-				declaration->identifier_token());
-			definition_lookup_context.definition_namespace =
-				fallback_definition_namespace;
-		}
-		definition_lookup_context.current_instantiation_name =
-			owning_instantiated_name;
+			ensureReplayDefinitionLookupContext(
+				static_member.initializerDefinitionLookupContext(),
+				declaration->identifier_token(),
+				fallback_definition_namespace,
+				owning_instantiated_name);
 		substitution_context.definition_lookup_context =
 			definition_lookup_context.is_valid()
 				? &definition_lookup_context
@@ -8036,7 +8028,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.initializer_position,
 						static_member.initializerDefinitionLookupContext(),
 						static_member.is_constexpr);
-					instantiated_nested_struct_ref.add_static_member(
+					instantiated_nested_struct_ref.addStaticMember(
 						static_member.getName(),
 						substituted_type_index,
 						substituted_size,
@@ -8769,7 +8761,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			member_decl.is_no_unique_address);
 	}
 	for (const auto& static_member : struct_info_ptr->static_members) {
-		instantiated_struct_ref.add_static_member(
+		instantiated_struct_ref.addStaticMember(
 			static_member.name,
 			static_member.type_index,
 			static_member.size,
@@ -10271,11 +10263,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						nullptr,
 						currentTemplateSubstitutionFailurePolicy());
 
+				const DeclarationNode* declaration_ptr =
+					get_decl_from_symbol(*out_of_line_var.declaration);
+				if (declaration_ptr == nullptr) {
+					return false;
+				}
+
 				TemplateDefinitionLookupContext definition_lookup_context =
-					out_of_line_var.definition_lookup_context;
+					ensureReplayDefinitionLookupContext(
+						out_of_line_var.definition_lookup_context,
+						declaration_ptr->identifier_token(),
+						struct_info_ptr->getNamespaceHandle(),
+						instantiated_name);
 				const TemplateDefinitionLookupContext* active_definition_lookup_context = nullptr;
 				if (definition_lookup_context.is_valid()) {
-					definition_lookup_context.current_instantiation_name = instantiated_name;
 					active_definition_lookup_context = &definition_lookup_context;
 				}
 				substitution_context.definition_lookup_context =
@@ -10291,12 +10292,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				setCurrentTemplateParamNames(out_of_line_var.template_param_names);
 
 				restore_lexer_position_only(*out_of_line_var.initializer_position);
-
-				const DeclarationNode* declaration_ptr =
-					get_decl_from_symbol(*out_of_line_var.declaration);
-				if (declaration_ptr == nullptr) {
-					return false;
-				}
 				DeclarationNode declaration_copy = *declaration_ptr;
 				TypeSpecifierNode& type_spec = declaration_copy.type_specifier_node();
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4308,6 +4308,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							static_member.array_dimensions,
 							static_member.declaration,
 							static_member.initializer_position,
+							static_member.initializerDefinitionLookupContext(),
 							static_member.is_constexpr);
 					}
 				}
@@ -4404,13 +4405,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									nullptr,
 									currentTemplateSubstitutionFailurePolicy());
 
-							TemplateDefinitionLookupContext definition_lookup_context;
-							definition_lookup_context.definition_line =
-								declaration->identifier_token().line();
-							definition_lookup_context.definition_file_index =
-								declaration->identifier_token().file_index();
-							definition_lookup_context.definition_namespace =
-								spec_decl_ns;
+							TemplateDefinitionLookupContext definition_lookup_context =
+								static_member.initializerDefinitionLookupContext();
+							if (!definition_lookup_context.is_valid()) {
+								definition_lookup_context.setDefinitionToken(
+									declaration->identifier_token());
+								definition_lookup_context.definition_namespace =
+									spec_decl_ns;
+							}
 							definition_lookup_context.current_instantiation_name =
 								instantiated_name;
 							substitution_context.definition_lookup_context =
@@ -4573,6 +4575,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.array_dimensions,
 						static_member.declaration,
 						static_member.initializer_position,
+						static_member.initializerDefinitionLookupContext(),
 						static_member.is_constexpr);
 				}
 			}
@@ -5029,6 +5032,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					static_member.array_dimensions,
 					static_member.declaration,
 					static_member.initializer_position,
+					static_member.initializerDefinitionLookupContext(),
 					static_member.is_constexpr);
 			}
 
@@ -7383,7 +7387,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		[&](
 			const auto& static_member,
 			const auto& template_params,
-			std::span<const TemplateTypeArg> template_args) -> std::optional<ASTNode> {
+			std::span<const TemplateTypeArg> template_args,
+			StringHandle owning_instantiated_name,
+			NamespaceHandle fallback_definition_namespace) -> std::optional<ASTNode> {
 		if (!static_member.initializer_position.has_value() ||
 			!static_member.declaration.has_value()) {
 			return std::nullopt;
@@ -7405,15 +7411,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				nullptr,
 				currentTemplateSubstitutionFailurePolicy());
 
-		TemplateDefinitionLookupContext definition_lookup_context;
-		definition_lookup_context.definition_line =
-			declaration->identifier_token().line();
-		definition_lookup_context.definition_file_index =
-			declaration->identifier_token().file_index();
-		definition_lookup_context.definition_namespace =
-			struct_info->getNamespaceHandle();
+		TemplateDefinitionLookupContext definition_lookup_context =
+			static_member.initializerDefinitionLookupContext();
+		if (!definition_lookup_context.is_valid()) {
+			definition_lookup_context.setDefinitionToken(
+				declaration->identifier_token());
+			definition_lookup_context.definition_namespace =
+				fallback_definition_namespace;
+		}
 		definition_lookup_context.current_instantiation_name =
-			instantiated_name;
+			owning_instantiated_name;
 		substitution_context.definition_lookup_context =
 			definition_lookup_context.is_valid()
 				? &definition_lookup_context
@@ -7485,6 +7492,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			const auto& static_member,
 			const auto& template_params,
 			std::span<const TemplateTypeArg> template_args,
+			StringHandle owning_instantiated_name,
+			NamespaceHandle fallback_definition_namespace,
 			const auto& fallback_template_args) -> std::optional<ASTNode> {
 		if (!static_member.initializer.has_value()) {
 			return std::nullopt;
@@ -7496,7 +7505,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				try_reparse_in_class_static_initializer_fallback(
 					static_member,
 					template_params,
-					template_args);
+					template_args,
+					owning_instantiated_name,
+					fallback_definition_namespace);
 		} catch (const std::exception& ex) {
 			FLASH_LOG(Templates, Debug,
 					  "Replay substitution failed for in-class static member: ",
@@ -7728,7 +7739,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				lazy_info.declaration = static_member.declaration;
 				lazy_info.initializer = static_member.initializer;
 				lazy_info.initializer_position = static_member.initializer_position;
-				if (current_template_definition_lookup_context_ != nullptr &&
+				if (static_member.initializerDefinitionLookupContext().is_valid()) {
+					lazy_info.definition_lookup_context =
+						static_member.initializerDefinitionLookupContext();
+				} else if (current_template_definition_lookup_context_ != nullptr &&
 					current_template_definition_lookup_context_->is_valid()) {
 					lazy_info.definition_lookup_context =
 						*current_template_definition_lookup_context_;
@@ -7736,10 +7750,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						   static_member.declaration->is<DeclarationNode>()) {
 					const Token& declaration_token =
 						static_member.declaration->as<DeclarationNode>().identifier_token();
-					lazy_info.definition_lookup_context.definition_line =
-						declaration_token.line();
-					lazy_info.definition_lookup_context.definition_file_index =
-						declaration_token.file_index();
+					lazy_info.definition_lookup_context.setDefinitionToken(
+						declaration_token);
 					lazy_info.definition_lookup_context.definition_namespace =
 						struct_info->getNamespaceHandle();
 				}
@@ -7781,6 +7793,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					resolved_array_dimensions,
 					static_member.declaration,
 					static_member.initializer_position,
+					static_member.initializerDefinitionLookupContext(),
 					static_member.is_constexpr);
 
 				continue; // Skip the eager processing below
@@ -7794,6 +7807,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::span<const TemplateTypeArg>(
 						effective_template_args_vector.data(),
 						effective_template_args_vector.size()),
+					instantiated_name,
+					struct_info->getNamespaceHandle(),
 					effective_template_args);
 
 			auto [substituted_type_index, substituted_size, substituted_alignment, is_array_member, resolved_array_dimensions] =
@@ -7828,6 +7843,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				resolved_array_dimensions,
 				static_member.declaration,
 				static_member.initializer_position,
+				static_member.initializerDefinitionLookupContext(),
 				static_member.is_constexpr);
 			if (normalized_initializer.has_value()) {
 				if (StructStaticMember* instantiated_static_member =
@@ -7858,6 +7874,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::span<const TemplateTypeArg>(
 						effective_template_args_vector.data(),
 						effective_template_args_vector.size()),
+					instantiated_name,
+					struct_info->getNamespaceHandle(),
 					effective_template_args);
 			struct_info->addStaticMember(
 				static_member.name,
@@ -7873,6 +7891,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				static_member.array_dimensions,
 				static_member.declaration,
 				static_member.initializer_position,
+				static_member.initializerDefinitionLookupContext(),
 				static_member.is_constexpr);
 		}
 	}
@@ -7993,10 +8012,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					TypeIndex substituted_type_index = substitute_template_parameter(
 						original_type_spec, template_params, template_args_to_use);
 					size_t substituted_size = get_substituted_type_size_bytes(substituted_type_index);
-					std::optional<ASTNode> substituted_initializer = static_member.initializer.has_value()
-																		 ? std::optional<ASTNode>(substituteTemplateParameters(
-																			   *static_member.initializer, template_params, template_args_to_use))
-																		 : std::nullopt;
+					std::optional<ASTNode> substituted_initializer =
+						substitute_in_class_static_initializer_replay_first(
+							static_member,
+							template_params,
+							template_args_to_use,
+							qualified_name,
+							nested_struct_info->getNamespaceHandle(),
+							template_args_to_use);
 					nested_struct_info->addStaticMember(
 						static_member.getName(),
 						substituted_type_index,
@@ -8011,6 +8034,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.array_dimensions,
 						static_member.declaration,
 						static_member.initializer_position,
+						static_member.initializerDefinitionLookupContext(),
 						static_member.is_constexpr);
 					instantiated_nested_struct_ref.add_static_member(
 						static_member.getName(),
@@ -8026,6 +8050,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.array_dimensions,
 						static_member.declaration,
 						static_member.initializer_position,
+						static_member.initializerDefinitionLookupContext(),
 						static_member.is_constexpr);
 				}
 			};
@@ -8758,6 +8783,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			static_member.array_dimensions,
 			static_member.declaration,
 			static_member.initializer_position,
+			static_member.initializerDefinitionLookupContext(),
 			static_member.is_constexpr);
 	}
 
@@ -10336,6 +10362,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (out_of_line_var.initializer_position.has_value()) {
 					existing_member->setInitializerPosition(*out_of_line_var.initializer_position);
 				}
+				existing_member->setInitializerDefinitionLookupContext(
+					out_of_line_var.definition_lookup_context);
 				// Member already exists - update the initializer with the out-of-line definition
 				if (substituted_initializer.has_value()) {
 					existing_member->initializer = substituted_initializer;
@@ -10365,6 +10393,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					array_dimensions,
 					out_of_line_var.declaration,
 					out_of_line_var.initializer_position,
+					out_of_line_var.definition_lookup_context,
 					out_of_line_is_constexpr);
 
 				FLASH_LOG(Templates, Debug, "Added out-of-line static member ", out_of_line_var.member_name,
@@ -10623,6 +10652,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (static_member.initializer_position.has_value()) {
 							existing_member->setInitializerPosition(*static_member.initializer_position);
 						}
+						existing_member->setInitializerDefinitionLookupContext(
+							static_member.initializerDefinitionLookupContext());
 						existing_member->normalized_init.reset();
 					}
 					// Skip adding duplicate
@@ -10641,6 +10672,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						static_member.array_dimensions,
 						static_member.declaration,
 						static_member.initializer_position,
+						static_member.initializerDefinitionLookupContext(),
 						static_member.is_constexpr);
 				}
 			}

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -1412,8 +1412,11 @@ void Parser::reparse_template_function_body(
 			}
 		}
 		TemplateDefinitionLookupContext definition_lookup_context;
-		definition_lookup_context.definition_line = phase1_cutoff_line_;
-		definition_lookup_context.definition_file_index = phase1_cutoff_file_idx_;
+		definition_lookup_context.setDefinitionLocation(
+			SourceLocation::fromParts(
+				phase1_cutoff_line_,
+				0,
+				phase1_cutoff_file_idx_));
 		definition_lookup_context.definition_namespace = gSymbolTable.get_current_namespace_handle();
 		if (current_function_ != nullptr && !current_function_->parent_struct_name().empty()) {
 			definition_lookup_context.current_instantiation_name =

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2158,8 +2158,11 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			// be installed -- parsing proceeds without phase-1 cutoff for this body.
 		}
 		TemplateDefinitionLookupContext definition_lookup_context;
-		definition_lookup_context.definition_line = phase1_cutoff_line_;
-		definition_lookup_context.definition_file_index = phase1_cutoff_file_idx_;
+		definition_lookup_context.setDefinitionLocation(
+			SourceLocation::fromParts(
+				phase1_cutoff_line_,
+				0,
+				phase1_cutoff_file_idx_));
 		definition_lookup_context.definition_namespace = gSymbolTable.get_current_namespace_handle();
 		definition_lookup_context.current_instantiation_name =
 			StringTable::getOrInternStringHandle(struct_name);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -3393,10 +3393,8 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(
 		if (!definition_lookup_context.is_valid()) {
 			const DeclarationNode& declaration =
 				pattern_var_decl.declaration();
-			definition_lookup_context.definition_line =
-				declaration.identifier_token().line();
-			definition_lookup_context.definition_file_index =
-				declaration.identifier_token().file_index();
+			definition_lookup_context.setDefinitionToken(
+				declaration.identifier_token());
 			definition_lookup_context.definition_namespace =
 				gSymbolTable.get_current_namespace_handle();
 		}
@@ -4100,6 +4098,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 				static_member.array_dimensions,
 				static_member.declaration,
 				static_member.initializer_position,
+				static_member.initializerDefinitionLookupContext(),
 				static_member.is_constexpr);
 		}
 	} else {

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1262,7 +1262,8 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			lazy_info.member_name,
 			substituted_initializer,
 			lazy_info.declaration,
-			lazy_info.initializer_position)) {
+			lazy_info.initializer_position,
+			lazy_info.definition_lookup_context)) {
 		// Member doesn't exist yet - add it (shouldn't normally happen with lazy instantiation)
 		struct_info->addStaticMember(
 			lazy_info.member_name,
@@ -1278,6 +1279,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			lazy_info.array_dimensions,
 			lazy_info.declaration,
 			lazy_info.initializer_position,
+			lazy_info.definition_lookup_context,
 			lazy_info.is_constexpr);
 	}
 

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -614,8 +614,7 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 			current_template_definition_lookup_context_->is_valid()) {
 			definition_lookup_context = *current_template_definition_lookup_context_;
 		} else {
-			definition_lookup_context.definition_line = function_name_token.line();
-			definition_lookup_context.definition_file_index = function_name_token.file_index();
+			definition_lookup_context.setDefinitionToken(function_name_token);
 			definition_lookup_context.definition_namespace = gSymbolTable.get_current_namespace_handle();
 			definition_lookup_context.current_instantiation_name =
 				StringTable::getOrInternStringHandle(qualified_class_name);

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -609,16 +609,10 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 	if (peek() == "="_tok) {
 		// This is a static member variable definition: template<typename T> Type ClassName<T>::member = value;
 		SaveHandle initializer_position = save_token_position();
-		TemplateDefinitionLookupContext definition_lookup_context;
-		if (current_template_definition_lookup_context_ != nullptr &&
-			current_template_definition_lookup_context_->is_valid()) {
-			definition_lookup_context = *current_template_definition_lookup_context_;
-		} else {
-			definition_lookup_context.setDefinitionToken(function_name_token);
-			definition_lookup_context.definition_namespace = gSymbolTable.get_current_namespace_handle();
-			definition_lookup_context.current_instantiation_name =
-				StringTable::getOrInternStringHandle(qualified_class_name);
-		}
+		TemplateDefinitionLookupContext definition_lookup_context =
+			buildDefinitionLookupContextFromToken(
+				function_name_token,
+				StringTable::getOrInternStringHandle(qualified_class_name));
 
 		ASTNode var_declaration_node = create_out_of_line_static_member_declaration();
 		VariableDeclarationNode& var_declaration_ref = var_declaration_node.as<VariableDeclarationNode>();

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -20,10 +20,7 @@ TemplateDefinitionLookupContext Parser::buildVariableTemplateInitializerDefiniti
 	}
 
 	TemplateDefinitionLookupContext definition_lookup_context;
-	definition_lookup_context.definition_line =
-		variable_name_token.line();
-	definition_lookup_context.definition_file_index =
-		variable_name_token.file_index();
+	definition_lookup_context.setDefinitionToken(variable_name_token);
 	definition_lookup_context.definition_namespace =
 		gSymbolTable.get_current_namespace_handle();
 	if (current_instantiation_name.isValid()) {

--- a/src/Parser_Templates_Variable.cpp
+++ b/src/Parser_Templates_Variable.cpp
@@ -4,8 +4,8 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
-TemplateDefinitionLookupContext Parser::buildVariableTemplateInitializerDefinitionLookupContext(
-	const Token& variable_name_token,
+TemplateDefinitionLookupContext Parser::buildDefinitionLookupContextFromToken(
+	const Token& definition_token,
 	StringHandle current_instantiation_name) const {
 	if (current_template_definition_lookup_context_ &&
 		current_template_definition_lookup_context_->is_valid()) {
@@ -20,12 +20,41 @@ TemplateDefinitionLookupContext Parser::buildVariableTemplateInitializerDefiniti
 	}
 
 	TemplateDefinitionLookupContext definition_lookup_context;
-	definition_lookup_context.setDefinitionToken(variable_name_token);
+	definition_lookup_context.setDefinitionToken(definition_token);
 	definition_lookup_context.definition_namespace =
 		gSymbolTable.get_current_namespace_handle();
 	if (current_instantiation_name.isValid()) {
 		definition_lookup_context.current_instantiation_name =
 			current_instantiation_name;
+	}
+	return definition_lookup_context;
+}
+
+TemplateDefinitionLookupContext Parser::buildVariableTemplateInitializerDefinitionLookupContext(
+	const Token& variable_name_token,
+	StringHandle current_instantiation_name) const {
+	return buildDefinitionLookupContextFromToken(
+		variable_name_token,
+		current_instantiation_name);
+}
+
+TemplateDefinitionLookupContext Parser::ensureReplayDefinitionLookupContext(
+	TemplateDefinitionLookupContext definition_lookup_context,
+	const Token& fallback_definition_token,
+	NamespaceHandle fallback_definition_namespace,
+	StringHandle fallback_current_instantiation_name) const {
+	if (!definition_lookup_context.is_valid()) {
+		definition_lookup_context.setDefinitionToken(fallback_definition_token);
+		definition_lookup_context.definition_namespace =
+			fallback_definition_namespace;
+		if (fallback_current_instantiation_name.isValid()) {
+			definition_lookup_context.current_instantiation_name =
+				fallback_current_instantiation_name;
+		}
+	} else if (!definition_lookup_context.current_instantiation_name.isValid() &&
+			   fallback_current_instantiation_name.isValid()) {
+		definition_lookup_context.current_instantiation_name =
+			fallback_current_instantiation_name;
 	}
 	return definition_lookup_context;
 }

--- a/tests/test_member_template_nested_static_member_two_phase_definition_lookup_ret0.cpp
+++ b/tests/test_member_template_nested_static_member_two_phase_definition_lookup_ret0.cpp
@@ -1,0 +1,24 @@
+// Regression: nested member-template static member definitions must preserve
+// definition-time ordinary lookup while replay still carries outer + inner bindings.
+
+int choose_nested(long) {
+	return 1;
+}
+
+template <typename T, int OuterN>
+struct Outer {
+	template <int InnerN>
+	struct Inner {
+		static constexpr int value =
+			choose_nested(0) + static_cast<int>(sizeof(T)) + OuterN + InnerN;
+	};
+};
+
+int choose_nested(int) {
+	return 100;
+}
+
+int main() {
+	using Inst = typename Outer<long long, 3>::template Inner<5>;
+	return Inst::value - 17;
+}

--- a/tests/test_member_template_nested_static_member_two_phase_poi_env_ret0.cpp
+++ b/tests/test_member_template_nested_static_member_two_phase_poi_env_ret0.cpp
@@ -1,0 +1,28 @@
+// Regression: nested member-template static member replay must preserve both
+// outer and inner template environments while completing dependent lookup at POI.
+
+constexpr int adl_nested(long) {
+	return 1;
+}
+
+template <typename T, int OuterN>
+struct Outer {
+	template <typename U>
+	struct Inner {
+		static constexpr int value =
+			adl_nested(T{}) + OuterN + static_cast<int>(sizeof(U));
+	};
+};
+
+namespace N {
+	struct Tag {
+		friend constexpr int adl_nested(Tag) {
+			return 36;
+		}
+	};
+}
+
+int main() {
+	using Inst = typename Outer<N::Tag, 2>::template Inner<int>;
+	return Inst::value == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## What changed
- preserve definition-time replay metadata on template static members, including nested/member-template static-member paths
- switch the remaining covered static-member instantiation flows to replay-first substitution instead of dropping directly to AST-only substitution
- add focused regressions for nested member-template static-member two-phase lookup and update the template architecture docs

## Why
The parser was already computing definition-context lookup information for in-class static-member initializers, but the static-member carriers were dropping that metadata. Later replay paths had to reconstruct lookup boundaries heuristically, which left nested/member-template static-member instantiation relying on AST-only fallback more often than necessary.

## Impact
This makes the template infrastructure more C++20-conformant for two-phase lookup in static-member replay paths, especially where nested/member-template statics need both definition-time ordinary lookup and preserved outer/inner template bindings.

## Root cause
In-class static-member declarations kept the initializer AST and replay position, but not the `TemplateDefinitionLookupContext`. That broke the semantic contract needed to replay with the original lookup boundary during later instantiation and lazy materialization.

## Validation
  - result: `2487` regular tests passed, `181` expected-fail tests behaved as expected
