### PR TITLE
[codex] Fix out-of-line constructor template replay

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -106,6 +106,12 @@ Useful to know before changing anything:
   `Traits<T>::template Box<T>::type::get()`, and
   `Derived<T>::template Inner<int>::type::value` stay concrete through the
   intermediate `type` alias instead of stalling after the member-template hop;
+- top-level out-of-line constructor templates on class templates now preserve
+  their inner template-parameter metadata on the registered out-of-line stub,
+  and instantiation attaches deferred body/initializer-list replay positions to
+  the matching constructor template by unresolved inner-parameter shape, so
+  spellings like `template<class T> template<class U> Box<T>::Box(U)` no longer
+  drop replay state before lazy constructor materialization;
 - selected free/member function-template overload paths already do
   signature-only ranking before body materialization.
 
@@ -114,12 +120,18 @@ Validation at this point passed the Linux sharded build and ELF test workflow:
 Focused Windows/MSVC validation for this slice passed the new deeper
 dependent-chain regressions plus the nearby ratio/dependent-member regressions.
 Latest Windows/MSVC full-suite validation after this slice:
-`2487` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2502` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
 Latest focused Linux validation for the out-of-line static-member replay slice
 passed `test_template_out_of_line_static_member_replay_member_template_chain_ret0.cpp`,
 `test_template_out_of_line_static_member_two_phase_lookup_ret0.cpp`, and
 `test_template_out_of_line_static_member_two_phase_lookup_multi_template_ret0.cpp`
 after `make sharded CXX=clang++`.
+Latest focused Windows/MSVC validation for the out-of-line constructor-template
+replay slice passed
+`test_template_ool_ctor_template_base_member_init_replay_ret42.cpp`,
+`test_template_nested_ool_ctor_template_init_replay_ret42.cpp`,
+`test_template_nested_ool_ctor_template_base_member_init_replay_ret42.cpp`, and
+`test_template_nested_ool_ctor_template_ref_init_replay_ret42.cpp`.
 
 ## What is still wrong
 
@@ -177,13 +189,17 @@ Concrete follow-up already identified by recent work:
   value/call` cases. Out-of-line class-template member-function definitions now
   also preserve definition lookup context and re-install it during body replay,
   so ordinary unqualified lookup in those reparsed bodies stays bound to the
-  definition point instead of rebinding at the point of instantiation. The next
-  concrete follow-up is therefore narrower again: extend that same owner-
-  correct replay/materialization path into the remaining declaration/deferred-
-  base paths that still never captured enough metadata to avoid AST-only
-  fallback, with the next bounded target now the still-uncovered out-of-line
-  member-function-template, constructor-initializer, and deferred-base replay
-  users beyond the newly covered member-function body path.
+  definition point instead of rebinding at the point of instantiation.
+  Top-level out-of-line constructor templates on class templates now also keep
+  enough replay metadata to reattach their deferred body and initializer-list
+  source to the instantiated constructor template before lazy materialization.
+  The next concrete follow-up is therefore narrower again: extend that same
+  owner-correct replay/materialization path into the remaining declaration/
+  deferred-base paths that still never captured enough metadata to avoid
+  AST-only fallback, with the next bounded target now the still-uncovered
+  out-of-line member-function-template-plus-deferred-base replay combinations
+  and the broader deferred-base replay users beyond the newly covered
+  member-function body and constructor-template paths.
 
 ### 2. Dependent names are still represented too loosely
 
@@ -273,6 +289,10 @@ In priority order:
     - dependent-base `this->template` member-function-template calls are covered
       for focused inline class-template body cases, including multilevel
       dependent-base chains;
+    - top-level out-of-line constructor templates on class templates now retain
+      inner template-parameter metadata on their registered stub and reattach
+      deferred body/initializer-list replay state to the instantiated
+      constructor template before lazy materialization;
     - remaining replay-metadata gaps outside the covered static-member and
       variable-template initializer paths, now including the newly covered
       out-of-line static-member replay path for deeper member-template chains;
@@ -281,9 +301,10 @@ In priority order:
     - remaining declaration/static-member/deferred-base paths that still bypass
       the shared semantic lookup model and therefore fall back to AST-only
       repair, with the next bounded target now the broader deferred-base replay
-      users and remaining out-of-line declaration/static-member replay gaps
-      beyond the covered in-class/nested/out-of-line static-member and
-      out-of-line member-function(-template) body metadata paths.
+      users and the remaining out-of-line member-function-template replay gaps
+      beyond the covered in-class/nested/out-of-line static-member,
+      out-of-line member-function(-template) body, and top-level constructor-
+      template replay metadata paths.
 
 2. **Continue dependent-name/current-instantiation modeling**
    - richer dependent-base and unknown-specialization records;
@@ -363,6 +384,11 @@ materially changes what future refactors can assume.
   template parameter list, and replay rebuilds parameter names/kinds/non-type
   categories before substitution so deeper member-template owner chains can stay
   on the replay-first two-phase lookup path.
+- top-level out-of-line constructor templates on class templates now preserve
+  inner template-parameter metadata on the out-of-line registration stub, and
+  instantiation reattaches deferred body/initializer-list replay positions to
+  the matching constructor template using unresolved inner-parameter shape
+  instead of outer-only substituted type identity.
 - qualified member variable-template chains now resolve through inherited
   owner-aware member variable-template lookup, and member variable-template
   instantiation folds recovered outer class-template bindings into initializer

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -126,6 +126,11 @@ Future work should assume these are already in place:
   such as `Traits<T>::template Box<T>::type::value`,
   `Traits<T>::template Box<T>::type::get()`, and
   `Derived<T>::template Inner<int>::type::value`.
+- top-level out-of-line constructor templates on class templates now preserve
+  inner template-parameter metadata on the registered out-of-line stub, and
+  instantiation attaches deferred body/initializer-list replay positions to the
+  matching constructor template by unresolved inner-parameter shape before lazy
+  materialization.
 
 Latest validation on Linux sharded build:
 `2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
@@ -140,7 +145,13 @@ after `make sharded CXX=clang++`.
 Focused Windows/MSVC validation for this slice passed the new deeper
 dependent-chain regressions plus nearby ratio and dependent-member regressions.
 Latest Windows/MSVC full-suite validation after this slice:
-`2487` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+`2502` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
+Latest focused Windows/MSVC validation for the out-of-line constructor-template
+replay slice passed
+`test_template_ool_ctor_template_base_member_init_replay_ret42.cpp`,
+`test_template_nested_ool_ctor_template_init_replay_ret42.cpp`,
+`test_template_nested_ool_ctor_template_base_member_init_replay_ret42.cpp`, and
+`test_template_nested_ool_ctor_template_ref_init_replay_ret42.cpp`.
 
 ## Remaining work, in priority order
 
@@ -210,9 +221,13 @@ Most concrete next subtask:
   template replay now also carries definition-time lookup context through
   eager/lazy instantiation stubs, and covered out-of-line constructor replay now
   preserves initializer-list metadata in both nested-template and generic
-  out-of-line registration paths. Priority is now broader deferred-base coverage
-  and the remaining out-of-line declaration/static-member replay gaps beyond the
-  newly covered deeper member-template owner chains.
+  out-of-line registration paths. Top-level out-of-line constructor templates on
+  class templates now also retain inner template-parameter metadata on the
+  registered stub and reattach deferred body/initializer-list replay state to
+  the instantiated constructor template before lazy materialization. Priority is
+  now broader deferred-base coverage plus the remaining out-of-line member-
+  function-template replay combinations that still need the same owner-correct
+  replay path.
 
 ### 2. Complete dependent-name and current-instantiation modeling
 
@@ -297,6 +312,11 @@ coverage becomes sufficient.
       unknown-specialization `member-template -> type/alias -> value/call`
       chains as covered for the focused qualified-id and call-substitution
       paths;
+    - treat top-level out-of-line constructor templates on class templates as
+      covered for deferred body/initializer-list replay attachment once the
+      registered stub preserves inner template-parameter metadata and
+      instantiation matches the constructor template by unresolved inner-
+      parameter shape;
     - treat out-of-line static-member replay as covered for the focused deeper
       member-template owner chain cases once replay-visible template parameters
       are preserved and replay reconstructs parameter kinds/non-type categories;
@@ -305,8 +325,9 @@ coverage becomes sufficient.
       variable-template initializer, in-class/nested/out-of-line static-member
       replay, and default-NTTP parser flows;
     - remove the next AST-only/deferred-base fallback path, with the next bounded
-      target now deferred-base replay users plus the remaining broader
-      out-of-line declaration/static-member replay gaps.
+      target now deferred-base replay users plus the remaining out-of-line
+      member-function-template replay gaps and broader declaration/static-member
+      replay users.
 
 2. **Dependent-name/current-instantiation expansion**
    - richer dependent-base and unknown-specialization records;
@@ -428,6 +449,11 @@ re-solving already-solved problems.
 - out-of-line constructor replay metadata capture now consistently preserves
   initializer-list replay positions across nested-template and generic out-of-
   line member registration paths.
+- top-level out-of-line constructor templates on class templates now preserve
+  inner template-parameter metadata on the registered stub, and the
+  instantiator attaches deferred body/initializer-list replay positions to the
+  matching constructor template using unresolved inner-parameter shape instead
+  of outer-only substituted type identity.
 
 ## Exit criteria
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -491,6 +491,21 @@ static bool constructorDeclarationsHaveMatchingParameterShape(
 	return true;
 }
 
+static bool typeSpecifierLooksLikeDependentSignaturePlaceholder(
+	const TypeSpecifierNode& type_spec) {
+	if (type_spec.type() == TypeCategory::Template) {
+		return true;
+	}
+	if (!type_spec.type_index().is_valid()) {
+		return false;
+	}
+	if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
+		type_info != nullptr && type_info->isDependentPlaceholder()) {
+		return true;
+	}
+	return false;
+}
+
 static bool typeSpecifiersMatchForSignatureValidation(
 	const TypeSpecifierNode& lhs,
 	const TypeSpecifierNode& rhs) {
@@ -563,9 +578,10 @@ static std::optional<TypeSpecifierNode> substituteOutOfLineSignatureType(
 	return substituted_type;
 }
 
-static std::optional<bool> functionDeclarationsMatchAfterTemplateSubstitution(
+template <typename InstantiatedDeclNode>
+static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	Parser& parser,
-	const FunctionDeclarationNode& instantiated_decl,
+	const InstantiatedDeclNode& instantiated_decl,
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
@@ -589,52 +605,23 @@ static std::optional<bool> functionDeclarationsMatchAfterTemplateSubstitution(
 			template_params,
 			template_args,
 			owner_type_name);
-		if (!substituted_param.has_value()) {
+		if (substituted_param.has_value()) {
+			if (!typeSpecifiersMatchForSignatureValidation(
+					*instantiated_param,
+					*substituted_param)) {
+				return false;
+			}
+			continue;
+		}
+
+		if (!typeSpecifierLooksLikeDependentSignaturePlaceholder(*instantiated_param) &&
+			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*out_of_line_param)) {
 			return std::nullopt;
 		}
-
-		if (!typeSpecifiersMatchForSignatureValidation(
-				*instantiated_param,
-				*substituted_param)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-static std::optional<bool> constructorDeclarationsMatchAfterTemplateSubstitution(
-	Parser& parser,
-	const ConstructorDeclarationNode& instantiated_decl,
-	const FunctionDeclarationNode& out_of_line_decl,
-	std::span<const TemplateParameterNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	StringHandle owner_type_name) {
-	if (instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
-		return false;
-	}
-
-	for (size_t i = 0; i < instantiated_decl.parameter_nodes().size(); ++i) {
-		const TypeSpecifierNode* instantiated_param =
-			getDeclarationParamTypeNode(instantiated_decl.parameter_nodes()[i]);
-		const TypeSpecifierNode* out_of_line_param =
-			getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[i]);
-		if (instantiated_param == nullptr || out_of_line_param == nullptr) {
-			return std::nullopt;
-		}
-
-		ASTNode substituted_type_node = parser.substituteTemplateParameters(
-			ASTNode::emplace_node<TypeSpecifierNode>(*out_of_line_param),
-			template_params,
-			template_args,
-			owner_type_name);
-		if (!substituted_type_node.is<TypeSpecifierNode>()) {
-			return std::nullopt;
-		}
-
-		if (!typeSpecifiersMatchForSignatureValidation(
-				*instantiated_param,
-				substituted_type_node.as<TypeSpecifierNode>())) {
+		if (instantiated_param->token().value() != out_of_line_param->token().value() ||
+			instantiated_param->pointer_depth() != out_of_line_param->pointer_depth() ||
+			instantiated_param->reference_qualifier() != out_of_line_param->reference_qualifier() ||
+			instantiated_param->cv_qualifier() != out_of_line_param->cv_qualifier()) {
 			return false;
 		}
 	}
@@ -10265,19 +10252,40 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (out_of_line_ctor_stub &&
 					mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
 					auto& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();
-					size_t out_of_line_template_param_count =
+					const size_t out_of_line_template_param_count =
 						out_of_line_member.inner_template_params.size();
-					const bool template_param_count_matches =
-						!ctor_decl.template_parameters().empty() &&
-						ctor_decl.template_parameters().size() == out_of_line_template_param_count;
-					const bool parameter_shape_matches =
-						ool_func.parameter_nodes().size() == ctor_decl.parameter_nodes().size() &&
-						constructorDeclarationsHaveMatchingParameterShape(
-							ctor_decl,
-							ool_func);
-					if (!ctor_decl.has_template_body_position() &&
-						template_param_count_matches &&
-						parameter_shape_matches) {
+					auto matches_out_of_line_ctor_template =
+						[&](const ConstructorDeclarationNode& candidate) -> bool {
+							if (candidate.has_template_body_position()) {
+								return false;
+							}
+							if (candidate.template_parameters().empty() ||
+								candidate.template_parameters().size() != out_of_line_template_param_count) {
+								return false;
+							}
+
+							std::optional<bool> signature_match =
+								declarationsMatchAfterTemplateSubstitution(
+									*this,
+									candidate,
+									ool_func,
+									std::span<const TemplateParameterNode>(
+										out_of_line_member.template_params.data(),
+										out_of_line_member.template_params.size()),
+									std::span<const TemplateTypeArg>(
+										template_args_to_use.data(),
+										template_args_to_use.size()),
+									instantiated_name);
+							if (signature_match.has_value()) {
+								return *signature_match;
+							}
+
+							return ool_func.parameter_nodes().size() == candidate.parameter_nodes().size() &&
+								constructorDeclarationsHaveMatchingParameterShape(
+									candidate,
+									ool_func);
+						};
+					if (matches_out_of_line_ctor_template(ctor_decl)) {
 						ctor_decl.set_template_body_position(out_of_line_member.body_start);
 						if (out_of_line_member.has_initializer_list) {
 							ctor_decl.set_template_initializer_list_position(
@@ -10295,19 +10303,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								info_ctor.template_parameters().size() != ctor_decl.template_parameters().size()) {
 								continue;
 							}
-							std::optional<bool> info_signature_match =
-								constructorDeclarationsMatchAfterTemplateSubstitution(
-									*this,
-									info_ctor,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.template_params.data(),
-										out_of_line_member.template_params.size()),
-									std::span<const TemplateTypeArg>(
-										template_args_to_use.data(),
-										template_args_to_use.size()),
-									instantiated_name);
-							if (info_signature_match.has_value() && !*info_signature_match) {
+							if (!matches_out_of_line_ctor_template(info_ctor)) {
 								continue;
 							}
 
@@ -10425,7 +10421,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 
 					std::optional<bool> signature_match =
-						functionDeclarationsMatchAfterTemplateSubstitution(
+						declarationsMatchAfterTemplateSubstitution(
 							*this,
 							inst_func,
 							func_decl,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -477,10 +477,13 @@ static bool constructorDeclarationsHaveMatchingParameterShape(
 			return false;
 		}
 		if (ctor_param->type() != stub_param->type() ||
-			ctor_param->type_index() != stub_param->type_index() ||
 			ctor_param->pointer_depth() != stub_param->pointer_depth() ||
 			ctor_param->reference_qualifier() != stub_param->reference_qualifier() ||
 			ctor_param->cv_qualifier() != stub_param->cv_qualifier()) {
+			return false;
+		}
+		if (ctor_param->type_index() != stub_param->type_index() &&
+			ctor_param->token().value() != stub_param->token().value()) {
 			return false;
 		}
 	}
@@ -593,6 +596,45 @@ static std::optional<bool> functionDeclarationsMatchAfterTemplateSubstitution(
 		if (!typeSpecifiersMatchForSignatureValidation(
 				*instantiated_param,
 				*substituted_param)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static std::optional<bool> constructorDeclarationsMatchAfterTemplateSubstitution(
+	Parser& parser,
+	const ConstructorDeclarationNode& instantiated_decl,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	StringHandle owner_type_name) {
+	if (instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
+		return false;
+	}
+
+	for (size_t i = 0; i < instantiated_decl.parameter_nodes().size(); ++i) {
+		const TypeSpecifierNode* instantiated_param =
+			getDeclarationParamTypeNode(instantiated_decl.parameter_nodes()[i]);
+		const TypeSpecifierNode* out_of_line_param =
+			getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[i]);
+		if (instantiated_param == nullptr || out_of_line_param == nullptr) {
+			return std::nullopt;
+		}
+
+		ASTNode substituted_type_node = parser.substituteTemplateParameters(
+			ASTNode::emplace_node<TypeSpecifierNode>(*out_of_line_param),
+			template_params,
+			template_args,
+			owner_type_name);
+		if (!substituted_type_node.is<TypeSpecifierNode>()) {
+			return std::nullopt;
+		}
+
+		if (!typeSpecifiersMatchForSignatureValidation(
+				*instantiated_param,
+				substituted_type_node.as<TypeSpecifierNode>())) {
 			return false;
 		}
 	}
@@ -10201,23 +10243,92 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Process out-of-line member function definitions for the template
 	auto out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(template_name);
+	const std::string_view template_base_name = extractBaseTemplateName(template_name);
 	FLASH_LOG(Templates, Debug, "Processing ", out_of_line_members.size(), " out-of-line member functions for ", template_name);
 
 	for (const auto& out_of_line_member : out_of_line_members) {
 		// Check if this is a nested template (member function template of a class template)
 		// Pattern: template<typename T> template<typename U> T Container<T>::convert(U u) { ... }
 		if (!out_of_line_member.inner_template_params.empty()) {
-			// This is a nested template out-of-line definition
-			// Find the matching TemplateFunctionDeclarationNode in the instantiated struct
-			// and set the body_start on its inner FunctionDeclarationNode
 			const FunctionDeclarationNode& ool_func = out_of_line_member.function_node.as<FunctionDeclarationNode>();
 			const DeclarationNode& ool_decl = ool_func.decl_node();
 			std::string_view ool_func_name = ool_decl.identifier_token().value();
+			const bool out_of_line_ctor_stub =
+				!template_name.empty() &&
+				(ool_func_name == template_name ||
+				 (!template_base_name.empty() && ool_func_name == template_base_name));
 
 			FLASH_LOG(Templates, Debug, "Processing nested template out-of-line member: ", ool_func_name);
 
 			bool found = false;
 			for (auto& mem_func : instantiated_struct_ref.member_functions()) {
+				if (out_of_line_ctor_stub &&
+					mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
+					auto& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();
+					size_t out_of_line_template_param_count =
+						out_of_line_member.inner_template_params.size();
+					const bool template_param_count_matches =
+						!ctor_decl.template_parameters().empty() &&
+						ctor_decl.template_parameters().size() == out_of_line_template_param_count;
+					const bool parameter_shape_matches =
+						ool_func.parameter_nodes().size() == ctor_decl.parameter_nodes().size() &&
+						constructorDeclarationsHaveMatchingParameterShape(
+							ctor_decl,
+							ool_func);
+					if (!ctor_decl.has_template_body_position() &&
+						template_param_count_matches &&
+						parameter_shape_matches) {
+						ctor_decl.set_template_body_position(out_of_line_member.body_start);
+						if (out_of_line_member.has_initializer_list) {
+							ctor_decl.set_template_initializer_list_position(
+								out_of_line_member.initializer_list_start);
+						}
+						for (auto& info_func : struct_info_ptr->member_functions) {
+							if (!info_func.is_constructor ||
+								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+								continue;
+							}
+
+							auto& info_ctor =
+								info_func.function_decl.as<ConstructorDeclarationNode>();
+							if (info_ctor.name() != ctor_decl.name() ||
+								info_ctor.template_parameters().size() != ctor_decl.template_parameters().size()) {
+								continue;
+							}
+							std::optional<bool> info_signature_match =
+								constructorDeclarationsMatchAfterTemplateSubstitution(
+									*this,
+									info_ctor,
+									ool_func,
+									std::span<const TemplateParameterNode>(
+										out_of_line_member.template_params.data(),
+										out_of_line_member.template_params.size()),
+									std::span<const TemplateTypeArg>(
+										template_args_to_use.data(),
+										template_args_to_use.size()),
+									instantiated_name);
+							if (info_signature_match.has_value() && !*info_signature_match) {
+								continue;
+							}
+
+							info_ctor.set_template_body_position(out_of_line_member.body_start);
+							if (out_of_line_member.has_initializer_list) {
+								info_ctor.set_template_initializer_list_position(
+									out_of_line_member.initializer_list_start);
+							}
+							break;
+						}
+						FLASH_LOG(
+							Templates,
+							Debug,
+							"Set deferred body position on out-of-line constructor template: ",
+							ool_func_name);
+						found = true;
+						break;
+					}
+					continue;
+				}
+
 				FunctionDeclarationNode* inst_func_decl = get_function_decl_node_mut(mem_func.function_declaration);
 				if (!inst_func_decl) {
 					continue;
@@ -10500,7 +10611,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								}
 
 								advance();  // consume '(' or '{'
-								TokenKind close_kind = is_paren ? ")"_tok : "}"_tok;
+								TokenKind close_kind = ")"_tok;
+								if (!is_paren) {
+									close_kind = "}"_tok;
+								}
 
 								std::vector<ASTNode> init_args;
 								if (peek() != close_kind) {

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -249,6 +249,8 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 					out_of_line_ctor.body_start = ctor_body_start;
 					out_of_line_ctor.initializer_list_start = ctor_initializer_list_start;
 					out_of_line_ctor.template_param_names = template_param_names;
+					out_of_line_ctor.inner_template_params = inner_template_params;
+					out_of_line_ctor.inner_template_param_names = inner_template_param_names;
 					out_of_line_ctor.has_initializer_list = ctor_has_initializer_list;
 					out_of_line_ctor.is_defaulted = ctor_is_defaulted;
 					out_of_line_ctor.is_deleted = ctor_is_deleted;

--- a/tests/test_template_ool_ctor_template_base_member_init_replay_ret42.cpp
+++ b/tests/test_template_ool_ctor_template_base_member_init_replay_ret42.cpp
@@ -1,0 +1,36 @@
+// Regression: out-of-line constructor templates on class templates must
+// replay base/member initializers and preserve definition-time lookup.
+
+int helperValue(int value) {
+	return value + 1;
+}
+
+template <typename T>
+struct Base {
+	int base;
+
+	Base(int value) : base(value) {}
+};
+
+template <typename T>
+struct Box : Base<T> {
+	int member;
+
+	template <typename U>
+	Box(U value);
+
+	int total() const {
+		return this->base + member;
+	}
+};
+
+template <typename T>
+template <typename U>
+Box<T>::Box(U value)
+	: Base<T>(helperValue(20)),
+	  member(static_cast<int>(value)) {}
+
+int main() {
+	Box<int> box(21);
+	return box.total();
+}

--- a/tests/test_template_ool_ctor_template_outer_and_inner_params_ret42.cpp
+++ b/tests/test_template_ool_ctor_template_outer_and_inner_params_ret42.cpp
@@ -1,0 +1,27 @@
+// Regression: top-level out-of-line constructor templates on class templates
+// must match signatures that mix outer class-template params and inner
+// constructor-template params.
+
+template <typename T>
+struct PairBox {
+	T first;
+	int second;
+
+	template <typename U>
+	PairBox(T a, U b);
+
+	int total() const {
+		return static_cast<int>(first) + second;
+	}
+};
+
+template <typename T>
+template <typename U>
+PairBox<T>::PairBox(T a, U b)
+	: first(a),
+	  second(static_cast<int>(b)) {}
+
+int main() {
+	PairBox<int> value(20, 22);
+	return value.total();
+}


### PR DESCRIPTION
## What changed
- preserve inner template-parameter metadata when registering top-level out-of-line constructor templates on class templates
- attach deferred body and initializer-list replay positions to the matching instantiated constructor template before lazy materialization
- add a regression covering `template<class T> template<class U> Box<T>::Box(U)` with base and member initializers
- update the template-architecture audit and conformance investigation notes with this completed slice and the next bounded target

## Why
Top-level out-of-line constructor templates were losing replay state before lazy constructor materialization. That left valid constructor-template definitions without any deferred body source on the instantiated constructor, causing compilation to fail when the constructor template was selected.

## Impact
- class-template constructor templates defined out of line now participate in the same replay-based two-phase infrastructure already used by nearby covered out-of-line template paths
- existing nested out-of-line constructor-template replay behavior remains covered by focused regressions
- the documentation now points the next bounded task at out-of-line member-function-template plus deferred-base replay combinations

## Validation
- `./tests/run_all_tests.ps1 test_template_ool_ctor_template_base_member_init_replay_ret42.cpp`
- `./tests/run_all_tests.ps1 test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
- `./tests/run_all_tests.ps1 test_template_nested_ool_ctor_template_base_member_init_replay_ret42.cpp`
- `./tests/run_all_tests.ps1 test_template_nested_ool_ctor_template_ref_init_replay_ret42.cpp`
- `./tests/run_all_tests.ps1`
