### PR TITLE
Template replay integration follow-ups

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -3,434 +3,119 @@
 **Date:** 2026-05-12  
 **Last updated:** 2026-05-22
 
-This document is the short audit for FlashCpp's template infrastructure. Its
-main purpose is to describe what is still structurally wrong, what the next
-highest-impact work is, and what "good enough" current behavior already exists
-so later refactors do not regress it.
+This document should stay forward-facing. It is not a historical ledger or
+release log. Keep only the minimum completed-state context needed to explain
+the current architecture and the next highest-impact work.
 
 ## Executive summary
 
-FlashCpp is no longer in the "basic template support" phase. The main
-remaining problem is architectural: template classification, dependent-name
-modeling, two-phase lookup, deduction, and instantiation still cross parser,
-registry, `TypeInfo`, and late substitution layers instead of being owned by
-one semantic pipeline.
+FlashCpp now handles many practical C++20 template cases, but the main
+remaining standards gap is still two-phase lookup across replayed template
+infrastructure.
 
-The compiler now handles a broad set of practical C++20 template cases, but it
-is still not standard-conforming as a whole. The largest remaining conformance
-lever is still two-phase lookup and dependent-name ownership, not another broad
-parser cleanup.
+The highest-impact work is no longer broad parser cleanup. It is finishing the
+owner-correct replay path for out-of-line member-function-template bodies that
+interact with dependent bases.
 
-## Current state in one page
+## Current state
 
-Useful to know before changing anything:
+Useful assumptions before changing this area:
 
-- explicit template arguments are mostly classified by parameter context, not
-  only parser heuristics;
-- main function/member/qualified/alias/operator template lookup paths already
-  use semantic lookup requests/records;
-- selected non-dependent calls in templates already preserve definition-context
-  lookup records;
-- unresolved dependent unqualified calls already preserve POI completion
-  metadata through substitution, sema, constexpr, and lazy-static paths;
-- several static-member instantiation paths now prefer replay-from-source with
-  preserved definition-context lookup rather than AST-only substitution;
-- inherited dependent-base member-template alias owners now resolve through the
-  shared member-chain concretization path for covered base-specifier/member-chain
-  cases such as `Mid<T>::template rebind<int>`;
-- alias-selected default-NTTP qualified-id owners now canonicalize through a
-  shared owner-materialization primitive instead of local alias/default-NTTP
-  recovery logic in expression substitution;
-- deferred alias/member-chain materialization now recursively concretizes nested
-  alias-target template-instantiation arguments, so stored
-  `IsEmpty<Type>`-style args become `IsEmpty<Concrete>` before deferred-base
-  trait evaluation;
-- current-owner qualified-id substitution now resolves member aliases through the
-  same member-side lookup/materialization path used by current-instantiation
-  member-type lookup, preserving direct dependent-member-target handling and the
-  concrete member-alias cache when a concrete sibling alias must be synthesized;
-- typed NTTP identity is implemented for integral, enum, `nullptr`, object
-  pointer, reference, function pointer, non-null/null member-data pointer, and
-  floating-point cases that already materialize as concrete semantic values;
-- default non-type template arguments now materialize with their substituted
-  declared parameter type for covered scalar/enum cases, so
-  `template<class T, T V = 1>` preserves `T=short` instead of storing `V` as
-  `int`;
-- namespace and member variable-template initializers now capture initializer
-  replay positions and definition lookup contexts, and variable-template
-  instantiation prefers replay-first initializer materialization before the
-  compatibility AST-substitution fallback;
-- in-class static-member declarations now preserve initializer definition
-  lookup context alongside replay positions on both AST and instantiated
-  static-member carriers, and covered nested/member-template static-member
-  instantiation now reuses replay-first substitution instead of AST-only
-  substitution;
-- out-of-line static-member definitions now preserve the full replay-visible
-  template-parameter list, and instantiation rebuilds replay state with
-  parameter kinds/non-type categories before replay-first substitution, covering
-  deeper owner/member-template chains such as
-  `MetaFactory<T>::template Wrap<char>::template Step<N>::value`;
-- qualified member variable-template chains now use owner-aware lookup through
-  instantiated owners and dependent bases, preserving recovered outer class
-  template bindings for cases such as `Derived<T>::template member_v<T>`;
-- `this->template` member-function-template calls can now find member templates
-  declared in dependent base class templates while parsing the derived class
-  template body, because deferred base template names are stored on
-  `StructTypeInfo` before the primary `TemplateClassDeclarationNode` is
-  registered;
-- deferred alias targets now preserve and materialize multi-hop member-template
-  suffixes for covered alias and base-specifier flows, so spellings like
-  `Traits<T>::template Box<U>::template Rebind<T>` are no longer truncated to a
-  single dependent member-template hop;
-- member alias-template declarations now preserve deferred member suffixes and
-  enclosing class-template bindings for covered non-template intermediate member
-  chains such as `Provider<T>::Node::template Apply<U>`;
-- template-parameter default arguments now route dependent owner template-ids
-  such as `Provider<T>::Node::template Apply<T>::value` through the same
-  deferred qualified-member-chain parser used in template bodies, instead of
-  falling through to the generic postfix `::` parser and stopping before
-  semantic substitution/evaluation;
-- lookup-time owner materialization for concrete template instantiations now
-  canonicalizes through the shared owner helper before qualified member-chain
-  resolution, so ratio-like inherited `::type::value` chains can find inherited
-  static members during default-NTTP evaluation without reopening deferred-base
-  attachment fallback paths;
-- direct member-template lookup on fully qualified instantiated nested owners
-  now retries shortened nested-owner spellings, so declarations that materialize
-  owners like `Outer<int>::Inner::template Apply<int>` can find member-template
-  registrations stored under nested names such as `Inner::Apply`;
-- dependent qualified-id and call substitution now share owner-correct prefix
-  materialization for covered unknown-specialization and dependent-base chains,
-  so general expression/lazy-static paths such as
-  `Traits<T>::template Box<T>::type::value`,
-  `Traits<T>::template Box<T>::type::get()`, and
-  `Derived<T>::template Inner<int>::type::value` stay concrete through the
-  intermediate `type` alias instead of stalling after the member-template hop;
-- top-level out-of-line constructor templates on class templates now preserve
-  their inner template-parameter metadata on the registered out-of-line stub,
-  and instantiation attaches deferred body/initializer-list replay positions to
-  the matching constructor template by unresolved inner-parameter shape, so
-  spellings like `template<class T> template<class U> Box<T>::Box(U)` no longer
-  drop replay state before lazy constructor materialization;
-- selected free/member function-template overload paths already do
-  signature-only ranking before body materialization.
+- the main template lookup paths already prefer semantic lookup records over
+  raw parser heuristics;
+- covered non-dependent template-body lookup already preserves
+  definition-context binding;
+- several replay-heavy paths now preserve enough metadata to reparse from
+  source instead of depending on AST-only substitution;
+- covered dependent owner/member-template chains already reuse a shared
+  owner-aware materialization path;
+- out-of-line constructor-template replay now preserves inner template metadata
+  and matches renamed inner template parameters in the covered paths;
+- nested out-of-line member-function-template replay now preserves
+  instantiated outer parameter bindings while still copying definition-side
+  parameter names.
 
-Validation at this point passed the Linux sharded build and ELF test workflow:
-`2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Focused Windows/MSVC validation for this slice passed the new deeper
-dependent-chain regressions plus the nearby ratio/dependent-member regressions.
-Latest Windows/MSVC full-suite validation after this slice:
+Latest recorded full-suite validation:
 `2502` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Latest focused Linux validation for the out-of-line static-member replay slice
-passed `test_template_out_of_line_static_member_replay_member_template_chain_ret0.cpp`,
-`test_template_out_of_line_static_member_two_phase_lookup_ret0.cpp`, and
-`test_template_out_of_line_static_member_two_phase_lookup_multi_template_ret0.cpp`
-after `make sharded CXX=clang++`.
-Latest focused Windows/MSVC validation for the out-of-line constructor-template
-replay slice passed
-`test_template_ool_ctor_template_base_member_init_replay_ret42.cpp`,
-`test_template_nested_ool_ctor_template_init_replay_ret42.cpp`,
-`test_template_nested_ool_ctor_template_base_member_init_replay_ret42.cpp`, and
-`test_template_nested_ool_ctor_template_ref_init_replay_ret42.cpp`.
+
+Latest focused replay regressions added on the current branch:
+- `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
+- `test_template_ool_ctor_template_param_rename_replay_ret0.cpp`
 
 ## What is still wrong
 
-### 1. Two-phase lookup is still incomplete
+### 1. Two-phase lookup and replay ownership are still incomplete
 
-This remains the biggest standards gap.
+This is still the main conformance problem.
 
-What still needs work:
+The remaining issue is not that replay exists. The issue is that some replay
+paths still do not capture enough semantic metadata at parse time, so later
+instantiation has to recover intent from partially substituted AST state.
 
-- remaining current-instantiation and type-alias spellings that do not yet
-  reuse the same owner-correct POI/definition-time path;
-- remaining declaration/static-member paths outside the newly covered in-class
-  and nested static-member replay flows that still need AST-only fallback
-  because replay metadata was never captured at parse time;
-- richer dependent-base lookup and deeper member-template/member-type chains;
-- remaining parser-time ADL-sensitive paths outside the already-covered call
-  and static-member flows.
+The largest remaining uncovered surface is replayed out-of-line
+member-function-template bodies that perform dependent-base lookup.
 
-Concrete follow-up already identified by recent work:
+### 2. Dependent-name modeling is still too weak
 
-- the explicit-template unknown-specialization owner-record gap is now narrower:
-  replayed deferred qualified-call records keep the instantiated placeholder
-  `owner_type`, so declaration-time replay is no longer forced to recover that
-  identity from the raw owner spelling alone. Deferred non-call and call-shaped
-  qualified expressions now also keep member-template segment arguments such as
-  `Traits<T>::template Box<T>::value` and
-  `Traits<T>::template Box<T>::get()` instead of dropping the `Box<T>` segment
-  at parse time.
-- default NTTP declared-type materialization and variable-template initializer
-  replay metadata are now covered for the targeted scalar/member-chain cases.
-  In-class static members now preserve definition lookup context on the stored
-  static-member carriers as well, and covered nested/member-template static-
-  member instantiation now reuses replay-first substitution with outer/inner
-  template bindings instead of immediate AST-only substitution.
-  Out-of-line static-member definitions now preserve the full replay-visible
-  template-parameter list as well, and replay rebuilds parameter
-  names/kinds/non-type categories before substitution so deeper
-  owner/member-template chains stay on the replay-first path instead of falling
-  back immediately to AST substitution.
-  Qualified member variable-template chains through dependent bases are now
-  covered for the focused initializer/constexpr paths, and dependent-base
-  `this->template` member-function-template calls are covered for the focused
-  inline class-template body paths. Deferred alias targets now keep covered
-  multi-hop member-template suffixes in alias declarations and base-specifier
-  materialization. Member alias-template chains with covered non-template
-  intermediate members and enclosing class-template bindings now preserve enough
-  metadata for declarations such as `Provider<T>::Node::template Apply<U>`.
-  The parser-side declaration stop for dependent owner template-ids in default
-  NTTPs is now covered, including direct member-template and nested alias chains
-  ending in `::value`, and the later lookup-time `<ratio>` owner gap is now
-  covered by canonical owner materialization before inherited member-chain
-  lookup. General expression/lazy-static substitution now also reuses a shared
-  owner-correct prefix-chain materialization path for the focused
-  unknown-specialization and dependent-base `member-template -> type/alias ->
-  value/call` cases. Out-of-line class-template member-function definitions now
-  also preserve definition lookup context and re-install it during body replay,
-  so ordinary unqualified lookup in those reparsed bodies stays bound to the
-  definition point instead of rebinding at the point of instantiation.
-  Top-level out-of-line constructor templates on class templates now also keep
-  enough replay metadata to reattach their deferred body and initializer-list
-  source to the instantiated constructor template before lazy materialization.
-  The next concrete follow-up is therefore narrower again: extend that same
-  owner-correct replay/materialization path into the remaining declaration/
-  deferred-base paths that still never captured enough metadata to avoid
-  AST-only fallback, with the next bounded target now the still-uncovered
-  out-of-line member-function-template-plus-deferred-base replay combinations
-  and the broader deferred-base replay users beyond the newly covered
-  member-function body and constructor-template paths.
+`DependentQualifiedNameRecord` is useful, but it is still not a complete
+`[temp.dep]` model. The remaining gaps matter mainly because they block the
+replay/lookup work above.
 
-### 2. Dependent names are still represented too loosely
+### 3. Lower-priority work remains open
 
-`TypeInfo::DependentQualifiedNameRecord` now covers useful cases, but the full
-`[temp.dep]` model is still missing.
+These are still incomplete, but they are not the next best use of effort unless
+they directly block item 1:
 
-Still open:
-
-- broader expression/member-template segment chains outside the covered lazy
-  static initializer paths;
-- plain dependent bases and more unknown-specialization paths;
-- injected-class-name modeling;
-- alias ordering and current-instantiation identity across all qualified-name
-  paths;
-- one canonical equivalence service for dependent unevaluated expressions.
-
-### 3. NTTP support is still incomplete
-
-Supported identity is much better than before, but C++20 coverage is still not
-complete.
-
-Still open:
-
-- non-null member-function-pointer semantic values;
-- structural class-type NTTPs;
-- any remaining floating-point paths that do not yet round-trip through the
-  same semantic identity/mangling flow;
-- replacing the remaining conservative function/member-pointer mangling
-  fallbacks in `TODO(item-8)` in `NameMangling.h`; the type side is richer now,
-  but value encoding still intentionally falls back conservatively.
-
-### 4. Deduction, constraints, and overload resolution are still too coupled to instantiation
-
-Some important overload paths now rank candidates without materializing losing
-bodies, but this is still partial.
-
-Still open:
-
-- more full-instantiation fallback removal;
-- non-deduced contexts and forwarding-reference edge cases;
-- packs in more positions;
-- template-template parameter matching;
-- CTAD and deduction guides;
-- constraint normalization/subsumption and cleaner sema-owned candidate
-  ranking.
-
-### 5. Static-member materialization is still too repair-oriented
-
-Recent work fixed many regressions by preserving replay metadata and using
-definition-context lookup more often, but the model is still not purely sema-
-owned.
-
-Still open:
-
-- declarations that never capture replay metadata at parse time;
-- remaining eager substitution paths that still need AST-only fallback;
-- final cleanup to make invalid non-dependent cases diagnostics/invariants
-  instead of repair paths.
-
-### 6. Constructor fallback is still intentionally soft
-
-The codegen-time constructor fallback is no longer needed for current valid
-coverage in tested paths, but it still exists for uncovered/invalid cases.
-
-Target end state:
-
-- sema always annotates the valid cases;
-- codegen fallback becomes a diagnostic or invariant, not a compatibility path.
+- NTTP completion for the remaining C++20 categories;
+- broader sema-owned deduction/ranking;
+- final removal of repair-oriented fallback paths.
 
 ## Highest-impact next steps
 
-In priority order:
+1. **Finish out-of-line member-function-template replay through dependent bases**
+   - This is the next bounded target.
+   - Goal: replayed out-of-line member-function-template bodies should use the
+     same owner-correct deferred-base lookup path already used by the covered
+     inline and constructor-template cases.
+   - Success condition: no AST-only fallback is needed for replayed
+     `this->template ...` or equivalent dependent-base member-template lookup.
 
-1. **Finish the next two-phase lookup slice**
-   - current-instantiation/type-alias follow-up work after inherited member-template
-       alias recovery, nested alias-target deferred-base materialization, and the
-       current-owner member-alias qualified-id cleanup is now complete for the
-       deeper covered member-chain cases;
-   - lookup-time canonical owner materialization now covers the focused
-      ratio-style inherited `::type::value` default-NTTP path without mutating
-      deferred-base attachment;
-    - general expression/lazy-static substitution now covers the focused
-      deeper dependent-base and unknown-specialization
-      `member-template -> type/alias -> value/call` chains via a shared
-      owner-correct prefix materialization path reused by qualified-id and call
-      substitution;
-    - dependent-base `this->template` member-function-template calls are covered
-      for focused inline class-template body cases, including multilevel
-      dependent-base chains;
-    - top-level out-of-line constructor templates on class templates now retain
-      inner template-parameter metadata on their registered stub and reattach
-      deferred body/initializer-list replay state to the instantiated
-      constructor template before lazy materialization;
-    - remaining replay-metadata gaps outside the covered static-member and
-      variable-template initializer paths, now including the newly covered
-      out-of-line static-member replay path for deeper member-template chains;
-    - out-of-line class-template member-function bodies now preserve and replay
-      definition-context lookup metadata for non-dependent unqualified lookup;
-    - remaining declaration/static-member/deferred-base paths that still bypass
-      the shared semantic lookup model and therefore fall back to AST-only
-      repair, with the next bounded target now the broader deferred-base replay
-      users and the remaining out-of-line member-function-template replay gaps
-      beyond the covered in-class/nested/out-of-line static-member,
-      out-of-line member-function(-template) body, and top-level constructor-
-      template replay metadata paths.
+2. **Remove the next AST-only replay fallback**
+   - After item 1, continue with the remaining declaration/static-member/
+     deferred-base replay paths that still never captured enough replay
+     metadata.
+   - Prefer replay-first semantic attachment over adding more repair logic.
 
-2. **Continue dependent-name/current-instantiation modeling**
-   - richer dependent-base and unknown-specialization records;
-   - broader member-template chains outside the covered current lazy-static
-     cases;
-   - canonical dependent-expression equivalence.
-
-3. **Complete the remaining NTTP categories**
-   - non-null member-function-pointers;
-   - structural class-type NTTPs;
-   - remove remaining mangling fallbacks where standard encodings are possible.
-
-4. **Expand sema-owned deduction/ranking**
-   - keep moving ordinary overload selection away from full-instantiation
-     fallback and toward candidate construction + deduction + constraints +
-     ranking before materialization.
+3. **Strengthen dependent-name/current-instantiation modeling only where it unblocks 1-2**
+   - Expand richer dependent-base and unknown-specialization records only when
+     required by the replay/lookup path above.
+   - Avoid broad redesign work that does not directly reduce fallback behavior.
 
 ## Short completed-state summary
 
-This section is intentionally compact. It only records the completed work that
-materially changes what future refactors can assume.
+The following are complete enough to rely on:
 
-- semantic analyzer unification on parser-owned template-name lookup is done
-  for the previously remaining sema-layer probe paths;
-- semantic lookup records cover the main template lookup paths used by parser
-  and sema;
-- member function template bodies now participate in definition-context lookup;
-- unresolved dependent unqualified calls preserve POI completion metadata;
-- multiple static-member initialization/copy/update paths now preserve replay
-  metadata and definition-context lookup;
-- dependent template-template owner concretization is in place for covered
-  parser substitution paths;
-- inherited dependent-base member-template alias owner lookup is now shared for
-  covered base-specifier/member-chain concretization cases;
-- alias-template lookup results now expose a canonical semantic owner/result
-  name and the main qualified-id substitution paths prefer that semantic owner
-  over helper instantiated names;
-- default-NTTP qualified-id substitution now reuses a shared canonical
-  owner-materialization primitive with parser-side owner lookup materialization
-  instead of bespoke alias/type-index probing in `ExpressionSubstitutor`;
-- current-owner qualified-id member-alias substitution now reuses
-  `resolveBaseClassMemberTypeChain` plus dependent-member materialization helpers
-  instead of the last open-coded local alias repair block in
-  `ExpressionSubstitutor`;
-- deeper current-instantiation/type-alias qualified-id namespace chains now also
-  resolve through that shared member-side path, and replayed qualified-ids now
-  capture current-instantiation metadata early enough that lazy/static replay no
-  longer has to depend on a repair-only fallback for those covered chains;
-- member-pointer NTTPs now preserve declaring-class identity through
-  constexpr/template-arg storage, substitute as `&Class::member` inside template
-  bodies, and distinguish same-name/same-offset members from unrelated classes;
-- member-pointer NTTP mangling now carries richer member-pointer type identity
-  (including the declaring class when recoverable), while value encoding still
-  intentionally falls back conservatively until a full Itanium external-name
-  form is wired for those values;
-- default NTTP values now use the substituted declared parameter type when
-  materialized through the shared default-evaluation paths, preserving identity
-  for cases like `template<class T, T V = 1>` instantiated as `T=short`.
-- variable-template initializers now store replay metadata and definition lookup
-  context for namespace and member variable templates, with replay-first
-  instantiation covering definition-time lookup and dependent member-template
-  chains;
-- out-of-line class-template member-function bodies now store definition lookup
-  context in the replay metadata, and instantiation re-enters that context
-  before reparsing the saved body so non-dependent unqualified calls stay
-  definition-bound in the covered non-constructor path.
-- nested out-of-line member-function-template stubs now also carry
-  definition-time lookup context through eager/lazy instantiation stubs, and
-  replay re-enters that captured namespace scope (including global namespace)
-  before reparsing.
-- static-member declarations now store definition lookup context alongside
-  replay positions on both AST and instantiated static-member carriers, and
-  covered nested/member-template static-member instantiation reuses that stored
-  metadata for replay-first substitution before falling back to AST
-  substitution.
-- out-of-line static-member definitions now also store the full replay-visible
-  template parameter list, and replay rebuilds parameter names/kinds/non-type
-  categories before substitution so deeper member-template owner chains can stay
-  on the replay-first two-phase lookup path.
-- top-level out-of-line constructor templates on class templates now preserve
-  inner template-parameter metadata on the out-of-line registration stub, and
-  instantiation reattaches deferred body/initializer-list replay positions to
-  the matching constructor template using unresolved inner-parameter shape
-  instead of outer-only substituted type identity.
-- qualified member variable-template chains now resolve through inherited
-  owner-aware member variable-template lookup, and member variable-template
-  instantiation folds recovered outer class-template bindings into initializer
-  replay/substitution identity.
-- dependent-base member-function-template lookup now stores deferred base
-  template pattern names on `StructTypeInfo`, so inline class-template bodies can
-  resolve `this->template member<...>()` through dependent base class templates
-  before the derived `TemplateClassDeclarationNode` is registered.
-- deferred alias targets now store a member-template segment chain instead of a
-  single member hop, and covered alias/base-specifier materialization walks that
-  chain through the shared owner-aware member lookup path.
-- member alias-template declarations now capture deferred suffix chains and
-  register instantiated/nested aliases with recovered outer class-template
-  bindings, covering non-template intermediate member chains such as
-  `Provider<T>::Node::template Apply<U>`.
-- template-parameter default arguments now preserve dependent qualified
-  member-template chains ending in static-member lookups, covering focused
-  declaration-time shapes such as `Provider<T>::Node::template Apply<T>::value`
-  and `Provider<T>::Node::type::value` instead of rejecting them in the postfix
-  parser before default evaluation.
-- lookup-time concrete owner resolution now routes through
-  `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
-  resolution, covering ratio-style inherited `::type` then default-NTTP
-  `::value` flows without adding a new deferred-base or constexpr fallback.
-- dependent qualified-id and qualified-call substitution now share owner-
-  correct prefix-chain materialization for the covered general
-  expression/lazy-static cases where a member-template hop produces an
-  intermediate type/alias before the final static member or member call.
-- out-of-line template member registration now preserves constructor
-  initializer-list replay metadata in both nested-template and generic
-  out-of-line parsing paths, and covered ctor replay paths reuse that metadata
-  when materializing initializers before body parsing.
+- semantic lookup records back the main template lookup paths;
+- covered non-dependent template-body lookup preserves definition-time binding;
+- covered owner/member-template chains now stay on a shared owner-aware
+  materialization path;
+- out-of-line static-member replay preserves replay-visible template
+  parameters in the covered paths;
+- top-level out-of-line constructor-template replay preserves inner template
+  metadata and reattaches deferred body/initializer-list state correctly in the
+  covered paths;
+- nested out-of-line member-function-template replay preserves instantiated
+  outer parameter types while importing definition-side parameter names.
 
-## Exit criteria for this audit
+## Exit criteria
 
-This audit can eventually be retired when all of the following are true:
+This audit can be retired when:
 
-- template argument kind is no longer decided by parser heuristics in ambiguous
-  cases;
-- two-phase lookup is covered for non-dependent definition-time binding and
-  dependent POI completion across the main call/member/static paths;
-- NTTP equivalence is complete for the supported C++20 categories;
-- dependent-name/current-instantiation behavior is owned by semantic records
-  instead of string-like placeholders;
-- normal overload ranking no longer materializes losing candidates by default.
+- the main replay paths no longer require AST-only fallback for valid template
+  code;
+- definition-time vs POI lookup timing is preserved across the main template
+  body, member, static-member, and replay paths;
+- dependent-name/current-instantiation behavior is semantically modeled rather
+  than reconstructed from placeholder spellings;
+- ordinary overload ranking no longer materializes losing candidates by
+  default.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -3,155 +3,43 @@
 **Date:** 2026-05-12  
 **Last updated:** 2026-05-22
 
-This document is the execution plan for moving FlashCpp's template
-infrastructure toward C++20 conformance. It intentionally focuses on remaining
-work. Completed work is kept only when it changes what the next refactor can
-assume.
+This document should stay forward-facing. It is not a historical ledger or
+release log. Keep completed work only when it changes what the next refactor
+can assume or what the next highest-impact step should be.
 
 ## Goal
 
-Converge from parser- and registry-owned repair paths to one sema-owned
-template system where:
+Move FlashCpp from parser- and registry-owned repair paths toward one
+sema-owned template system where:
 
-- declaration lookup owns dependency classification and definition-vs-POI
-  timing;
-- template arguments are classified against the target parameter, not guessed
-  early;
-- dependent names preserve semantic identity instead of string placeholders;
-- NTTP identity models C++20 equivalence for the supported categories;
-- deduction, constraints, ranking, substitution, and materialization are
-  separate phases;
-- static-member and constructor behavior becomes invariant-driven instead of
-  fallback-driven.
+- dependency classification and definition-vs-POI timing are explicit;
+- template arguments are classified against the target parameter;
+- dependent names preserve semantic identity;
+- substitution, deduction, ranking, and materialization are separate phases;
+- replay-heavy paths become invariant-driven instead of fallback-driven.
 
-## Compatibility constraints to preserve
+## Current assumptions
 
-Refactors must not regress these existing behaviors:
+Future work can rely on these being in place:
 
-1. scalar-only static-member folding and normalized-byte preference;
-2. bounded recursive static-member evaluation;
-3. template static-member normalization applies template-parameter
-   substitution before expression-level substitution;
-4. per-member IR rollback only rolls back the failing member;
-5. missing sema constructor annotations still fall back to runtime overload
-   resolution until sema coverage is complete;
-6. enum functional casts stay consistently categorized as `TypeCategory::Enum`;
-7. alias-backed non-struct concrete types still resolve size through the
-   existing fallback chain;
-8. qualified template-body calls preserve definition-context lookup metadata;
-9. floating-point NTTP identity continues to round-trip through constexpr and
-   mangling for already-supported cases.
+- semantic lookup records cover the main template lookup paths;
+- covered non-dependent template-body lookup preserves definition-context
+  binding;
+- several replay paths already preserve source positions plus definition lookup
+  context instead of relying only on substituted AST state;
+- covered owner/member-template chains already reuse a shared owner-aware
+  materialization path;
+- top-level out-of-line constructor-template replay preserves inner template
+  metadata and matches renamed inner template parameters in the covered paths;
+- nested out-of-line member-function-template replay preserves instantiated
+  outer parameter types while copying definition-side parameter identifiers.
 
-## Current assumptions you can rely on
-
-Future work should assume these are already in place:
-
-- semantic template-name lookup requests/records cover the main parser/sema
-  lookup paths;
-- selected non-dependent template-body calls already preserve definition-time
-  lookup records;
-- unresolved dependent unqualified calls already preserve POI completion
-  metadata through substitution, sema, constexpr, and lazy-static paths;
-- multiple static-member replay/copy/update paths already preserve replay
-  metadata and definition-context lookup;
-- inherited dependent-base member-template alias owners already resolve through
-  the shared member-chain concretization path for covered base-specifier flows;
-- deferred alias/member-chain materialization now recursively concretizes nested
-  alias-target template-instantiation arguments before deferred-base trait
-  evaluation;
-- current-owner qualified-id member aliases now reuse the same member-side
-  lookup/materialization path as nearby current-instantiation member-type
-  resolution, including direct dependent-member-target handling and concrete
-  member-alias cache population when a concrete sibling alias must be materialized;
-- typed NTTP identity already exists for integral, enum, `nullptr`, object
-  pointer, reference, function pointer, non-null/null member-data pointer, and
-  covered floating-point cases;
-- default NTTP values use the substituted declared parameter type in the shared
-  default-evaluation paths for covered scalar/enum cases, so
-  `template<class T, T V = 1>` preserves the `T` identity after substitution;
-- member alias-template type-specifier parsing now uses the shared dependent
-  member-alias materialization path before falling back to direct target
-  rebinding, so aliases like
-  `typename Select<true>::template Apply<Wrap, int>` can materialize through
-  `typename Function<Type>::type` to a concrete type for variable-template
-  constexpr checks;
-- `sizeof...(Pack)` now parses and preserves as a dependent value expression
-  inside alias-template target argument lists, covering MSVC-style
-  `index_sequence_for = make_index_sequence<sizeof...(Types)>`;
-- selected free/member function-template overload paths already rank
-  signatures before materializing bodies.
-- namespace and member variable-template initializers now preserve replay
-  positions and definition lookup contexts; instantiation uses replay-first
-  materialization for covered initializer expressions before falling back to
-  stored AST substitution.
-- in-class static-member declarations now preserve replay positions and
-  definition lookup contexts on both AST and instantiated static-member
-  carriers, and covered nested/member-template static-member instantiation now
-  reuses replay-first substitution instead of direct AST-only substitution.
-- out-of-line static-member definitions now preserve the full replay-visible
-  template-parameter list, and replay rebuilds parameter names/kinds/non-type
-  categories before substitution so deeper owner/member-template chains can stay
-  on the replay-first path.
-- out-of-line class-template member-function definitions now preserve
-  definition-context lookup metadata, and instantiation re-enters that context
-  before reparsing the saved body so covered non-dependent unqualified lookup in
-  those bodies stays bound to the definition point.
-- qualified member variable-template chains through instantiated owners and
-  dependent bases now recover the canonical member variable-template owner and
-  outer class-template bindings for covered constexpr/initializer flows.
-- dependent-base `this->template` member-function-template calls in inline
-  class-template bodies now keep enough deferred-base owner metadata to find
-  member templates declared in base class templates before the derived class
-  template declaration is registered.
-- deferred alias targets now keep multi-hop member-template suffixes and
-  materialize the covered alias/base-specifier cases through the shared
-  owner-aware member lookup path instead of storing only one suffix hop.
-- member alias-template declarations now capture deferred suffix chains and
-  merge recovered outer class-template bindings while materializing covered
-  non-template intermediate member chains such as
-  `Provider<T>::Node::template Apply<U>`.
-- template-parameter default arguments now reuse the deferred qualified-member
-  chain parser for dependent owner template-ids, so declaration-time defaults
-  like `Provider<T>::Node::template Apply<T>::value` and
-  `Provider<T>::Node::type::value` no longer stop in the generic postfix `::`
-  path before semantic substitution/evaluation.
-- lookup-time owner materialization for concrete template instantiations now
-  reuses the shared canonical owner helper before inherited member-chain
-  resolution, covering ratio-style inherited `::type::value` lookup during
-  default-NTTP evaluation without perturbing deferred-base attachment.
-- dependent qualified-id and qualified-call substitution now share owner-
-  correct prefix-chain materialization for the focused general
-  expression/lazy-static cases where a member-template hop produces an
-  intermediate type/alias before a final static value or call, covering shapes
-  such as `Traits<T>::template Box<T>::type::value`,
-  `Traits<T>::template Box<T>::type::get()`, and
-  `Derived<T>::template Inner<int>::type::value`.
-- top-level out-of-line constructor templates on class templates now preserve
-  inner template-parameter metadata on the registered out-of-line stub, and
-  instantiation attaches deferred body/initializer-list replay positions to the
-  matching constructor template by unresolved inner-parameter shape before lazy
-  materialization.
-
-Latest validation on Linux sharded build:
-`2440` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Targeted validation for the latest member alias-template non-template
-intermediate chain slice passed the focused ELF regressions after
-`make sharded CXX=clang++`.
-Latest focused Linux validation for the out-of-line static-member replay slice
-passed `test_template_out_of_line_static_member_replay_member_template_chain_ret0.cpp`,
-`test_template_out_of_line_static_member_two_phase_lookup_ret0.cpp`, and
-`test_template_out_of_line_static_member_two_phase_lookup_multi_template_ret0.cpp`
-after `make sharded CXX=clang++`.
-Focused Windows/MSVC validation for this slice passed the new deeper
-dependent-chain regressions plus nearby ratio and dependent-member regressions.
-Latest Windows/MSVC full-suite validation after this slice:
+Latest recorded full-suite validation:
 `2502` regular tests compiled/linked/runtime-pass, `181` expected-fail tests.
-Latest focused Windows/MSVC validation for the out-of-line constructor-template
-replay slice passed
-`test_template_ool_ctor_template_base_member_init_replay_ret42.cpp`,
-`test_template_nested_ool_ctor_template_init_replay_ret42.cpp`,
-`test_template_nested_ool_ctor_template_base_member_init_replay_ret42.cpp`, and
-`test_template_nested_ool_ctor_template_ref_init_replay_ret42.cpp`.
+
+Latest focused regressions added on the current branch:
+- `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
+- `test_template_ool_ctor_template_param_rename_replay_ret0.cpp`
 
 ## Remaining work, in priority order
 
@@ -159,312 +47,84 @@ replay slice passed
 
 This is still the highest-impact track.
 
-Immediate targets:
+Next bounded target:
 
-- current-instantiation and type-alias spellings that still bypass the shared
-  owner-correct lookup/materialization path;
-- remaining declarations and static-member paths outside the newly covered
-  in-class/nested static-member replay flows that never captured replay
-  metadata at parse time and therefore still require AST-only fallback;
-- remaining dependent-base and deeper member-template/member-type chains;
-- remaining parser-time ADL-sensitive lookup paths outside the already-covered
-  call flows.
+- make replayed out-of-line member-function-template bodies use the same
+  owner-correct deferred-base lookup path already used by the covered inline
+  class-template-body and constructor-template replay cases.
 
-Most concrete next subtask:
+Why this is next:
 
-- finish the remaining declaration/static-member two-phase lookup work after the
-  latest replay-metadata improvements: deferred explicit-template
-  qualified-call records now preserve the instantiated placeholder `owner_type`
-  instead of dropping it at parse time, and variable-template initializers now
-  capture replay metadata for covered namespace/member declarations. Deferred
-  non-call qualified expressions preserve deeper member-template segment
-  arguments such as `Traits<T>::template Box<T>::value`, and call-shaped
-  expressions preserve `Traits<T>::template Box<T>::get()`. Qualified member
-  variable-template chains now recover concrete explicit template arguments and
-  outer owner bindings for the covered initializer/constexpr paths.
-  `this->template` member-function-template calls through dependent bases now
-  work for focused inline class-template body cases, including multilevel base
-  chains. The newly covered declaration-time parser stop for dependent owner
-  template-ids in default NTTPs is now joined by lookup-time canonical owner
-  materialization for the focused `<ratio>` inherited `::type::value` path, so
-  parsing/substitution/evaluation no longer lose that chain when concrete owner
-  lookup runs. Parsing/substitution now progress past the fixed default-NTTP
-  declared-type materialization, the lookup-time ratio owner gap,
-  materialization, dependent member-template argument paths, covered member
-  alias-template target materialization path, alias-template `sizeof...` NTTP
-  target arguments, covered variable-template initializer replay paths, covered
-  member variable-template chain recovery, covered dependent-base
-  `this->template` member-function-template lookup, and the newly covered
-  default-NTTP member-chain parser path. In-class static members now also keep
-  definition lookup context on stored AST/instantiated static-member carriers,
-  and covered nested/member-template static-member instantiation reuses
-  replay-first substitution with outer/inner template bindings instead of
-  immediate AST-only substitution.
-  Out-of-line static-member definitions now likewise preserve the full replay-
-  visible template-parameter list, and replay reconstructs names/kinds/non-type
-  categories before substitution so deeper member-template owner chains keep the
-  same semantic replay path.
-  Covered deferred alias member-template suffix chains in declarations and base
-  specifiers now work as well, and covered member alias-template declarations
-  now preserve non-template intermediate member segments plus enclosing
-  class-template bindings for cases like `Provider<T>::Node::template Apply<U>`.
-  General expression/lazy-static substitution now also covers the focused
-  deeper dependent-base/unknown-specialization
-  `member-template -> type/alias -> value/call` chains via a shared owner-
-  correct prefix materialization path reused by qualified-id and call
-  substitution. The next bounded follow-up is therefore the remaining
-  declaration/static-member/deferred-base paths that still never captured enough
-  metadata to stay on that semantic path and still require AST-only fallback.
-  The next bounded follow-up is therefore the remaining replay users outside the
-  covered in-class/nested/out-of-line static-member metadata and out-of-line
-  member-function/body metadata paths. Nested out-of-line member-function-
-  template replay now also carries definition-time lookup context through
-  eager/lazy instantiation stubs, and covered out-of-line constructor replay now
-  preserves initializer-list metadata in both nested-template and generic
-  out-of-line registration paths. Top-level out-of-line constructor templates on
-  class templates now also retain inner template-parameter metadata on the
-  registered stub and reattach deferred body/initializer-list replay state to
-  the instantiated constructor template before lazy materialization. Priority is
-  now broader deferred-base coverage plus the remaining out-of-line member-
-  function-template replay combinations that still need the same owner-correct
-  replay path.
+- it closes a still-open standards gap in two-phase lookup;
+- it removes another AST-only replay fallback instead of adding new repair
+  logic;
+- it builds directly on the metadata-preservation work that already landed.
 
-### 2. Complete dependent-name and current-instantiation modeling
+Success condition:
 
-`DependentQualifiedNameRecord` is a useful base, but it is not a complete
-`[temp.dep]` model.
+- replayed out-of-line member-function-template bodies performing dependent-base
+  lookup no longer need special fallback behavior to find the correct member
+  template or owner.
 
-Still needed:
+### 2. Remove the next replay-metadata gap
+
+After item 1, continue with the remaining declaration/static-member/
+deferred-base replay paths that still never captured enough metadata at parse
+time.
+
+Rule for this work:
+
+- prefer replay-first semantic attachment;
+- do not add new AST-only repair paths unless they are strictly temporary and
+  documented.
+
+### 3. Expand dependent-name/current-instantiation modeling only as needed
+
+Still open:
 
 - richer dependent-base records;
 - more unknown-specialization coverage;
-- deeper expression/member-template chains;
-- injected-class-name handling;
-- consistent current-instantiation identity across qualified-name paths;
-- alias-ordering correctness.
+- deeper member-template/type chains;
+- consistent current-instantiation identity across qualified-name paths.
 
-### 3. Centralize dependent-expression equivalence
+This work should support items 1-2, not replace them as the main track.
 
-One canonical semantic equivalence service is still missing.
+### 4. Leave lower-priority tracks for later unless they block 1-3
 
-That service should be used by:
+Still open, but not the next best slice:
 
-- NTTP identity;
-- substitution/materialization comparisons;
-- any future dependent-expression memoization or lookup keys.
-
-Without this, identity tracking and later evaluation can still diverge.
-
-### 4. Finish NTTP conformance
-
-The main unsupported categories remain:
-
-- non-null member-function pointers;
-- structural class-type NTTPs;
-- remaining end-to-end floating-point coverage if any paths still rely on local
-  normalization instead of semantic value identity.
-
-Also required:
-
-- replace the remaining conservative function/member-pointer mangling fallbacks;
-  member-pointer type information is richer now, but value encoding still falls
-  back conservatively until a full standard external-name form is available
-  from current semantic data.
-
-### 5. Expand deduction/constraint separation before materialization
-
-The current shape-only ranking coverage is useful but partial.
-
-Still needed:
-
-- more overload paths off the full-instantiation fallback;
-- non-deduced contexts;
-- forwarding references;
-- more pack shapes;
-- template-template parameter matching;
-- CTAD and deduction guides;
-- stronger constraint normalization/subsumption in ranking.
-
-### 6. Turn fallback-heavy areas into invariants
-
-Two areas still need endgame cleanup:
-
-- constructor annotation fallback;
-- static-member materialization fallbacks that remain only because semantic
-  ownership is still incomplete.
-
-The goal is not to add more fallback code. The goal is to delete it as semantic
-coverage becomes sufficient.
+- remaining NTTP categories;
+- broader sema-owned deduction and ranking;
+- final conversion of repair paths into invariants/diagnostics.
 
 ## Recommended implementation order
 
-1. **Two-phase lookup follow-up**
-   - treat the deeper current-instantiation/type-alias member-chain recovery work
-      after the current-owner member-alias qualified-id cleanup as complete for
-      the covered qualified-id/member-side cases;
-   - keep reusing the shared member-side lookup/materialization path in the
-      remaining qualified-id spellings so local repair logic is not reintroduced;
-    - treat dependent owner template-ids in template-parameter defaults as
-      covered for the focused member-template and nested-alias `::value` cases;
-    - treat lookup-time canonical owner materialization as covered for the
-      focused ratio-style inherited `::type::value` default-NTTP path;
-    - treat general expression/lazy-static deeper dependent-base and
-      unknown-specialization `member-template -> type/alias -> value/call`
-      chains as covered for the focused qualified-id and call-substitution
-      paths;
-    - treat top-level out-of-line constructor templates on class templates as
-      covered for deferred body/initializer-list replay attachment once the
-      registered stub preserves inner template-parameter metadata and
-      instantiation matches the constructor template by unresolved inner-
-      parameter shape;
-    - treat out-of-line static-member replay as covered for the focused deeper
-      member-template owner chain cases once replay-visible template parameters
-      are preserved and replay reconstructs parameter kinds/non-type categories;
-    - extend owner-correct replay/materialization into the remaining
-      declaration, static-member, and deferred-base paths outside the covered
-      variable-template initializer, in-class/nested/out-of-line static-member
-      replay, and default-NTTP parser flows;
-    - remove the next AST-only/deferred-base fallback path, with the next bounded
-      target now deferred-base replay users plus the remaining out-of-line
-      member-function-template replay gaps and broader declaration/static-member
-      replay users.
+1. add a narrow regression for replayed out-of-line member-function-template
+   dependent-base lookup;
+2. make that path reuse the same owner-correct replay/lookup machinery as the
+   covered inline and constructor-template cases;
+3. remove the local fallback that becomes redundant;
+4. update these docs with the next remaining replay-metadata gap.
 
-2. **Dependent-name/current-instantiation expansion**
-   - richer dependent-base and unknown-specialization records;
-   - deeper member-template chains;
-   - owner-correct alias ordering.
+## Regression focus
 
-3. **Dependent-expression equivalence service**
-   - one reusable semantic identity model for unevaluated dependent
-     expressions.
+Keep adding narrow regressions in these areas:
 
-4. **NTTP completion**
-   - non-null member-function pointers;
-   - structural class NTTPs;
-   - remaining mangling cleanup.
-
-5. **Deduction/constraint separation**
-   - continue removing full-instantiation fallback from ordinary overload
-     selection.
-
-6. **Invariant cleanup**
-   - constructor fallback;
-   - remaining lookup/materialization repair paths.
-
-## Short artifact list
-
-These are the main architectural pieces still worth building or finishing:
-
-- a fuller sema-owned current-instantiation/dependent-name model;
-- a canonical dependent-expression equivalence service;
-- fuller `TemplateInstantiationContext` ownership in legacy substitution paths;
-- a complete NTTP value representation for the remaining C++20 categories;
-- broader sema-owned candidate construction/deduction/constraint/ranking;
-- final removal of repair-oriented fallback paths.
-
-## Regression focus for future slices
-
-When working on the remaining items, keep adding narrow regressions in these
-areas:
-
-- argument classification ambiguities driven by parameter kind;
-- definition-time vs POI lookup timing;
-- dependent-base and current-instantiation member-template/type chains;
-- NTTP identity for unsupported or partially supported categories;
-- deduction edge cases: non-deduced contexts, forwarding refs, packs,
-  template-template params, CTAD, guides, constraints;
-- static-member replay/ODR-use timing and hidden-friend cases.
-
-## Done, but only as context
-
-This section is intentionally short. It exists only to stop future work from
-re-solving already-solved problems.
-
-- alias-selected default-NTTP qualified-id substitution now canonicalizes the
-  substituted owner through a shared parser/substitutor owner-materialization
-  primitive instead of bespoke alias/default-NTTP recovery in
-  `ExpressionSubstitutor`;
-
-- semantic analyzer unification on parser-owned template-name lookup is done
-  for the previously remaining sema-layer probe paths;
-- selected member function template bodies already apply definition-context
-  lookup;
-- dependent unqualified POI completion is already first-class metadata, not an
-  ad hoc retry path;
-- several static-member replay and copy/update paths already preserve metadata;
-- inherited dependent-base member-template alias owner recovery is already in
-  place for covered base-specifier/member-chain cases;
-- main qualified-id substitution paths now prefer semantic alias owners over
-  helper instantiated names when alias materialization already resolved a
-  concrete `TypeInfo`;
-- current-owner member-alias qualified-id substitution now resolves through
-  `resolveBaseClassMemberTypeChain` and dependent-member materialization helpers
-  instead of bespoke local alias repair in `ExpressionSubstitutor`;
-- deeper current-instantiation/type-alias qualified-id namespace chains now go
-  through the same shared member-side path, and replay parsing preserves covered
-  current-instantiation qualified-id metadata early enough for lazy/static
-  substitution to stay semantic instead of falling back to repair;
-- member-data-pointer NTTPs now keep declaring-class identity through
-  constexpr/template-arg round-trips and substitute correctly inside template
-  bodies; mangling now preserves richer member-pointer type identity but still
-  keeps conservative fallback value encoding until a full external-name form is
-  available.
-- variable-template initializer replay is now available for namespace and member
-  variable templates, covering definition-time lookup and dependent
-  member-template call chains.
-- static-member replay metadata now includes definition lookup context on both
-  AST and instantiated static-member carriers, covering the focused nested
-  member-template static-member replay paths where outer/inner template
-  bindings and definition-time ordinary lookup must survive instantiation.
-- qualified member variable-template chain recovery now covers direct,
-  dependent-owner, and inherited dependent-base cases such as
-  `Derived<T>::template member_v<T>` by resolving the owner-aware member
-  variable-template name and folding outer bindings into replay/substitution.
-- deferred base template pattern names are now stored on `StructTypeInfo`, so
-  inline class-template body parsing can resolve `this->template member<...>()`
-  through dependent base class templates without waiting for the derived
-  `TemplateClassDeclarationNode` to be registered.
-- deferred alias target capture now stores a member-template segment chain, and
-  covered alias/base-specifier materialization walks each segment through
-  owner-aware lookup so `Owner<T>::template Box<U>::template Rebind<T>` is not
-  rejected or truncated at parse time.
-- dependent owner template-ids in template-parameter defaults now reuse the
-  deferred qualified-member parser instead of the generic postfix `::` path, so
-  focused declaration-time chains like
-  `Provider<T>::Node::template Apply<T>::value` and
-  `Provider<T>::Node::type::value` reach substitution/evaluation as semantic
-  qualified names instead of stopping at parse time.
-- lookup-time concrete owner resolution now routes through
-  `resolveCanonicalInstantiatedOwnerForLookup` before inherited member-chain
-  resolution, covering ratio-style inherited `::type` followed by default-NTTP
-  `::value` use without introducing another fallback path.
-- dependent qualified-id and qualified-call substitution now share owner-
-  correct prefix-chain materialization for the covered general
-  expression/lazy-static chains where a member-template hop feeds an
-  intermediate type/alias before the final static member or member call.
-- nested out-of-line member-function-template replay now preserves and reuses
-  definition-time lookup context in both eager and lazy instantiation stubs, and
-  replay re-enters that captured namespace scope (including global namespace)
-  before body parsing.
-- out-of-line constructor replay metadata capture now consistently preserves
-  initializer-list replay positions across nested-template and generic out-of-
-  line member registration paths.
-- top-level out-of-line constructor templates on class templates now preserve
-  inner template-parameter metadata on the registered stub, and the
-  instantiator attaches deferred body/initializer-list replay positions to the
-  matching constructor template using unresolved inner-parameter shape instead
-  of outer-only substituted type identity.
+- replayed out-of-line member-function-template bodies using `this->template`
+  or equivalent dependent-base lookup;
+- declaration/definition attachment where inner and outer template parameters
+  interact;
+- remaining declaration/static-member replay paths that still fall back to
+  partially substituted AST state.
 
 ## Exit criteria
 
 This plan is complete when:
 
-- argument kind is always parameter-context-driven for ambiguous template-ids;
-- the main template-body/member/static lookup paths obey definition-vs-POI
-  timing with explicit semantic records;
+- the main replay paths preserve definition-time vs POI lookup timing through
+  semantic metadata instead of fallback recovery;
 - dependent-name/current-instantiation behavior is semantically modeled rather
-  than string-reconstructed;
-- NTTP identity is complete for the supported C++20 categories;
+  than reconstructed from placeholder spellings;
+- remaining repair paths have been converted into diagnostics or invariants;
 - ordinary overload selection does not materialize losing candidates by
-  default;
-- remaining repair paths have been converted into diagnostics or invariants.
+  default.

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2066,6 +2066,9 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 			node.set_outer_template_bindings(outer_template_param_names, filtered_template_args);
 		}
 	}
+	static void copyDefinitionParameterIdentifiers(
+		std::span<ASTNode> instantiated_params,
+		std::span<const ASTNode> definition_params);
 	static StringHandle computeInstantiatedLookupName(
 		StringHandle original_name,
 		OverloadableOperator op_kind,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -5579,11 +5579,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						ctor_decl.set_template_initializer_list_position(
 							out_of_line_member.initializer_list_start);
 					}
-					StructTypeInfo* instantiated_struct_info = struct_type_info.getStructInfo();
-					if (instantiated_struct_info == nullptr) {
+					StructTypeInfo* ctor_instantiated_struct_info = struct_type_info.getStructInfo();
+					if (ctor_instantiated_struct_info == nullptr) {
 						break;
 					}
-					for (auto& info_func : instantiated_struct_info->member_functions) {
+					for (auto& info_func : ctor_instantiated_struct_info->member_functions) {
 						if (!info_func.is_constructor ||
 							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
 							continue;
@@ -11084,20 +11084,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									// Check if this is a base class by looking at the struct's base classes
 									for (const auto& base : struct_type_info.struct_info_->base_classes) {
 										std::string_view base_name = base.name;
-										bool names_match =
+										bool base_names_match =
 											(base_name == init_name || extractBaseTemplateName(base_name) == init_name);
-										if (!names_match) {
+										if (!base_names_match) {
 											if (const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
 												base_type_info && base_type_info->isTemplateInstantiation()) {
 												StringHandle qualified_base_template_name =
 													gNamespaceRegistry.buildQualifiedIdentifier(
 														base_type_info->sourceNamespace(),
 														base_type_info->baseTemplateName());
-												names_match =
+												base_names_match =
 													StringTable::getStringView(qualified_base_template_name) == init_name;
 											}
 										}
-										if (names_match) {
+										if (base_names_match) {
 											is_base_init = true;
 											matched_base_name = StringTable::getOrInternStringHandle(base_name);
 											break;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -793,6 +793,59 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		out_of_line_inner_template_params);
 }
 
+static bool outOfLineConstructorTemplateMatchesCandidate(
+	Parser& parser,
+	const ConstructorDeclarationNode& candidate,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> candidate_inner_template_params,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
+		return false;
+	}
+
+	std::optional<bool> substituted_signature_match = declarationsMatchAfterTemplateSubstitution(
+		parser,
+		candidate,
+		out_of_line_decl,
+		outer_template_params,
+		outer_template_args,
+		owner_type_name,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params);
+	if (substituted_signature_match.has_value()) {
+		return *substituted_signature_match;
+	}
+
+	return constructorDeclarationsHaveMatchingParameterShape(
+		candidate,
+		out_of_line_decl,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params);
+}
+
+static void copyDefinitionParameterIdentifiers(
+	std::span<ASTNode> instantiated_params,
+	std::span<const ASTNode> definition_params) {
+	if (instantiated_params.size() != definition_params.size()) {
+		return;
+	}
+
+	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+		const DeclarationNode* instantiated_decl_const = get_decl_from_symbol(instantiated_params[param_index]);
+		DeclarationNode* instantiated_decl = const_cast<DeclarationNode*>(instantiated_decl_const);
+		const DeclarationNode* definition_decl = get_decl_from_symbol(definition_params[param_index]);
+		if (!instantiated_decl || !definition_decl) {
+			continue;
+		}
+		if (!definition_decl->identifier_token().value().empty()) {
+			instantiated_decl->set_identifier_token(definition_decl->identifier_token());
+		}
+	}
+}
+
 // Resolve any stored template arguments on a deferred base member-type chain after a class
 // template's substitution maps are available.
 // Returns std::nullopt when any pack expansion or concrete member argument cannot be resolved.
@@ -8644,9 +8697,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								: nullptr;
 						const bool out_of_line_ctor_stub_matches =
 							!out_of_line_ctor_stub_decl ||
-							(out_of_line_ctor_stub_decl->parameter_nodes().size() == ctor_decl.parameter_nodes().size() &&
-							 (nested_out_of_line_members.size() == 1 ||
-							  constructorDeclarationsHaveMatchingParameterShape(ctor_decl, *out_of_line_ctor_stub_decl)));
+							(nested_out_of_line_members.size() == 1 ||
+							 outOfLineConstructorTemplateMatchesCandidate(
+								*this,
+								ctor_decl,
+								*out_of_line_ctor_stub_decl,
+								std::span<const TemplateParameterNode>(
+									template_params.data(),
+									template_params.size()),
+								std::span<const TemplateTypeArg>(
+									template_args_to_use.data(),
+									template_args_to_use.size()),
+								qualified_name,
+								std::span<const TemplateParameterNode>(
+									ctor_decl.template_parameters().data(),
+									ctor_decl.template_parameters().size()),
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.inner_template_params.data(),
+									out_of_line_member.inner_template_params.size())));
 						if (!ctor_decl.is_materialized() &&
 							!ctor_decl.has_template_body_position() &&
 							template_param_count_matches &&
@@ -10577,26 +10645,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								return false;
 							}
 
-							std::optional<bool> signature_match =
-								declarationsMatchAfterTemplateSubstitution(
-									*this,
-									candidate,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.template_params.data(),
-										out_of_line_member.template_params.size()),
-									std::span<const TemplateTypeArg>(
-										template_args_to_use.data(),
-										template_args_to_use.size()),
-									instantiated_name);
-							if (signature_match.has_value()) {
-								return *signature_match;
-							}
-
-							return ool_func.parameter_nodes().size() == candidate.parameter_nodes().size() &&
-								constructorDeclarationsHaveMatchingParameterShape(
-									candidate,
-									ool_func);
+							return outOfLineConstructorTemplateMatchesCandidate(
+								*this,
+								candidate,
+								ool_func,
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.template_params.data(),
+									out_of_line_member.template_params.size()),
+								std::span<const TemplateTypeArg>(
+									template_args_to_use.data(),
+									template_args_to_use.size()),
+								instantiated_name,
+								std::span<const TemplateParameterNode>(
+									candidate.template_parameters().data(),
+									candidate.template_parameters().size()),
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.inner_template_params.data(),
+									out_of_line_member.inner_template_params.size()));
 						};
 					if (matches_out_of_line_ctor_template(ctor_decl)) {
 						ctor_decl.set_template_body_position(out_of_line_member.body_start);
@@ -10667,7 +10732,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Set the body position and definition-time lookup context from the
 				// out-of-line definition so two-phase lookup uses the definition namespace.
 				inst_func_decl->set_template_body_position(out_of_line_member.body_start);
-				inst_func_decl->update_parameter_nodes_from_definition(
+				copyDefinitionParameterIdentifiers(
+					inst_func_decl->parameter_nodes(),
 					ool_func.parameter_nodes());
 				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 				FLASH_LOG(Templates, Debug, "Set body position on nested template member: ", ool_func_name);
@@ -10708,7 +10774,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 
 						recovered_func_decl->set_template_body_position(out_of_line_member.body_start);
-						recovered_func_decl->update_parameter_nodes_from_definition(
+						copyDefinitionParameterIdentifiers(
+							recovered_func_decl->parameter_nodes(),
 							ool_func.parameter_nodes());
 						recovered_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 						OverloadableOperator recovered_operator_kind = original_member.operator_kind;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -463,9 +463,17 @@ static void applyResolvedTemplateArgTypeMetadata(TypeSpecifierNode& target, cons
 	}
 }
 
+static bool dependentTemplatePlaceholderNamesMatch(
+	std::string_view instantiated_name,
+	std::string_view out_of_line_name,
+	std::span<const TemplateParameterNode> instantiated_template_params,
+	std::span<const TemplateParameterNode> out_of_line_template_params);
+
 static bool constructorDeclarationsHaveMatchingParameterShape(
 	const ConstructorDeclarationNode& ctor_decl,
-	const FunctionDeclarationNode& out_of_line_stub) {
+	const FunctionDeclarationNode& out_of_line_stub,
+	std::span<const TemplateParameterNode> instantiated_template_params = {},
+	std::span<const TemplateParameterNode> out_of_line_template_params = {}) {
 	if (ctor_decl.parameter_nodes().size() != out_of_line_stub.parameter_nodes().size()) {
 		return false;
 	}
@@ -483,7 +491,56 @@ static bool constructorDeclarationsHaveMatchingParameterShape(
 			return false;
 		}
 		if (ctor_param->type_index() != stub_param->type_index() &&
+			!dependentTemplatePlaceholderNamesMatch(
+				ctor_param->token().value(),
+				stub_param->token().value(),
+				instantiated_template_params,
+				out_of_line_template_params) &&
 			ctor_param->token().value() != stub_param->token().value()) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool dependentTemplatePlaceholderNamesMatch(
+	std::string_view instantiated_name,
+	std::string_view out_of_line_name,
+	std::span<const TemplateParameterNode> instantiated_template_params,
+	std::span<const TemplateParameterNode> out_of_line_template_params);
+
+static bool functionDeclarationsHaveMatchingParameterShape(
+	const FunctionDeclarationNode& instantiated_decl,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> instantiated_template_params = {},
+	std::span<const TemplateParameterNode> out_of_line_template_params = {}) {
+	if (instantiated_decl.is_const_member_function() != out_of_line_decl.is_const_member_function() ||
+		instantiated_decl.is_volatile_member_function() != out_of_line_decl.is_volatile_member_function() ||
+		instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
+		return false;
+	}
+
+	for (size_t i = 0; i < instantiated_decl.parameter_nodes().size(); ++i) {
+		const TypeSpecifierNode* instantiated_param =
+			getDeclarationParamTypeNode(instantiated_decl.parameter_nodes()[i]);
+		const TypeSpecifierNode* out_of_line_param =
+			getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[i]);
+		if (!instantiated_param || !out_of_line_param) {
+			return false;
+		}
+		if (instantiated_param->type() != out_of_line_param->type() ||
+			instantiated_param->pointer_depth() != out_of_line_param->pointer_depth() ||
+			instantiated_param->reference_qualifier() != out_of_line_param->reference_qualifier() ||
+			instantiated_param->cv_qualifier() != out_of_line_param->cv_qualifier()) {
+			return false;
+		}
+		if (instantiated_param->type_index() != out_of_line_param->type_index() &&
+			!dependentTemplatePlaceholderNamesMatch(
+				instantiated_param->token().value(),
+				out_of_line_param->token().value(),
+				instantiated_template_params,
+				out_of_line_template_params)) {
 			return false;
 		}
 	}
@@ -578,6 +635,50 @@ static std::optional<TypeSpecifierNode> substituteOutOfLineSignatureType(
 	return substituted_type;
 }
 
+static const TemplateParameterNode* findTemplateParameterByName(
+	std::span<const TemplateParameterNode> template_params,
+	std::string_view param_name,
+	size_t* index_out = nullptr) {
+	for (size_t i = 0; i < template_params.size(); ++i) {
+		if (template_params[i].name() != param_name) {
+			continue;
+		}
+		if (index_out != nullptr) {
+			*index_out = i;
+		}
+		return &template_params[i];
+	}
+	return nullptr;
+}
+
+static bool dependentTemplatePlaceholderNamesMatch(
+	std::string_view instantiated_name,
+	std::string_view out_of_line_name,
+	std::span<const TemplateParameterNode> instantiated_template_params,
+	std::span<const TemplateParameterNode> out_of_line_template_params) {
+	if (instantiated_name == out_of_line_name) {
+		return true;
+	}
+
+	size_t instantiated_index = 0;
+	size_t out_of_line_index = 0;
+	const TemplateParameterNode* instantiated_param = findTemplateParameterByName(
+		instantiated_template_params,
+		instantiated_name,
+		&instantiated_index);
+	const TemplateParameterNode* out_of_line_param = findTemplateParameterByName(
+		out_of_line_template_params,
+		out_of_line_name,
+		&out_of_line_index);
+	if (instantiated_param == nullptr || out_of_line_param == nullptr) {
+		return false;
+	}
+
+	return instantiated_index == out_of_line_index &&
+		instantiated_param->kind() == out_of_line_param->kind() &&
+		instantiated_param->is_variadic() == out_of_line_param->is_variadic();
+}
+
 template <typename InstantiatedDeclNode>
 static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	Parser& parser,
@@ -585,7 +686,9 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle owner_type_name) {
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> instantiated_template_params = {},
+	std::span<const TemplateParameterNode> out_of_line_template_params = {}) {
 	if (instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
 		return false;
 	}
@@ -599,12 +702,24 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 			return std::nullopt;
 		}
 
-		std::optional<TypeSpecifierNode> substituted_param = substituteOutOfLineSignatureType(
-			parser,
-			*out_of_line_param,
-			template_params,
-			template_args,
-			owner_type_name);
+		const bool instantiated_is_template_param_placeholder =
+			findTemplateParameterByName(
+				instantiated_template_params,
+				instantiated_param->token().value()) != nullptr;
+		const bool out_of_line_is_template_param_placeholder =
+			findTemplateParameterByName(
+				out_of_line_template_params,
+				out_of_line_param->token().value()) != nullptr;
+
+		std::optional<TypeSpecifierNode> substituted_param;
+		if (!out_of_line_is_template_param_placeholder) {
+			substituted_param = substituteOutOfLineSignatureType(
+				parser,
+				*out_of_line_param,
+				template_params,
+				template_args,
+				owner_type_name);
+		}
 		if (substituted_param.has_value()) {
 			if (!typeSpecifiersMatchForSignatureValidation(
 					*instantiated_param,
@@ -614,19 +729,68 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 			continue;
 		}
 
-		if (!typeSpecifierLooksLikeDependentSignaturePlaceholder(*instantiated_param) &&
+		if (!instantiated_is_template_param_placeholder &&
+			!out_of_line_is_template_param_placeholder &&
+			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*instantiated_param) &&
 			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*out_of_line_param)) {
 			return std::nullopt;
 		}
-		if (instantiated_param->token().value() != out_of_line_param->token().value() ||
-			instantiated_param->pointer_depth() != out_of_line_param->pointer_depth() ||
+		if (instantiated_param->pointer_depth() != out_of_line_param->pointer_depth() ||
 			instantiated_param->reference_qualifier() != out_of_line_param->reference_qualifier() ||
 			instantiated_param->cv_qualifier() != out_of_line_param->cv_qualifier()) {
+			return false;
+		}
+		if (!dependentTemplatePlaceholderNamesMatch(
+				instantiated_param->token().value(),
+				out_of_line_param->token().value(),
+				instantiated_template_params,
+				out_of_line_template_params)) {
 			return false;
 		}
 	}
 
 	return true;
+}
+
+static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
+	Parser& parser,
+	const ASTNode& candidate_member,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	if (!candidate_member.is<TemplateFunctionDeclarationNode>()) {
+		return false;
+	}
+
+	const TemplateFunctionDeclarationNode& candidate_template =
+		candidate_member.as<TemplateFunctionDeclarationNode>();
+	std::span<const TemplateParameterNode> candidate_inner_template_params(
+		candidate_template.template_parameters().data(),
+		candidate_template.template_parameters().size());
+	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
+		return false;
+	}
+
+	std::optional<bool> substituted_signature_match = declarationsMatchAfterTemplateSubstitution(
+		parser,
+		candidate_template.function_decl_node(),
+		out_of_line_decl,
+		outer_template_params,
+		outer_template_args,
+		owner_type_name,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params);
+	if (substituted_signature_match.has_value() && *substituted_signature_match) {
+		return true;
+	}
+
+	return functionDeclarationsHaveMatchingParameterShape(
+		candidate_template.function_decl_node(),
+		out_of_line_decl,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params);
 }
 
 // Resolve any stored template arguments on a deferred base member-type chain after a class
@@ -3804,6 +3968,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					const ConstructorDeclarationNode& orig_ctor = mem_func.function_declaration.as<ConstructorDeclarationNode>();
 					auto [new_ctor_node, new_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
 						instantiated_name, orig_ctor.name());
+					setOuterTemplateBindingsFromParams(new_ctor_ref, template_params, template_args_for_member_copy);
+					if (!orig_ctor.is_materialized() || orig_ctor.has_template_body_position()) {
+						new_ctor_ref.set_template_parameters(orig_ctor.template_parameters());
+					}
+					if (orig_ctor.has_template_body_position()) {
+						new_ctor_ref.set_template_body_position(orig_ctor.template_body_position());
+						if (orig_ctor.has_template_initializer_list_position()) {
+							new_ctor_ref.set_template_initializer_list_position(
+								orig_ctor.template_initializer_list_position());
+						}
+					}
 					size_t saved_pack_info = pack_param_info_.size();
 					substituteAndCopyParams(
 						orig_ctor.parameter_nodes(),
@@ -5074,6 +5249,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						orig_ctor.name() // Constructor name (same as template name)
 					);
 					setOuterTemplateBindingsFromParams(new_ctor_ref, template_params, template_args_for_pattern);
+					if (!orig_ctor.is_materialized() || orig_ctor.has_template_body_position()) {
+						new_ctor_ref.set_template_parameters(orig_ctor.template_parameters());
+					}
+					if (orig_ctor.has_template_body_position()) {
+						new_ctor_ref.set_template_body_position(orig_ctor.template_body_position());
+						if (orig_ctor.has_template_initializer_list_position()) {
+							new_ctor_ref.set_template_initializer_list_position(
+								orig_ctor.template_initializer_list_position());
+						}
+					}
 
 					// Copy parameters with template parameter substitution
 					size_t saved_pack_info = pack_param_info_.size();
@@ -5257,6 +5442,123 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_virtual, mem_func.is_pure_virtual,
 						mem_func.is_override, mem_func.is_final,
 						mem_func.cv_qualifier);
+				}
+			}
+
+			auto out_of_line_members = gTemplateRegistry.getOutOfLineMemberFunctions(template_name);
+			const std::string_view template_base_name = extractBaseTemplateName(template_name);
+			FLASH_LOG(Templates, Debug, "Processing ", out_of_line_members.size(),
+				" out-of-line member functions for ", template_name);
+			for (const auto& out_of_line_member : out_of_line_members) {
+				if (out_of_line_member.inner_template_params.empty()) {
+					continue;
+				}
+
+				const FunctionDeclarationNode& ool_func =
+					out_of_line_member.function_node.as<FunctionDeclarationNode>();
+				const DeclarationNode& ool_decl = ool_func.decl_node();
+				std::string_view ool_func_name = ool_decl.identifier_token().value();
+				const bool out_of_line_ctor_stub =
+					!template_name.empty() &&
+					(ool_func_name == template_name ||
+						(!template_base_name.empty() && ool_func_name == template_base_name));
+				if (!out_of_line_ctor_stub) {
+					continue;
+				}
+
+				for (auto& mem_func : instantiated_struct_ref.member_functions()) {
+					if (!mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
+						continue;
+					}
+
+					auto& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();
+					const size_t out_of_line_template_param_count =
+						out_of_line_member.inner_template_params.size();
+					auto matches_out_of_line_ctor_template =
+						[&](const ConstructorDeclarationNode& candidate) -> bool {
+							if (candidate.has_template_body_position()) {
+								return false;
+							}
+							if (candidate.template_parameters().empty() ||
+								candidate.template_parameters().size() != out_of_line_template_param_count) {
+								return false;
+							}
+
+							std::optional<bool> signature_match =
+								declarationsMatchAfterTemplateSubstitution(
+									*this,
+									candidate,
+									ool_func,
+									std::span<const TemplateParameterNode>(
+										template_params.data(),
+										template_params.size()),
+									std::span<const TemplateTypeArg>(
+										template_args_for_pattern.data(),
+										template_args_for_pattern.size()),
+									instantiated_name,
+									std::span<const TemplateParameterNode>(
+										candidate.template_parameters().data(),
+										candidate.template_parameters().size()),
+									std::span<const TemplateParameterNode>(
+										out_of_line_member.inner_template_params.data(),
+										out_of_line_member.inner_template_params.size()));
+							if (signature_match.has_value()) {
+								return *signature_match;
+							}
+
+							return ool_func.parameter_nodes().size() == candidate.parameter_nodes().size() &&
+								constructorDeclarationsHaveMatchingParameterShape(
+									candidate,
+									ool_func,
+									std::span<const TemplateParameterNode>(
+										candidate.template_parameters().data(),
+										candidate.template_parameters().size()),
+									std::span<const TemplateParameterNode>(
+										out_of_line_member.inner_template_params.data(),
+										out_of_line_member.inner_template_params.size()));
+						};
+					if (!matches_out_of_line_ctor_template(ctor_decl)) {
+						continue;
+					}
+
+					ctor_decl.set_template_body_position(out_of_line_member.body_start);
+					if (out_of_line_member.has_initializer_list) {
+						ctor_decl.set_template_initializer_list_position(
+							out_of_line_member.initializer_list_start);
+					}
+					StructTypeInfo* instantiated_struct_info = struct_type_info.getStructInfo();
+					if (instantiated_struct_info == nullptr) {
+						break;
+					}
+					for (auto& info_func : instantiated_struct_info->member_functions) {
+						if (!info_func.is_constructor ||
+							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+							continue;
+						}
+
+						auto& info_ctor =
+							info_func.function_decl.as<ConstructorDeclarationNode>();
+						if (info_ctor.name() != ctor_decl.name() ||
+							info_ctor.template_parameters().size() != ctor_decl.template_parameters().size()) {
+							continue;
+						}
+						if (!matches_out_of_line_ctor_template(info_ctor)) {
+							continue;
+						}
+
+						info_ctor.set_template_body_position(out_of_line_member.body_start);
+						if (out_of_line_member.has_initializer_list) {
+							info_ctor.set_template_initializer_list_position(
+								out_of_line_member.initializer_list_start);
+						}
+						break;
+					}
+					FLASH_LOG(
+						Templates,
+						Debug,
+						"Set deferred body position on out-of-line constructor template: ",
+						ool_func_name);
+					break;
 				}
 			}
 
@@ -10022,7 +10324,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 						ASTNode new_param_type_node = emplace_node<TypeSpecifierNode>(
 							new_param_type, param_type_spec.qualifier(),
-							get_type_size_bits(new_param_type), Token(), param_type_spec.cv_qualifier());
+							get_type_size_bits(new_param_type), param_type_spec.token(), param_type_spec.cv_qualifier());
 						auto& new_param_spec = new_param_type_node.as<TypeSpecifierNode>();
 						new_param_spec.set_type_index(new_param_type_index);
 						for (const auto& pl : param_type_spec.pointer_levels())
@@ -10248,6 +10550,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			FLASH_LOG(Templates, Debug, "Processing nested template out-of-line member: ", ool_func_name);
 
 			bool found = false;
+			size_t same_name_member_template_count = 0;
+			for (const auto& mem_func : instantiated_struct_ref.member_functions()) {
+				if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
+					continue;
+				}
+				const auto& candidate_func =
+					mem_func.function_declaration.as<TemplateFunctionDeclarationNode>().function_decl_node();
+				if (candidate_func.decl_node().identifier_token().value() == ool_func_name) {
+					++same_name_member_template_count;
+				}
+			}
 			for (auto& mem_func : instantiated_struct_ref.member_functions()) {
 				if (out_of_line_ctor_stub &&
 					mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
@@ -10329,15 +10642,37 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (!inst_func_decl) {
 					continue;
 				}
-				if (inst_func_decl->decl_node().identifier_token().value() == ool_func_name) {
-					// Set the body position and definition-time lookup context from the
-					// out-of-line definition so two-phase lookup uses the definition namespace.
-					inst_func_decl->set_template_body_position(out_of_line_member.body_start);
-					inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
-					FLASH_LOG(Templates, Debug, "Set body position on nested template member: ", ool_func_name);
-					found = true;
-					break;
+				if (inst_func_decl->decl_node().identifier_token().value() != ool_func_name) {
+					continue;
 				}
+				if (same_name_member_template_count > 1) {
+					std::optional<bool> signature_match = nestedOutOfLineMemberTemplateMatchesCandidate(
+						*this,
+						mem_func.function_declaration,
+						ool_func,
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.template_params.data(),
+							out_of_line_member.template_params.size()),
+						std::span<const TemplateTypeArg>(
+							template_args_to_use.data(),
+							template_args_to_use.size()),
+						instantiated_name,
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.inner_template_params.data(),
+							out_of_line_member.inner_template_params.size()));
+					if (!signature_match.has_value() || !*signature_match) {
+						continue;
+					}
+				}
+				// Set the body position and definition-time lookup context from the
+				// out-of-line definition so two-phase lookup uses the definition namespace.
+				inst_func_decl->set_template_body_position(out_of_line_member.body_start);
+				inst_func_decl->update_parameter_nodes_from_definition(
+					ool_func.parameter_nodes());
+				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
+				FLASH_LOG(Templates, Debug, "Set body position on nested template member: ", ool_func_name);
+				found = true;
+				break;
 			}
 
 			if (!found) {
@@ -10352,8 +10687,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (recovered_func_decl->decl_node().identifier_token().value() != ool_func_name) {
 							continue;
 						}
+						if (same_name_member_template_count > 1) {
+							std::optional<bool> signature_match = nestedOutOfLineMemberTemplateMatchesCandidate(
+								*this,
+								recovered_member,
+								ool_func,
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.template_params.data(),
+									out_of_line_member.template_params.size()),
+								std::span<const TemplateTypeArg>(
+									template_args_to_use.data(),
+									template_args_to_use.size()),
+								instantiated_name,
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.inner_template_params.data(),
+									out_of_line_member.inner_template_params.size()));
+							if (!signature_match.has_value() || !*signature_match) {
+								continue;
+							}
+						}
 
 						recovered_func_decl->set_template_body_position(out_of_line_member.body_start);
+						recovered_func_decl->update_parameter_nodes_from_definition(
+							ool_func.parameter_nodes());
 						recovered_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 						OverloadableOperator recovered_operator_kind = original_member.operator_kind;
 						if (recovered_operator_kind == OverloadableOperator::None) {
@@ -10592,6 +10948,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 								std::string_view init_name = init_name_token.value();
 
+								// Replay the same qualified mem-initializer spelling accepted by the
+								// shared constructor-initializer parsers (e.g. N::Base<T>(...)).
+								init_name = consume_qualified_name_suffix(init_name);
+
 								// Check for template arguments: Base<T>(...) in base class initializer
 								if (peek() == "<"_tok) {
 									skip_template_arguments();
@@ -10657,7 +11017,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									// Check if this is a base class by looking at the struct's base classes
 									for (const auto& base : struct_type_info.struct_info_->base_classes) {
 										std::string_view base_name = base.name;
-										if (base_name == init_name || extractBaseTemplateName(base_name) == init_name) {
+										bool names_match =
+											(base_name == init_name || extractBaseTemplateName(base_name) == init_name);
+										if (!names_match) {
+											if (const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
+												base_type_info && base_type_info->isTemplateInstantiation()) {
+												StringHandle qualified_base_template_name =
+													gNamespaceRegistry.buildQualifiedIdentifier(
+														base_type_info->sourceNamespace(),
+														base_type_info->baseTemplateName());
+												names_match =
+													StringTable::getStringView(qualified_base_template_name) == init_name;
+											}
+										}
+										if (names_match) {
 											is_base_init = true;
 											matched_base_name = StringTable::getOrInternStringHandle(base_name);
 											break;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -495,20 +495,13 @@ static bool constructorDeclarationsHaveMatchingParameterShape(
 				ctor_param->token().value(),
 				stub_param->token().value(),
 				instantiated_template_params,
-				out_of_line_template_params) &&
-			ctor_param->token().value() != stub_param->token().value()) {
+				out_of_line_template_params)) {
 			return false;
 		}
 	}
 
 	return true;
 }
-
-static bool dependentTemplatePlaceholderNamesMatch(
-	std::string_view instantiated_name,
-	std::string_view out_of_line_name,
-	std::span<const TemplateParameterNode> instantiated_template_params,
-	std::span<const TemplateParameterNode> out_of_line_template_params);
 
 static bool functionDeclarationsHaveMatchingParameterShape(
 	const FunctionDeclarationNode& instantiated_decl,
@@ -752,56 +745,17 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	return true;
 }
 
-static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
+template <typename InstantiatedDeclNode, typename ShapeMatcherFn>
+static bool outOfLineTemplateMatchesCandidateWithFallback(
 	Parser& parser,
-	const ASTNode& candidate_member,
-	const FunctionDeclarationNode& out_of_line_decl,
-	std::span<const TemplateParameterNode> outer_template_params,
-	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
-	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
-	if (!candidate_member.is<TemplateFunctionDeclarationNode>()) {
-		return false;
-	}
-
-	const TemplateFunctionDeclarationNode& candidate_template =
-		candidate_member.as<TemplateFunctionDeclarationNode>();
-	std::span<const TemplateParameterNode> candidate_inner_template_params(
-		candidate_template.template_parameters().data(),
-		candidate_template.template_parameters().size());
-	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
-		return false;
-	}
-
-	std::optional<bool> substituted_signature_match = declarationsMatchAfterTemplateSubstitution(
-		parser,
-		candidate_template.function_decl_node(),
-		out_of_line_decl,
-		outer_template_params,
-		outer_template_args,
-		owner_type_name,
-		candidate_inner_template_params,
-		out_of_line_inner_template_params);
-	if (substituted_signature_match.has_value() && *substituted_signature_match) {
-		return true;
-	}
-
-	return functionDeclarationsHaveMatchingParameterShape(
-		candidate_template.function_decl_node(),
-		out_of_line_decl,
-		candidate_inner_template_params,
-		out_of_line_inner_template_params);
-}
-
-static bool outOfLineConstructorTemplateMatchesCandidate(
-	Parser& parser,
-	const ConstructorDeclarationNode& candidate,
+	const InstantiatedDeclNode& candidate,
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
-	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params,
+	ShapeMatcherFn&& shape_matcher) {
 	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
 		return false;
 	}
@@ -819,11 +773,72 @@ static bool outOfLineConstructorTemplateMatchesCandidate(
 		return *substituted_signature_match;
 	}
 
-	return constructorDeclarationsHaveMatchingParameterShape(
+	return shape_matcher(candidate_inner_template_params, out_of_line_inner_template_params);
+}
+
+static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
+	Parser& parser,
+	const ASTNode& candidate_member,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	if (!candidate_member.is<TemplateFunctionDeclarationNode>()) {
+		return false;
+	}
+
+	const TemplateFunctionDeclarationNode& candidate_template =
+		candidate_member.as<TemplateFunctionDeclarationNode>();
+	std::span<const TemplateParameterNode> candidate_inner_template_params(
+		candidate_template.template_parameters().data(),
+		candidate_template.template_parameters().size());
+
+	return outOfLineTemplateMatchesCandidateWithFallback(
+		parser,
+		candidate_template.function_decl_node(),
+		out_of_line_decl,
+		outer_template_params,
+		outer_template_args,
+		owner_type_name,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params,
+		[&](std::span<const TemplateParameterNode> instantiated_inner_template_params,
+			std::span<const TemplateParameterNode> definition_inner_template_params) {
+			return functionDeclarationsHaveMatchingParameterShape(
+				candidate_template.function_decl_node(),
+				out_of_line_decl,
+				instantiated_inner_template_params,
+				definition_inner_template_params);
+		});
+}
+
+static bool outOfLineConstructorTemplateMatchesCandidate(
+	Parser& parser,
+	const ConstructorDeclarationNode& candidate,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> candidate_inner_template_params,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	return outOfLineTemplateMatchesCandidateWithFallback(
+		parser,
 		candidate,
 		out_of_line_decl,
+		outer_template_params,
+		outer_template_args,
+		owner_type_name,
 		candidate_inner_template_params,
-		out_of_line_inner_template_params);
+		out_of_line_inner_template_params,
+		[&](std::span<const TemplateParameterNode> instantiated_inner_template_params,
+			std::span<const TemplateParameterNode> definition_inner_template_params) {
+			return constructorDeclarationsHaveMatchingParameterShape(
+				candidate,
+				out_of_line_decl,
+				instantiated_inner_template_params,
+				definition_inner_template_params);
+		});
 }
 
 static void copyDefinitionParameterIdentifiers(
@@ -834,8 +849,7 @@ static void copyDefinitionParameterIdentifiers(
 	}
 
 	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
-		const DeclarationNode* instantiated_decl_const = get_decl_from_symbol(instantiated_params[param_index]);
-		DeclarationNode* instantiated_decl = const_cast<DeclarationNode*>(instantiated_decl_const);
+		DeclarationNode* instantiated_decl = Parser::get_decl_from_symbol_mut(instantiated_params[param_index]);
 		const DeclarationNode* definition_decl = get_decl_from_symbol(definition_params[param_index]);
 		if (!instantiated_decl || !definition_decl) {
 			continue;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -841,7 +841,7 @@ static bool outOfLineConstructorTemplateMatchesCandidate(
 		});
 }
 
-static void copyDefinitionParameterIdentifiers(
+void Parser::copyDefinitionParameterIdentifiers(
 	std::span<ASTNode> instantiated_params,
 	std::span<const ASTNode> definition_params) {
 	if (instantiated_params.size() != definition_params.size()) {

--- a/tests/test_template_nested_ool_member_template_outer_param_binding_ret0.cpp
+++ b/tests/test_template_nested_ool_member_template_outer_param_binding_ret0.cpp
@@ -1,0 +1,25 @@
+template<class T>
+struct Sum {
+	template<class U>
+	int add(T left, U right);
+
+	template<class U>
+	int add(U left, U right);
+};
+
+template<class T>
+template<class U>
+int Sum<T>::add(T left, U right) {
+	return left + right;
+}
+
+template<class T>
+template<class U>
+int Sum<T>::add(U left, U right) {
+	return left - right;
+}
+
+int main() {
+	Sum<int> sum;
+	return sum.add(40, 2) == 42 ? 0 : 1;
+}

--- a/tests/test_template_nested_ool_member_template_overload_binding_ret0.cpp
+++ b/tests/test_template_nested_ool_member_template_overload_binding_ret0.cpp
@@ -1,0 +1,21 @@
+template<class T>
+struct Box {
+	template<class U>
+	int pick(U);
+
+	template<class U>
+	int pick(U, U);
+};
+
+template<class T>
+template<class U>
+int Box<T>::pick(U) { return 1; }
+
+template<class T>
+template<class U>
+int Box<T>::pick(U, U) { return 42; }
+
+int main() {
+	Box<int> b;
+	return b.pick(0, 0) - 42;
+}

--- a/tests/test_template_ool_ctor_member_helper_overload_replay_ret0.cpp
+++ b/tests/test_template_ool_ctor_member_helper_overload_replay_ret0.cpp
@@ -1,0 +1,40 @@
+// Regression: out-of-line constructor replay must preserve complete-class
+// overload visibility for helper calls inside member-initializer expressions.
+
+template<unsigned I, typename... Ts>
+struct TupleImpl;
+
+template<unsigned I>
+struct TupleImpl<I> {
+	int leaf = 0;
+};
+
+template<unsigned I, typename Head, typename... Tail>
+struct TupleImpl<I, Head, Tail...> : TupleImpl<I + 1, Tail...> {
+	using Inherited = TupleImpl<I + 1, Tail...>;
+	Head head{};
+
+	static constexpr Inherited& tail(TupleImpl& t) noexcept { return t; }
+	static constexpr const Inherited& tail(const TupleImpl& t) noexcept { return t; }
+
+	TupleImpl() = default;
+
+	TupleImpl(const Inherited& tail_value, Head value)
+		: Inherited(tail_value), head(value) {}
+
+	template<typename U>
+	TupleImpl(U, const TupleImpl& in);
+};
+
+template<unsigned I, typename Head, typename... Tail>
+template<typename U>
+TupleImpl<I, Head, Tail...>::TupleImpl(U, const TupleImpl& in)
+	: Inherited(tail(in)), head(in.head) {}
+
+int main() {
+	TupleImpl<1u, int> tail_value;
+	tail_value.head = 7;
+	TupleImpl<0u, int, int> a(tail_value, 3);
+	TupleImpl<0u, int, int> b(0, a);
+	return 0;
+}

--- a/tests/test_template_ool_ctor_qualified_base_init_replay_ret0.cpp
+++ b/tests/test_template_ool_ctor_qualified_base_init_replay_ret0.cpp
@@ -1,0 +1,23 @@
+// Regression: out-of-line class-template constructors must replay qualified
+// base mem-initializers as base initializers during instantiation.
+
+namespace N {
+	template<class T>
+	struct Base {
+		int value;
+		Base(int v) : value(v) {}
+	};
+}
+
+template<class T>
+struct Derived : N::Base<T> {
+	Derived(int v);
+};
+
+template<class T>
+Derived<T>::Derived(int v) : N::Base<T>(v) {}
+
+int main() {
+	Derived<int> d(42);
+	return d.value == 42 ? 0 : 1;
+}

--- a/tests/test_template_ool_ctor_template_param_rename_replay_ret0.cpp
+++ b/tests/test_template_ool_ctor_template_param_rename_replay_ret0.cpp
@@ -1,0 +1,16 @@
+template<class T>
+struct Box {
+	int value;
+
+	template<class U>
+	Box(U v);
+};
+
+template<class T>
+template<class V>
+Box<T>::Box(V v) : value(v) {}
+
+int main() {
+	Box<int> box(42);
+	return box.value == 42 ? 0 : 1;
+}

--- a/tests/test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp
+++ b/tests/test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp
@@ -1,0 +1,26 @@
+int pick(long) { return 40; }
+
+template<class T>
+struct Base {
+	template<class U>
+	int call(U) { return 2; }
+};
+
+template<class T>
+struct Derived : Base<T> {
+	template<class U>
+	int run(U);
+};
+
+template<class T>
+template<class U>
+int Derived<T>::run(U u) {
+	return pick(0) + this->template call<U>(u);
+}
+
+int pick(int) { return 100; }
+
+int main() {
+	Derived<int> d;
+	return d.run(0) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- fix replay attachment for nested out-of-line member-function templates so instantiated outer parameter types are preserved while definition-side parameter names are imported
- fix out-of-line constructor-template replay matching so renamed inner template parameters still bind by template-parameter slot/kind
- cover additional replay cases for dependent-base member-template lookup, qualified base mem-initializers, overload-dependent constructor helper initializers, and nested out-of-line member-template overload binding
- rewrite the template infrastructure audit/conformance docs to stay forward-facing and to call out the next highest-impact replay target explicitly

## Replay changes from `main`
- extend `src/Parser_Templates_Inst_ClassTemplate.cpp` with shared matching helpers for out-of-line constructor-template replay and nested out-of-line member-template attachment
- preserve deferred body/initializer-list replay state for the covered out-of-line constructor-template paths
- preserve definition-time lookup context for the covered nested out-of-line member-template replay paths
- avoid replacing instantiated parameter AST nodes with raw definition-side template placeholders during nested replay attachment
- classify covered qualified base mem-initializers correctly during out-of-line constructor replay

## Regressions added
- `tests/test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
- `tests/test_template_ool_ctor_member_helper_overload_replay_ret0.cpp`
- `tests/test_template_ool_ctor_qualified_base_init_replay_ret0.cpp`
- `tests/test_template_nested_ool_member_template_overload_binding_ret0.cpp`
- `tests/test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
- `tests/test_template_ool_ctor_template_param_rename_replay_ret0.cpp`

## Testing
- replay/code changes were validated on the parent branch before this doc-only follow-up
- this commit itself is documentation-only and was not re-tested separately
