### PR TITLE
Refactor template replay attachment

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-24 (declaration-only member stub substitution now strips only top-level by-value cv qualifiers, preserving pointer/reference cv identity so replay-first OOL plain-member attachment materializes constructor+member template cases correctly)
+**Last updated:** 2026-05-25 (primary-template OOL plain-constructor attachment is now replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -51,6 +51,12 @@ Useful assumptions before changing this area:
   overloads)**: these paths now resolve the source declaration first, then map
   source-member→instantiated-stub identity before replaying the body, removing
   the old instantiated-member name/arity scan in this slice.
+- **primary-template plain out-of-line constructor attachment is now replay-first
+  and identity-map-backed (including same-name overloads)**: constructor replay
+  now resolves source constructor declarations through source-member→stub
+  identity, disambiguates overloads via substituted signature matching, and
+  synchronizes `StructTypeInfo` constructor bodies by matched instantiated
+  signature instead of name-only updates.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   keeping replay-first source-member signature matching and mangled identity
@@ -115,6 +121,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_nttp_deferred_ctor_body_pointer_function_ret0.cpp`
 - `test_template_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## What is still wrong
@@ -131,6 +138,9 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
+  - the largest remaining constructor slice is partial-spec out-of-line
+    constructor-template attachment, which still scans instantiated constructor
+    members instead of resolving source constructor identity first.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -156,9 +166,10 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
-   - Continue replacing the remaining constructor/non-static replay attachment
-     paths that still recover targets from instantiated-member scans instead of
-     source-member identity.
+   - Continue replacing the remaining constructor/non-static replay attachment paths
+     that still recover targets from instantiated-member scans instead of
+     source-member identity, starting with partial-spec out-of-line
+     constructor-template attachment.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.
@@ -194,6 +205,10 @@ The following are complete enough to rely on:
   partial specializations now also resolves through source-member→stub identity,
   including same-name overload cases, with no instantiated-member name/arity
   attachment scan in that slice;
+- primary-template plain out-of-line constructor replay now also resolves
+  source-member→stub identity first (including overload disambiguation by
+  substituted signature), and `StructTypeInfo` constructor-body synchronization
+  in this path no longer uses name-only matching;
 - partial-spec nested out-of-line member-template attachment now mirrors that
   replay-first source-member→stub identity path (including same-name overload
   disambiguation), with no scan-first fallback in this slice;

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested-class OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe nested StructTypeInfo sync)
+**Last updated:** 2026-05-25 (primary-template nested OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -69,6 +69,11 @@ Useful assumptions before changing this area:
   instantiated stubs first, applies deferred body/initializer metadata on the
   identity-resolved target, and syncs nested `StructTypeInfo` constructor-template
   metadata via signature-equivalent matching.
+- **primary-template nested out-of-line constructor-template attachment is now
+  replay-first and identity-map-backed (including same-name overloads)**:
+  constructor-template stub attachment now resolves source constructor declarations
+  through source-member→stub identity, with overload-safe `StructTypeInfo`
+  synchronization by signature-equivalent matching.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   keeping replay-first source-member signature matching and mangled identity
@@ -136,6 +141,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_ool_ctor_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## What is still wrong
@@ -152,10 +158,9 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
-  - the next constructor-focused slice is the primary-template nested
-    out-of-line constructor-template attachment path, where constructor-template
-    stubs are still selected by instantiated-member scan matching rather than
-    source-member identity.
+  - constructor-template attachment matching still allows shape-based fallback
+    when substituted signatures cannot be fully classified; this remains a
+    replay/attachment correctness risk in edge overload sets.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -181,10 +186,9 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
-   - Continue replacing the remaining constructor/non-static replay attachment paths
-     that still recover targets from instantiated-member scans instead of
-     source-member identity, starting with primary-template nested out-of-line
-     constructor-template attachment.
+   - Tighten constructor-template attachment matching to prefer substituted
+     canonical signatures and reduce shape-based fallback use in replay-first
+     attachment helpers.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.
@@ -232,6 +236,9 @@ The following are complete enough to rely on:
   source-member→stub identity first (including same-name overload handling), and
   nested `StructTypeInfo` constructor-template metadata sync in this path no
   longer relies on scan/name-only matching;
+- primary-template nested out-of-line constructor-template attachment now mirrors
+  that replay-first source-member→stub identity path, with no
+  instantiated-member scan-first target selection in this slice;
 - partial-spec nested out-of-line member-template attachment now mirrors that
   replay-first source-member→stub identity path (including same-name overload
   disambiguation), with no scan-first fallback in this slice;

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (primary-template OOL plain-constructor attachment is now replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
+**Last updated:** 2026-05-25 (nested-class OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe nested StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -57,6 +57,18 @@ Useful assumptions before changing this area:
   identity, disambiguates overloads via substituted signature matching, and
   synchronizes `StructTypeInfo` constructor bodies by matched instantiated
   signature instead of name-only updates.
+- **partial-spec out-of-line constructor-template attachment is now replay-first
+  and identity-map-backed (including same-name overloads)**: constructor-template
+  attachment now resolves source constructor declarations through
+  source-member→stub identity before setting deferred body metadata, and
+  synchronizes `StructTypeInfo` constructor-template metadata by signature rather
+  than scan/name-only matching.
+- **nested-class out-of-line constructor-template attachment now also resolves
+  replay-first through source-member→stub identity (including same-name
+  overloads)**: nested replay now maps source constructor declarations to
+  instantiated stubs first, applies deferred body/initializer metadata on the
+  identity-resolved target, and syncs nested `StructTypeInfo` constructor-template
+  metadata via signature-equivalent matching.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   keeping replay-first source-member signature matching and mangled identity
@@ -122,6 +134,8 @@ Latest focused replay regressions added on the current branch:
 - `test_template_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_ool_ctor_same_name_overload_ret0.cpp`
+- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## What is still wrong
@@ -138,9 +152,10 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
-  - the largest remaining constructor slice is partial-spec out-of-line
-    constructor-template attachment, which still scans instantiated constructor
-    members instead of resolving source constructor identity first.
+  - the next constructor-focused slice is the primary-template nested
+    out-of-line constructor-template attachment path, where constructor-template
+    stubs are still selected by instantiated-member scan matching rather than
+    source-member identity.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -168,7 +183,7 @@ they directly block items 1-2:
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
    - Continue replacing the remaining constructor/non-static replay attachment paths
      that still recover targets from instantiated-member scans instead of
-     source-member identity, starting with partial-spec out-of-line
+     source-member identity, starting with primary-template nested out-of-line
      constructor-template attachment.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
@@ -209,6 +224,14 @@ The following are complete enough to rely on:
   source-member→stub identity first (including overload disambiguation by
   substituted signature), and `StructTypeInfo` constructor-body synchronization
   in this path no longer uses name-only matching;
+- partial-spec out-of-line constructor-template attachment now mirrors that
+  replay-first source-member→stub identity flow (including overload
+  disambiguation), and `StructTypeInfo` constructor-template metadata sync in
+  this path no longer relies on scan/name-only matching;
+- nested-class out-of-line constructor-template attachment now also resolves
+  source-member→stub identity first (including same-name overload handling), and
+  nested `StructTypeInfo` constructor-template metadata sync in this path no
+  longer relies on scan/name-only matching;
 - partial-spec nested out-of-line member-template attachment now mirrors that
   replay-first source-member→stub identity path (including same-name overload
   disambiguation), with no scan-first fallback in this slice;

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (primary-template OOL plain-constructor attachment is now replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
+**Last updated:** 2026-05-25 (nested-class OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe nested StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -56,6 +56,16 @@ Future work can rely on these being in place:
   same-name overloads)**: constructor replay disambiguates via substituted
   signatures and updates `StructTypeInfo` constructor bodies with
   signature-equivalent matching instead of name-only syncing.
+- **partial-spec out-of-line constructor-template attachment now also uses
+  replay-first source-member→instantiated-stub identity lookup (including
+  same-name overloads)**: constructor-template attachment disambiguates via
+  substituted signatures and updates `StructTypeInfo` constructor-template
+  metadata with signature-equivalent matching instead of scan/name-only sync.
+- **nested-class out-of-line constructor-template attachment now also uses
+  replay-first source-member→instantiated-stub identity lookup (including
+  same-name overloads)**: nested replay disambiguates constructor-template
+  targets through source-member identity and updates nested `StructTypeInfo`
+  constructor-template metadata via signature-equivalent matching.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   so replay-first source-member signature matching and mangled identity remain
@@ -121,6 +131,8 @@ Latest focused regressions added on the current branch:
 - `test_template_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_ool_ctor_same_name_overload_ret0.cpp`
+- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## Remaining work, in priority order
@@ -137,8 +149,8 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity, starting with partial-spec out-of-line
-    constructor-template attachment.
+    not keyed by source-member identity, starting with primary-template nested
+    out-of-line constructor-template attachment.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -170,7 +182,7 @@ Still open, but not the next best slice:
 1. remove remaining declaration replay scans in non-static template-member
    attachment paths, starting with constructor attachment/replay paths that
    still recover targets from instantiated members instead of source members
-   (next: partial-spec out-of-line constructor-template attachment);
+   (next: primary-template nested out-of-line constructor-template attachment);
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
 2. update these docs with the next remaining replay-metadata gap.
@@ -184,7 +196,8 @@ Keep adding narrow regressions in these areas:
 - declaration/definition attachment where inner and outer template parameters
   interact;
 - remaining non-static declaration replay paths that still fall back to
-  partially substituted AST state, especially constructor attachment paths.
+  partially substituted AST state, especially primary-template nested
+  constructor-template attachment paths.
 
 ## Exit criteria
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-24 (declaration-only member stub substitution now strips only top-level by-value cv qualifiers, preserving pointer/reference cv identity so replay-first OOL plain-member attachment materializes constructor+member template cases correctly)
+**Last updated:** 2026-05-25 (primary-template OOL plain-constructor attachment is now replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -51,6 +51,11 @@ Future work can rely on these being in place:
   attachment now use replay-first source-member→instantiated-stub identity
   lookup (including same-name overloads)**, removing the old
   instantiated-member name/arity attachment scan for that slice.
+- **primary-template plain out-of-line constructor attachment now also uses
+  replay-first source-member→instantiated-stub identity lookup (including
+  same-name overloads)**: constructor replay disambiguates via substituted
+  signatures and updates `StructTypeInfo` constructor bodies with
+  signature-equivalent matching instead of name-only syncing.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   so replay-first source-member signature matching and mangled identity remain
@@ -115,6 +120,7 @@ Latest focused regressions added on the current branch:
 - `test_template_nttp_deferred_ctor_body_pointer_function_ret0.cpp`
 - `test_template_ool_plain_member_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## Remaining work, in priority order
@@ -131,7 +137,8 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity.
+    not keyed by source-member identity, starting with partial-spec out-of-line
+    constructor-template attachment.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -162,7 +169,8 @@ Still open, but not the next best slice:
 
 1. remove remaining declaration replay scans in non-static template-member
    attachment paths, starting with constructor attachment/replay paths that
-   still recover targets from instantiated members instead of source members;
+   still recover targets from instantiated members instead of source members
+   (next: partial-spec out-of-line constructor-template attachment);
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
 2. update these docs with the next remaining replay-metadata gap.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested-class OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe nested StructTypeInfo sync)
+**Last updated:** 2026-05-25 (primary-template nested OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -66,6 +66,11 @@ Future work can rely on these being in place:
   same-name overloads)**: nested replay disambiguates constructor-template
   targets through source-member identity and updates nested `StructTypeInfo`
   constructor-template metadata via signature-equivalent matching.
+- **primary-template nested out-of-line constructor-template attachment now also
+  uses replay-first source-member→instantiated-stub identity lookup (including
+  same-name overloads)**: nested constructor-template targets are now attached
+  through source-member identity with signature-equivalent `StructTypeInfo`
+  synchronization.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   so replay-first source-member signature matching and mangled identity remain
@@ -133,6 +138,7 @@ Latest focused regressions added on the current branch:
 - `test_template_ool_ctor_same_name_overload_ret0.cpp`
 - `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 
 ## Remaining work, in priority order
@@ -149,8 +155,9 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity, starting with primary-template nested
-    out-of-line constructor-template attachment.
+    not keyed by source-member identity; then tighten constructor-template
+    signature matching to reduce shape-based fallback when substituted
+    signatures are unavailable.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -182,7 +189,8 @@ Still open, but not the next best slice:
 1. remove remaining declaration replay scans in non-static template-member
    attachment paths, starting with constructor attachment/replay paths that
    still recover targets from instantiated members instead of source members
-   (next: primary-template nested out-of-line constructor-template attachment);
+   (next: tighten constructor-template matching to canonical substituted-signature
+   matching where shape fallback is still used);
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
 2. update these docs with the next remaining replay-metadata gap.
@@ -196,8 +204,8 @@ Keep adding narrow regressions in these areas:
 - declaration/definition attachment where inner and outer template parameters
   interact;
 - remaining non-static declaration replay paths that still fall back to
-  partially substituted AST state, especially primary-template nested
-  constructor-template attachment paths.
+  partially substituted AST state, especially constructor-template attachment
+  paths that still require shape-based fallback disambiguation.
 
 ## Exit criteria
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -113,6 +113,15 @@ static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param
 static bool typeSpecifiersMatchForSignatureValidation(
 	const TypeSpecifierNode& lhs,
 	const TypeSpecifierNode& rhs);
+static bool outOfLineConstructorTemplateMatchesCandidate(
+	Parser& parser,
+	const ConstructorDeclarationNode& candidate,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> candidate_inner_template_params,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params);
 
 static const void* sourceMemberAstNodeKey(const ASTNode& node) {
 	if (!node.has_value())
@@ -347,6 +356,113 @@ static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 		if (matches_candidate) {
 			resolved_matches.push_back(inst_ctor_decl);
 		}
+	}
+
+	OutOfLineConstructorStubResolution resolution;
+	if (resolved_matches.size() == 1) {
+		resolution.ctor = resolved_matches.front();
+		return resolution;
+	}
+	if (resolved_matches.size() > 1) {
+		resolution.ambiguous = true;
+	}
+	return resolution;
+}
+
+static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubByIdentity(
+	Parser& parser,
+	SourceMemberIdentityMaps& identity_maps,
+	std::span<const StructMemberFunctionDecl> source_members,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	size_t source_ctor_count = 0;
+	for (const StructMemberFunctionDecl& source_member : source_members) {
+		if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+			++source_ctor_count;
+		}
+	}
+
+	std::vector<ConstructorDeclarationNode*> resolved_matches;
+	for (const StructMemberFunctionDecl& source_member : source_members) {
+		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+
+		ASTNode* matched_stub = findSourceMemberStubByIdentity(
+			identity_maps,
+			source_member.function_declaration);
+		if (matched_stub == nullptr || !matched_stub->is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+
+		ConstructorDeclarationNode* inst_ctor_decl =
+			&matched_stub->as<ConstructorDeclarationNode>();
+		if (inst_ctor_decl->has_template_body_position()) {
+			continue;
+		}
+
+		if (!inst_ctor_decl->template_parameters().empty() &&
+			inst_ctor_decl->template_parameters().size() !=
+				out_of_line_inner_template_params.size()) {
+			continue;
+		}
+
+		bool matches_candidate = outOfLineConstructorTemplateMatchesCandidate(
+			parser,
+			*inst_ctor_decl,
+			out_of_line_decl,
+			outer_template_params,
+			outer_template_args,
+			owner_type_name,
+			std::span<const TemplateParameterNode>(
+				inst_ctor_decl->template_parameters().data(),
+				inst_ctor_decl->template_parameters().size()),
+			out_of_line_inner_template_params);
+		if (!matches_candidate && inst_ctor_decl->template_parameters().empty()) {
+			std::optional<bool> signature_match =
+				declarationsMatchAfterTemplateSubstitution(
+					parser,
+					*inst_ctor_decl,
+					out_of_line_decl,
+					outer_template_params,
+					outer_template_args,
+					owner_type_name,
+					std::span<const TemplateParameterNode>{},
+					out_of_line_inner_template_params);
+			if (signature_match.has_value()) {
+				matches_candidate = *signature_match;
+			} else if (source_ctor_count <= 1) {
+				matches_candidate = true;
+			} else if (inst_ctor_decl->parameter_nodes().size() ==
+					   out_of_line_decl.parameter_nodes().size()) {
+				matches_candidate = true;
+				for (size_t param_index = 0;
+					 param_index < inst_ctor_decl->parameter_nodes().size();
+					 ++param_index) {
+					const TypeSpecifierNode* candidate_param_type =
+						getDeclarationParamTypeNode(inst_ctor_decl->parameter_nodes()[param_index]);
+					const TypeSpecifierNode* out_of_line_param_type =
+						getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[param_index]);
+					if (candidate_param_type == nullptr ||
+						out_of_line_param_type == nullptr ||
+						!typeSpecifiersMatchForSignatureValidation(
+							*candidate_param_type,
+							*out_of_line_param_type)) {
+						matches_candidate = false;
+						break;
+					}
+				}
+			}
+		}
+
+		if (!matches_candidate) {
+			continue;
+		}
+
+		resolved_matches.push_back(inst_ctor_decl);
 	}
 
 	OutOfLineConstructorStubResolution resolution;
@@ -6601,100 +6717,99 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					continue;
 				}
 
-				for (auto& mem_func : instantiated_struct_ref.member_functions()) {
-					if (!mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
-						continue;
-					}
+				OutOfLineConstructorStubResolution ctor_resolution =
+					findOutOfLineConstructorTemplateStubByIdentity(
+						*this,
+						source_member_identity_maps,
+						std::span<const StructMemberFunctionDecl>(
+							pattern_struct.member_functions().data(),
+							pattern_struct.member_functions().size()),
+						ool_func,
+						std::span<const TemplateParameterNode>(
+							template_params.data(),
+							template_params.size()),
+						std::span<const TemplateTypeArg>(
+							template_args_for_pattern.data(),
+							template_args_for_pattern.size()),
+						instantiated_name,
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.inner_template_params.data(),
+							out_of_line_member.inner_template_params.size()));
+				if (ctor_resolution.ambiguous) {
+					FLASH_LOG(
+						Templates,
+						Error,
+						"Ambiguous replay-first attachment for partial-spec out-of-line constructor template '",
+						ool_func_name,
+						"' in instantiated class '",
+						instantiated_name,
+						"'");
+					continue;
+				}
+				if (ctor_resolution.ctor == nullptr) {
+					FLASH_LOG(
+						Templates,
+						Error,
+						"Could not attach partial-spec out-of-line constructor template '",
+						ool_func_name,
+						"' for instantiated class '",
+						instantiated_name,
+						"' via replay identity map");
+					continue;
+				}
 
-					auto& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();
-					const size_t out_of_line_template_param_count =
-						out_of_line_member.inner_template_params.size();
-					auto matches_out_of_line_ctor_template =
-						[&](const ConstructorDeclarationNode& candidate) -> bool {
-							if (candidate.has_template_body_position()) {
-								return false;
-							}
-							if (candidate.template_parameters().empty() ||
-								candidate.template_parameters().size() != out_of_line_template_param_count) {
-								return false;
-							}
+				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
+				ctor_decl.set_template_body_position(out_of_line_member.body_start);
+				if (out_of_line_member.has_initializer_list) {
+					ctor_decl.set_template_initializer_list_position(
+						out_of_line_member.initializer_list_start);
+				}
 
-							std::optional<bool> signature_match =
-								declarationsMatchAfterTemplateSubstitution(
-									*this,
-									candidate,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										template_params.data(),
-										template_params.size()),
-									std::span<const TemplateTypeArg>(
-										template_args_for_pattern.data(),
-										template_args_for_pattern.size()),
-									instantiated_name,
-									std::span<const TemplateParameterNode>(
-										candidate.template_parameters().data(),
-										candidate.template_parameters().size()),
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.inner_template_params.data(),
-										out_of_line_member.inner_template_params.size()));
-							if (signature_match.has_value()) {
-								return *signature_match;
-							}
-
-							return ool_func.parameter_nodes().size() == candidate.parameter_nodes().size() &&
-								constructorDeclarationsHaveMatchingParameterShape(
-									candidate,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										candidate.template_parameters().data(),
-										candidate.template_parameters().size()),
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.inner_template_params.data(),
-										out_of_line_member.inner_template_params.size()));
-						};
-					if (!matches_out_of_line_ctor_template(ctor_decl)) {
-						continue;
-					}
-
-					ctor_decl.set_template_body_position(out_of_line_member.body_start);
-					if (out_of_line_member.has_initializer_list) {
-						ctor_decl.set_template_initializer_list_position(
-							out_of_line_member.initializer_list_start);
-					}
-					StructTypeInfo* ctor_instantiated_struct_info = struct_type_info.getStructInfo();
-					if (ctor_instantiated_struct_info == nullptr) {
-						break;
-					}
+				if (StructTypeInfo* ctor_instantiated_struct_info = struct_type_info.getStructInfo();
+					ctor_instantiated_struct_info != nullptr) {
+					size_t info_ctor_match_count = 0;
+					ConstructorDeclarationNode* matched_info_ctor = nullptr;
 					for (auto& info_func : ctor_instantiated_struct_info->member_functions) {
 						if (!info_func.is_constructor ||
 							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
 							continue;
 						}
-
-						auto& info_ctor =
-							info_func.function_decl.as<ConstructorDeclarationNode>();
-						if (info_ctor.name() != ctor_decl.name() ||
-							info_ctor.template_parameters().size() != ctor_decl.template_parameters().size()) {
+						auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+						if (info_ctor.has_template_body_position()) {
 							continue;
 						}
-						if (!matches_out_of_line_ctor_template(info_ctor)) {
+						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+								info_ctor,
+								ctor_decl)) {
 							continue;
 						}
+						++info_ctor_match_count;
+						matched_info_ctor = &info_ctor;
+					}
 
-						info_ctor.set_template_body_position(out_of_line_member.body_start);
+					if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
+						matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
 						if (out_of_line_member.has_initializer_list) {
-							info_ctor.set_template_initializer_list_position(
+							matched_info_ctor->set_template_initializer_list_position(
 								out_of_line_member.initializer_list_start);
 						}
-						break;
+					} else if (info_ctor_match_count > 1) {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Ambiguous StructTypeInfo constructor-template sync for partial-spec out-of-line constructor template '",
+							ool_func_name,
+							"' in instantiated class '",
+							instantiated_name,
+							"'");
 					}
-					FLASH_LOG(
-						Templates,
-						Debug,
-						"Set deferred body position on out-of-line constructor template: ",
-						ool_func_name);
-					break;
 				}
+
+				FLASH_LOG(
+					Templates,
+					Debug,
+					"Set deferred body position on out-of-line constructor template: ",
+					ool_func_name);
 			}
 
 			// Re-evaluate deferred static_asserts with substituted template parameters
@@ -9817,56 +9932,196 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 			}
 
-			for (const auto& out_of_line_member : nested_out_of_line_members) {
-				for (auto& mem_func : nested_struct.member_functions()) {
-					const bool out_of_line_ctor_stub =
-						out_of_line_member.function_node.is<FunctionDeclarationNode>() &&
-						out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node().identifier_token().value() ==
-							nested_struct.name().view();
-					if (mem_func.function_declaration.is<ConstructorDeclarationNode>() &&
-						(out_of_line_member.function_node.is<ConstructorDeclarationNode>() || out_of_line_ctor_stub)) {
-						ASTNode ctor_node = mem_func.function_declaration;
-						auto& ctor_decl = ctor_node.as<ConstructorDeclarationNode>();
-						size_t out_of_line_template_param_count = out_of_line_member.function_node.is<ConstructorDeclarationNode>()
-							? out_of_line_member.function_node.as<ConstructorDeclarationNode>().template_parameters().size()
-							: out_of_line_member.inner_template_params.size();
-						const bool template_param_count_matches =
-							ctor_decl.template_parameters().empty() ||
-							ctor_decl.template_parameters().size() == out_of_line_template_param_count;
-						const FunctionDeclarationNode* out_of_line_ctor_stub_decl =
-							out_of_line_member.function_node.is<FunctionDeclarationNode>()
-								? &out_of_line_member.function_node.as<FunctionDeclarationNode>()
-								: nullptr;
-						const bool out_of_line_ctor_stub_matches =
-							!out_of_line_ctor_stub_decl ||
-							(nested_out_of_line_members.size() == 1 ||
-							 outOfLineConstructorTemplateMatchesCandidate(
-								*this,
-								ctor_decl,
-								*out_of_line_ctor_stub_decl,
-								std::span<const TemplateParameterNode>(
-									template_params.data(),
-									template_params.size()),
-								std::span<const TemplateTypeArg>(
-									template_args_to_use.data(),
-									template_args_to_use.size()),
-								qualified_name,
-								std::span<const TemplateParameterNode>(
-									ctor_decl.template_parameters().data(),
-									ctor_decl.template_parameters().size()),
-								std::span<const TemplateParameterNode>(
-									out_of_line_member.inner_template_params.data(),
-									out_of_line_member.inner_template_params.size())));
-						if (!ctor_decl.is_materialized() &&
-							!ctor_decl.has_template_body_position() &&
-							template_param_count_matches &&
-							out_of_line_ctor_stub_matches) {
-							ctor_decl.set_template_body_position(out_of_line_member.body_start);
-							if (out_of_line_member.has_initializer_list) {
-								ctor_decl.set_template_initializer_list_position(out_of_line_member.initializer_list_start);
-							}
+			const std::span<const StructMemberFunctionDecl> nested_source_member_functions =
+				nested_struct.member_functions();
+
+			SourceMemberIdentityMaps nested_source_member_identity_maps;
+			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
+				ASTNode instantiated_stub = source_member.function_declaration;
+				if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+					const ConstructorDeclarationNode& source_ctor =
+						source_member.function_declaration.as<ConstructorDeclarationNode>();
+					size_t struct_info_ctor_match_count = 0;
+					ASTNode struct_info_ctor_stub;
+					for (const auto& info_func : nested_struct_info->member_functions) {
+						if (!info_func.is_constructor ||
+							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+							continue;
 						}
-					} else if (!out_of_line_member.inner_template_params.empty() &&
+						const ConstructorDeclarationNode& info_ctor =
+							info_func.function_decl.as<ConstructorDeclarationNode>();
+						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+								info_ctor,
+								source_ctor)) {
+							continue;
+						}
+						++struct_info_ctor_match_count;
+						struct_info_ctor_stub = info_func.function_decl;
+					}
+					if (struct_info_ctor_match_count == 1 &&
+						struct_info_ctor_stub.has_value()) {
+						instantiated_stub = struct_info_ctor_stub;
+					}
+				}
+				registerSourceMemberStubIdentity(
+					nested_source_member_identity_maps,
+					source_member.function_declaration,
+					instantiated_stub);
+			}
+
+			for (const auto& out_of_line_member : nested_out_of_line_members) {
+				if (!out_of_line_member.inner_template_params.empty() &&
+					out_of_line_member.function_node.is<ConstructorDeclarationNode>()) {
+					const ConstructorDeclarationNode& out_of_line_ctor_decl =
+						out_of_line_member.function_node.as<ConstructorDeclarationNode>();
+					std::vector<ConstructorDeclarationNode*> resolved_ctor_matches;
+					for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
+						if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+							continue;
+						}
+						const ConstructorDeclarationNode& source_ctor_decl =
+							source_member.function_declaration.as<ConstructorDeclarationNode>();
+						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+								source_ctor_decl,
+								out_of_line_ctor_decl)) {
+							continue;
+						}
+						ASTNode* matched_stub = findSourceMemberStubByIdentity(
+							nested_source_member_identity_maps,
+							source_member.function_declaration);
+						if (matched_stub == nullptr ||
+							!matched_stub->is<ConstructorDeclarationNode>()) {
+							continue;
+						}
+						ConstructorDeclarationNode& matched_ctor =
+							matched_stub->as<ConstructorDeclarationNode>();
+						if (matched_ctor.has_template_body_position()) {
+							continue;
+						}
+						resolved_ctor_matches.push_back(&matched_ctor);
+					}
+
+					if (resolved_ctor_matches.size() == 1) {
+						ConstructorDeclarationNode& ctor_decl = *resolved_ctor_matches.front();
+						ctor_decl.set_template_body_position(out_of_line_member.body_start);
+						if (out_of_line_member.has_initializer_list) {
+							ctor_decl.set_template_initializer_list_position(
+								out_of_line_member.initializer_list_start);
+						}
+					} else if (resolved_ctor_matches.size() > 1) {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Ambiguous replay-first attachment for nested out-of-line constructor template '",
+							out_of_line_ctor_decl.name(),
+							"' in instantiated class '",
+							StringTable::getStringView(qualified_name),
+							"'");
+					}
+					continue;
+				}
+
+				const bool out_of_line_ctor_stub =
+					out_of_line_member.function_node.is<FunctionDeclarationNode>() &&
+					out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node().identifier_token().value() ==
+						nested_struct.name().view();
+				if (out_of_line_ctor_stub &&
+					out_of_line_member.function_node.is<FunctionDeclarationNode>()) {
+					const FunctionDeclarationNode& out_of_line_ctor_stub_decl =
+						out_of_line_member.function_node.as<FunctionDeclarationNode>();
+					OutOfLineConstructorStubResolution ctor_resolution =
+						findOutOfLineConstructorTemplateStubByIdentity(
+							*this,
+							nested_source_member_identity_maps,
+							std::span<const StructMemberFunctionDecl>(
+								nested_source_member_functions.data(),
+								nested_source_member_functions.size()),
+							out_of_line_ctor_stub_decl,
+							std::span<const TemplateParameterNode>(
+								template_params.data(),
+								template_params.size()),
+							std::span<const TemplateTypeArg>(
+								template_args_to_use.data(),
+								template_args_to_use.size()),
+							qualified_name,
+							std::span<const TemplateParameterNode>(
+								out_of_line_member.inner_template_params.data(),
+								out_of_line_member.inner_template_params.size()));
+					if (ctor_resolution.ambiguous) {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Ambiguous replay-first attachment for nested out-of-line constructor template '",
+							out_of_line_ctor_stub_decl.decl_node().identifier_token().value(),
+							"' in instantiated class '",
+							StringTable::getStringView(qualified_name),
+							"'");
+						continue;
+					}
+					if (ctor_resolution.ctor == nullptr) {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Could not attach nested out-of-line constructor template '",
+							out_of_line_ctor_stub_decl.decl_node().identifier_token().value(),
+							"' for instantiated class '",
+							StringTable::getStringView(qualified_name),
+							"' via replay identity map");
+						continue;
+					}
+
+					ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
+					if (!ctor_decl.is_materialized() &&
+						!ctor_decl.has_template_body_position()) {
+						ctor_decl.set_template_body_position(out_of_line_member.body_start);
+						if (out_of_line_member.has_initializer_list) {
+							ctor_decl.set_template_initializer_list_position(
+								out_of_line_member.initializer_list_start);
+						}
+					}
+
+					if (nested_struct_info != nullptr) {
+						size_t info_ctor_match_count = 0;
+						ConstructorDeclarationNode* matched_info_ctor = nullptr;
+						for (auto& info_func : nested_struct_info->member_functions) {
+							if (!info_func.is_constructor ||
+								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+								continue;
+							}
+							auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+							if (info_ctor.has_template_body_position()) {
+								continue;
+							}
+							if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+									info_ctor,
+									ctor_decl)) {
+								continue;
+							}
+							++info_ctor_match_count;
+							matched_info_ctor = &info_ctor;
+						}
+						if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
+							matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
+							if (out_of_line_member.has_initializer_list) {
+								matched_info_ctor->set_template_initializer_list_position(
+									out_of_line_member.initializer_list_start);
+							}
+						} else if (info_ctor_match_count > 1) {
+							FLASH_LOG(
+								Templates,
+								Error,
+								"Ambiguous StructTypeInfo constructor-template sync for nested out-of-line constructor template '",
+								out_of_line_ctor_stub_decl.decl_node().identifier_token().value(),
+								"' in instantiated class '",
+								StringTable::getStringView(qualified_name),
+								"'");
+						}
+					}
+					continue;
+				}
+
+				for (auto& mem_func : nested_struct.member_functions()) {
+					if (!out_of_line_member.inner_template_params.empty() &&
 							   mem_func.function_declaration.is<TemplateFunctionDeclarationNode>() &&
 							   out_of_line_member.function_node.is<FunctionDeclarationNode>()) {
 						ASTNode nested_func_node = mem_func.function_declaration;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -500,6 +500,45 @@ static bool constructorDeclarationsHaveEquivalentInstantiatedSignature(
 	return true;
 }
 
+template <typename EligibleFn>
+static OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
+	StructTypeInfo& struct_info,
+	const ConstructorDeclarationNode& ctor_decl,
+	EligibleFn&& is_candidate_eligible) {
+	OutOfLineConstructorStubResolution resolution;
+	for (auto& info_func : struct_info.member_functions) {
+		if (!info_func.is_constructor ||
+			!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+
+		auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+		if (!is_candidate_eligible(info_ctor) ||
+			!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+				info_ctor,
+				ctor_decl)) {
+			continue;
+		}
+
+		if (resolution.ctor != nullptr) {
+			resolution.ambiguous = true;
+			return resolution;
+		}
+		resolution.ctor = &info_ctor;
+	}
+	return resolution;
+}
+
+static void setOutOfLineConstructorTemplateReplayMetadata(
+	ConstructorDeclarationNode& ctor_decl,
+	const OutOfLineMemberFunction& out_of_line_member) {
+	ctor_decl.set_template_body_position(out_of_line_member.body_start);
+	if (out_of_line_member.has_initializer_list) {
+		ctor_decl.set_template_initializer_list_position(
+			out_of_line_member.initializer_list_start);
+	}
+}
+
 bool Parser::static_initializer_requires_replay_metadata(
 	const std::optional<ASTNode>& initializer,
 	std::span<const TemplateParameterNode> template_params_for_substitution) {
@@ -6774,41 +6813,25 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 
 				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
-				ctor_decl.set_template_body_position(out_of_line_member.body_start);
-				if (out_of_line_member.has_initializer_list) {
-					ctor_decl.set_template_initializer_list_position(
-						out_of_line_member.initializer_list_start);
-				}
+				setOutOfLineConstructorTemplateReplayMetadata(
+					ctor_decl,
+					out_of_line_member);
 
 				if (StructTypeInfo* ctor_instantiated_struct_info = struct_type_info.getStructInfo();
 					ctor_instantiated_struct_info != nullptr) {
-					size_t info_ctor_match_count = 0;
-					ConstructorDeclarationNode* matched_info_ctor = nullptr;
-					for (auto& info_func : ctor_instantiated_struct_info->member_functions) {
-						if (!info_func.is_constructor ||
-							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-							continue;
-						}
-						auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-						if (info_ctor.has_template_body_position()) {
-							continue;
-						}
-						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-								info_ctor,
-								ctor_decl)) {
-							continue;
-						}
-						++info_ctor_match_count;
-						matched_info_ctor = &info_ctor;
-					}
+					OutOfLineConstructorStubResolution info_ctor_resolution =
+						findMatchingConstructorInStructInfo(
+							*ctor_instantiated_struct_info,
+							ctor_decl,
+							[](const ConstructorDeclarationNode& info_ctor) {
+								return !info_ctor.has_template_body_position();
+							});
 
-					if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
-						matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
-						if (out_of_line_member.has_initializer_list) {
-							matched_info_ctor->set_template_initializer_list_position(
-								out_of_line_member.initializer_list_start);
-						}
-					} else if (info_ctor_match_count > 1) {
+					if (info_ctor_resolution.ctor != nullptr) {
+						setOutOfLineConstructorTemplateReplayMetadata(
+							*info_ctor_resolution.ctor,
+							out_of_line_member);
+					} else if (info_ctor_resolution.ambiguous) {
 						FLASH_LOG(
 							Templates,
 							Error,
@@ -10088,40 +10111,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
 					if (!ctor_decl.is_materialized() &&
 						!ctor_decl.has_template_body_position()) {
-						ctor_decl.set_template_body_position(out_of_line_member.body_start);
-						if (out_of_line_member.has_initializer_list) {
-							ctor_decl.set_template_initializer_list_position(
-								out_of_line_member.initializer_list_start);
-						}
+						setOutOfLineConstructorTemplateReplayMetadata(
+							ctor_decl,
+							out_of_line_member);
 					}
 
 					if (nested_struct_info != nullptr) {
-						size_t info_ctor_match_count = 0;
-						ConstructorDeclarationNode* matched_info_ctor = nullptr;
-						for (auto& info_func : nested_struct_info->member_functions) {
-							if (!info_func.is_constructor ||
-								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-								continue;
-							}
-							auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-							if (info_ctor.has_template_body_position()) {
-								continue;
-							}
-							if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-									info_ctor,
-									ctor_decl)) {
-								continue;
-							}
-							++info_ctor_match_count;
-							matched_info_ctor = &info_ctor;
-						}
-						if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
-							matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
-							if (out_of_line_member.has_initializer_list) {
-								matched_info_ctor->set_template_initializer_list_position(
-									out_of_line_member.initializer_list_start);
-							}
-						} else if (info_ctor_match_count > 1) {
+						OutOfLineConstructorStubResolution info_ctor_resolution =
+							findMatchingConstructorInStructInfo(
+								*nested_struct_info,
+								ctor_decl,
+								[](const ConstructorDeclarationNode& info_ctor) {
+									return !info_ctor.has_template_body_position();
+								});
+						if (info_ctor_resolution.ctor != nullptr) {
+							setOutOfLineConstructorTemplateReplayMetadata(
+								*info_ctor_resolution.ctor,
+								out_of_line_member);
+						} else if (info_ctor_resolution.ambiguous) {
 							FLASH_LOG(
 								Templates,
 								Error,
@@ -12108,40 +12115,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 
 				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
-				ctor_decl.set_template_body_position(out_of_line_member.body_start);
-				if (out_of_line_member.has_initializer_list) {
-					ctor_decl.set_template_initializer_list_position(
-						out_of_line_member.initializer_list_start);
-				}
+				setOutOfLineConstructorTemplateReplayMetadata(
+					ctor_decl,
+					out_of_line_member);
 
 				if (struct_info_ptr != nullptr) {
-					size_t info_ctor_match_count = 0;
-					ConstructorDeclarationNode* matched_info_ctor = nullptr;
-					for (auto& info_func : struct_info_ptr->member_functions) {
-						if (!info_func.is_constructor ||
-							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-							continue;
-						}
-						auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-						if (info_ctor.has_template_body_position()) {
-							continue;
-						}
-						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-								info_ctor,
-								ctor_decl)) {
-							continue;
-						}
-						++info_ctor_match_count;
-						matched_info_ctor = &info_ctor;
-					}
+					OutOfLineConstructorStubResolution info_ctor_resolution =
+						findMatchingConstructorInStructInfo(
+							*struct_info_ptr,
+							ctor_decl,
+							[](const ConstructorDeclarationNode& info_ctor) {
+								return !info_ctor.has_template_body_position();
+							});
 
-					if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
-						matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
-						if (out_of_line_member.has_initializer_list) {
-							matched_info_ctor->set_template_initializer_list_position(
-								out_of_line_member.initializer_list_start);
-						}
-					} else if (info_ctor_match_count > 1) {
+					if (info_ctor_resolution.ctor != nullptr) {
+						setOutOfLineConstructorTemplateReplayMetadata(
+							*info_ctor_resolution.ctor,
+							out_of_line_member);
+					} else if (info_ctor_resolution.ambiguous) {
 						std::string error_msg = std::string(StringBuilder()
 							.append("Ambiguous StructTypeInfo constructor-template sync for out-of-line constructor template '")
 							.append(ool_func_name)
@@ -12563,27 +12554,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ctor.set_definition(substituted_body);
 					// Also update the StructTypeInfo's copy (used by codegen)
 					if (struct_type_info.struct_info_) {
-						size_t info_ctor_match_count = 0;
-						ConstructorDeclarationNode* matched_info_ctor = nullptr;
-						for (auto& info_func : struct_type_info.struct_info_->member_functions) {
-							if (!info_func.is_constructor ||
-								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-								continue;
-							}
-
-							auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-							if (info_ctor.is_materialized()) {
-								continue;
-							}
-							if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(info_ctor, ctor)) {
-								continue;
-							}
-							++info_ctor_match_count;
-							matched_info_ctor = &info_ctor;
-						}
-						if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
-							matched_info_ctor->set_definition(substituted_body);
-						} else if (info_ctor_match_count > 1) {
+						OutOfLineConstructorStubResolution info_ctor_resolution =
+							findMatchingConstructorInStructInfo(
+								*struct_type_info.struct_info_,
+								ctor,
+								[](const ConstructorDeclarationNode& info_ctor) {
+									return !info_ctor.is_materialized();
+								});
+						if (info_ctor_resolution.ctor != nullptr) {
+							info_ctor_resolution.ctor->set_definition(substituted_body);
+						} else if (info_ctor_resolution.ambiguous) {
 							std::string error_msg = std::string(StringBuilder()
 								.append("Ambiguous StructTypeInfo constructor sync for out-of-line constructor '")
 								.append(decl.identifier_token().value())

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -12044,84 +12044,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 			}
 			if (out_of_line_ctor_stub) {
-				for (auto& mem_func : instantiated_struct_ref.member_functions()) {
-					if (!mem_func.function_declaration.is<ConstructorDeclarationNode>())
-						continue;
-					auto& ctor_decl =
-						mem_func.function_declaration.as<ConstructorDeclarationNode>();
-					const size_t out_of_line_template_param_count =
-						out_of_line_member.inner_template_params.size();
-					auto matches_out_of_line_ctor_template =
-						[&](const ConstructorDeclarationNode& candidate) -> bool {
-							if (candidate.has_template_body_position()) {
-								return false;
-							}
-							if (candidate.template_parameters().empty() ||
-								candidate.template_parameters().size() != out_of_line_template_param_count) {
-								return false;
-							}
-
-							return outOfLineConstructorTemplateMatchesCandidate(
-								*this,
-								candidate,
-								ool_func,
-								std::span<const TemplateParameterNode>(
-									out_of_line_member.template_params.data(),
-									out_of_line_member.template_params.size()),
-								std::span<const TemplateTypeArg>(
-									template_args_to_use.data(),
-									template_args_to_use.size()),
-								instantiated_name,
-								std::span<const TemplateParameterNode>(
-									candidate.template_parameters().data(),
-									candidate.template_parameters().size()),
-								std::span<const TemplateParameterNode>(
-									out_of_line_member.inner_template_params.data(),
-									out_of_line_member.inner_template_params.size()));
-						};
-					if (matches_out_of_line_ctor_template(ctor_decl)) {
-						ctor_decl.set_template_body_position(out_of_line_member.body_start);
-						if (out_of_line_member.has_initializer_list) {
-							ctor_decl.set_template_initializer_list_position(
-								out_of_line_member.initializer_list_start);
-						}
-						for (auto& info_func : struct_info_ptr->member_functions) {
-							if (!info_func.is_constructor ||
-								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-								continue;
-							}
-
-							auto& info_ctor =
-								info_func.function_decl.as<ConstructorDeclarationNode>();
-							if (info_ctor.name() != ctor_decl.name() ||
-								info_ctor.template_parameters().size() != ctor_decl.template_parameters().size()) {
-								continue;
-							}
-							if (!matches_out_of_line_ctor_template(info_ctor)) {
-								continue;
-							}
-
-							info_ctor.set_template_body_position(out_of_line_member.body_start);
-							if (out_of_line_member.has_initializer_list) {
-								info_ctor.set_template_initializer_list_position(
-									out_of_line_member.initializer_list_start);
-							}
-							break;
-						}
-						FLASH_LOG(
-							Templates,
-							Debug,
-							"Set deferred body position on out-of-line constructor template: ",
-							ool_func_name);
-						found = true;
-						break;
-					}
-				}
-				if (!found) {
+				OutOfLineConstructorStubResolution ctor_resolution =
+					findOutOfLineConstructorTemplateStubByIdentity(
+						*this,
+						source_member_identity_maps,
+						std::span<const StructMemberFunctionDecl>(
+							effective_member_functions.data(),
+							effective_member_functions.size()),
+						ool_func,
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.template_params.data(),
+							out_of_line_member.template_params.size()),
+						std::span<const TemplateTypeArg>(
+							template_args_to_use.data(),
+							template_args_to_use.size()),
+						instantiated_name,
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.inner_template_params.data(),
+							out_of_line_member.inner_template_params.size()));
+				if (ctor_resolution.ambiguous) {
 					std::string error_msg = std::string(StringBuilder()
-						.append("Could not attach out-of-line constructor template stub '")
+						.append("Ambiguous replay-first attachment for out-of-line constructor template '")
 						.append(ool_func_name)
-						.append("' for instantiated class '")
+						.append("' in instantiated class '")
 						.append(instantiated_name)
 						.append("'")
 						.commit());
@@ -12129,7 +12074,78 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						throw InternalError(error_msg);
 					}
 					FLASH_LOG(Templates, Error, error_msg);
+					continue;
 				}
+
+				if (ctor_resolution.ctor == nullptr) {
+					std::string error_msg = std::string(StringBuilder()
+						.append("Could not attach out-of-line constructor template stub '")
+						.append(ool_func_name)
+						.append("' for instantiated class '")
+						.append(instantiated_name)
+						.append("' via replay identity map")
+						.commit());
+					if (force_eager) {
+						throw InternalError(error_msg);
+					}
+					FLASH_LOG(Templates, Error, error_msg);
+					continue;
+				}
+
+				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
+				ctor_decl.set_template_body_position(out_of_line_member.body_start);
+				if (out_of_line_member.has_initializer_list) {
+					ctor_decl.set_template_initializer_list_position(
+						out_of_line_member.initializer_list_start);
+				}
+
+				if (struct_info_ptr != nullptr) {
+					size_t info_ctor_match_count = 0;
+					ConstructorDeclarationNode* matched_info_ctor = nullptr;
+					for (auto& info_func : struct_info_ptr->member_functions) {
+						if (!info_func.is_constructor ||
+							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+							continue;
+						}
+						auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+						if (info_ctor.has_template_body_position()) {
+							continue;
+						}
+						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
+								info_ctor,
+								ctor_decl)) {
+							continue;
+						}
+						++info_ctor_match_count;
+						matched_info_ctor = &info_ctor;
+					}
+
+					if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
+						matched_info_ctor->set_template_body_position(out_of_line_member.body_start);
+						if (out_of_line_member.has_initializer_list) {
+							matched_info_ctor->set_template_initializer_list_position(
+								out_of_line_member.initializer_list_start);
+						}
+					} else if (info_ctor_match_count > 1) {
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous StructTypeInfo constructor-template sync for out-of-line constructor template '")
+							.append(ool_func_name)
+							.append("' in instantiated class '")
+							.append(instantiated_name)
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						FLASH_LOG(Templates, Error, error_msg);
+					}
+				}
+
+				FLASH_LOG(
+					Templates,
+					Debug,
+					"Set deferred body position on out-of-line constructor template: ",
+					ool_func_name);
 				continue;
 			}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -109,6 +109,10 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	StringHandle owner_type_name,
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params);
+static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param);
+static bool typeSpecifiersMatchForSignatureValidation(
+	const TypeSpecifierNode& lhs,
+	const TypeSpecifierNode& rhs);
 
 static const void* sourceMemberAstNodeKey(const ASTNode& node) {
 	if (!node.has_value())
@@ -283,6 +287,101 @@ static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
 	}
 
 	return nullptr;
+}
+
+struct OutOfLineConstructorStubResolution {
+	ConstructorDeclarationNode* ctor = nullptr;
+	bool ambiguous = false;
+};
+
+static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIdentity(
+	Parser& parser,
+	SourceMemberIdentityMaps& identity_maps,
+	std::span<const StructMemberFunctionDecl> source_members,
+	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name) {
+	size_t source_ctor_count = 0;
+	for (const StructMemberFunctionDecl& source_member : source_members) {
+		if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+			++source_ctor_count;
+		}
+	}
+
+	std::vector<ConstructorDeclarationNode*> resolved_matches;
+	for (const StructMemberFunctionDecl& source_member : source_members) {
+		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+
+		ASTNode* matched_stub = findSourceMemberStubByIdentity(
+			identity_maps,
+			source_member.function_declaration);
+		if (matched_stub == nullptr || !matched_stub->is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+
+		ConstructorDeclarationNode* inst_ctor_decl =
+			&matched_stub->as<ConstructorDeclarationNode>();
+		std::optional<bool> signature_match =
+			declarationsMatchAfterTemplateSubstitution(
+				parser,
+				*inst_ctor_decl,
+				out_of_line_decl,
+				outer_template_params,
+				outer_template_args,
+				owner_type_name,
+				std::span<const TemplateParameterNode>{},
+				std::span<const TemplateParameterNode>{});
+
+		bool matches_candidate = false;
+		if (signature_match.has_value()) {
+			matches_candidate = *signature_match;
+		} else if (source_ctor_count <= 1) {
+			// Preserve prior non-overload behavior when substitution cannot fully
+			// classify a single constructor declaration.
+			matches_candidate = true;
+		}
+
+		if (matches_candidate) {
+			resolved_matches.push_back(inst_ctor_decl);
+		}
+	}
+
+	OutOfLineConstructorStubResolution resolution;
+	if (resolved_matches.size() == 1) {
+		resolution.ctor = resolved_matches.front();
+		return resolution;
+	}
+	if (resolved_matches.size() > 1) {
+		resolution.ambiguous = true;
+	}
+	return resolution;
+}
+
+static bool constructorDeclarationsHaveEquivalentInstantiatedSignature(
+	const ConstructorDeclarationNode& lhs,
+	const ConstructorDeclarationNode& rhs) {
+	if (lhs.template_parameters().size() != rhs.template_parameters().size() ||
+		lhs.parameter_nodes().size() != rhs.parameter_nodes().size()) {
+		return false;
+	}
+
+	for (size_t i = 0; i < lhs.parameter_nodes().size(); ++i) {
+		const TypeSpecifierNode* lhs_param =
+			getDeclarationParamTypeNode(lhs.parameter_nodes()[i]);
+		const TypeSpecifierNode* rhs_param =
+			getDeclarationParamTypeNode(rhs.parameter_nodes()[i]);
+		if (lhs_param == nullptr || rhs_param == nullptr) {
+			return false;
+		}
+		if (!typeSpecifiersMatchForSignatureValidation(*lhs_param, *rhs_param)) {
+			return false;
+		}
+	}
+
+	return true;
 }
 
 bool Parser::static_initializer_requires_replay_metadata(
@@ -11932,250 +12031,290 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			continue;
 		}
 
-		for (auto& mem_func : instantiated_struct_ref.member_functions()) {
-			// Also check ConstructorDeclarationNode members for out-of-line constructor definitions
-			// The out-of-line definition uses the template name (e.g., "Buffer") but the
-			// instantiated constructor uses the instantiated name (e.g., "Buffer$hash")
-			if (mem_func.is_constructor && mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
-				auto& ctor = mem_func.function_declaration.as<ConstructorDeclarationNode>();
-				std::string_view ool_name = decl.identifier_token().value();
-				std::string_view ctor_name = StringTable::getStringView(ctor.name());
-				// Match if names are equal, or if ctor name starts with ool_name + '$'
-				bool names_match = (ctor_name == ool_name);
-				if (!names_match && ctor_name.size() > ool_name.size() &&
-					ctor_name[ool_name.size()] == '$' &&
-					ctor_name.substr(0, ool_name.size()) == ool_name) {
-					names_match = true;
+		const bool out_of_line_ctor_stub = isOutOfLineConstructorStubName(
+			decl.identifier_token().value(),
+			template_name,
+			template_base_name);
+		if (out_of_line_ctor_stub) {
+			OutOfLineConstructorStubResolution ctor_resolution =
+				findPlainOutOfLineConstructorStubByIdentity(
+					*this,
+					source_member_identity_maps,
+					std::span<const StructMemberFunctionDecl>(
+						effective_member_functions.data(),
+						effective_member_functions.size()),
+					func_decl,
+					std::span<const TemplateParameterNode>(
+						out_of_line_member.template_params.data(),
+						out_of_line_member.template_params.size()),
+					std::span<const TemplateTypeArg>(
+						template_args_to_use.data(),
+						template_args_to_use.size()),
+					instantiated_name);
+			if (ctor_resolution.ambiguous) {
+				std::string ambiguity_msg = std::string(StringBuilder()
+					.append("Ambiguous replay-first attachment for out-of-line constructor '")
+					.append(decl.identifier_token().value())
+					.append("' in instantiated class '")
+					.append(instantiated_name)
+					.append("'")
+					.commit());
+				if (force_eager) {
+					throw InternalError(ambiguity_msg);
 				}
-				if (names_match) {
-					// Save current position
-					SaveHandle saved_pos = save_token_position();
+				FLASH_LOG(Templates, Error, ambiguity_msg);
+			} else if (ctor_resolution.ctor != nullptr) {
+				ConstructorDeclarationNode& ctor = *ctor_resolution.ctor;
+				// Save current position
+				SaveHandle saved_pos = save_token_position();
 
-					// Restore to the out-of-line definition position
-					// For constructors with initializer lists, restore to ':' so parse_function_body
-					// can parse the initializer list; otherwise restore to '{'.
-					if (out_of_line_member.has_initializer_list && out_of_line_member.initializer_list_start != 0) {
-						restore_lexer_position_only(out_of_line_member.initializer_list_start);
-					} else {
-						restore_lexer_position_only(out_of_line_member.body_start);
-					}
+				// Restore to the out-of-line definition position
+				// For constructors with initializer lists, restore to ':' so parse_function_body
+				// can parse the initializer list; otherwise restore to '{'.
+				if (out_of_line_member.has_initializer_list && out_of_line_member.initializer_list_start != 0) {
+					restore_lexer_position_only(out_of_line_member.initializer_list_start);
+				} else {
+					restore_lexer_position_only(out_of_line_member.body_start);
+				}
 
-					// Use setup_member_function_context for full member context:
-					// member context push, member-function registration, and 'this' injection.
-					// Constructors use ConstructorDeclarationNode (not FunctionDeclarationNode),
-					// so we manage the scope manually but delegate context to the shared helper.
-					TemplateDefinitionLookupContext definition_lookup_context =
-						ensureReplayDefinitionLookupContext(
-							out_of_line_member.definition_lookup_context,
-							decl.identifier_token(),
-							gSymbolTable.get_current_namespace_handle(),
-							instantiated_name);
-					ScopedDefinitionLookupContext ctx_scope(
-						current_template_definition_lookup_context_,
-						definition_lookup_context.is_valid()
-							? &definition_lookup_context
-							: nullptr);
+				// Use setup_member_function_context for full member context:
+				// member context push, member-function registration, and 'this' injection.
+				// Constructors use ConstructorDeclarationNode (not FunctionDeclarationNode),
+				// so we manage the scope manually but delegate context to the shared helper.
+				TemplateDefinitionLookupContext definition_lookup_context =
+					ensureReplayDefinitionLookupContext(
+						out_of_line_member.definition_lookup_context,
+						decl.identifier_token(),
+						gSymbolTable.get_current_namespace_handle(),
+						instantiated_name);
+				ScopedDefinitionLookupContext ctx_scope(
+					current_template_definition_lookup_context_,
+					definition_lookup_context.is_valid()
+						? &definition_lookup_context
+						: nullptr);
 
-					gSymbolTable.enter_scope(ScopeType::Function);
-					register_parameters_in_scope(ctor.parameter_nodes());
-					setup_member_function_context(
-						&instantiated_struct_ref,
-						instantiated_name,
-						struct_type_info.type_index_,
-						true);
+				gSymbolTable.enter_scope(ScopeType::Function);
+				register_parameters_in_scope(ctor.parameter_nodes());
+				setup_member_function_context(
+					&instantiated_struct_ref,
+					instantiated_name,
+					struct_type_info.type_index_,
+					true);
 
-					// Parse constructor initializer list if present (before parsing body)
-					if (out_of_line_member.has_initializer_list) {
-						if (peek() == ":"_tok) {
-							advance();  // consume ':'
+				// Parse constructor initializer list if present (before parsing body)
+				if (out_of_line_member.has_initializer_list) {
+					if (peek() == ":"_tok) {
+						advance();  // consume ':'
 
-							// Parse initializers until we hit '{', ';', or 'try'
-							while (true) {
-								TokenKind next_token = peek();
-								if (next_token == "{"_tok || next_token == ";"_tok || next_token == "try"_tok || next_token.is_eof()) {
-									break;
-								}
-
-								// Parse initializer name (could be base class or member)
-								auto init_name_token = advance();
-								if (!init_name_token.kind().is_identifier()) {
-									FLASH_LOG(Templates, Error, "Expected member or base class name in constructor initializer list, got '",
-											  init_name_token.value(), "'");
-									break;
-								}
-
-								std::string_view init_name = init_name_token.value();
-
-								// Replay the same qualified mem-initializer spelling accepted by the
-								// shared constructor-initializer parsers (e.g. N::Base<T>(...)).
-								init_name = consume_qualified_name_suffix(init_name);
-
-								// Check for template arguments: Base<T>(...) in base class initializer
-								if (peek() == "<"_tok) {
-									skip_template_arguments();
-								}
-
-								// Expect '(' or '{'
-								bool is_paren = peek() == "("_tok;
-								bool is_brace = peek() == "{"_tok;
-								if (!is_paren && !is_brace) {
-									FLASH_LOG(Templates, Error, "Expected '(' or '{' after initializer name in constructor, got '",
-											  peek_info().value(), "'");
-									break;
-								}
-
-								advance();  // consume '(' or '{'
-								TokenKind close_kind = ")"_tok;
-								if (!is_paren) {
-									close_kind = "}"_tok;
-								}
-
-								std::vector<ASTNode> init_args;
-								if (peek() != close_kind) {
-									while (true) {
-										ParseResult arg_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-										if (arg_result.is_error()) {
-											break;
-										}
-										if (auto arg_node = arg_result.node()) {
-											init_args.push_back(*arg_node);
-										}
-										if (peek() != ","_tok) {
-											break;
-										}
-										advance();
-									}
-								}
-
-								if (!consume(close_kind)) {
-									FLASH_LOG(Templates, Error, "Expected ", is_paren ? "')'" : "'}'",
-											  " after initializer arguments, got '", peek_info().value(), "'");
-									break;
-								}
-
-								// Substitute template parameters in initializer arguments
-								std::vector<ASTNode> substituted_args;
-								for (const auto& arg : init_args) {
-									try {
-										ASTNode substituted_arg = substituteTemplateParameters(
-											arg,
-											out_of_line_member.template_params,
-											template_args_to_use);
-										substituted_args.push_back(substituted_arg);
-									} catch (const std::exception& e) {
-										FLASH_LOG(Templates, Error, "Exception during template parameter substitution in constructor initializer: ", e.what());
-									}
-								}
-
-								// Determine if this is a base class or member initializer
-								bool is_base_init = false;
-								StringHandle matched_base_name;
-								StringHandle init_name_handle = StringTable::getOrInternStringHandle(init_name);
-								if (struct_type_info.struct_info_) {
-									// Check if this is a base class by looking at the struct's base classes
-									for (const auto& base : struct_type_info.struct_info_->base_classes) {
-										std::string_view base_name = base.name;
-										bool base_names_match =
-											(base_name == init_name || extractBaseTemplateName(base_name) == init_name);
-										if (!base_names_match) {
-											if (const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
-												base_type_info && base_type_info->isTemplateInstantiation()) {
-												StringHandle qualified_base_template_name =
-													gNamespaceRegistry.buildQualifiedIdentifier(
-														base_type_info->sourceNamespace(),
-														base_type_info->baseTemplateName());
-												base_names_match =
-													StringTable::getStringView(qualified_base_template_name) == init_name;
-											}
-										}
-										if (base_names_match) {
-											is_base_init = true;
-											matched_base_name = StringTable::getOrInternStringHandle(base_name);
-											break;
-										}
-									}
-
-									if (!is_base_init && struct_type_info.struct_info_->has_deferred_base_classes) {
-										for (const auto& deferred_base_entry : struct_type_info.struct_info_->deferred_template_bases) {
-											if (deferred_base_entry.base_template_name == init_name_handle) {
-												is_base_init = true;
-												matched_base_name = deferred_base_entry.base_template_name;
-												break;
-											}
-										}
-									}
-								}
-
-								if (is_base_init) {
-									ctor.add_base_initializer(matched_base_name, std::move(substituted_args));
-								}
-
-								if (!is_base_init) {
-									auto make_initializer_list = [&](InitializerListNode::InitializationStyle style) -> ASTNode {
-										auto [init_list_node, init_list_ref] = create_node_ref(InitializerListNode(style));
-										for (const auto& arg : substituted_args) {
-											init_list_ref.add_initializer(arg);
-										}
-										return init_list_node;
-									};
-
-									// It's a member initializer
-									if (is_brace) {
-										ctor.add_member_initializer(init_name, make_initializer_list(InitializerListNode::InitializationStyle::Brace));
-									} else if (substituted_args.size() > 1) {
-										ctor.add_member_initializer(init_name, make_initializer_list(InitializerListNode::InitializationStyle::Paren));
-									} else if (!substituted_args.empty()) {
-										ctor.add_member_initializer(init_name, substituted_args[0]);
-									}
-								}
-
-								// Continue if there's a comma
-								if (peek() != ","_tok) {
-									break;
-								}
-								advance();  // consume ','
+						// Parse initializers until we hit '{', ';', or 'try'
+						while (true) {
+							TokenKind next_token = peek();
+							if (next_token == "{"_tok || next_token == ";"_tok || next_token == "try"_tok || next_token.is_eof()) {
+								break;
 							}
-						}
-					}
 
-					// Parse the function body (handles function-try-blocks too)
-					// Pass true for is_ctor_or_dtor so constructor function-try-blocks
-					// get the C++20 [except.handle]/15 implicit rethrow at catch handler ends.
-					auto body_result = parse_function_body(true /* is_ctor_or_dtor */);
-					member_function_context_stack_.pop_back();
-					gSymbolTable.exit_scope();
-					restore_lexer_position_only(saved_pos);
+							// Parse initializer name (could be base class or member)
+							auto init_name_token = advance();
+							if (!init_name_token.kind().is_identifier()) {
+								FLASH_LOG(Templates, Error, "Expected member or base class name in constructor initializer list, got '",
+										  init_name_token.value(), "'");
+								break;
+							}
 
-					if (body_result.is_error() || !body_result.node().has_value()) {
-						FLASH_LOG(Templates, Error, "Failed to parse out-of-line constructor body for ",
-								  decl.identifier_token().value());
-						continue;
-					}
+							std::string_view init_name = init_name_token.value();
 
-					try {
-						ASTNode substituted_body = substituteTemplateParameters(
-							*body_result.node(),
-							out_of_line_member.template_params,
-							template_args_to_use);
-						ctor.set_definition(substituted_body);
-						// Also update the StructTypeInfo's copy (used by codegen)
-						if (struct_type_info.struct_info_) {
-							for (auto& info_func : struct_type_info.struct_info_->member_functions) {
-								if (info_func.is_constructor && info_func.function_decl.is<ConstructorDeclarationNode>()) {
-									auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-									if (info_ctor.name() == ctor.name() && !info_ctor.is_materialized()) {
-										info_ctor.set_definition(substituted_body);
+							// Replay the same qualified mem-initializer spelling accepted by the
+							// shared constructor-initializer parsers (e.g. N::Base<T>(...)).
+							init_name = consume_qualified_name_suffix(init_name);
+
+							// Check for template arguments: Base<T>(...) in base class initializer
+							if (peek() == "<"_tok) {
+								skip_template_arguments();
+							}
+
+							// Expect '(' or '{'
+							bool is_paren = peek() == "("_tok;
+							bool is_brace = peek() == "{"_tok;
+							if (!is_paren && !is_brace) {
+								FLASH_LOG(Templates, Error, "Expected '(' or '{' after initializer name in constructor, got '",
+										  peek_info().value(), "'");
+								break;
+							}
+
+							advance();  // consume '(' or '{'
+							TokenKind close_kind = ")"_tok;
+							if (!is_paren) {
+								close_kind = "}"_tok;
+							}
+
+							std::vector<ASTNode> init_args;
+							if (peek() != close_kind) {
+								while (true) {
+									ParseResult arg_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
+									if (arg_result.is_error()) {
+										break;
+									}
+									if (auto arg_node = arg_result.node()) {
+										init_args.push_back(*arg_node);
+									}
+									if (peek() != ","_tok) {
+										break;
+									}
+									advance();
+								}
+							}
+
+							if (!consume(close_kind)) {
+								FLASH_LOG(Templates, Error, "Expected ", is_paren ? "')'" : "'}'",
+										  " after initializer arguments, got '", peek_info().value(), "'");
+								break;
+							}
+
+							// Substitute template parameters in initializer arguments
+							std::vector<ASTNode> substituted_args;
+							for (const auto& arg : init_args) {
+								try {
+									ASTNode substituted_arg = substituteTemplateParameters(
+										arg,
+										out_of_line_member.template_params,
+										template_args_to_use);
+									substituted_args.push_back(substituted_arg);
+								} catch (const std::exception& e) {
+									FLASH_LOG(Templates, Error, "Exception during template parameter substitution in constructor initializer: ", e.what());
+								}
+							}
+
+							// Determine if this is a base class or member initializer
+							bool is_base_init = false;
+							StringHandle matched_base_name;
+							StringHandle init_name_handle = StringTable::getOrInternStringHandle(init_name);
+							if (struct_type_info.struct_info_) {
+								// Check if this is a base class by looking at the struct's base classes
+								for (const auto& base : struct_type_info.struct_info_->base_classes) {
+									std::string_view base_name = base.name;
+									bool base_names_match =
+										(base_name == init_name || extractBaseTemplateName(base_name) == init_name);
+									if (!base_names_match) {
+										if (const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
+											base_type_info && base_type_info->isTemplateInstantiation()) {
+											StringHandle qualified_base_template_name =
+												gNamespaceRegistry.buildQualifiedIdentifier(
+													base_type_info->sourceNamespace(),
+													base_type_info->baseTemplateName());
+											base_names_match =
+												StringTable::getStringView(qualified_base_template_name) == init_name;
+										}
+									}
+									if (base_names_match) {
+										is_base_init = true;
+										matched_base_name = StringTable::getOrInternStringHandle(base_name);
 										break;
 									}
 								}
+
+								if (!is_base_init && struct_type_info.struct_info_->has_deferred_base_classes) {
+									for (const auto& deferred_base_entry : struct_type_info.struct_info_->deferred_template_bases) {
+										if (deferred_base_entry.base_template_name == init_name_handle) {
+											is_base_init = true;
+											matched_base_name = deferred_base_entry.base_template_name;
+											break;
+										}
+									}
+								}
 							}
+
+							if (is_base_init) {
+								ctor.add_base_initializer(matched_base_name, std::move(substituted_args));
+							}
+
+							if (!is_base_init) {
+								auto make_initializer_list = [&](InitializerListNode::InitializationStyle style) -> ASTNode {
+									auto [init_list_node, init_list_ref] = create_node_ref(InitializerListNode(style));
+									for (const auto& arg : substituted_args) {
+										init_list_ref.add_initializer(arg);
+									}
+									return init_list_node;
+								};
+
+								// It's a member initializer
+								if (is_brace) {
+									ctor.add_member_initializer(init_name, make_initializer_list(InitializerListNode::InitializationStyle::Brace));
+								} else if (substituted_args.size() > 1) {
+									ctor.add_member_initializer(init_name, make_initializer_list(InitializerListNode::InitializationStyle::Paren));
+								} else if (!substituted_args.empty()) {
+									ctor.add_member_initializer(init_name, substituted_args[0]);
+								}
+							}
+
+							// Continue if there's a comma
+							if (peek() != ","_tok) {
+								break;
+							}
+							advance();  // consume ','
 						}
-						found_match = true;
-						break;
-					} catch (const std::exception& e) {
-						FLASH_LOG(Templates, Error, "Exception during template parameter substitution for out-of-line constructor ",
-								  decl.identifier_token().value(), ": ", e.what());
 					}
+				}
+
+				// Parse the function body (handles function-try-blocks too)
+				// Pass true for is_ctor_or_dtor so constructor function-try-blocks
+				// get the C++20 [except.handle]/15 implicit rethrow at catch handler ends.
+				auto body_result = parse_function_body(true /* is_ctor_or_dtor */);
+				member_function_context_stack_.pop_back();
+				gSymbolTable.exit_scope();
+				restore_lexer_position_only(saved_pos);
+
+				if (body_result.is_error() || !body_result.node().has_value()) {
+					FLASH_LOG(Templates, Error, "Failed to parse out-of-line constructor body for ",
+							  decl.identifier_token().value());
+					continue;
+				}
+
+				try {
+					ASTNode substituted_body = substituteTemplateParameters(
+						*body_result.node(),
+						out_of_line_member.template_params,
+						template_args_to_use);
+					ctor.set_definition(substituted_body);
+					// Also update the StructTypeInfo's copy (used by codegen)
+					if (struct_type_info.struct_info_) {
+						size_t info_ctor_match_count = 0;
+						ConstructorDeclarationNode* matched_info_ctor = nullptr;
+						for (auto& info_func : struct_type_info.struct_info_->member_functions) {
+							if (!info_func.is_constructor ||
+								!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+								continue;
+							}
+
+							auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+							if (info_ctor.is_materialized()) {
+								continue;
+							}
+							if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(info_ctor, ctor)) {
+								continue;
+							}
+							++info_ctor_match_count;
+							matched_info_ctor = &info_ctor;
+						}
+						if (info_ctor_match_count == 1 && matched_info_ctor != nullptr) {
+							matched_info_ctor->set_definition(substituted_body);
+						} else if (info_ctor_match_count > 1) {
+							std::string error_msg = std::string(StringBuilder()
+								.append("Ambiguous StructTypeInfo constructor sync for out-of-line constructor '")
+								.append(decl.identifier_token().value())
+								.append("' in instantiated class '")
+								.append(instantiated_name)
+								.append("'")
+								.commit());
+							if (force_eager) {
+								throw InternalError(error_msg);
+							}
+							FLASH_LOG(Templates, Error, error_msg);
+						}
+					}
+					found_match = true;
+				} catch (const std::exception& e) {
+					FLASH_LOG(Templates, Error, "Exception during template parameter substitution for out-of-line constructor ",
+							  decl.identifier_token().value(), ": ", e.what());
 				}
 			}
 		}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -318,7 +318,7 @@ static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 		}
 	}
 
-	std::vector<ConstructorDeclarationNode*> resolved_matches;
+	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -385,7 +385,7 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 		}
 	}
 
-	std::vector<ConstructorDeclarationNode*> resolved_matches;
+	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -1258,19 +1258,34 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 				out_of_line_template_params,
 				out_of_line_param->token().value()) != nullptr;
 
-		std::optional<TypeSpecifierNode> substituted_param;
+		std::optional<TypeSpecifierNode> substituted_instantiated_param;
+		if (!instantiated_is_template_param_placeholder) {
+			substituted_instantiated_param = substituteOutOfLineSignatureType(
+				parser,
+				*instantiated_param,
+				template_params,
+				template_args,
+				owner_type_name);
+		}
+
+		std::optional<TypeSpecifierNode> substituted_out_of_line_param;
 		if (!out_of_line_is_template_param_placeholder) {
-			substituted_param = substituteOutOfLineSignatureType(
+			substituted_out_of_line_param = substituteOutOfLineSignatureType(
 				parser,
 				*out_of_line_param,
 				template_params,
 				template_args,
 				owner_type_name);
 		}
-		if (substituted_param.has_value()) {
+		if (substituted_instantiated_param.has_value() ||
+			substituted_out_of_line_param.has_value()) {
 			if (!typeSpecifiersMatchForSignatureValidation(
-					*instantiated_param,
-					*substituted_param)) {
+					substituted_instantiated_param.has_value()
+						? *substituted_instantiated_param
+						: *instantiated_param,
+					substituted_out_of_line_param.has_value()
+						? *substituted_out_of_line_param
+						: *out_of_line_param)) {
 				return false;
 			}
 			continue;
@@ -9974,7 +9989,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					out_of_line_member.function_node.is<ConstructorDeclarationNode>()) {
 					const ConstructorDeclarationNode& out_of_line_ctor_decl =
 						out_of_line_member.function_node.as<ConstructorDeclarationNode>();
-					std::vector<ConstructorDeclarationNode*> resolved_ctor_matches;
+					InlineVector<ConstructorDeclarationNode*, 4> resolved_ctor_matches;
 					for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
 						if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 							continue;

--- a/tests/test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp
+++ b/tests/test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp
@@ -1,0 +1,46 @@
+// Regression: nested out-of-line constructor-template attachment must resolve
+// source constructor declarations first and replay through source-member identity
+// so same-name constructor-template overloads bind to the correct stub.
+template<class T>
+struct Outer {
+	struct Inner {
+		int which;
+
+		template<class U>
+		Inner(T*, U);
+
+		template<class U>
+		Inner(long*, U);
+	};
+};
+
+template<class T>
+template<class U>
+Outer<T>::Inner::Inner(T*, U)
+	: which(0) {
+	which = 2;
+}
+
+template<class T>
+template<class U>
+Outer<T>::Inner::Inner(long*, U)
+	: which(0) {
+	which = 1;
+}
+
+int main() {
+	int value = 0;
+	long long_value = 0;
+
+	Outer<int>::Inner from_t_ptr(&value, 0);
+	if (from_t_ptr.which != 2) {
+		return 1;
+	}
+
+	Outer<int>::Inner from_long_ptr(&long_value, 0);
+	if (from_long_ptr.which != 1) {
+		return 2;
+	}
+
+	return 0;
+}

--- a/tests/test_template_ool_ctor_same_name_overload_ret0.cpp
+++ b/tests/test_template_ool_ctor_same_name_overload_ret0.cpp
@@ -1,0 +1,53 @@
+// Regression: primary-template out-of-line constructor attachment must resolve
+// replay-first through source-member identity so same-name ctor overloads attach
+// to the right instantiated declaration/body.
+template<class T>
+struct CtorOverloadBox {
+	int which;
+	CtorOverloadBox(T*);
+	CtorOverloadBox(T**);
+	CtorOverloadBox(long*);
+};
+
+template<class T>
+CtorOverloadBox<T>::CtorOverloadBox(T*)
+	: which(0) {
+	which = 1;
+}
+
+template<class T>
+CtorOverloadBox<T>::CtorOverloadBox(T**)
+	: which(0) {
+	which = 2;
+}
+
+template<class T>
+CtorOverloadBox<T>::CtorOverloadBox(long*)
+	: which(0) {
+	which = 3;
+}
+
+int main() {
+	int value = 7;
+	int* ptr = &value;
+	int** ptr_ptr = &ptr;
+	long lvalue = 9;
+	long* long_ptr = &lvalue;
+
+	CtorOverloadBox<int> from_ptr(&value);
+	if (from_ptr.which != 1) {
+		return 1;
+	}
+
+	CtorOverloadBox<int> from_double_ptr(ptr_ptr);
+	if (from_double_ptr.which != 2) {
+		return 2;
+	}
+
+	CtorOverloadBox<int> from_long(long_ptr);
+	if (from_long.which != 3) {
+		return 3;
+	}
+
+	return 0;
+}

--- a/tests/test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
+++ b/tests/test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
@@ -1,0 +1,48 @@
+// Regression: partial-specialization out-of-line constructor-template attachment
+// must resolve source constructor declarations first and map source-member ->
+// instantiated-stub identity so same-name constructor-template overloads attach
+// to the correct instantiated declaration.
+template<class T>
+struct PartialCtorTemplateOverload;
+
+template<class T>
+struct PartialCtorTemplateOverload<T*> {
+	int which;
+
+	template<class U>
+	PartialCtorTemplateOverload(T*, U);
+
+	template<class U>
+	PartialCtorTemplateOverload(long*, U);
+};
+
+template<class T>
+template<class U>
+PartialCtorTemplateOverload<T*>::PartialCtorTemplateOverload(T*, U)
+	: which(0) {
+	which = 2;
+}
+
+template<class T>
+template<class U>
+PartialCtorTemplateOverload<T*>::PartialCtorTemplateOverload(long*, U)
+	: which(0) {
+	which = 1;
+}
+
+int main() {
+	int value = 0;
+	long long_value = 0;
+
+	PartialCtorTemplateOverload<int*> from_t_ptr(&value, 0);
+	if (from_t_ptr.which != 2) {
+		return 1;
+	}
+
+	PartialCtorTemplateOverload<int*> from_long_ptr(&long_value, 0);
+	if (from_long_ptr.which != 1) {
+		return 2;
+	}
+
+	return 0;
+}

--- a/tests/test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp
+++ b/tests/test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp
@@ -1,0 +1,45 @@
+// Regression: primary-template out-of-line constructor-template attachment must
+// resolve source constructor declarations first and replay source-member ->
+// instantiated-stub identity so same-name constructor-template overloads attach
+// to the correct instantiated declaration.
+template<class T>
+struct PrimaryCtorTemplateOverload {
+	int which;
+
+	template<class U>
+	PrimaryCtorTemplateOverload(T*, U);
+
+	template<class U>
+	PrimaryCtorTemplateOverload(long*, U);
+};
+
+template<class T>
+template<class U>
+PrimaryCtorTemplateOverload<T>::PrimaryCtorTemplateOverload(T*, U)
+	: which(0) {
+	which = 2;
+}
+
+template<class T>
+template<class U>
+PrimaryCtorTemplateOverload<T>::PrimaryCtorTemplateOverload(long*, U)
+	: which(0) {
+	which = 1;
+}
+
+int main() {
+	int value = 0;
+	long long_value = 0;
+
+	PrimaryCtorTemplateOverload<int> from_t_ptr(&value, 0);
+	if (from_t_ptr.which != 2) {
+		return 1;
+	}
+
+	PrimaryCtorTemplateOverload<int> from_long_ptr(&long_value, 0);
+	if (from_long_ptr.which != 1) {
+		return 2;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Continues the template-infrastructure refactor by moving remaining constructor replay attachment paths to replay-first source-member identity resolution, with overload-safe StructTypeInfo synchronization and focused regressions.