### PR TITLE
Fix nested struct template member overload scan (signature-based disambiguation)

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (primary-template nested OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
+**Last updated:** 2026-05-27 (nested-struct OOL template member overload scan replaced with signature-based disambiguation)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -118,9 +118,16 @@ Useful assumptions before changing this area:
   source-member→stub identity is now registered during partial-spec member
   instantiation and used for nested OOL attachment/disambiguation, with the
   old instantiated-member scan-first path removed for this slice.
+- **nested-struct template member OOL scan now uses signature-based
+  disambiguation for overloads**: the name+arity-only scan that previously
+  mis-attached OOL bodies when two template member functions shared a name and
+  inner-template-parameter count but differed in non-template parameter types
+  has been replaced with a `nestedOutOfLineMemberTemplateMatchesCandidate`-gated
+  match (using the `same_name_count > 1` strictness gate). The loop now also
+  breaks after the first successful attachment and logs an error on no-match.
 
 Latest recorded full-suite validation:
-`2501` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2553` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -143,6 +150,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
+- `test_template_nested_ool_member_template_overload_ret0.cpp`
 
 ## What is still wrong
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (primary-template nested OOL constructor-template attachment now resolves replay-first via source-member→stub identity with overload-safe StructTypeInfo sync)
+**Last updated:** 2026-05-27 (nested-struct OOL template member overload scan replaced with signature-based disambiguation)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -115,9 +115,16 @@ Future work can rely on these being in place:
   + declaration-location identities)**: same-name overload disambiguation now
   validates substituted signatures on identity-resolved stubs, and this slice
   no longer relies on instantiated-member scan-first matching.
+- **nested-struct template member OOL scan now uses signature-based
+  disambiguation for overloads**: the prior name+arity-only scan mis-attached
+  OOL bodies when two template member functions in a nested struct shared a
+  name and inner-template-parameter count but differed in non-template parameter
+  types; replaced with a `nestedOutOfLineMemberTemplateMatchesCandidate`-gated
+  match (using the established `same_name_count > 1` strictness gate), with a
+  `break` after the first successful attachment and error logging on no-match.
 
 Latest recorded full-suite validation:
-`2501` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2553` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -140,6 +147,7 @@ Latest focused regressions added on the current branch:
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
+- `test_template_nested_ool_member_template_overload_ret0.cpp`
 
 ## Remaining work, in priority order
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -10178,7 +10178,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Pre-count same-name same-arity candidates without a body so that
 					// we can gate signature matching on overload ambiguity (mirrors the
 					// pattern used at the partial-spec and primary-template call sites).
-					std::vector<const StructMemberFunctionDecl*> same_name_candidates;
+					InlineVector<const StructMemberFunctionDecl*, 4> same_name_candidates;
 					for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
 						if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
 							continue;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -10168,21 +10168,93 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					continue;
 				}
 
-				for (auto& mem_func : nested_struct.member_functions()) {
-					if (!out_of_line_member.inner_template_params.empty() &&
-							   mem_func.function_declaration.is<TemplateFunctionDeclarationNode>() &&
-							   out_of_line_member.function_node.is<FunctionDeclarationNode>()) {
-						ASTNode nested_func_node = mem_func.function_declaration;
-						auto& nested_template_func = nested_func_node.as<TemplateFunctionDeclarationNode>();
-						auto* nested_func_decl = get_function_decl_node_mut(nested_func_node);
-						const auto& out_of_line_decl = out_of_line_member.function_node.as<FunctionDeclarationNode>().decl_node();
-						if (nested_func_decl != nullptr &&
-							!nested_func_decl->has_any_body_source() &&
-							nested_template_func.template_parameters().size() == out_of_line_member.inner_template_params.size() &&
-							nested_func_decl->decl_node().identifier_token().value() == out_of_line_decl.identifier_token().value()) {
-							nested_func_decl->set_template_body_position(out_of_line_member.body_start);
-							nested_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
+				if (!out_of_line_member.inner_template_params.empty() &&
+					out_of_line_member.function_node.is<FunctionDeclarationNode>()) {
+					const FunctionDeclarationNode& ool_func =
+						out_of_line_member.function_node.as<FunctionDeclarationNode>();
+					std::string_view ool_func_name =
+						ool_func.decl_node().identifier_token().value();
+
+					// Pre-count same-name same-arity candidates without a body so that
+					// we can gate signature matching on overload ambiguity (mirrors the
+					// pattern used at the partial-spec and primary-template call sites).
+					std::vector<const StructMemberFunctionDecl*> same_name_candidates;
+					for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
+						if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
+							continue;
 						}
+						const auto& nested_template_func =
+							mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
+						const FunctionDeclarationNode* nested_func_decl =
+							get_function_decl_node(mem_func.function_declaration);
+						if (nested_func_decl == nullptr) {
+							continue;
+						}
+						if (!nested_func_decl->has_any_body_source() &&
+							nested_template_func.template_parameters().size() ==
+								out_of_line_member.inner_template_params.size() &&
+							nested_func_decl->decl_node().identifier_token().value() == ool_func_name) {
+							same_name_candidates.push_back(&mem_func);
+						}
+					}
+
+					const size_t same_name_member_template_count = same_name_candidates.size();
+					FunctionDeclarationNode* matched_nested_func_decl = nullptr;
+					for (const StructMemberFunctionDecl* source_member : same_name_candidates) {
+						ASTNode* matched_stub = findSourceMemberStubByIdentity(
+							nested_source_member_identity_maps,
+							source_member->function_declaration);
+						if (matched_stub == nullptr ||
+							!matched_stub->is<TemplateFunctionDeclarationNode>()) {
+							continue;
+						}
+						if (same_name_member_template_count > 1) {
+							std::optional<bool> signature_match =
+								nestedOutOfLineMemberTemplateMatchesCandidate(
+									*this,
+									*matched_stub,
+									ool_func,
+									std::span<const TemplateParameterNode>(
+										template_params.data(),
+										template_params.size()),
+									std::span<const TemplateTypeArg>(
+										template_args_to_use.data(),
+										template_args_to_use.size()),
+									qualified_name,
+									std::span<const TemplateParameterNode>(
+										out_of_line_member.inner_template_params.data(),
+										out_of_line_member.inner_template_params.size()));
+							if (!signature_match.has_value() || !*signature_match) {
+								continue;
+							}
+						}
+						matched_nested_func_decl = get_function_decl_node_mut(*matched_stub);
+						if (matched_nested_func_decl == nullptr) {
+							continue;
+						}
+						break;
+					}
+
+					if (matched_nested_func_decl != nullptr) {
+						matched_nested_func_decl->set_template_body_position(out_of_line_member.body_start);
+						matched_nested_func_decl->set_definition_lookup_context(
+							out_of_line_member.definition_lookup_context);
+						FLASH_LOG(
+							Templates,
+							Debug,
+							"Set body position on nested struct template member: ",
+							ool_func_name);
+					} else {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Could not attach nested out-of-line member template '",
+							ool_func_name,
+							"' for nested struct '",
+							nested_struct.name().view(),
+							"' in instantiated class '",
+							StringTable::getStringView(qualified_name),
+							"'");
 					}
 				}
 			}

--- a/tests/test_template_nested_ool_member_template_overload_ret0.cpp
+++ b/tests/test_template_nested_ool_member_template_overload_ret0.cpp
@@ -1,0 +1,41 @@
+// Regression: nested struct template member function overloads with the same
+// name and same inner template parameter count but different non-template
+// parameter types must each bind to the correct OOL body.
+// Previously, the name+arity-only scan caused both overloads to receive the
+// first OOL body and the second OOL body was silently dropped.
+template<class T>
+struct Outer {
+	struct Inner {
+		template<class U>
+		int process(U, int);
+
+		template<class U>
+		int process(U, double);
+	};
+};
+
+template<class T>
+template<class U>
+int Outer<T>::Inner::process(U, int) {
+	return 10;
+}
+
+template<class T>
+template<class U>
+int Outer<T>::Inner::process(U, double) {
+	return 20;
+}
+
+int main() {
+	Outer<int>::Inner obj;
+
+	if (obj.process(0, 1) != 10) {
+		return 1;
+	}
+
+	if (obj.process(0, 1.0) != 20) {
+		return 2;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary

Fixes a correctness bug in the OOL template member function attachment scan for nested structs.

### Bug
In \Parser_Templates_Inst_ClassTemplate.cpp\, the scan that attaches out-of-line template member function bodies to nested struct source members matched only by name + inner template parameter count. When two template member functions had the same name and same template parameter count but different non-template parameter types (e.g., \	emplate<U> int process(U, int)\ vs \	emplate<U> int process(U, double)\), both source members got the first OOL body, and the second OOL body was silently dropped for all instantiations (source members are shared across instantiations).

### Fix
- Pre-count same-name-same-arity source template members
- When \same_name_count > 1\, require \
estedOutOfLineMemberTemplateMatchesCandidate\ to return \	rue\ (strict for overloads) — same pattern as existing call sites at lines 6720–6760 and 12200–12232
- Add missing \reak\ after successful body attachment (inconsistency with all similar sites)
- Add error logging (\FLASH_LOG(Templates, Error, ...)\) when no matching member is found
- Use \InlineVector<const StructMemberFunctionDecl*, 4>\ for \same_name_candidates\ to avoid heap allocation in typical case

### Test
Added \	ests/test_template_nested_ool_member_template_overload_ret0.cpp\: \Outer<T>::Inner\ with two \process\ overloads returning distinct values; verifies correct dispatch.

### Results
- 2553/2553 regular tests pass, 181/181 expected-fail tests pass
- Includes InlineVector optimization for small candidate sets (typical: 0-4 overloads)