### PR TITLE
Tighten ctor-template replay attachment matching

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (nested-struct OOL template member overload scan replaced with signature-based disambiguation)
+**Last updated:** 2026-05-25 (constructor-template replay attachment now prefers canonical substituted-signature evidence over shape fallback)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -74,6 +74,11 @@ Useful assumptions before changing this area:
   constructor-template stub attachment now resolves source constructor declarations
   through source-member→stub identity, with overload-safe `StructTypeInfo`
   synchronization by signature-equivalent matching.
+- **out-of-line constructor-template replay attachment no longer accepts
+  shape-based fallback in overload-sensitive matching**: constructor-template
+  attachment now requires canonical substituted-signature evidence for positive
+  matches, with only a narrow single-candidate unresolved compatibility path
+  retained when substitution cannot classify and no overload choice is required.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   keeping replay-first source-member signature matching and mangled identity
@@ -127,7 +132,7 @@ Useful assumptions before changing this area:
   breaks after the first successful attachment and logs an error on no-match.
 
 Latest recorded full-suite validation:
-`2553` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2554` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -149,6 +154,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -166,9 +172,10 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
-  - constructor-template attachment matching still allows shape-based fallback
-    when substituted signatures cannot be fully classified; this remains a
-    replay/attachment correctness risk in edge overload sets.
+  - constructor attachment/replay still has narrow unresolved-signature fallback
+    behavior when substitution returns `nullopt`; this should be removed by
+    capturing the missing replay metadata or converting unresolved attachment
+    into explicit diagnostics.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -194,9 +201,9 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
-   - Tighten constructor-template attachment matching to prefer substituted
-     canonical signatures and reduce shape-based fallback use in replay-first
-     attachment helpers.
+   - Remove remaining unresolved-signature fallback behavior in constructor
+     attachment helpers (including single-candidate `nullopt` acceptance), so
+     replay attachment either has canonical evidence or fails explicitly.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.
@@ -240,6 +247,10 @@ The following are complete enough to rely on:
   replay-first source-member→stub identity flow (including overload
   disambiguation), and `StructTypeInfo` constructor-template metadata sync in
   this path no longer relies on scan/name-only matching;
+- constructor-template replay-first attachment no longer admits shape-based
+  positive matches in overload-sensitive paths; canonical substituted-signature
+  evidence is now required, with only a narrow single-candidate unresolved
+  compatibility path retained;
 - nested-class out-of-line constructor-template attachment now also resolves
   source-member→stub identity first (including same-name overload handling), and
   nested `StructTypeInfo` constructor-template metadata sync in this path no

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (nested-struct OOL template member overload scan replaced with signature-based disambiguation)
+**Last updated:** 2026-05-25 (constructor-template replay attachment now prefers canonical substituted-signature evidence over shape fallback)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -71,6 +71,12 @@ Future work can rely on these being in place:
   same-name overloads)**: nested constructor-template targets are now attached
   through source-member identity with signature-equivalent `StructTypeInfo`
   synchronization.
+- **out-of-line constructor-template replay attachment no longer accepts
+  shape-based fallback in overload-sensitive matching**: constructor-template
+  attachment now requires canonical substituted-signature evidence for positive
+  matches, with only a narrow single-candidate unresolved compatibility path
+  retained when substitution cannot classify and overload disambiguation is not
+  needed.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   so replay-first source-member signature matching and mangled identity remain
@@ -124,7 +130,7 @@ Future work can rely on these being in place:
   `break` after the first successful attachment and error logging on no-match.
 
 Latest recorded full-suite validation:
-`2553` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2554` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -146,6 +152,7 @@ Latest focused regressions added on the current branch:
 - `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -163,9 +170,9 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity; then tighten constructor-template
-    signature matching to reduce shape-based fallback when substituted
-    signatures are unavailable.
+    not keyed by source-member identity; then remove remaining unresolved
+    single-candidate fallback acceptance in constructor attachment paths when
+    substituted-signature classification returns `nullopt`.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -196,9 +203,9 @@ Still open, but not the next best slice:
 
 1. remove remaining declaration replay scans in non-static template-member
    attachment paths, starting with constructor attachment/replay paths that
-   still recover targets from instantiated members instead of source members
-   (next: tighten constructor-template matching to canonical substituted-signature
-   matching where shape fallback is still used);
+   still recover targets from instantiated members instead of source members;
+   then remove remaining constructor replay fallback acceptance that relies on
+   unresolved (`nullopt`) substitution outcomes;
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
 2. update these docs with the next remaining replay-metadata gap.
@@ -212,8 +219,9 @@ Keep adding narrow regressions in these areas:
 - declaration/definition attachment where inner and outer template parameters
   interact;
 - remaining non-static declaration replay paths that still fall back to
-  partially substituted AST state, especially constructor-template attachment
-  paths that still require shape-based fallback disambiguation.
+  partially substituted AST state, especially constructor attachment paths that
+  still accept unresolved (`nullopt`) substitution outcomes in single-candidate
+  scenarios.
 
 ## Exit criteria
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -387,7 +387,6 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
 	ConstructorDeclarationNode* unknown_single_candidate = nullptr;
-	bool unknown_single_candidate_conflict = false;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -429,17 +428,13 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 
 		if (!matches_candidate) {
 			if (!substituted_signature_match.has_value() &&
-				source_ctor_count <= 1 &&
+				source_ctor_count == 1 &&
 				inst_ctor_decl->template_parameters().size() ==
 					out_of_line_inner_template_params.size()) {
 				// Compatibility-only fallback: when there is exactly one source
 				// constructor declaration and substitution cannot classify it,
 				// keep replay attachment behavior explicit and narrow.
-				if (unknown_single_candidate == nullptr) {
-					unknown_single_candidate = inst_ctor_decl;
-				} else if (unknown_single_candidate != inst_ctor_decl) {
-					unknown_single_candidate_conflict = true;
-				}
+				unknown_single_candidate = inst_ctor_decl;
 			}
 			continue;
 		}
@@ -453,8 +448,7 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 		return resolution;
 	}
 	if (resolved_matches.empty() &&
-		unknown_single_candidate != nullptr &&
-		!unknown_single_candidate_conflict) {
+		unknown_single_candidate != nullptr) {
 		resolution.ctor = unknown_single_candidate;
 		return resolution;
 	}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1061,40 +1061,6 @@ static bool dependentTemplatePlaceholderNamesMatch(
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params);
 
-static bool constructorDeclarationsHaveMatchingParameterShape(
-	const ConstructorDeclarationNode& ctor_decl,
-	const FunctionDeclarationNode& out_of_line_stub,
-	std::span<const TemplateParameterNode> instantiated_template_params = {},
-	std::span<const TemplateParameterNode> out_of_line_template_params = {}) {
-	if (ctor_decl.parameter_nodes().size() != out_of_line_stub.parameter_nodes().size()) {
-		return false;
-	}
-
-	for (size_t i = 0; i < ctor_decl.parameter_nodes().size(); ++i) {
-		const TypeSpecifierNode* ctor_param = getDeclarationParamTypeNode(ctor_decl.parameter_nodes()[i]);
-		const TypeSpecifierNode* stub_param = getDeclarationParamTypeNode(out_of_line_stub.parameter_nodes()[i]);
-		if (!ctor_param || !stub_param) {
-			return false;
-		}
-		if (ctor_param->type() != stub_param->type() ||
-			ctor_param->pointer_depth() != stub_param->pointer_depth() ||
-			ctor_param->reference_qualifier() != stub_param->reference_qualifier() ||
-			ctor_param->cv_qualifier() != stub_param->cv_qualifier()) {
-			return false;
-		}
-		if (ctor_param->type_index() != stub_param->type_index() &&
-			!dependentTemplatePlaceholderNamesMatch(
-				ctor_param->token().value(),
-				stub_param->token().value(),
-				instantiated_template_params,
-				out_of_line_template_params)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 static bool functionDeclarationsHaveMatchingParameterShape(
 	const FunctionDeclarationNode& instantiated_decl,
 	const FunctionDeclarationNode& out_of_line_decl,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -113,7 +113,7 @@ static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param
 static bool typeSpecifiersMatchForSignatureValidation(
 	const TypeSpecifierNode& lhs,
 	const TypeSpecifierNode& rhs);
-static bool outOfLineConstructorTemplateMatchesCandidate(
+static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
 	Parser& parser,
 	const ConstructorDeclarationNode& candidate,
 	const FunctionDeclarationNode& out_of_line_decl,
@@ -386,6 +386,8 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	}
 
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
+	ConstructorDeclarationNode* unknown_single_candidate = nullptr;
+	bool unknown_single_candidate_conflict = false;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -410,7 +412,8 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 			continue;
 		}
 
-		bool matches_candidate = outOfLineConstructorTemplateMatchesCandidate(
+		std::optional<bool> substituted_signature_match =
+			outOfLineConstructorTemplateMatchesCandidate(
 			parser,
 			*inst_ctor_decl,
 			out_of_line_decl,
@@ -421,44 +424,23 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 				inst_ctor_decl->template_parameters().data(),
 				inst_ctor_decl->template_parameters().size()),
 			out_of_line_inner_template_params);
-		if (!matches_candidate && inst_ctor_decl->template_parameters().empty()) {
-			std::optional<bool> signature_match =
-				declarationsMatchAfterTemplateSubstitution(
-					parser,
-					*inst_ctor_decl,
-					out_of_line_decl,
-					outer_template_params,
-					outer_template_args,
-					owner_type_name,
-					std::span<const TemplateParameterNode>{},
-					out_of_line_inner_template_params);
-			if (signature_match.has_value()) {
-				matches_candidate = *signature_match;
-			} else if (source_ctor_count <= 1) {
-				matches_candidate = true;
-			} else if (inst_ctor_decl->parameter_nodes().size() ==
-					   out_of_line_decl.parameter_nodes().size()) {
-				matches_candidate = true;
-				for (size_t param_index = 0;
-					 param_index < inst_ctor_decl->parameter_nodes().size();
-					 ++param_index) {
-					const TypeSpecifierNode* candidate_param_type =
-						getDeclarationParamTypeNode(inst_ctor_decl->parameter_nodes()[param_index]);
-					const TypeSpecifierNode* out_of_line_param_type =
-						getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[param_index]);
-					if (candidate_param_type == nullptr ||
-						out_of_line_param_type == nullptr ||
-						!typeSpecifiersMatchForSignatureValidation(
-							*candidate_param_type,
-							*out_of_line_param_type)) {
-						matches_candidate = false;
-						break;
-					}
-				}
-			}
-		}
+		bool matches_candidate =
+			substituted_signature_match.has_value() && *substituted_signature_match;
 
 		if (!matches_candidate) {
+			if (!substituted_signature_match.has_value() &&
+				source_ctor_count <= 1 &&
+				inst_ctor_decl->template_parameters().size() ==
+					out_of_line_inner_template_params.size()) {
+				// Compatibility-only fallback: when there is exactly one source
+				// constructor declaration and substitution cannot classify it,
+				// keep replay attachment behavior explicit and narrow.
+				if (unknown_single_candidate == nullptr) {
+					unknown_single_candidate = inst_ctor_decl;
+				} else if (unknown_single_candidate != inst_ctor_decl) {
+					unknown_single_candidate_conflict = true;
+				}
+			}
 			continue;
 		}
 
@@ -468,6 +450,12 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	OutOfLineConstructorStubResolution resolution;
 	if (resolved_matches.size() == 1) {
 		resolution.ctor = resolved_matches.front();
+		return resolution;
+	}
+	if (resolved_matches.empty() &&
+		unknown_single_candidate != nullptr &&
+		!unknown_single_candidate_conflict) {
+		resolution.ctor = unknown_single_candidate;
 		return resolution;
 	}
 	if (resolved_matches.size() > 1) {
@@ -1441,7 +1429,7 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		});
 }
 
-static bool outOfLineConstructorTemplateMatchesCandidate(
+static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
 	Parser& parser,
 	const ConstructorDeclarationNode& candidate,
 	const FunctionDeclarationNode& out_of_line_decl,
@@ -1450,7 +1438,11 @@ static bool outOfLineConstructorTemplateMatchesCandidate(
 	StringHandle owner_type_name,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
-	return outOfLineTemplateMatchesCandidateWithFallback(
+	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
+		return false;
+	}
+
+	return declarationsMatchAfterTemplateSubstitution(
 		parser,
 		candidate,
 		out_of_line_decl,
@@ -1458,15 +1450,7 @@ static bool outOfLineConstructorTemplateMatchesCandidate(
 		outer_template_args,
 		owner_type_name,
 		candidate_inner_template_params,
-		out_of_line_inner_template_params,
-		[&](std::span<const TemplateParameterNode> instantiated_inner_template_params,
-			std::span<const TemplateParameterNode> definition_inner_template_params) {
-			return constructorDeclarationsHaveMatchingParameterShape(
-				candidate,
-				out_of_line_decl,
-				instantiated_inner_template_params,
-				definition_inner_template_params);
-		});
+		out_of_line_inner_template_params);
 }
 
 void Parser::copyDefinitionParameterIdentifiers(

--- a/tests/test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp
+++ b/tests/test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp
@@ -1,0 +1,40 @@
+// Regression: out-of-line constructor-template replay attachment must not
+// accept non-template constructor stubs by shape/signature fallback when
+// matching in same-name overload sets.
+template<class T>
+struct CtorTemplateDefaultArgReplay {
+	int which;
+
+	template<class U = void>
+	CtorTemplateDefaultArgReplay(T*);
+
+	CtorTemplateDefaultArgReplay(T*)
+		: which(22) {}
+
+	CtorTemplateDefaultArgReplay(long*)
+		: which(33) {}
+};
+
+template<class T>
+template<class U>
+CtorTemplateDefaultArgReplay<T>::CtorTemplateDefaultArgReplay(T*)
+	: which(0) {
+	which = 11;
+}
+
+int main() {
+	int value = 0;
+	long long_value = 0;
+
+	CtorTemplateDefaultArgReplay<int> instance(&value);
+	if (instance.which != 22) {
+		return 1;
+	}
+
+	CtorTemplateDefaultArgReplay<int> from_long_ptr(&long_value);
+	if (from_long_ptr.which != 33) {
+		return 2;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- tighten out-of-line constructor-template replay attachment to require canonical substituted-signature evidence in overload-sensitive matching
- remove shape-based acceptance fallback in constructor-template candidate resolution and keep only a narrow single-candidate unresolved compatibility path
- add focused regression coverage for same-name constructor overload interaction in constructor-template replay attachment
- update template refactor tracking docs with completed state and next-step focus
