### PR TITLE
Remove ctor replay nullopt fallback acceptance

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (constructor-template replay attachment now prefers canonical substituted-signature evidence over shape fallback)
+**Last updated:** 2026-05-25 (constructor replay attachment now requires canonical substituted-signature evidence; single-candidate `nullopt` fallback removed)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -74,11 +74,11 @@ Useful assumptions before changing this area:
   constructor-template stub attachment now resolves source constructor declarations
   through source-member→stub identity, with overload-safe `StructTypeInfo`
   synchronization by signature-equivalent matching.
-- **out-of-line constructor-template replay attachment no longer accepts
-  shape-based fallback in overload-sensitive matching**: constructor-template
-  attachment now requires canonical substituted-signature evidence for positive
-  matches, with only a narrow single-candidate unresolved compatibility path
-  retained when substitution cannot classify and no overload choice is required.
+- **out-of-line constructor replay attachment now requires canonical
+  substituted-signature evidence across both plain and constructor-template
+  helper paths**: single-candidate unresolved (`nullopt`) acceptance has been
+  removed; no-match cases now surface explicit replay-attachment diagnostics
+  instead of silent fallback attachment.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   keeping replay-first source-member signature matching and mangled identity
@@ -132,7 +132,7 @@ Useful assumptions before changing this area:
   breaks after the first successful attachment and logs an error on no-match.
 
 Latest recorded full-suite validation:
-`2554` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2554` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -155,6 +155,8 @@ Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
+- `test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp`
+- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -172,10 +174,10 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
-  - constructor attachment/replay still has narrow unresolved-signature fallback
-    behavior when substitution returns `nullopt`; this should be removed by
-    capturing the missing replay metadata or converting unresolved attachment
-    into explicit diagnostics.
+  - remaining constructor and non-constructor replay paths still produce
+    unresolved substitution outcomes (`nullopt`) because required replay-visible
+    metadata is not always captured early enough; these need metadata completion
+    so canonical matching succeeds more often without broad fallback machinery.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -201,9 +203,10 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
-   - Remove remaining unresolved-signature fallback behavior in constructor
-     attachment helpers (including single-candidate `nullopt` acceptance), so
-     replay attachment either has canonical evidence or fails explicitly.
+   - Remove remaining declaration replay scans that still recover targets from
+     partially substituted instantiated members instead of source-member identity.
+   - Improve replay metadata capture in unresolved substitution (`nullopt`) paths
+     so canonical substituted-signature matching classifies more valid code.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.
@@ -247,10 +250,10 @@ The following are complete enough to rely on:
   replay-first source-member→stub identity flow (including overload
   disambiguation), and `StructTypeInfo` constructor-template metadata sync in
   this path no longer relies on scan/name-only matching;
-- constructor-template replay-first attachment no longer admits shape-based
-  positive matches in overload-sensitive paths; canonical substituted-signature
-  evidence is now required, with only a narrow single-candidate unresolved
-  compatibility path retained;
+- constructor replay-first attachment no longer admits unresolved
+  single-candidate fallback acceptance in plain or constructor-template helper
+  paths; canonical substituted-signature evidence is now required for positive
+  attachment, and no-match surfaces explicit diagnostics;
 - nested-class out-of-line constructor-template attachment now also resolves
   source-member→stub identity first (including same-name overload handling), and
   nested `StructTypeInfo` constructor-template metadata sync in this path no

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (constructor-template replay attachment now prefers canonical substituted-signature evidence over shape fallback)
+**Last updated:** 2026-05-25 (constructor replay attachment now requires canonical substituted-signature evidence; single-candidate `nullopt` fallback removed)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -71,12 +71,11 @@ Future work can rely on these being in place:
   same-name overloads)**: nested constructor-template targets are now attached
   through source-member identity with signature-equivalent `StructTypeInfo`
   synchronization.
-- **out-of-line constructor-template replay attachment no longer accepts
-  shape-based fallback in overload-sensitive matching**: constructor-template
-  attachment now requires canonical substituted-signature evidence for positive
-  matches, with only a narrow single-candidate unresolved compatibility path
-  retained when substitution cannot classify and overload disambiguation is not
-  needed.
+- **out-of-line constructor replay attachment now requires canonical
+  substituted-signature evidence across both plain and constructor-template
+  helper paths**: single-candidate unresolved (`nullopt`) acceptance has been
+  removed; no-match cases now surface explicit replay-attachment diagnostics
+  instead of silent fallback attachment.
 - **declaration-only member stub substitution now strips only top-level
   by-value cv qualifiers**: pointer/reference pointee cv metadata is preserved,
   so replay-first source-member signature matching and mangled identity remain
@@ -130,7 +129,7 @@ Future work can rely on these being in place:
   `break` after the first successful attachment and error logging on no-match.
 
 Latest recorded full-suite validation:
-`2554` regular tests compiled/linked/runtime-pass, `0` fail, `181` expected-fail tests.
+`2554` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -153,6 +152,8 @@ Latest focused regressions added on the current branch:
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
+- `test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp`
+- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -170,9 +171,9 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity; then remove remaining unresolved
-    single-candidate fallback acceptance in constructor attachment paths when
-    substituted-signature classification returns `nullopt`.
+    not keyed by source-member identity; then improve replay metadata capture
+    for unresolved substitution (`nullopt`) outcomes so canonical
+    substituted-signature classification can succeed in more valid cases.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -204,8 +205,9 @@ Still open, but not the next best slice:
 1. remove remaining declaration replay scans in non-static template-member
    attachment paths, starting with constructor attachment/replay paths that
    still recover targets from instantiated members instead of source members;
-   then remove remaining constructor replay fallback acceptance that relies on
-   unresolved (`nullopt`) substitution outcomes;
+   then improve replay metadata capture for unresolved (`nullopt`)
+   substituted-signature outcomes so attachment remains evidence-driven without
+   broad compatibility fallback;
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
 2. update these docs with the next remaining replay-metadata gap.
@@ -219,9 +221,9 @@ Keep adding narrow regressions in these areas:
 - declaration/definition attachment where inner and outer template parameters
   interact;
 - remaining non-static declaration replay paths that still fall back to
-  partially substituted AST state, especially constructor attachment paths that
-  still accept unresolved (`nullopt`) substitution outcomes in single-candidate
-  scenarios.
+  partially substituted AST state, especially paths that still produce unresolved
+  (`nullopt`) substituted-signature outcomes because replay metadata was not
+  captured early enough.
 
 ## Exit criteria
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -311,13 +311,6 @@ static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name) {
-	size_t source_ctor_count = 0;
-	for (const StructMemberFunctionDecl& source_member : source_members) {
-		if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
-			++source_ctor_count;
-		}
-	}
-
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
@@ -344,14 +337,8 @@ static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 				std::span<const TemplateParameterNode>{},
 				std::span<const TemplateParameterNode>{});
 
-		bool matches_candidate = false;
-		if (signature_match.has_value()) {
-			matches_candidate = *signature_match;
-		} else if (source_ctor_count <= 1) {
-			// Preserve prior non-overload behavior when substitution cannot fully
-			// classify a single constructor declaration.
-			matches_candidate = true;
-		}
+		const bool matches_candidate =
+			signature_match.has_value() && *signature_match;
 
 		if (matches_candidate) {
 			resolved_matches.push_back(inst_ctor_decl);
@@ -378,15 +365,7 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
-	size_t source_ctor_count = 0;
-	for (const StructMemberFunctionDecl& source_member : source_members) {
-		if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
-			++source_ctor_count;
-		}
-	}
-
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
-	ConstructorDeclarationNode* unknown_single_candidate = nullptr;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -427,15 +406,6 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 			substituted_signature_match.has_value() && *substituted_signature_match;
 
 		if (!matches_candidate) {
-			if (!substituted_signature_match.has_value() &&
-				source_ctor_count == 1 &&
-				inst_ctor_decl->template_parameters().size() ==
-					out_of_line_inner_template_params.size()) {
-				// Compatibility-only fallback: when there is exactly one source
-				// constructor declaration and substitution cannot classify it,
-				// keep replay attachment behavior explicit and narrow.
-				unknown_single_candidate = inst_ctor_decl;
-			}
 			continue;
 		}
 
@@ -445,11 +415,6 @@ static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	OutOfLineConstructorStubResolution resolution;
 	if (resolved_matches.size() == 1) {
 		resolution.ctor = resolved_matches.front();
-		return resolution;
-	}
-	if (resolved_matches.empty() &&
-		unknown_single_candidate != nullptr) {
-		resolution.ctor = unknown_single_candidate;
 		return resolution;
 	}
 	if (resolved_matches.size() > 1) {
@@ -12137,8 +12102,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (force_eager) {
 						throw InternalError(error_msg);
 					}
-					FLASH_LOG(Templates, Error, error_msg);
-					continue;
+					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
 
 				if (ctor_resolution.ctor == nullptr) {
@@ -12152,8 +12116,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (force_eager) {
 						throw InternalError(error_msg);
 					}
-					FLASH_LOG(Templates, Error, error_msg);
-					continue;
+					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
 
 				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
@@ -12381,8 +12344,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (force_eager) {
 					throw InternalError(ambiguity_msg);
 				}
-				FLASH_LOG(Templates, Error, ambiguity_msg);
-			} else if (ctor_resolution.ctor != nullptr) {
+				return failTemplateInstantiation(ambiguity_msg, nullptr, std::nullopt);
+			}
+			if (ctor_resolution.ctor == nullptr) {
+				std::string error_msg = std::string(StringBuilder()
+					.append("Could not attach out-of-line constructor stub '")
+					.append(decl.identifier_token().value())
+					.append("' for instantiated class '")
+					.append(instantiated_name)
+					.append("' via replay identity map")
+					.commit());
+				if (force_eager) {
+					throw InternalError(error_msg);
+				}
+				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
+			}
+
+			if (ctor_resolution.ctor != nullptr) {
 				ConstructorDeclarationNode& ctor = *ctor_resolution.ctor;
 				// Save current position
 				SaveHandle saved_pos = save_token_position();

--- a/tests/test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp
+++ b/tests/test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp
@@ -1,0 +1,26 @@
+// Expected-fail regression: out-of-line constructor-template replay attachment
+// no longer accepts unresolved-signature single-candidate fallback.
+
+struct NulloptCtorTemplateTag {
+	using type = int;
+};
+
+template <class T>
+struct CtorTemplateNulloptReplay {
+	int which = 0;
+
+	template <class U>
+	CtorTemplateNulloptReplay(U, typename T::type*)
+		: which(11) {}
+};
+
+template <class T>
+template <class U>
+CtorTemplateNulloptReplay<T>::CtorTemplateNulloptReplay(U, typename T::type*)
+	: which(99) {}
+
+int main() {
+	int value = 0;
+	CtorTemplateNulloptReplay<NulloptCtorTemplateTag> instance(0, &value);
+	return instance.which == 11 ? 0 : 1;
+}

--- a/tests/test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp
+++ b/tests/test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp
@@ -1,0 +1,26 @@
+// Expected-fail regression: primary-template plain out-of-line constructor replay
+// attachment no longer accepts unresolved-signature single-candidate fallback.
+
+struct NulloptCtorTag {
+	template <class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template <class T>
+struct PlainCtorNulloptReplay {
+	int which = 0;
+
+	PlainCtorNulloptReplay(typename T::template AddPtr<int>::type);
+};
+
+template <class T>
+PlainCtorNulloptReplay<T>::PlainCtorNulloptReplay(typename T::template AddPtr<int>::type)
+	: which(99) {}
+
+int main() {
+	int value = 0;
+	PlainCtorNulloptReplay<NulloptCtorTag> instance(&value);
+	return instance.which == 99 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- remove unresolved-signature (`nullopt`) single-candidate fallback acceptance from out-of-line constructor replay attachment helpers for both plain and constructor-template paths
- keep replay attachment evidence-driven by requiring canonical substituted-signature matches for positive constructor-stub attachment
- fail class-template instantiation explicitly on constructor replay attachment ambiguity/no-match in non-eager mode to avoid downstream invariant/internal-error cascades
- add focused expected-fail regressions:
  - `tests/test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp`
  - `tests/test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
- update template refactor audit/investigation docs with completed state and next highest-impact steps

## Validation
- `.\build_flashcpp.bat`
- `pwsh .\tests\run_all_tests.ps1 test_template_ool_ctor_same_name_overload_ret0.cpp test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
- `pwsh .\tests\run_all_tests.ps1`

## Notes
- I ran a dedicated review pass after implementation and addressed a high-severity issue by converting constructor replay no-match/ambiguity paths to explicit instantiation failure in non-eager mode, rather than allowing later internal-invariant failures.
