### PR TITLE
Remove nested ctor stub preselection scan

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (constructor replay attachment now requires canonical substituted-signature evidence; single-candidate `nullopt` fallback removed)
+**Last updated:** 2026-05-25 (nested constructor-template replay attachment now routes through replay-first identity helpers with canonical substituted-signature matching)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -130,9 +130,14 @@ Useful assumptions before changing this area:
   has been replaced with a `nestedOutOfLineMemberTemplateMatchesCandidate`-gated
   match (using the `same_name_count > 1` strictness gate). The loop now also
   breaks after the first successful attachment and logs an error on no-match.
+- **nested constructor-template OOL attachment path that previously used
+  local signature-scan-first matching now routes through the replay-first
+  `findOutOfLineConstructorTemplateStubByIdentity` helper** (constructor-node
+  and function-node definitions), so selection remains source-member-identity
+  centered and canonical-substitution based.
 
 Latest recorded full-suite validation:
-`2554` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
+`2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -157,6 +162,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
 - `test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp`
 - `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
+- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -174,6 +180,11 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
+  - nested constructor source-member preselection into
+    `nested_source_member_identity_maps` still uses signature-equivalence scan
+    against `nested_struct_info->member_functions`; this should be replaced with
+    source-member identity registration that does not depend on scan-first
+    constructor matching.
   - remaining constructor and non-constructor replay paths still produce
     unresolved substitution outcomes (`nullopt`) because required replay-visible
     metadata is not always captured early enough; these need metadata completion
@@ -205,6 +216,9 @@ they directly block items 1-2:
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
    - Remove remaining declaration replay scans that still recover targets from
      partially substituted instantiated members instead of source-member identity.
+   - Start with nested constructor source-member preselection into
+     `nested_source_member_identity_maps`, replacing signature-scan-first stub
+     selection with source-member identity registration.
    - Improve replay metadata capture in unresolved substitution (`nullopt`) paths
      so canonical substituted-signature matching classifies more valid code.
    - Keep function-parameter adjustment rules centralized in shared substitution

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor-template replay attachment now routes through replay-first identity helpers with canonical substituted-signature matching)
+**Last updated:** 2026-05-25 (nested constructor source-member preselection now uses direct source-member identity registration, removing signature-scan-first stub selection)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -135,6 +135,10 @@ Useful assumptions before changing this area:
   `findOutOfLineConstructorTemplateStubByIdentity` helper** (constructor-node
   and function-node definitions), so selection remains source-member-identity
   centered and canonical-substitution based.
+- **nested constructor source-member preselection in
+  `nested_source_member_identity_maps` no longer uses signature-equivalence
+  scan against `nested_struct_info->member_functions`**: registration now uses
+  direct source-member identity mapping for constructors and non-constructors.
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
@@ -180,11 +184,6 @@ The next highest-value remaining surface:
 
 - remaining declaration replay paths outside static-member initializers that
   still recover intent from partially substituted AST state.
-  - nested constructor source-member preselection into
-    `nested_source_member_identity_maps` still uses signature-equivalence scan
-    against `nested_struct_info->member_functions`; this should be replaced with
-    source-member identity registration that does not depend on scan-first
-    constructor matching.
   - remaining constructor and non-constructor replay paths still produce
     unresolved substitution outcomes (`nullopt`) because required replay-visible
     metadata is not always captured early enough; these need metadata completion
@@ -216,9 +215,9 @@ they directly block items 1-2:
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
    - Remove remaining declaration replay scans that still recover targets from
      partially substituted instantiated members instead of source-member identity.
-   - Start with nested constructor source-member preselection into
-     `nested_source_member_identity_maps`, replacing signature-scan-first stub
-     selection with source-member identity registration.
+   - Continue with remaining attachment/synchronization surfaces that still
+     depend on signature-only matching where source-member identity can be
+     preserved end-to-end.
    - Improve replay metadata capture in unresolved substitution (`nullopt`) paths
      so canonical substituted-signature matching classifies more valid code.
    - Keep function-parameter adjustment rules centralized in shared substitution

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (constructor replay attachment now requires canonical substituted-signature evidence; single-candidate `nullopt` fallback removed)
+**Last updated:** 2026-05-25 (nested constructor-template replay attachment now routes through replay-first identity helpers with canonical substituted-signature matching)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -127,9 +127,14 @@ Future work can rely on these being in place:
   types; replaced with a `nestedOutOfLineMemberTemplateMatchesCandidate`-gated
   match (using the established `same_name_count > 1` strictness gate), with a
   `break` after the first successful attachment and error logging on no-match.
+- **nested constructor-template OOL attachment path that previously used
+  local signature-scan-first matching now routes through the replay-first
+  `findOutOfLineConstructorTemplateStubByIdentity` helper** (constructor-node
+  and function-node definitions), so selection remains source-member-identity
+  centered and canonical-substitution based.
 
 Latest recorded full-suite validation:
-`2554` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
+`2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -154,6 +159,7 @@ Latest focused regressions added on the current branch:
 - `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
 - `test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_fail.cpp`
 - `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_fail.cpp`
+- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
 - `out_of_line_template_member_with_ctor_ret0.cpp`
 - `test_template_nested_ool_member_template_overload_ret0.cpp`
 
@@ -171,7 +177,10 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity; then improve replay metadata capture
+    not keyed by source-member identity (next: nested constructor stub
+    preselection in `nested_source_member_identity_maps` still uses
+    signature-scan-first matching against `nested_struct_info`); then improve
+    replay metadata capture
     for unresolved substitution (`nullopt`) outcomes so canonical
     substituted-signature classification can succeed in more valid cases.
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor-template replay attachment now routes through replay-first identity helpers with canonical substituted-signature matching)
+**Last updated:** 2026-05-25 (nested constructor source-member preselection now uses direct source-member identity registration, removing signature-scan-first stub selection)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -132,6 +132,10 @@ Future work can rely on these being in place:
   `findOutOfLineConstructorTemplateStubByIdentity` helper** (constructor-node
   and function-node definitions), so selection remains source-member-identity
   centered and canonical-substitution based.
+- **nested constructor source-member preselection in
+  `nested_source_member_identity_maps` no longer uses signature-equivalence
+  scan against `nested_struct_info->member_functions`**: registration now uses
+  direct source-member identity mapping for constructors and non-constructors.
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
@@ -177,10 +181,7 @@ Rule for this work:
   documented.
 - next slices:
   - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity (next: nested constructor stub
-    preselection in `nested_source_member_identity_maps` still uses
-    signature-scan-first matching against `nested_struct_info`); then improve
-    replay metadata capture
+    not keyed by source-member identity; then improve replay metadata capture
     for unresolved substitution (`nullopt`) outcomes so canonical
     substituted-signature classification can succeed in more valid cases.
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -99,11 +99,11 @@ struct SourceMemberIdentityMaps {
 	std::unordered_map<uint64_t, ASTNode> by_location;
 };
 
-template <typename InstantiatedDeclNode>
+template <typename InstantiatedDeclNode, typename OutOfLineDeclNode>
 static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	Parser& parser,
 	const InstantiatedDeclNode& instantiated_decl,
-	const FunctionDeclarationNode& out_of_line_decl,
+	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	StringHandle owner_type_name,
@@ -117,6 +117,15 @@ static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
 	Parser& parser,
 	const ConstructorDeclarationNode& candidate,
 	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> candidate_inner_template_params,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params);
+static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
+	Parser& parser,
+	const ConstructorDeclarationNode& candidate,
+	const ConstructorDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name,
@@ -356,11 +365,12 @@ static OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 	return resolution;
 }
 
+template <typename OutOfLineDeclNode>
 static OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubByIdentity(
 	Parser& parser,
 	SourceMemberIdentityMaps& identity_maps,
 	std::span<const StructMemberFunctionDecl> source_members,
-	const FunctionDeclarationNode& out_of_line_decl,
+	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name,
@@ -1198,11 +1208,11 @@ static bool dependentTemplatePlaceholderNamesMatch(
 		instantiated_param->is_variadic() == out_of_line_param->is_variadic();
 }
 
-template <typename InstantiatedDeclNode>
+template <typename InstantiatedDeclNode, typename OutOfLineDeclNode>
 static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	Parser& parser,
 	const InstantiatedDeclNode& instantiated_decl,
-	const FunctionDeclarationNode& out_of_line_decl,
+	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	StringHandle owner_type_name,
@@ -1358,6 +1368,30 @@ static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
 	Parser& parser,
 	const ConstructorDeclarationNode& candidate,
 	const FunctionDeclarationNode& out_of_line_decl,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name,
+	std::span<const TemplateParameterNode> candidate_inner_template_params,
+	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
+	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
+		return false;
+	}
+
+	return declarationsMatchAfterTemplateSubstitution(
+		parser,
+		candidate,
+		out_of_line_decl,
+		outer_template_params,
+		outer_template_args,
+		owner_type_name,
+		candidate_inner_template_params,
+		out_of_line_inner_template_params);
+}
+
+static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
+	Parser& parser,
+	const ConstructorDeclarationNode& candidate,
+	const ConstructorDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	StringHandle owner_type_name,
@@ -9947,41 +9981,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					out_of_line_member.function_node.is<ConstructorDeclarationNode>()) {
 					const ConstructorDeclarationNode& out_of_line_ctor_decl =
 						out_of_line_member.function_node.as<ConstructorDeclarationNode>();
-					InlineVector<ConstructorDeclarationNode*, 4> resolved_ctor_matches;
-					for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
-						if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
-							continue;
-						}
-						const ConstructorDeclarationNode& source_ctor_decl =
-							source_member.function_declaration.as<ConstructorDeclarationNode>();
-						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-								source_ctor_decl,
-								out_of_line_ctor_decl)) {
-							continue;
-						}
-						ASTNode* matched_stub = findSourceMemberStubByIdentity(
+					OutOfLineConstructorStubResolution ctor_resolution =
+						findOutOfLineConstructorTemplateStubByIdentity(
+							*this,
 							nested_source_member_identity_maps,
-							source_member.function_declaration);
-						if (matched_stub == nullptr ||
-							!matched_stub->is<ConstructorDeclarationNode>()) {
-							continue;
-						}
-						ConstructorDeclarationNode& matched_ctor =
-							matched_stub->as<ConstructorDeclarationNode>();
-						if (matched_ctor.has_template_body_position()) {
-							continue;
-						}
-						resolved_ctor_matches.push_back(&matched_ctor);
-					}
+							std::span<const StructMemberFunctionDecl>(
+								nested_source_member_functions.data(),
+								nested_source_member_functions.size()),
+							out_of_line_ctor_decl,
+							std::span<const TemplateParameterNode>(
+								template_params.data(),
+								template_params.size()),
+							std::span<const TemplateTypeArg>(
+								template_args_to_use.data(),
+								template_args_to_use.size()),
+							qualified_name,
+							std::span<const TemplateParameterNode>(
+								out_of_line_member.inner_template_params.data(),
+								out_of_line_member.inner_template_params.size()));
 
-					if (resolved_ctor_matches.size() == 1) {
-						ConstructorDeclarationNode& ctor_decl = *resolved_ctor_matches.front();
-						ctor_decl.set_template_body_position(out_of_line_member.body_start);
-						if (out_of_line_member.has_initializer_list) {
-							ctor_decl.set_template_initializer_list_position(
-								out_of_line_member.initializer_list_start);
-						}
-					} else if (resolved_ctor_matches.size() > 1) {
+					if (ctor_resolution.ambiguous) {
 						FLASH_LOG(
 							Templates,
 							Error,
@@ -9990,6 +10009,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							"' in instantiated class '",
 							StringTable::getStringView(qualified_name),
 							"'");
+					} else if (ctor_resolution.ctor != nullptr) {
+						ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
+						setOutOfLineConstructorTemplateReplayMetadata(
+							ctor_decl,
+							out_of_line_member);
+					} else {
+						FLASH_LOG(
+							Templates,
+							Error,
+							"Could not attach nested out-of-line constructor template '",
+							out_of_line_ctor_decl.name(),
+							"' for instantiated class '",
+							StringTable::getStringView(qualified_name),
+							"' via replay identity map");
 					}
 					continue;
 				}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -9944,36 +9944,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			SourceMemberIdentityMaps nested_source_member_identity_maps;
 			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
-				ASTNode instantiated_stub = source_member.function_declaration;
-				if (source_member.function_declaration.is<ConstructorDeclarationNode>()) {
-					const ConstructorDeclarationNode& source_ctor =
-						source_member.function_declaration.as<ConstructorDeclarationNode>();
-					size_t struct_info_ctor_match_count = 0;
-					ASTNode struct_info_ctor_stub;
-					for (const auto& info_func : nested_struct_info->member_functions) {
-						if (!info_func.is_constructor ||
-							!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-							continue;
-						}
-						const ConstructorDeclarationNode& info_ctor =
-							info_func.function_decl.as<ConstructorDeclarationNode>();
-						if (!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-								info_ctor,
-								source_ctor)) {
-							continue;
-						}
-						++struct_info_ctor_match_count;
-						struct_info_ctor_stub = info_func.function_decl;
-					}
-					if (struct_info_ctor_match_count == 1 &&
-						struct_info_ctor_stub.has_value()) {
-						instantiated_stub = struct_info_ctor_stub;
-					}
-				}
 				registerSourceMemberStubIdentity(
 					nested_source_member_identity_maps,
 					source_member.function_declaration,
-					instantiated_stub);
+					source_member.function_declaration);
 			}
 
 			for (const auto& out_of_line_member : nested_out_of_line_members) {

--- a/tests/test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp
+++ b/tests/test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp
@@ -1,0 +1,29 @@
+// Regression: nested out-of-line constructor templates in class templates must
+// attach replay metadata using canonical substituted signatures, even when the
+// inner template parameter names differ between declaration and definition.
+
+template <typename T>
+struct Outer {
+	struct Inner {
+		int left;
+		int right;
+
+		template <typename U>
+		Inner(U a, U b);
+
+		int total() const {
+			return left + right;
+		}
+	};
+};
+
+template <typename T>
+template <typename V>
+Outer<T>::Inner::Inner(V a, V b)
+	: left(static_cast<int>(a)),
+	  right(static_cast<int>(b)) {}
+
+int main() {
+	Outer<int>::Inner value(20, 22);
+	return value.total();
+}


### PR DESCRIPTION
## Summary
- remove nested constructor preselection scan in `nested_source_member_identity_maps` (`Parser_Templates_Inst_ClassTemplate.cpp`) that matched constructors by signature against `nested_struct_info->member_functions`
- register nested source members (including constructors) directly via source-member identity mapping, keeping replay attachment selection in replay-first helpers
- update template architecture and standard-conformance investigation docs with completed-state notes and adjusted next steps