### PR TITLE
Prefer identity-first constructor replay sync

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor source-member preselection now uses direct source-member identity registration, removing signature-scan-first stub selection)
+**Last updated:** 2026-05-25 (nested constructor preselection/sync now prefer source-member or direct node identity; dependent placeholder signature detection widened for replay matching)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -139,6 +139,14 @@ Useful assumptions before changing this area:
   `nested_source_member_identity_maps` no longer uses signature-equivalence
   scan against `nested_struct_info->member_functions`**: registration now uses
   direct source-member identity mapping for constructors and non-constructors.
+- **constructor synchronization into `StructTypeInfo` now first checks direct
+  constructor-node identity before signature-equivalence scan**, reducing
+  dependence on scan-only matching when replay attachment already resolved a
+  concrete constructor node.
+- **replay signature placeholder detection now uses
+  `typeSpecStillUsesDependentPlaceholder(...)`** (instead of only direct
+  `TypeInfo::isDependentPlaceholder()`), improving dependent signature
+  classification coverage in canonical replay matching.
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor source-member preselection now uses direct source-member identity registration, removing signature-scan-first stub selection)
+**Last updated:** 2026-05-25 (nested constructor preselection/sync now prefer source-member or direct node identity; dependent placeholder signature detection widened for replay matching)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -136,6 +136,14 @@ Future work can rely on these being in place:
   `nested_source_member_identity_maps` no longer uses signature-equivalence
   scan against `nested_struct_info->member_functions`**: registration now uses
   direct source-member identity mapping for constructors and non-constructors.
+- **constructor synchronization into `StructTypeInfo` now first checks direct
+  constructor-node identity before signature-equivalence scan**, reducing
+  dependence on scan-only matching when replay attachment already resolved a
+  concrete constructor node.
+- **replay signature placeholder detection now uses
+  `typeSpecStillUsesDependentPlaceholder(...)`** (instead of only direct
+  `TypeInfo::isDependentPlaceholder()`), improving dependent signature
+  classification coverage in canonical replay matching.
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -463,6 +463,23 @@ static OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
 	const ConstructorDeclarationNode& ctor_decl,
 	EligibleFn&& is_candidate_eligible) {
 	OutOfLineConstructorStubResolution resolution;
+
+	// Prefer direct node identity when the StructTypeInfo stores the same
+	// constructor node instance as the replay-attached declaration.
+	for (auto& info_func : struct_info.member_functions) {
+		if (!info_func.is_constructor ||
+			!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+			continue;
+		}
+		auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+		if (&info_ctor == &ctor_decl) {
+			if (is_candidate_eligible(info_ctor)) {
+				resolution.ctor = &info_ctor;
+			}
+			return resolution;
+		}
+	}
+
 	for (auto& info_func : struct_info.member_functions) {
 		if (!info_func.is_constructor ||
 			!info_func.function_decl.is<ConstructorDeclarationNode>()) {
@@ -1082,14 +1099,7 @@ static bool typeSpecifierLooksLikeDependentSignaturePlaceholder(
 	if (type_spec.type() == TypeCategory::Template) {
 		return true;
 	}
-	if (!type_spec.type_index().is_valid()) {
-		return false;
-	}
-	if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
-		type_info != nullptr && type_info->isDependentPlaceholder()) {
-		return true;
-	}
-	return false;
+	return typeSpecStillUsesDependentPlaceholder(type_spec);
 }
 
 static bool typeSpecifiersMatchForSignatureValidation(


### PR DESCRIPTION
## Summary
- prefer direct constructor-node identity when syncing replay-attached constructors into StructTypeInfo before falling back to signature-equivalence scanning
- route replay placeholder-signature detection through typeSpecStillUsesDependentPlaceholder(...) to improve dependent placeholder classification coverage
- update template-argument architecture and standard-conformance tracking docs with the completed slice and next steps
