### PR TITLE
Require canonical member-template replay matching

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor preselection/sync now prefer source-member or direct node identity; dependent placeholder signature detection widened for replay matching)
+**Last updated:** 2026-05-25 (non-constructor nested/member-template replay matching now requires canonical substituted-signature evidence; strict disambiguation pre-counts narrowed to relevant candidates)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -147,6 +147,12 @@ Useful assumptions before changing this area:
   `typeSpecStillUsesDependentPlaceholder(...)`** (instead of only direct
   `TypeInfo::isDependentPlaceholder()`), improving dependent signature
   classification coverage in canonical replay matching.
+- **non-constructor nested/member-template out-of-line replay disambiguation no
+  longer uses shape fallback when substituted-signature comparison returns
+  `nullopt`**: these paths now require canonical substituted-signature evidence
+  for positive attachment, and strict disambiguation pre-counts are narrowed to
+  relevant candidates (same name + inner template-parameter count + function
+  parameter count).
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
@@ -221,8 +227,9 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Remove the next remaining declaration replay scans outside static-member initializers**
-   - Remove remaining declaration replay scans that still recover targets from
-     partially substituted instantiated members instead of source-member identity.
+   - Continue with remaining declaration replay scans that still recover targets
+     from partially substituted instantiated members instead of source-member
+     identity.
    - Continue with remaining attachment/synchronization surfaces that still
      depend on signature-only matching where source-member identity can be
      preserved end-to-end.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-25 (nested constructor preselection/sync now prefer source-member or direct node identity; dependent placeholder signature detection widened for replay matching)
+**Last updated:** 2026-05-25 (non-constructor nested/member-template replay matching now requires canonical substituted-signature evidence; strict disambiguation pre-counts narrowed to relevant candidates)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -144,6 +144,12 @@ Future work can rely on these being in place:
   `typeSpecStillUsesDependentPlaceholder(...)`** (instead of only direct
   `TypeInfo::isDependentPlaceholder()`), improving dependent signature
   classification coverage in canonical replay matching.
+- **non-constructor nested/member-template out-of-line replay disambiguation no
+  longer uses shape fallback when substituted-signature comparison returns
+  `nullopt`**: these paths now require canonical substituted-signature evidence
+  for positive attachment, and strict disambiguation pre-counts are narrowed to
+  relevant candidates (same name + inner template-parameter count + function
+  parameter count).
 
 Latest recorded full-suite validation:
 `2557` regular tests compiled/linked/runtime-pass, `0` fail, `183` expected-fail tests.
@@ -188,9 +194,9 @@ Rule for this work:
 - do not add new AST-only repair paths unless they are strictly temporary and
   documented.
 - next slices:
-  - remove the remaining constructor/non-static declaration replay scans still
-    not keyed by source-member identity; then improve replay metadata capture
-    for unresolved substitution (`nullopt`) outcomes so canonical
+- continue removing remaining constructor/non-static declaration replay scans
+  still not keyed by source-member identity; then improve replay metadata
+  capture for unresolved substitution (`nullopt`) outcomes so canonical
     substituted-signature classification can succeed in more valid cases.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1047,44 +1047,6 @@ static bool dependentTemplatePlaceholderNamesMatch(
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params);
 
-static bool functionDeclarationsHaveMatchingParameterShape(
-	const FunctionDeclarationNode& instantiated_decl,
-	const FunctionDeclarationNode& out_of_line_decl,
-	std::span<const TemplateParameterNode> instantiated_template_params = {},
-	std::span<const TemplateParameterNode> out_of_line_template_params = {}) {
-	if (instantiated_decl.is_const_member_function() != out_of_line_decl.is_const_member_function() ||
-		instantiated_decl.is_volatile_member_function() != out_of_line_decl.is_volatile_member_function() ||
-		instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
-		return false;
-	}
-
-	for (size_t i = 0; i < instantiated_decl.parameter_nodes().size(); ++i) {
-		const TypeSpecifierNode* instantiated_param =
-			getDeclarationParamTypeNode(instantiated_decl.parameter_nodes()[i]);
-		const TypeSpecifierNode* out_of_line_param =
-			getDeclarationParamTypeNode(out_of_line_decl.parameter_nodes()[i]);
-		if (!instantiated_param || !out_of_line_param) {
-			return false;
-		}
-		if (instantiated_param->type() != out_of_line_param->type() ||
-			instantiated_param->pointer_depth() != out_of_line_param->pointer_depth() ||
-			instantiated_param->reference_qualifier() != out_of_line_param->reference_qualifier() ||
-			instantiated_param->cv_qualifier() != out_of_line_param->cv_qualifier()) {
-			return false;
-		}
-		if (instantiated_param->type_index() != out_of_line_param->type_index() &&
-			!dependentTemplatePlaceholderNamesMatch(
-				instantiated_param->token().value(),
-				out_of_line_param->token().value(),
-				instantiated_template_params,
-				out_of_line_template_params)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
 static bool isOutOfLineConstructorStubName(
 	std::string_view member_name,
 	std::string_view template_name,
@@ -1306,37 +1268,6 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	return true;
 }
 
-template <typename InstantiatedDeclNode, typename ShapeMatcherFn>
-static bool outOfLineTemplateMatchesCandidateWithFallback(
-	Parser& parser,
-	const InstantiatedDeclNode& candidate,
-	const FunctionDeclarationNode& out_of_line_decl,
-	std::span<const TemplateParameterNode> outer_template_params,
-	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
-	std::span<const TemplateParameterNode> candidate_inner_template_params,
-	std::span<const TemplateParameterNode> out_of_line_inner_template_params,
-	ShapeMatcherFn&& shape_matcher) {
-	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
-		return false;
-	}
-
-	std::optional<bool> substituted_signature_match = declarationsMatchAfterTemplateSubstitution(
-		parser,
-		candidate,
-		out_of_line_decl,
-		outer_template_params,
-		outer_template_args,
-		owner_type_name,
-		candidate_inner_template_params,
-		out_of_line_inner_template_params);
-	if (substituted_signature_match.has_value()) {
-		return *substituted_signature_match;
-	}
-
-	return shape_matcher(candidate_inner_template_params, out_of_line_inner_template_params);
-}
-
 static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 	Parser& parser,
 	const ASTNode& candidate_member,
@@ -1355,7 +1286,11 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		candidate_template.template_parameters().data(),
 		candidate_template.template_parameters().size());
 
-	return outOfLineTemplateMatchesCandidateWithFallback(
+	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
+		return false;
+	}
+
+	return declarationsMatchAfterTemplateSubstitution(
 		parser,
 		candidate_template.function_decl_node(),
 		out_of_line_decl,
@@ -1363,15 +1298,7 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		outer_template_args,
 		owner_type_name,
 		candidate_inner_template_params,
-		out_of_line_inner_template_params,
-		[&](std::span<const TemplateParameterNode> instantiated_inner_template_params,
-			std::span<const TemplateParameterNode> definition_inner_template_params) {
-			return functionDeclarationsHaveMatchingParameterShape(
-				candidate_template.function_decl_node(),
-				out_of_line_decl,
-				instantiated_inner_template_params,
-				definition_inner_template_params);
-		});
+		out_of_line_inner_template_params);
 }
 
 static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
@@ -6648,26 +6575,36 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Non-ctor OOL member function template in a partial specialization:
 					// replay-first attachment against source members, then source-member->stub
 					// identity resolution (mirrors the primary-template path).
-					std::vector<const StructMemberFunctionDecl*> same_name_source_member_templates;
+					std::vector<const StructMemberFunctionDecl*> relevant_source_member_templates;
+					const size_t ool_inner_template_param_count =
+						out_of_line_member.inner_template_params.size();
+					const size_t ool_function_param_count = ool_func.parameter_nodes().size();
 					for (const StructMemberFunctionDecl& source_member :
 						 pattern_struct.member_functions()) {
 						if (!source_member.function_declaration.is<TemplateFunctionDeclarationNode>()) {
 							continue;
 						}
+						const auto& source_template_func =
+							source_member.function_declaration.as<TemplateFunctionDeclarationNode>();
 						const FunctionDeclarationNode* source_func_decl =
 							get_function_decl_node(source_member.function_declaration);
 						if (source_func_decl == nullptr) {
 							continue;
 						}
-						if (source_func_decl->decl_node().identifier_token().value() == ool_func_name) {
-							same_name_source_member_templates.push_back(&source_member);
+						if (source_func_decl->decl_node().identifier_token().value() ==
+								ool_func_name &&
+							source_template_func.template_parameters().size() ==
+								ool_inner_template_param_count &&
+							source_func_decl->parameter_nodes().size() ==
+								ool_function_param_count) {
+							relevant_source_member_templates.push_back(&source_member);
 						}
 					}
-					const size_t same_name_member_template_count =
-						same_name_source_member_templates.size();
+					const size_t relevant_member_template_count =
+						relevant_source_member_templates.size();
 					FunctionDeclarationNode* inst_func_decl = nullptr;
 					for (const StructMemberFunctionDecl* source_member :
-						 same_name_source_member_templates) {
+						 relevant_source_member_templates) {
 						const FunctionDeclarationNode* source_func_decl =
 							get_function_decl_node(source_member->function_declaration);
 						if (source_func_decl == nullptr) {
@@ -6679,7 +6616,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (matched_stub == nullptr || !matched_stub->is<TemplateFunctionDeclarationNode>()) {
 							continue;
 						}
-						if (same_name_member_template_count > 1) {
+						if (relevant_member_template_count > 1) {
 							std::optional<bool> signature_match =
 								nestedOutOfLineMemberTemplateMatchesCandidate(
 									*this,
@@ -10105,6 +10042,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// we can gate signature matching on overload ambiguity (mirrors the
 					// pattern used at the partial-spec and primary-template call sites).
 					InlineVector<const StructMemberFunctionDecl*, 4> same_name_candidates;
+					const size_t ool_function_param_count = ool_func.parameter_nodes().size();
 					for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
 						if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
 							continue;
@@ -10119,12 +10057,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (!nested_func_decl->has_any_body_source() &&
 							nested_template_func.template_parameters().size() ==
 								out_of_line_member.inner_template_params.size() &&
+							nested_func_decl->parameter_nodes().size() ==
+								ool_function_param_count &&
 							nested_func_decl->decl_node().identifier_token().value() == ool_func_name) {
 							same_name_candidates.push_back(&mem_func);
 						}
 					}
 
-					const size_t same_name_member_template_count = same_name_candidates.size();
+					const size_t relevant_member_template_count = same_name_candidates.size();
 					FunctionDeclarationNode* matched_nested_func_decl = nullptr;
 					for (const StructMemberFunctionDecl* source_member : same_name_candidates) {
 						ASTNode* matched_stub = findSourceMemberStubByIdentity(
@@ -10134,7 +10074,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							!matched_stub->is<TemplateFunctionDeclarationNode>()) {
 							continue;
 						}
-						if (same_name_member_template_count > 1) {
+						if (relevant_member_template_count > 1) {
 							std::optional<bool> signature_match =
 								nestedOutOfLineMemberTemplateMatchesCandidate(
 									*this,
@@ -12078,15 +12018,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			FLASH_LOG(Templates, Debug, "Processing nested template out-of-line member: ", ool_func_name);
 
 			bool found = false;
-			size_t same_name_member_template_count = 0;
-			for (const auto& mem_func : instantiated_struct_ref.member_functions()) {
+			size_t relevant_member_template_count = 0;
+			const size_t ool_inner_template_param_count =
+				out_of_line_member.inner_template_params.size();
+			const size_t ool_function_param_count = ool_func.parameter_nodes().size();
+			for (const auto& mem_func : effective_member_functions) {
 				if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
 					continue;
 				}
-				const auto& candidate_func =
-					mem_func.function_declaration.as<TemplateFunctionDeclarationNode>().function_decl_node();
-				if (candidate_func.decl_node().identifier_token().value() == ool_func_name) {
-					++same_name_member_template_count;
+				const auto& candidate_template_func =
+					mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
+				const auto& candidate_func = candidate_template_func.function_decl_node();
+				if (candidate_func.decl_node().identifier_token().value() == ool_func_name &&
+					candidate_template_func.template_parameters().size() ==
+						ool_inner_template_param_count &&
+					candidate_func.parameter_nodes().size() == ool_function_param_count) {
+					++relevant_member_template_count;
 				}
 			}
 			if (out_of_line_ctor_stub) {
@@ -12184,12 +12131,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (!source_member.function_declaration.is<TemplateFunctionDeclarationNode>()) {
 					continue;
 				}
+				const auto& source_template_func =
+					source_member.function_declaration.as<TemplateFunctionDeclarationNode>();
 				const FunctionDeclarationNode* source_func_decl =
 					get_function_decl_node(source_member.function_declaration);
 				if (source_func_decl == nullptr) {
 					continue;
 				}
-				if (source_func_decl->decl_node().identifier_token().value() != ool_func_name) {
+				if (source_func_decl->decl_node().identifier_token().value() != ool_func_name ||
+					source_template_func.template_parameters().size() !=
+						ool_inner_template_param_count ||
+					source_func_decl->parameter_nodes().size() != ool_function_param_count) {
 					continue;
 				}
 				ASTNode* matched_stub = findSourceMemberStubByIdentity(
@@ -12201,7 +12153,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (!matched_stub->is<TemplateFunctionDeclarationNode>()) {
 					continue;
 				}
-				if (same_name_member_template_count > 1) {
+				if (relevant_member_template_count > 1) {
 					std::optional<bool> signature_match = nestedOutOfLineMemberTemplateMatchesCandidate(
 						*this,
 						*matched_stub,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1268,6 +1268,26 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	return true;
 }
 
+static bool isMatchingMemberTemplate(
+	const StructMemberFunctionDecl& member,
+	std::string_view ool_func_name,
+	size_t ool_inner_template_param_count,
+	size_t ool_function_param_count) {
+	if (!member.function_declaration.is<TemplateFunctionDeclarationNode>()) {
+		return false;
+	}
+	const auto& template_func =
+		member.function_declaration.as<TemplateFunctionDeclarationNode>();
+	const FunctionDeclarationNode* func_decl =
+		get_function_decl_node(member.function_declaration);
+	if (func_decl == nullptr) {
+		return false;
+	}
+	return func_decl->decl_node().identifier_token().value() == ool_func_name &&
+		template_func.template_parameters().size() == ool_inner_template_param_count &&
+		func_decl->parameter_nodes().size() == ool_function_param_count;
+}
+
 static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 	Parser& parser,
 	const ASTNode& candidate_member,
@@ -6581,22 +6601,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					const size_t ool_function_param_count = ool_func.parameter_nodes().size();
 					for (const StructMemberFunctionDecl& source_member :
 						 pattern_struct.member_functions()) {
-						if (!source_member.function_declaration.is<TemplateFunctionDeclarationNode>()) {
-							continue;
-						}
-						const auto& source_template_func =
-							source_member.function_declaration.as<TemplateFunctionDeclarationNode>();
-						const FunctionDeclarationNode* source_func_decl =
-							get_function_decl_node(source_member.function_declaration);
-						if (source_func_decl == nullptr) {
-							continue;
-						}
-						if (source_func_decl->decl_node().identifier_token().value() ==
-								ool_func_name &&
-							source_template_func.template_parameters().size() ==
-								ool_inner_template_param_count &&
-							source_func_decl->parameter_nodes().size() ==
-								ool_function_param_count) {
+						if (isMatchingMemberTemplate(
+								source_member,
+								ool_func_name,
+								ool_inner_template_param_count,
+								ool_function_param_count)) {
 							relevant_source_member_templates.push_back(&source_member);
 						}
 					}
@@ -10042,24 +10051,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// we can gate signature matching on overload ambiguity (mirrors the
 					// pattern used at the partial-spec and primary-template call sites).
 					InlineVector<const StructMemberFunctionDecl*, 4> same_name_candidates;
+					const size_t ool_inner_template_param_count =
+						out_of_line_member.inner_template_params.size();
 					const size_t ool_function_param_count = ool_func.parameter_nodes().size();
 					for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
-						if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
-							continue;
-						}
-						const auto& nested_template_func =
-							mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
 						const FunctionDeclarationNode* nested_func_decl =
 							get_function_decl_node(mem_func.function_declaration);
 						if (nested_func_decl == nullptr) {
 							continue;
 						}
 						if (!nested_func_decl->has_any_body_source() &&
-							nested_template_func.template_parameters().size() ==
-								out_of_line_member.inner_template_params.size() &&
-							nested_func_decl->parameter_nodes().size() ==
-								ool_function_param_count &&
-							nested_func_decl->decl_node().identifier_token().value() == ool_func_name) {
+							isMatchingMemberTemplate(
+								mem_func,
+								ool_func_name,
+								ool_inner_template_param_count,
+								ool_function_param_count)) {
 							same_name_candidates.push_back(&mem_func);
 						}
 					}
@@ -12023,16 +12029,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				out_of_line_member.inner_template_params.size();
 			const size_t ool_function_param_count = ool_func.parameter_nodes().size();
 			for (const auto& mem_func : effective_member_functions) {
-				if (!mem_func.function_declaration.is<TemplateFunctionDeclarationNode>()) {
-					continue;
-				}
-				const auto& candidate_template_func =
-					mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
-				const auto& candidate_func = candidate_template_func.function_decl_node();
-				if (candidate_func.decl_node().identifier_token().value() == ool_func_name &&
-					candidate_template_func.template_parameters().size() ==
-						ool_inner_template_param_count &&
-					candidate_func.parameter_nodes().size() == ool_function_param_count) {
+				if (isMatchingMemberTemplate(
+						mem_func,
+						ool_func_name,
+						ool_inner_template_param_count,
+						ool_function_param_count)) {
 					++relevant_member_template_count;
 				}
 			}
@@ -12128,20 +12129,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// resolve to instantiated stubs via source_member_to_stub identity mapping.
 			FunctionDeclarationNode* inst_func_decl = nullptr;
 			for (const auto& source_member : effective_member_functions) {
-				if (!source_member.function_declaration.is<TemplateFunctionDeclarationNode>()) {
-					continue;
-				}
-				const auto& source_template_func =
-					source_member.function_declaration.as<TemplateFunctionDeclarationNode>();
-				const FunctionDeclarationNode* source_func_decl =
-					get_function_decl_node(source_member.function_declaration);
-				if (source_func_decl == nullptr) {
-					continue;
-				}
-				if (source_func_decl->decl_node().identifier_token().value() != ool_func_name ||
-					source_template_func.template_parameters().size() !=
-						ool_inner_template_param_count ||
-					source_func_decl->parameter_nodes().size() != ool_function_param_count) {
+				if (!isMatchingMemberTemplate(
+						source_member,
+						ool_func_name,
+						ool_inner_template_param_count,
+						ool_function_param_count)) {
 					continue;
 				}
 				ASTNode* matched_stub = findSourceMemberStubByIdentity(


### PR DESCRIPTION
## Summary
- remove non-constructor nested/member-template out-of-line replay nullopt-to-shape fallback and require canonical substituted-signature evidence for attachment
- narrow strict disambiguation pre-counts to relevant candidates (same name + inner template-parameter count + function parameter count) across primary, partial-spec, and nested call sites
- update template-argument architecture and standard-conformance docs with the completed slice and next steps
