### PR TITLE
[codex] Fix Windows limits regressions

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -4,28 +4,21 @@ This file records confirmed bugs and quality-of-implementation (QoI) deficiencie
 FlashCpp C++20 compiler. Each entry includes the root cause, the affected code path, and
 (where applicable) a recommended fix.
 
-## 1) MSVC `<limits>` now stops later on `numeric_limits` constexpr member initialization
+---
 
-- **Symptom**: On Windows/MSVC STL, `tests/std/test_std_limits.cpp` now gets past
-  the UCRT `__crt_va_start` wrappers but stops later with
-  `Fatal error: static constexpr member initializer for 'std::_Num_float_base::has_denorm' is not a constant expression: initializer is unresolved`.
-- **Current frontier**: `limits` around the `_Num_base` / `_Num_float_base`
-  `static constexpr float_denorm_style has_denorm = denorm_absent/present;`
-  members.
-- **Root cause**: Not reduced yet. The parser and preprocessor now survive the
-  previous `corecrt_wstdio.h` barrier, so the remaining blocker appears to be
-  constexpr/sema handling for enum-valued `static constexpr` data members in the
-  MSVC STL numeric-limits hierarchy.
-- **Impact**: Windows/MSVC `<limits>` analysis is no longer "time to first UCRT
-  parse failure", but the header still does not complete semantic analysis.
+## 1) `std::_Optional_payload` / `std::_Tuple_impl` — type size 0 in IR codegen (OPEN)
+
+- **Symptom**: `IR conversion failed for node 'move': Type with no runtime size reached
+  codegen in reference identifier lvalue lowering (type=28, ...)` when compiling
+  `<optional>` and `<tuple>`.
+- **Root cause**: `type=28` is a struct/class type whose size was not computed before
+  codegen. The payload/impl types are recursive union variants whose sizeof is not
+  resolved during template instantiation.
+- **Impact**: `test_std_optional`, `test_std_tuple` fail.
 
 ---
 
-## 2) `tests/std/test_std_ratio.cpp` — link-time `__security_cookie` conflict (OPEN)
-
-**Remaining blockers** (non-crashing, but prevent `.o` output):
-
-### 2a) Standard-library template-instantiation noise during `<ratio>` compile
+## 2) Standard-library template-instantiation noise during `<ratio>` compile
 
 - **Symptom**: compiling `tests/std/test_std_ratio.cpp` now emits
   `[ERROR][Templates] [depth=1]: All 2 template overload(s) failed for 'swap'`,
@@ -40,26 +33,22 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-### 2b) Link-time `__security_cookie` multiple-definition conflict
+## 3) Windows/MSVC standard-header link step emits duplicate CRT/runtime symbols (OPEN)
 
-- **Symptom**: `tests/std/test_std_ratio.cpp` now compiles successfully but
-  fails to link with `LIBCMT.lib(gs_cookie.obj) : error LNK2005:
-  __security_cookie already defined`.
-- **Root cause**: Still under investigation. After fixing the imported-CRT
-  naming issue (preserving `extern "C"` over `_ACRTIMP`/`dllimport` in parser
-  linkage precedence), the next remaining blocker is that FlashCpp's output now
-  collides with the CRT-provided GS cookie symbol.
-- **Affected path**: Link stage for the object generated from `<ratio>` and the
-  headers it pulls in.
-- **Impact**: `tests/std/test_std_ratio.cpp` still does not produce a runnable
-  executable, even though it now compiles.
-- **Fix direction**: Audit where FlashCpp synthesizes or exports the GS cookie
-  runtime state and make it coexist with the CRT-provided definition instead of
-  emitting a second strong symbol.
+- **Symptom**: after the `<limits>` compile-stage fix, manually linking the object
+  produced from `tests/std/test_std_limits.cpp` can fail with multiple-definition
+  errors such as `__security_cookie`, `__local_stdio_printf_options`,
+  `__local_stdio_scanf_options`, `vsnprintf`, `_vsprintf_s_l`, `sprintf_s`, and
+  `snprintf`.
+- **Root cause**: still under investigation. FlashCpp's generated object appears
+  to emit CRT/runtime definitions that should remain owned by the MSVC CRT when
+  standard headers pull in the corresponding declarations and wrappers.
+- **Impact**: some Windows/MSVC standard-header tests now compile through object
+  generation but still do not link cleanly outside the main regression suite.
 
 ---
 
-## 5) OOL member-function-template dependent member-template pointer parameter dereference (OPEN)
+## 4) OOL member-function-template dependent member-template pointer parameter dereference (OPEN)
 
 - **Symptom**: A reduced out-of-line member-function-template body using
   `typename T::template AddPtr<int>::type` as a parameter can still crash at

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1075,6 +1075,93 @@ private:
 																  const TypeSpecifierNode& param_type,
 																  const CallArgReferenceBindingInfo* binding_info,
 																  const Token& source_token);
+	const FunctionDeclarationNode* findCurrentStructStaticMemberFunction(StringHandle member_name) const {
+		if (!current_struct_name_.isValid()) {
+			return nullptr;
+		}
+
+		auto current_struct_it = getTypesByNameMap().find(current_struct_name_);
+		if (current_struct_it == getTypesByNameMap().end() ||
+			!current_struct_it->second ||
+			!current_struct_it->second->isStruct()) {
+			return nullptr;
+		}
+
+		const StructTypeInfo* current_struct_info = current_struct_it->second->getStructInfo();
+		if (!current_struct_info) {
+			return nullptr;
+		}
+
+		const auto member_function_result =
+			current_struct_info->findMemberFunctionRecursive(member_name);
+		const StructMemberFunction* member_function = member_function_result.first;
+		if (!member_function || !member_function->function_decl.is<FunctionDeclarationNode>()) {
+			return nullptr;
+		}
+
+		const auto& function_decl = member_function->function_decl.as<FunctionDeclarationNode>();
+		return function_decl.is_static() ? &function_decl : nullptr;
+	}
+
+	std::optional<TypeSpecifierNode> tryBuildCurrentStructStaticMemberFunctionPointerType(
+		StringHandle member_name) const {
+		const FunctionDeclarationNode* function_decl =
+			findCurrentStructStaticMemberFunction(member_name);
+		if (!function_decl) {
+			return std::nullopt;
+		}
+
+		FunctionSignature signature;
+		const TypeSpecifierNode& return_type = function_decl->decl_node().type_specifier_node();
+		signature.return_type_index = return_type.type_index();
+		signature.return_pointer_depth = static_cast<int>(return_type.pointer_depth());
+		signature.return_reference_qualifier = return_type.reference_qualifier();
+		for (const auto& param_node : function_decl->parameter_nodes()) {
+			if (!param_node.is<DeclarationNode>()) {
+				continue;
+			}
+			const auto& param_type =
+				param_node.as<DeclarationNode>().type_specifier_node();
+			signature.parameter_type_indices.push_back(param_type.type_index());
+		}
+
+		TypeSpecifierNode function_pointer_type(
+			TypeCategory::FunctionPointer,
+			TypeQualifier::None,
+			64,
+			function_decl->decl_node().identifier_token(),
+			CVQualifier::None);
+		function_pointer_type.set_function_signature(signature);
+		return function_pointer_type;
+	}
+
+	std::optional<ExprResult> tryEmitCurrentStructStaticMemberFunctionAddress(
+		StringHandle member_name,
+		const Token& token) {
+		const FunctionDeclarationNode* function_decl =
+			findCurrentStructStaticMemberFunction(member_name);
+		if (!function_decl) {
+			return std::nullopt;
+		}
+
+		std::string_view mangled = generateMangledNameForCall(*function_decl, StringHandle{}, {});
+		TempVar func_addr_var = var_counter.next();
+		FunctionAddressOp op;
+		op.result.setType(TypeCategory::FunctionPointer);
+		op.result.ir_type = IrType::FunctionPointer;
+		op.result.size_in_bits = SizeInBits{64};
+		op.result.value = func_addr_var;
+		op.function_name = member_name;
+		op.mangled_name = StringTable::getOrInternStringHandle(mangled);
+		ir_.addInstruction(IrInstruction(IrOpcode::FunctionAddress, std::move(op), token));
+
+		return makeExprResult(
+			nativeTypeIndex(TypeCategory::FunctionPointer),
+			SizeInBits{64},
+			IrOperand{func_addr_var},
+			PointerDepth{},
+			ValueStorage::ContainsAddress);
+	}
 
 	// ========== Lambda Capture Helper Functions ==========
 

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -281,6 +281,54 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		if (callee_type_query.state == TypeSpecifierQueryResult::State::Available) {
 			callee_type = callee_type_query.type;
 		}
+		if (isInconclusiveCallableType(callee_type) &&
+			std::holds_alternative<IdentifierNode>(object_node.as<ExpressionNode>()) &&
+			current_struct_name_.isValid()) {
+			const auto& identifier = std::get<IdentifierNode>(object_node.as<ExpressionNode>());
+			auto current_struct_it = getTypesByNameMap().find(current_struct_name_);
+			if (current_struct_it != getTypesByNameMap().end() &&
+				current_struct_it->second->isStruct()) {
+				const StructTypeInfo* current_struct_info = current_struct_it->second->getStructInfo();
+				if (current_struct_info) {
+					const auto member_function_result =
+						current_struct_info->findMemberFunctionRecursive(identifier.nameHandle());
+					if (const StructMemberFunction* member_function = member_function_result.first) {
+						if (member_function->function_decl.is<FunctionDeclarationNode>()) {
+							const auto& function_decl =
+								member_function->function_decl.as<FunctionDeclarationNode>();
+							if (function_decl.is_static()) {
+								FunctionSignature signature;
+								const TypeSpecifierNode& return_type =
+									function_decl.decl_node().type_specifier_node();
+								signature.return_type_index = return_type.type_index();
+								signature.return_pointer_depth =
+									static_cast<int>(return_type.pointer_depth());
+								signature.return_reference_qualifier =
+									return_type.reference_qualifier();
+								for (const auto& param_node : function_decl.parameter_nodes()) {
+									if (!param_node.is<DeclarationNode>()) {
+										continue;
+									}
+									const auto& param_type =
+										param_node.as<DeclarationNode>().type_specifier_node();
+									signature.parameter_type_indices.push_back(
+										param_type.type_index());
+								}
+
+								TypeSpecifierNode function_pointer_type(
+									TypeCategory::FunctionPointer,
+									TypeQualifier::None,
+									64,
+									function_decl.decl_node().identifier_token(),
+									CVQualifier::None);
+								function_pointer_type.set_function_signature(signature);
+								callee_type = function_pointer_type;
+							}
+						}
+					}
+				}
+			}
+		}
 		const bool callee_type_unusable_for_callable =
 			isInconclusiveCallableType(callee_type) ||
 			(callee_type.has_value() &&

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -285,48 +285,11 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 			std::holds_alternative<IdentifierNode>(object_node.as<ExpressionNode>()) &&
 			current_struct_name_.isValid()) {
 			const auto& identifier = std::get<IdentifierNode>(object_node.as<ExpressionNode>());
-			auto current_struct_it = getTypesByNameMap().find(current_struct_name_);
-			if (current_struct_it != getTypesByNameMap().end() &&
-				current_struct_it->second->isStruct()) {
-				const StructTypeInfo* current_struct_info = current_struct_it->second->getStructInfo();
-				if (current_struct_info) {
-					const auto member_function_result =
-						current_struct_info->findMemberFunctionRecursive(identifier.nameHandle());
-					if (const StructMemberFunction* member_function = member_function_result.first) {
-						if (member_function->function_decl.is<FunctionDeclarationNode>()) {
-							const auto& function_decl =
-								member_function->function_decl.as<FunctionDeclarationNode>();
-							if (function_decl.is_static()) {
-								FunctionSignature signature;
-								const TypeSpecifierNode& return_type =
-									function_decl.decl_node().type_specifier_node();
-								signature.return_type_index = return_type.type_index();
-								signature.return_pointer_depth =
-									static_cast<int>(return_type.pointer_depth());
-								signature.return_reference_qualifier =
-									return_type.reference_qualifier();
-								for (const auto& param_node : function_decl.parameter_nodes()) {
-									if (!param_node.is<DeclarationNode>()) {
-										continue;
-									}
-									const auto& param_type =
-										param_node.as<DeclarationNode>().type_specifier_node();
-									signature.parameter_type_indices.push_back(
-										param_type.type_index());
-								}
-
-								TypeSpecifierNode function_pointer_type(
-									TypeCategory::FunctionPointer,
-									TypeQualifier::None,
-									64,
-									function_decl.decl_node().identifier_token(),
-									CVQualifier::None);
-								function_pointer_type.set_function_signature(signature);
-								callee_type = function_pointer_type;
-							}
-						}
-					}
-				}
+			if (auto static_member_function_type =
+					tryBuildCurrentStructStaticMemberFunctionPointerType(
+						identifier.nameHandle());
+				static_member_function_type.has_value()) {
+				callee_type = *static_member_function_type;
 			}
 		}
 		const bool callee_type_unusable_for_callable =

--- a/src/IrGenerator_Expr_Primitives.cpp
+++ b/src/IrGenerator_Expr_Primitives.cpp
@@ -1107,6 +1107,44 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 		}
 	}
 	if (!symbol.has_value()) {
+		if (current_struct_name_.isValid()) {
+			auto current_struct_it = getTypesByNameMap().find(current_struct_name_);
+			if (current_struct_it != getTypesByNameMap().end() &&
+				current_struct_it->second->isStruct()) {
+				const StructTypeInfo* current_struct_info = current_struct_it->second->getStructInfo();
+				if (current_struct_info) {
+					const auto member_function_result =
+						current_struct_info->findMemberFunctionRecursive(identifierNode.nameHandle());
+					if (const StructMemberFunction* member_function = member_function_result.first) {
+						if (member_function->function_decl.is<FunctionDeclarationNode>()) {
+							const auto& function_decl =
+								member_function->function_decl.as<FunctionDeclarationNode>();
+							if (function_decl.is_static()) {
+								std::string_view mangled = generateMangledNameForCall(function_decl, StringHandle{}, {});
+
+								TempVar func_addr_var = var_counter.next();
+								FunctionAddressOp op;
+								op.result.setType(TypeCategory::FunctionPointer);
+								op.result.ir_type = IrType::FunctionPointer;
+								op.result.size_in_bits = SizeInBits{64};
+								op.result.value = func_addr_var;
+								op.function_name = StringTable::getOrInternStringHandle(identifierNode.name());
+								op.mangled_name = StringTable::getOrInternStringHandle(mangled);
+								ir_.addInstruction(IrInstruction(IrOpcode::FunctionAddress, std::move(op), Token()));
+
+								return makeExprResult(
+									nativeTypeIndex(TypeCategory::FunctionPointer),
+									SizeInBits{64},
+									IrOperand{func_addr_var},
+									PointerDepth{},
+									ValueStorage::ContainsAddress);
+							}
+						}
+					}
+				}
+			}
+		}
+
 		FLASH_LOG(Codegen, Error, "Symbol '", identifierNode.name(), "' not found in symbol table during code generation");
 		FLASH_LOG(Codegen, Error, "  Current function: ", current_function_name_);
 		FLASH_LOG(Codegen, Error, "  Current struct: ", current_struct_name_);

--- a/src/IrGenerator_Expr_Primitives.cpp
+++ b/src/IrGenerator_Expr_Primitives.cpp
@@ -1107,42 +1107,12 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 		}
 	}
 	if (!symbol.has_value()) {
-		if (current_struct_name_.isValid()) {
-			auto current_struct_it = getTypesByNameMap().find(current_struct_name_);
-			if (current_struct_it != getTypesByNameMap().end() &&
-				current_struct_it->second->isStruct()) {
-				const StructTypeInfo* current_struct_info = current_struct_it->second->getStructInfo();
-				if (current_struct_info) {
-					const auto member_function_result =
-						current_struct_info->findMemberFunctionRecursive(identifierNode.nameHandle());
-					if (const StructMemberFunction* member_function = member_function_result.first) {
-						if (member_function->function_decl.is<FunctionDeclarationNode>()) {
-							const auto& function_decl =
-								member_function->function_decl.as<FunctionDeclarationNode>();
-							if (function_decl.is_static()) {
-								std::string_view mangled = generateMangledNameForCall(function_decl, StringHandle{}, {});
-
-								TempVar func_addr_var = var_counter.next();
-								FunctionAddressOp op;
-								op.result.setType(TypeCategory::FunctionPointer);
-								op.result.ir_type = IrType::FunctionPointer;
-								op.result.size_in_bits = SizeInBits{64};
-								op.result.value = func_addr_var;
-								op.function_name = StringTable::getOrInternStringHandle(identifierNode.name());
-								op.mangled_name = StringTable::getOrInternStringHandle(mangled);
-								ir_.addInstruction(IrInstruction(IrOpcode::FunctionAddress, std::move(op), Token()));
-
-								return makeExprResult(
-									nativeTypeIndex(TypeCategory::FunctionPointer),
-									SizeInBits{64},
-									IrOperand{func_addr_var},
-									PointerDepth{},
-									ValueStorage::ContainsAddress);
-							}
-						}
-					}
-				}
-			}
+		if (auto static_member_function_address =
+				tryEmitCurrentStructStaticMemberFunctionAddress(
+					StringTable::getOrInternStringHandle(identifierNode.name()),
+					Token());
+			static_member_function_address.has_value()) {
+			return *static_member_function_address;
 		}
 
 		FLASH_LOG(Codegen, Error, "Symbol '", identifierNode.name(), "' not found in symbol table during code generation");

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -532,10 +532,22 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 							.append("'")
 							.commit()));
 					}
+					auto isFloatingBuiltinReturnExpr = [&]() {
+						if (!expr_opt.has_value() || !expr_opt->is<CallExprNode>()) {
+							return false;
+						}
+						const std::string_view callee_name =
+							expr_opt->as<CallExprNode>().callee().declaration().identifier_token().value();
+						return callee_name.starts_with("__builtin_"sv);
+					};
 					// sema should annotate standard arithmetic return conversions.
 					// Same-type size mismatches are not type conversions.
 					if (sema_normalized_current_function_ && expr_type != return_type &&
 						is_standard_arithmetic_type(expr_type) && is_standard_arithmetic_type(return_type)) {
+						if (isFloatingBuiltinReturnExpr()) {
+							operands = generateTypeConversion(operands, expr_type, return_type, node.return_token());
+							goto return_conversion_done;
+						}
 						throw InternalError(
 							std::string("sema missed return conversion (") +
 							std::string(getTypeName(expr_type)) + " -> " +
@@ -546,6 +558,7 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 				}
 			}
 		}
+return_conversion_done:
 
 		// For reference returns, prefer materializing the referred-to address in IR when we
 		// have direct member lvalue metadata. This avoids relying on backend reconstruction

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -536,8 +536,13 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 						if (!expr_opt.has_value() || !expr_opt->is<CallExprNode>()) {
 							return false;
 						}
+						const FunctionDeclarationNode* func_decl =
+							expr_opt->as<CallExprNode>().callee().function_declaration_or_null();
+						if (!func_decl) {
+							return false;
+						}
 						const std::string_view callee_name =
-							expr_opt->as<CallExprNode>().callee().declaration().identifier_token().value();
+							func_decl->decl_node().identifier_token().value();
 						return callee_name.starts_with("__builtin_"sv);
 					};
 					// sema should annotate standard arithmetic return conversions.

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -401,6 +401,25 @@ struct PointerConversionInfo {
 	const FunctionDeclarationNode* function = nullptr;
 };
 
+std::optional<TypeCategory> getBuiltinCallReturnCategory(std::string_view callee_name) {
+	if (callee_name == "__builtin_huge_valf"sv || callee_name == "__builtin_huge_valf__"sv ||
+		callee_name == "__builtin_nanf"sv || callee_name == "__builtin_nanf__"sv ||
+		callee_name == "__builtin_nansf"sv || callee_name == "__builtin_nansf__"sv) {
+		return TypeCategory::Float;
+	}
+	if (callee_name == "__builtin_huge_val"sv || callee_name == "__builtin_huge_val__"sv ||
+		callee_name == "__builtin_nan"sv || callee_name == "__builtin_nan__"sv ||
+		callee_name == "__builtin_nans"sv || callee_name == "__builtin_nans__"sv) {
+		return TypeCategory::Double;
+	}
+	if (callee_name == "__builtin_huge_vall"sv || callee_name == "__builtin_huge_vall__"sv ||
+		callee_name == "__builtin_nanl"sv || callee_name == "__builtin_nanl__"sv ||
+		callee_name == "__builtin_nansl"sv || callee_name == "__builtin_nansl__"sv) {
+		return TypeCategory::LongDouble;
+	}
+	return std::nullopt;
+}
+
 // Builds a CanonicalTypeDesc for a base class subobject, inheriting the CV
 // qualifier of the derived object so that const-ness propagates through
 // inheritance when looking up pointer conversion operators.
@@ -5079,6 +5098,35 @@ CanonicalTypeId SemanticAnalysis::inferStaticMemberTypeFromContext(const Identif
 	return {};
 }
 
+CanonicalTypeId SemanticAnalysis::inferStaticMemberFunctionTypeFromContext(const IdentifierNode& identifier) {
+	const MemberContext* member_context = getCurrentMemberContext();
+	if (!member_context || !member_context->type_index.is_valid()) {
+		return {};
+	}
+
+	const StructTypeInfo* current_struct_info = tryGetStructTypeInfo(member_context->type_index);
+	if (!current_struct_info) {
+		return {};
+	}
+
+	const StringHandle member_name = identifier.getOrInternNameHandle();
+	const auto member_function_result = current_struct_info->findMemberFunctionRecursive(member_name);
+	const StructMemberFunction* member_function = member_function_result.first;
+	if (!member_function) {
+		return {};
+	}
+
+	const FunctionDeclarationNode* function_decl =
+		getCallTargetFunctionCandidate(member_function->function_decl);
+	if (!function_decl || !function_decl->is_static()) {
+		return {};
+	}
+
+	return canonicalizeType(
+		FlashCpp::ParserFunctionTypeHelpers::buildFunctionPointerTypeFromFunctionDeclaration(
+			*function_decl));
+}
+
 // --- Expression type inference ---
 
 CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
@@ -5162,6 +5210,10 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 			if (e.binding() == IdentifierBinding::StaticMember) {
 				if (const CanonicalTypeId static_member_type_id = inferStaticMemberTypeFromContext(e)) {
 					return static_member_type_id;
+				}
+				if (const CanonicalTypeId static_member_function_type_id =
+						inferStaticMemberFunctionTypeFromContext(e)) {
+					return static_member_function_type_id;
 				}
 			}
 
@@ -5808,6 +5860,14 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 				if (const CanonicalTypeId resolved_type_id =
 						inferCallReturnType(resolveCallArgAnnotationTarget(call_info, &e))) {
 					return resolved_type_id;
+				}
+
+				if (std::optional<TypeCategory> builtin_return_type =
+						getBuiltinCallReturnCategory(e.callee().declaration().identifier_token().value());
+					builtin_return_type.has_value()) {
+					CanonicalTypeDesc desc;
+					desc.type_index = nativeTypeIndex(*builtin_return_type);
+					return type_context_.intern(desc);
 				}
 
 				const DeclarationNode& decl = e.callee().declaration();

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5862,8 +5862,13 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 					return resolved_type_id;
 				}
 
+				const FunctionDeclarationNode* builtin_call_decl =
+					e.callee().function_declaration_or_null();
 				if (std::optional<TypeCategory> builtin_return_type =
-						getBuiltinCallReturnCategory(e.callee().declaration().identifier_token().value());
+						builtin_call_decl
+							? getBuiltinCallReturnCategory(
+								builtin_call_decl->decl_node().identifier_token().value())
+							: std::nullopt;
 					builtin_return_type.has_value()) {
 					CanonicalTypeDesc desc;
 					desc.type_index = nativeTypeIndex(*builtin_return_type);

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -462,6 +462,7 @@ private:
 	CanonicalTypeId inferExpressionType(const ASTNode& node);
 	CanonicalTypeId inferResolvedSymbolType(const ASTNode& symbol);
 	CanonicalTypeId inferStaticMemberTypeFromContext(const IdentifierNode& identifier);
+	CanonicalTypeId inferStaticMemberFunctionTypeFromContext(const IdentifierNode& identifier);
 	ValueCategory inferExpressionValueCategory(const ASTNode& node);
 	const MemberContext* getCurrentMemberContext() const;
 	std::optional<ResolvedMemberAccessObjectInfo> resolveMemberAccessObjectInfo(const MemberAccessNode& member_access);

--- a/tests/test_builtin_return_long_double_ret0.cpp
+++ b/tests/test_builtin_return_long_double_ret0.cpp
@@ -1,0 +1,24 @@
+// Regression: builtin floating calls in return statements still perform the
+// required arithmetic conversion to the function's declared long double return type.
+extern "C" double __builtin_huge_val();
+extern "C" double __builtin_nan(const char*);
+extern "C" double __builtin_nans(const char*);
+
+long double builtinInfinity() {
+	return __builtin_huge_val();
+}
+
+long double builtinQuietNan() {
+	return __builtin_nan("0");
+}
+
+long double builtinSignalingNan() {
+	return __builtin_nans("1");
+}
+
+int main() {
+	const bool infinity_ok = builtinInfinity() > 1.0L;
+	const bool quiet_nan_ok = builtinQuietNan() != 0.0L;
+	const bool signaling_nan_ok = builtinSignalingNan() != 0.0L;
+	return (infinity_ok && quiet_nan_ok && signaling_nan_ok) ? 0 : 1;
+}

--- a/tests/test_parenthesized_static_member_call_ret0.cpp
+++ b/tests/test_parenthesized_static_member_call_ret0.cpp
@@ -1,0 +1,14 @@
+// Regression: parenthesized static member function names remain callable.
+struct LimitsLike {
+	static int max() {
+		return 7;
+	}
+
+	static int lowest() {
+		return (max)();
+	}
+};
+
+int main() {
+	return LimitsLike::lowest() - 7;
+}


### PR DESCRIPTION
## What changed

This PR fixes the Windows/MSVC regression that surfaced while compiling `<limits>` and adds focused regression coverage for the reduced cases.

It updates the compiler to:
- treat parenthesized static member function names such as `(max)()` as callable inside member bodies
- lower static member function identifiers in member scope as function addresses when they are used as values
- preserve return conversion for builtin floating calls when a function returns `long double`
- refresh `KNOWN_ISSUES.md` so it reflects the current live Windows issues instead of the stale `<limits>` compile-stage blocker

## Why it changed

The original Windows `<limits>` blocker was no longer the documented constexpr-member issue. The live failure had moved to two narrower bugs:
- `numeric_limits<long double>::lowest()` uses the MSVC pattern `(max)()` and FlashCpp no longer treated that parenthesized static member name as callable in sema/codegen
- `numeric_limits<long double>::infinity()/quiet_NaN()/signaling_NaN()` return builtin floating calls whose `double -> long double` return conversion was being missed by the sema/codegen boundary

## User impact

Windows/MSVC standard-header coverage moves forward again:
- the reduced parenthesized static-member call case now compiles, links, and runs
- the reduced builtin-return-to-`long double` case now compiles, links, and runs
- `tests/std/test_std_limits.cpp` now compiles through object generation instead of stopping at the previous compile-stage failure

## Root cause

The core issue was semantic/callable metadata getting lost at two edges:
- member-scope bare static member functions were not consistently modeled as callable values once wrapped in parentheses
- builtin floating call results could still reach return lowering without the expected arithmetic conversion metadata, even though the generated IR path itself already knew how to materialize the builtin values

## Validation

- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1 test_parenthesized_static_member_call_ret0.cpp`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1 test_builtin_return_long_double_ret0.cpp`
- `pwsh -NoProfile -ExecutionPolicy Bypass -File .\tests\run_all_tests.ps1`
