### PR TITLE
Preserve member-template alias metadata in OOL replay

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -48,16 +48,16 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 
 ---
 
-## 4) OOL member-function-template dependent member-template pointer parameter dereference (OPEN)
+## 4) OOL member-function-template overloads with dependent member-template alias parameters can fail attachment (OPEN)
 
-- **Symptom**: A reduced out-of-line member-function-template body using
-  `typename T::template AddPtr<int>::type` as a parameter can still crash at
-  runtime when the body directly dereferences or forwards that parameter as an
-  `int*`, even though signature replay now accepts the member-template type
-  chain.
-- **Root cause**: The replay/signature path can resolve the chain for matching,
-  but some lazy member-function-template body/codegen surfaces still preserve
-  placeholder ABI metadata for the parameter.
-- **Impact**: Regression coverage currently checks pointer substitution through
-  `sizeof(value)` rather than direct dereference until the remaining body/codegen
-  metadata gap is closed.
+- **Symptom**: Two out-of-line member-function-template overloads whose
+  signatures differ only by `typename T::template AddPtr<int>::type` vs
+  `typename T::template AddPtr<long>::type` can fail replay identity attachment;
+  later calls may both select the `$ol0` materialization and link against a body
+  that was never emitted.
+- **Root cause**: The new alias-metadata path handles single-declaration body
+  replay, but same-name overload preselection still does not fully distinguish
+  member-template alias targets after owner substitution.
+- **Impact**: Keep the next replay-metadata slice focused on overloaded
+  member-template alias parameters once the non-overloaded forwarding paths stay
+  stable.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (OOL member-function-template signatures now resolve type-parameter-qualified member-template type chains during replay)
+**Last updated:** 2026-05-27 (OOL member-function-template bodies now preserve type-parameter-qualified member-template alias metadata)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -190,9 +190,17 @@ Useful assumptions before changing this area:
   segments are materialized through concrete owner bindings and only
   accepted when canonical type identity matches, without restoring
   broad shape fallback attachment.
+- **OOL member-function-template body replay now preserves concrete alias
+  metadata for type-parameter-qualified member-template type parameters**:
+  direct dereference, forwarding, and reference-to-alias-parameter forwarding of
+  `typename T::template AddPtr<int>::type` now materialize body-local parameter
+  metadata as the resolved pointer type instead of a zero-sized alias placeholder.
+  Alias-owner recovery is narrowed to evidence-backed dependent-owner records or
+  a unique concrete struct owner, so existing alias-template default NTTP and
+  non-template-intermediate member-alias paths remain stable.
 
 Latest recorded full-suite validation:
-`2559` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
+`2595` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -224,6 +232,8 @@ Latest focused replay regressions added on the current branch:
 - `test_template_ool_member_template_dependent_member_swap_body_ret0.cpp`
 - `test_template_param_qualified_static_member_auto_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_deref_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp`
 
 ## What is still wrong
 
@@ -243,10 +253,11 @@ The next highest-value remaining surface:
     substitution outcomes (`nullopt`) because required replay-visible metadata
     is not always captured early enough; these need metadata completion so
     canonical matching succeeds more often without broad fallback machinery.
-  - direct dereference/forwarding of OOL member-function-template parameters
-    whose type came from `T::template AddPtr<int>::type` still exposes
-    placeholder ABI/body-codegen metadata; close that body metadata gap before
-    expanding the signature-matching slice broadly.
+  - overloaded OOL member-function-template declarations whose parameter types
+    differ only by concrete member-template alias targets still need stronger
+    source-member identity and alias-target disambiguation; a reduced
+    `AddPtr<int>`/`AddPtr<long>` case can still select the wrong `$olN`
+    materialization and fail to attach the replayed body.
   - dependent-member OOL swap regressions now cover the first constructor
     replay/body-selection gap; continue looking for remaining swap-shaped gaps
     in less-covered member-template and nested replay surfaces.
@@ -283,10 +294,10 @@ they directly block items 1-2:
    - Continue with any remaining OOL dependent-member swap slices in
      member-template or nested overload sets where replay-selected stubs and
      deferred body parsing can still drift after owner-artifact recovery.
-   - Continue the type-parameter-qualified lookup slice into nested/overloaded
-     member-template type-chain replay surfaces, and close the remaining body
-     metadata gap where direct dereference/forwarding of parameters typed through
-     `T::template AddPtr<int>::type` can still preserve placeholder ABI state.
+   - Continue the type-parameter-qualified lookup slice into overloaded
+     member-template type-chain replay surfaces, especially same-name OOL
+     member-function-template overloads whose parameters differ by resolved
+     member-template alias target (`AddPtr<int>` vs `AddPtr<long>`).
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (OOL member-function-template signatures now resolve type-parameter-qualified member-template type chains during replay)
+**Last updated:** 2026-05-27 (OOL member-function-template bodies now preserve type-parameter-qualified member-template alias metadata)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -187,9 +187,17 @@ Future work can rely on these being in place:
   segments are materialized through concrete owner bindings and only
   accepted when canonical type identity matches, without restoring
   broad shape fallback attachment.
+- **OOL member-function-template body replay now preserves concrete alias
+  metadata for type-parameter-qualified member-template type parameters**:
+  direct dereference, forwarding, and reference-to-alias-parameter forwarding of
+  `typename T::template AddPtr<int>::type` now materialize body-local parameter
+  metadata as the resolved pointer type instead of a zero-sized alias placeholder.
+  Alias-owner recovery is narrowed to evidence-backed dependent-owner records or
+  a unique concrete struct owner, so existing alias-template default NTTP and
+  non-template-intermediate member-alias paths remain stable.
 
 Latest recorded full-suite validation:
-`2559` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
+`2595` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -221,6 +229,8 @@ Latest focused regressions added on the current branch:
 - `test_template_ool_member_template_dependent_member_swap_body_ret0.cpp`
 - `test_template_param_qualified_static_member_auto_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_deref_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp`
 
 ## Remaining work, in priority order
 
@@ -239,9 +249,11 @@ Rule for this work:
   (`nullopt`) outcomes in the remaining non-constructor declaration replay
   paths so canonical substituted-signature classification can succeed in more
   valid cases.
-- close the remaining OOL member-function-template body metadata gap where
-  parameters typed through `T::template AddPtr<int>::type` can still carry
-  placeholder ABI/codegen state when directly dereferenced or forwarded.
+- overloaded OOL member-function-template declarations whose parameter types
+  differ only by concrete member-template alias targets still need stronger
+  source-member identity and alias-target disambiguation; a reduced
+  `AddPtr<int>`/`AddPtr<long>` case can still select the wrong `$olN`
+  materialization and fail to attach the replayed body.
 - continue looking for remaining OOL dependent-member swap regressions in
   less-covered member-template and nested replay surfaces now that the first
   constructor replay/body-selection gap has been closed.
@@ -285,8 +297,9 @@ Still open, but not the next best slice:
    prioritize remaining OOL dependent-member swap follow-ups in member-template
    or nested overload sets where replay-selected stubs and deferred body parsing
    can still drift after owner-artifact recovery;
-   close the `T::AddPtr` parameter body metadata gap for direct dereference or
-   forwarding before broadening to nested/overloaded member-template chains;
+   continue into overloaded member-template alias parameter chains now that the
+   non-overloaded `T::AddPtr` body metadata gap is covered for direct
+   dereference, forwarding, and reference forwarding;
 2. update these docs with the next remaining replay-metadata gap.
 
 ## Regression focus

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1883,10 +1883,27 @@ inline ResolvedAliasTypeInfo resolveAliasTypeInfo(TypeIndex type_index) {
 			}
 		}
 
+		TypeIndex next_type_index = type_info->type_index_;
+		if (type_info->isTypeAlias()) {
+			if (const TypeSpecifierNode* alias_type_spec = type_info->aliasTypeSpecifier()) {
+				TypeIndex alias_spec_type_index = alias_type_spec->type_index();
+				if (!alias_spec_type_index.is_valid() &&
+					alias_type_spec->category() != TypeCategory::Invalid) {
+					alias_spec_type_index = nativeTypeIndex(alias_type_spec->category());
+				}
+				if (alias_spec_type_index.is_valid() &&
+					(!next_type_index.is_valid() ||
+					 next_type_index.index() == current_type_index.index())) {
+					next_type_index =
+						alias_spec_type_index.withCategory(alias_type_spec->category());
+				}
+			}
+		}
+
 		if (!type_info->isTypeAlias() ||
-			!type_info->type_index_.is_valid() ||
-			type_info->type_index_.index() == current_type_index.index()) {
-			if (type_info->isTypeAlias() && !type_info->type_index_.is_valid() && type_info->typeEnum() != TypeCategory::Invalid) {
+			!next_type_index.is_valid() ||
+			next_type_index.index() == current_type_index.index()) {
+			if (type_info->isTypeAlias() && !next_type_index.is_valid() && type_info->typeEnum() != TypeCategory::Invalid) {
 				TypeIndex canonical_type_index = nativeTypeIndex(type_info->typeEnum());
 				resolved.type_index = canonical_type_index.is_valid()
 										  ? canonical_type_index
@@ -1897,7 +1914,7 @@ inline ResolvedAliasTypeInfo resolveAliasTypeInfo(TypeIndex type_index) {
 			return resolved;
 		}
 
-		current_type_index = type_info->type_index_;
+		current_type_index = next_type_index;
 	}
 
 	if (const TypeInfo* type_info = tryGetTypeInfo(current_type_index)) {

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1038,11 +1038,11 @@ private:
 		TypeIndex target_type_index,
 		bool source_is_const) const;
 
-	// Determine whether an initializer expression node yields a const-qualified object.
-	// Returns true for:
-	//  - a ConstCastNode whose target type has the 'const' CV-qualifier
-	//  - an IdentifierNode that resolves (in symbol_table) to a const-typed VariableDeclarationNode
-	// Used to pick the correct const/non-const conversion-operator overload.
+	// Determine whether an expression node yields a const-qualified object.
+	// Covers direct declaration constness plus semantic expression types such as
+	// const-qualified reference-returning calls.
+	// Used to pick the correct const/non-const conversion-operator overload and
+	// to reject assignments to non-modifiable const expressions.
 	bool isExprConstQualified(const ASTNode& expr_node) const;
 
 	// Emit a call to a user-defined conversion operator and return the converted ExprResult.

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -1333,6 +1333,13 @@ ExprResult AstToIr::generateTernaryOperatorIr(const TernaryOperatorNode& ternary
 
 ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOperatorNode) {
 	const auto& op = binaryOperatorNode.op();
+	const bool is_assignment_like = op == "=" || isCompoundAssignmentOp(op);
+
+	if (is_assignment_like &&
+		binaryOperatorNode.get_lhs().is<ExpressionNode>() &&
+		isExprConstQualified(binaryOperatorNode.get_lhs())) {
+		throw CompileError("Assignment to const-qualified expression is not allowed");
+	}
 
 	// Special handling for comma operator
 	// The comma operator evaluates both operands left-to-right and returns the right operand

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -3650,6 +3650,7 @@ bool AstToIr::resolveMemberAccessType(const MemberAccessNode& member_access,
 // Returns true for:
 //   - a ConstCastNode whose target type has the 'const' CV-qualifier
 //   - an IdentifierNode resolved (via symbol_table) to a const-typed VariableDeclarationNode
+//   - any expression whose semantic type resolves to a const-qualified type
 bool AstToIr::isExprConstQualified(const ASTNode& expr_node) const {
 	if (!expr_node.is<ExpressionNode>())
 		return false;
@@ -3701,6 +3702,10 @@ bool AstToIr::isExprConstQualified(const ASTNode& expr_node) const {
 				}
 			}
 		}
+	}
+
+	if (auto expr_type = parser_.get_expression_type(expr_node); expr_type.has_value()) {
+		return expr_type->is_const();
 	}
 
 	return false;

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1779,7 +1779,7 @@ private:
 		StringHandle owner_name,
 		StringHandle member_name,
 		bool is_dependent) const;
-	std::vector<TemplateNameLookupCandidate> lookupMemberFunctionTemplateCandidatesForInstantiation(
+	InlineVector<TemplateNameLookupCandidate, 4> lookupMemberFunctionTemplateCandidatesForInstantiation(
 		std::string_view struct_name,
 		std::string_view member_name);
 	std::vector<ASTNode> materializeFunctionTemplateCandidateDeclarations(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -489,6 +489,17 @@ class Parser {
 	friend class SemanticAnalysis;
 	friend class FlashCpp::FunctionParsingScopeGuard;  // Access current_function_, setup_member_function_context, etc.
 	friend struct DeferredBaseReplayContextScope;
+	template <typename ParserLike, typename ParamContainer, typename ArgContainer>
+	friend TypeIndex resolveDependentMemberTemplateSubstitutionArtifacts(
+		ParserLike& parser,
+		const ASTNode* original_type_node,
+		const TypeSpecifierNode& original_type_spec,
+		const ParamContainer& template_params,
+		const ArgContainer& template_args,
+		TypeIndex substituted_type_index,
+		bool resolve_concrete_owner,
+		bool resolve_concrete_owner_artifact,
+		bool resolve_materialized_member_alias);
 
 public:
 	static constexpr size_t default_ast_tree_size_ = 256 * 1024;

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -178,7 +178,7 @@ inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
 	}
 	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
+		original_type_info != nullptr && original_type_info->hasDependentQualifiedName()
 			? original_type_info->dependentQualifiedName()
 			: nullptr;
 
@@ -363,10 +363,22 @@ inline std::optional<TypeIndex> resolveDependentPlaceholderFromTemplateParams(
 	const TypeInfo* type_info,
 	const ParamContainer& tmpl_params,
 	const ArgContainer& tmpl_args) {
-	if (type_info == nullptr || !type_info->isDependentPlaceholder()) {
+	if (type_info == nullptr) {
 		return std::nullopt;
 	}
-	const auto* dependent_record = type_info->dependentQualifiedName();
+	const TypeInfo* dependent_type_info = type_info;
+	if (!dependent_type_info->isDependentPlaceholder()) {
+		const ResolvedAliasTypeInfo resolved_alias =
+			resolveAliasTypeInfo(type_info->registeredTypeIndex().withCategory(type_info->typeEnum()));
+		if (resolved_alias.terminal_type_info != nullptr &&
+			resolved_alias.terminal_type_info->isDependentPlaceholder()) {
+			dependent_type_info = resolved_alias.terminal_type_info;
+		}
+	}
+	if (!dependent_type_info->isDependentPlaceholder()) {
+		return std::nullopt;
+	}
+	const auto* dependent_record = dependent_type_info->dependentQualifiedName();
 	if (dependent_record == nullptr || !dependent_record->owner_name.isValid()) {
 		return std::nullopt;
 	}
@@ -394,11 +406,6 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 		return substituted_type_index;
 	}
 
-	const TypeInfo* owner_type_info = tryGetTypeInfo(substituted_type_index);
-	if (owner_type_info == nullptr || !is_struct_type(owner_type_info->typeEnum())) {
-		return substituted_type_index;
-	}
-
 	const TypeInfo* original_type_info = nullptr;
 	if (original_type_spec.type_index().is_valid()) {
 		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
@@ -407,6 +414,20 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
 			? original_type_info->dependentQualifiedName()
 			: nullptr;
+	if (dependent_record == nullptr && original_type_info != nullptr) {
+		const ResolvedAliasTypeInfo resolved_alias =
+			resolveAliasTypeInfo(original_type_info->registeredTypeIndex().withCategory(original_type_info->typeEnum()));
+		if (resolved_alias.terminal_type_info != nullptr &&
+			resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
+			dependent_record = resolved_alias.terminal_type_info->dependentQualifiedName();
+		}
+	}
+	if (dependent_record == nullptr) {
+		if (const TypeInfo* substituted_type_info = tryGetTypeInfo(substituted_type_index);
+			substituted_type_info != nullptr && substituted_type_info->hasDependentQualifiedName()) {
+			dependent_record = substituted_type_info->dependentQualifiedName();
+		}
+	}
 	if (dependent_record == nullptr && original_type_node != nullptr) {
 		if (original_type_node->is<QualifiedIdentifierNode>()) {
 			dependent_record =
@@ -418,11 +439,172 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 			}
 		}
 	}
+	if (original_type_info != nullptr) {
+		std::string_view base_template_name =
+			original_type_info->isTemplateInstantiation()
+				? StringTable::getStringView(original_type_info->baseTemplateName())
+				: std::string_view{};
+		std::string_view owner_name;
+		std::string_view member_template_name;
+		const size_t owner_sep = base_template_name.rfind("::");
+		if (owner_sep != std::string_view::npos) {
+			owner_name = base_template_name.substr(0, owner_sep);
+			member_template_name = base_template_name.substr(owner_sep + 2);
+		} else {
+			std::string_view original_type_name =
+				StringTable::getStringView(original_type_info->name());
+			const size_t hash_pos = original_type_name.find('$');
+			if (hash_pos != std::string_view::npos) {
+				member_template_name = original_type_name.substr(0, hash_pos);
+			}
+		}
+		if (owner_name.empty() &&
+			dependent_record != nullptr &&
+			dependent_record->owner_name.isValid()) {
+			owner_name = StringTable::getStringView(dependent_record->owner_name);
+		}
+		if (!member_template_name.empty()) {
+			auto try_resolve_for_owner = [&](const TypeInfo* owner_type_info) -> TypeIndex {
+			if (owner_type_info != nullptr && is_struct_type(owner_type_info->typeEnum())) {
+				std::vector<TemplateTypeArg> concrete_template_args;
+				concrete_template_args.reserve(original_type_info->templateArgs().size());
+				for (const auto& arg_info : original_type_info->templateArgs()) {
+					TemplateTypeArg concrete_arg =
+						materializeTemplateArg(arg_info, template_params, template_args);
+					if (concrete_arg.is_dependent ||
+						concrete_arg.dependent_name.isValid() ||
+						concrete_arg.dependent_expr.has_value()) {
+						return substituted_type_index;
+					}
+					concrete_template_args.push_back(std::move(concrete_arg));
+				}
+				const std::string concrete_template_name = std::string(StringBuilder()
+					.append(StringTable::getStringView(owner_type_info->name()))
+					.append("::")
+					.append(member_template_name)
+					.commit());
+				std::optional<ASTNode> instantiated_member_template =
+					instantiate_class_template(
+						concrete_template_name,
+						std::span<const TemplateTypeArg>(
+							concrete_template_args.data(),
+							concrete_template_args.size()),
+						false);
+				if (instantiated_member_template.has_value() &&
+					instantiated_member_template->is<StructDeclarationNode>()) {
+					std::string_view instantiated_name =
+						StringTable::getStringView(
+							instantiated_member_template->as<StructDeclarationNode>().name());
+					std::string qualified_instantiated_name;
+					if (instantiated_name.find("::") == std::string_view::npos) {
+						qualified_instantiated_name = std::string(StringBuilder()
+							.append(StringTable::getStringView(owner_type_info->name()))
+							.append("::")
+							.append(instantiated_name)
+							.commit());
+					}
+					std::string_view original_type_name =
+						StringTable::getStringView(original_type_info->name());
+					const size_t member_sep = original_type_name.rfind("::");
+					const std::string_view terminal_member =
+						member_sep != std::string_view::npos
+							? original_type_name.substr(member_sep + 2)
+							: std::string_view{};
+					if (!terminal_member.empty()) {
+						auto lookup_member_type = [&](std::string_view instantiated_owner_name) -> const TypeInfo* {
+							if (instantiated_owner_name.empty()) {
+								return nullptr;
+							}
+							return findTypeByName(StringTable::getOrInternStringHandle(
+								StringBuilder()
+									.append(instantiated_owner_name)
+									.append("::")
+									.append(terminal_member)
+									.commit()));
+						};
+						const TypeInfo* member_type_info =
+							lookup_member_type(qualified_instantiated_name);
+						if (member_type_info == nullptr) {
+							member_type_info = lookup_member_type(instantiated_name);
+						}
+						if (member_type_info != nullptr) {
+							return member_type_info->registeredTypeIndex().withCategory(
+								member_type_info->typeEnum());
+						}
+					}
+				}
+			}
+				return TypeIndex{};
+			};
+			if (!owner_name.empty()) {
+				for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
+					const TemplateParameterNode* template_param =
+						tryGetTemplateParameterNode(template_params[i]);
+					if (template_param == nullptr ||
+						StringTable::getStringView(template_param->nameHandle()) != owner_name ||
+						template_args[i].is_value) {
+						continue;
+					}
+					TypeIndex resolved = try_resolve_for_owner(tryGetTypeInfo(template_args[i].type_index));
+					if (resolved.is_valid()) {
+						return resolved;
+					}
+					break;
+				}
+			} else {
+				const TypeInfo* unique_owner_type_info = nullptr;
+				for (size_t i = 0; i < template_args.size(); ++i) {
+					if (template_args[i].is_value) {
+						continue;
+					}
+					const TypeInfo* candidate_owner_info =
+						tryGetTypeInfo(template_args[i].type_index);
+					if (candidate_owner_info == nullptr ||
+						!is_struct_type(candidate_owner_info->typeEnum())) {
+						continue;
+					}
+					if (unique_owner_type_info != nullptr) {
+						unique_owner_type_info = nullptr;
+						break;
+					}
+					unique_owner_type_info = candidate_owner_info;
+				}
+				if (unique_owner_type_info != nullptr) {
+					TypeIndex resolved = try_resolve_for_owner(unique_owner_type_info);
+					if (resolved.is_valid()) {
+						return resolved;
+					}
+				}
+			}
+		}
+	}
 	if (dependent_record == nullptr || dependent_record->member_chain.empty()) {
 		return substituted_type_index;
 	}
 
+	const TypeInfo* owner_type_info = tryGetTypeInfo(substituted_type_index);
+	if (owner_type_info == nullptr || !is_struct_type(owner_type_info->typeEnum())) {
+		owner_type_info = nullptr;
+		if (dependent_record->owner_name.isValid()) {
+			for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
+				const TemplateParameterNode* template_param =
+					tryGetTemplateParameterNode(template_params[i]);
+				if (template_param == nullptr ||
+					template_param->nameHandle() != dependent_record->owner_name ||
+					template_args[i].is_value) {
+					continue;
+				}
+				owner_type_info = tryGetTypeInfo(template_args[i].type_index);
+				break;
+			}
+		}
+		if (owner_type_info == nullptr || !is_struct_type(owner_type_info->typeEnum())) {
+			return substituted_type_index;
+		}
+	}
+
 	const TypeInfo* current_type_info = owner_type_info;
+	std::string current_lookup_name(StringTable::getStringView(owner_type_info->name()));
 	for (const auto& member : dependent_record->member_chain) {
 		if (!member.name.isValid()) {
 			return substituted_type_index;
@@ -476,15 +658,38 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 
 			const StringHandle instantiated_name =
 				instantiated_member_template->as<StructDeclarationNode>().name();
-			current_type_info = findTypeByName(instantiated_name);
+			std::string_view instantiated_name_view =
+				StringTable::getStringView(instantiated_name);
+			std::string qualified_instantiated_name;
+			if (instantiated_name_view.find("::") == std::string_view::npos) {
+				const size_t owner_sep = template_name.rfind("::");
+				if (owner_sep != std::string::npos) {
+					qualified_instantiated_name = std::string(StringBuilder()
+						.append(std::string_view(template_name).substr(0, owner_sep))
+						.append("::")
+						.append(instantiated_name_view)
+						.commit());
+				}
+			}
+			const TypeInfo* instantiated_type_info = nullptr;
+			if (!qualified_instantiated_name.empty()) {
+				instantiated_type_info = findTypeByName(
+					StringTable::getOrInternStringHandle(qualified_instantiated_name));
+				if (instantiated_type_info != nullptr) {
+					current_lookup_name = qualified_instantiated_name;
+				}
+			}
+			if (instantiated_type_info == nullptr) {
+				instantiated_type_info = findTypeByName(instantiated_name);
+				current_lookup_name = std::string(instantiated_name_view);
+			}
+			current_type_info = instantiated_type_info;
 		} else {
-			const std::string_view current_name =
-				StringTable::getStringView(current_type_info->name());
-			if (current_name.empty()) {
+			if (current_lookup_name.empty()) {
 				return substituted_type_index;
 			}
 			const std::string qualified_member_name = std::string(StringBuilder()
-				.append(current_name)
+				.append(current_lookup_name)
 				.append("::")
 				.append(StringTable::getStringView(member.name))
 				.commit());
@@ -499,10 +704,6 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 
 	TypeIndex resolved_type_index =
 		current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum());
-	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(resolved_type_index);
-	if (resolved_alias.type_index.is_valid()) {
-		return resolved_alias.type_index.withCategory(resolved_alias.typeEnum());
-	}
 	return resolved_type_index;
 }
 

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -161,6 +161,124 @@ TypeIndex resolveOwnerAliasTypeIndex(
 	return current_type_index;
 }
 
+template <typename ParamContainer, typename ArgContainer, typename InstantiateFn>
+inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	InstantiateFn&& instantiate_class_template,
+	TypeIndex substituted_type_index);
+
+template <typename ParamContainer, typename ArgContainer, typename InstantiateFn>
+inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+	const ASTNode* original_type_node,
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	InstantiateFn&& instantiate_class_template,
+	TypeIndex substituted_type_index);
+
+template <typename ParserLike, typename ParamContainer, typename ArgContainer>
+inline TypeIndex resolveDependentMemberTemplateSubstitutionArtifacts(
+	ParserLike& parser,
+	const ASTNode* original_type_node,
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	TypeIndex substituted_type_index,
+	bool resolve_concrete_owner,
+	bool resolve_concrete_owner_artifact,
+	bool resolve_materialized_member_alias);
+
+template <
+	typename ParamContainer,
+	typename ArgContainer,
+	typename InstantiateFn,
+	typename MaterializeMemberAliasFn>
+inline TypeIndex resolveDependentMemberTemplateSubstitutionArtifacts(
+	const ASTNode* original_type_node,
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	InstantiateFn&& instantiate_class_template,
+	MaterializeMemberAliasFn&& materialize_member_alias,
+	TypeIndex substituted_type_index,
+	bool resolve_concrete_owner,
+	bool resolve_concrete_owner_artifact,
+	bool resolve_materialized_member_alias) {
+	if (resolve_concrete_owner) {
+		substituted_type_index =
+			resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+				original_type_spec,
+				template_params,
+				template_args,
+				instantiate_class_template,
+				substituted_type_index);
+	}
+	if (resolve_concrete_owner_artifact) {
+		substituted_type_index =
+			resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+				original_type_node,
+				original_type_spec,
+				template_params,
+				template_args,
+				instantiate_class_template,
+				substituted_type_index);
+	}
+	if (resolve_materialized_member_alias) {
+		if (const TypeInfo* materialized_member_alias =
+				materialize_member_alias(
+					original_type_spec,
+					template_params,
+					template_args)) {
+			substituted_type_index =
+				materialized_member_alias->registeredTypeIndex().withCategory(
+					materialized_member_alias->typeEnum());
+		}
+	}
+	return substituted_type_index;
+}
+
+template <typename ParserLike, typename ParamContainer, typename ArgContainer>
+inline TypeIndex resolveDependentMemberTemplateSubstitutionArtifacts(
+	ParserLike& parser,
+	const ASTNode* original_type_node,
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	TypeIndex substituted_type_index,
+	bool resolve_concrete_owner,
+	bool resolve_concrete_owner_artifact,
+	bool resolve_materialized_member_alias) {
+	return resolveDependentMemberTemplateSubstitutionArtifacts(
+		original_type_node,
+		original_type_spec,
+		template_params,
+		template_args,
+		[&parser](
+			std::string_view template_name,
+			std::span<const TemplateTypeArg> template_args,
+			bool force_eager) {
+			return parser.try_instantiate_class_template(
+				template_name,
+				template_args,
+				force_eager);
+		},
+		[&parser](
+			const TypeSpecifierNode& type_spec,
+			const auto& params,
+			const auto& args) {
+			return parser.materializeInstantiatedMemberAliasTarget(
+				type_spec,
+				std::span<const TemplateParameterNode>(params.data(), params.size()),
+				std::span<const TemplateTypeArg>(args.data(), args.size()));
+		},
+		substituted_type_index,
+		resolve_concrete_owner,
+		resolve_concrete_owner_artifact,
+		resolve_materialized_member_alias);
+}
+
 inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 	const TypeSpecifierNode& original_type_spec,
 	TypeIndex substituted_type_index) {
@@ -394,6 +512,127 @@ inline std::optional<TypeIndex> resolveDependentPlaceholderFromTemplateParams(
 	return std::nullopt;
 }
 
+template <typename ArgContainer>
+inline const TypeInfo* findUniqueStructOwnerTypeFromTemplateArgs(
+	const ArgContainer& template_args) {
+	const TypeInfo* unique_owner_type_info = nullptr;
+	for (size_t i = 0; i < template_args.size(); ++i) {
+		if (template_args[i].is_value) {
+			continue;
+		}
+		const TypeInfo* candidate_owner_info =
+			tryGetTypeInfo(template_args[i].type_index);
+		if (candidate_owner_info == nullptr ||
+			!is_struct_type(candidate_owner_info->typeEnum())) {
+			continue;
+		}
+		if (unique_owner_type_info != nullptr) {
+			return nullptr;
+		}
+		unique_owner_type_info = candidate_owner_info;
+	}
+	return unique_owner_type_info;
+}
+
+template <typename ParamContainer, typename ArgContainer, typename InstantiateFn>
+inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+	const TypeSpecifierNode& original_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	InstantiateFn&& instantiate_class_template,
+	TypeIndex substituted_type_index) {
+	if (!substituted_type_index.is_valid()) {
+		return substituted_type_index;
+	}
+
+	const TypeInfo* owner_type_info = tryGetTypeInfo(substituted_type_index);
+	if (owner_type_info == nullptr || !is_struct_type(owner_type_info->typeEnum())) {
+		return substituted_type_index;
+	}
+
+	const TypeInfo* original_type_info = nullptr;
+	if (original_type_spec.type_index().is_valid()) {
+		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
+	}
+	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
+			? original_type_info->dependentQualifiedName()
+			: nullptr;
+	if (dependent_record == nullptr || dependent_record->member_chain.empty()) {
+		return substituted_type_index;
+	}
+
+	const TypeInfo* current_type_info = owner_type_info;
+	for (const auto& member : dependent_record->member_chain) {
+		if (!member.name.isValid()) {
+			return substituted_type_index;
+		}
+
+		if (member.has_template_arguments) {
+			std::vector<TemplateTypeArg> concrete_template_args;
+			concrete_template_args.reserve(member.template_arguments.size());
+			for (const auto& arg_info : member.template_arguments) {
+				TemplateTypeArg concrete_arg =
+					materializeTemplateArg(arg_info, template_params, template_args);
+				if (!concrete_arg.is_value && concrete_arg.type_index.is_valid()) {
+					if (const TypeInfo* concrete_type_info =
+							tryGetTypeInfo(concrete_arg.type_index);
+						concrete_type_info != nullptr) {
+						concrete_arg.type_index =
+							concrete_type_info->registeredTypeIndex().withCategory(
+								concrete_type_info->typeEnum());
+						concrete_arg.setCategory(concrete_type_info->typeEnum());
+					}
+				}
+				concrete_template_args.push_back(std::move(concrete_arg));
+			}
+
+			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
+			if (current_name.empty()) {
+				return substituted_type_index;
+			}
+			const std::string template_name = std::string(StringBuilder()
+				.append(current_name)
+				.append("::")
+				.append(StringTable::getStringView(member.name))
+				.commit());
+			std::optional<ASTNode> instantiated_member_template =
+				instantiate_class_template(
+					template_name,
+					std::span<const TemplateTypeArg>(
+						concrete_template_args.data(),
+						concrete_template_args.size()),
+					false);
+			if (!instantiated_member_template.has_value() ||
+				!instantiated_member_template->is<StructDeclarationNode>()) {
+				return substituted_type_index;
+			}
+
+			const StringHandle instantiated_name =
+				instantiated_member_template->as<StructDeclarationNode>().name();
+			current_type_info = findTypeByName(instantiated_name);
+		} else {
+			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
+			if (current_name.empty()) {
+				return substituted_type_index;
+			}
+			const std::string qualified_member_name = std::string(StringBuilder()
+				.append(current_name)
+				.append("::")
+				.append(StringTable::getStringView(member.name))
+				.commit());
+			current_type_info = findTypeByName(
+				StringTable::getOrInternStringHandle(qualified_member_name));
+		}
+
+		if (current_type_info == nullptr) {
+			return substituted_type_index;
+		}
+	}
+
+	return current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum());
+}
+
 template <typename ParamContainer, typename ArgContainer, typename InstantiateFn>
 inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
 	const ASTNode* original_type_node,
@@ -552,23 +791,8 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 					break;
 				}
 			} else {
-				const TypeInfo* unique_owner_type_info = nullptr;
-				for (size_t i = 0; i < template_args.size(); ++i) {
-					if (template_args[i].is_value) {
-						continue;
-					}
-					const TypeInfo* candidate_owner_info =
-						tryGetTypeInfo(template_args[i].type_index);
-					if (candidate_owner_info == nullptr ||
-						!is_struct_type(candidate_owner_info->typeEnum())) {
-						continue;
-					}
-					if (unique_owner_type_info != nullptr) {
-						unique_owner_type_info = nullptr;
-						break;
-					}
-					unique_owner_type_info = candidate_owner_info;
-				}
+				const TypeInfo* unique_owner_type_info =
+					findUniqueStructOwnerTypeFromTemplateArgs(template_args);
 				if (unique_owner_type_info != nullptr) {
 					TypeIndex resolved = try_resolve_for_owner(unique_owner_type_info);
 					if (resolved.is_valid()) {

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -5,6 +5,17 @@ ASTNode rebindStaticMemberInitializerFunctionCalls(
 	const StructTypeInfo* struct_info,
 	bool set_qualified_name);
 
+// Helper to build qualified name strings for template/member lookup
+// Returns a StringHandle that can be passed to findTypeByName
+inline StringHandle buildQualifiedName(std::string_view owner, std::string_view member) {
+	return StringTable::getOrInternStringHandle(
+		StringBuilder()
+			.append(owner)
+			.append("::")
+			.append(member)
+			.commit());
+}
+
 inline void normalizeSubstitutedTypeSpec(TypeSpecifierNode& type_spec) {
 	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_spec.type_index());
 	if (resolved_alias.type_index.is_valid()) {
@@ -21,10 +32,14 @@ inline void normalizeSubstitutedTypeSpec(TypeSpecifierNode& type_spec) {
 	}
 	if (!resolved_alias.array_dimensions.empty()) {
 		const std::span<const size_t> type_dimensions = type_spec.array_dimensions();
-		std::vector<size_t> array_dimensions(type_dimensions.begin(), type_dimensions.end());
-		array_dimensions.insert(array_dimensions.end(),
-								resolved_alias.array_dimensions.begin(),
-								resolved_alias.array_dimensions.end());
+		InlineVector<size_t, 4> array_dimensions;
+		array_dimensions.reserve(type_dimensions.size() + resolved_alias.array_dimensions.size());
+		for (size_t dimension : type_dimensions) {
+			array_dimensions.push_back(dimension);
+		}
+		for (size_t dimension : resolved_alias.array_dimensions) {
+			array_dimensions.push_back(dimension);
+		}
 		type_spec.set_array_dimensions(array_dimensions);
 	}
 	if (const int resolved_size_bits = getTypeSpecSizeBits(type_spec); resolved_size_bits > 0) {
@@ -569,7 +584,7 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
 		}
 
 		if (member.has_template_arguments) {
-			std::vector<TemplateTypeArg> concrete_template_args;
+			InlineVector<TemplateTypeArg, 4> concrete_template_args;
 			concrete_template_args.reserve(member.template_arguments.size());
 			for (const auto& arg_info : member.template_arguments) {
 				TemplateTypeArg concrete_arg =
@@ -587,18 +602,16 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
 				concrete_template_args.push_back(std::move(concrete_arg));
 			}
 
-			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
+			const std::string_view current_name =
+				StringTable::getStringView(current_type_info->name());
 			if (current_name.empty()) {
 				return substituted_type_index;
 			}
-			const std::string template_name = std::string(StringBuilder()
-				.append(current_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
+			const std::string_view member_name = StringTable::getStringView(member.name);
+			const StringHandle template_name = buildQualifiedName(current_name, member_name);
 			std::optional<ASTNode> instantiated_member_template =
 				instantiate_class_template(
-					template_name,
+					StringTable::getStringView(template_name),
 					std::span<const TemplateTypeArg>(
 						concrete_template_args.data(),
 						concrete_template_args.size()),
@@ -612,17 +625,13 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
 				instantiated_member_template->as<StructDeclarationNode>().name();
 			current_type_info = findTypeByName(instantiated_name);
 		} else {
-			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
+			const std::string_view current_name =
+				StringTable::getStringView(current_type_info->name());
 			if (current_name.empty()) {
 				return substituted_type_index;
 			}
-			const std::string qualified_member_name = std::string(StringBuilder()
-				.append(current_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
-			current_type_info = findTypeByName(
-				StringTable::getOrInternStringHandle(qualified_member_name));
+			const std::string_view member_name = StringTable::getStringView(member.name);
+			current_type_info = findTypeByName(buildQualifiedName(current_name, member_name));
 		}
 
 		if (current_type_info == nullptr) {
@@ -704,75 +713,66 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 		}
 		if (!member_template_name.empty()) {
 			auto try_resolve_for_owner = [&](const TypeInfo* owner_type_info) -> TypeIndex {
-			if (owner_type_info != nullptr && is_struct_type(owner_type_info->typeEnum())) {
-				std::vector<TemplateTypeArg> concrete_template_args;
-				concrete_template_args.reserve(original_type_info->templateArgs().size());
-				for (const auto& arg_info : original_type_info->templateArgs()) {
-					TemplateTypeArg concrete_arg =
-						materializeTemplateArg(arg_info, template_params, template_args);
-					if (concrete_arg.is_dependent ||
-						concrete_arg.dependent_name.isValid() ||
-						concrete_arg.dependent_expr.has_value()) {
-						return substituted_type_index;
+				if (owner_type_info != nullptr && is_struct_type(owner_type_info->typeEnum())) {
+					InlineVector<TemplateTypeArg, 4> concrete_template_args;
+					concrete_template_args.reserve(original_type_info->templateArgs().size());
+					for (const auto& arg_info : original_type_info->templateArgs()) {
+						TemplateTypeArg concrete_arg =
+							materializeTemplateArg(arg_info, template_params, template_args);
+						if (concrete_arg.is_dependent ||
+							concrete_arg.dependent_name.isValid() ||
+							concrete_arg.dependent_expr.has_value()) {
+							return substituted_type_index;
+						}
+						concrete_template_args.push_back(std::move(concrete_arg));
 					}
-					concrete_template_args.push_back(std::move(concrete_arg));
-				}
-				const std::string concrete_template_name = std::string(StringBuilder()
-					.append(StringTable::getStringView(owner_type_info->name()))
-					.append("::")
-					.append(member_template_name)
-					.commit());
-				std::optional<ASTNode> instantiated_member_template =
-					instantiate_class_template(
-						concrete_template_name,
-						std::span<const TemplateTypeArg>(
-							concrete_template_args.data(),
-							concrete_template_args.size()),
-						false);
-				if (instantiated_member_template.has_value() &&
-					instantiated_member_template->is<StructDeclarationNode>()) {
-					std::string_view instantiated_name =
-						StringTable::getStringView(
-							instantiated_member_template->as<StructDeclarationNode>().name());
-					std::string qualified_instantiated_name;
-					if (instantiated_name.find("::") == std::string_view::npos) {
-						qualified_instantiated_name = std::string(StringBuilder()
-							.append(StringTable::getStringView(owner_type_info->name()))
-							.append("::")
-							.append(instantiated_name)
-							.commit());
-					}
-					std::string_view original_type_name =
-						StringTable::getStringView(original_type_info->name());
-					const size_t member_sep = original_type_name.rfind("::");
-					const std::string_view terminal_member =
-						member_sep != std::string_view::npos
-							? original_type_name.substr(member_sep + 2)
-							: std::string_view{};
-					if (!terminal_member.empty()) {
-						auto lookup_member_type = [&](std::string_view instantiated_owner_name) -> const TypeInfo* {
-							if (instantiated_owner_name.empty()) {
-								return nullptr;
+					const std::string_view owner_name_view =
+						StringTable::getStringView(owner_type_info->name());
+					const StringHandle concrete_template_name =
+						buildQualifiedName(owner_name_view, member_template_name);
+					std::optional<ASTNode> instantiated_member_template =
+						instantiate_class_template(
+							StringTable::getStringView(concrete_template_name),
+							std::span<const TemplateTypeArg>(
+								concrete_template_args.data(),
+								concrete_template_args.size()),
+							false);
+					if (instantiated_member_template.has_value() &&
+						instantiated_member_template->is<StructDeclarationNode>()) {
+						std::string_view instantiated_name =
+							StringTable::getStringView(
+								instantiated_member_template->as<StructDeclarationNode>().name());
+						StringHandle qualified_instantiated_name;
+						if (instantiated_name.find("::") == std::string_view::npos) {
+							qualified_instantiated_name =
+								buildQualifiedName(owner_name_view, instantiated_name);
+						}
+						std::string_view original_type_name =
+							StringTable::getStringView(original_type_info->name());
+						const size_t member_sep = original_type_name.rfind("::");
+						const std::string_view terminal_member =
+							member_sep != std::string_view::npos
+								? original_type_name.substr(member_sep + 2)
+								: std::string_view{};
+						if (!terminal_member.empty()) {
+							auto lookup_member_type = [&](std::string_view instantiated_owner_name) -> const TypeInfo* {
+								if (instantiated_owner_name.empty()) {
+									return nullptr;
+								}
+								return findTypeByName(buildQualifiedName(instantiated_owner_name, terminal_member));
+							};
+							const TypeInfo* member_type_info =
+								lookup_member_type(StringTable::getStringView(qualified_instantiated_name));
+							if (member_type_info == nullptr) {
+								member_type_info = lookup_member_type(instantiated_name);
 							}
-							return findTypeByName(StringTable::getOrInternStringHandle(
-								StringBuilder()
-									.append(instantiated_owner_name)
-									.append("::")
-									.append(terminal_member)
-									.commit()));
-						};
-						const TypeInfo* member_type_info =
-							lookup_member_type(qualified_instantiated_name);
-						if (member_type_info == nullptr) {
-							member_type_info = lookup_member_type(instantiated_name);
-						}
-						if (member_type_info != nullptr) {
-							return member_type_info->registeredTypeIndex().withCategory(
-								member_type_info->typeEnum());
+							if (member_type_info != nullptr) {
+								return member_type_info->registeredTypeIndex().withCategory(
+									member_type_info->typeEnum());
+							}
 						}
 					}
 				}
-			}
 				return TypeIndex{};
 			};
 			if (!owner_name.empty()) {
@@ -828,14 +828,14 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 	}
 
 	const TypeInfo* current_type_info = owner_type_info;
-	std::string current_lookup_name(StringTable::getStringView(owner_type_info->name()));
+	std::string_view current_lookup_name = StringTable::getStringView(owner_type_info->name());
 	for (const auto& member : dependent_record->member_chain) {
 		if (!member.name.isValid()) {
 			return substituted_type_index;
 		}
 
 		if (member.has_template_arguments) {
-			std::vector<TemplateTypeArg> concrete_template_args;
+			InlineVector<TemplateTypeArg, 4> concrete_template_args;
 			concrete_template_args.reserve(member.template_arguments.size());
 			for (const auto& arg_info : member.template_arguments) {
 				TemplateTypeArg concrete_arg =
@@ -863,14 +863,11 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 			if (current_name.empty()) {
 				return substituted_type_index;
 			}
-			const std::string template_name = std::string(StringBuilder()
-				.append(current_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
+			const std::string_view member_name = StringTable::getStringView(member.name);
+			const StringHandle template_name = buildQualifiedName(current_name, member_name);
 			std::optional<ASTNode> instantiated_member_template =
 				instantiate_class_template(
-					template_name,
+					StringTable::getStringView(template_name),
 					std::span<const TemplateTypeArg>(
 						concrete_template_args.data(),
 						concrete_template_args.size()),
@@ -884,41 +881,34 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 				instantiated_member_template->as<StructDeclarationNode>().name();
 			std::string_view instantiated_name_view =
 				StringTable::getStringView(instantiated_name);
-			std::string qualified_instantiated_name;
+			StringHandle qualified_instantiated_name;
+			const std::string_view template_name_view = StringTable::getStringView(template_name);
 			if (instantiated_name_view.find("::") == std::string_view::npos) {
-				const size_t owner_sep = template_name.rfind("::");
-				if (owner_sep != std::string::npos) {
-					qualified_instantiated_name = std::string(StringBuilder()
-						.append(std::string_view(template_name).substr(0, owner_sep))
-						.append("::")
-						.append(instantiated_name_view)
-						.commit());
+				const size_t owner_sep = template_name_view.rfind("::");
+				if (owner_sep != std::string_view::npos) {
+					qualified_instantiated_name = buildQualifiedName(
+						template_name_view.substr(0, owner_sep),
+						instantiated_name_view);
 				}
 			}
 			const TypeInfo* instantiated_type_info = nullptr;
-			if (!qualified_instantiated_name.empty()) {
-				instantiated_type_info = findTypeByName(
-					StringTable::getOrInternStringHandle(qualified_instantiated_name));
+			if (qualified_instantiated_name.isValid()) {
+				instantiated_type_info = findTypeByName(qualified_instantiated_name);
 				if (instantiated_type_info != nullptr) {
-					current_lookup_name = qualified_instantiated_name;
+					current_lookup_name = StringTable::getStringView(qualified_instantiated_name);
 				}
 			}
 			if (instantiated_type_info == nullptr) {
 				instantiated_type_info = findTypeByName(instantiated_name);
-				current_lookup_name = std::string(instantiated_name_view);
+				current_lookup_name = instantiated_name_view;
 			}
 			current_type_info = instantiated_type_info;
 		} else {
 			if (current_lookup_name.empty()) {
 				return substituted_type_index;
 			}
-			const std::string qualified_member_name = std::string(StringBuilder()
-				.append(current_lookup_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
-			current_type_info = findTypeByName(
-				StringTable::getOrInternStringHandle(qualified_member_name));
+			const std::string_view member_name = StringTable::getStringView(member.name);
+			current_type_info = findTypeByName(buildQualifiedName(current_lookup_name, member_name));
 		}
 
 		if (current_type_info == nullptr) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -94,6 +94,69 @@ static void buildTemplateParameterReplayState(
 	}
 }
 
+template <typename ParamContainer, typename ArgContainer>
+static TypeIndex resolveDependentMemberTemplateArtifactsForParam(
+	Parser& parser,
+	ASTNode* original_param_type_node,
+	const TypeSpecifierNode& param_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	TypeIndex substituted_type_index,
+	bool resolve_materialized_member_alias) {
+	if (auto resolved_param = resolveDependentPlaceholderFromTemplateParams(
+			tryGetTypeInfo(param_type_spec.type_index()),
+			template_params,
+			template_args)) {
+		substituted_type_index = *resolved_param;
+	}
+	return resolveDependentMemberTemplateSubstitutionArtifacts(
+		parser,
+		original_param_type_node,
+		param_type_spec,
+		template_params,
+		template_args,
+		substituted_type_index,
+		true,
+		true,
+		resolve_materialized_member_alias);
+}
+
+template <typename ParamContainer, typename ArgContainer>
+static ASTNode buildMaterializedParamTypeNode(
+	const TypeSpecifierNode& param_type_spec,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	TypeCategory new_param_type,
+	TypeIndex new_param_type_index) {
+	ASTNode new_param_type_node = ASTNode::emplace_node<TypeSpecifierNode>(
+		new_param_type,
+		param_type_spec.qualifier(),
+		get_type_size_bits(new_param_type),
+		param_type_spec.token(),
+		param_type_spec.cv_qualifier());
+	auto& new_param_spec = new_param_type_node.as<TypeSpecifierNode>();
+	new_param_spec.set_type_index(new_param_type_index);
+	for (const auto& pl : param_type_spec.pointer_levels()) {
+		new_param_spec.add_pointer_level(pl.cv_qualifier);
+	}
+	new_param_spec.set_reference_qualifier(param_type_spec.reference_qualifier());
+	if (param_type_spec.has_function_signature()) {
+		new_param_spec.set_function_signature(param_type_spec.function_signature());
+	} else if (new_param_type_index.category() == TypeCategory::FunctionPointer ||
+			   new_param_type_index.category() == TypeCategory::MemberFunctionPointer) {
+		if (const auto* arg = findTemplateArgByName(
+				param_type_spec.token().value(),
+				template_params,
+				template_args)) {
+			if (arg->function_signature.has_value()) {
+				new_param_spec.set_function_signature(*arg->function_signature);
+			}
+		}
+	}
+	normalizeSubstitutedTypeSpec(new_param_spec);
+	return new_param_type_node;
+}
+
 struct SourceMemberIdentityMaps {
 	std::unordered_map<const void*, ASTNode> by_node;
 	std::unordered_map<uint64_t, ASTNode> by_location;
@@ -2952,22 +3015,15 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 		{
 			ASTNode original_param_type_node = param_decl.type_node();
 			TypeIndex dependent_member_type_index = substituted_param_type.type_index();
-			if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
-					tryGetTypeInfo(param_type_spec.type_index()),
+			dependent_member_type_index =
+				resolveDependentMemberTemplateArtifactsForParam(
+					*this,
+					&original_param_type_node,
+					param_type_spec,
 					template_params,
-					template_args_inline)) {
-				dependent_member_type_index = *resolved_outer_param;
-			}
-			dependent_member_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
-				*this,
-				&original_param_type_node,
-				param_type_spec,
-				template_params,
-				template_args_inline,
-				dependent_member_type_index,
-				true,
-				true,
-				false);
+					template_args_inline,
+					dependent_member_type_index,
+					false);
 			if (dependent_member_type_index.is_valid() &&
 				dependent_member_type_index != substituted_param_type.type_index()) {
 				substituted_param_type.set_type_index(
@@ -4177,19 +4233,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				original_param_type_node,
 				param_type_spec,
 				param_type_index);
-			if (auto resolved_param = resolveDependentPlaceholderFromTemplateParams(
-					tryGetTypeInfo(param_type_spec.type_index()), tmpl_params, tmpl_args)) {
-				param_type_index = *resolved_param;
-			}
-			param_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+			param_type_index = resolveDependentMemberTemplateArtifactsForParam(
 				*this,
 				&original_param_type_node,
 				param_type_spec,
 				tmpl_params,
 				tmpl_args,
 				param_type_index,
-				true,
-				true,
 				false);
 			TypeSpecifierNode substituted_param_type = full_substituted_param_node.is<TypeSpecifierNode>()
 				? full_substituted_param_node.as<TypeSpecifierNode>()
@@ -7344,48 +7394,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									original_param_type_node,
 									param_type_spec,
 									subst_idx);
-								if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
-										tryGetTypeInfo(param_type_spec.type_index()),
-										template_params,
-										template_args_for_pattern)) {
-									subst_idx = *resolved_outer_param;
-								}
-								subst_idx = resolveDependentMemberTemplateSubstitutionArtifacts(
+								subst_idx = resolveDependentMemberTemplateArtifactsForParam(
 									*this,
 									&original_param_type_node,
 									param_type_spec,
 									template_params,
 									template_args_for_pattern,
 									subst_idx,
-									true,
-									true,
 									true);
 								new_param_type = subst_idx.category();
 								new_param_type_index = subst_idx;
 							}
 
-							ASTNode new_param_type_node = emplace_node<TypeSpecifierNode>(
-								new_param_type, param_type_spec.qualifier(),
-								get_type_size_bits(new_param_type), param_type_spec.token(), param_type_spec.cv_qualifier());
-							auto& new_param_spec = new_param_type_node.as<TypeSpecifierNode>();
-							new_param_spec.set_type_index(new_param_type_index);
-							for (const auto& pl : param_type_spec.pointer_levels())
-								new_param_spec.add_pointer_level(pl.cv_qualifier);
-							new_param_spec.set_reference_qualifier(param_type_spec.reference_qualifier());
-							if (param_type_spec.has_function_signature()) {
-								new_param_spec.set_function_signature(param_type_spec.function_signature());
-							} else if (new_param_type_index.category() == TypeCategory::FunctionPointer ||
-									   new_param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-								if (const auto* arg = findTemplateArgByName(
-										param_type_spec.token().value(),
-										template_params,
-										template_args_for_pattern)) {
-									if (arg->function_signature.has_value()) {
-										new_param_spec.set_function_signature(*arg->function_signature);
-									}
-								}
-							}
-							normalizeSubstitutedTypeSpec(new_param_spec);
+							ASTNode new_param_type_node = buildMaterializedParamTypeNode(
+								param_type_spec,
+								template_params,
+								template_args_for_pattern,
+								new_param_type,
+								new_param_type_index);
 
 							auto new_param_decl = emplace_node<DeclarationNode>(
 								new_param_type_node, param_decl.identifier_token());
@@ -13126,48 +13152,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								original_param_type_node,
 								param_type_spec,
 								subst_idx);
-							if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
-									tryGetTypeInfo(param_type_spec.type_index()),
-									template_params,
-									template_args_to_use)) {
-								subst_idx = *resolved_outer_param;
-							}
-							subst_idx = resolveDependentMemberTemplateSubstitutionArtifacts(
+							subst_idx = resolveDependentMemberTemplateArtifactsForParam(
 								*this,
 								&original_param_type_node,
 								param_type_spec,
 								template_params,
 								template_args_to_use,
 								subst_idx,
-								true,
-								true,
 								true);
 							new_param_type = subst_idx.category();
 							new_param_type_index = subst_idx;
 						}
 
-						ASTNode new_param_type_node = emplace_node<TypeSpecifierNode>(
-							new_param_type, param_type_spec.qualifier(),
-							get_type_size_bits(new_param_type), param_type_spec.token(), param_type_spec.cv_qualifier());
-						auto& new_param_spec = new_param_type_node.as<TypeSpecifierNode>();
-						new_param_spec.set_type_index(new_param_type_index);
-						for (const auto& pl : param_type_spec.pointer_levels())
-							new_param_spec.add_pointer_level(pl.cv_qualifier);
-						new_param_spec.set_reference_qualifier(param_type_spec.reference_qualifier());
-						if (param_type_spec.has_function_signature()) {
-							new_param_spec.set_function_signature(param_type_spec.function_signature());
-						} else if (new_param_type_index.category() == TypeCategory::FunctionPointer ||
-								   new_param_type_index.category() == TypeCategory::MemberFunctionPointer) {
-							if (const auto* arg = findTemplateArgByName(
-									param_type_spec.token().value(),
-									template_params,
-									template_args_to_use)) {
-								if (arg->function_signature.has_value()) {
-									new_param_spec.set_function_signature(*arg->function_signature);
-								}
-							}
-						}
-						normalizeSubstitutedTypeSpec(new_param_spec);
+						ASTNode new_param_type_node = buildMaterializedParamTypeNode(
+							param_type_spec,
+							template_params,
+							template_args_to_use,
+							new_param_type,
+							new_param_type_index);
 
 						auto new_param_decl = emplace_node<DeclarationNode>(
 							new_param_type_node, param_decl.identifier_token());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1101,105 +1101,6 @@ static std::vector<TemplateTypeArg> materializeTemplateArgsExpandingPacks(
 	return result;
 }
 
-template <typename ParamContainer, typename ArgContainer, typename InstantiateFn>
-static TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
-	const TypeSpecifierNode& original_type_spec,
-	const ParamContainer& template_params,
-	const ArgContainer& template_args,
-	InstantiateFn&& instantiate_class_template,
-	TypeIndex substituted_type_index) {
-	if (!substituted_type_index.is_valid()) {
-		return substituted_type_index;
-	}
-
-	const TypeInfo* owner_type_info = tryGetTypeInfo(substituted_type_index);
-	if (owner_type_info == nullptr || !is_struct_type(owner_type_info->typeEnum())) {
-		return substituted_type_index;
-	}
-
-	const TypeInfo* original_type_info = nullptr;
-	if (original_type_spec.type_index().is_valid()) {
-		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
-	}
-	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
-			? original_type_info->dependentQualifiedName()
-			: nullptr;
-	if (dependent_record == nullptr || dependent_record->member_chain.empty()) {
-		return substituted_type_index;
-	}
-
-	const TypeInfo* current_type_info = owner_type_info;
-	for (const auto& member : dependent_record->member_chain) {
-		if (!member.name.isValid()) {
-			return substituted_type_index;
-		}
-
-		if (member.has_template_arguments) {
-			std::vector<TemplateTypeArg> concrete_template_args;
-			concrete_template_args.reserve(member.template_arguments.size());
-			for (const auto& arg_info : member.template_arguments) {
-				TemplateTypeArg concrete_arg =
-					materializeTemplateArg(arg_info, template_params, template_args);
-				if (!concrete_arg.is_value && concrete_arg.type_index.is_valid()) {
-					if (const TypeInfo* concrete_type_info =
-							tryGetTypeInfo(concrete_arg.type_index);
-						concrete_type_info != nullptr) {
-						concrete_arg.type_index =
-							concrete_type_info->registeredTypeIndex().withCategory(
-								concrete_type_info->typeEnum());
-						concrete_arg.setCategory(concrete_type_info->typeEnum());
-					}
-				}
-				concrete_template_args.push_back(std::move(concrete_arg));
-			}
-
-			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
-			if (current_name.empty()) {
-				return substituted_type_index;
-			}
-			const std::string template_name = std::string(StringBuilder()
-				.append(current_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
-			std::optional<ASTNode> instantiated_member_template =
-				instantiate_class_template(
-					template_name,
-					std::span<const TemplateTypeArg>(
-						concrete_template_args.data(),
-						concrete_template_args.size()),
-					false);
-			if (!instantiated_member_template.has_value() ||
-				!instantiated_member_template->is<StructDeclarationNode>()) {
-				return substituted_type_index;
-			}
-
-			const StringHandle instantiated_name =
-				instantiated_member_template->as<StructDeclarationNode>().name();
-			current_type_info = findTypeByName(instantiated_name);
-		} else {
-			const std::string_view current_name = StringTable::getStringView(current_type_info->name());
-			if (current_name.empty()) {
-				return substituted_type_index;
-			}
-			const std::string qualified_member_name = std::string(StringBuilder()
-				.append(current_name)
-				.append("::")
-				.append(StringTable::getStringView(member.name))
-				.commit());
-			current_type_info = findTypeByName(
-				StringTable::getOrInternStringHandle(qualified_member_name));
-		}
-
-		if (current_type_info == nullptr) {
-			return substituted_type_index;
-		}
-	}
-
-	return current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum());
-}
-
 static const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param) {
 	if (!param.is<DeclarationNode>()) {
 		return nullptr;
@@ -3057,35 +2958,16 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 					template_args_inline)) {
 				dependent_member_type_index = *resolved_outer_param;
 			}
-			dependent_member_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
-				param_type_spec,
-				template_params,
-				template_args_inline,
-				[this](
-					std::string_view template_name,
-					std::span<const TemplateTypeArg> template_args,
-					bool force_eager) {
-					return try_instantiate_class_template(
-						template_name,
-						template_args,
-						force_eager);
-				},
-				dependent_member_type_index);
-			dependent_member_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+			dependent_member_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+				*this,
 				&original_param_type_node,
 				param_type_spec,
 				template_params,
 				template_args_inline,
-				[this](
-					std::string_view template_name,
-					std::span<const TemplateTypeArg> template_args,
-					bool force_eager) {
-					return try_instantiate_class_template(
-						template_name,
-						template_args,
-						force_eager);
-				},
-				dependent_member_type_index);
+				dependent_member_type_index,
+				true,
+				true,
+				false);
 			if (dependent_member_type_index.is_valid() &&
 				dependent_member_type_index != substituted_param_type.type_index()) {
 				substituted_param_type.set_type_index(
@@ -4299,35 +4181,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					tryGetTypeInfo(param_type_spec.type_index()), tmpl_params, tmpl_args)) {
 				param_type_index = *resolved_param;
 			}
-			param_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
-				param_type_spec,
-				tmpl_params,
-				tmpl_args,
-				[this](
-					std::string_view template_name,
-					std::span<const TemplateTypeArg> template_args,
-					bool force_eager) {
-					return try_instantiate_class_template(
-						template_name,
-						template_args,
-						force_eager);
-				},
-				param_type_index);
-			param_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+			param_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+				*this,
 				&original_param_type_node,
 				param_type_spec,
 				tmpl_params,
 				tmpl_args,
-				[this](
-					std::string_view template_name,
-					std::span<const TemplateTypeArg> template_args,
-					bool force_eager) {
-					return try_instantiate_class_template(
-						template_name,
-						template_args,
-						force_eager);
-				},
-				param_type_index);
+				param_type_index,
+				true,
+				true,
+				false);
 			TypeSpecifierNode substituted_param_type = full_substituted_param_node.is<TypeSpecifierNode>()
 				? full_substituted_param_node.as<TypeSpecifierNode>()
 				: TypeSpecifierNode(
@@ -7487,44 +7350,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										template_args_for_pattern)) {
 									subst_idx = *resolved_outer_param;
 								}
-								subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
-									param_type_spec,
-									template_params,
-									template_args_for_pattern,
-									[this](
-										std::string_view template_name,
-										std::span<const TemplateTypeArg> template_args,
-										bool force_eager) {
-										return try_instantiate_class_template(
-											template_name,
-											template_args,
-											force_eager);
-									},
-									subst_idx);
-								subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+								subst_idx = resolveDependentMemberTemplateSubstitutionArtifacts(
+									*this,
 									&original_param_type_node,
 									param_type_spec,
 									template_params,
 									template_args_for_pattern,
-									[this](
-										std::string_view template_name,
-										std::span<const TemplateTypeArg> template_args,
-										bool force_eager) {
-										return try_instantiate_class_template(
-											template_name,
-											template_args,
-											force_eager);
-									},
-									subst_idx);
-								if (const TypeInfo* materialized_member_alias =
-										materializeInstantiatedMemberAliasTarget(
-											param_type_spec,
-											template_params,
-											template_args_for_pattern)) {
-									subst_idx =
-										materialized_member_alias->registeredTypeIndex().withCategory(
-											materialized_member_alias->typeEnum());
-								}
+									subst_idx,
+									true,
+									true,
+									true);
 								new_param_type = subst_idx.category();
 								new_param_type_index = subst_idx;
 							}
@@ -13297,44 +13132,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									template_args_to_use)) {
 								subst_idx = *resolved_outer_param;
 							}
-							subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
-								param_type_spec,
-								template_params,
-								template_args_to_use,
-								[this](
-									std::string_view template_name,
-									std::span<const TemplateTypeArg> template_args,
-									bool force_eager) {
-									return try_instantiate_class_template(
-										template_name,
-										template_args,
-										force_eager);
-								},
-								subst_idx);
-							subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+							subst_idx = resolveDependentMemberTemplateSubstitutionArtifacts(
+								*this,
 								&original_param_type_node,
 								param_type_spec,
 								template_params,
 								template_args_to_use,
-								[this](
-									std::string_view template_name,
-									std::span<const TemplateTypeArg> template_args,
-									bool force_eager) {
-									return try_instantiate_class_template(
-										template_name,
-										template_args,
-										force_eager);
-								},
-								subst_idx);
-							if (const TypeInfo* materialized_member_alias =
-									materializeInstantiatedMemberAliasTarget(
-										param_type_spec,
-										template_params,
-										template_args_to_use)) {
-								subst_idx =
-									materialized_member_alias->registeredTypeIndex().withCategory(
-										materialized_member_alias->typeEnum());
-							}
+								subst_idx,
+								true,
+								true,
+								true);
 							new_param_type = subst_idx.category();
 							new_param_type_index = subst_idx;
 						}
@@ -13811,47 +13618,28 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								template_args_to_use.data(),
 								template_args_to_use.size());
 							TypeIndex resolved_index = owner_index.is_valid()
-								? resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+								? resolveDependentMemberTemplateSubstitutionArtifacts(
+									  *this,
+									  nullptr,
 									  definition_type,
 									  outer_params_span,
 									  outer_args_span,
-									  [this](
-										  std::string_view template_name,
-										  std::span<const TemplateTypeArg> args,
-										  bool force_eager) {
-										  return try_instantiate_class_template(
-											  template_name,
-											  args,
-											  force_eager);
-									  },
-									  owner_index)
+									  owner_index,
+									  true,
+									  true,
+									  true)
 								: definition_type.type_index();
 							ASTNode definition_type_node = definition_decl->type_node();
-							resolved_index =
-								resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
-									&definition_type_node,
-									definition_type,
-									outer_params_span,
-									outer_args_span,
-									[this](
-										std::string_view template_name,
-										std::span<const TemplateTypeArg> args,
-										bool force_eager) {
-										return try_instantiate_class_template(
-											template_name,
-											args,
-											force_eager);
-									},
-									resolved_index);
-							if (const TypeInfo* materialized_member_alias =
-									materializeInstantiatedMemberAliasTarget(
-										definition_type,
-										outer_params_span,
-										outer_args_span)) {
-								resolved_index =
-									materialized_member_alias->registeredTypeIndex().withCategory(
-										materialized_member_alias->typeEnum());
-							}
+							resolved_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+								*this,
+								&definition_type_node,
+								definition_type,
+								outer_params_span,
+								outer_args_span,
+								resolved_index,
+								false,
+								true,
+								true);
 							if (!resolved_index.is_valid() || resolved_index == owner_index) {
 								continue;
 							}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3048,6 +3048,52 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			TypeIndex{},
 			apply_bound_metadata_to_full_substitution,
 			apply_resolved_index_to_full_substitution);
+		{
+			ASTNode original_param_type_node = param_decl.type_node();
+			TypeIndex dependent_member_type_index = substituted_param_type.type_index();
+			if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
+					tryGetTypeInfo(param_type_spec.type_index()),
+					template_params,
+					template_args_inline)) {
+				dependent_member_type_index = *resolved_outer_param;
+			}
+			dependent_member_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+				param_type_spec,
+				template_params,
+				template_args_inline,
+				[this](
+					std::string_view template_name,
+					std::span<const TemplateTypeArg> template_args,
+					bool force_eager) {
+					return try_instantiate_class_template(
+						template_name,
+						template_args,
+						force_eager);
+				},
+				dependent_member_type_index);
+			dependent_member_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+				&original_param_type_node,
+				param_type_spec,
+				template_params,
+				template_args_inline,
+				[this](
+					std::string_view template_name,
+					std::span<const TemplateTypeArg> template_args,
+					bool force_eager) {
+					return try_instantiate_class_template(
+						template_name,
+						template_args,
+						force_eager);
+				},
+				dependent_member_type_index);
+			if (dependent_member_type_index.is_valid() &&
+				dependent_member_type_index != substituted_param_type.type_index()) {
+				substituted_param_type.set_type_index(
+					dependent_member_type_index.withCategory(dependent_member_type_index.category()));
+				substituted_param_type.set_category(dependent_member_type_index.category());
+				normalizeSubstitutedTypeSpec(substituted_param_type);
+			}
+		}
 		if (!preserve_parameter_cv_qualifier) {
 			// Preserve cv-qualification that participates in pointee/referred type identity.
 			// Only strip top-level cv on by-value parameters, matching function-parameter
@@ -7416,9 +7462,69 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 							TypeCategory new_param_type = param_type_spec.type();
 							TypeIndex new_param_type_index = param_type_spec.type_index();
-							if (new_param_type == TypeCategory::UserDefined) {
+							if (new_param_type == TypeCategory::UserDefined ||
+								new_param_type == TypeCategory::TypeAlias ||
+								new_param_type == TypeCategory::Template) {
+								ASTNode original_param_type_node = param_decl.type_node();
 								TypeIndex subst_idx = substitute_template_parameter(
 									param_type_spec, template_params, template_args_for_pattern);
+								subst_idx = resolveOwnerAliasTypeIndex(
+									[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+										return substitute_template_parameter(type_spec, params, args);
+									},
+									pattern_struct,
+									param_type_spec,
+									template_params,
+									template_args_for_pattern,
+									subst_idx);
+								subst_idx = resolveDependentMemberPlaceholderFromOwnerArtifact(
+									original_param_type_node,
+									param_type_spec,
+									subst_idx);
+								if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
+										tryGetTypeInfo(param_type_spec.type_index()),
+										template_params,
+										template_args_for_pattern)) {
+									subst_idx = *resolved_outer_param;
+								}
+								subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+									param_type_spec,
+									template_params,
+									template_args_for_pattern,
+									[this](
+										std::string_view template_name,
+										std::span<const TemplateTypeArg> template_args,
+										bool force_eager) {
+										return try_instantiate_class_template(
+											template_name,
+											template_args,
+											force_eager);
+									},
+									subst_idx);
+								subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+									&original_param_type_node,
+									param_type_spec,
+									template_params,
+									template_args_for_pattern,
+									[this](
+										std::string_view template_name,
+										std::span<const TemplateTypeArg> template_args,
+										bool force_eager) {
+										return try_instantiate_class_template(
+											template_name,
+											template_args,
+											force_eager);
+									},
+									subst_idx);
+								if (const TypeInfo* materialized_member_alias =
+										materializeInstantiatedMemberAliasTarget(
+											param_type_spec,
+											template_params,
+											template_args_for_pattern)) {
+									subst_idx =
+										materialized_member_alias->registeredTypeIndex().withCategory(
+											materialized_member_alias->typeEnum());
+								}
 								new_param_type = subst_idx.category();
 								new_param_type_index = subst_idx;
 							}
@@ -13169,6 +13275,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (new_param_type == TypeCategory::UserDefined ||
 							new_param_type == TypeCategory::TypeAlias ||
 							new_param_type == TypeCategory::Template) {
+							ASTNode original_param_type_node = param_decl.type_node();
 							TypeIndex subst_idx = substitute_template_parameter(
 								param_type_spec, template_params, template_args_to_use);
 							subst_idx = resolveOwnerAliasTypeIndex(
@@ -13181,8 +13288,53 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								template_args_to_use,
 								subst_idx);
 							subst_idx = resolveDependentMemberPlaceholderFromOwnerArtifact(
+								original_param_type_node,
 								param_type_spec,
 								subst_idx);
+							if (auto resolved_outer_param = resolveDependentPlaceholderFromTemplateParams(
+									tryGetTypeInfo(param_type_spec.type_index()),
+									template_params,
+									template_args_to_use)) {
+								subst_idx = *resolved_outer_param;
+							}
+							subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+								param_type_spec,
+								template_params,
+								template_args_to_use,
+								[this](
+									std::string_view template_name,
+									std::span<const TemplateTypeArg> template_args,
+									bool force_eager) {
+									return try_instantiate_class_template(
+										template_name,
+										template_args,
+										force_eager);
+								},
+								subst_idx);
+							subst_idx = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+								&original_param_type_node,
+								param_type_spec,
+								template_params,
+								template_args_to_use,
+								[this](
+									std::string_view template_name,
+									std::span<const TemplateTypeArg> template_args,
+									bool force_eager) {
+									return try_instantiate_class_template(
+										template_name,
+										template_args,
+										force_eager);
+								},
+								subst_idx);
+							if (const TypeInfo* materialized_member_alias =
+									materializeInstantiatedMemberAliasTarget(
+										param_type_spec,
+										template_params,
+										template_args_to_use)) {
+								subst_idx =
+									materialized_member_alias->registeredTypeIndex().withCategory(
+										materialized_member_alias->typeEnum());
+							}
 							new_param_type = subst_idx.category();
 							new_param_type_index = subst_idx;
 						}
@@ -13588,12 +13740,133 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Set the body position and definition-time lookup context from the
 				// out-of-line definition so two-phase lookup uses the definition namespace.
 				inst_func_decl->set_template_body_position(out_of_line_member.body_start);
-				copyDefinitionParameterTypes(
-					inst_func_decl->parameter_nodes(),
-					ool_func.parameter_nodes());
 				copyDefinitionParameterIdentifiers(
 					inst_func_decl->parameter_nodes(),
 					ool_func.parameter_nodes());
+				{
+					std::span<ASTNode> instantiated_params = inst_func_decl->parameter_nodes();
+					std::span<const ASTNode> definition_params = ool_func.parameter_nodes();
+					if (instantiated_params.size() == definition_params.size()) {
+						for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+							DeclarationNode* instantiated_decl =
+								Parser::get_decl_from_symbol_mut(instantiated_params[param_index]);
+							const DeclarationNode* definition_decl =
+								get_decl_from_symbol(definition_params[param_index]);
+							if (instantiated_decl == nullptr || definition_decl == nullptr) {
+								continue;
+							}
+							const TypeSpecifierNode& definition_type =
+								definition_decl->type_specifier_node();
+							const TypeInfo* definition_type_info =
+								tryGetTypeInfo(definition_type.type_index());
+							if (definition_type_info == nullptr) {
+								continue;
+							}
+							const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+								definition_type_info->dependentQualifiedName();
+							if (dependent_record == nullptr) {
+								const ResolvedAliasTypeInfo resolved_alias =
+									resolveAliasTypeInfo(
+										definition_type_info->registeredTypeIndex().withCategory(
+											definition_type_info->typeEnum()));
+								if (resolved_alias.terminal_type_info != nullptr &&
+									resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
+									dependent_record =
+										resolved_alias.terminal_type_info->dependentQualifiedName();
+								}
+							}
+							TypeIndex owner_index{};
+							if (dependent_record != nullptr &&
+								dependent_record->owner_name.isValid()) {
+								for (size_t outer_index = 0;
+									 outer_index < out_of_line_member.template_params.size() &&
+									 outer_index < template_args_to_use.size();
+									 ++outer_index) {
+									if (out_of_line_member.template_params[outer_index].nameHandle() !=
+										dependent_record->owner_name ||
+										template_args_to_use[outer_index].is_value) {
+										continue;
+									}
+									owner_index = template_args_to_use[outer_index].type_index.withCategory(
+										template_args_to_use[outer_index].typeEnum());
+									break;
+								}
+							}
+							bool has_member_template_segment = false;
+							if (dependent_record != nullptr) {
+								for (const auto& member : dependent_record->member_chain) {
+									if (member.has_template_arguments) {
+										has_member_template_segment = true;
+										break;
+									}
+								}
+								if (!has_member_template_segment) {
+									continue;
+								}
+							}
+							auto outer_params_span = std::span<const TemplateParameterNode>(
+								out_of_line_member.template_params.data(),
+								out_of_line_member.template_params.size());
+							auto outer_args_span = std::span<const TemplateTypeArg>(
+								template_args_to_use.data(),
+								template_args_to_use.size());
+							TypeIndex resolved_index = owner_index.is_valid()
+								? resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
+									  definition_type,
+									  outer_params_span,
+									  outer_args_span,
+									  [this](
+										  std::string_view template_name,
+										  std::span<const TemplateTypeArg> args,
+										  bool force_eager) {
+										  return try_instantiate_class_template(
+											  template_name,
+											  args,
+											  force_eager);
+									  },
+									  owner_index)
+								: definition_type.type_index();
+							ASTNode definition_type_node = definition_decl->type_node();
+							resolved_index =
+								resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+									&definition_type_node,
+									definition_type,
+									outer_params_span,
+									outer_args_span,
+									[this](
+										std::string_view template_name,
+										std::span<const TemplateTypeArg> args,
+										bool force_eager) {
+										return try_instantiate_class_template(
+											template_name,
+											args,
+											force_eager);
+									},
+									resolved_index);
+							if (const TypeInfo* materialized_member_alias =
+									materializeInstantiatedMemberAliasTarget(
+										definition_type,
+										outer_params_span,
+										outer_args_span)) {
+								resolved_index =
+									materialized_member_alias->registeredTypeIndex().withCategory(
+										materialized_member_alias->typeEnum());
+							}
+							if (!resolved_index.is_valid() || resolved_index == owner_index) {
+								continue;
+							}
+							TypeSpecifierNode replay_type = definition_type;
+							replay_type.set_type_index(resolved_index.withCategory(resolved_index.category()));
+							replay_type.set_category(resolved_index.category());
+							normalizeSubstitutedTypeSpec(replay_type);
+							if (replay_type.type() == TypeCategory::TypeAlias &&
+								replay_type.size_in_bits() == 0) {
+								continue;
+							}
+							instantiated_decl->set_type_node(replay_type);
+						}
+					}
+				}
 				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 				FLASH_LOG(
 					Templates,

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -275,10 +275,10 @@ TemplateNameLookupRequest Parser::buildMemberFunctionTemplateLookupRequest(
 	return request;
 }
 
-std::vector<TemplateNameLookupCandidate> Parser::lookupMemberFunctionTemplateCandidatesForInstantiation(
+InlineVector<TemplateNameLookupCandidate, 4> Parser::lookupMemberFunctionTemplateCandidatesForInstantiation(
 	std::string_view struct_name,
 	std::string_view member_name) {
-	std::vector<TemplateNameLookupCandidate> candidates;
+	InlineVector<TemplateNameLookupCandidate, 4> candidates;
 	std::unordered_set<const void*> seen_declarations;
 	const StringHandle member_name_handle = StringTable::getOrInternStringHandle(member_name);
 	const StringHandle requested_owner = StringTable::getOrInternStringHandle(struct_name);
@@ -551,7 +551,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	ScopedParserInstantiationContext inst_ctx_guard(*this, template_instantiation_mode_, qualified_name);
 
 	// Route member template lookup through the semantic two-phase lookup request.
-	std::vector<TemplateNameLookupCandidate> template_candidates =
+	InlineVector<TemplateNameLookupCandidate, 4> template_candidates =
 		lookupMemberFunctionTemplateCandidatesForInstantiation(struct_name, member_name);
 
 	if (template_candidates.empty()) {
@@ -569,7 +569,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	struct CandidateResult {
 		const ASTNode* template_node = nullptr;
 		StringHandle lookup_name{};
-		std::vector<TemplateTypeArg> template_args;
+		InlineVector<TemplateTypeArg, 4> template_args;
 		int specificity = 0;
 		size_t overload_index = 0;  // assigned externally to template_candidates index; used to build
 		                            // discriminated cache keys when multiple overloads exist
@@ -602,12 +602,15 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 				func_decl,
 				arg_types,
 				0)) {
+			InlineVector<TemplateTypeArg, 4> deduced_template_args;
+			deduced_template_args.reserve(shared_deduction->template_args.size());
+			for (const TemplateTypeArg& template_arg : shared_deduction->template_args) {
+				deduced_template_args.push_back(template_arg);
+			}
 			return CandidateResult{
 				&template_node_cand,
 				lookup_candidate.identity.lookup_name,
-				std::vector<TemplateTypeArg>(
-					shared_deduction->template_args.begin(),
-					shared_deduction->template_args.end()),
+				std::move(deduced_template_args),
 				computeFunctionTemplateSpecificity(template_func)};
 		}
 
@@ -672,7 +675,8 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 			return std::nullopt;
 		}
 
-		std::vector<TemplateTypeArg> template_args;
+		InlineVector<TemplateTypeArg, 4> template_args;
+		template_args.reserve(template_params.size());
 		size_t arg_index = 0;
 		for (const auto& template_param_node : template_params) {
 			const TemplateParameterNode& param = template_param_node;
@@ -767,7 +771,8 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	// (preserves the pre-partial-ordering behavior and avoids spurious ambiguity errors).
 	size_t best_idx = std::numeric_limits<size_t>::max();
 	int best_specificity = -1;
-	std::vector<CandidateResult> viable;
+	InlineVector<CandidateResult, 4> viable;
+	viable.reserve(template_candidates.size());
 	for (size_t i = 0; i < template_candidates.size(); ++i) {
 		auto candidate = tryDeduceCandidate(template_candidates[i]);
 		if (!candidate.has_value()) {
@@ -786,8 +791,8 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 	}
 
 	if (viable.size() > 1) {
-		std::vector<ASTNode> shape_overloads;
-		std::vector<size_t> shape_candidate_indices;
+		InlineVector<ASTNode, 4> shape_overloads;
+		InlineVector<size_t, 4> shape_candidate_indices;
 		shape_overloads.reserve(viable.size());
 		shape_candidate_indices.reserve(viable.size());
 		for (size_t i = 0; i < viable.size(); ++i) {
@@ -1071,8 +1076,8 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 		lazy_info.template_params.push_back(TemplateParameterNode(outer_name, outer_token));
 	}
 	for (const auto& outer_arg : outer_args) {
-		const std::vector<ASTNode> no_params;
-		const std::vector<TemplateTypeArg> no_args;
+		const InlineVector<ASTNode, 1> no_params;
+		const InlineVector<TemplateTypeArg, 1> no_args;
 		lazy_info.template_args.push_back(materializeTemplateArg(
 			outer_arg,
 			no_params,
@@ -1201,7 +1206,8 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 	auto materialize_template_ctor_candidates =
 		[&](const ConstructorDeclarationNode* preferred_template_ctor)
 			-> const ConstructorDeclarationNode* {
-		std::vector<const ConstructorDeclarationNode*> concrete_matches;
+		InlineVector<const ConstructorDeclarationNode*, 4> concrete_matches;
+		concrete_matches.reserve(struct_info.member_functions.size());
 
 		auto try_materialize_candidate =
 			[&](const ConstructorDeclarationNode& template_ctor) {
@@ -1455,7 +1461,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 	}
 
 	// Route member template overload discovery through the semantic two-phase lookup request.
-	std::vector<TemplateNameLookupCandidate> template_candidates =
+	InlineVector<TemplateNameLookupCandidate, 4> template_candidates =
 		lookupMemberFunctionTemplateCandidatesForInstantiation(struct_name, member_name);
 
 	if (template_candidates.empty()) {
@@ -1567,11 +1573,13 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 			}
 		}
 
-		const std::vector<TypeSpecifierNode> empty_call_arg_types;
+		const InlineVector<TypeSpecifierNode, 1> empty_call_arg_types;
 		std::span<const TypeSpecifierNode> call_arg_types =
 			current_explicit_call_arg_types_ != nullptr
 				? *current_explicit_call_arg_types_
-				: empty_call_arg_types;
+				: std::span<const TypeSpecifierNode>(
+					empty_call_arg_types.data(),
+					empty_call_arg_types.size());
 		// Prefer the declaring owner from inheritance lookup; fall back to deriving
 		// the owner from the candidate's qualified name rather than re-using the
 		// requested receiver (which may be a derived type, not the declaring base).
@@ -1937,7 +1945,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			type_index.category() == TypeCategory::UserDefined) {
 			const TypeInfo* ti = tryGetTypeInfo(type_index);
 			if (ti && ti->isTemplateInstantiation()) {
-				std::vector<TemplateTypeArg> concrete_args =
+				auto concrete_args =
 					materializePlaceholderTemplateArgs(*ti, template_params, template_args);
 
 				if (outer_binding) {
@@ -2005,11 +2013,15 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		}
 		if (alias_type_spec.is_array()) {
 			const std::span<const size_t> target_dimensions = target.array_dimensions();
-			std::vector<size_t> merged_dimensions(target_dimensions.begin(), target_dimensions.end());
-			merged_dimensions.insert(
-				merged_dimensions.end(),
-				alias_type_spec.array_dimensions().begin(),
-				alias_type_spec.array_dimensions().end());
+			InlineVector<size_t, 4> merged_dimensions;
+			merged_dimensions.reserve(
+				target_dimensions.size() + alias_type_spec.array_dimensions().size());
+			for (size_t dimension : target_dimensions) {
+				merged_dimensions.push_back(dimension);
+			}
+			for (size_t dimension : alias_type_spec.array_dimensions()) {
+				merged_dimensions.push_back(dimension);
+			}
 			target.set_array_dimensions(merged_dimensions);
 		}
 		if (const int resolved_size_bits = getTypeSpecSizeBits(target); resolved_size_bits > 0) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -137,10 +137,10 @@ ASTNode rebuildResolvedSubstitutedTypeSpec(
 	const TemplateTypeArg* resolved_arg) {
 	ASTNode substituted_type = ASTNode::emplace_node<TypeSpecifierNode>(
 		resolved_type_index.category(),
-		TypeQualifier::None,
+		original_type_spec.qualifier(),
 		get_type_size_bits(resolved_type_index.category()),
-		Token(),
-		CVQualifier::None);
+		original_type_spec.token(),
+		original_type_spec.cv_qualifier());
 
 	auto& substituted_type_spec = substituted_type.as<TypeSpecifierNode>();
 	substituted_type_spec.set_type_index(resolved_type_index);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1792,7 +1792,9 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			}
 			return {type_index, nullptr};
 		}
-		if (type_index.category() == TypeCategory::UserDefined) {
+		if (type_index.category() == TypeCategory::UserDefined ||
+			type_index.category() == TypeCategory::TypeAlias ||
+			type_index.category() == TypeCategory::Template) {
 			const TypeInfo* ti = tryGetTypeInfo(type_index);
 			if (!ti) {
 				return {type_index, nullptr};
@@ -2260,11 +2262,32 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					param_type_index = *resolved_outer;
 				}
 			}
+			InlineVector<TemplateParameterNode, 4> member_template_resolution_params;
+			InlineVector<TemplateTypeArg, 4> member_template_resolution_args;
+			if (func_decl.has_outer_template_bindings()) {
+				for (size_t outer_index = 0;
+					 outer_index < func_decl.outer_template_param_names().size() &&
+					 outer_index < func_decl.outer_template_args().size();
+					 ++outer_index) {
+					member_template_resolution_params.push_back(
+						rebuildOuterTemplateParameter(
+							func_decl.outer_template_param_names()[outer_index],
+							func_decl.outer_template_args()[outer_index]));
+					member_template_resolution_args.push_back(
+						toTemplateTypeArg(func_decl.outer_template_args()[outer_index]));
+				}
+			}
+			for (const auto& template_param : template_params) {
+				member_template_resolution_params.push_back(template_param);
+			}
+			for (const auto& template_arg : template_args) {
+				member_template_resolution_args.push_back(template_arg);
+			}
 			param_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
 				&original_param_type_node,
 				param_type_spec,
-				template_params,
-				template_args,
+				member_template_resolution_params,
+				member_template_resolution_args,
 				[this](
 					std::string_view template_name,
 					std::span<const TemplateTypeArg> template_args,
@@ -2275,6 +2298,15 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 						force_eager);
 				},
 				param_type_index);
+			if (const TypeInfo* materialized_member_alias =
+					materializeInstantiatedMemberAliasTarget(
+						param_type_spec,
+						member_template_resolution_params,
+						member_template_resolution_args)) {
+				param_type_index =
+					materialized_member_alias->registeredTypeIndex().withCategory(
+						materialized_member_alias->typeEnum());
+			}
 
 			// Create the substituted parameter type specifier
 			auto substituted_param_type = emplace_node<TypeSpecifierNode>(
@@ -2292,6 +2324,16 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			substituted_param_type_spec.set_reference_qualifier(param_type_spec.reference_qualifier());
 			propagate_function_signature(substituted_param_type_spec, param_type_spec, resolved_arg);
 			apply_resolved_type_metadata(substituted_param_type_spec, resolved_arg, param_type_index);
+			if (const TypeInfo* param_type_info = tryGetTypeInfo(param_type_index);
+				param_type_info != nullptr &&
+				param_type_info->isTypeAlias()) {
+				if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
+					alias_type_spec != nullptr &&
+					!typeSpecStillUsesDependentPlaceholder(*alias_type_spec)) {
+					substituted_param_type_spec = *alias_type_spec;
+				}
+			}
+			normalizeSubstitutedTypeSpec(substituted_param_type_spec);
 
 			// Create the new parameter declaration
 			auto new_param_decl = emplace_node<DeclarationNode>(substituted_param_type, param_decl.identifier_token());

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -81,6 +81,84 @@ StringHandle getMemberTemplateOwnerName(StringHandle qualified_lookup_name, cons
 
 	return {};
 }
+
+void propagateSubstitutedFunctionSignature(
+	TypeSpecifierNode& target,
+	const TypeSpecifierNode& original,
+	const TemplateTypeArg* resolved_arg) {
+	if (original.has_function_signature()) {
+		target.set_function_signature(original.function_signature());
+	} else if (resolved_arg && resolved_arg->function_signature.has_value()) {
+		target.set_function_signature(*resolved_arg->function_signature);
+	}
+}
+
+void applyResolvedSubstitutedTypeMetadata(
+	TypeSpecifierNode& target,
+	const TemplateTypeArg* resolved_arg,
+	TypeIndex source_type_index) {
+	if (resolved_arg) {
+		for (size_t i = 0; i < resolved_arg->pointer_depth; ++i) {
+			CVQualifier cv = i < resolved_arg->pointer_cv_qualifiers.size()
+								 ? resolved_arg->pointer_cv_qualifiers[i]
+								 : CVQualifier::None;
+			target.add_pointer_level(cv);
+		}
+		if (target.reference_qualifier() == ReferenceQualifier::None &&
+			resolved_arg->ref_qualifier != ReferenceQualifier::None) {
+			target.set_reference_qualifier(resolved_arg->ref_qualifier);
+		}
+	}
+
+	if (source_type_index.is_valid()) {
+		const ResolvedAliasTypeInfo alias_info = resolveAliasTypeInfo(source_type_index);
+		if (alias_info.type_index.is_valid() && alias_info.type_index != source_type_index) {
+			target.set_type_index(alias_info.type_index.withCategory(alias_info.typeEnum()));
+		}
+		target.add_pointer_levels(static_cast<int>(alias_info.pointer_depth));
+		if (target.reference_qualifier() == ReferenceQualifier::None &&
+			alias_info.reference_qualifier != ReferenceQualifier::None) {
+			target.set_reference_qualifier(alias_info.reference_qualifier);
+		}
+		if (!target.has_function_signature() && alias_info.function_signature.has_value()) {
+			target.set_function_signature(*alias_info.function_signature);
+		}
+	}
+
+	const int resolved_size_bits = getTypeSpecSizeBits(target);
+	if (resolved_size_bits > 0) {
+		target.set_size_in_bits(resolved_size_bits);
+	}
+}
+
+ASTNode rebuildResolvedSubstitutedTypeSpec(
+	const TypeSpecifierNode& original_type_spec,
+	TypeIndex resolved_type_index,
+	const TemplateTypeArg* resolved_arg) {
+	ASTNode substituted_type = ASTNode::emplace_node<TypeSpecifierNode>(
+		resolved_type_index.category(),
+		TypeQualifier::None,
+		get_type_size_bits(resolved_type_index.category()),
+		Token(),
+		CVQualifier::None);
+
+	auto& substituted_type_spec = substituted_type.as<TypeSpecifierNode>();
+	substituted_type_spec.set_type_index(resolved_type_index);
+	for (const auto& ptr_level : original_type_spec.pointer_levels()) {
+		substituted_type_spec.add_pointer_level(ptr_level.cv_qualifier);
+	}
+	substituted_type_spec.set_reference_qualifier(
+		original_type_spec.reference_qualifier());
+	propagateSubstitutedFunctionSignature(
+		substituted_type_spec,
+		original_type_spec,
+		resolved_arg);
+	applyResolvedSubstitutedTypeMetadata(
+		substituted_type_spec,
+		resolved_arg,
+		resolved_type_index);
+	return substituted_type;
+}
 }
 
 bool Parser::tryAppendMemberDefaultTemplateArg(
@@ -1910,50 +1988,6 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		return {type_index, nullptr};
 	};
 
-	// Propagates function_signature to a substituted TypeSpecifierNode:
-	// prefers the original type spec's signature, falls back to the template arg's signature.
-	auto propagate_function_signature = [](TypeSpecifierNode& target,
-										   const TypeSpecifierNode& original, const TemplateTypeArg* resolved_arg) {
-		if (original.has_function_signature()) {
-			target.set_function_signature(original.function_signature());
-		} else if (resolved_arg && resolved_arg->function_signature.has_value()) {
-			target.set_function_signature(*resolved_arg->function_signature);
-		}
-	};
-	auto apply_resolved_type_metadata = [](TypeSpecifierNode& target, const TemplateTypeArg* resolved_arg, TypeIndex source_type_index) {
-		if (resolved_arg) {
-			for (size_t i = 0; i < resolved_arg->pointer_depth; ++i) {
-				CVQualifier cv = i < resolved_arg->pointer_cv_qualifiers.size()
-									 ? resolved_arg->pointer_cv_qualifiers[i]
-									 : CVQualifier::None;
-				target.add_pointer_level(cv);
-			}
-			if (target.reference_qualifier() == ReferenceQualifier::None &&
-				resolved_arg->ref_qualifier != ReferenceQualifier::None) {
-				target.set_reference_qualifier(resolved_arg->ref_qualifier);
-			}
-		}
-
-		if (source_type_index.is_valid()) {
-			const ResolvedAliasTypeInfo alias_info = resolveAliasTypeInfo(source_type_index);
-			if (alias_info.type_index.is_valid() && alias_info.type_index != source_type_index) {
-				target.set_type_index(alias_info.type_index.withCategory(alias_info.typeEnum()));
-			}
-			target.add_pointer_levels(static_cast<int>(alias_info.pointer_depth));
-			if (target.reference_qualifier() == ReferenceQualifier::None &&
-				alias_info.reference_qualifier != ReferenceQualifier::None) {
-				target.set_reference_qualifier(alias_info.reference_qualifier);
-			}
-			if (!target.has_function_signature() && alias_info.function_signature.has_value()) {
-				target.set_function_signature(*alias_info.function_signature);
-			}
-		}
-
-		const int resolved_size_bits = getTypeSpecSizeBits(target);
-		if (resolved_size_bits > 0) {
-			target.set_size_in_bits(resolved_size_bits);
-		}
-	};
 	auto merge_alias_target_type_spec = [](TypeSpecifierNode& target, const TypeSpecifierNode& alias_type_spec) {
 		if (alias_type_spec.type_index().is_valid()) {
 			target.set_type_index(alias_type_spec.type_index().withCategory(alias_type_spec.type()));
@@ -1996,22 +2030,10 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 						orig_decl.identifier_token().file_index());
 
 	// Create return type node
-	ASTNode substituted_return_type = emplace_node<TypeSpecifierNode>(
-		return_type_index.category(),
-		TypeQualifier::None,
-		get_type_size_bits(return_type_index.category()),
-		Token(),
-		CVQualifier::None);
-
-	// Copy pointer levels and set type_index from the resolved type
-	auto& substituted_return_type_spec = substituted_return_type.as<TypeSpecifierNode>();
-	substituted_return_type_spec.set_type_index(return_type_index);
-	for (const auto& ptr_level : return_type_spec.pointer_levels()) {
-		substituted_return_type_spec.add_pointer_level(ptr_level.cv_qualifier);
-	}
-	substituted_return_type_spec.set_reference_qualifier(return_type_spec.reference_qualifier());
-	propagate_function_signature(substituted_return_type_spec, return_type_spec, return_resolved_arg);
-	apply_resolved_type_metadata(substituted_return_type_spec, return_resolved_arg, return_type_index);
+	ASTNode substituted_return_type = rebuildResolvedSubstitutedTypeSpec(
+		return_type_spec,
+		return_type_index,
+		return_resolved_arg);
 
 	// Create the new function declaration
 	auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(substituted_return_type, mangled_token);
@@ -2323,21 +2345,12 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				true);
 
 			// Create the substituted parameter type specifier
-			auto substituted_param_type = emplace_node<TypeSpecifierNode>(
-				param_type_index.category(),
-				TypeQualifier::None,
-				get_type_size_bits(param_type_index.category()),
-				Token(), CVQualifier::None);
+			auto substituted_param_type = rebuildResolvedSubstitutedTypeSpec(
+				param_type_spec,
+				param_type_index,
+				resolved_arg);
 
-			// Copy pointer levels and set type_index from the resolved type
 			auto& substituted_param_type_spec = substituted_param_type.as<TypeSpecifierNode>();
-			substituted_param_type_spec.set_type_index(param_type_index);
-			for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-				substituted_param_type_spec.add_pointer_level(ptr_level.cv_qualifier);
-			}
-			substituted_param_type_spec.set_reference_qualifier(param_type_spec.reference_qualifier());
-			propagate_function_signature(substituted_param_type_spec, param_type_spec, resolved_arg);
-			apply_resolved_type_metadata(substituted_param_type_spec, resolved_arg, param_type_index);
 			if (const TypeInfo* param_type_info = tryGetTypeInfo(param_type_index);
 				param_type_info != nullptr &&
 				param_type_info->isTypeAlias()) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1954,6 +1954,34 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			target.set_size_in_bits(resolved_size_bits);
 		}
 	};
+	auto merge_alias_target_type_spec = [](TypeSpecifierNode& target, const TypeSpecifierNode& alias_type_spec) {
+		if (alias_type_spec.type_index().is_valid()) {
+			target.set_type_index(alias_type_spec.type_index().withCategory(alias_type_spec.type()));
+		}
+		target.set_category(alias_type_spec.type());
+		target.add_cv_qualifier(alias_type_spec.cv_qualifier());
+		for (const auto& ptr_level : alias_type_spec.pointer_levels()) {
+			target.add_pointer_level(ptr_level.cv_qualifier);
+		}
+		target.set_reference_qualifier(collapseReferenceQualifiers(
+			alias_type_spec.reference_qualifier(),
+			target.reference_qualifier()));
+		if (!target.has_function_signature() && alias_type_spec.has_function_signature()) {
+			target.set_function_signature(alias_type_spec.function_signature());
+		}
+		if (alias_type_spec.is_array()) {
+			const std::span<const size_t> target_dimensions = target.array_dimensions();
+			std::vector<size_t> merged_dimensions(target_dimensions.begin(), target_dimensions.end());
+			merged_dimensions.insert(
+				merged_dimensions.end(),
+				alias_type_spec.array_dimensions().begin(),
+				alias_type_spec.array_dimensions().end());
+			target.set_array_dimensions(merged_dimensions);
+		}
+		if (const int resolved_size_bits = getTypeSpecSizeBits(target); resolved_size_bits > 0) {
+			target.set_size_in_bits(resolved_size_bits);
+		}
+	};
 	// Substitute the return type if it's a template parameter
 	const TypeSpecifierNode& return_type_spec = orig_decl.type_specifier_node();
 	auto [return_type_index, return_resolved_arg] = resolve_template_type(return_type_spec.type_index());
@@ -2283,30 +2311,16 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			for (const auto& template_arg : template_args) {
 				member_template_resolution_args.push_back(template_arg);
 			}
-			param_type_index = resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtifact(
+			param_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+				*this,
 				&original_param_type_node,
 				param_type_spec,
 				member_template_resolution_params,
 				member_template_resolution_args,
-				[this](
-					std::string_view template_name,
-					std::span<const TemplateTypeArg> template_args,
-					bool force_eager) {
-					return try_instantiate_class_template(
-						template_name,
-						template_args,
-						force_eager);
-				},
-				param_type_index);
-			if (const TypeInfo* materialized_member_alias =
-					materializeInstantiatedMemberAliasTarget(
-						param_type_spec,
-						member_template_resolution_params,
-						member_template_resolution_args)) {
-				param_type_index =
-					materialized_member_alias->registeredTypeIndex().withCategory(
-						materialized_member_alias->typeEnum());
-			}
+				param_type_index,
+				true,
+				true,
+				true);
 
 			// Create the substituted parameter type specifier
 			auto substituted_param_type = emplace_node<TypeSpecifierNode>(
@@ -2330,7 +2344,9 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
 					alias_type_spec != nullptr &&
 					!typeSpecStillUsesDependentPlaceholder(*alias_type_spec)) {
-					substituted_param_type_spec = *alias_type_spec;
+					merge_alias_target_type_spec(
+						substituted_param_type_spec,
+						*alias_type_spec);
 				}
 			}
 			normalizeSubstitutedTypeSpec(substituted_param_type_spec);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1427,6 +1427,17 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		if (alias_node == nullptr) {
 			return false;
 		}
+		if (alias_node->is_deferred()) {
+			return false;
+		}
+		if (const TypeInfo* alias_target_info =
+				tryGetTypeInfo(alias_node->target_type_node().type_index());
+			alias_target_info != nullptr &&
+			(alias_target_info->isTemplateInstantiation() ||
+			 alias_target_info->isDependentMemberType() ||
+			 alias_target_info->hasDependentQualifiedName())) {
+			return false;
+		}
 		std::optional<TemplateTypeArg> rebound_arg =
 			tryRebindAliasTargetTemplateArg(*alias_node, template_args);
 		if (!rebound_arg.has_value() || rebound_arg->is_value) {
@@ -1694,7 +1705,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		}
 	}
 	if (alias_node != nullptr &&
-		result.resolved_type_info != nullptr) {
+		result.resolved_type_info != nullptr &&
+		!templateArgsStillNeedAliasLookupMaterialization(template_args)) {
 		// Prefer a direct alias target over the helper instantiation itself.
 		// Member-alias targets are checked after this because an alias target like
 		// `Owner<B>::template type<T, F>` must first select `Owner<B>` and then
@@ -1706,17 +1718,32 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					effective_template_params,
 					effective_template_args);
 			concrete_member_alias != nullptr) {
-			const TypeInfo* resolved_member_info = concrete_member_alias;
-			ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(
-				concrete_member_alias->registeredTypeIndex().withCategory(
-					concrete_member_alias->typeEnum()));
-			if (resolved_member_alias.terminal_type_info != nullptr &&
-				!alias_preserves_surface_type(resolved_member_alias)) {
-				resolved_member_info = resolved_member_alias.terminal_type_info;
+			bool member_alias_has_dependent_args = false;
+			for (const auto& arg_info : concrete_member_alias->templateArgs()) {
+				TemplateTypeArg arg = toTemplateTypeArg(arg_info);
+				if (arg.is_dependent ||
+					arg.dependent_name.isValid() ||
+					arg.dependent_expr.has_value() ||
+					(!arg.is_value &&
+					 arg.type_index.is_valid() &&
+					 typeIndexContainsDependentPlaceholder(arg.type_index))) {
+					member_alias_has_dependent_args = true;
+					break;
+				}
 			}
-			result.resolved_type_info = resolved_member_info;
-			result.instantiated_name =
-				StringTable::getStringView(resolved_member_info->name());
+			if (!member_alias_has_dependent_args) {
+				const TypeInfo* resolved_member_info = concrete_member_alias;
+				ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(
+					concrete_member_alias->registeredTypeIndex().withCategory(
+						concrete_member_alias->typeEnum()));
+				if (resolved_member_alias.terminal_type_info != nullptr &&
+					!alias_preserves_surface_type(resolved_member_alias)) {
+					resolved_member_info = resolved_member_alias.terminal_type_info;
+				}
+				result.resolved_type_info = resolved_member_info;
+				result.instantiated_name =
+					StringTable::getStringView(resolved_member_info->name());
+			}
 		}
 	}
 	if (alias_node != nullptr &&
@@ -1758,10 +1785,14 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					resolved_type_info.sizeInBits().value,
 					&alias_registration_type_spec,
 					&resolved_type_info);
+			} else if (!is_qualified_alias_template) {
+				alias_type_info = &add_type_alias_copy(
+					alias_handle,
+					alias_target_index,
+					resolved_type_info.sizeInBits().value,
+					alias_registration_type_spec,
+					resolved_type_info);
 			}
-			// Only normalize entries that were already created by earlier
-			// parsing/materialization. Creating fresh aliases here changes
-			// ordinary alias-chain lookup and can perturb sizeof/NTTP behavior.
 			return alias_type_info;
 		};
 
@@ -2262,7 +2293,39 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	if (dependent_base_info == nullptr && dependent_name->owner_name.isValid()) {
 		dependent_base_info = findTypeByName(dependent_name->owner_name);
 	}
-	if (!dependent_base_info || !dependent_base_info->isTemplateInstantiation()) {
+	if ((dependent_base_info == nullptr ||
+		 !is_struct_type(dependent_base_info->typeEnum())) &&
+		dependent_name->owner_name.isValid()) {
+		for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
+			if (template_params[i].nameHandle() == dependent_name->owner_name &&
+				!template_args[i].is_value) {
+				dependent_base_info = tryGetTypeInfo(template_args[i].type_index);
+				break;
+			}
+		}
+	}
+	if (dependent_base_info == nullptr ||
+		!is_struct_type(dependent_base_info->typeEnum())) {
+		const TypeInfo* unique_owner_type_info = nullptr;
+		for (size_t i = 0; i < template_args.size(); ++i) {
+			if (template_args[i].is_value) {
+				continue;
+			}
+			const TypeInfo* candidate_owner_info =
+				tryGetTypeInfo(template_args[i].type_index);
+			if (candidate_owner_info == nullptr ||
+				!is_struct_type(candidate_owner_info->typeEnum())) {
+				continue;
+			}
+			if (unique_owner_type_info != nullptr) {
+				unique_owner_type_info = nullptr;
+				break;
+			}
+			unique_owner_type_info = candidate_owner_info;
+		}
+		dependent_base_info = unique_owner_type_info;
+	}
+	if (!dependent_base_info || !is_struct_type(dependent_base_info->typeEnum())) {
 		return nullptr;
 	}
 	std::string_view dependent_base_name =
@@ -2375,34 +2438,36 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		return direct_concrete_member_it->second;
 	}
 
-	StringHandle base_template_name_handle = gNamespaceRegistry.buildQualifiedIdentifier(
-		dependent_base_info->sourceNamespace(),
-		dependent_base_info->baseTemplateName());
-	if (dependent_name->owner_name.isValid()) {
-		base_template_name_handle = dependent_name->owner_name;
-	}
-	InlineVector<TemplateTypeArg, 4> concrete_base_args =
-		!dependent_name->owner_template_arguments.empty()
-			? materialize_template_args_with_environment(
-				  dependent_name->owner_template_arguments)
-			: materialize_template_args_from_type_info(*dependent_base_info);
-	if (template_args_still_dependent(concrete_base_args)) {
-		return nullptr;
-	}
-	AliasTemplateMaterializationResult materialized_alias_base =
-		materializeTemplateInstantiationForLookup(
-			StringTable::getStringView(base_template_name_handle),
-			concrete_base_args);
-	if (materialized_alias_base.instantiated_name.empty() &&
-		base_template_name_handle != dependent_base_info->baseTemplateName()) {
-		materialized_alias_base = materializeTemplateInstantiationForLookup(
-			StringTable::getStringView(dependent_base_info->baseTemplateName()),
-			concrete_base_args);
-	}
-	std::string_view materialized_alias_base_name =
-		materialized_alias_base.canonicalName();
-	if (materialized_alias_base_name.empty()) {
-		return nullptr;
+	std::string_view materialized_alias_base_name = dependent_base_name;
+	if (dependent_base_info->isTemplateInstantiation()) {
+		StringHandle base_template_name_handle = gNamespaceRegistry.buildQualifiedIdentifier(
+			dependent_base_info->sourceNamespace(),
+			dependent_base_info->baseTemplateName());
+		if (dependent_name->owner_name.isValid()) {
+			base_template_name_handle = dependent_name->owner_name;
+		}
+		InlineVector<TemplateTypeArg, 4> concrete_base_args =
+			!dependent_name->owner_template_arguments.empty()
+				? materialize_template_args_with_environment(
+					  dependent_name->owner_template_arguments)
+				: materialize_template_args_from_type_info(*dependent_base_info);
+		if (template_args_still_dependent(concrete_base_args)) {
+			return nullptr;
+		}
+		AliasTemplateMaterializationResult materialized_alias_base =
+			materializeTemplateInstantiationForLookup(
+				StringTable::getStringView(base_template_name_handle),
+				concrete_base_args);
+		if (materialized_alias_base.instantiated_name.empty() &&
+			base_template_name_handle != dependent_base_info->baseTemplateName()) {
+			materialized_alias_base = materializeTemplateInstantiationForLookup(
+				StringTable::getStringView(dependent_base_info->baseTemplateName()),
+				concrete_base_args);
+		}
+		materialized_alias_base_name = materialized_alias_base.canonicalName();
+		if (materialized_alias_base_name.empty()) {
+			return nullptr;
+		}
 	}
 
 	StringHandle member_alias_handle =
@@ -2413,6 +2478,53 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				.append(dependent_member_path)
 				.commit());
 	StringHandle materialized_member_alias_handle = member_alias_handle;
+	if (!gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
+		if (dependent_name->owner_name.isValid()) {
+			StringHandle pattern_member_alias_handle =
+				StringTable::getOrInternStringHandle(
+					StringBuilder()
+						.append(StringTable::getStringView(dependent_name->owner_name))
+						.append("::")
+						.append(dependent_member_path)
+						.commit());
+			if (gTemplateRegistry.lookup_alias_template(pattern_member_alias_handle).has_value()) {
+				materialized_member_alias_handle = pattern_member_alias_handle;
+			}
+		}
+	}
+	if (!gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
+		if (dependent_base_info->baseTemplateName().isValid()) {
+			StringHandle pattern_member_alias_handle =
+				StringTable::getOrInternStringHandle(
+					StringBuilder()
+						.append(StringTable::getStringView(dependent_base_info->baseTemplateName()))
+						.append("::")
+						.append(dependent_member_path)
+						.commit());
+			if (gTemplateRegistry.lookup_alias_template(pattern_member_alias_handle).has_value()) {
+				materialized_member_alias_handle = pattern_member_alias_handle;
+			}
+		}
+	}
+	if (!gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
+		const size_t instantiated_marker = dependent_base_name.find('$');
+		const size_t nested_owner_sep = dependent_base_name.find("::");
+		if (instantiated_marker != std::string_view::npos &&
+			nested_owner_sep != std::string_view::npos &&
+			instantiated_marker < nested_owner_sep) {
+			StringHandle pattern_member_alias_handle =
+				StringTable::getOrInternStringHandle(
+					StringBuilder()
+						.append(dependent_base_name.substr(0, instantiated_marker))
+						.append(dependent_base_name.substr(nested_owner_sep))
+						.append("::")
+						.append(dependent_member_path)
+						.commit());
+			if (gTemplateRegistry.lookup_alias_template(pattern_member_alias_handle).has_value()) {
+				materialized_member_alias_handle = pattern_member_alias_handle;
+			}
+		}
+	}
 	if (!gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
 		std::string_view inherited_member_alias_name =
 			lookup_inherited_member_template_name(

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -4,6 +4,7 @@
 #include "ExpressionSubstitutor.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
+#include "ParserTemplateClassShared.h"
 #include "TypeTraitEvaluator.h"
 
 static void buildVariableTemplateParameterReplayState(
@@ -2306,24 +2307,8 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	}
 	if (dependent_base_info == nullptr ||
 		!is_struct_type(dependent_base_info->typeEnum())) {
-		const TypeInfo* unique_owner_type_info = nullptr;
-		for (size_t i = 0; i < template_args.size(); ++i) {
-			if (template_args[i].is_value) {
-				continue;
-			}
-			const TypeInfo* candidate_owner_info =
-				tryGetTypeInfo(template_args[i].type_index);
-			if (candidate_owner_info == nullptr ||
-				!is_struct_type(candidate_owner_info->typeEnum())) {
-				continue;
-			}
-			if (unique_owner_type_info != nullptr) {
-				unique_owner_type_info = nullptr;
-				break;
-			}
-			unique_owner_type_info = candidate_owner_info;
-		}
-		dependent_base_info = unique_owner_type_info;
+		dependent_base_info =
+			findUniqueStructOwnerTypeFromTemplateArgs(template_args);
 	}
 	if (!dependent_base_info || !is_struct_type(dependent_base_info->typeEnum())) {
 		return nullptr;

--- a/tests/test_template_member_func_template_const_ref_callsite_fail.cpp
+++ b/tests/test_template_member_func_template_const_ref_callsite_fail.cpp
@@ -1,0 +1,15 @@
+template<typename T>
+struct Box {
+	T value;
+
+	template<typename U>
+	const T& get() {
+		return value;
+	}
+};
+
+int main() {
+	Box<int> box{42};
+	box.get<int>() = 7;
+	return 0;
+}

--- a/tests/test_template_member_func_template_const_ref_return_fail.cpp
+++ b/tests/test_template_member_func_template_const_ref_return_fail.cpp
@@ -1,0 +1,19 @@
+template<typename T>
+struct Box {
+	T value;
+
+	template<typename U>
+	const T& get();
+};
+
+template<typename T>
+template<typename U>
+const T& Box<T>::get() {
+	return value;
+}
+
+int& (Box<int>::*pmf)() = &Box<int>::template get<int>;
+
+int main() {
+	return 0;
+}

--- a/tests/test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp
+++ b/tests/test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp
@@ -1,0 +1,39 @@
+// Regression: OOL member-function-template body replay must parse parameters
+// whose concrete type is recovered from a type-parameter-qualified member
+// template type with the instantiated parameter metadata, not a placeholder
+// definition-side type.  Direct dereference and forwarding both require the
+// body parameter to behave as the resolved int*.
+
+struct OolMemberTemplateDependentMemberTemplateTypeForwardDerefTag {
+	template <class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+int ool_member_template_forward_deref_read(int* value) {
+	return *value;
+}
+
+template <class T>
+struct OolMemberTemplateDependentMemberTemplateTypeForwardDerefReplay {
+	template <class U>
+	int pick(U seed, typename T::template AddPtr<int>::type value);
+};
+
+template <class T>
+template <class U>
+int OolMemberTemplateDependentMemberTemplateTypeForwardDerefReplay<T>::pick(
+	U seed,
+	typename T::template AddPtr<int>::type value) {
+	return static_cast<int>(sizeof(*value)) +
+		static_cast<int>(sizeof(ool_member_template_forward_deref_read(value))) -
+		8 + seed - seed;
+}
+
+int main() {
+	int int_value = 41;
+	OolMemberTemplateDependentMemberTemplateTypeForwardDerefReplay<
+		OolMemberTemplateDependentMemberTemplateTypeForwardDerefTag> replay;
+	return replay.pick(3, &int_value);
+}

--- a/tests/test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp
+++ b/tests/test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp
@@ -1,0 +1,36 @@
+// Regression: OOL member-function-template body replay must preserve both
+// alias-carried pointer metadata and an outer reference qualifier when a
+// type-parameter-qualified member-template type is forwarded from the body.
+
+struct OolMemberTemplateDependentMemberTemplateTypeRefTag {
+	template <class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+int ool_member_template_ref_read(int* value) {
+	return *value;
+}
+
+template <class T>
+struct OolMemberTemplateDependentMemberTemplateTypeRefReplay {
+	template <class U>
+	int pick(U seed, typename T::template AddPtr<int>::type& value);
+};
+
+template <class T>
+template <class U>
+int OolMemberTemplateDependentMemberTemplateTypeRefReplay<T>::pick(
+	U seed,
+	typename T::template AddPtr<int>::type& value) {
+	return ool_member_template_ref_read(value) + seed - seed;
+}
+
+int main() {
+	int int_value = 42;
+	int* pointer = &int_value;
+	OolMemberTemplateDependentMemberTemplateTypeRefReplay<
+		OolMemberTemplateDependentMemberTemplateTypeRefTag> replay;
+	return replay.pick(3, pointer) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Preserve concrete alias metadata for out-of-line member-function-template replay when parameters are typed through dependent member-template aliases such as `typename T::template AddPtr<int>::type`
- Strengthen alias normalization/recovery so self-referential alias entries can resolve through their stored type specifier without broad fallback
- Add focused forwarding/reference-forwarding regressions and document the remaining same-name overload attachment gap
- Update the template-argument architecture/conformance docs with completed state and next steps

## Validation
- `.\build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1 test_template_ool_member_template_dependent_member_template_type_param_deref_ret0.cpp test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp test_alias_chain_partial_default_nttp_ret0.cpp test_member_alias_template_non_template_intermediate_outer_binding_ret0.cpp`
- `pwsh tests/run_all_tests.ps1` (2595 regular tests passed, 182 expected-fail tests failed as expected)