### PR TITLE
Fix template alias-target replay overloads

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (OOL member-function-template bodies now preserve type-parameter-qualified member-template alias metadata)
+**Last updated:** 2026-05-28 (OOL member-template alias-target overload replay now preserves dependent owner/member-template identity end-to-end)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep only the minimum completed-state context needed to explain
@@ -198,9 +198,19 @@ Useful assumptions before changing this area:
   Alias-owner recovery is narrowed to evidence-backed dependent-owner records or
   a unique concrete struct owner, so existing alias-template default NTTP and
   non-template-intermediate member-alias paths remain stable.
+- **OOL member-function-template overloads whose parameters differ only by
+  concrete type-parameter-qualified member-template alias targets now preserve
+  dependent owner/member-template identity across copied instantiated stubs,
+  replay attachment, lazy member-template shape instantiation, and concrete
+  alias materialization**: `typename T::template AddPtr<int>::type` vs
+  `...AddPtr<long>::type` no longer collapses to the same owner artifact or the
+  same `$olN` body. The adjacent plain-member dependent-qualified replay path
+  now concretizes those definition-side alias targets after attachment, and the
+  nested dependent-member swap replay path now concretizes non-template
+  dependent member aliases before overload-shape reuse.
 
 Latest recorded full-suite validation:
-`2595` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
+`2598` regular tests compiled/linked/runtime-pass, `0` fail, `185` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -231,6 +241,7 @@ Latest focused replay regressions added on the current branch:
 - `test_template_ool_ctor_dependent_member_swap_body_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_swap_body_ret0.cpp`
 - `test_template_param_qualified_static_member_auto_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_deref_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp`
@@ -253,14 +264,13 @@ The next highest-value remaining surface:
     substitution outcomes (`nullopt`) because required replay-visible metadata
     is not always captured early enough; these need metadata completion so
     canonical matching succeeds more often without broad fallback machinery.
-  - overloaded OOL member-function-template declarations whose parameter types
-    differ only by concrete member-template alias targets still need stronger
-    source-member identity and alias-target disambiguation; a reduced
-    `AddPtr<int>`/`AddPtr<long>` case can still select the wrong `$olN`
-    materialization and fail to attach the replayed body.
   - dependent-member OOL swap regressions now cover the first constructor
     replay/body-selection gap; continue looking for remaining swap-shaped gaps
     in less-covered member-template and nested replay surfaces.
+  - continue looking for remaining declaration-copy or lazy-shape surfaces
+    where dependent owner/member-template identity is still erased too early or
+    preserved too long, especially in deeper owner/member-template chains
+    beyond the covered `AddPtr<int>`/`AddPtr<long>` overload case.
 ### 2. Dependent-name modeling is still too weak
 
 `DependentQualifiedNameRecord` is useful, but it is still not a complete
@@ -294,10 +304,10 @@ they directly block items 1-2:
    - Continue with any remaining OOL dependent-member swap slices in
      member-template or nested overload sets where replay-selected stubs and
      deferred body parsing can still drift after owner-artifact recovery.
-   - Continue the type-parameter-qualified lookup slice into overloaded
-     member-template type-chain replay surfaces, especially same-name OOL
-     member-function-template overloads whose parameters differ by resolved
-     member-template alias target (`AddPtr<int>` vs `AddPtr<long>`).
+   - Continue the type-parameter-qualified lookup slice into deeper
+     owner/member-template chains and remaining declaration-copy / lazy-shape
+     identity gaps beyond the covered `AddPtr<int>` vs `AddPtr<long>`
+     overload case.
    - Keep function-parameter adjustment rules centralized in shared substitution
      helpers so replay/attachment compares canonical signatures instead of
      path-specific normalized variants.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-27 (OOL member-function-template bodies now preserve type-parameter-qualified member-template alias metadata)
+**Last updated:** 2026-05-28 (OOL member-template alias-target overload replay now preserves dependent owner/member-template identity end-to-end)
 
 This document should stay forward-facing. It is not a historical ledger or
 release log. Keep completed work only when it changes what the next refactor
@@ -195,9 +195,19 @@ Future work can rely on these being in place:
   Alias-owner recovery is narrowed to evidence-backed dependent-owner records or
   a unique concrete struct owner, so existing alias-template default NTTP and
   non-template-intermediate member-alias paths remain stable.
+- **OOL member-function-template overloads whose parameters differ only by
+  concrete type-parameter-qualified member-template alias targets now preserve
+  dependent owner/member-template identity across copied instantiated stubs,
+  replay attachment, lazy member-template shape instantiation, and concrete
+  alias materialization**: `typename T::template AddPtr<int>::type` vs
+  `...AddPtr<long>::type` no longer collapses to the same owner artifact or the
+  same `$olN` body. The adjacent plain-member dependent-qualified replay path
+  now concretizes those definition-side alias targets after attachment, and the
+  nested dependent-member swap replay path now concretizes non-template
+  dependent member aliases before overload-shape reuse.
 
 Latest recorded full-suite validation:
-`2595` regular tests compiled/linked/runtime-pass, `0` fail, `182` expected-fail tests.
+`2598` regular tests compiled/linked/runtime-pass, `0` fail, `185` expected-fail tests.
 
 Latest focused regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -228,6 +238,7 @@ Latest focused regressions added on the current branch:
 - `test_template_ool_ctor_dependent_member_swap_body_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_swap_body_ret0.cpp`
 - `test_template_param_qualified_static_member_auto_ret0.cpp`
+- `test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_deref_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_forward_deref_ret0.cpp`
 - `test_template_ool_member_template_dependent_member_template_type_param_ref_forward_ret0.cpp`
@@ -249,17 +260,16 @@ Rule for this work:
   (`nullopt`) outcomes in the remaining non-constructor declaration replay
   paths so canonical substituted-signature classification can succeed in more
   valid cases.
-- overloaded OOL member-function-template declarations whose parameter types
-  differ only by concrete member-template alias targets still need stronger
-  source-member identity and alias-target disambiguation; a reduced
-  `AddPtr<int>`/`AddPtr<long>` case can still select the wrong `$olN`
-  materialization and fail to attach the replayed body.
 - continue looking for remaining OOL dependent-member swap regressions in
   less-covered member-template and nested replay surfaces now that the first
   constructor replay/body-selection gap has been closed.
 - extend dependent/current-instantiation lookup only where needed to unblock
   replay attachment for still-failing type-parameter-qualified member-template
   and member-type references in nested/overloaded member-template surfaces.
+- continue looking for remaining declaration-copy or lazy-shape surfaces where
+  dependent owner/member-template identity is still erased too early or
+  preserved too long, especially in deeper owner/member-template chains beyond
+  the covered `AddPtr<int>`/`AddPtr<long>` overload case.
 
 ### 2. Expand dependent-name/current-instantiation modeling only as needed
 
@@ -297,9 +307,9 @@ Still open, but not the next best slice:
    prioritize remaining OOL dependent-member swap follow-ups in member-template
    or nested overload sets where replay-selected stubs and deferred body parsing
    can still drift after owner-artifact recovery;
-   continue into overloaded member-template alias parameter chains now that the
-   non-overloaded `T::AddPtr` body metadata gap is covered for direct
-   dereference, forwarding, and reference forwarding;
+   continue into deeper owner/member-template chains and remaining
+   declaration-copy / lazy-shape identity gaps beyond the covered
+   `T::AddPtr<int>` vs `T::AddPtr<long>` overload case;
 2. update these docs with the next remaining replay-metadata gap.
 
 ## Regression focus

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1959,9 +1959,10 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				templateArgsStillDependent(std::span<const TemplateTypeArg>(substituted_template_args.data(), substituted_template_args.size()));
 			const bool has_variable_template_candidate =
 				gTemplateRegistry.lookupVariableTemplate(func_name).has_value() ||
-				(call.has_qualified_name() && gTemplateRegistry.lookupVariableTemplate(call.qualified_name()).has_value());
+				(call.has_qualified_name() &&
+					gTemplateRegistry.lookupVariableTemplate(call.qualified_name()).has_value());
 			std::optional<ASTNode> var_template_node;
-			if (has_variable_template_candidate) {
+			if (gTemplateRegistry.lookupVariableTemplate(func_name).has_value()) {
 				var_template_node =
 					parser_.try_instantiate_variable_template(
 						func_name,

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1960,13 +1960,26 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			const bool has_variable_template_candidate =
 				gTemplateRegistry.lookupVariableTemplate(func_name).has_value() ||
 				(call.has_qualified_name() && gTemplateRegistry.lookupVariableTemplate(call.qualified_name()).has_value());
-			auto var_template_node = parser_.try_instantiate_variable_template(func_name, substituted_template_args, nullptr);
+			std::optional<ASTNode> var_template_node;
+			if (has_variable_template_candidate) {
+				var_template_node =
+					parser_.try_instantiate_variable_template(
+						func_name,
+						substituted_template_args,
+						nullptr);
+			}
 			if (var_template_node.has_value()) {
 				normalizePendingSemanticRoots();
 			}
 			// If not found by simple name, try qualified name if available
-			if (!var_template_node.has_value() && call.has_qualified_name()) {
-				var_template_node = parser_.try_instantiate_variable_template(call.qualified_name(), substituted_template_args, nullptr);
+			if (!var_template_node.has_value() &&
+				call.has_qualified_name() &&
+				gTemplateRegistry.lookupVariableTemplate(call.qualified_name()).has_value()) {
+				var_template_node =
+					parser_.try_instantiate_variable_template(
+						call.qualified_name(),
+						substituted_template_args,
+						nullptr);
 				if (var_template_node.has_value()) {
 					normalizePendingSemanticRoots();
 				}

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2129,7 +2129,8 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		SubstitutedDefaultArgumentPolicy default_argument_policy, // Default-arg substitution strategy
 		bool preserve_parameter_cv_qualifier, // Keep declared cv qualifier; false reproduces decl-only legacy behavior
 		bool apply_bound_metadata_to_full_substitution, // Apply bound arg pointer/ref metadata on substituted node
-		bool apply_resolved_index_to_full_substitution); // Force substituted TypeIndex onto full AST substitutions
+		bool apply_resolved_index_to_full_substitution, // Force substituted TypeIndex onto full AST substitutions
+		bool preserve_dependent_member_template_signature_identity); // Preserve member-template dependent placeholders when replay needs exact identity
 	template <typename TemplateParamsContainer, typename TemplateArgsContainer>
 	StringHandle resolveBaseInitializerNameForTemplateArgs(
 		StringHandle base_name,

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -586,8 +586,8 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
 		}
 	}
 	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
-			? original_type_info->dependentQualifiedName()
+		template_source_type_info != nullptr && template_source_type_info->isDependentPlaceholder()
+			? template_source_type_info->dependentQualifiedName()
 			: nullptr;
 	if (dependent_record == nullptr || dependent_record->member_chain.empty()) {
 		return substituted_type_index;
@@ -686,8 +686,8 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 		}
 	}
 	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
-			? original_type_info->dependentQualifiedName()
+		template_source_type_info != nullptr && template_source_type_info->isDependentPlaceholder()
+			? template_source_type_info->dependentQualifiedName()
 			: nullptr;
 	if (dependent_record == nullptr && original_type_info != nullptr) {
 		const ResolvedAliasTypeInfo resolved_alias =

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -321,8 +321,13 @@ inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 	bool appended_member = false;
 	if (dependent_record != nullptr && !dependent_record->member_chain.empty()) {
 		for (const auto& member : dependent_record->member_chain) {
-			if (!member.name.isValid() || member.has_template_arguments) {
+			if (!member.name.isValid()) {
 				return substituted_type_index;
+			}
+			if (member.has_template_arguments) {
+				return original_type_spec.type_index().is_valid()
+					? original_type_spec.type_index()
+					: substituted_type_index;
 			}
 			qualified_member_name_builder.append("::");
 			qualified_member_name_builder.append(StringTable::getStringView(member.name));
@@ -569,6 +574,17 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwner(
 	if (original_type_spec.type_index().is_valid()) {
 		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
 	}
+	const TypeInfo* template_source_type_info = original_type_info;
+	if (template_source_type_info != nullptr &&
+		!template_source_type_info->isTemplateInstantiation()) {
+		const ResolvedAliasTypeInfo resolved_original_alias =
+			resolveAliasTypeInfo(
+				template_source_type_info->registeredTypeIndex().withCategory(
+					template_source_type_info->typeEnum()));
+		if (resolved_original_alias.terminal_type_info != nullptr) {
+			template_source_type_info = resolved_original_alias.terminal_type_info;
+		}
+	}
 	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
 			? original_type_info->dependentQualifiedName()
@@ -658,6 +674,17 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 	if (original_type_spec.type_index().is_valid()) {
 		original_type_info = tryGetTypeInfo(original_type_spec.type_index());
 	}
+	const TypeInfo* template_source_type_info = original_type_info;
+	if (template_source_type_info != nullptr &&
+		!template_source_type_info->isTemplateInstantiation()) {
+		const ResolvedAliasTypeInfo resolved_original_alias =
+			resolveAliasTypeInfo(
+				template_source_type_info->registeredTypeIndex().withCategory(
+					template_source_type_info->typeEnum()));
+		if (resolved_original_alias.terminal_type_info != nullptr) {
+			template_source_type_info = resolved_original_alias.terminal_type_info;
+		}
+	}
 	const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 		original_type_info != nullptr && original_type_info->isDependentPlaceholder()
 			? original_type_info->dependentQualifiedName()
@@ -687,10 +714,10 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 			}
 		}
 	}
-	if (original_type_info != nullptr) {
+	if (template_source_type_info != nullptr) {
 		std::string_view base_template_name =
-			original_type_info->isTemplateInstantiation()
-				? StringTable::getStringView(original_type_info->baseTemplateName())
+			template_source_type_info->isTemplateInstantiation()
+				? StringTable::getStringView(template_source_type_info->baseTemplateName())
 				: std::string_view{};
 		std::string_view owner_name;
 		std::string_view member_template_name;
@@ -700,7 +727,7 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 			member_template_name = base_template_name.substr(owner_sep + 2);
 		} else {
 			std::string_view original_type_name =
-				StringTable::getStringView(original_type_info->name());
+				StringTable::getStringView(template_source_type_info->name());
 			const size_t hash_pos = original_type_name.find('$');
 			if (hash_pos != std::string_view::npos) {
 				member_template_name = original_type_name.substr(0, hash_pos);
@@ -711,12 +738,34 @@ inline TypeIndex resolveDependentMemberTemplatePlaceholderFromConcreteOwnerArtif
 			dependent_record->owner_name.isValid()) {
 			owner_name = StringTable::getStringView(dependent_record->owner_name);
 		}
+		if (dependent_record != nullptr &&
+			dependent_record->owner_name.isValid()) {
+			std::string_view dependent_owner_name =
+				StringTable::getStringView(dependent_record->owner_name);
+			if (size_t dependent_owner_sep = dependent_owner_name.rfind("::");
+				dependent_owner_sep != std::string_view::npos) {
+				if (member_template_name.empty()) {
+					member_template_name =
+						dependent_owner_name.substr(dependent_owner_sep + 2);
+				}
+				owner_name = dependent_owner_name.substr(0, dependent_owner_sep);
+			}
+		}
 		if (!member_template_name.empty()) {
 			auto try_resolve_for_owner = [&](const TypeInfo* owner_type_info) -> TypeIndex {
 				if (owner_type_info != nullptr && is_struct_type(owner_type_info->typeEnum())) {
 					InlineVector<TemplateTypeArg, 4> concrete_template_args;
-					concrete_template_args.reserve(original_type_info->templateArgs().size());
-					for (const auto& arg_info : original_type_info->templateArgs()) {
+					std::span<const TypeInfo::TemplateArgInfo> owner_template_args =
+						(dependent_record != nullptr &&
+						 !dependent_record->owner_template_arguments.empty())
+							? std::span<const TypeInfo::TemplateArgInfo>(
+								  dependent_record->owner_template_arguments.data(),
+								  dependent_record->owner_template_arguments.size())
+							: std::span<const TypeInfo::TemplateArgInfo>(
+								  template_source_type_info->templateArgs().data(),
+								  template_source_type_info->templateArgs().size());
+					concrete_template_args.reserve(owner_template_args.size());
+					for (const auto& arg_info : owner_template_args) {
 						TemplateTypeArg concrete_arg =
 							materializeTemplateArg(arg_info, template_params, template_args);
 						if (concrete_arg.is_dependent ||

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1274,7 +1274,19 @@ static bool typeSpecifierLooksLikeDependentSignaturePlaceholder(
 	if (type_spec.type() == TypeCategory::Template) {
 		return true;
 	}
-	return typeSpecStillUsesDependentPlaceholder(type_spec);
+	if (typeSpecStillUsesDependentPlaceholder(type_spec)) {
+		return true;
+	}
+	if (type_spec.type_index().is_valid()) {
+		const ResolvedAliasTypeInfo resolved_alias =
+			resolveAliasTypeInfo(type_spec.type_index());
+		if (resolved_alias.terminal_type_info != nullptr &&
+			(resolved_alias.terminal_type_info->isDependentPlaceholder() ||
+			 resolved_alias.terminal_type_info->hasDependentQualifiedName())) {
+			return true;
+		}
+	}
+	return false;
 }
 
 struct SignatureValidationIndirection {
@@ -2014,6 +2026,54 @@ static bool dependentQualifiedNameRecordsMatchForSignature(
 	return true;
 }
 
+static const TypeInfo::DependentQualifiedNameRecord* dependentQualifiedNameRecordForSignatureMatch(
+	const TypeInfo* type_info) {
+	if (type_info == nullptr) {
+		return nullptr;
+	}
+	if (type_info->hasDependentQualifiedName()) {
+		return type_info->dependentQualifiedName();
+	}
+	ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+		type_info->registeredTypeIndex().withCategory(type_info->typeEnum()));
+	if (resolved_alias.terminal_type_info != nullptr &&
+		resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
+		return resolved_alias.terminal_type_info->dependentQualifiedName();
+	}
+	return nullptr;
+}
+
+static bool dependentQualifiedNameHasMemberTemplateSegment(
+	const TypeInfo::DependentQualifiedNameRecord* dependent_record) {
+	if (dependent_record == nullptr) {
+		return false;
+	}
+	for (const auto& member : dependent_record->member_chain) {
+		if (member.has_template_arguments) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static bool typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
+	const TypeSpecifierNode& type_spec) {
+	const TypeInfo* type_info = type_spec.type_index().is_valid()
+		? tryGetTypeInfo(type_spec.type_index())
+		: nullptr;
+	return dependentQualifiedNameHasMemberTemplateSegment(
+		dependentQualifiedNameRecordForSignatureMatch(type_info));
+}
+
+static bool typeIndexPreservesDependentMemberTemplateSignatureIdentity(
+	TypeIndex type_index) {
+	const TypeInfo* type_info = type_index.is_valid()
+		? tryGetTypeInfo(type_index)
+		: nullptr;
+	return dependentQualifiedNameHasMemberTemplateSegment(
+		dependentQualifiedNameRecordForSignatureMatch(type_info));
+}
+
 static bool dependentTemplatePlaceholderNamesMatch(
 	const TypeSpecifierNode& instantiated_type,
 	const TypeSpecifierNode& out_of_line_type,
@@ -2041,22 +2101,17 @@ static bool dependentTemplatePlaceholderNamesMatch(
 		? tryGetTypeInfo(out_of_line_type.type_index())
 		: findTypeByName(StringTable::getOrInternStringHandle(out_of_line_name));
 
-	if (instantiated_type_info != nullptr &&
-		out_of_line_type_info != nullptr &&
-		instantiated_type_info->isDependentPlaceholder() &&
-		out_of_line_type_info->isDependentPlaceholder()) {
-		const TypeInfo::DependentQualifiedNameRecord* instantiated_record =
-			instantiated_type_info->dependentQualifiedName();
-		const TypeInfo::DependentQualifiedNameRecord* out_of_line_record =
-			out_of_line_type_info->dependentQualifiedName();
-		if (instantiated_record != nullptr &&
-			out_of_line_record != nullptr) {
-			return dependentQualifiedNameRecordsMatchForSignature(
-				*instantiated_record,
-				*out_of_line_record,
-				instantiated_template_params,
-				out_of_line_template_params);
-		}
+	const TypeInfo::DependentQualifiedNameRecord* instantiated_record =
+		dependentQualifiedNameRecordForSignatureMatch(instantiated_type_info);
+	const TypeInfo::DependentQualifiedNameRecord* out_of_line_record =
+		dependentQualifiedNameRecordForSignatureMatch(out_of_line_type_info);
+	if (instantiated_record != nullptr &&
+		out_of_line_record != nullptr) {
+		return dependentQualifiedNameRecordsMatchForSignature(
+			*instantiated_record,
+			*out_of_line_record,
+			instantiated_template_params,
+			out_of_line_template_params);
 	}
 
 	if (instantiated_name == out_of_line_name) {
@@ -2155,6 +2210,156 @@ static bool dependentTemplatePlaceholderNamesMatch(
 		instantiated_param->is_variadic() == out_of_line_param->is_variadic();
 }
 
+static bool shouldAcceptReplaySubstitutedSignatureMatch(
+	const TypeSpecifierNode& substituted_instantiated_type,
+	const TypeSpecifierNode& substituted_out_of_line_type,
+	const TypeSpecifierNode& original_instantiated_type,
+	const TypeSpecifierNode& original_out_of_line_type,
+	std::span<const TemplateParameterNode> instantiated_template_params,
+	std::span<const TemplateParameterNode> out_of_line_template_params) {
+	if (!typeSpecifiersMatchForSignatureValidation(
+			substituted_instantiated_type,
+			substituted_out_of_line_type)) {
+		return false;
+	}
+
+	if (!typeSpecifierLooksLikeDependentSignaturePlaceholder(original_instantiated_type) ||
+		!typeSpecifierLooksLikeDependentSignaturePlaceholder(original_out_of_line_type)) {
+		return true;
+	}
+
+	return dependentTemplatePlaceholderNamesMatch(
+		original_instantiated_type,
+		original_out_of_line_type,
+		instantiated_template_params,
+		out_of_line_template_params);
+}
+
+static void copyDefinitionParameterTypesForDependentMemberTemplateSegments(
+	std::span<ASTNode> instantiated_params,
+	std::span<const ASTNode> definition_params) {
+	if (instantiated_params.size() != definition_params.size()) {
+		return;
+	}
+
+	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+		DeclarationNode* instantiated_decl =
+			const_cast<DeclarationNode*>(
+				get_decl_from_symbol(instantiated_params[param_index]));
+		const DeclarationNode* definition_decl =
+			get_decl_from_symbol(definition_params[param_index]);
+		if (instantiated_decl == nullptr || definition_decl == nullptr) {
+			continue;
+		}
+
+		const TypeSpecifierNode& definition_type =
+			definition_decl->type_specifier_node();
+		const TypeInfo* definition_type_info =
+			tryGetTypeInfo(definition_type.type_index());
+		if (definition_type_info == nullptr) {
+			continue;
+		}
+		const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+			dependentQualifiedNameRecordForSignatureMatch(definition_type_info);
+		if (dependent_record == nullptr) {
+			continue;
+		}
+		for (const auto& member : dependent_record->member_chain) {
+			if (!member.has_template_arguments) {
+				continue;
+			}
+			instantiated_decl->set_type_node(definition_decl->type_specifier_node());
+			break;
+		}
+	}
+}
+
+static void syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+	Parser& parser,
+	std::span<ASTNode> instantiated_params,
+	std::span<const ASTNode> definition_params,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args) {
+	(void)parser;
+	(void)outer_template_params;
+	(void)outer_template_args;
+	if (instantiated_params.size() != definition_params.size()) {
+		return;
+	}
+
+	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+		DeclarationNode* instantiated_decl =
+			const_cast<DeclarationNode*>(
+				get_decl_from_symbol(instantiated_params[param_index]));
+		const DeclarationNode* definition_decl =
+			get_decl_from_symbol(definition_params[param_index]);
+		if (instantiated_decl == nullptr || definition_decl == nullptr) {
+			continue;
+		}
+
+		const TypeSpecifierNode& definition_type =
+			definition_decl->type_specifier_node();
+		const TypeInfo* definition_type_info =
+			tryGetTypeInfo(definition_type.type_index());
+		if (definition_type_info == nullptr) {
+			continue;
+		}
+
+		const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+			dependentQualifiedNameRecordForSignatureMatch(definition_type_info);
+		const bool has_member_template_segment =
+			dependentQualifiedNameHasMemberTemplateSegment(dependent_record);
+		if (!has_member_template_segment) {
+			continue;
+		}
+		instantiated_decl->set_type_node(definition_type);
+	}
+}
+
+static void preserveDependentMemberTemplateParameterPlaceholdersFromPattern(
+	std::span<ASTNode> instantiated_params,
+	std::span<const ASTNode> pattern_params) {
+	if (instantiated_params.size() != pattern_params.size()) {
+		return;
+	}
+
+	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+		DeclarationNode* instantiated_decl =
+			const_cast<DeclarationNode*>(
+				get_decl_from_symbol(instantiated_params[param_index]));
+		const DeclarationNode* pattern_decl =
+			get_decl_from_symbol(pattern_params[param_index]);
+		if (instantiated_decl == nullptr || pattern_decl == nullptr) {
+			continue;
+		}
+
+		const TypeSpecifierNode& pattern_type =
+			pattern_decl->type_specifier_node();
+		const TypeSpecifierNode& instantiated_type =
+			instantiated_decl->type_specifier_node();
+		if (!typeSpecStillUsesDependentPlaceholder(instantiated_type)) {
+			continue;
+		}
+		const TypeInfo* pattern_type_info =
+			tryGetTypeInfo(pattern_type.type_index());
+		if (pattern_type_info == nullptr) {
+			continue;
+		}
+		const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+			dependentQualifiedNameRecordForSignatureMatch(pattern_type_info);
+		if (dependent_record == nullptr) {
+			continue;
+		}
+		const bool has_member_template_segment =
+			dependentQualifiedNameHasMemberTemplateSegment(dependent_record);
+		if (!has_member_template_segment) {
+			continue;
+		}
+
+		instantiated_decl->set_type_node(pattern_decl->type_specifier_node());
+	}
+}
+
 template <typename InstantiatedDeclNode, typename OutOfLineDeclNode>
 static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 	Parser& parser,
@@ -2216,7 +2421,13 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 				substituted_out_of_line_param.has_value()
 					? *substituted_out_of_line_param
 					: *out_of_line_param;
-			if (typeSpecifiersMatchForSignatureValidation(lhs_type, rhs_type)) {
+			if (shouldAcceptReplaySubstitutedSignatureMatch(
+					lhs_type,
+					rhs_type,
+					*instantiated_param,
+					*out_of_line_param,
+					instantiated_template_params,
+					out_of_line_template_params)) {
 				continue;
 			}
 
@@ -2890,7 +3101,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 	SubstitutedDefaultArgumentPolicy default_argument_policy,
 	bool preserve_parameter_cv_qualifier,
 	bool apply_bound_metadata_to_full_substitution,
-	bool apply_resolved_index_to_full_substitution) {
+	bool apply_resolved_index_to_full_substitution,
+	bool preserve_dependent_member_template_signature_identity) {
 	if (self_type_from_index.is_valid() != self_type_to_index.is_valid()) {
 		throw InternalError("substituteAndCopyMemberFunctionParameters requires both self rewrite indices or neither.");
 	}
@@ -2928,7 +3140,6 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 
 		const DeclarationNode& param_decl = param.as<DeclarationNode>();
 		const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
 		bool handled_as_pack = false;
 		if (param_decl.is_parameter_pack() &&
 			(param_type_spec.category() == TypeCategory::UserDefined ||
@@ -2995,6 +3206,10 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			continue;
 		}
 
+		const bool preserve_dependent_member_template_identity =
+			preserve_dependent_member_template_signature_identity &&
+			typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
+				param_type_spec);
 		TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
 			param_type_spec,
 			param_decl.type_node(),
@@ -3012,6 +3227,9 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			TypeIndex{},
 			apply_bound_metadata_to_full_substitution,
 			apply_resolved_index_to_full_substitution);
+		if (preserve_dependent_member_template_identity) {
+			substituted_param_type = param_type_spec;
+		}
 		{
 			ASTNode original_param_type_node = param_decl.type_node();
 			TypeIndex dependent_member_type_index = substituted_param_type.type_index();
@@ -3023,13 +3241,20 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 					template_params,
 					template_args_inline,
 					dependent_member_type_index,
-					false);
+					!preserve_dependent_member_template_identity);
+			if (preserve_dependent_member_template_identity &&
+				!typeIndexPreservesDependentMemberTemplateSignatureIdentity(
+					dependent_member_type_index)) {
+				dependent_member_type_index = param_type_spec.type_index();
+			}
 			if (dependent_member_type_index.is_valid() &&
 				dependent_member_type_index != substituted_param_type.type_index()) {
 				substituted_param_type.set_type_index(
 					dependent_member_type_index.withCategory(dependent_member_type_index.category()));
 				substituted_param_type.set_category(dependent_member_type_index.category());
-				normalizeSubstitutedTypeSpec(substituted_param_type);
+				if (!preserve_dependent_member_template_identity) {
+					normalizeSubstitutedTypeSpec(substituted_param_type);
+				}
 			}
 		}
 		if (!preserve_parameter_cv_qualifier) {
@@ -4221,6 +4446,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// The TypeIndex from substitute_template_parameter+self_type_rewrite is applied
 			// on top to handle self-referential types.
 			ASTNode original_param_type_node = param_decl.type_node();
+			const bool preserve_dependent_member_template_identity =
+				typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
+					param_type_spec);
 			ASTNode full_substituted_param_node = substituteTemplateParameters(
 				original_param_type_node, tmpl_params, tmpl_args);
 			TypeIndex param_type_index = substitute_template_parameter(
@@ -4240,15 +4468,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				tmpl_params,
 				tmpl_args,
 				param_type_index,
-				false);
-			TypeSpecifierNode substituted_param_type = full_substituted_param_node.is<TypeSpecifierNode>()
-				? full_substituted_param_node.as<TypeSpecifierNode>()
-				: TypeSpecifierNode(
-					  param_type_index.category(),
-					  param_type_spec.qualifier(),
-					  get_substituted_type_size_bits(param_type_index),
-					  param_decl.identifier_token(),
-					  param_type_spec.cv_qualifier());
+				!preserve_dependent_member_template_identity);
+			if (preserve_dependent_member_template_identity &&
+				!typeIndexPreservesDependentMemberTemplateSignatureIdentity(
+					param_type_index)) {
+				param_type_index = param_type_spec.type_index();
+			}
+			TypeSpecifierNode substituted_param_type = preserve_dependent_member_template_identity
+				? param_type_spec
+				: full_substituted_param_node.is<TypeSpecifierNode>()
+					  ? full_substituted_param_node.as<TypeSpecifierNode>()
+					  : TypeSpecifierNode(
+							param_type_index.category(),
+							param_type_spec.qualifier(),
+							get_substituted_type_size_bits(param_type_index),
+							param_decl.identifier_token(),
+							param_type_spec.cv_qualifier());
 			// Apply the resolved TypeIndex (self-type rewrite or alias resolution).
 			if (param_type_index.is_valid()) {
 				substituted_param_type.set_type_index(
@@ -4274,7 +4509,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 				}
 			}
-			normalizeSubstitutedTypeSpec(substituted_param_type);
+			if (!preserve_dependent_member_template_identity) {
+				normalizeSubstitutedTypeSpec(substituted_param_type);
+			}
 			auto substituted_param_type_node = emplace_node<TypeSpecifierNode>(substituted_param_type);
 			auto substituted_param_decl = emplace_node<DeclarationNode>(
 				substituted_param_type_node, param_decl.identifier_token());
@@ -5947,7 +6184,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
 						true,  // Preserve declared parameter cv-qualifier in this path
 						false, // Do not re-apply bound metadata to full substitution
-						false);// Do not force resolved TypeIndex onto full AST substitutions
+						false, // Do not force resolved TypeIndex onto full AST substitutions
+						false);// Plain member path does not need dependent member-template signature preservation
 
 					copy_function_properties(new_func_ref, orig_func);
 					// Ensure is_const_member_function is set from pattern so propagateAstProperties derives cv_qualifier.
@@ -7366,79 +7604,39 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							instantiated_name);
 						applyMergedOuterTemplateBindings(new_func_ref);
 
-						for (const auto& param : func_decl.parameter_nodes()) {
-							if (!param.is<DeclarationNode>()) {
-								continue;
-							}
-							const DeclarationNode& param_decl = param.as<DeclarationNode>();
-							const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-							TypeCategory new_param_type = param_type_spec.type();
-							TypeIndex new_param_type_index = param_type_spec.type_index();
-							if (new_param_type == TypeCategory::UserDefined ||
-								new_param_type == TypeCategory::TypeAlias ||
-								new_param_type == TypeCategory::Template) {
-								ASTNode original_param_type_node = param_decl.type_node();
-								TypeIndex subst_idx = substitute_template_parameter(
-									param_type_spec, template_params, template_args_for_pattern);
-								subst_idx = resolveOwnerAliasTypeIndex(
-									[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-										return substitute_template_parameter(type_spec, params, args);
-									},
-									pattern_struct,
-									param_type_spec,
-									template_params,
-									template_args_for_pattern,
-									subst_idx);
-								subst_idx = resolveDependentMemberPlaceholderFromOwnerArtifact(
-									original_param_type_node,
-									param_type_spec,
-									subst_idx);
-								subst_idx = resolveDependentMemberTemplateArtifactsForParam(
-									*this,
-									&original_param_type_node,
-									param_type_spec,
-									template_params,
-									template_args_for_pattern,
-									subst_idx,
-									true);
-								new_param_type = subst_idx.category();
-								new_param_type_index = subst_idx;
-							}
-
-							ASTNode new_param_type_node = buildMaterializedParamTypeNode(
-								param_type_spec,
-								template_params,
-								template_args_for_pattern,
-								new_param_type,
-								new_param_type_index);
-
-							auto new_param_decl = emplace_node<DeclarationNode>(
-								new_param_type_node, param_decl.identifier_token());
-							if (param_decl.has_default_value()) {
-								std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
-								std::unordered_map<std::string_view, int64_t> nontype_sub_map;
-								for (size_t i = 0; i < template_params.size() && i < template_args_for_pattern.size(); ++i) {
-									const TemplateParameterNode* template_param = tryGetTemplateParameterNode(template_params[i]);
-									if (template_param == nullptr)
-										continue;
-									if (template_param->kind() == TemplateParameterKind::Type && !template_args_for_pattern[i].is_value) {
-										auto type_it = getTypesByNameMap().find(template_param->nameHandle());
-										if (type_it != getTypesByNameMap().end()) {
-											type_sub_map[type_it->second->type_index_] = template_args_for_pattern[i];
-										} else {
-											type_sub_map[TypeIndex{getTypeInfoCount() + type_sub_map.size() + 1}] = template_args_for_pattern[i];
-										}
-									} else if (template_param->kind() == TemplateParameterKind::NonType && template_args_for_pattern[i].is_value) {
-										nontype_sub_map[template_param->name()] = template_args_for_pattern[i].value;
-									}
-								}
-								ASTNode substituted_default = substitute_template_params_in_expression(
-									param_decl.default_value(), type_sub_map, nontype_sub_map, StringHandle{});
-								new_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
-							}
-							new_func_ref.add_parameter_node(new_param_decl);
-						}
+						size_t saved_pack_info = pack_param_info_.size();
+						substituteAndCopyMemberFunctionParameters(
+							func_decl.parameter_nodes(),
+							new_func_ref,
+							template_params,
+							template_args_for_pattern,
+							&pattern_struct,
+							TypeIndex{},
+							TypeIndex{},
+							TypeIndex{},
+							SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+							true,
+							false,
+							true,
+							true);
+						pack_param_info_.resize(saved_pack_info);
+						syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+							*this,
+							std::span<ASTNode>(
+								new_func_ref.parameter_nodes().data(),
+								new_func_ref.parameter_nodes().size()),
+							std::span<const ASTNode>(
+								func_decl.parameter_nodes().data(),
+								func_decl.parameter_nodes().size()),
+							template_params,
+							template_args_for_pattern);
+						preserveDependentMemberTemplateParameterPlaceholdersFromPattern(
+							std::span<ASTNode>(
+								new_func_ref.parameter_nodes().data(),
+								new_func_ref.parameter_nodes().size()),
+							std::span<const ASTNode>(
+								func_decl.parameter_nodes().data(),
+								func_decl.parameter_nodes().size()));
 
 						copy_function_properties(new_func_ref, func_decl);
 						new_func_ref.set_is_const_member_function(mem_func.is_const());
@@ -7589,7 +7787,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
 						true,  // Preserve declared parameter cv-qualifier in this path
 						false, // Do not re-apply bound metadata to full substitution
-						true); // Force resolved TypeIndex onto full AST substitutions
+						true,  // Force resolved TypeIndex onto full AST substitutions
+						false); // Plain member path does not need dependent member-template signature preservation
 					std::unordered_map<std::string_view, TemplateTypeArg> deduced_args;
 					for (size_t i = 0; i < template_params.size() && i < template_args_for_pattern.size(); ++i) {
 						std::string_view pname = template_params[i].name();
@@ -7891,7 +8090,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::optional<bool> signature_match =
 								nestedOutOfLineMemberTemplateMatchesCandidate(
 									*this,
-									*matched_stub,
+									source_member->function_declaration,
 									ool_func,
 									std::span<const TemplateParameterNode>(
 										template_params.data(),
@@ -7916,6 +8115,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (inst_func_decl != nullptr) {
 						inst_func_decl->set_template_body_position(out_of_line_member.body_start);
 						copyDefinitionParameterIdentifiers(
+							inst_func_decl->parameter_nodes(),
+							ool_func.parameter_nodes());
+						copyDefinitionParameterTypesForDependentMemberTemplateSegments(
 							inst_func_decl->parameter_nodes(),
 							ool_func.parameter_nodes());
 						inst_func_decl->set_definition_lookup_context(
@@ -11395,7 +11597,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::optional<bool> signature_match =
 								nestedOutOfLineMemberTemplateMatchesCandidate(
 									*this,
-									*matched_stub,
+									source_member->function_declaration,
 									ool_func,
 									std::span<const TemplateParameterNode>(
 										template_params.data(),
@@ -11421,6 +11623,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (matched_nested_func_decl != nullptr) {
 						matched_nested_func_decl->set_template_body_position(out_of_line_member.body_start);
 						copyDefinitionParameterIdentifiers(
+							matched_nested_func_decl->parameter_nodes(),
+							ool_func.parameter_nodes());
+						copyDefinitionParameterTypesForDependentMemberTemplateSegments(
 							matched_nested_func_decl->parameter_nodes(),
 							ool_func.parameter_nodes());
 						matched_nested_func_decl->set_definition_lookup_context(
@@ -12337,7 +12542,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor,
 					true,  // Preserve declared parameter cv-qualifier in this path
 					false, // Do not re-apply bound metadata to full substitution
-					true); // Force resolved TypeIndex onto full AST substitutions
+					true,  // Force resolved TypeIndex onto full AST substitutions
+					false); // Plain member path does not need dependent member-template signature preservation
 				pack_param_info_.resize(saved_pack_info);
 
 				// Copy function properties but DO NOT set definition. Delay mangling until
@@ -12427,7 +12633,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					SubstitutedDefaultArgumentPolicy::ExpressionSubstitutor,
 					true,  // Preserve declared parameter cv-qualifier in this path
 					false, // Do not re-apply bound metadata to full substitution
-					true); // Force resolved TypeIndex onto full AST substitutions
+					true,  // Force resolved TypeIndex onto full AST substitutions
+					false); // Plain member path does not need dependent member-template signature preservation
 
 				// Get the function body - either from definition or by re-parsing from saved position
 				std::optional<ASTNode> body_to_substitute;
@@ -12616,7 +12823,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					SubstitutedDefaultArgumentPolicy::None,
 					false, // Declaration-only path: strip only top-level by-value cv-qualifiers
 					false, // Do not re-apply bound metadata to full substitution
-					true); // Force resolved TypeIndex onto full AST substitutions
+					true,  // Force resolved TypeIndex onto full AST substitutions
+					false); // Plain member path does not need dependent member-template signature preservation
 				pack_param_info_.resize(saved_pack_info);
 
 				// Copy other function properties
@@ -13123,82 +13331,39 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					instantiated_name);
 				applyMergedOuterTemplateBindings(new_func_ref);
 
-				// Copy parameter nodes with outer template parameter substitution
-				for (const auto& param : func_decl.parameter_nodes()) {
-					if (param.is<DeclarationNode>()) {
-						const DeclarationNode& param_decl = param.as<DeclarationNode>();
-						const TypeSpecifierNode& param_type_spec = param_decl.type_specifier_node();
-
-						TypeCategory new_param_type = param_type_spec.type();
-						TypeIndex new_param_type_index = param_type_spec.type_index();
-
-						// Substitute outer-dependent types (but not inner-template placeholders like Auto/U).
-						if (new_param_type == TypeCategory::UserDefined ||
-							new_param_type == TypeCategory::TypeAlias ||
-							new_param_type == TypeCategory::Template) {
-							ASTNode original_param_type_node = param_decl.type_node();
-							TypeIndex subst_idx = substitute_template_parameter(
-								param_type_spec, template_params, template_args_to_use);
-							subst_idx = resolveOwnerAliasTypeIndex(
-								[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
-									return substitute_template_parameter(type_spec, params, args);
-								},
-								class_decl,
-								param_type_spec,
-								template_params,
-								template_args_to_use,
-								subst_idx);
-							subst_idx = resolveDependentMemberPlaceholderFromOwnerArtifact(
-								original_param_type_node,
-								param_type_spec,
-								subst_idx);
-							subst_idx = resolveDependentMemberTemplateArtifactsForParam(
-								*this,
-								&original_param_type_node,
-								param_type_spec,
-								template_params,
-								template_args_to_use,
-								subst_idx,
-								true);
-							new_param_type = subst_idx.category();
-							new_param_type_index = subst_idx;
-						}
-
-						ASTNode new_param_type_node = buildMaterializedParamTypeNode(
-							param_type_spec,
-							template_params,
-							template_args_to_use,
-							new_param_type,
-							new_param_type_index);
-
-						auto new_param_decl = emplace_node<DeclarationNode>(
-							new_param_type_node, param_decl.identifier_token());
-						// Copy default value if present
-						if (param_decl.has_default_value()) {
-							std::unordered_map<TypeIndex, TemplateTypeArg> type_sub_map;
-							std::unordered_map<std::string_view, int64_t> nontype_sub_map;
-							for (size_t i = 0; i < template_params.size() && i < template_args_to_use.size(); ++i) {
-								const TemplateParameterNode* template_param = tryGetTemplateParameterNode(template_params[i]);
-								if (template_param == nullptr)
-									continue;
-								if (template_param->kind() == TemplateParameterKind::Type && !template_args_to_use[i].is_value) {
-									auto type_it = getTypesByNameMap().find(template_param->nameHandle());
-									if (type_it != getTypesByNameMap().end()) {
-										type_sub_map[type_it->second->type_index_] = template_args_to_use[i];
-									} else {
-										type_sub_map[TypeIndex{getTypeInfoCount() + type_sub_map.size() + 1}] = template_args_to_use[i];
-									}
-								} else if (template_param->kind() == TemplateParameterKind::NonType && template_args_to_use[i].is_value) {
-									nontype_sub_map[template_param->name()] = template_args_to_use[i].value;
-								}
-							}
-							ASTNode substituted_default = substitute_template_params_in_expression(
-								param_decl.default_value(), type_sub_map, nontype_sub_map, StringHandle{});
-							new_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
-						}
-						new_func_ref.add_parameter_node(new_param_decl);
-					}
-				}
+				size_t saved_pack_info = pack_param_info_.size();
+				substituteAndCopyMemberFunctionParameters(
+					func_decl.parameter_nodes(),
+					new_func_ref,
+					template_params,
+					template_args_to_use,
+					&class_decl,
+					instantiated_member_owner_type_index,
+					TypeIndex{},
+					TypeIndex{},
+					SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+					true,
+					false,
+					true,
+					true);
+				pack_param_info_.resize(saved_pack_info);
+				syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+					*this,
+					std::span<ASTNode>(
+						new_func_ref.parameter_nodes().data(),
+						new_func_ref.parameter_nodes().size()),
+					std::span<const ASTNode>(
+						func_decl.parameter_nodes().data(),
+						func_decl.parameter_nodes().size()),
+					template_params,
+					template_args_to_use);
+				preserveDependentMemberTemplateParameterPlaceholdersFromPattern(
+					std::span<ASTNode>(
+						new_func_ref.parameter_nodes().data(),
+						new_func_ref.parameter_nodes().size()),
+					std::span<const ASTNode>(
+						func_decl.parameter_nodes().data(),
+						func_decl.parameter_nodes().size()));
 
 				// Copy function specifiers
 				copy_function_properties(new_func_ref, func_decl);
@@ -13522,7 +13687,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (relevant_member_template_count > 1) {
 					std::optional<bool> signature_match = nestedOutOfLineMemberTemplateMatchesCandidate(
 						*this,
-						*matched_stub,
+						source_member.function_declaration,
 						ool_func,
 						std::span<const TemplateParameterNode>(
 							out_of_line_member.template_params.data(),
@@ -13552,112 +13717,60 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				copyDefinitionParameterIdentifiers(
 					inst_func_decl->parameter_nodes(),
 					ool_func.parameter_nodes());
-				{
-					std::span<ASTNode> instantiated_params = inst_func_decl->parameter_nodes();
-					std::span<const ASTNode> definition_params = ool_func.parameter_nodes();
-					if (instantiated_params.size() == definition_params.size()) {
-						for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
-							DeclarationNode* instantiated_decl =
-								Parser::get_decl_from_symbol_mut(instantiated_params[param_index]);
-							const DeclarationNode* definition_decl =
-								get_decl_from_symbol(definition_params[param_index]);
-							if (instantiated_decl == nullptr || definition_decl == nullptr) {
-								continue;
-							}
-							const TypeSpecifierNode& definition_type =
-								definition_decl->type_specifier_node();
-							const TypeInfo* definition_type_info =
-								tryGetTypeInfo(definition_type.type_index());
-							if (definition_type_info == nullptr) {
-								continue;
-							}
-							const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-								definition_type_info->dependentQualifiedName();
-							if (dependent_record == nullptr) {
-								const ResolvedAliasTypeInfo resolved_alias =
-									resolveAliasTypeInfo(
-										definition_type_info->registeredTypeIndex().withCategory(
-											definition_type_info->typeEnum()));
-								if (resolved_alias.terminal_type_info != nullptr &&
-									resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
-									dependent_record =
-										resolved_alias.terminal_type_info->dependentQualifiedName();
-								}
-							}
-							TypeIndex owner_index{};
-							if (dependent_record != nullptr &&
-								dependent_record->owner_name.isValid()) {
-								for (size_t outer_index = 0;
-									 outer_index < out_of_line_member.template_params.size() &&
-									 outer_index < template_args_to_use.size();
-									 ++outer_index) {
-									if (out_of_line_member.template_params[outer_index].nameHandle() !=
-										dependent_record->owner_name ||
-										template_args_to_use[outer_index].is_value) {
-										continue;
-									}
-									owner_index = template_args_to_use[outer_index].type_index.withCategory(
-										template_args_to_use[outer_index].typeEnum());
-									break;
-								}
-							}
-							bool has_member_template_segment = false;
-							if (dependent_record != nullptr) {
-								for (const auto& member : dependent_record->member_chain) {
-									if (member.has_template_arguments) {
-										has_member_template_segment = true;
-										break;
-									}
-								}
-								if (!has_member_template_segment) {
-									continue;
-								}
-							}
-							auto outer_params_span = std::span<const TemplateParameterNode>(
-								out_of_line_member.template_params.data(),
-								out_of_line_member.template_params.size());
-							auto outer_args_span = std::span<const TemplateTypeArg>(
-								template_args_to_use.data(),
-								template_args_to_use.size());
-							TypeIndex resolved_index = owner_index.is_valid()
-								? resolveDependentMemberTemplateSubstitutionArtifacts(
-									  *this,
-									  nullptr,
-									  definition_type,
-									  outer_params_span,
-									  outer_args_span,
-									  owner_index,
-									  true,
-									  true,
-									  true)
-								: definition_type.type_index();
-							ASTNode definition_type_node = definition_decl->type_node();
-							resolved_index = resolveDependentMemberTemplateSubstitutionArtifacts(
-								*this,
-								&definition_type_node,
-								definition_type,
-								outer_params_span,
-								outer_args_span,
-								resolved_index,
-								false,
-								true,
-								true);
-							if (!resolved_index.is_valid() || resolved_index == owner_index) {
-								continue;
-							}
-							TypeSpecifierNode replay_type = definition_type;
-							replay_type.set_type_index(resolved_index.withCategory(resolved_index.category()));
-							replay_type.set_category(resolved_index.category());
-							normalizeSubstitutedTypeSpec(replay_type);
-							if (replay_type.type() == TypeCategory::TypeAlias &&
-								replay_type.size_in_bits() == 0) {
-								continue;
-							}
-							instantiated_decl->set_type_node(replay_type);
+				copyDefinitionParameterTypesForDependentMemberTemplateSegments(
+					inst_func_decl->parameter_nodes(),
+					ool_func.parameter_nodes());
+				auto outer_params_span = std::span<const TemplateParameterNode>(
+					out_of_line_member.template_params.data(),
+					out_of_line_member.template_params.size());
+				auto outer_args_span = std::span<const TemplateTypeArg>(
+					template_args_to_use.data(),
+					template_args_to_use.size());
+				syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+					*this,
+					inst_func_decl->parameter_nodes(),
+					ool_func.parameter_nodes(),
+					outer_params_span,
+					outer_args_span);
+				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
+				if (struct_info_ptr != nullptr) {
+					OutOfLineFunctionStubResolution info_func_resolution =
+						findMatchingFunctionInStructInfo(
+							*struct_info_ptr,
+							*inst_func_decl,
+							[](const FunctionDeclarationNode& info_func) {
+								return !info_func.has_template_body_position();
+							});
+					if (info_func_resolution.ambiguous) {
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous StructTypeInfo sync for out-of-line member template '")
+							.append(ool_func_name)
+							.append("' in instantiated class '")
+							.append(instantiated_name)
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
 						}
+						FLASH_LOG(Templates, Error, error_msg);
+					} else if (info_func_resolution.func != nullptr) {
+						info_func_resolution.func->set_template_body_position(out_of_line_member.body_start);
+						copyDefinitionParameterIdentifiers(
+							info_func_resolution.func->parameter_nodes(),
+							ool_func.parameter_nodes());
+						copyDefinitionParameterTypes(
+							info_func_resolution.func->parameter_nodes(),
+							inst_func_decl->parameter_nodes());
+						syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+							*this,
+							info_func_resolution.func->parameter_nodes(),
+							ool_func.parameter_nodes(),
+							outer_params_span,
+							outer_args_span);
+						info_func_resolution.func->set_definition_lookup_context(
+							out_of_line_member.definition_lookup_context);
 					}
 				}
-				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 				FLASH_LOG(
 					Templates,
 					Debug,
@@ -13783,6 +13896,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					copyDefinitionParameterIdentifiers(
 						info_func_resolution.func->parameter_nodes(),
 						func_decl.parameter_nodes());
+					copyDefinitionParameterTypes(
+						info_func_resolution.func->parameter_nodes(),
+						inst_func->parameter_nodes());
 					info_func_resolution.func->set_definition(*inst_func->get_definition());
 					finalize_function_after_definition(*info_func_resolution.func, true);
 				} else {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2167,10 +2167,11 @@ static bool dependentTemplatePlaceholderNamesMatch(
 
 	if (instantiated_type_info != nullptr &&
 		instantiated_type_info->isDependentPlaceholder()) {
-		if (const auto* instantiated_record = instantiated_type_info->dependentQualifiedName();
-			instantiated_record != nullptr &&
+		if (const auto* instantiated_placeholder_record =
+				instantiated_type_info->dependentQualifiedName();
+			instantiated_placeholder_record != nullptr &&
 			owner_matches_named_placeholder(
-				*instantiated_record,
+				*instantiated_placeholder_record,
 				out_of_line_type_info,
 				out_of_line_name)) {
 			return true;
@@ -2178,10 +2179,11 @@ static bool dependentTemplatePlaceholderNamesMatch(
 	}
 	if (out_of_line_type_info != nullptr &&
 		out_of_line_type_info->isDependentPlaceholder()) {
-		if (const auto* out_of_line_record = out_of_line_type_info->dependentQualifiedName();
-			out_of_line_record != nullptr &&
+		if (const auto* out_of_line_placeholder_record =
+				out_of_line_type_info->dependentQualifiedName();
+			out_of_line_placeholder_record != nullptr &&
 			owner_matches_named_placeholder(
-				*out_of_line_record,
+				*out_of_line_placeholder_record,
 				instantiated_type_info,
 				instantiated_name)) {
 			return true;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3995,8 +3995,6 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 		std::vector<ASTNode> shape_overloads;
 		shape_candidates.reserve(all_templates.size());
 		shape_overloads.reserve(all_templates.size());
-		StringHandle template_name_handle = StringTable::getOrInternStringHandle(template_name);
-
 		for (size_t sorted_idx = 0; sorted_idx < overload_iteration_order.size(); ++sorted_idx) {
 			size_t overload_idx = overload_iteration_order[sorted_idx];
 			const ASTNode& template_node = all_templates[overload_idx];

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -239,6 +239,15 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 		return DependentAliasResolutionStatus::StillDependent;
 
 	std::string_view type_name = StringTable::getStringView(type_info->name());
+	const TypeInfo* semantic_type_info = type_info;
+	if ((!semantic_type_info->isDependentMemberType() ||
+		 !semantic_type_info->hasDependentQualifiedName()) &&
+		ts.type_index().is_valid()) {
+		ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(ts.type_index());
+		if (resolved_alias.terminal_type_info != nullptr) {
+			semantic_type_info = resolved_alias.terminal_type_info;
+		}
+	}
 	auto emplaceResolvedSpec = [&](const TypeInfo* resolved_info) {
 		ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(resolved_info->registeredTypeIndex());
 		TypeIndex resolved_type_index = resolved_alias.type_index.is_valid()
@@ -258,11 +267,11 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 		return DependentAliasResolutionStatus::Resolved;
 	};
 
-	if (type_info->isDependentMemberType() &&
-		type_info->hasDependentQualifiedName()) {
+	if (semantic_type_info->isDependentMemberType() &&
+		semantic_type_info->hasDependentQualifiedName()) {
 		if (const TypeInfo* resolved_dependent_type =
 				resolveDependentMemberTypeSemantic(
-					*type_info,
+					*semantic_type_info,
 					template_params,
 					template_args,
 					StringHandle{});
@@ -626,6 +635,23 @@ static bool functionDeclarationsHaveMatchingShape(
 		}
 	}
 	return true;
+}
+
+static StringHandle makeOverloadDiscriminatedFunctionTemplateKeyName(
+	std::string_view template_name,
+	const FunctionDeclarationNode& func_decl) {
+	const Token& overload_token = func_decl.decl_node().identifier_token();
+	StringBuilder builder;
+	return StringTable::getOrInternStringHandle(
+		builder
+			.append(template_name)
+			.append("$olsrc")
+			.append(static_cast<uint64_t>(overload_token.file_index()))
+			.append("_")
+			.append(static_cast<uint64_t>(overload_token.line()))
+			.append("_")
+			.append(static_cast<uint64_t>(overload_token.column()))
+			.commit());
 }
 
 static bool hasLaterUsableTemplateDefinitionWithMatchingShape(
@@ -2674,7 +2700,11 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 	const bool skip_body_materialization =
 		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::SkipBodyMaterialization);
 	const DeclarationNode& orig_decl = func_decl.decl_node();
-	std::string_view mangled_name = gTemplateRegistry.mangleTemplateName(template_name, template_args);
+	std::string_view mangled_base_name = template_name;
+	if (key.base_template.isValid()) {
+		mangled_base_name = StringTable::getStringView(key.base_template);
+	}
+	std::string_view mangled_name = gTemplateRegistry.mangleTemplateName(mangled_base_name, template_args);
 
 	auto apply_resolved_alias_metadata_local = [&](TypeSpecifierNode& type_spec) {
 		if (!type_spec.type_index().is_valid()) {
@@ -4002,10 +4032,12 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 				continue;
 			}
 
-			auto key = FlashCpp::makeInstantiationKey(
-				template_name_handle,
-				template_args);
 			const uintptr_t overload_id = reinterpret_cast<uintptr_t>(&func_decl);
+			auto key = FlashCpp::makeInstantiationKey(
+				makeOverloadDiscriminatedFunctionTemplateKeyName(
+					template_name,
+					func_decl),
+				template_args);
 			if (gTemplateRegistry.isFailedInstantiation(key, overload_id)) {
 				continue;
 			}
@@ -4656,14 +4688,17 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	}
 
 	// Step 2: Check if we already have this instantiation
-	auto key = FlashCpp::makeInstantiationKey(
-		StringTable::getOrInternStringHandle(template_name), template_args);
 	// Per-overload discriminator for the SFINAE failure memo.  Using the
 	// address of the overload's FunctionDeclarationNode separates overloads
 	// of the same template name whose deduced arg lists and arities are
 	// identical but whose SFINAE predicates are not (e.g. two `process(T)`
 	// overloads, one enabled for `is_int<T>` and the other for `is_double<T>`).
 	const uintptr_t overload_id = reinterpret_cast<uintptr_t>(&func_decl);
+	auto key = FlashCpp::makeInstantiationKey(
+		makeOverloadDiscriminatedFunctionTemplateKeyName(
+			template_name,
+			func_decl),
+		template_args);
 
 	// SFINAE fast-path: if a previous probe against *this same overload*
 	// already recorded a substitution failure for the same deduced args,

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2644,13 +2644,13 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 						substituted_param_type_spec,
 						*concrete_alias_type_spec);
 				} else if (original_param_type_info != nullptr) {
-					if (std::optional<TypeSpecifierNode> concrete_alias_type_spec =
+					if (std::optional<TypeSpecifierNode> original_concrete_alias_type_spec =
 							materialize_alias_target_from_instantiation_context(
 								*original_param_type_info);
-						concrete_alias_type_spec.has_value()) {
+						original_concrete_alias_type_spec.has_value()) {
 						merge_alias_target_type_spec(
 							substituted_param_type_spec,
-							*concrete_alias_type_spec);
+							*original_concrete_alias_type_spec);
 					} else if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
 						alias_type_spec != nullptr &&
 						!alias_type_spec_still_uses_active_template_param(*alias_type_spec)) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -159,6 +159,50 @@ ASTNode rebuildResolvedSubstitutedTypeSpec(
 		resolved_type_index);
 	return substituted_type;
 }
+
+void appendMemberTemplateResolutionOuterBindings(
+	const OuterTemplateBinding* outer_binding,
+	InlineVector<TemplateParameterNode, 4>& resolution_params,
+	InlineVector<TemplateTypeArg, 4>& resolution_args) {
+	if (outer_binding == nullptr) {
+		return;
+	}
+	if (!outer_binding->params.empty()) {
+		const size_t pair_count =
+			std::min(outer_binding->params.size(), outer_binding->param_args.size());
+		for (size_t i = 0; i < pair_count; ++i) {
+			const TemplateParameterNode* outer_param =
+				tryGetTemplateParameterNode(outer_binding->params[i]);
+			if (outer_param == nullptr) {
+				continue;
+			}
+			resolution_params.push_back(*outer_param);
+			resolution_args.push_back(outer_binding->param_args[i]);
+		}
+		return;
+	}
+	const size_t pair_count =
+		std::min(outer_binding->param_names.size(), outer_binding->param_args.size());
+	for (size_t i = 0; i < pair_count; ++i) {
+		Token param_token(
+			Token::Type::Identifier,
+			StringTable::getStringView(outer_binding->param_names[i]),
+			0,
+			0,
+			0);
+		resolution_params.push_back(
+			TemplateParameterNode(outer_binding->param_names[i], param_token));
+		resolution_args.push_back(outer_binding->param_args[i]);
+	}
+}
+
+bool dependentQualifiedRecordHasMemberTemplateSegment(
+	const TypeInfo::DependentQualifiedNameRecord* dependent_record) {
+	return dependent_record != nullptr &&
+		std::ranges::any_of(
+			dependent_record->member_chain,
+			[](const auto& member) { return member.has_template_arguments; });
+}
 }
 
 bool Parser::tryAppendMemberDefaultTemplateArg(
@@ -790,6 +834,78 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 		return std::nullopt;
 	}
 
+	auto concretize_shape_params =
+		[&](
+			FunctionDeclarationNode& function_decl,
+			const ASTNode& template_node_for_candidate,
+			StringHandle lookup_name,
+			std::span<const TemplateTypeArg> candidate_template_args) {
+			if (!template_node_for_candidate.is<TemplateFunctionDeclarationNode>()) {
+				return;
+			}
+			InlineVector<TemplateParameterNode, 4> resolution_params;
+			InlineVector<TemplateTypeArg, 4> resolution_args;
+			appendMemberTemplateResolutionOuterBindings(
+				gTemplateRegistry.getOuterTemplateBinding(lookup_name.view()),
+				resolution_params,
+				resolution_args);
+			const auto& inner_template_params =
+				template_node_for_candidate.as<TemplateFunctionDeclarationNode>().template_parameters();
+			for (const TemplateParameterNode& template_param : inner_template_params) {
+				resolution_params.push_back(template_param);
+			}
+			for (const TemplateTypeArg& template_arg : candidate_template_args) {
+				resolution_args.push_back(template_arg);
+			}
+
+			for (ASTNode& param_node : function_decl.parameter_nodes()) {
+				DeclarationNode* param_decl =
+					const_cast<DeclarationNode*>(get_decl_from_symbol(param_node));
+				if (param_decl == nullptr) {
+					continue;
+				}
+				const TypeSpecifierNode& param_type = param_decl->type_specifier_node();
+				const TypeInfo* param_type_info =
+					param_type.type_index().is_valid()
+						? tryGetTypeInfo(param_type.type_index())
+						: nullptr;
+				const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+					param_type_info != nullptr && param_type_info->hasDependentQualifiedName()
+						? param_type_info->dependentQualifiedName()
+						: nullptr;
+				if (dependent_record == nullptr && param_type_info != nullptr) {
+					ResolvedAliasTypeInfo resolved_alias =
+						resolveAliasTypeInfo(
+							param_type_info->registeredTypeIndex().withCategory(
+								param_type_info->typeEnum()));
+					if (resolved_alias.terminal_type_info != nullptr &&
+						resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
+						dependent_record =
+							resolved_alias.terminal_type_info->dependentQualifiedName();
+					}
+				}
+				if (dependent_record == nullptr ||
+					dependentQualifiedRecordHasMemberTemplateSegment(dependent_record)) {
+					continue;
+				}
+
+				ASTNode concretized_param_type =
+					ASTNode::emplace_node<TypeSpecifierNode>(param_type);
+				if (resolveDependentMemberAlias(
+						concretized_param_type,
+						std::span<const TemplateParameterNode>(
+							resolution_params.data(),
+							resolution_params.size()),
+						std::span<const TemplateTypeArg>(
+							resolution_args.data(),
+							resolution_args.size())) ==
+					DependentAliasResolutionStatus::Resolved) {
+					normalizeSubstitutedTypeSpec(concretized_param_type.as<TypeSpecifierNode>());
+					param_decl->set_type_node(concretized_param_type.as<TypeSpecifierNode>());
+				}
+			}
+		};
+
 	if (viable.size() > 1) {
 		InlineVector<ASTNode, 4> shape_overloads;
 		InlineVector<size_t, 4> shape_candidate_indices;
@@ -808,6 +924,11 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 			auto shape_key = FlashCpp::makeInstantiationKey(shape_key_qualified_name, candidate.template_args);
 			if (auto existing_inst = gTemplateRegistry.getInstantiation(shape_key);
 				existing_inst.has_value() && existing_inst->is<FunctionDeclarationNode>()) {
+				concretize_shape_params(
+					existing_inst->as<FunctionDeclarationNode>(),
+					*candidate.template_node,
+					candidate.lookup_name,
+					candidate.template_args);
 				shape_overloads.push_back(*existing_inst);
 				shape_candidate_indices.push_back(i);
 				continue;
@@ -826,6 +947,11 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 				arg_types,
 				false);
 			if (shape_node.has_value() && shape_node->is<FunctionDeclarationNode>()) {
+				concretize_shape_params(
+					shape_node->as<FunctionDeclarationNode>(),
+					*candidate.template_node,
+					candidate.lookup_name,
+					candidate.template_args);
 				shape_overloads.push_back(*shape_node);
 				shape_candidate_indices.push_back(i);
 			}
@@ -873,7 +999,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 		return *existing_inst;  // Return existing instantiation
 	}
 
-	return instantiate_member_function_template_core(
+	std::optional<ASTNode> instantiated_member = instantiate_member_function_template_core(
 		// Prefer the instantiated struct_name over the pattern-level best_owner_name.
 		// best_owner_name is derived from the template's lookup_name which may be the
 		// uninstantiated pattern (e.g. "Outer::Inner") rather than the concrete
@@ -893,6 +1019,15 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 		best.lookup_name,
 		key_qualified_name,
 		*best.template_node, best.template_args, key, arg_types, true);
+	if (instantiated_member.has_value() &&
+		instantiated_member->is<FunctionDeclarationNode>()) {
+		concretize_shape_params(
+			instantiated_member->as<FunctionDeclarationNode>(),
+			*best.template_node,
+			best.lookup_name,
+			best.template_args);
+	}
+	return instantiated_member;
 }
 
 std::optional<ASTNode> Parser::try_instantiate_constructor_template(
@@ -1886,6 +2021,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				return {type_index, nullptr};
 			}
 			std::string_view tn = StringTable::getStringView(ti->name());
+			const bool is_dependent_member_type = ti->isDependentMemberType();
 
 			// Check inner template params first
 			for (size_t i = 0; i < template_params.size(); ++i) {
@@ -1902,7 +2038,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					}
 				}
 
-				if (ti->isDependentPlaceholder()) {
+				if (ti->isDependentPlaceholder() &&
+					!is_dependent_member_type) {
 					if (const auto* dependent_record = ti->dependentQualifiedName();
 						dependent_record != nullptr && dependent_record->owner_name.isValid()) {
 						for (size_t i = 0;
@@ -2027,6 +2164,59 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		if (const int resolved_size_bits = getTypeSpecSizeBits(target); resolved_size_bits > 0) {
 			target.set_size_in_bits(resolved_size_bits);
 		}
+	};
+	auto materialize_alias_target_from_instantiation_context =
+		[this](const TypeInfo& alias_type_info) -> std::optional<TypeSpecifierNode> {
+		const TypeSpecifierNode* alias_type_spec = alias_type_info.aliasTypeSpecifier();
+		if (alias_type_spec == nullptr) {
+			return std::nullopt;
+		}
+		const TypeInfo::InstantiationContext* inst_ctx =
+			alias_type_info.instantiationContext();
+		if (inst_ctx == nullptr) {
+			return std::nullopt;
+		}
+
+		InlineVector<TemplateParameterNode, 4> ctx_params;
+		InlineVector<TemplateTypeArg, 4> ctx_args;
+		auto append_instantiation_context =
+			[&](const auto& self, const TypeInfo::InstantiationContext* current_ctx) -> void {
+			if (current_ctx == nullptr) {
+				return;
+			}
+			self(self, current_ctx->parent);
+			size_t binding_count = current_ctx->param_names.size();
+			if (current_ctx->param_args.size() < binding_count) {
+				binding_count = current_ctx->param_args.size();
+			}
+			for (size_t binding_index = 0; binding_index < binding_count; ++binding_index) {
+				ctx_params.push_back(
+					rebuildOuterTemplateParameter(
+						current_ctx->param_names[binding_index],
+						current_ctx->param_args[binding_index]));
+				ctx_args.push_back(
+					toTemplateTypeArg(current_ctx->param_args[binding_index]));
+			}
+		};
+		append_instantiation_context(append_instantiation_context, inst_ctx);
+		if (ctx_params.empty() || ctx_args.empty()) {
+			return std::nullopt;
+		}
+
+		TypeIndex concrete_alias_index = substitute_template_parameter(
+			*alias_type_spec,
+			std::span<const TemplateParameterNode>(ctx_params.data(), ctx_params.size()),
+			std::span<const TemplateTypeArg>(ctx_args.data(), ctx_args.size()));
+		if (!concrete_alias_index.is_valid()) {
+			return std::nullopt;
+		}
+
+		TypeSpecifierNode concrete_alias_spec = *alias_type_spec;
+		concrete_alias_spec.set_type_index(
+			concrete_alias_index.withCategory(concrete_alias_index.category()));
+		concrete_alias_spec.set_category(concrete_alias_index.category());
+		normalizeSubstitutedTypeSpec(concrete_alias_spec);
+		return concrete_alias_spec;
 	};
 	// Substitute the return type if it's a template parameter
 	const TypeSpecifierNode& return_type_spec = orig_decl.type_specifier_node();
@@ -2316,9 +2506,13 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				original_param_type_node,
 				param_type_spec,
 				param_type_index);
-			if (func_decl.has_outer_template_bindings()) {
+			const TypeInfo* original_param_type_info =
+				tryGetTypeInfo(param_type_spec.type_index());
+			if (func_decl.has_outer_template_bindings() &&
+				!(original_param_type_info != nullptr &&
+				  original_param_type_info->isDependentMemberType())) {
 				if (auto resolved_outer = resolveDependentPlaceholderFromOuterBindings(
-						tryGetTypeInfo(param_type_spec.type_index()),
+						original_param_type_info,
 						func_decl.outer_template_param_names(),
 						func_decl.outer_template_args())) {
 					param_type_index = *resolved_outer;
@@ -2345,36 +2539,214 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			for (const auto& template_arg : template_args) {
 				member_template_resolution_args.push_back(template_arg);
 			}
-			param_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
-				*this,
-				&original_param_type_node,
-				param_type_spec,
-				member_template_resolution_params,
-				member_template_resolution_args,
-				param_type_index,
-				true,
-				true,
-				true);
+			const TypeInfo* semantic_param_type_info = original_param_type_info;
+			if (semantic_param_type_info != nullptr &&
+				(!semantic_param_type_info->isDependentMemberType() ||
+				 !semantic_param_type_info->hasDependentQualifiedName()) &&
+				param_type_spec.type_index().is_valid()) {
+				ResolvedAliasTypeInfo resolved_param_alias =
+					resolveAliasTypeInfo(param_type_spec.type_index());
+				if (resolved_param_alias.terminal_type_info != nullptr) {
+					semantic_param_type_info = resolved_param_alias.terminal_type_info;
+				}
+			}
+			if (semantic_param_type_info != nullptr &&
+				semantic_param_type_info->isDependentMemberType() &&
+				semantic_param_type_info->hasDependentQualifiedName()) {
+				if (const TypeInfo* resolved_dependent_param_type =
+						resolveDependentMemberTypeSemantic(
+							*semantic_param_type_info,
+							member_template_resolution_params,
+							member_template_resolution_args,
+							current_owner_type_name);
+					resolved_dependent_param_type != nullptr) {
+					param_type_index =
+						resolved_dependent_param_type->registeredTypeIndex().withCategory(
+							resolved_dependent_param_type->typeEnum());
+				}
+			}
+			ASTNode resolved_original_dependent_param_type;
+			bool resolved_original_dependent_alias = false;
+			if (semantic_param_type_info != nullptr &&
+				semantic_param_type_info->isDependentMemberType() &&
+				semantic_param_type_info->hasDependentQualifiedName()) {
+				resolved_original_dependent_param_type =
+					emplace_node<TypeSpecifierNode>(param_type_spec);
+				if (resolveDependentMemberAlias(
+						resolved_original_dependent_param_type,
+						member_template_resolution_params,
+						member_template_resolution_args) ==
+					DependentAliasResolutionStatus::Resolved) {
+					param_type_index =
+						resolved_original_dependent_param_type
+							.as<TypeSpecifierNode>()
+							.type_index();
+					resolved_original_dependent_alias = true;
+				}
+			}
+			if (!resolved_original_dependent_alias) {
+				param_type_index = resolveDependentMemberTemplateSubstitutionArtifacts(
+					*this,
+					&original_param_type_node,
+					param_type_spec,
+					member_template_resolution_params,
+					member_template_resolution_args,
+					param_type_index,
+					true,
+					true,
+					true);
+			}
 
 			// Create the substituted parameter type specifier
 			auto substituted_param_type = rebuildResolvedSubstitutedTypeSpec(
 				param_type_spec,
 				param_type_index,
 				resolved_arg);
+			if (resolved_original_dependent_alias) {
+				substituted_param_type = resolved_original_dependent_param_type;
+			}
 
 			auto& substituted_param_type_spec = substituted_param_type.as<TypeSpecifierNode>();
+			auto alias_type_spec_still_uses_active_template_param =
+				[&](const TypeSpecifierNode& alias_type_spec) {
+					if (typeSpecStillUsesDependentPlaceholder(alias_type_spec)) {
+						return true;
+					}
+					StringHandle alias_type_name{};
+					if (alias_type_spec.type_index().is_valid()) {
+						if (const TypeInfo* alias_type_info =
+								tryGetTypeInfo(alias_type_spec.type_index())) {
+							alias_type_name = alias_type_info->name();
+						}
+					}
+					if (!alias_type_name.isValid()) {
+						alias_type_name = alias_type_spec.token().handle();
+					}
+					if (!alias_type_name.isValid()) {
+						return false;
+					}
+					for (const TemplateParameterNode& active_template_param :
+						 member_template_resolution_params) {
+						if (active_template_param.nameHandle() == alias_type_name) {
+							return true;
+						}
+					}
+					return false;
+				};
 			if (const TypeInfo* param_type_info = tryGetTypeInfo(param_type_index);
 				param_type_info != nullptr &&
 				param_type_info->isTypeAlias()) {
-				if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
+				if (std::optional<TypeSpecifierNode> concrete_alias_type_spec =
+						materialize_alias_target_from_instantiation_context(
+							*param_type_info);
+					concrete_alias_type_spec.has_value()) {
+					merge_alias_target_type_spec(
+						substituted_param_type_spec,
+						*concrete_alias_type_spec);
+				} else if (original_param_type_info != nullptr) {
+					if (std::optional<TypeSpecifierNode> concrete_alias_type_spec =
+							materialize_alias_target_from_instantiation_context(
+								*original_param_type_info);
+						concrete_alias_type_spec.has_value()) {
+						merge_alias_target_type_spec(
+							substituted_param_type_spec,
+							*concrete_alias_type_spec);
+					} else if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
+						alias_type_spec != nullptr &&
+						!alias_type_spec_still_uses_active_template_param(*alias_type_spec)) {
+						merge_alias_target_type_spec(
+							substituted_param_type_spec,
+							*alias_type_spec);
+					}
+				} else if (const TypeSpecifierNode* alias_type_spec = param_type_info->aliasTypeSpecifier();
 					alias_type_spec != nullptr &&
-					!typeSpecStillUsesDependentPlaceholder(*alias_type_spec)) {
+					!alias_type_spec_still_uses_active_template_param(*alias_type_spec)) {
 					merge_alias_target_type_spec(
 						substituted_param_type_spec,
 						*alias_type_spec);
 				}
 			}
 			normalizeSubstitutedTypeSpec(substituted_param_type_spec);
+			if (semantic_param_type_info != nullptr &&
+				semantic_param_type_info->isDependentMemberType() &&
+				semantic_param_type_info->hasDependentQualifiedName()) {
+				TypeIndex normalized_param_type_index = substituted_param_type_spec.type_index();
+				const TypeInfo* normalized_param_type_info =
+					normalized_param_type_index.is_valid()
+						? tryGetTypeInfo(normalized_param_type_index)
+						: nullptr;
+				if (normalized_param_type_info != nullptr) {
+					TypeSpecifierNode rebuilt_param_type_spec = buildSubstitutedTypeSpecifier(
+						param_type_spec,
+						param_decl.type_node(),
+						param_decl.identifier_token(),
+						member_template_resolution_params,
+						member_template_resolution_args,
+						[this](const ASTNode& node, const auto& params, const auto& args) {
+							return substituteTemplateParameters(node, params, args);
+						},
+						[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+							return substitute_template_parameter(type_spec, params, args);
+						},
+						nullptr,
+						TypeIndex{},
+						TypeIndex{},
+						false,
+						true);
+					ASTNode rebuilt_param_type = emplace_node<TypeSpecifierNode>(rebuilt_param_type_spec);
+					if (resolveDependentMemberAlias(
+							rebuilt_param_type,
+							member_template_resolution_params,
+							member_template_resolution_args) ==
+						DependentAliasResolutionStatus::Resolved) {
+						normalizeSubstitutedTypeSpec(rebuilt_param_type.as<TypeSpecifierNode>());
+						substituted_param_type = rebuilt_param_type;
+					}
+				}
+			}
+			if (semantic_param_type_info != nullptr &&
+				semantic_param_type_info->isDependentMemberType() &&
+				semantic_param_type_info->hasDependentQualifiedName()) {
+				auto has_member_template_segment =
+					[](const TypeInfo* type_info) {
+						if (type_info == nullptr) {
+							return false;
+						}
+						const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+							type_info->hasDependentQualifiedName()
+								? type_info->dependentQualifiedName()
+								: nullptr;
+						if (dependent_record == nullptr) {
+							ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+								type_info->registeredTypeIndex().withCategory(
+									type_info->typeEnum()));
+							if (resolved_alias.terminal_type_info != nullptr &&
+								resolved_alias.terminal_type_info->hasDependentQualifiedName()) {
+								dependent_record =
+									resolved_alias.terminal_type_info->dependentQualifiedName();
+							}
+						}
+						if (dependent_record == nullptr) {
+							return false;
+						}
+						return std::ranges::any_of(
+							dependent_record->member_chain,
+							[](const auto& member) { return member.has_template_arguments; });
+					};
+				if (!has_member_template_segment(semantic_param_type_info)) {
+					ASTNode concretized_param_type =
+						emplace_node<TypeSpecifierNode>(substituted_param_type.as<TypeSpecifierNode>());
+					if (resolveDependentMemberAlias(
+							concretized_param_type,
+							member_template_resolution_params,
+							member_template_resolution_args) ==
+						DependentAliasResolutionStatus::Resolved) {
+						normalizeSubstitutedTypeSpec(
+							concretized_param_type.as<TypeSpecifierNode>());
+						substituted_param_type = concretized_param_type;
+					}
+				}
+			}
 
 			// Create the new parameter declaration
 			auto new_param_decl = emplace_node<DeclarationNode>(substituted_param_type, param_decl.identifier_token());

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -860,7 +860,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 
 			for (ASTNode& param_node : function_decl.parameter_nodes()) {
 				DeclarationNode* param_decl =
-					const_cast<DeclarationNode*>(get_decl_from_symbol(param_node));
+					Parser::get_decl_from_symbol_mut(param_node);
 				if (param_decl == nullptr) {
 					continue;
 				}

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2267,11 +2267,22 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		return nullptr;
 	}
 
-	if (original_alias_target_info->isDependentMemberType() &&
-		original_alias_target_info->hasDependentQualifiedName()) {
+	const TypeInfo* semantic_alias_target_info = original_alias_target_info;
+	if ((!semantic_alias_target_info->isDependentMemberType() ||
+		 !semantic_alias_target_info->hasDependentQualifiedName()) &&
+		alias_type_spec.type_index().is_valid()) {
+		ResolvedAliasTypeInfo resolved_alias =
+			resolveAliasTypeInfo(alias_type_spec.type_index());
+		if (resolved_alias.terminal_type_info != nullptr) {
+			semantic_alias_target_info = resolved_alias.terminal_type_info;
+		}
+	}
+
+	if (semantic_alias_target_info->isDependentMemberType() &&
+		semantic_alias_target_info->hasDependentQualifiedName()) {
 		if (const TypeInfo* resolved_dependent_type =
 				resolveDependentMemberTypeSemantic(
-					*original_alias_target_info,
+					*semantic_alias_target_info,
 					template_params,
 					template_args,
 					StringHandle{});
@@ -2281,7 +2292,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	}
 
 	const TypeInfo::DependentQualifiedNameRecord* dependent_name =
-		original_alias_target_info->dependentQualifiedName();
+		semantic_alias_target_info->dependentQualifiedName();
 	if (dependent_name == nullptr ||
 		dependent_name->member_chain.empty()) {
 		return nullptr;
@@ -2312,6 +2323,18 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	}
 	if (!dependent_base_info || !is_struct_type(dependent_base_info->typeEnum())) {
 		return nullptr;
+	}
+	if (semantic_alias_target_info->isDependentMemberType() &&
+		semantic_alias_target_info->hasDependentQualifiedName()) {
+		if (const TypeInfo* resolved_with_concrete_owner =
+				resolveDependentMemberTypeSemantic(
+					*semantic_alias_target_info,
+					template_params,
+					template_args,
+					dependent_base_info->name());
+			resolved_with_concrete_owner != nullptr) {
+			return resolved_with_concrete_owner;
+		}
 	}
 	std::string_view dependent_base_name =
 		StringTable::getStringView(dependent_base_info->name());
@@ -2428,8 +2451,43 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		StringHandle base_template_name_handle = gNamespaceRegistry.buildQualifiedIdentifier(
 			dependent_base_info->sourceNamespace(),
 			dependent_base_info->baseTemplateName());
+		auto resolve_composite_owner_template_name =
+			[&](StringHandle candidate_handle) -> StringHandle {
+			if (!candidate_handle.isValid()) {
+				return candidate_handle;
+			}
+			std::string_view candidate_name =
+				StringTable::getStringView(candidate_handle);
+			size_t owner_sep = candidate_name.rfind("::");
+			if (owner_sep == std::string_view::npos) {
+				return candidate_handle;
+			}
+			std::string_view owner_prefix = candidate_name.substr(0, owner_sep);
+			std::string_view member_template_name =
+				candidate_name.substr(owner_sep + 2);
+			for (size_t i = 0; i < template_params.size() && i < template_args.size(); ++i) {
+				const TemplateParameterNode* template_param =
+					tryGetTemplateParameterNode(template_params[i]);
+				if (template_param == nullptr ||
+					template_param->name() != owner_prefix ||
+					template_args[i].is_value) {
+					continue;
+				}
+				const TypeInfo* concrete_owner_type_info =
+					tryGetTypeInfo(template_args[i].type_index);
+				if (concrete_owner_type_info == nullptr) {
+					break;
+				}
+				return buildQualifiedName(
+					StringTable::getStringView(concrete_owner_type_info->name()),
+					member_template_name);
+			}
+			return candidate_handle;
+		};
 		if (dependent_name->owner_name.isValid()) {
-			base_template_name_handle = dependent_name->owner_name;
+			base_template_name_handle =
+				resolve_composite_owner_template_name(
+					dependent_name->owner_name);
 		}
 		InlineVector<TemplateTypeArg, 4> concrete_base_args =
 			!dependent_name->owner_template_arguments.empty()
@@ -2452,6 +2510,48 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		materialized_alias_base_name = materialized_alias_base.canonicalName();
 		if (materialized_alias_base_name.empty()) {
 			return nullptr;
+		}
+	}
+
+	bool has_member_template_segment = false;
+	for (const auto& member_record : dependent_name->member_chain) {
+		if (member_record.has_template_arguments) {
+			has_member_template_segment = true;
+			break;
+		}
+	}
+	if (has_member_template_segment) {
+		std::vector<QualifiedTypeMemberAccess> materialized_member_chain;
+		materialized_member_chain.reserve(dependent_name->member_chain.size());
+		for (const auto& member_record : dependent_name->member_chain) {
+			QualifiedTypeMemberAccess member_access;
+			member_access.member_name = member_record.name;
+			if (member_record.has_template_arguments) {
+				InlineVector<TemplateTypeArg, 4> concrete_member_args =
+					materialize_template_args_with_environment(
+						member_record.template_arguments);
+				if (template_args_still_dependent(concrete_member_args)) {
+					return nullptr;
+				}
+				std::vector<TemplateTypeArg> materialized_args(
+					concrete_member_args.begin(),
+					concrete_member_args.end());
+				member_access.has_template_arguments = true;
+				member_access.template_arguments =
+					&gChunkedAnyStorage.emplace_back<std::vector<TemplateTypeArg>>(
+						std::move(materialized_args));
+			}
+			materialized_member_chain.push_back(std::move(member_access));
+		}
+
+		if (const TypeInfo* resolved_member =
+				resolveBaseClassMemberTypeChain(
+					materialized_alias_base_name,
+					std::span<const QualifiedTypeMemberAccess>(
+						materialized_member_chain.data(),
+						materialized_member_chain.size()));
+			resolved_member != nullptr) {
+			return resolved_member;
 		}
 	}
 
@@ -3272,7 +3372,7 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(
 		template_opt = gTemplateRegistry.lookupVariableTemplate(simple_template_name);
 	}
 	if (!template_opt.has_value()) {
-		FLASH_LOG(Templates, Error, "Variable template '", template_name, "' not found");
+		FLASH_LOG(Templates, Debug, "Variable template '", template_name, "' not found");
 		return std::nullopt;
 	}
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -652,7 +652,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
 		true,  // Preserve declared parameter cv-qualifier in this path
 		false, // Do not re-apply bound metadata to full substitution
-		true); // Force resolved TypeIndex onto full AST substitutions
+		true,  // Force resolved TypeIndex onto full AST substitutions
+		false); // Plain member lazy replay does not need dependent member-template signature preservation
 
 	// Get the function body - either from definition or by re-parsing from saved position
 	std::optional<ASTNode> body_to_substitute;

--- a/tests/test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp
+++ b/tests/test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp
@@ -1,0 +1,49 @@
+// Regression: overloaded OOL member-function-template replay must not treat
+// owner-only artifacts from `typename T::template AddPtr<...>::type`
+// substitution as an early signature match. The `int` and `long` alias-target
+// overloads must each attach to their own out-of-line body.
+struct OolMemberTemplateDependentMemberTemplateAliasOverloadTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct OolMemberTemplateDependentMemberTemplateAliasOverload {
+	template<class U>
+	int pick(U seed, typename T::template AddPtr<int>::type value);
+
+	template<class U>
+	int pick(U seed, typename T::template AddPtr<long>::type value);
+};
+
+template<class T>
+template<class U>
+int OolMemberTemplateDependentMemberTemplateAliasOverload<T>::pick(
+	U seed,
+	typename T::template AddPtr<long>::type value) {
+	return static_cast<int>(sizeof(*value)) + seed + 10;
+}
+
+template<class T>
+template<class U>
+int OolMemberTemplateDependentMemberTemplateAliasOverload<T>::pick(
+	U seed,
+	typename T::template AddPtr<int>::type value) {
+	return static_cast<int>(sizeof(*value)) + seed + 20;
+}
+
+int main() {
+	int int_value = 0;
+	long long_value = 0;
+	OolMemberTemplateDependentMemberTemplateAliasOverload<
+		OolMemberTemplateDependentMemberTemplateAliasOverloadTag> value;
+	if (value.pick(1, &int_value) != 25) {
+		return 1;
+	}
+	if (value.pick(2, &long_value) != 16) {
+		return 2;
+	}
+	return 0;
+}

--- a/tests/test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp
+++ b/tests/test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp
@@ -42,7 +42,7 @@ int main() {
 	if (value.pick(1, &int_value) != 25) {
 		return 1;
 	}
-	if (value.pick(2, &long_value) != 16) {
+	if (value.pick(2, &long_value) != static_cast<int>(sizeof(long_value)) + 12) {
 		return 2;
 	}
 	return 0;


### PR DESCRIPTION
## Summary
- preserve dependent owner/member-template identity for OOL member-function-template alias-target overloads
- fix nearby plain-member, nested swap, and specialization regressions exposed by full-suite validation
- update the template-architecture docs and add an AddPtr<int> vs AddPtr<long> regression test
