### PR TITLE
Fix __declspec(dllimport) on variable declarations silently discarding Linkage info

### DIFF
--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -394,6 +394,9 @@ public:
 	void set_is_constinit(bool is_constinit) { is_constinit_ = is_constinit; }
 	bool is_constinit() const { return is_constinit_; }
 
+	void set_linkage(Linkage linkage) { linkage_ = linkage; }
+	Linkage linkage() const { return linkage_; }
+
 	template <typename NameContainer, typename ArgContainer>
 	void set_outer_template_bindings(const NameContainer& template_param_names, const ArgContainer& template_args) {
 		outer_template_param_names_.clear();
@@ -435,6 +438,7 @@ private:
 	ASTNode declaration_node_;
 	std::optional<ASTNode> initializer_;
 	StorageClass storage_class_;
+	Linkage linkage_ = Linkage::None;
 	bool is_thread_local_ = false;
 	bool is_constexpr_;
 	bool is_constinit_;

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -1237,9 +1237,12 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 			// and `extern "C" int x __asm__("y");` (Linkage::C with StorageClass::None).
 		bool is_asm_alias_only = decl.has_mangled_name() &&
 								 !node.initializer();
-			// C++20 [basic.link]: An extern declaration without an initializer is a
-			// declaration, not a definition — it must not allocate storage.
-		if (node.storage_class() == StorageClass::Extern && !node.initializer()) {
+		// C++20 [basic.link]: An extern declaration without an initializer is a
+		// declaration, not a definition — it must not allocate storage.
+		// __declspec(dllimport) always refers to an external symbol provided by a
+		// DLL at runtime — it must never allocate local storage, regardless of
+		// initializer presence (initializers on dllimport are semantically invalid).
+		if (node.linkage() == Linkage::DllImport || (node.storage_class() == StorageClass::Extern && !node.initializer())) {
 			op.is_extern_only = true;
 		}
 		if (!is_asm_alias_only) {

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -945,6 +945,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		global_decl_node.set_is_thread_local(specs.is_thread_local);
 		global_decl_node.set_is_constexpr(is_constexpr);
 		global_decl_node.set_is_constinit(is_constinit);
+		global_decl_node.set_linkage(specs.linkage);
 
 		// Parse the initializer against the registered declaration node so later
 		// unsized-array inference updates the same AST object already stored in the
@@ -1121,6 +1122,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				next_var_decl.set_is_thread_local(specs.is_thread_local);
 				next_var_decl.set_is_constexpr(is_constexpr);
 				next_var_decl.set_is_constinit(is_constinit);
+				next_var_decl.set_linkage(specs.linkage);
 
 				if (!gSymbolTable.insert(next_identifier_token.value(), next_var_node)) {
 					return ParseResult::error(ParserError::RedefinedSymbolWithDifferentValue, next_identifier_token);

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -994,7 +994,7 @@ ParseResult Parser::parse_variable_declaration() {
 	bool is_constexpr = specs.is_constexpr();
 	bool is_constinit = specs.is_constinit();
 	StorageClass storage_class = specs.storage_class;
-	[[maybe_unused]] Linkage linkage = specs.linkage;
+	Linkage linkage = specs.linkage;
 
 	// Parse the type specifier and identifier (name)
 	ParseResult type_and_name_result = parse_type_and_name();
@@ -1047,10 +1047,11 @@ ParseResult Parser::parse_variable_declaration() {
 			std::nullopt,
 			storage_class);
 
-		// Set constexpr/constinit flags
+		// Set constexpr/constinit flags and linkage
 		var_decl.set_is_thread_local(specs.is_thread_local);
 		var_decl.set_is_constexpr(is_constexpr);
 		var_decl.set_is_constinit(is_constinit);
+		var_decl.set_linkage(linkage);
 
 		// Add the VariableDeclarationNode to the symbol table
 		// This preserves the is_constexpr flag and initializer for constant expression evaluation

--- a/tests/run_all_tests.ps1
+++ b/tests/run_all_tests.ps1
@@ -221,6 +221,7 @@ $extraCHelpers = @{
 	"test_external_abi_simple.cpp" = @("test_external_abi_simple_helper.c")
 	"test_atomic_builtin_pointer_intrinsics_ret0.cpp" = @("test_atomic_builtin_pointer_intrinsics_helper.c")
 	"test_extern_var_ret42.cpp" = @("test_extern_var_ret42_helper.c")
+	"test_declspec_dllimport_var_ret42.cpp" = @("test_declspec_dllimport_var_ret42_helper.c")
 }
 
 # Pre-cache main() detection to avoid reading files twice

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -107,7 +107,7 @@ EXPECTED_LINK_FAIL=(
 # Format: "test_file.cpp:helper_file.c" pairs, space-separated.
 # The helper .c file is expected to live in the tests/ directory.
 # This is exported so the parallel worker function can access it.
-EXTRA_C_HELPERS="test_external_abi.cpp:test_external_abi_helper.c test_external_abi_simple.cpp:test_external_abi_simple_helper.c test_atomic_builtin_pointer_intrinsics_ret0.cpp:test_atomic_builtin_pointer_intrinsics_helper.c test_extern_var_ret42.cpp:test_extern_var_ret42_helper.c"
+EXTRA_C_HELPERS="test_external_abi.cpp:test_external_abi_helper.c test_external_abi_simple.cpp:test_external_abi_simple_helper.c test_atomic_builtin_pointer_intrinsics_ret0.cpp:test_atomic_builtin_pointer_intrinsics_helper.c test_extern_var_ret42.cpp:test_extern_var_ret42_helper.c test_declspec_dllimport_var_ret42.cpp:test_declspec_dllimport_var_ret42_helper.c"
 export EXTRA_C_HELPERS
 
 # Expected runtime crashes - files that compile and link but crash at runtime

--- a/tests/test_declspec_dllimport_var_ret42.cpp
+++ b/tests/test_declspec_dllimport_var_ret42.cpp
@@ -1,0 +1,15 @@
+// Regression test: __declspec(dllimport) on a variable declaration must
+// not allocate local storage — the symbol is provided by the importing DLL.
+//
+// Before the fix, FlashCpp silently discarded the dllimport linkage on
+// variable declarations and emitted a strong definition, causing
+// duplicate-definition errors.
+//
+// After the fix, the dllimport declaration is emitted as an undefined
+// external reference, resolved by the definition in the helper .c file.
+
+__declspec(dllimport) int testDllImportVar;
+
+int main() {
+	return testDllImportVar;
+}

--- a/tests/test_declspec_dllimport_var_ret42_helper.c
+++ b/tests/test_declspec_dllimport_var_ret42_helper.c
@@ -1,0 +1,2 @@
+// Helper: defines the dllimport variable used by test_declspec_dllimport_var_ret42.cpp
+int testDllImportVar = 42;


### PR DESCRIPTION
## Summary

`__declspec(dllimport)` on variable declarations was parsed but silently discarded — `VariableDeclarationNode` had no `linkage_` field, and the parser stored it as `[[maybe_unused]] Linkage linkage = specs.linkage;`.

Without this fix, `__declspec(dllimport) int foo;` would allocate local storage (treated as a definition), causing duplicate-symbol link errors when the actual DLL definition is also present.

## Changes

| File | Change |
|------|--------|
| `src/AstNodeTypes_Template.h` | Add `Linkage linkage_` member + `set_linkage()`/`linkage()` to `VariableDeclarationNode` |
| `src/Parser_Statements.cpp` | Store `specs.linkage` on the node (was `[[maybe_unused]]`) |
| `src/Parser_Decl_FunctionOrVar.cpp` | Store `specs.linkage` on the node in the fallback and multi-declarator paths |
| `src/IrGenerator_Stmt_Decl.cpp` | Extend `is_extern_only` condition to cover `Linkage::DllImport` |
| `tests/test_declspec_dllimport_var_ret42.cpp` | Regression test — `__declspec(dllimport) int testDllImportVar;` links cleanly against helper .c |
| `tests/test_declspec_dllimport_var_ret42_helper.c` | Defines `int testDllImportVar = 42;` |

## Verification

- **New test**: compiles, links, returns 42
- **Full suite**: 2600/2600 pass, 185/185 `_fail` tests fail as expected
- **0 regressions**

This is a follow-up to the extern declaration fix in #1728.