### PR TITLE
Add parser validation for invalid __declspec(dllimport) combinations on variables

### DIFF
--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -947,6 +947,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		global_decl_node.set_is_constinit(is_constinit);
 		global_decl_node.set_linkage(specs.linkage);
 
+		// Validate: constexpr/constinit are incompatible with dllimport
+		if (specs.linkage == Linkage::DllImport && (is_constexpr || is_constinit)) {
+			return ParseResult::error("'constexpr' and '__declspec(dllimport)' are incompatible", global_decl_node.declaration().identifier_token());
+		}
+
 		// Parse the initializer against the registered declaration node so later
 		// unsized-array inference updates the same AST object already stored in the
 		// symbol table and returned VariableDeclarationNode.
@@ -1017,6 +1022,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		}
 
 		global_decl_node.set_initializer(initializer);
+
+		// Validate: __declspec(dllimport) data must not have a definition (initializer)
+		if (specs.linkage == Linkage::DllImport && initializer.has_value()) {
+			return ParseResult::error("definition of dllimport data is not allowed", identifier_token);
+		}
 
 		// Semantic checks for constexpr/constinit - only enforce for global/static variables
 		// For local constexpr variables, they can fall back to runtime initialization (like const)
@@ -1124,6 +1134,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				next_var_decl.set_is_constinit(is_constinit);
 				next_var_decl.set_linkage(specs.linkage);
 
+				// Validate: constexpr/constinit are incompatible with dllimport
+				if (specs.linkage == Linkage::DllImport && (is_constexpr || is_constinit)) {
+					return ParseResult::error("'constexpr' and '__declspec(dllimport)' are incompatible", next_identifier_token);
+				}
+
 				if (!gSymbolTable.insert(next_identifier_token.value(), next_var_node)) {
 					return ParseResult::error(ParserError::RedefinedSymbolWithDifferentValue, next_identifier_token);
 				}
@@ -1157,6 +1172,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				}
 
 				next_var_decl.set_initializer(next_initializer);
+
+				// Validate: __declspec(dllimport) data must not have a definition (initializer)
+				if (specs.linkage == Linkage::DllImport && next_initializer.has_value()) {
+					return ParseResult::error("definition of dllimport data is not allowed", next_identifier_token);
+				}
 
 				// Add to block
 				block_ref.add_statement_node(next_var_node);

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1053,6 +1053,11 @@ ParseResult Parser::parse_variable_declaration() {
 		var_decl.set_is_constinit(is_constinit);
 		var_decl.set_linkage(linkage);
 
+		// Validate: constexpr/constinit are incompatible with dllimport
+		if (linkage == Linkage::DllImport && (is_constexpr || is_constinit)) {
+			return ParseResult::error("'constexpr' and '__declspec(dllimport)' are incompatible", decl.identifier_token());
+		}
+
 		// Add the VariableDeclarationNode to the symbol table
 		// This preserves the is_constexpr flag and initializer for constant expression evaluation
 		const Token& identifier_token = decl.identifier_token();
@@ -1236,6 +1241,11 @@ ParseResult Parser::parse_variable_declaration() {
 	}
 	first_var_decl.set_initializer(first_init_expr);
 
+	// Validate: __declspec(dllimport) data must not have a definition (initializer)
+	if (first_var_decl.linkage() == Linkage::DllImport && first_init_expr.has_value()) {
+		return ParseResult::error("definition of dllimport data is not allowed", first_decl.identifier_token());
+	}
+
 	// Check for use of deleted default constructor: Struct s{} where default ctor is deleted
 	if (type_specifier.category() == TypeCategory::Struct && !type_specifier.is_pointer() &&
 		first_init_expr.has_value() && first_init_expr->is<InitializerListNode>()) {
@@ -1322,7 +1332,13 @@ ParseResult Parser::parse_variable_declaration() {
 				inferUnsizedArraySizeFromInitializer(next_decl, next_type_specifier, init_expr);
 			}
 
-			var_decl_node.as<VariableDeclarationNode>().set_initializer(init_expr);
+			auto& var_decl_ref = var_decl_node.as<VariableDeclarationNode>();
+			var_decl_ref.set_initializer(init_expr);
+
+			// Validate: __declspec(dllimport) data must not have a definition (initializer)
+			if (var_decl_ref.linkage() == Linkage::DllImport && init_expr.has_value()) {
+				return ParseResult::error("definition of dllimport data is not allowed", var_decl_ref.declaration().identifier_token());
+			}
 
 			// Add this declaration to the block
 			block_ref.add_statement_node(var_decl_node);

--- a/tests/test_declspec_dllimport_constexpr_fail.cpp
+++ b/tests/test_declspec_dllimport_constexpr_fail.cpp
@@ -1,0 +1,6 @@
+// Expected error: constexpr and __declspec(dllimport) are incompatible
+__declspec(dllimport) constexpr int x = 42;
+
+int main() {
+	return x;
+}

--- a/tests/test_declspec_dllimport_constinit_fail.cpp
+++ b/tests/test_declspec_dllimport_constinit_fail.cpp
@@ -1,0 +1,6 @@
+// Expected error: constinit and __declspec(dllimport) are incompatible
+__declspec(dllimport) constinit int x = 42;
+
+int main() {
+	return x;
+}

--- a/tests/test_declspec_dllimport_initializer_fail.cpp
+++ b/tests/test_declspec_dllimport_initializer_fail.cpp
@@ -1,0 +1,6 @@
+// Expected error: definition of dllimport data is not allowed
+__declspec(dllimport) int x = 42;
+
+int main() {
+	return x;
+}


### PR DESCRIPTION
## Summary

Adds early parse-time rejection of semantically invalid `__declspec(dllimport)` combinations on variable declarations, matching MSVC's behavior:

- `__declspec(dllimport) constexpr int x = 42;` — `'constexpr' and '__declspec(dllimport)' are incompatible`
- `__declspec(dllimport) constinit int x = 42;` — same error
- `__declspec(dllimport) int x = 42;` — `definition of dllimport data is not allowed`

## Changes

**Parser validation (4 paths covered):**
- `Parser_Statements.cpp`: `create_var_decl` lambda (constexpr/constinit check), single-decl path after `set_initializer` (initializer check), multi-decl loop
- `Parser_Decl_FunctionOrVar.cpp`: main fallback path, multi-decl loop

**Tests (3 `_fail.cpp` files):**
- `test_declspec_dllimport_constexpr_fail.cpp`
- `test_declspec_dllimport_constinit_fail.cpp`
- `test_declspec_dllimport_initializer_fail.cpp`

## Verification

- All 3 `_fail` tests fail compilation as expected
- 2600/2600 regular tests pass, 188/188 `_fail` tests fail as expected