### PR TITLE
Fix nested dependent alias replay and explicit member overload caching

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -216,14 +216,27 @@ Useful assumptions before changing this area:
   owner/member chain plus concrete alias arguments during placeholder rebinding
   and materialization. Covered nested alias uses therefore resolve through
   semantic dependent-name records instead of collapsing to terminal-name lookup.
+- **nested dependent member-template records now keep prefix segments aligned
+  with member-template arguments, and alias rebinding can re-enter outer
+  template bindings through the un-hashed base alias name**: paths such as
+  `Provider<T>::Node::template Apply<U>` no longer mis-attach `Apply`'s template
+  arguments to the preceding `Node` segment, and materialization can recover
+  `T -> int` through the stored outer binding when the alias target is an outer
+  class-template parameter.
 - **dependent alias resolution now re-enters semantic owner/member-chain
   resolution after direct alias substitution before touching the legacy
   `base::member` textual path**: covered alias-template chains no longer depend
   on terminal-name reconstruction once the substituted target already carries a
   semantic dependent-qualified-name record.
+- **explicit member-template calls no longer cache the first overload before
+  call-argument types are known**: parser-side explicit-template instantiation
+  now carries collected call argument types into overload selection and rejects
+  pointer-depth-incompatible candidates before cache hits, so calls such as
+  `holder.pick<char>(&value)` do not materialize the value overload first and
+  then reuse that losing candidate.
 
 Latest recorded full-suite validation:
-`2598` regular tests compiled/linked/runtime-pass, `0` fail, `185` expected-fail tests.
+`2603` regular tests compiled/linked/runtime-pass, `0` fail, `188` expected-fail tests.
 
 Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`
@@ -246,6 +259,8 @@ Latest focused replay regressions added on the current branch:
 - `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_primary_nested_ool_ctor_template_same_name_overload_ret0.cpp`
 - `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
+- `test_template_ool_member_template_nested_alias_overload_ret0.cpp`
+- `test_explicit_member_template_pointer_overload_cache_ret0.cpp`
 - `test_template_ool_plain_ctor_nullopt_single_candidate_no_attach_ret0.cpp`
 - `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
 - `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
@@ -314,11 +329,17 @@ they directly block items 1-2:
 ## Highest-impact next steps
 
 1. **Finish the remaining replay-metadata and attachment gaps outside static-member initializers**
+   - Delete the remaining terminal-name / `base::member` string-split fallback in
+     `resolveDependentMemberAlias(...)` once the last recordless
+     parameter-materialization callers preserve semantic owner/member-chain
+     metadata end-to-end.
    - Continue with non-constructor attachment/synchronization surfaces that
      still depend on signature-only matching where source-member identity can
-     be preserved end-to-end.
+     be preserved end-to-end, especially any declaration-copy or lazy-shape
+     path that still erases dependent owner/member-template identity too early.
    - Improve replay metadata capture in unresolved substitution (`nullopt`) paths
-     so canonical substituted-signature matching classifies more valid code.
+     so canonical substituted-signature matching classifies more valid code
+     outside the now-covered nested member-template alias / explicit-call slice.
    - Continue with any remaining OOL dependent-member swap slices in
      member-template or nested overload sets where replay-selected stubs and
      deferred body parsing can still drift after owner-artifact recovery.
@@ -395,6 +416,14 @@ The following are complete enough to rely on:
   nodes, registers qualified names, and attaches outer template bindings so the
   replay path can materialize bodies with the correct class-template parameters
   in scope.
+- nested dependent member-template alias materialization now preserves prefix
+  owner/member-chain alignment for paths like
+  `Provider<T>::Node::template Apply<U>`, and concrete alias rebinding can
+  recover outer class-template bindings through the stored base alias name.
+- explicit member-template overload selection no longer instantiates and caches
+  the first candidate before parsing call arguments; explicit-call overload
+  resolution now sees collected call argument types before cache hits and can
+  reject pointer-depth-incompatible candidates.
 - deferred class-template constructor bodies now store template-parameter names
   at parse time, so replay sets `hasActiveTemplateParameters() = true`; replay
   substitution now preserves full typed NTTP identity metadata and reuses the

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -276,7 +276,8 @@ Rule for this work:
 - continue improving replay metadata capture for unresolved substitution
   (`nullopt`) outcomes in the remaining non-constructor declaration replay
   paths so canonical substituted-signature classification can succeed in more
-  valid cases.
+  valid cases outside the now-covered nested member-template alias /
+  explicit-call overload slice.
 - continue looking for remaining OOL dependent-member swap regressions in
   less-covered member-template and nested replay surfaces now that the first
   constructor replay/body-selection gap has been closed.
@@ -319,6 +320,9 @@ Still open, but not the next best slice:
    template-member attachment paths so unresolved (`nullopt`)
    substituted-signature outcomes classify more often and attachment remains
    evidence-driven without broad compatibility fallback;
+   remove the last recordless dependent-alias callers so
+   `resolveDependentMemberAlias(...)` can drop the terminal-name /
+   `base::member` fallback entirely;
    keep function-parameter adjustment rules centralized so replay/attachment
    compares canonical signatures across eager/lazy/declaration-only paths;
    prioritize remaining OOL dependent-member swap follow-ups in member-template
@@ -337,6 +341,9 @@ Keep adding narrow regressions in these areas:
   or equivalent dependent-base lookup — particularly through partial specs;
 - declaration/definition attachment where inner and outer template parameters
   interact;
+- explicit member-template calls whose overloads differ only in pointer depth or
+  dependent member-template alias shape, so parser-side pre-argument caching
+  cannot reintroduce the losing overload;
 - remaining non-static declaration replay paths that still fall back to
   partially substituted AST state, especially paths that still produce unresolved
   (`nullopt`) substituted-signature outcomes because replay metadata was not
@@ -353,3 +360,13 @@ This plan is complete when:
 - remaining repair paths have been converted into diagnostics or invariants;
 - ordinary overload selection does not materialize losing candidates by
   default.
+
+Latest validation after the current slice:
+
+- `2603` regular tests compiled/linked/runtime-pass, `0` fail;
+- `188` expected-fail tests still fail as expected.
+
+Latest focused regressions added on the current branch:
+
+- `test_template_ool_member_template_nested_alias_overload_ret0.cpp`
+- `test_explicit_member_template_pointer_overload_cache_ret0.cpp`

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -5,6 +5,40 @@ ASTNode rebindStaticMemberInitializerFunctionCalls(
 	const StructTypeInfo* struct_info,
 	bool set_qualified_name);
 
+// ---------------------------------------------------------------------------
+// Structural-dependency helpers for TemplateTypeArg
+// ---------------------------------------------------------------------------
+
+/// Returns true when \p arg is still structurally dependent on unresolved
+/// template parameters — i.e. it cannot yet be used as a concrete
+/// instantiation key.
+///
+/// Covers:
+///  • is_dependent flag (type arg that was never fully substituted)
+///  • surviving dependent_name (belt-and-suspenders guard)
+///  • Auto / DeclTypeAuto placeholder categories
+///
+/// Does NOT include is_pack — call sites that need pack-deferral must check
+/// arg.is_pack separately (e.g. explicitTemplateArgsRequireDeferredInstantiation).
+inline bool templateArgIsStructurallyDependent(const TemplateTypeArg& arg) {
+	if (arg.is_dependent || arg.dependent_name.isValid())
+		return true;
+	const TypeCategory cat = arg.category();
+	return cat == TypeCategory::Auto || cat == TypeCategory::DeclTypeAuto;
+}
+
+/// Returns true when *any* argument in \p args is structurally dependent.
+/// Accepts InlineVector via its implicit operator std::span<const TemplateTypeArg>.
+inline bool anyTemplateArgIsStructurallyDependent(std::span<const TemplateTypeArg> args) {
+	for (const TemplateTypeArg& arg : args) {
+		if (templateArgIsStructurallyDependent(arg))
+			return true;
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+
 // Helper to build qualified name strings for template/member lookup
 // Returns a StringHandle that can be passed to findTypeByName
 inline StringHandle buildQualifiedName(std::string_view owner, std::string_view member) {

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -16,12 +16,13 @@ ASTNode rebindStaticMemberInitializerFunctionCalls(
 /// Covers:
 ///  • is_dependent flag (type arg that was never fully substituted)
 ///  • surviving dependent_name (belt-and-suspenders guard)
+///  • dependent NTTP expressions that still carry AST-backed unresolved identity
 ///  • Auto / DeclTypeAuto placeholder categories
 ///
 /// Does NOT include is_pack — call sites that need pack-deferral must check
 /// arg.is_pack separately (e.g. explicitTemplateArgsRequireDeferredInstantiation).
 inline bool templateArgIsStructurallyDependent(const TemplateTypeArg& arg) {
-	if (arg.is_dependent || arg.dependent_name.isValid())
+	if (arg.is_dependent || arg.dependent_name.isValid() || arg.dependent_expr.has_value())
 		return true;
 	const TypeCategory cat = arg.category();
 	return cat == TypeCategory::Auto || cat == TypeCategory::DeclTypeAuto;

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -322,9 +322,15 @@ inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 	if (dependent_record != nullptr && !dependent_record->member_chain.empty()) {
 		for (const auto& member : dependent_record->member_chain) {
 			if (!member.name.isValid()) {
+				qualified_member_name_builder.reset();
 				return substituted_type_index;
 			}
 			if (member.has_template_arguments) {
+				// Cannot instantiate a member template alias here (no template params/args
+				// available in the non-template overload). Reset the in-progress builder
+				// and return the best available type — the original dependent placeholder
+				// if one exists, so downstream template-aware callers can finish resolution.
+				qualified_member_name_builder.reset();
 				return original_type_spec.type_index().is_valid()
 					? original_type_spec.type_index()
 					: substituted_type_index;
@@ -348,6 +354,7 @@ inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 			member_suffix = token_name;
 		}
 		if (member_suffix.empty()) {
+			qualified_member_name_builder.reset();
 			return substituted_type_index;
 		}
 		if (member_suffix.find("::") == std::string_view::npos) {
@@ -375,6 +382,7 @@ inline TypeIndex resolveDependentMemberPlaceholderFromOwnerArtifact(
 	}
 
 	if (!appended_member) {
+		qualified_member_name_builder.reset();
 		return substituted_type_index;
 	}
 

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -35,6 +35,13 @@ std::optional<ASTNode> Parser::tryResolveMemberFunctionTemplate(
 	auto struct_name = StringTable::getStringView(type_info->name());
 	instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
 	if (explicit_template_args.has_value()) {
+		// Propagate call argument types so overload resolution can reject mismatched
+		// overloads (e.g. value vs pointer).  Without this, the first successful
+		// overload candidate is always returned regardless of argument compatibility.
+		FlashCpp::ScopedState guard_explicit_call_arg_types(current_explicit_call_arg_types_);
+		if (!arg_types.empty()) {
+			current_explicit_call_arg_types_ = &arg_types;
+		}
 		return try_instantiate_member_function_template_explicit(struct_name, member_name, *explicit_template_args);
 	} else if (!arg_types.empty()) {
 		return try_instantiate_member_function_template(struct_name, member_name, arg_types);
@@ -319,6 +326,15 @@ std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
 	// syntactically non-empty call still has no collected types here, preserving the
 	// old behavior by deferring deduction is safer than forcing a hard failure.
 	if (explicit_template_args.has_value()) {
+		// Propagate call argument types so that explicit member template calls
+		// (e.g. outer.pick<char>(&nine)) can discriminate between overloads that
+		// differ only in pointer depth.  Without this, the value overload would
+		// always be chosen over the pointer overload because the overload loop
+		// returns on the first successfully-instantiated candidate.
+		FlashCpp::ScopedState guard_explicit_call_arg_types(current_explicit_call_arg_types_);
+		if (!call_arg_types.empty()) {
+			current_explicit_call_arg_types_ = &call_arg_types;
+		}
 		return try_instantiate_member_function_template_explicit(
 			struct_name,
 			member_name,
@@ -458,12 +474,14 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		explicit_template_args.destroy_pattern_ = TokenDestroyPattern::Discard;
 
 		const FunctionDeclarationNode* known_member_func = nullptr;
-		if (explicit_template_args) {
-			std::optional<ASTNode> instantiated_template = tryResolveMemberFunctionTemplate(result, member_name_token.value(), explicit_template_args.read_template_type_args(), {});
-			FLASH_LOG(Parser, Debug, "parse_member_postfix: tryResolveMemberFunctionTemplate result has_value=", instantiated_template.has_value());
-		} else {
+		if (!explicit_template_args) {
 			known_member_func = tryResolveConcreteMemberFunction(result, member_name_token.value());
 		}
+		// Note: when explicit_template_args is set, we do NOT do an early instantiation
+		// here (before parsing arguments), because the result would be discarded and —
+		// more importantly — it would cache the FIRST overload candidate, preventing the
+		// later call (tryInstantiateMemberFunctionTemplateCall below, which has the actual
+		// call-argument types) from selecting the correct overload.
 
 		advance(); // consume '('
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5,6 +5,7 @@
 #include "NameMangling.h"
 #include "OverloadResolution.h"
 #include "Parser_FunctionTypeHelpers.h"
+#include "ParserTemplateClassShared.h"
 #include "StringLiteralTokenUtils.h"
 #include "TypeTraitEvaluator.h"
 
@@ -21,12 +22,9 @@ void applyDeclarationArrayBoundsToTypeSpec(
 
 namespace {
 bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<TemplateTypeArg, 4>& template_args) {
-	return std::any_of(
-		template_args.begin(),
-		template_args.end(),
-		[](const TemplateTypeArg& arg) {
-			return arg.is_dependent || arg.dependent_name.isValid() || arg.is_pack;
-		});
+	return std::any_of(template_args.begin(), template_args.end(), [](const TemplateTypeArg& arg) {
+		return arg.is_pack || templateArgIsStructurallyDependent(arg);
+	});
 }
 
 struct ExpressionDependentMemberSegmentInfo {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1893,12 +1893,21 @@ static bool dependentQualifiedTemplateArgMatchesForSignature(
 		return false;
 	}
 
+	// When both sides carry a valid dependent_name (i.e. they refer to a template
+	// parameter by name), the dependent_name check above is the authoritative
+	// comparison.  TypeIndex values for template parameters are context-specific
+	// and can differ between the in-class declaration context and each OOL
+	// definition context — do NOT reject the match based on those indices.
+	const bool has_dependent_name =
+		instantiated_arg.dependent_name.isValid() && out_of_line_arg.dependent_name.isValid();
+
 	TypeIndex instantiated_type_index =
 		canonicalizeTemplateSignatureMatchTypeIndex(instantiated_arg.type_index);
 	TypeIndex out_of_line_type_index =
 		canonicalizeTemplateSignatureMatchTypeIndex(out_of_line_arg.type_index);
-	if (instantiated_type_index != out_of_line_type_index ||
-		instantiated_type_index.category() != out_of_line_type_index.category()) {
+	if (!has_dependent_name &&
+		(instantiated_type_index != out_of_line_type_index ||
+		 instantiated_type_index.category() != out_of_line_type_index.category())) {
 		return false;
 	}
 
@@ -1942,7 +1951,20 @@ static bool dependentQualifiedNameRecordsMatchForSignature(
 	const TypeInfo::DependentQualifiedNameRecord& out_of_line_record,
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params) {
-	if (instantiated_record.owner_kind != out_of_line_record.owner_kind ||
+	using OwnerKind = TypeInfo::DependentQualifiedNameRecord::OwnerKind;
+	// DependentInstantiation and UnknownSpecialization both represent a
+	// dependent template instantiation; they differ only due to parse context
+	// at which the type was recorded.  For OOL-signature matching purposes they
+	// are equivalent and should be accepted as the same kind.
+	auto owner_kind_compatible = [](OwnerKind a, OwnerKind b) -> bool {
+		if (a == b) return true;
+		auto is_dep_or_unknown = [](OwnerKind k) {
+			return k == OwnerKind::DependentInstantiation ||
+			       k == OwnerKind::UnknownSpecialization;
+		};
+		return is_dep_or_unknown(a) && is_dep_or_unknown(b);
+	};
+	if (!owner_kind_compatible(instantiated_record.owner_kind, out_of_line_record.owner_kind) ||
 		instantiated_record.names_current_instantiation !=
 			out_of_line_record.names_current_instantiation ||
 		instantiated_record.member_chain.size() != out_of_line_record.member_chain.size() ||
@@ -12302,6 +12324,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					inst_alias_name,
 					*alias_opt,
 					&outer_binding);
+				// Also register the outer binding for the un-hashed base alias name
+				// so that lookups by base template name (e.g. "Provider::Node::Apply"
+				// as stored in TypeInfo::baseTemplateName()) can find the outer binding
+				// (e.g. T=int) even when the alias TypeInfo records the un-hashed form.
+				// Only do this when all outer params are concrete (non-dependent); a
+				// dependent-param instantiation (e.g. Provider<T>) must not overwrite
+				// a concrete binding that was registered earlier.
+				const bool all_concrete_args = std::all_of(
+					outer_binding.param_args.begin(),
+					outer_binding.param_args.end(),
+					[](const TemplateTypeArg& arg) { return !arg.is_dependent; });
+				if (all_concrete_args) {
+					StringHandle base_alias_handle =
+						StringTable::getOrInternStringHandle(base_alias_name);
+					// Don't overwrite an already-registered concrete binding: the first
+					// concrete registration (from the intended instantiation, e.g.
+					// Provider<int> from Outer<int>) wins over later spurious ones.
+					if (gTemplateRegistry.getOuterTemplateBinding(base_alias_handle) == nullptr) {
+						gTemplateRegistry.registerOuterTemplateBinding(
+							base_alias_handle,
+							outer_binding);
+					}
+				}
 			}
 		}
 	}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -12331,10 +12331,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Only do this when all outer params are concrete (non-dependent); a
 				// dependent-param instantiation (e.g. Provider<T>) must not overwrite
 				// a concrete binding that was registered earlier.
-				const bool all_concrete_args = std::all_of(
-					outer_binding.param_args.begin(),
-					outer_binding.param_args.end(),
-					[](const TemplateTypeArg& arg) { return !arg.is_dependent; });
+				const bool all_concrete_args = !anyTemplateArgIsStructurallyDependent(
+					std::span<const TemplateTypeArg>(
+						outer_binding.param_args.begin(),
+						outer_binding.param_args.end()));
 				if (all_concrete_args) {
 					StringHandle base_alias_handle =
 						StringTable::getOrInternStringHandle(base_alias_name);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3597,18 +3597,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		if (overload_mismatch)
 			continue;  // SFINAE: try next overload
 
-		const auto has_structurally_dependent_template_args = [](std::span<const TemplateTypeArg> args) {
-			return std::any_of(
-				args.begin(),
-				args.end(),
-				[](const TemplateTypeArg& arg) {
-					return arg.is_dependent ||
-						   arg.dependent_name.isValid() ||
-						   arg.category() == TypeCategory::Auto ||
-						   arg.category() == TypeCategory::DeclTypeAuto;
-				});
-		};
-		if (has_structurally_dependent_template_args(template_args)) {
+		if (anyTemplateArgIsStructurallyDependent(template_args)) {
 			continue;
 		}
 
@@ -4051,16 +4040,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 			}
 
 			InlineVector<TemplateTypeArg, 4> template_args = deduction_candidate->template_args;
-			const bool has_structurally_dependent_template_args = std::any_of(
-				template_args.begin(),
-				template_args.end(),
-				[](const TemplateTypeArg& arg) {
-					return arg.is_dependent ||
-						   arg.dependent_name.isValid() ||
-						   arg.category() == TypeCategory::Auto ||
-						   arg.category() == TypeCategory::DeclTypeAuto;
-				});
-			if (has_structurally_dependent_template_args) {
+			if (anyTemplateArgIsStructurallyDependent(template_args)) {
 				continue;
 			}
 
@@ -4704,18 +4684,7 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 	InlineVector<TemplateTypeArg, 4> template_args = std::move(deduction_candidate->template_args);
 	std::optional<CallArgDeductionInfo> deduction_info = std::move(deduction_candidate->deduction_info);
 	// template_args is already std::vector<TemplateTypeArg> — no conversion needed.
-	const auto has_structurally_dependent_template_args = [](std::span<const TemplateTypeArg> args) {
-		return std::any_of(
-			args.begin(),
-			args.end(),
-			[](const TemplateTypeArg& arg) {
-				return arg.is_dependent ||
-					   arg.dependent_name.isValid() ||
-					   arg.category() == TypeCategory::Auto ||
-					   arg.category() == TypeCategory::DeclTypeAuto;
-			});
-	};
-	if (has_structurally_dependent_template_args(template_args)) {
+	if (anyTemplateArgIsStructurallyDependent(template_args)) {
 		return std::nullopt;
 	}
 

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1664,6 +1664,54 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 		const auto& template_args = completed_template_args;
 		auto key = FlashCpp::makeInstantiationKey(candidate_qualified_name, template_args);
 
+		// Determine call arg types for this explicit call path.  Do this before
+		// the cache lookup so we can skip stale cached overloads whose pointer
+		// depth doesn't match the current call's arguments.
+		const InlineVector<TypeSpecifierNode, 1> empty_call_arg_types_storage;
+		std::span<const TypeSpecifierNode> call_arg_types =
+			current_explicit_call_arg_types_ != nullptr
+				? *current_explicit_call_arg_types_
+				: std::span<const TypeSpecifierNode>(
+					empty_call_arg_types_storage.data(),
+					empty_call_arg_types_storage.size());
+
+		// Pointer-depth overload pre-filter: reject a candidate whose DECLARED
+		// parameter pointer-depth is clearly incompatible with the call arguments.
+		// We only apply the directional check "call arg is a pointer but the
+		// declared parameter is a value", because the reverse (arg is a null
+		// pointer / value, param is a pointer) is still valid in C++ via implicit
+		// null-pointer conversion.  This check uses the declared (pre-substitution)
+		// parameter types, which already carry the correct pointer depth even for
+		// dependent alias parameters (e.g. Apply<U> vs Apply<U>*).
+		if (!call_arg_types.empty()) {
+			const auto& decl_params = func_decl.parameter_nodes();
+			bool incompatible = false;
+			for (size_t pi = 0;
+				 pi < call_arg_types.size() && pi < decl_params.size();
+				 ++pi) {
+				const auto& pn = decl_params[pi];
+				if (!pn.is<DeclarationNode>()) {
+					continue;
+				}
+				const DeclarationNode& pdecl = pn.as<DeclarationNode>();
+				if (pdecl.is_parameter_pack()) {
+					break;  // variadic: don't apply the check to pack params
+				}
+				const TypeSpecifierNode& pts = pdecl.type_specifier_node();
+				const size_t param_ptr = pts.pointer_depth();
+				const size_t arg_ptr   = call_arg_types[pi].pointer_depth();
+				if (arg_ptr > 0 && param_ptr == 0) {
+					// Call passes a concrete pointer but this overload expects a
+					// value: this overload cannot be viable.
+					incompatible = true;
+					break;
+				}
+			}
+			if (incompatible) {
+				continue;
+			}
+		}
+
 		// Check if we already have this instantiation
 		auto existing_inst = gTemplateRegistry.getInstantiation(key);
 		if (existing_inst.has_value()) {
@@ -1708,13 +1756,6 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 			}
 		}
 
-		const InlineVector<TypeSpecifierNode, 1> empty_call_arg_types;
-		std::span<const TypeSpecifierNode> call_arg_types =
-			current_explicit_call_arg_types_ != nullptr
-				? *current_explicit_call_arg_types_
-				: std::span<const TypeSpecifierNode>(
-					empty_call_arg_types.data(),
-					empty_call_arg_types.size());
 		// Prefer the declaring owner from inheritance lookup; fall back to deriving
 		// the owner from the candidate's qualified name rather than re-using the
 		// requested receiver (which may be a derived type, not the declaring base).
@@ -2767,6 +2808,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	}
 
 	copy_function_properties(new_func_ref, func_decl);
+
 	auto orig_body = func_decl.get_definition();
 	if (!materialize_body) {
 		compute_and_set_mangled_name(new_func_ref);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1698,6 +1698,39 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 					break;  // variadic: don't apply the check to pack params
 				}
 				const TypeSpecifierNode& pts = pdecl.type_specifier_node();
+				// Only skip the pointer-depth check when the parameter's BASE TYPE is
+				// itself directly one of this member function template's own type
+				// parameters (e.g. `pick(U value)` where U is in template_params).
+				// In that case the explicit template arg supplies the FULL type
+				// (including pointer depth) for U, so the declared pointer_depth of 0
+				// is meaningless — `pick<int*>(&v)` with U=int* IS valid.
+				//
+				// Do NOT skip for complex dependent types like `Apply<U>` or
+				// `Provider<T>::Node::Apply<U>`: those have a structurally-known
+				// pointer depth in the declaration (e.g. depth 0 for `Apply<U>` vs
+				// depth 1 for `Apply<U>*`) that the pre-filter should honour.
+				if (typeSpecStillUsesDependentPlaceholder(pts)) {
+					// Determine the base type name of the parameter.
+					StringHandle base_name;
+					if (const TypeInfo* ti = tryGetTypeInfo(pts.type_index())) {
+						base_name = ti->name();
+					}
+					if (!base_name.isValid()) {
+						base_name = pts.token().handle();
+					}
+					bool is_direct_tparam = false;
+					if (base_name.isValid()) {
+						for (const auto& tp : template_params) {
+							if (tp.nameHandle() == base_name) {
+								is_direct_tparam = true;
+								break;
+							}
+						}
+					}
+					if (is_direct_tparam) {
+						continue;  // skip: U could be int*, pointer depth unknown before substitution
+					}
+				}
 				const size_t param_ptr = pts.pointer_depth();
 				const size_t arg_ptr   = call_arg_types[pi].pointer_depth();
 				if (arg_ptr > 0 && param_ptr == 0) {

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1441,6 +1441,25 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		}
 		std::optional<TemplateTypeArg> rebound_arg =
 			tryRebindAliasTargetTemplateArg(*alias_node, template_args);
+		// If rebinding via the alias's own template params failed, the alias target
+		// may be an *outer* template parameter (e.g. `template<typename U> using Apply = T`
+		// where T comes from an enclosing class template's outer binding T=int).
+		// Look it up in the stored outer binding before giving up.
+		if (!rebound_arg.has_value() && outer_binding != nullptr) {
+			StringHandle alias_target_name =
+				getAliasTargetNameHandle(alias_node->target_type_node());
+			if (alias_target_name.isValid()) {
+				for (size_t i = 0;
+					 i < outer_binding->param_names.size() &&
+					 i < outer_binding->param_args.size();
+					 ++i) {
+					if (outer_binding->param_names[i] == alias_target_name) {
+						rebound_arg = outer_binding->param_args[i];
+						break;
+					}
+				}
+			}
+		}
 		if (!rebound_arg.has_value() || rebound_arg->is_value) {
 			return false;
 		}
@@ -2721,9 +2740,29 @@ std::string_view Parser::instantiate_and_register_base_template(
 
 		const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
 		if (!alias_node.is_deferred()) {
-			if (std::optional<TemplateTypeArg> rebound_alias_arg =
-					tryRebindAliasTargetTemplateArg(alias_node, template_args);
-				rebound_alias_arg.has_value() && !rebound_alias_arg->is_value) {
+			std::optional<TemplateTypeArg> rebound_alias_arg =
+				tryRebindAliasTargetTemplateArg(alias_node, template_args);
+			// If the alias's own params don't contain the target (e.g.
+			// `template<typename U> using Apply = T` where T is an outer param),
+			// fall back to the stored outer binding for this alias template name.
+			if (!rebound_alias_arg.has_value()) {
+				const OuterTemplateBinding* outer = gTemplateRegistry.getOuterTemplateBinding(base_class_name);
+				if (outer != nullptr) {
+					StringHandle alias_target_name =
+						getAliasTargetNameHandle(alias_node.target_type_node());
+					if (alias_target_name.isValid()) {
+						for (size_t i = 0;
+							 i < outer->param_names.size() && i < outer->param_args.size();
+							 ++i) {
+							if (outer->param_names[i] == alias_target_name) {
+								rebound_alias_arg = outer->param_args[i];
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (rebound_alias_arg.has_value() && !rebound_alias_arg->is_value) {
 				if (const TypeInfo* rebound_type_info = tryGetTypeInfo(rebound_alias_arg->type_index);
 					rebound_type_info != nullptr) {
 					base_class_name = StringTable::getStringView(rebound_type_info->name());

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2336,12 +2336,28 @@ ParseResult Parser::parse_type_specifier() {
 						}
 						std::string_view dependent_member_path =
 							member_path_builder.commit();
+						InlineVector<std::string_view, 4> dependent_member_components =
+							splitDependentMemberPathComponents(dependent_member_path);
 						InlineVector<DependentMemberSegmentInfo, 4> all_segment_infos;
+						// The member path may contain prefix components (e.g. "Node" in
+						// "Node::Apply<1 args>") that appear before the terminal member
+						// whose template args we just parsed.  Without padding, those
+						// prefix components would receive the terminal member's template
+						// args in makeDependentQualifiedNameRecord.  Insert one null entry
+						// per prefix component so the segment info indices stay aligned
+						// with the path component indices.
+						{
+							const size_t total_components = dependent_member_components.size();
+							const size_t suffix_count = 1u + nested_segment_infos.size();
+							const size_t prefix_count =
+								total_components > suffix_count ? total_components - suffix_count : 0u;
+							for (size_t i = 0; i < prefix_count; ++i) {
+								all_segment_infos.push_back({false, std::nullopt});
+							}
+						}
 						all_segment_infos.push_back({had_template_keyword, dependent_member_template_args});
 						for (const DependentMemberSegmentInfo& seg : nested_segment_infos)
 							all_segment_infos.push_back(seg);
-						InlineVector<std::string_view, 4> dependent_member_components =
-							splitDependentMemberPathComponents(dependent_member_path);
 						type_info.setDependentQualifiedName(
 							makeDependentQualifiedNameRecord(
 								StringTable::getOrInternStringHandle(type_name),

--- a/tests/test_explicit_member_template_dependent_param_ptr_arg_ret0.cpp
+++ b/tests/test_explicit_member_template_dependent_param_ptr_arg_ret0.cpp
@@ -1,0 +1,45 @@
+// Regression test: pointer-depth pre-filter must not reject a candidate when
+// the declared parameter type IS a template type parameter (e.g. U, not U*).
+//
+// Before the fix, `pick<int*>(&value)` was incorrectly rejected by the
+// pre-filter because the declared parameter `U` has pointer_depth()==0, even
+// though U is being *explicitly* instantiated as `int*` — making the effective
+// parameter type `int*` (depth 1).
+//
+// The pointer-depth check should only fire when the parameter type is a fully
+// concrete, non-dependent type whose pointer depth is structurally known before
+// substitution.
+//
+// Overload-selection logic:
+//   pick<int*>(&x):  explicit U=int*
+//     pick(U  value) → pick(int*)  — param=int*, arg=int*  → VIABLE  (returns 0)
+//     pick(U* value) → pick(int**) — param=int**, arg=int* → NOT VIABLE
+//   So pick(U value) with U=int* must win → return 0.
+
+template <typename T>
+struct Holder {
+	// Overload 1: parameter type IS the member-template param U (depth 0 declared)
+	template <typename U>
+	int pick(U value) {
+		(void)value;
+		return 0;  // correct winner when called as pick<int*>(&x)
+	}
+
+	// Overload 2: parameter is U* (depth 1 declared)
+	template <typename U>
+	int pick(U* value) {
+		(void)value;
+		return 1;  // not viable when called as pick<int*>(&x) — would need int**
+	}
+};
+
+int main() {
+	Holder<int> h;
+	int x = 42;
+	// Explicit template arg int* → U=int*.
+	// pick(U value) = pick(int*):  arg int* → viable → should return 0.
+	// pick(U* value) = pick(int**): arg int* → not viable.
+	// Before the fix the pre-filter wrongly dropped pick(U value) because the
+	// *declared* U had pointer_depth()==0 while the call arg was a pointer.
+	return h.pick<int*>(&x);
+}

--- a/tests/test_explicit_member_template_pointer_overload_cache_ret0.cpp
+++ b/tests/test_explicit_member_template_pointer_overload_cache_ret0.cpp
@@ -1,0 +1,18 @@
+template <typename T>
+struct Holder {
+	template <typename U>
+	int pick(T value) {
+		return value == 4 ? 1 : 7;
+	}
+
+	template <typename U>
+	int pick(T* value) {
+		return value != nullptr && *value == 4 ? 0 : 9;
+	}
+};
+
+int main() {
+	Holder<int> holder;
+	int value = 4;
+	return holder.pick<char>(&value);
+}

--- a/tests/test_template_ool_member_template_nested_alias_overload_ret0.cpp
+++ b/tests/test_template_ool_member_template_nested_alias_overload_ret0.cpp
@@ -1,0 +1,40 @@
+template <typename T>
+struct Provider {
+	struct Node {
+		template <typename U>
+		using Apply = T;
+	};
+};
+
+template <typename T>
+struct Outer {
+	template <typename U>
+	int pick(typename Provider<T>::Node::template Apply<U> value);
+
+	template <typename U>
+	int pick(typename Provider<T>::Node::template Apply<U>* value);
+};
+
+template <typename T>
+template <typename U>
+int Outer<T>::pick(typename Provider<T>::Node::template Apply<U> value) {
+	return value == 7 ? 0 : 11;
+}
+
+template <typename T>
+template <typename U>
+int Outer<T>::pick(typename Provider<T>::Node::template Apply<U>* value) {
+	return value != nullptr && *value == 9 ? 0 : 13;
+}
+
+int main() {
+	Outer<int> outer;
+	int nine = 9;
+	if (outer.pick<double>(7) != 0) {
+		return 1;
+	}
+	if (outer.pick<char>(&nine) != 0) {
+		return 2;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary
- preserve nested dependent member-template alias metadata for paths like `Provider<T>::Node::template Apply<U>` through parsing, alias materialization, and replay matching
- stop explicit member-template calls from caching the first overload before call-argument types are known, and prefilter pointer-depth-incompatible explicit candidates before cache hits
- update the template architecture audit and standard-conformance investigation docs with the covered slice, refreshed validation numbers, and the next remaining gap

## Testing
- `./build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1`
- `pwsh tests/run_all_tests.ps1 test_explicit_member_template_pointer_overload_cache_ret0.cpp test_template_ool_member_template_nested_alias_overload_ret0.cpp`