### PR TITLE
template: semantic dependent-member alias resolution with surface-modifier preservation

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-30
+**Last updated:** 2026-06-01
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -10,10 +10,10 @@ highest-value cleanup should be.
 ## Executive summary
 
 The template system has moved away from broad AST-only replay and toward
-owner-aware semantic records plus replay-first attachment. The biggest
-remaining gap is no longer general parser cleanup. It is the small set of
-template replay and dependent-alias routes that still lose semantic
-owner/member-chain identity and later recover it textually.
+owner-aware semantic records plus replay-first attachment. The legacy textual
+`base::member` dependent-alias path has now been removed; dependent member
+alias resolution is semantic-only. The biggest remaining gap is keeping replay
+attachment evidence-driven rather than shape-driven.
 
 ## What the current design can assume
 
@@ -30,54 +30,47 @@ owner/member-chain identity and later recover it textually.
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
-- dependent alias resolution now re-enters semantic owner/member-chain
-  resolution before touching the legacy textual `base::member` path
+- dependent alias resolution is now semantic-only: the legacy textual
+  `base::member` path in `resolveDependentMemberAlias(...)` has been removed,
+  and resolution flows through the preserved `DependentQualifiedNameRecord`,
+  instantiation-context bindings, and `materializeInstantiatedMemberAliasTarget`
 - `materializeAliasTemplateInstance` now has a fallback to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias
   cases (`template<T> using id = T`) where `instantiated_name` is empty
   but the alias node is non-null
+- member type aliases preserve surface modifiers (pointer/reference/cv/array/
+  function) across alias chains via the shared
+  `typeAliasPreservesSurfaceModifiers()` helper, so collapsing an alias to its
+  terminal type no longer silently drops indirection
 
 ## Main remaining architectural gap
 
-The remaining problem is not that replay exists. The problem is that a few
-paths still fail to preserve enough semantic metadata at parse/materialization
-time, so deduction-time resolution still has to recover intent from partial or
-recordless state.
-
-The clearest example is the residual textual `base::member` path in
-`resolveDependentMemberAlias(...)`. A direct removal probe showed that it is no
-longer broad infrastructure; it now only protects a small cluster of legacy
-recordless cases:
+The residual textual `base::member` path in `resolveDependentMemberAlias(...)`
+has been removed. The previously-blocking recordless cases now resolve through
+semantic owner/member-chain records that are preserved end-to-end at
+parse/materialization time:
 
 - `test_member_template_alias_preserves_outer_metadata_ret0.cpp`
 - `test_alias_template_nested_member_value_ret42.cpp`
 - `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
 
-That is the next best cleanup target.
-
-A removal probe was attempted in this refactoring slice. Confirmed: removing
-the textual path causes exactly those three tests to fail. The root cause is
-that their `TypeInfo` nodes do **not** carry a `DependentQualifiedNameRecord`
-by the time `resolveDependentMemberAlias` is called, so
-`tryResolveCurrentTypeNodeFromSemanticRecord()` returns `nullopt` and the code
-falls through to the textual path.
-
-To unblock removal, the parse/materialization pipelines for these three patterns
-must be traced to find where the semantic record is dropped or never set, and
-`DependentQualifiedNameRecord` must be preserved end-to-end.
+The remaining problem is no longer textual recovery. It is keeping replay
+attachment evidence-driven: a few declaration-replay paths still lean on
+name/arity shape rather than source identity plus canonical substituted-signature
+evidence. Tightening those is the next best cleanup target.
 
 ## Recommended implementation order
 
-1. Remove the last recordless dependent-alias routes.
-   Preserve full semantic owner/member-chain records in the three remaining
-   cases above, then delete the textual `base::member` path entirely.
+1. ~~Remove the last recordless dependent-alias routes.~~ **Done.**
+   Semantic owner/member-chain records are now preserved in the three former
+   blocker cases and the textual `base::member` path has been deleted.
 
 2. Keep replay attachment evidence-driven.
    Continue tightening declaration replay so attachment succeeds because source
    identity and canonical substituted signatures match, not because a fallback
    scan guessed correctly.
 
-3. Extend dependent-name modeling only where it unlocks step 1 or 2.
+3. Extend dependent-name modeling only where it unlocks step 2.
    Richer current-instantiation and unknown-specialization handling still
    matters, but it should be pulled in to unblock concrete replay/alias gaps,
    not pursued as a detached refactor.
@@ -99,6 +92,6 @@ must be traced to find where the semantic record is dropped or never set, and
 When changing this area, always rerun:
 
 - the focused regression that motivated the slice
-- the three residual textual-path blockers listed above when touching dependent
-  alias ownership
+- the three former textual-path blockers listed above when touching dependent
+  alias ownership (they now exercise the semantic-only route)
 - `pwsh tests/run_all_tests.ps1` before closing the slice

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-28
+**Last updated:** 2026-05-30
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -32,6 +32,10 @@ owner/member-chain identity and later recover it textually.
   materialization
 - dependent alias resolution now re-enters semantic owner/member-chain
   resolution before touching the legacy textual `base::member` path
+- `materializeAliasTemplateInstance` now has a fallback to
+  `materializeInstantiatedMemberAliasTarget` for direct-parameter alias
+  cases (`template<T> using id = T`) where `instantiated_name` is empty
+  but the alias node is non-null
 
 ## Main remaining architectural gap
 
@@ -50,6 +54,17 @@ recordless cases:
 - `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
 
 That is the next best cleanup target.
+
+A removal probe was attempted in this refactoring slice. Confirmed: removing
+the textual path causes exactly those three tests to fail. The root cause is
+that their `TypeInfo` nodes do **not** carry a `DependentQualifiedNameRecord`
+by the time `resolveDependentMemberAlias` is called, so
+`tryResolveCurrentTypeNodeFromSemanticRecord()` returns `nullopt` and the code
+falls through to the textual path.
+
+To unblock removal, the parse/materialization pipelines for these three patterns
+must be traced to find where the semantic record is dropped or never set, and
+`DependentQualifiedNameRecord` must be preserved end-to-end.
 
 ## Recommended implementation order
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-30
+**Last updated:** 2026-06-01
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -28,41 +28,40 @@ Move FlashCpp toward a sema-owned template system where:
   and replay cases
 - explicit member-template call handling now carries enough early argument
   information to avoid wrong cached overload reuse
-- dependent alias resolution already prefers semantic owner/member-chain
-  re-entry before the remaining textual fallback
+- dependent alias resolution is semantic-only: the textual fallback in
+  `resolveDependentMemberAlias(...)` has been removed in favor of preserved
+  owner/member-chain records and instantiation-context bindings
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type
+- member type aliases preserve surface modifiers (pointer/reference/cv/array/
+  function) across alias chains rather than collapsing to the terminal type
 
 ## Highest-value remaining standards gap
 
-The next conformance step is not a broad rewrite. It is deleting the last
-textual dependent-alias recovery path by preserving semantic records in the
-remaining recordless callers.
-
-Current blockers:
+The textual dependent-alias recovery path has been deleted; the former blockers
+now resolve through preserved semantic records:
 
 - `test_member_template_alias_preserves_outer_metadata_ret0.cpp`
 - `test_alias_template_nested_member_value_ret42.cpp`
 - `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
 
-A removal probe in this slice confirmed these are the only three remaining
-dependents. The specific failure cause: each test's `TypeInfo` is missing a
-`DependentQualifiedNameRecord` at deduction time, so the semantic path returns
-`nullopt` and the textual path is entered. The next step is to trace each
-pattern through parsing and materialization to find where the record is dropped
-or never populated.
+With textual recovery gone, the next conformance step is keeping replay
+attachment invariant-driven: tighten the remaining replay paths so valid cases
+succeed via source identity plus canonical substituted-signature evidence rather
+than name/arity fallback scans, and expand current-instantiation /
+unknown-specialization modeling only where it unblocks those paths.
 
 ## Priority order
 
-1. Preserve semantic owner/member-chain records in the remaining dependent
-   alias callers.
+1. ~~Preserve semantic owner/member-chain records in the remaining dependent
+   alias callers.~~ **Done** — the textual recovery path is removed.
 
 2. Continue tightening replay attachment so valid cases succeed via source
    identity plus canonical substituted-signature evidence, not fallback scans.
 
 3. Expand current-instantiation, dependent-base, and unknown-specialization
-   handling only where that unblocks steps 1 or 2.
+   handling only where that unblocks step 2.
 
 4. Leave broader cleanup for later unless it becomes a blocker:
    sema-owned ranking/deduction expansion, remaining repair-path removal, and
@@ -81,6 +80,7 @@ or never populated.
 For work in this area:
 
 - add a focused regression first when a new gap is identified
-- rerun the three residual dependent-alias blocker tests when touching alias
-  ownership or current-instantiation handling
+- rerun the three former dependent-alias blocker tests when touching alias
+  ownership or current-instantiation handling (they now exercise the
+  semantic-only route)
 - run `pwsh tests/run_all_tests.ps1` before considering the slice complete

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-05-28
+**Last updated:** 2026-05-30
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -30,6 +30,9 @@ Move FlashCpp toward a sema-owned template system where:
   information to avoid wrong cached overload reuse
 - dependent alias resolution already prefers semantic owner/member-chain
   re-entry before the remaining textual fallback
+- `materializeAliasTemplateInstance` now falls back to
+  `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
+  where the instantiated name resolves to a member type
 
 ## Highest-value remaining standards gap
 
@@ -43,8 +46,12 @@ Current blockers:
 - `test_alias_template_nested_member_value_ret42.cpp`
 - `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
 
-If those routes preserve full owner/member-chain identity, the residual
-`base::member` textual path in `resolveDependentMemberAlias(...)` can go away.
+A removal probe in this slice confirmed these are the only three remaining
+dependents. The specific failure cause: each test's `TypeInfo` is missing a
+`DependentQualifiedNameRecord` at deduction time, so the semantic path returns
+`nullopt` and the textual path is entered. The next step is to trace each
+pattern through parsing and materialization to find where the record is dropped
+or never populated.
 
 ## Priority order
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1231,6 +1231,9 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 				/*prefer_current_owner_type_name=*/true);
 		std::string_view materialized_owner_name =
 			materialized_owner.canonicalName();
+		FLASH_LOG(Templates, Debug, "lookupMaterializedDependentMember owner ",
+				  StringTable::getStringView(dependent_name->owner_name), " -> ", materialized_owner_name,
+				  " members=", dependent_name->member_chain.size());
 		if (!materialized_owner_name.empty()) {
 			std::vector<QualifiedTypeMemberAccess> member_chain;
 			member_chain.reserve(dependent_name->member_chain.size());
@@ -1254,6 +1257,8 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 				parser_.resolveBaseClassMemberTypeChain(
 					materialized_owner_name,
 					member_chain);
+			FLASH_LOG(Templates, Debug, "lookupMaterializedDependentMember chain result ",
+					  resolved_type != nullptr ? StringTable::getStringView(resolved_type->name()) : std::string_view{"<null>"});
 			if (resolved_type != nullptr) {
 				if (!dependent_name->member_chain.empty()) {
 					StringBuilder full_path_builder;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1224,6 +1224,19 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 
 	if (const TypeInfo::DependentQualifiedNameRecord* dependent_name =
 			type_info.dependentQualifiedName()) {
+		auto resolveConcreteAliasChain = [&](const TypeInfo* candidate_type_info) -> const TypeInfo* {
+			const TypeInfo* current_type_info = candidate_type_info;
+			for (size_t alias_depth = 0; current_type_info != nullptr && current_type_info->isTypeAlias() && alias_depth < 32; ++alias_depth) {
+				ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+					current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum()));
+				if (resolved_alias.terminal_type_info == nullptr ||
+					resolved_alias.terminal_type_info == current_type_info) {
+					break;
+				}
+				current_type_info = resolved_alias.terminal_type_info;
+			}
+			return current_type_info;
+		};
 		Parser::AliasTemplateMaterializationResult materialized_owner =
 			materializeDependentQualifiedRecordOwner(
 				*dependent_name,
@@ -1257,6 +1270,7 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 				parser_.resolveBaseClassMemberTypeChain(
 					materialized_owner_name,
 					member_chain);
+			resolved_type = resolveConcreteAliasChain(resolved_type);
 			FLASH_LOG(Templates, Debug, "lookupMaterializedDependentMember chain result ",
 					  resolved_type != nullptr ? StringTable::getStringView(resolved_type->name()) : std::string_view{"<null>"});
 			if (resolved_type != nullptr) {
@@ -2658,7 +2672,10 @@ ASTNode ExpressionSubstitutor::substituteIdentifier(const IdentifierNode& id) {
 		const TemplateTypeArg& arg = it->second;
 		FLASH_LOG(Templates, Debug, "  Found template parameter substitution: ", id.name(),
 				  " -> type=", (int)arg.typeEnum(), ", type_index=", arg.type_index, ", is_value=", arg.is_value,
-				  ", is_template_template_arg=", arg.is_template_template_arg);
+				  ", is_template_template_arg=", arg.is_template_template_arg,
+				  ", is_dependent=", arg.is_dependent,
+				  ", dependent_name='", (arg.dependent_name.isValid() ? StringTable::getStringView(arg.dependent_name) : std::string_view()), "'",
+				  ", has_typed_identity=", arg.has_typed_value_identity ? 1 : 0);
 
 		// Handle template-template parameters
 		// When W is a TTP bound to "box", we need to return an identifier for "box"

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -981,6 +981,37 @@ ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
 				findTypeByName(current_owner_type_name_);
 			break;
 		}
+		if (!dependent_name.owner_template_arguments.empty()) {
+			InlineVector<TemplateTypeArg, 4> owner_args =
+				materializeDependentRecordTemplateArgs(
+					dependent_name.owner_template_arguments,
+					depth);
+			if (!templateArgsStillDependent(owner_args)) {
+				materialized_owner =
+					parser_.resolveCanonicalInstantiatedOwnerForLookup(
+						owner_name,
+						std::span<const TemplateTypeArg>(
+							owner_args.data(),
+							owner_args.size()));
+				if (materialized_owner.instantiated_name.empty() &&
+					materialized_owner.resolved_type_info == nullptr &&
+					!owner_args.empty()) {
+					materialized_owner.instantiated_name =
+						parser_.get_instantiated_class_name(owner_name, owner_args);
+					if (!materialized_owner.instantiated_name.empty()) {
+						materialized_owner.resolved_type_info = findTypeByName(
+							StringTable::getOrInternStringHandle(
+								materialized_owner.instantiated_name));
+					}
+				}
+				if (materialized_owner.instantiated_name.empty() &&
+					materialized_owner.resolved_type_info == nullptr &&
+					dependent_name.owner_type.is_valid()) {
+					assign_owner_type(tryGetTypeInfo(dependent_name.owner_type));
+				}
+				break;
+			}
+		}
 		if (dependent_name.owner_type.is_valid()) {
 			assign_owner_type(tryGetTypeInfo(dependent_name.owner_type));
 		}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1258,6 +1258,13 @@ ExpressionSubstitutor::lookupMaterializedDependentMember(const TypeInfo& type_in
 		auto resolveConcreteAliasChain = [&](const TypeInfo* candidate_type_info) -> const TypeInfo* {
 			const TypeInfo* current_type_info = candidate_type_info;
 			for (size_t alias_depth = 0; current_type_info != nullptr && current_type_info->isTypeAlias() && alias_depth < 32; ++alias_depth) {
+				// A member alias like `using type = T;` resolved with `T = int*`
+				// keeps its pointer/reference/array/cv indirection in the alias
+				// specifier while its TypeIndex points at the terminal type. Stop
+				// before collapsing such an alias so those surface modifiers survive.
+				if (typeAliasPreservesSurfaceModifiers(*current_type_info)) {
+					break;
+				}
 				ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
 					current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum()));
 				if (resolved_alias.terminal_type_info == nullptr ||

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -6283,8 +6283,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									QualifiedIdentifierNode dependent_qual_id(ns_handle, final_identifier);
 									dependent_qual_id.setDependentQualifiedName(
 										makeExpressionDependentQualifiedNameRecord(
-											StringTable::getOrInternStringHandle(qualified_template_name),
-											lookupRecordedDependentOwnerType(dependent_owner_handle),
+											dependent_owner_handle,
+											materialized_owner_names_current_instantiation
+												? TypeIndex{}
+												: lookupRecordedDependentOwnerType(dependent_owner_handle),
 											materialized_owner_names_current_instantiation
 												? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
 												: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
@@ -6437,9 +6439,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										deferred_final_identifier);
 									dependent_qual_id.setDependentQualifiedName(
 										makeExpressionDependentQualifiedNameRecord(
-											StringTable::getOrInternStringHandle(template_name),
-											lookupRecordedDependentOwnerType(
-												StringTable::getOrInternStringHandle(instantiated_name)),
+											StringTable::getOrInternStringHandle(instantiated_name),
+											materialized_owner_names_current_instantiation
+												? TypeIndex{}
+												: lookupRecordedDependentOwnerType(
+													StringTable::getOrInternStringHandle(instantiated_name)),
 											materialized_owner_names_current_instantiation
 												? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
 												: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
@@ -7448,8 +7452,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							QualifiedIdentifierNode dependent_qual_id(ns_handle, final_identifier);
 							dependent_qual_id.setDependentQualifiedName(
 								makeExpressionDependentQualifiedNameRecord(
-									StringTable::getOrInternStringHandle(qualified_template_name),
-									lookupRecordedDependentOwnerType(dependent_owner_handle),
+									dependent_owner_handle,
+									materialized_owner_names_current_instantiation
+										? TypeIndex{}
+										: lookupRecordedDependentOwnerType(dependent_owner_handle),
 									materialized_owner_names_current_instantiation
 										? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
 										: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
@@ -7600,9 +7606,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								deferred_final_identifier);
 							dependent_qual_id.setDependentQualifiedName(
 								makeExpressionDependentQualifiedNameRecord(
-									StringTable::getOrInternStringHandle(identifier_token.value()),
-									lookupRecordedDependentOwnerType(
-										StringTable::getOrInternStringHandle(instantiated_class_name)),
+									StringTable::getOrInternStringHandle(instantiated_class_name),
+									materialized_owner_names_current_instantiation
+										? TypeIndex{}
+										: lookupRecordedDependentOwnerType(
+											StringTable::getOrInternStringHandle(instantiated_class_name)),
 									materialized_owner_names_current_instantiation
 										? TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation
 										: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1286,6 +1286,8 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 					member_access.member_name,
 					0);
 			if (qualified_member_template_name.empty()) {
+				FLASH_LOG(Templates, Debug, "resolveBaseClassMemberTypeChain failed member-template lookup ",
+						  current_base_name, "::", member_name);
 				return nullptr;
 			}
 
@@ -1304,6 +1306,8 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 					StringTable::getOrInternStringHandle(materialized_member.instantiated_name));
 			}
 			if (resolved_type == nullptr) {
+				FLASH_LOG(Templates, Debug, "resolveBaseClassMemberTypeChain failed materialized member-template ",
+						  qualified_member_template_name);
 				return nullptr;
 			}
 			normalizeResolvedMemberOwner(resolved_type, current_base_name);
@@ -1322,6 +1326,8 @@ const TypeInfo* Parser::resolveBaseClassMemberTypeChain(
 			resolved_type = lookup_inherited_type_alias(current_base_name, member_name);
 		}
 		if (resolved_type == nullptr) {
+			FLASH_LOG(Templates, Debug, "resolveBaseClassMemberTypeChain failed member lookup ",
+					  current_base_name, "::", member_name);
 			return nullptr;
 		}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -9490,7 +9490,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						TypeIndex resolved_index = type_spec.type_index();
 						bool resolved = false;
 						auto is_concrete_materialized_arg =
-							[this](const TemplateTypeArg& candidate_arg) {
+							[](const TemplateTypeArg& candidate_arg) {
 							if (candidate_arg.is_dependent ||
 								candidate_arg.dependent_name.isValid() ||
 								candidate_arg.dependent_expr.has_value()) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -94,27 +94,6 @@ static void buildTemplateParameterReplayState(
 	}
 }
 
-static bool isConcreteAliasSemanticSourceForClassTemplate(const TypeInfo* type_info) {
-	if (type_info == nullptr) {
-		return false;
-	}
-	if (type_info->isTemplatePlaceholder() ||
-		type_info->isDependentPlaceholder() ||
-		(type_info->is_incomplete_instantiation_ &&
-		 type_info->isDependentMemberType())) {
-		return false;
-	}
-	const TypeIndex registered_index =
-		type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
-	if (!registered_index.is_valid()) {
-		return false;
-	}
-	if (typeIndexContainsDependentPlaceholder(registered_index)) {
-		return false;
-	}
-	return true;
-}
-
 template <typename ParamContainer, typename ArgContainer>
 static TypeIndex resolveDependentMemberTemplateArtifactsForParam(
 	Parser& parser,
@@ -4074,7 +4053,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					TypeInfo* alias_info = nullptr;
 					const TypeInfo* alias_semantic_source =
-						isConcreteAliasSemanticSourceForClassTemplate(resolved_info)
+						isConcreteAliasSemanticSource(resolved_info)
 							? resolved_info
 							: nullptr;
 					auto existing_it = getTypesByNameMap().find(alias_instantiated_handle);
@@ -7245,7 +7224,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituted_size = concrete_member_info->sizeInBits().value;
 					alias_semantic_source = concrete_member_info;
 				}
-				if (!isConcreteAliasSemanticSourceForClassTemplate(alias_semantic_source)) {
+				if (!isConcreteAliasSemanticSource(alias_semantic_source)) {
 					alias_semantic_source = nullptr;
 				}
 
@@ -12106,18 +12085,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (template_arg.is_template_template_arg) {
 					return !template_arg.template_name_handle.isValid();
 				}
-				if (template_arg.is_value) {
-					if (template_arg.is_dependent ||
-						template_arg.dependent_name.isValid() ||
-						template_arg.dependent_expr.has_value()) {
-						return true;
-					}
-					return false;
-				}
-				if (template_arg.is_dependent ||
+				const bool is_dependent = template_arg.is_dependent ||
 					template_arg.dependent_name.isValid() ||
-					template_arg.dependent_expr.has_value()) {
+					template_arg.dependent_expr.has_value();
+				if (is_dependent) {
 					return true;
+				}
+				if (template_arg.is_value) {
+					return false;
 				}
 				TypeIndex arg_type_index =
 					template_arg.type_index.withCategory(template_arg.typeEnum());
@@ -12239,7 +12214,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			substituted_size = concrete_member_info->sizeInBits().value;
 			alias_semantic_source = concrete_member_info;
 		}
-		if (!isConcreteAliasSemanticSourceForClassTemplate(alias_semantic_source)) {
+		if (!isConcreteAliasSemanticSource(alias_semantic_source)) {
 			alias_semantic_source = nullptr;
 		}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -94,6 +94,27 @@ static void buildTemplateParameterReplayState(
 	}
 }
 
+static bool isConcreteAliasSemanticSourceForClassTemplate(const TypeInfo* type_info) {
+	if (type_info == nullptr) {
+		return false;
+	}
+	if (type_info->isTemplatePlaceholder() ||
+		type_info->isDependentPlaceholder() ||
+		(type_info->is_incomplete_instantiation_ &&
+		 type_info->isDependentMemberType())) {
+		return false;
+	}
+	const TypeIndex registered_index =
+		type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
+	if (!registered_index.is_valid()) {
+		return false;
+	}
+	if (typeIndexContainsDependentPlaceholder(registered_index)) {
+		return false;
+	}
+	return true;
+}
+
 template <typename ParamContainer, typename ArgContainer>
 static TypeIndex resolveDependentMemberTemplateArtifactsForParam(
 	Parser& parser,
@@ -4052,6 +4073,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 
 					TypeInfo* alias_info = nullptr;
+					const TypeInfo* alias_semantic_source =
+						isConcreteAliasSemanticSourceForClassTemplate(resolved_info)
+							? resolved_info
+							: nullptr;
 					auto existing_it = getTypesByNameMap().find(alias_instantiated_handle);
 					if (existing_it != getTypesByNameMap().end() && existing_it->second != nullptr) {
 						alias_info = existing_it->second;
@@ -4060,14 +4085,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							resolved_registered_index,
 							resolved_info->sizeInBits().value,
 							&alias_type_spec,
-							resolved_info);
+							alias_semantic_source);
 					} else {
-						alias_info = &add_type_alias_copy(
-							alias_instantiated_handle,
-							resolved_registered_index,
-							resolved_info->sizeInBits().value,
-							alias_type_spec,
-							*resolved_info);
+						if (alias_semantic_source != nullptr) {
+							alias_info = &add_type_alias_copy(
+								alias_instantiated_handle,
+								resolved_registered_index,
+								resolved_info->sizeInBits().value,
+								alias_type_spec,
+								*alias_semantic_source);
+						} else {
+							alias_info = &add_type_alias_copy(
+								alias_instantiated_handle,
+								resolved_registered_index,
+								resolved_info->sizeInBits().value,
+								alias_type_spec);
+						}
 					}
 
 					if (alias_info != nullptr) {
@@ -4862,7 +4895,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				});
 		}
 
-		TypeSpecifierNode substituted_type_spec = type_alias.type_node.as<TypeSpecifierNode>();
+		const TypeSpecifierNode alias_decl_pattern_spec =
+			type_alias.type_node.as<TypeSpecifierNode>();
+		TypeSpecifierNode substituted_type_spec = alias_decl_pattern_spec;
 		substituted_type_spec.set_type_index(substituted_type_index.withCategory(substituted_type));
 		substituted_type_spec.set_category(substituted_type);
 		std::optional<TemplateTypeArg> rebound_arg;
@@ -4870,9 +4905,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// signature; the existing alias-resolution path below preserves that full
 		// signature, while direct rebinding here is only for aliases shaped like T,
 		// T*, T&, and cv-qualified variants.
-		StringHandle alias_target_name = substituted_type_spec.has_function_signature()
+		StringHandle alias_target_name = alias_decl_pattern_spec.has_function_signature()
 											 ? StringHandle{}
-											 : getAliasTargetNameHandle(substituted_type_spec);
+											 : getAliasTargetNameHandle(alias_decl_pattern_spec);
 		if (alias_target_name.isValid()) {
 			forEachNonPackTemplateParamArgBinding(
 				params,
@@ -4883,7 +4918,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						param.nameHandle() == alias_target_name) {
 						rebound_arg = rebindDependentTemplateTypeArg(
 							concrete_arg,
-							TemplateTypeArg(substituted_type_spec));
+							TemplateTypeArg(alias_decl_pattern_spec));
 					}
 				});
 		}
@@ -7210,6 +7245,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituted_size = concrete_member_info->sizeInBits().value;
 					alias_semantic_source = concrete_member_info;
 				}
+				if (!isConcreteAliasSemanticSourceForClassTemplate(alias_semantic_source)) {
+					alias_semantic_source = nullptr;
+				}
 
 				if (const TypeInfo* alias_target_info = tryGetTypeInfo(TypeIndex{substituted_type_index});
 					alias_target_info != nullptr && alias_target_info->isTemplateInstantiation()) {
@@ -7266,12 +7304,42 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern, instantiated_name);
+				bool use_resolved_alias_override =
+					resolved_alias_type_spec_override.has_value();
+				if (use_resolved_alias_override) {
+					const TypeSpecifierNode& override_spec =
+						resolved_alias_type_spec_override.value();
+					if (override_spec.type_index().is_valid() &&
+						typeIndexContainsDependentPlaceholder(
+							override_spec.type_index())) {
+						use_resolved_alias_override = false;
+					} else if (const TypeInfo* override_info =
+								   tryGetTypeInfo(override_spec.type_index());
+							   override_info != nullptr &&
+							   (override_info->isTemplatePlaceholder() ||
+								override_info->isDependentPlaceholder())) {
+						use_resolved_alias_override = false;
+					}
+				}
 				const TypeSpecifierNode& alias_registration_type_spec =
-					resolved_alias_type_spec_override.has_value()
+					use_resolved_alias_override
 						? resolved_alias_type_spec_override.value()
 						: (substituted_alias_type_spec.has_value()
 							   ? substituted_alias_type_spec.value()
 							   : alias_type_spec);
+				FLASH_LOG(
+					Parser,
+					Debug,
+					"Class alias register(pattern): name='",
+					StringTable::getStringView(qualified_alias_name),
+					"', substituted_type=",
+					static_cast<int>(substituted_type),
+					", substituted_index=",
+					TypeIndex{substituted_type_index}.index(),
+					", reg_spec_type=",
+					static_cast<int>(alias_registration_type_spec.type()),
+					", reg_spec_index=",
+					alias_registration_type_spec.type_index().index());
 				auto& alias_type_info =
 					alias_semantic_source != nullptr
 						? add_type_alias_copy(
@@ -9421,6 +9489,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						TypeCategory resolved_type = type_spec.type();
 						TypeIndex resolved_index = type_spec.type_index();
 						bool resolved = false;
+						auto is_concrete_materialized_arg =
+							[this](const TemplateTypeArg& candidate_arg) {
+							if (candidate_arg.is_dependent ||
+								candidate_arg.dependent_name.isValid() ||
+								candidate_arg.dependent_expr.has_value()) {
+								return false;
+							}
+							if (candidate_arg.is_value || !candidate_arg.type_index.is_valid()) {
+								return true;
+							}
+							const TypeInfo* candidate_type_info =
+								tryGetTypeInfo(candidate_arg.type_index);
+							if (candidate_type_info == nullptr) {
+								return false;
+							}
+							if (candidate_type_info->isTemplatePlaceholder() ||
+								candidate_type_info->isDependentPlaceholder() ||
+								(candidate_type_info->isDependentMemberType() &&
+								 candidate_type_info->hasDependentQualifiedName())) {
+								return false;
+							}
+							return true;
+						};
 
 						if ((is_struct_type(resolved_type)) && resolved_index.is_valid()) {
 							if (const TypeInfo* resolved_ti = tryGetTypeInfo(resolved_index)) {
@@ -9448,12 +9539,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 												template_params,
 												template_args_to_use)) {
 										TemplateTypeArg member_arg = resolveTypeInfoToTemplateArg(*concrete_member_alias, type_spec);
-										member_arg.is_pack = arg_info.is_pack;
-										resolved_args.push_back(member_arg);
-										resolved = true;
-										FLASH_LOG_FORMAT(Templates, Debug,
-											"Resolved deferred base member alias '{}' to terminal type_index={}",
-											type_name, member_arg.type_index);
+										if (is_concrete_materialized_arg(member_arg)) {
+											member_arg.is_pack = arg_info.is_pack;
+											resolved_args.push_back(member_arg);
+											resolved = true;
+											FLASH_LOG_FORMAT(Templates, Debug,
+												"Resolved deferred base member alias '{}' to terminal type_index={}",
+												type_name, member_arg.type_index);
+										}
 									}
 								}
 								if (!resolved) {
@@ -9480,12 +9573,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 														alias_node.template_parameters(),
 														instantiated_args)) {
 												TemplateTypeArg inst_arg = resolveTypeInfoToTemplateArg(*concrete_member_alias, type_spec);
-												inst_arg.is_pack = arg_info.is_pack;
-												resolved_args.push_back(inst_arg);
-												resolved = true;
-												FLASH_LOG_FORMAT(Templates, Debug,
-													"Resolved deferred base alias-template member argument '{}' via alias target",
-													type_name);
+												if (is_concrete_materialized_arg(inst_arg)) {
+													inst_arg.is_pack = arg_info.is_pack;
+													resolved_args.push_back(inst_arg);
+													resolved = true;
+													FLASH_LOG_FORMAT(Templates, Debug,
+														"Resolved deferred base alias-template member argument '{}' via alias target",
+														type_name);
+												}
 											}
 											if (resolved) {
 												continue;
@@ -11992,7 +12087,46 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	// Copy type aliases from the template with template parameter substitution
+	const bool has_unresolved_primary_template_args =
+		std::ranges::any_of(
+			template_args_to_use,
+			[](const TemplateTypeArg& template_arg) {
+				auto lacksConcreteTypeIdentity = [](TypeIndex type_index) {
+					if (!type_index.is_valid()) {
+						if (TypeIndex native_index = nativeTypeIndex(type_index.category()); native_index.is_valid()) {
+							return false;
+						}
+						return true;
+					}
+					if (typeIndexContainsDependentPlaceholder(type_index)) {
+						return true;
+					}
+					return false;
+				};
+				if (template_arg.is_template_template_arg) {
+					return !template_arg.template_name_handle.isValid();
+				}
+				if (template_arg.is_value) {
+					if (template_arg.is_dependent ||
+						template_arg.dependent_name.isValid() ||
+						template_arg.dependent_expr.has_value()) {
+						return true;
+					}
+					return false;
+				}
+				if (template_arg.is_dependent ||
+					template_arg.dependent_name.isValid() ||
+					template_arg.dependent_expr.has_value()) {
+					return true;
+				}
+				TypeIndex arg_type_index =
+					template_arg.type_index.withCategory(template_arg.typeEnum());
+				return lacksConcreteTypeIdentity(arg_type_index);
+			});
 	for (const auto& type_alias : class_decl.type_aliases()) {
+		if (has_unresolved_primary_template_args) {
+			continue;
+		}
 		auto qualified_alias_name = StringTable::getOrInternStringHandle(StringBuilder().append(instantiated_name).append("::"sv).append(type_alias.alias_name));
 
 		// Get the aliased type and substitute template parameters
@@ -12105,6 +12239,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			substituted_size = concrete_member_info->sizeInBits().value;
 			alias_semantic_source = concrete_member_info;
 		}
+		if (!isConcreteAliasSemanticSourceForClassTemplate(alias_semantic_source)) {
+			alias_semantic_source = nullptr;
+		}
 
 		// Ensure size is computed for primitive type aliases that were substituted from template parameters.
 		// When 'typedef T value_type' in a template is instantiated with T=long, the alias type category
@@ -12122,12 +12259,70 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Register the type alias in getTypesByNameMap()
 		std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 			type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_to_use, instantiated_name);
+		bool use_resolved_alias_override =
+			resolved_alias_type_spec_override.has_value();
+		if (use_resolved_alias_override) {
+			const TypeSpecifierNode& override_spec =
+				resolved_alias_type_spec_override.value();
+			if (override_spec.type_index().is_valid() &&
+				typeIndexContainsDependentPlaceholder(
+					override_spec.type_index())) {
+				use_resolved_alias_override = false;
+			} else if (const TypeInfo* override_info =
+						   tryGetTypeInfo(override_spec.type_index());
+					   override_info != nullptr &&
+					   (override_info->isTemplatePlaceholder() ||
+						override_info->isDependentPlaceholder())) {
+				use_resolved_alias_override = false;
+			}
+		}
 		const TypeSpecifierNode& alias_registration_type_spec =
-			resolved_alias_type_spec_override.has_value()
+			use_resolved_alias_override
 				? resolved_alias_type_spec_override.value()
 				: (substituted_alias_type_spec.has_value()
 					   ? substituted_alias_type_spec.value()
 					   : alias_type_spec);
+		FLASH_LOG(
+			Parser,
+			Debug,
+			"Class alias register(primary): name='",
+			StringTable::getStringView(qualified_alias_name),
+			"', tmpl_args=",
+			template_args_to_use.size(),
+			"', substituted_type=",
+			static_cast<int>(substituted_type),
+			", substituted_index=",
+			TypeIndex{substituted_type_index}.index(),
+			", reg_spec_type=",
+			static_cast<int>(alias_registration_type_spec.type()),
+			", reg_spec_index=",
+			alias_registration_type_spec.type_index().index());
+		for (size_t alias_arg_index = 0; alias_arg_index < template_args_to_use.size(); ++alias_arg_index) {
+			const TemplateTypeArg& alias_arg = template_args_to_use[alias_arg_index];
+			const TypeInfo* alias_arg_info =
+				(!alias_arg.is_value && alias_arg.type_index.is_valid())
+					? tryGetTypeInfo(alias_arg.type_index)
+					: nullptr;
+			FLASH_LOG(
+				Parser,
+				Debug,
+				"  primary_arg[",
+				alias_arg_index,
+				"]: is_value=",
+				alias_arg.is_value ? 1 : 0,
+				", is_dep=",
+				alias_arg.is_dependent ? 1 : 0,
+				", type=",
+				static_cast<int>(alias_arg.typeEnum()),
+				", type_name='",
+				(alias_arg_info != nullptr
+					 ? StringTable::getStringView(alias_arg_info->name())
+					 : std::string_view()),
+				"', ref=",
+				static_cast<int>(alias_arg.ref_qualifier),
+				", ptr=",
+				static_cast<int>(alias_arg.pointer_depth));
+		}
 		auto& alias_type_info =
 			alias_semantic_source != nullptr
 				? add_type_alias_copy(

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -87,6 +87,53 @@ static ReferenceQualifier collapseTemplateArgumentReferenceQualifier(
 	return ReferenceQualifier::RValueReference;
 }
 
+static void appendInstantiationContextBindingsToSubstitutionMap(
+	const TypeInfo::InstantiationContext* context,
+	SubstitutionParamMap& sub_map) {
+	if (context == nullptr) {
+		return;
+	}
+	appendInstantiationContextBindingsToSubstitutionMap(context->parent, sub_map);
+	if (context->hasInstantiationContextBindings()) {
+		for (const auto& binding : context->bindings) {
+			if (!binding.name.isValid() || binding.args.empty()) {
+				continue;
+			}
+			std::string_view binding_name =
+				StringTable::getStringView(binding.name);
+			if (binding_name.empty()) {
+				continue;
+			}
+			if (std::ranges::find(sub_map.param_order, binding_name) ==
+				sub_map.param_order.end()) {
+				sub_map.param_order.push_back(binding_name);
+			}
+			sub_map.param_map[binding_name] =
+				toTemplateTypeArg(binding.args.front());
+		}
+		return;
+	}
+	for (size_t i = 0;
+		 i < context->param_names.size() &&
+		 i < context->param_args.size();
+		 ++i) {
+		if (!context->param_names[i].isValid()) {
+			continue;
+		}
+		std::string_view binding_name =
+			StringTable::getStringView(context->param_names[i]);
+		if (binding_name.empty()) {
+			continue;
+		}
+		if (std::ranges::find(sub_map.param_order, binding_name) ==
+			sub_map.param_order.end()) {
+			sub_map.param_order.push_back(binding_name);
+		}
+		sub_map.param_map[binding_name] =
+			toTemplateTypeArg(context->param_args[i]);
+	}
+}
+
 bool Parser::isTemplateFunctionParameterPack(
 	std::span<const TemplateParameterNode> template_params,
 	const DeclarationNode& func_param_decl) {
@@ -294,6 +341,27 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 			resolved_dependent_type != nullptr) {
 			return emplaceResolvedSpec(resolved_dependent_type);
 		}
+		if (current_type_info != current_semantic_type_info &&
+			current_type_info->hasInstantiationContext()) {
+			SubstitutionParamMap sub_map =
+				buildSubstitutionParamMap(template_params, template_args);
+			appendInstantiationContextBindingsToSubstitutionMap(
+				current_type_info->instantiationContext(),
+				sub_map);
+			appendInstantiationContextBindingsToSubstitutionMap(
+				current_semantic_type_info->instantiationContext(),
+				sub_map);
+			ExpressionSubstitutor contextual_substitutor(
+				sub_map.param_map,
+				*this,
+				sub_map.param_order);
+			if (const TypeInfo* resolved_with_alias_context =
+					contextual_substitutor.resolveDependentMemberTypeForSubstitution(
+						*current_semantic_type_info);
+				resolved_with_alias_context != nullptr) {
+				return emplaceResolvedSpec(resolved_with_alias_context);
+			}
+		}
 		if (const TypeInfo* materialized_member_alias =
 				materializeInstantiatedMemberAliasTarget(
 					current_type_spec,
@@ -355,170 +423,7 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 	if (sep_pos == std::string_view::npos)
 		return DependentAliasResolutionStatus::NotApplicable;
 
-	std::string base_part(type_name.substr(0, sep_pos));
-	std::string_view member_part = type_name.substr(sep_pos + 2);
-	auto build_resolved_handle = [](std::string_view base, std::string_view member) {
-		StringBuilder sb;
-		return StringTable::getOrInternStringHandle(sb.append(base).append("::").append(member).commit());
-	};
-	auto instantiate_base_and_get_name = [&](std::string_view base_template_name,
-										   std::span<const TemplateTypeArg> args_to_use) -> std::string_view {
-		auto instantiation = try_instantiate_class_template(base_template_name, args_to_use);
-		if (instantiation.has_value() && instantiation->is<StructDeclarationNode>()) {
-			return StringTable::getStringView(instantiation->as<StructDeclarationNode>().name());
-		}
-		auto registry_hit = gTemplateRegistry.getInstantiation(
-			StringTable::getOrInternStringHandle(base_template_name), args_to_use);
-		if (registry_hit.has_value() && registry_hit->is<StructDeclarationNode>()) {
-			return StringTable::getStringView(registry_hit->as<StructDeclarationNode>().name());
-		}
-		return get_instantiated_class_name(base_template_name, args_to_use);
-	};
-
-	FLASH_LOG(Templates, Debug, "resolveDependentMemberAlias: type_name=", type_name,
-			  " base_part=", base_part, " member_part=", member_part,
-			  " template_args=", template_args.size());
-
-	forEachNonPackTemplateParamArgBinding(
-		template_params,
-		template_args,
-		[&](const TemplateParameterNode& tparam, const TemplateTypeArg& arg, size_t) {
-			std::string_view tname = tparam.name();
-			auto pos = base_part.find(tname);
-			if (pos != std::string::npos) {
-				base_part.replace(pos, tname.size(), arg.toString());
-			}
-		});
-
-	StringHandle resolved_handle = build_resolved_handle(base_part, member_part);
-	FLASH_LOG(Templates, Debug, "resolveDependentMemberAlias: resolved_name=",
-			  StringTable::getStringView(resolved_handle));
-	auto type_it = getTypesByNameMap().find(resolved_handle);
-	if (type_it != getTypesByNameMap().end() &&
-		type_it->second != nullptr &&
-		type_it->second->is_incomplete_instantiation_) {
-		type_it = getTypesByNameMap().end();
-	}
-
-	std::vector<TemplateTypeArg> concrete_instantiation_args;
-	if (type_info->isTemplateInstantiation()) {
-		concrete_instantiation_args =
-			materializePlaceholderTemplateArgs(*type_info, template_params, template_args);
-	}
-	if (concrete_instantiation_args.empty()) {
-		auto base_type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(base_part));
-		if (base_type_it != getTypesByNameMap().end() &&
-			base_type_it->second != nullptr &&
-			base_type_it->second->isTemplateInstantiation()) {
-			concrete_instantiation_args =
-				materializePlaceholderTemplateArgs(*base_type_it->second, template_params, template_args);
-		}
-	}
-	if (type_it == getTypesByNameMap().end() && type_info->isTemplateInstantiation()) {
-		std::string_view base_template_name = StringTable::getStringView(type_info->baseTemplateName());
-		if (!base_template_name.empty()) {
-			std::string_view instantiated_base =
-				instantiate_base_and_get_name(base_template_name, concrete_instantiation_args);
-			resolved_handle = build_resolved_handle(instantiated_base, member_part);
-			type_it = getTypesByNameMap().find(resolved_handle);
-			if (type_it != getTypesByNameMap().end() &&
-				type_it->second != nullptr &&
-				type_it->second->is_incomplete_instantiation_) {
-				type_it = getTypesByNameMap().end();
-			}
-		}
-	}
-
-	auto resolve_base_template_name = [&](std::string_view candidate) {
-		std::string_view base_template_name = extractBaseTemplateName(candidate);
-		if (base_template_name.empty()) {
-			base_template_name = extract_base_template_name(candidate);
-		}
-		return base_template_name;
-	};
-	if (type_it == getTypesByNameMap().end()) {
-		std::string_view base_template_name = resolve_base_template_name(base_part);
-		if (!base_template_name.empty()) {
-			auto template_opt = gTemplateRegistry.lookupTemplate(base_template_name);
-			if (template_opt.has_value() && template_opt->is<TemplateClassDeclarationNode>()) {
-				std::vector<TemplateTypeArg> args_to_use = concrete_instantiation_args.empty()
-					? std::vector<TemplateTypeArg>(template_args.begin(), template_args.end())
-					: concrete_instantiation_args;
-				std::string_view instantiated_base =
-					instantiate_base_and_get_name(base_template_name, args_to_use);
-				resolved_handle = build_resolved_handle(instantiated_base, member_part);
-				type_it = getTypesByNameMap().find(resolved_handle);
-				if (type_it != getTypesByNameMap().end() &&
-					type_it->second != nullptr &&
-					type_it->second->is_incomplete_instantiation_) {
-					type_it = getTypesByNameMap().end();
-				}
-				if (type_it == getTypesByNameMap().end()) {
-					StringHandle primary_handle = build_resolved_handle(base_template_name, member_part);
-					type_it = getTypesByNameMap().find(primary_handle);
-					if (type_it != getTypesByNameMap().end() &&
-						type_it->second != nullptr &&
-						type_it->second->is_incomplete_instantiation_) {
-						type_it = getTypesByNameMap().end();
-					}
-				}
-				FLASH_LOG(Templates, Debug, "resolveDependentMemberAlias: after instantiation lookup '",
-						  StringTable::getStringView(resolved_handle), "' found=", (type_it != getTypesByNameMap().end()));
-			}
-		}
-	}
-
-	if (type_it == getTypesByNameMap().end()) {
-		if (type_info->isTemplateInstantiation()) {
-			std::string_view base_template_name = StringTable::getStringView(type_info->baseTemplateName());
-			if (!base_template_name.empty()) {
-				std::vector<TemplateTypeArg> args_to_use = concrete_instantiation_args.empty()
-					? std::vector<TemplateTypeArg>(template_args.begin(), template_args.end())
-					: concrete_instantiation_args;
-				auto instantiation_opt = gTemplateRegistry.getInstantiation(
-					StringTable::getOrInternStringHandle(base_template_name),
-					args_to_use);
-				if (instantiation_opt.has_value() && instantiation_opt->is<StructDeclarationNode>()) {
-					const auto& instantiated_struct = instantiation_opt->as<StructDeclarationNode>();
-					for (const auto& type_alias : instantiated_struct.type_aliases()) {
-						if (StringTable::getStringView(type_alias.alias_name) != member_part) {
-							continue;
-						}
-						StringHandle qualified_alias_handle = StringTable::getOrInternStringHandle(
-							StringBuilder()
-								.append(StringTable::getStringView(instantiated_struct.name()))
-								.append("::")
-								.append(member_part)
-								.commit());
-						auto qualified_alias_it = getTypesByNameMap().find(qualified_alias_handle);
-						if (qualified_alias_it != getTypesByNameMap().end() && qualified_alias_it->second != nullptr) {
-							FLASH_LOG(Templates, Debug, "Resolved dependent alias from registered qualified alias '",
-									  StringTable::getStringView(qualified_alias_handle), "'");
-							return emplaceResolvedSpec(qualified_alias_it->second);
-						}
-						if (type_alias.type_node.is<TypeSpecifierNode>()) {
-							type_node = emplace_node<TypeSpecifierNode>(type_alias.type_node.as<TypeSpecifierNode>());
-							FLASH_LOG(Templates, Debug, "Resolved dependent alias from instantiated struct '",
-									  type_name, "' -> ", member_part);
-							return DependentAliasResolutionStatus::Resolved;
-						}
-					}
-				}
-			}
-		}
-		auto alias_opt = gTemplateRegistry.lookup_alias_template(StringTable::getStringView(resolved_handle));
-		if (alias_opt.has_value() && alias_opt->is<TemplateAliasNode>()) {
-			const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
-			type_node = emplace_node<TypeSpecifierNode>(alias_node.target_type());
-			FLASH_LOG(Templates, Debug, "Resolved dependent alias via registry '", type_name, "' -> ", alias_node.alias_name());
-			return DependentAliasResolutionStatus::Resolved;
-		}
-		return DependentAliasResolutionStatus::StillDependent;
-	}
-	auto status = emplaceResolvedSpec(type_it->second);
-	FLASH_LOG(Templates, Debug, "Resolved dependent alias '", type_name, "' to type=", static_cast<int>(type_it->second->typeEnum()),
-			  ", index=", type_it->second->type_index_);
-	return status;
+	return DependentAliasResolutionStatus::StillDependent;
 }
 
 const TypeInfo* Parser::resolveDependentMemberTypeSemantic(
@@ -533,6 +438,46 @@ const TypeInfo* Parser::resolveDependentMemberTypeSemantic(
 
 	SubstitutionParamMap sub_map =
 		buildSubstitutionParamMap(template_params, template_args);
+	for (const TemplateParamSubstitution& substitution :
+		 template_param_substitutions_) {
+		if (!substitution.param_name.isValid()) {
+			continue;
+		}
+		std::string_view binding_name =
+			StringTable::getStringView(substitution.param_name);
+		if (binding_name.empty()) {
+			continue;
+		}
+
+		std::optional<TemplateTypeArg> bound_arg;
+		if (substitution.is_type_param) {
+			bound_arg = substitution.substituted_type;
+		} else if (substitution.is_template_template_param &&
+				   substitution.concrete_template_name.isValid()) {
+			bound_arg =
+				TemplateTypeArg::makeTemplate(substitution.concrete_template_name);
+		} else if (substitution.is_value_param) {
+			if (substitution.typed_value_identity.has_value()) {
+				bound_arg = TemplateTypeArg::makeValueIdentity(
+					*substitution.typed_value_identity);
+			} else {
+				bound_arg = TemplateTypeArg(
+					substitution.value,
+					substitution.value_type);
+			}
+		}
+		if (!bound_arg.has_value()) {
+			continue;
+		}
+		if (std::ranges::find(sub_map.param_order, binding_name) ==
+			sub_map.param_order.end()) {
+			sub_map.param_order.push_back(binding_name);
+		}
+		sub_map.param_map[binding_name] = *bound_arg;
+	}
+	appendInstantiationContextBindingsToSubstitutionMap(
+		dependent_type_info.instantiationContext(),
+		sub_map);
 	ExpressionSubstitutor substitutor(sub_map.param_map, *this, sub_map.param_order);
 	if (current_owner_type_name.isValid()) {
 		substitutor.setCurrentOwnerTypeName(current_owner_type_name);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -283,6 +283,8 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 			!current_semantic_type_info->hasDependentQualifiedName()) {
 			return std::nullopt;
 		}
+		FLASH_LOG(Templates, Debug, "resolveDependentMemberAlias semantic path for ",
+				  StringTable::getStringView(current_semantic_type_info->name()));
 		if (const TypeInfo* resolved_dependent_type =
 				resolveDependentMemberTypeSemantic(
 					*current_semantic_type_info,
@@ -300,6 +302,8 @@ Parser::DependentAliasResolutionStatus Parser::resolveDependentMemberAlias(
 			materialized_member_alias != nullptr) {
 			return emplaceResolvedSpec(materialized_member_alias);
 		}
+		FLASH_LOG(Templates, Debug, "resolveDependentMemberAlias semantic path still dependent for ",
+				  StringTable::getStringView(current_semantic_type_info->name()));
 		return std::nullopt;
 	};
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -107,9 +107,9 @@ static void appendInstantiationContextBindingsToSubstitutionMap(
 			if (std::ranges::find(sub_map.param_order, binding_name) ==
 				sub_map.param_order.end()) {
 				sub_map.param_order.push_back(binding_name);
+				sub_map.param_map[binding_name] =
+					toTemplateTypeArg(binding.args.front());
 			}
-			sub_map.param_map[binding_name] =
-				toTemplateTypeArg(binding.args.front());
 		}
 		return;
 	}
@@ -128,9 +128,9 @@ static void appendInstantiationContextBindingsToSubstitutionMap(
 		if (std::ranges::find(sub_map.param_order, binding_name) ==
 			sub_map.param_order.end()) {
 			sub_map.param_order.push_back(binding_name);
+			sub_map.param_map[binding_name] =
+				toTemplateTypeArg(context->param_args[i]);
 		}
-		sub_map.param_map[binding_name] =
-			toTemplateTypeArg(context->param_args[i]);
 	}
 }
 
@@ -472,8 +472,8 @@ const TypeInfo* Parser::resolveDependentMemberTypeSemantic(
 		if (std::ranges::find(sub_map.param_order, binding_name) ==
 			sub_map.param_order.end()) {
 			sub_map.param_order.push_back(binding_name);
+			sub_map.param_map[binding_name] = *bound_arg;
 		}
-		sub_map.param_map[binding_name] = *bound_arg;
 	}
 	appendInstantiationContextBindingsToSubstitutionMap(
 		dependent_type_info.instantiationContext(),

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1628,7 +1628,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			(void)tryMaterializeTemplateAliasTarget();
 		}
 		if (alias_node != nullptr &&
-			result.resolved_type_info == nullptr) {
+			result.resolved_type_info == nullptr &&
+			result.instantiated_name.empty()) {
 			if (const TypeInfo* concrete_member_alias =
 					materializeInstantiatedMemberAliasTarget(
 						alias_node->target_type_node(),

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -41,27 +41,6 @@ static bool hasComplexDeferredMemberChain(const TemplateAliasNode& node) {
 		});
 }
 
-static bool isConcreteAliasSemanticSource(const TypeInfo* type_info) {
-	if (type_info == nullptr) {
-		return false;
-	}
-	if (type_info->isTemplatePlaceholder() ||
-		type_info->isDependentPlaceholder() ||
-		(type_info->is_incomplete_instantiation_ &&
-		 type_info->isDependentMemberType())) {
-		return false;
-	}
-	const TypeIndex registered_index =
-		type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
-	if (!registered_index.is_valid()) {
-		return false;
-	}
-	if (typeIndexContainsDependentPlaceholder(registered_index)) {
-		return false;
-	}
-	return true;
-}
-
 static const TypeInfo* resolveConcreteAliasSemanticType(const TypeInfo* type_info) {
 	const TypeInfo* current_type_info = type_info;
 	for (size_t depth = 0; current_type_info != nullptr && depth < 32; ++depth) {

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2178,6 +2178,32 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 			base_template_name);
 	};
 
+	auto [qualified_base_template_handle, qualified_base_template_name, base_template_name] =
+		canonical_owner_template_names();
+	if (!owner_template_args.empty() &&
+		(can_materialize_owner_template(qualified_base_template_name) ||
+		 can_materialize_owner_template(base_template_name))) {
+		AliasTemplateMaterializationResult requested_owner;
+		if (!qualified_base_template_name.empty()) {
+			requested_owner =
+				materializeTemplateInstantiationForLookup(
+					qualified_base_template_name,
+					owner_template_args);
+		}
+		if ((requested_owner.instantiated_name.empty() &&
+			 requested_owner.resolved_type_info == nullptr) &&
+			!base_template_name.empty()) {
+			requested_owner =
+				materializeTemplateInstantiationForLookup(
+					base_template_name,
+					owner_template_args);
+		}
+		if (!requested_owner.instantiated_name.empty() ||
+			requested_owner.resolved_type_info != nullptr) {
+			return requested_owner;
+		}
+	}
+
 	auto try_materialize_exact_owner =
 		[&](std::span<const TypeInfo::TemplateArgInfo> stored_args) -> bool {
 		std::vector<TemplateTypeArg> concrete_template_args;
@@ -2194,8 +2220,6 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 			return false;
 		}
 
-		auto [qualified_base_template_handle, qualified_base_template_name, base_template_name] =
-			canonical_owner_template_names();
 		if (qualified_base_template_name.empty() && base_template_name.empty()) {
 			return false;
 		}
@@ -2258,33 +2282,6 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 		try_materialize_exact_owner(
 			canonical_owner_type_info->instantiationContext()->param_args)) {
 		return result;
-	}
-
-	auto [qualified_base_template_handle, qualified_base_template_name, base_template_name] =
-		canonical_owner_template_names();
-	if (!owner_template_args.empty() &&
-		(can_materialize_owner_template(qualified_base_template_name) ||
-		 can_materialize_owner_template(base_template_name))) {
-		AliasTemplateMaterializationResult canonical_owner;
-		if (can_materialize_owner_template(qualified_base_template_name)) {
-			canonical_owner =
-				materializeTemplateInstantiationForLookup(
-					qualified_base_template_name,
-					owner_template_args);
-		}
-		if ((canonical_owner.instantiated_name.empty() &&
-			 canonical_owner.resolved_type_info == nullptr) &&
-			can_materialize_owner_template(base_template_name) &&
-			qualified_base_template_handle != canonical_owner_type_info->baseTemplateName()) {
-			canonical_owner =
-				materializeTemplateInstantiationForLookup(
-					base_template_name,
-					owner_template_args);
-		}
-		if (!canonical_owner.instantiated_name.empty() ||
-			canonical_owner.resolved_type_info != nullptr) {
-			return canonical_owner;
-		}
 	}
 
 	return result;

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1627,6 +1627,19 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		if (!tryResolveDirectAliasTarget()) {
 			(void)tryMaterializeTemplateAliasTarget();
 		}
+		if (alias_node != nullptr &&
+			result.resolved_type_info == nullptr) {
+			if (const TypeInfo* concrete_member_alias =
+					materializeInstantiatedMemberAliasTarget(
+						alias_node->target_type_node(),
+						effective_template_params,
+						effective_template_args);
+				concrete_member_alias != nullptr) {
+				result.resolved_type_info = concrete_member_alias;
+				result.instantiated_name =
+					StringTable::getStringView(concrete_member_alias->name());
+			}
+		}
 		return result;
 	}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -41,6 +41,44 @@ static bool hasComplexDeferredMemberChain(const TemplateAliasNode& node) {
 		});
 }
 
+static bool isConcreteAliasSemanticSource(const TypeInfo* type_info) {
+	if (type_info == nullptr) {
+		return false;
+	}
+	if (type_info->isTemplatePlaceholder() ||
+		type_info->isDependentPlaceholder() ||
+		(type_info->is_incomplete_instantiation_ &&
+		 type_info->isDependentMemberType())) {
+		return false;
+	}
+	const TypeIndex registered_index =
+		type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
+	if (!registered_index.is_valid()) {
+		return false;
+	}
+	if (typeIndexContainsDependentPlaceholder(registered_index)) {
+		return false;
+	}
+	return true;
+}
+
+static const TypeInfo* resolveConcreteAliasSemanticType(const TypeInfo* type_info) {
+	const TypeInfo* current_type_info = type_info;
+	for (size_t depth = 0; current_type_info != nullptr && depth < 32; ++depth) {
+		ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+			current_type_info->registeredTypeIndex().withCategory(current_type_info->typeEnum()));
+		const TypeInfo* terminal_type_info = resolved_alias.terminal_type_info;
+		if (terminal_type_info == nullptr || terminal_type_info == current_type_info) {
+			break;
+		}
+		current_type_info = terminal_type_info;
+		if (isConcreteAliasSemanticSource(current_type_info)) {
+			break;
+		}
+	}
+	return current_type_info;
+}
+
 template <typename TemplateParamStorage, typename TemplateArgStorage, typename OnOuterParam>
 static bool appendOuterAliasTemplateSubstitutionInputs(
 	const OuterTemplateBinding& outer_binding,
@@ -757,6 +795,13 @@ std::optional<TemplateTypeArg> Parser::materializeDeferredAliasTemplateArg(
 				}
 			}
 		}
+		if (!normalized.is_value &&
+			!normalized.type_index.is_valid()) {
+			TypeIndex native_index = nativeTypeIndex(normalized.category());
+			if (native_index.is_valid()) {
+				normalized.type_index = native_index.withCategory(normalized.category());
+			}
+		}
 		return normalized;
 	};
 	const auto make_dependent_value_for_alias_param = [&](StringHandle param_name) -> std::optional<TemplateTypeArg> {
@@ -1168,6 +1213,46 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::materializeDeferredAlias
 			return std::nullopt;
 		}
 		substituted_args.push_back(std::move(*materialized_arg));
+	}
+
+	FLASH_LOG(
+		Parser,
+		Debug,
+		"materializeDeferredAliasTemplateArgs: alias='",
+		alias_node.alias_name(),
+		"', target='",
+		alias_node.target_template_name(),
+		"', input_args=",
+		template_args.size(),
+		", output_args=",
+		substituted_args.size());
+	for (size_t i = 0; i < substituted_args.size(); ++i) {
+		const TemplateTypeArg& arg = substituted_args[i];
+		const TypeInfo* arg_type_info =
+			(!arg.is_value && arg.type_index.is_valid())
+				? tryGetTypeInfo(arg.type_index)
+				: nullptr;
+		FLASH_LOG(
+			Parser,
+			Debug,
+			"  deferred_arg[",
+			i,
+			"]: is_value=",
+			arg.is_value ? 1 : 0,
+			", is_dep=",
+			arg.is_dependent ? 1 : 0,
+			", type=",
+			static_cast<int>(arg.category()),
+			", type_name='",
+			(arg_type_info != nullptr
+				 ? StringTable::getStringView(arg_type_info->name())
+				 : std::string_view()),
+			"', ref=",
+			static_cast<int>(arg.ref_qualifier),
+			", ptr=",
+			static_cast<int>(arg.pointer_depth),
+			", cv=",
+			static_cast<int>(arg.cv_qualifier));
 	}
 
 	return substituted_args;
@@ -1655,6 +1740,14 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					StringTable::getStringView(concrete_member_alias->name());
 			}
 		}
+		if (result.resolved_type_info != nullptr) {
+			if (const TypeInfo* concrete_type_info =
+					resolveConcreteAliasSemanticType(result.resolved_type_info);
+				concrete_type_info != nullptr) {
+				result.resolved_type_info = concrete_type_info;
+				result.instantiated_name = StringTable::getStringView(concrete_type_info->name());
+			}
+		}
 		return result;
 	}
 
@@ -1716,6 +1809,29 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 	const size_t alias_template_member_sep = alias_template_name.rfind("::");
 	const bool is_qualified_alias_template =
 		alias_template_member_sep != std::string_view::npos;
+	if (alias_node != nullptr &&
+		alias_node->is_deferred()) {
+		if (const TypeInfo* concrete_deferred_target =
+				materializeInstantiatedMemberAliasTarget(
+					alias_node->target_type_node(),
+					effective_template_params,
+					effective_template_args);
+			concrete_deferred_target != nullptr) {
+			const TypeInfo* resolved_deferred_target = concrete_deferred_target;
+			ResolvedAliasTypeInfo resolved_deferred_alias = resolveAliasTypeInfo(
+				concrete_deferred_target->registeredTypeIndex().withCategory(
+					concrete_deferred_target->typeEnum()));
+			if (resolved_deferred_alias.terminal_type_info != nullptr &&
+				isConcreteAliasSemanticSource(resolved_deferred_alias.terminal_type_info)) {
+				resolved_deferred_target = resolved_deferred_alias.terminal_type_info;
+			}
+			if (isConcreteAliasSemanticSource(resolved_deferred_target)) {
+				result.resolved_type_info = resolved_deferred_target;
+				result.instantiated_name =
+					StringTable::getStringView(resolved_deferred_target->name());
+			}
+		}
+	}
 	if (alias_node != nullptr &&
 		alias_node->is_deferred() &&
 		is_qualified_alias_template &&
@@ -1785,7 +1901,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					concrete_member_alias->registeredTypeIndex().withCategory(
 						concrete_member_alias->typeEnum()));
 				if (resolved_member_alias.terminal_type_info != nullptr &&
-					!alias_preserves_surface_type(resolved_member_alias)) {
+					isConcreteAliasSemanticSource(resolved_member_alias.terminal_type_info)) {
 					resolved_member_info = resolved_member_alias.terminal_type_info;
 				}
 				result.resolved_type_info = resolved_member_info;
@@ -1808,21 +1924,61 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					.commit());
 		}
 		const TypeInfo& resolved_type_info = *result.resolved_type_info;
+		ResolvedAliasTypeInfo resolved_alias_before_registration = resolveAliasTypeInfo(
+			resolved_type_info.registeredTypeIndex().withCategory(
+				resolved_type_info.typeEnum()));
+		FLASH_LOG(
+			Parser,
+			Debug,
+			"Alias registration source: alias='",
+			alias_template_name,
+			"', resolved='",
+			StringTable::getStringView(resolved_type_info.name()),
+			"', type=",
+			static_cast<int>(resolved_type_info.typeEnum()),
+			", type_index=",
+			resolved_type_info.registeredTypeIndex().index(),
+			", terminal='",
+			(resolved_alias_before_registration.terminal_type_info != nullptr
+				 ? StringTable::getStringView(
+					   resolved_alias_before_registration.terminal_type_info->name())
+				 : std::string_view()),
+			"'");
 		TypeIndex alias_target_index =
 			resolved_type_info.registeredTypeIndex().withCategory(
 				resolved_type_info.typeEnum());
-		TypeSpecifierNode alias_registration_type_spec = alias_node->target_type_node();
-		if (const TypeSpecifierNode* resolved_alias_spec =
-				resolved_type_info.aliasTypeSpecifier()) {
-			alias_registration_type_spec = *resolved_alias_spec;
+		const TypeSpecifierNode& alias_target_type_spec =
+			alias_node->target_type_node();
+		const bool alias_target_preserves_surface =
+			alias_target_type_spec.cv_qualifier() != CVQualifier::None ||
+			alias_target_type_spec.reference_qualifier() != ReferenceQualifier::None ||
+			alias_target_type_spec.pointer_depth() != 0 ||
+			alias_target_type_spec.has_function_signature() ||
+			alias_target_type_spec.is_array();
+		TypeSpecifierNode alias_registration_type_spec = alias_target_type_spec;
+		if (alias_target_preserves_surface) {
+			alias_registration_type_spec =
+				resolveTypeInfoToTypeSpec(
+					resolved_type_info,
+					alias_target_type_spec);
 		} else {
-			alias_registration_type_spec.set_type_index(alias_target_index);
-			alias_registration_type_spec.set_category(resolved_type_info.typeEnum());
-			alias_registration_type_spec.set_size_in_bits(resolved_type_info.sizeInBits());
+			alias_registration_type_spec =
+				resolveTypeInfoToTypeSpec(
+					resolved_type_info,
+					alias_target_type_spec);
+			if (!alias_registration_type_spec.type_index().is_valid()) {
+				alias_registration_type_spec.set_type_index(alias_target_index);
+				alias_registration_type_spec.set_category(resolved_type_info.typeEnum());
+				alias_registration_type_spec.set_size_in_bits(resolved_type_info.sizeInBits());
+			}
 		}
 
 		auto registerOrUpdateAlias = [&](StringHandle alias_handle) {
 			TypeInfo* alias_type_info = nullptr;
+			const TypeInfo* alias_semantic_source =
+				isConcreteAliasSemanticSource(&resolved_type_info)
+					? &resolved_type_info
+					: nullptr;
 			auto existing_alias_it = getTypesByNameMap().find(alias_handle);
 			if (existing_alias_it != getTypesByNameMap().end() &&
 				existing_alias_it->second != nullptr) {
@@ -1832,22 +1988,44 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					alias_target_index,
 					resolved_type_info.sizeInBits().value,
 					&alias_registration_type_spec,
-					&resolved_type_info);
+					alias_semantic_source);
 			} else if (!is_qualified_alias_template) {
-				alias_type_info = &add_type_alias_copy(
-					alias_handle,
-					alias_target_index,
-					resolved_type_info.sizeInBits().value,
-					alias_registration_type_spec,
-					resolved_type_info);
+				if (alias_semantic_source != nullptr) {
+					alias_type_info = &add_type_alias_copy(
+						alias_handle,
+						alias_target_index,
+						resolved_type_info.sizeInBits().value,
+						alias_registration_type_spec,
+						*alias_semantic_source);
+				} else {
+					alias_type_info = &add_type_alias_copy(
+						alias_handle,
+						alias_target_index,
+						resolved_type_info.sizeInBits().value,
+						alias_registration_type_spec);
+				}
 			}
 			return alias_type_info;
 		};
 
-		registerOrUpdateAlias(alias_instantiated_handle);
+		TypeInfo* alias_instantiated_type_info =
+			registerOrUpdateAlias(alias_instantiated_handle);
 		if (alias_instantiated_handle.view() != unqualified_alias_instantiated_name) {
 			registerOrUpdateAlias(
 				StringTable::getOrInternStringHandle(unqualified_alias_instantiated_name));
+		}
+		if (alias_instantiated_type_info != nullptr) {
+			result.resolved_type_info = alias_instantiated_type_info;
+			result.instantiated_name =
+				StringTable::getStringView(alias_instantiated_handle);
+		}
+	}
+	if (result.resolved_type_info != nullptr) {
+		if (const TypeInfo* concrete_type_info =
+				resolveConcreteAliasSemanticType(result.resolved_type_info);
+			concrete_type_info != nullptr) {
+			result.resolved_type_info = concrete_type_info;
+			result.instantiated_name = StringTable::getStringView(concrete_type_info->name());
 		}
 	}
 	return result;
@@ -2485,7 +2663,21 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		}
 		return false;
 	};
-
+	auto aliasPreservesSurfaceModifiers =
+		[](const TypeInfo& candidate_type_info) -> bool {
+		if (!candidate_type_info.isTypeAlias()) {
+			return false;
+		}
+		const TypeSpecifierNode* alias_spec = candidate_type_info.aliasTypeSpecifier();
+		if (alias_spec == nullptr) {
+			return false;
+		}
+		return alias_spec->pointer_depth() != 0 ||
+			   alias_spec->reference_qualifier() != ReferenceQualifier::None ||
+			   alias_spec->cv_qualifier() != CVQualifier::None ||
+			   alias_spec->is_array() ||
+			   alias_spec->has_function_signature();
+	};
 	StringHandle direct_concrete_member_handle =
 		StringTable::getOrInternStringHandle(
 			StringBuilder()
@@ -2498,11 +2690,33 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		direct_concrete_member_it->second != nullptr &&
 		!(direct_concrete_member_it->second->is_incomplete_instantiation_ &&
 		  direct_concrete_member_it->second->isDependentMemberType())) {
-		return direct_concrete_member_it->second;
+		ResolvedAliasTypeInfo resolved_direct_concrete_member = resolveAliasTypeInfo(
+			direct_concrete_member_it->second->registeredTypeIndex().withCategory(
+				direct_concrete_member_it->second->typeEnum()));
+		if (resolved_direct_concrete_member.terminal_type_info != nullptr &&
+			isConcreteAliasSemanticSource(resolved_direct_concrete_member.terminal_type_info)) {
+			if (aliasPreservesSurfaceModifiers(*direct_concrete_member_it->second)) {
+				return direct_concrete_member_it->second;
+			}
+			return resolved_direct_concrete_member.terminal_type_info;
+		}
+		if (isConcreteAliasSemanticSource(direct_concrete_member_it->second)) {
+			return direct_concrete_member_it->second;
+		}
+	}
+
+	bool owner_chain_uses_member_templates = false;
+	for (const auto& member_record : dependent_name->member_chain) {
+		if (member_record.has_template_arguments) {
+			owner_chain_uses_member_templates = true;
+			break;
+		}
 	}
 
 	std::string_view materialized_alias_base_name = dependent_base_name;
-	if (dependent_base_info->isTemplateInstantiation()) {
+	if (dependent_base_info->isTemplateInstantiation() ||
+		(!dependent_name->owner_template_arguments.empty() &&
+		 !owner_chain_uses_member_templates)) {
 		StringHandle base_template_name_handle = gNamespaceRegistry.buildQualifiedIdentifier(
 			dependent_base_info->sourceNamespace(),
 			dependent_base_info->baseTemplateName());
@@ -2544,6 +2758,10 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				resolve_composite_owner_template_name(
 					dependent_name->owner_name);
 		}
+		if (!base_template_name_handle.isValid() &&
+			dependent_name->owner_name.isValid()) {
+			base_template_name_handle = dependent_name->owner_name;
+		}
 		InlineVector<TemplateTypeArg, 4> concrete_base_args =
 			!dependent_name->owner_template_arguments.empty()
 				? materialize_template_args_with_environment(
@@ -2552,10 +2770,21 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		if (template_args_still_dependent(concrete_base_args)) {
 			return nullptr;
 		}
+		std::string_view owner_lookup_name =
+			base_template_name_handle.isValid()
+				? StringTable::getStringView(base_template_name_handle)
+				: dependent_base_name;
 		AliasTemplateMaterializationResult materialized_alias_base =
-			materializeTemplateInstantiationForLookup(
-				StringTable::getStringView(base_template_name_handle),
+			resolveCanonicalInstantiatedOwnerForLookup(
+				owner_lookup_name,
 				concrete_base_args);
+		if (materialized_alias_base.instantiated_name.empty() &&
+			materialized_alias_base.resolved_type_info == nullptr) {
+			materialized_alias_base =
+				materializeTemplateInstantiationForLookup(
+					owner_lookup_name,
+					concrete_base_args);
+		}
 		if (materialized_alias_base.instantiated_name.empty() &&
 			base_template_name_handle != dependent_base_info->baseTemplateName()) {
 			materialized_alias_base = materializeTemplateInstantiationForLookup(
@@ -2625,7 +2854,20 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 							materialized_member_chain.data(),
 							materialized_member_chain.size()));
 				resolved_member != nullptr) {
-				return resolved_member;
+				ResolvedAliasTypeInfo resolved_member_alias =
+					resolveAliasTypeInfo(
+						resolved_member->registeredTypeIndex().withCategory(
+							resolved_member->typeEnum()));
+				if (resolved_member_alias.terminal_type_info != nullptr &&
+					!resolved_member_alias.terminal_type_info->isDependentMemberType()) {
+					if (aliasPreservesSurfaceModifiers(*resolved_member)) {
+						return resolved_member;
+					}
+					return resolved_member_alias.terminal_type_info;
+				}
+				if (!resolved_member->isDependentMemberType()) {
+					return resolved_member;
+				}
 			}
 		}
 	}
@@ -2696,15 +2938,27 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				StringTable::getOrInternStringHandle(inherited_member_alias_name);
 		}
 	}
-	if (gTemplateRegistry.lookup_alias_template(materialized_member_alias_handle).has_value()) {
+	auto member_alias_entry =
+		gTemplateRegistry.lookup_alias_template(
+			StringTable::getStringView(materialized_member_alias_handle));
+	if (member_alias_entry.has_value()) {
 		InlineVector<TemplateTypeArg, 4> concrete_member_template_args;
+		size_t member_alias_param_count = 0;
+		if (member_alias_entry->is<TemplateAliasNode>()) {
+			member_alias_param_count =
+				member_alias_entry->as<TemplateAliasNode>().template_parameters().size();
+		}
 		if (dependent_member.has_template_arguments) {
 			concrete_member_template_args =
 				materialize_template_args_with_environment(
 					dependent_member.template_arguments);
-		} else if (!original_alias_target_info->templateArgs().empty()) {
+		} else if (member_alias_param_count != 0 &&
+				   !original_alias_target_info->templateArgs().empty()) {
 			concrete_member_template_args =
 				materialize_template_args_from_type_info(*original_alias_target_info);
+			if (concrete_member_template_args.size() > member_alias_param_count) {
+				concrete_member_template_args.resize(member_alias_param_count);
+			}
 		}
 		AliasTemplateMaterializationResult materialized_member_alias =
 			materializeAliasTemplateInstantiation(
@@ -2713,9 +2967,6 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		if (materialized_member_alias.resolved_type_info != nullptr) {
 			return materialized_member_alias.resolved_type_info;
 		}
-		auto member_alias_entry =
-			gTemplateRegistry.lookup_alias_template(
-				StringTable::getStringView(materialized_member_alias_handle));
 		if (member_alias_entry.has_value() &&
 			member_alias_entry->is<TemplateAliasNode>()) {
 			const TemplateAliasNode& member_alias_node =
@@ -2783,7 +3034,19 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		concrete_member_it->second != nullptr &&
 		!(concrete_member_it->second->is_incomplete_instantiation_ &&
 		  concrete_member_it->second->isDependentMemberType())) {
-		return concrete_member_it->second;
+		ResolvedAliasTypeInfo resolved_concrete_member = resolveAliasTypeInfo(
+			concrete_member_it->second->registeredTypeIndex().withCategory(
+				concrete_member_it->second->typeEnum()));
+		if (resolved_concrete_member.terminal_type_info != nullptr &&
+			isConcreteAliasSemanticSource(resolved_concrete_member.terminal_type_info)) {
+			if (aliasPreservesSurfaceModifiers(*concrete_member_it->second)) {
+				return concrete_member_it->second;
+			}
+			return resolved_concrete_member.terminal_type_info;
+		}
+		if (isConcreteAliasSemanticSource(concrete_member_it->second)) {
+			return concrete_member_it->second;
+		}
 	}
 
 	return nullptr;
@@ -2799,9 +3062,45 @@ bool Parser::resolveAliasTemplateInstantiation(
 		return false;
 	}
 
+	TypeSpecifierNode resolved_outer_spec = type_spec;
+	if (auto alias_entry = gTemplateRegistry.lookup_alias_template(alias_template_name);
+		alias_entry.has_value() && alias_entry->is<TemplateAliasNode>()) {
+		const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
+		const TypeSpecifierNode& alias_target_type_spec =
+			alias_node.target_type_node();
+		const bool alias_target_preserves_surface =
+			alias_target_type_spec.cv_qualifier() != CVQualifier::None ||
+			alias_target_type_spec.reference_qualifier() != ReferenceQualifier::None ||
+			alias_target_type_spec.pointer_depth() != 0 ||
+			alias_target_type_spec.has_function_signature() ||
+			alias_target_type_spec.is_array();
+		ASTNode substituted_alias_target_node = substituteTemplateParameters(
+			ASTNode(&alias_target_type_spec),
+			alias_node.template_parameters(),
+			template_args);
+		if (substituted_alias_target_node.is<TypeSpecifierNode>()) {
+			const TypeSpecifierNode& substituted_alias_target_spec =
+				substituted_alias_target_node.as<TypeSpecifierNode>();
+			if (alias_target_preserves_surface) {
+				if (const TypeInfo* concrete_member_alias =
+						materializeInstantiatedMemberAliasTarget(
+							substituted_alias_target_spec,
+							alias_node.template_parameters(),
+							template_args);
+					concrete_member_alias != nullptr) {
+					type_spec = resolveTypeInfoToTypeSpec(
+						*concrete_member_alias,
+						alias_target_type_spec);
+					return true;
+				}
+				resolved_outer_spec = alias_target_type_spec;
+			}
+		}
+	}
+
 	type_spec = resolveTypeInfoToTypeSpec(
 		*materialized_alias.resolved_type_info,
-		type_spec);
+		resolved_outer_spec);
 	return true;
 }
 
@@ -2932,7 +3231,22 @@ std::string_view Parser::instantiate_and_register_base_template(
 			// Now recursively instantiate the target template
 			// The target might itself be a template alias (chain of aliases)
 			std::string_view target_name(alias_node.target_template_name());
-			std::string_view instantiated_name = instantiate_and_register_base_template(target_name, substituted_args);
+			std::string_view instantiated_name;
+			if (!target_name.empty() &&
+				target_name != base_class_name &&
+				gTemplateRegistry.lookup_alias_template(target_name).has_value()) {
+				AliasTemplateMaterializationResult materialized_target_alias =
+					materializeAliasTemplateInstantiation(target_name, substituted_args);
+				if (materialized_target_alias.resolved_type_info != nullptr) {
+					instantiated_name =
+						StringTable::getStringView(materialized_target_alias.resolved_type_info->name());
+				} else {
+					instantiated_name = materialized_target_alias.instantiated_name;
+				}
+			}
+			if (instantiated_name.empty()) {
+				instantiated_name = instantiate_and_register_base_template(target_name, substituted_args);
+			}
 			if (!instantiated_name.empty()) {
 				if (alias_node.hasDeferredMemberTarget()) {
 					if (!hasComplexDeferredMemberChain(alias_node)) {
@@ -4211,6 +4525,9 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 						concrete_member_info->sizeInBits());
 				}
 			}
+			if (!isConcreteAliasSemanticSource(alias_semantic_source)) {
+				alias_semantic_source = nullptr;
+			}
 
 			// Register the type alias globally with its qualified name
 			TypeInfo* alias_info = nullptr;
@@ -4328,6 +4645,9 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 						original_nested_info->typeEnum());
 					alias_registration_type_spec.set_size_in_bits(
 						original_nested_info->sizeInBits());
+				}
+				if (!isConcreteAliasSemanticSource(alias_semantic_source)) {
+					alias_semantic_source = nullptr;
 				}
 
 				TypeInfo& alias_type_info =

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2645,10 +2645,6 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		}
 		return concrete_args;
 	};
-	auto materialize_template_args_from_type_info =
-		[&](const TypeInfo& source_type_info) -> InlineVector<TemplateTypeArg, 4> {
-		return materialize_template_args_with_environment(source_type_info.templateArgs());
-	};
 	auto template_args_still_dependent =
 		[](std::span<const TemplateTypeArg> args) -> bool {
 		for (const TemplateTypeArg& arg : args) {
@@ -2659,21 +2655,6 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			}
 		}
 		return false;
-	};
-	auto aliasPreservesSurfaceModifiers =
-		[](const TypeInfo& candidate_type_info) -> bool {
-		if (!candidate_type_info.isTypeAlias()) {
-			return false;
-		}
-		const TypeSpecifierNode* alias_spec = candidate_type_info.aliasTypeSpecifier();
-		if (alias_spec == nullptr) {
-			return false;
-		}
-		return alias_spec->pointer_depth() != 0 ||
-			   alias_spec->reference_qualifier() != ReferenceQualifier::None ||
-			   alias_spec->cv_qualifier() != CVQualifier::None ||
-			   alias_spec->is_array() ||
-			   alias_spec->has_function_signature();
 	};
 	StringHandle direct_concrete_member_handle =
 		StringTable::getOrInternStringHandle(
@@ -2692,7 +2673,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				direct_concrete_member_it->second->typeEnum()));
 		if (resolved_direct_concrete_member.terminal_type_info != nullptr &&
 			isConcreteAliasSemanticSource(resolved_direct_concrete_member.terminal_type_info)) {
-			if (aliasPreservesSurfaceModifiers(*direct_concrete_member_it->second)) {
+			if (typeAliasPreservesSurfaceModifiers(*direct_concrete_member_it->second)) {
 				return direct_concrete_member_it->second;
 			}
 			return resolved_direct_concrete_member.terminal_type_info;
@@ -2763,7 +2744,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			!dependent_name->owner_template_arguments.empty()
 				? materialize_template_args_with_environment(
 					  dependent_name->owner_template_arguments)
-				: materialize_template_args_from_type_info(*dependent_base_info);
+				: materialize_template_args_with_environment(dependent_base_info->templateArgs());
 		if (template_args_still_dependent(concrete_base_args)) {
 			return nullptr;
 		}
@@ -2821,8 +2802,8 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 						break;
 					}
 					InlineVector<TemplateTypeArg, 4> fallback_member_args =
-						materialize_template_args_from_type_info(
-							*original_alias_target_info);
+						materialize_template_args_with_environment(
+							original_alias_target_info->templateArgs());
 					if (template_args_still_dependent(fallback_member_args) ||
 						(!member_record.template_arguments.empty() &&
 						 fallback_member_args.size() !=
@@ -2857,7 +2838,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 							resolved_member->typeEnum()));
 				if (resolved_member_alias.terminal_type_info != nullptr &&
 					!resolved_member_alias.terminal_type_info->isDependentMemberType()) {
-					if (aliasPreservesSurfaceModifiers(*resolved_member)) {
+					if (typeAliasPreservesSurfaceModifiers(*resolved_member)) {
 						return resolved_member;
 					}
 					return resolved_member_alias.terminal_type_info;
@@ -2952,7 +2933,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		} else if (member_alias_param_count != 0 &&
 				   !original_alias_target_info->templateArgs().empty()) {
 			concrete_member_template_args =
-				materialize_template_args_from_type_info(*original_alias_target_info);
+				materialize_template_args_with_environment(original_alias_target_info->templateArgs());
 			if (concrete_member_template_args.size() > member_alias_param_count) {
 				concrete_member_template_args.resize(member_alias_param_count);
 			}
@@ -3036,7 +3017,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				concrete_member_it->second->typeEnum()));
 		if (resolved_concrete_member.terminal_type_info != nullptr &&
 			isConcreteAliasSemanticSource(resolved_concrete_member.terminal_type_info)) {
-			if (aliasPreservesSurfaceModifiers(*concrete_member_it->second)) {
+			if (typeAliasPreservesSurfaceModifiers(*concrete_member_it->second)) {
 				return concrete_member_it->second;
 			}
 			return resolved_concrete_member.terminal_type_info;

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -47,20 +47,43 @@ static bool appendOuterAliasTemplateSubstitutionInputs(
 	TemplateParamStorage& effective_template_params_storage,
 	TemplateArgStorage& effective_template_args_storage,
 	OnOuterParam on_outer_param) {
-	const size_t pair_count = std::min(
-		outer_binding.params.size(),
-		outer_binding.param_args.size());
-	for (size_t i = 0; i < pair_count; ++i) {
-		const TemplateParameterNode* outer_param =
-			tryGetTemplateParameterNode(outer_binding.params[i]);
-		if (outer_param == nullptr) {
-			return false;
+	if (!outer_binding.params.empty()) {
+		const size_t pair_count = std::min(
+			outer_binding.params.size(),
+			outer_binding.param_args.size());
+		for (size_t i = 0; i < pair_count; ++i) {
+			const TemplateParameterNode* outer_param =
+				tryGetTemplateParameterNode(outer_binding.params[i]);
+			if (outer_param == nullptr) {
+				continue;
+			}
+			effective_template_params_storage.push_back(*outer_param);
+			effective_template_args_storage.push_back(outer_binding.param_args[i]);
+			on_outer_param(*outer_param);
 		}
-		effective_template_params_storage.push_back(*outer_param);
-		effective_template_args_storage.push_back(outer_binding.param_args[i]);
-		on_outer_param(*outer_param);
+		if (!effective_template_args_storage.empty()) {
+			return true;
+		}
 	}
-	return true;
+
+	const size_t fallback_pair_count = std::min(
+		outer_binding.param_names.size(),
+		outer_binding.param_args.size());
+	for (size_t i = 0; i < fallback_pair_count; ++i) {
+		Token param_token(
+			Token::Type::Identifier,
+			StringTable::getStringView(outer_binding.param_names[i]),
+			0,
+			0,
+			0);
+		TemplateParameterNode outer_param(
+			outer_binding.param_names[i],
+			param_token);
+		effective_template_params_storage.push_back(outer_param);
+		effective_template_args_storage.push_back(outer_binding.param_args[i]);
+		on_outer_param(outer_param);
+	}
+	return !effective_template_args_storage.empty();
 }
 
 static void buildEffectiveAliasTemplateSubstitutionInputs(
@@ -1183,15 +1206,6 @@ std::optional<QualifiedTypeMemberAccess> Parser::materializeDeferredAliasMemberT
 	const DeferredAliasMemberTemplateSegment& segment,
 	std::span<const TemplateTypeArg> template_args,
 	StringHandle owner_qualified_handle) {
-	if (segment.has_template_arguments &&
-		!owner_qualified_handle.isValid()) {
-		FLASH_LOG_FORMAT(
-			Templates,
-			Debug,
-			"Skipping deferred alias member-template segment '{}' because owner-qualified template lookup did not resolve",
-			StringTable::getStringView(segment.name));
-		return std::nullopt;
-	}
 	const auto member_template_params = getTargetTemplateParameters(owner_qualified_handle);
 	InlineVector<TemplateTypeArg, 4> member_args;
 	std::span<const ASTNode> member_template_args(segment.template_args.data(), segment.template_args.size());
@@ -2397,6 +2411,14 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 		inherited_environment = buildTemplateEnvironment(*dependent_base_context);
 		inherited_environment_ptr = &inherited_environment;
 	}
+	TemplateEnvironment alias_target_environment;
+	if (const TypeInfo::InstantiationContext* alias_target_context =
+			semantic_alias_target_info->instantiationContext();
+		alias_target_context != nullptr) {
+		alias_target_environment = buildTemplateEnvironment(*alias_target_context);
+		alias_target_environment.parent = inherited_environment_ptr;
+		inherited_environment_ptr = &alias_target_environment;
+	}
 	TemplateEnvironment substitution_environment = buildTemplateEnvironment(
 		template_params,
 		template_args,
@@ -2556,6 +2578,7 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 	if (has_member_template_segment) {
 		std::vector<QualifiedTypeMemberAccess> materialized_member_chain;
 		materialized_member_chain.reserve(dependent_name->member_chain.size());
+		bool defer_to_alias_materialization = false;
 		for (const auto& member_record : dependent_name->member_chain) {
 			QualifiedTypeMemberAccess member_access;
 			member_access.member_name = member_record.name;
@@ -2564,7 +2587,24 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 					materialize_template_args_with_environment(
 						member_record.template_arguments);
 				if (template_args_still_dependent(concrete_member_args)) {
-					return nullptr;
+					const bool is_terminal_member =
+						&member_record == &dependent_name->member_chain.back();
+					if (!is_terminal_member ||
+						original_alias_target_info->templateArgs().empty()) {
+						defer_to_alias_materialization = true;
+						break;
+					}
+					InlineVector<TemplateTypeArg, 4> fallback_member_args =
+						materialize_template_args_from_type_info(
+							*original_alias_target_info);
+					if (template_args_still_dependent(fallback_member_args) ||
+						(!member_record.template_arguments.empty() &&
+						 fallback_member_args.size() !=
+							 member_record.template_arguments.size())) {
+						defer_to_alias_materialization = true;
+						break;
+					}
+					concrete_member_args = std::move(fallback_member_args);
 				}
 				std::vector<TemplateTypeArg> materialized_args(
 					concrete_member_args.begin(),
@@ -2577,14 +2617,16 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			materialized_member_chain.push_back(std::move(member_access));
 		}
 
-		if (const TypeInfo* resolved_member =
-				resolveBaseClassMemberTypeChain(
-					materialized_alias_base_name,
-					std::span<const QualifiedTypeMemberAccess>(
-						materialized_member_chain.data(),
-						materialized_member_chain.size()));
-			resolved_member != nullptr) {
-			return resolved_member;
+		if (!defer_to_alias_materialization) {
+			if (const TypeInfo* resolved_member =
+					resolveBaseClassMemberTypeChain(
+						materialized_alias_base_name,
+						std::span<const QualifiedTypeMemberAccess>(
+							materialized_member_chain.data(),
+							materialized_member_chain.size()));
+				resolved_member != nullptr) {
+				return resolved_member;
+			}
 		}
 	}
 
@@ -2660,15 +2702,9 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 			concrete_member_template_args =
 				materialize_template_args_with_environment(
 					dependent_member.template_arguments);
-			if (template_args_still_dependent(concrete_member_template_args)) {
-				return nullptr;
-			}
-		} else if (original_alias_target_info->isTemplateInstantiation()) {
+		} else if (!original_alias_target_info->templateArgs().empty()) {
 			concrete_member_template_args =
 				materialize_template_args_from_type_info(*original_alias_target_info);
-			if (template_args_still_dependent(concrete_member_template_args)) {
-				return nullptr;
-			}
 		}
 		AliasTemplateMaterializationResult materialized_member_alias =
 			materializeAliasTemplateInstantiation(
@@ -2676,6 +2712,62 @@ const TypeInfo* Parser::materializeInstantiatedMemberAliasTarget(
 				concrete_member_template_args);
 		if (materialized_member_alias.resolved_type_info != nullptr) {
 			return materialized_member_alias.resolved_type_info;
+		}
+		auto member_alias_entry =
+			gTemplateRegistry.lookup_alias_template(
+				StringTable::getStringView(materialized_member_alias_handle));
+		if (member_alias_entry.has_value() &&
+			member_alias_entry->is<TemplateAliasNode>()) {
+			const TemplateAliasNode& member_alias_node =
+				member_alias_entry->as<TemplateAliasNode>();
+			std::vector<TemplateParameterNode> combined_template_params;
+			std::vector<TemplateTypeArg> combined_template_args;
+			combined_template_params.reserve(
+				template_params.size() +
+				member_alias_node.template_parameters().size());
+			combined_template_args.reserve(
+				template_args.size() +
+				concrete_member_template_args.size());
+			combined_template_params.insert(
+				combined_template_params.end(),
+				template_params.begin(),
+				template_params.end());
+			combined_template_args.insert(
+				combined_template_args.end(),
+				template_args.begin(),
+				template_args.end());
+			const auto& member_alias_template_params =
+				member_alias_node.template_parameters();
+			const size_t member_alias_arg_count = std::min(
+				member_alias_template_params.size(),
+				concrete_member_template_args.size());
+			for (size_t i = 0; i < member_alias_arg_count; ++i) {
+				combined_template_params.push_back(
+					member_alias_template_params[i]);
+				combined_template_args.push_back(
+					concrete_member_template_args[i]);
+			}
+			ASTNode substituted_alias_target =
+				substituteTemplateParameters(
+					ASTNode(&member_alias_node.target_type_node()),
+					combined_template_params,
+					combined_template_args);
+			if (substituted_alias_target.is<TypeSpecifierNode>()) {
+				const TypeSpecifierNode& substituted_alias_target_spec =
+					substituted_alias_target.as<TypeSpecifierNode>();
+				if (const TypeInfo* substituted_alias_target_info =
+						tryGetTypeInfo(substituted_alias_target_spec.type_index());
+					substituted_alias_target_info != nullptr) {
+					ResolvedAliasTypeInfo resolved_alias_target =
+						resolveAliasTypeInfo(
+							substituted_alias_target_info->registeredTypeIndex().withCategory(
+								substituted_alias_target_info->typeEnum()));
+					if (resolved_alias_target.terminal_type_info != nullptr) {
+						return resolved_alias_target.terminal_type_info;
+					}
+					return substituted_alias_target_info;
+				}
+			}
 		}
 	}
 

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2759,8 +2759,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				parsed_type_info != nullptr && parsed_type_info->isTemplateInstantiation();
 			const bool token_names_entire_type =
 				parsed_type_info == nullptr ||
-				StringTable::getStringView(parsed_type_info->name()) ==
-					StringTable::getStringView(template_name_handle);
+				parsed_type_info->name() == template_name_handle;
 			if (template_name_handle.isValid() &&
 				token_names_entire_type &&
 				!parsed_type_is_template_id &&

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2757,7 +2757,12 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				: nullptr;
 			const bool parsed_type_is_template_id =
 				parsed_type_info != nullptr && parsed_type_info->isTemplateInstantiation();
+			const bool token_names_entire_type =
+				parsed_type_info == nullptr ||
+				StringTable::getStringView(parsed_type_info->name()) ==
+					StringTable::getStringView(template_name_handle);
 			if (template_name_handle.isValid() &&
+				token_names_entire_type &&
 				!parsed_type_is_template_id &&
 				(gTemplateRegistry.lookup_alias_template(template_name_handle).has_value() ||
 				 gTemplateRegistry.lookupTemplate(template_name_handle).has_value() ||

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1806,6 +1806,36 @@ ParseResult Parser::parse_type_specifier() {
 						// since we already know this is an alias template.
 						AliasTemplateMaterializationResult materialized_alias =
 							materializeAliasTemplateInstantiation(type_name, *template_args);
+						if (materialized_alias.resolved_type_info != nullptr) {
+							const TypeInfo* materialized_info = materialized_alias.resolved_type_info;
+							FLASH_LOG(
+								Parser,
+								Debug,
+								"Alias materialized: name='",
+								materialized_alias.instantiated_name,
+								"', resolved='",
+								StringTable::getStringView(materialized_info->name()),
+								"', type=",
+								static_cast<int>(materialized_info->typeEnum()),
+								", type_index=",
+								materialized_info->registeredTypeIndex().index());
+							if (const TypeSpecifierNode* alias_spec = materialized_info->aliasTypeSpecifier();
+								alias_spec != nullptr) {
+								FLASH_LOG(
+									Parser,
+									Debug,
+									"Alias materialized spec: type=",
+									static_cast<int>(alias_spec->type()),
+									", type_index=",
+									alias_spec->type_index().index(),
+									", cv=",
+									static_cast<int>(alias_spec->cv_qualifier()),
+									", ref=",
+									static_cast<int>(alias_spec->reference_qualifier()),
+									", ptr=",
+									alias_spec->pointer_depth());
+							}
+						}
 						if (!materialized_alias.instantiated_name.empty()) {
 							normalizePendingSemanticRoots();
 							if (materialized_alias.resolved_type_info == nullptr) {

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1711,6 +1711,41 @@ ParseResult Parser::parse_type_specifier() {
 						// member against the concrete instantiated base before falling back to the
 						// placeholder type carried by the alias target.
 						if (peek() != "::"_tok && targetMemberName.has_value()) {
+							// A chained alias may already be fully materialized to its resolved
+							// member type (e.g. require_integral<int> -> enable_if_t<...>::type ->
+							// int).  In that case `instantiated_type_name` denotes the terminal type
+							// rather than the base struct that exposes the member, so re-deriving
+							// "name::member" would fabricate a bogus dependent placeholder (size 0).
+							// Only append the member when the base type actually declares it.
+							StringHandle resolved_member_handle = buildQualifiedMemberNameHandle(
+								StringTable::getOrInternStringHandle(resolved_instantiated_type_name),
+								StringTable::getOrInternStringHandle(*targetMemberName));
+							const bool base_declares_member =
+								getTypesByNameMap().find(resolved_member_handle) != getTypesByNameMap().end();
+							if (!base_declares_member) {
+								// Map the terminal back to a concrete type.  The materialized name
+								// may be a builtin spelling ("int") or a canonical native name
+								// ("longlong"); both are already terminal and lack the member.
+								TypeCategory terminal_category = TypeCategory::Invalid;
+								if (auto builtin_type = get_builtin_type_info(resolved_instantiated_type_name)) {
+									terminal_category = builtin_type->first;
+								} else {
+									terminal_category = TemplateRegistry::stringToType(resolved_instantiated_type_name);
+								}
+								if (terminal_category != TypeCategory::Invalid) {
+									if (const TypeInfo* native_type_info =
+											tryGetTypeInfo(nativeTypeIndex(terminal_category));
+										native_type_info != nullptr) {
+										return buildTypeFromInfo(*native_type_info, type_name_token, true);
+									}
+								}
+								if (const TypeInfo* terminal_type_info = findTypeByName(
+										StringTable::getOrInternStringHandle(resolved_instantiated_type_name));
+									terminal_type_info != nullptr &&
+									!terminal_type_info->is_incomplete_instantiation_) {
+									return buildTypeFromInfo(*terminal_type_info, type_name_token, true);
+								}
+							}
 							if (const TypeInfo* concrete_member_info =
 									materializeInstantiatedMemberAliasTarget(
 										alias_node.target_type_node(),

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1197,6 +1197,118 @@ ParseResult Parser::parse_type_specifier() {
 					 alias_target_info->isDependentPlaceholder() ||
 					 alias_target_info->isTemplateInstantiation());
 				if (target_is_dependent) {
+					auto make_alias_target_dependent_record =
+						[&]() -> std::optional<TypeInfo::DependentQualifiedNameRecord> {
+						if (alias_target_info == nullptr) {
+							return std::nullopt;
+						}
+						std::string_view suffix_path = member_suffix;
+						if (suffix_path.starts_with("::")) {
+							suffix_path.remove_prefix(2);
+						}
+						if (suffix_path.empty()) {
+							return std::nullopt;
+						}
+
+						auto append_suffix_chain =
+							[&](TypeInfo::DependentQualifiedNameRecord& record) {
+							for (std::string_view component : splitDependentMemberPathComponents(suffix_path)) {
+								if (component.empty()) {
+									continue;
+								}
+								if (size_t template_marker = component.find('<');
+									template_marker != std::string_view::npos) {
+									component = component.substr(0, template_marker);
+								}
+								TypeInfo::DependentQualifiedNameRecord::Member member;
+								member.name = StringTable::getOrInternStringHandle(component);
+								record.member_chain.push_back(std::move(member));
+							}
+						};
+
+						if (alias_target_info->hasDependentQualifiedName()) {
+							TypeInfo::DependentQualifiedNameRecord record =
+								*alias_target_info->dependentQualifiedName();
+							append_suffix_chain(record);
+							return record;
+						}
+
+						if (!alias_target_info->isTemplateInstantiation()) {
+							return std::nullopt;
+						}
+
+						TypeInfo::DependentQualifiedNameRecord record;
+						record.owner_kind =
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
+						record.owner_name = alias_target_info->baseTemplateName();
+						StringHandle qualified_owner_name =
+							gNamespaceRegistry.buildQualifiedIdentifier(
+								alias_target_info->sourceNamespace(),
+								alias_target_info->baseTemplateName());
+						if (qualified_owner_name.isValid() &&
+							!StringTable::getStringView(qualified_owner_name).empty()) {
+							record.owner_name = qualified_owner_name;
+						}
+						record.owner_template_arguments =
+							alias_target_info->templateArgs();
+
+						auto classify_current_instantiation_owner =
+							[&](TypeIndex current_owner_type_index) {
+							if (!current_owner_type_index.is_valid()) {
+								return false;
+							}
+							const TypeInfo* current_owner_type_info =
+								tryGetTypeInfo(current_owner_type_index);
+							if (current_owner_type_info == nullptr ||
+								!current_owner_type_info->isTemplateInstantiation()) {
+								return false;
+							}
+							if (current_owner_type_info->baseTemplateName() !=
+								alias_target_info->baseTemplateName()) {
+								return false;
+							}
+							if (current_owner_type_info->sourceNamespace() !=
+								alias_target_info->sourceNamespace()) {
+								return false;
+							}
+							record.owner_kind =
+								TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation;
+							record.owner_type =
+								current_owner_type_info->registeredTypeIndex();
+							record.names_current_instantiation = true;
+							return true;
+						};
+						bool is_current_instantiation_owner = false;
+						if (!member_function_context_stack_.empty()) {
+							is_current_instantiation_owner =
+								classify_current_instantiation_owner(
+									member_function_context_stack_.back().struct_type_index);
+						}
+						if (!is_current_instantiation_owner &&
+							!struct_parsing_context_stack_.empty()) {
+							StringHandle active_struct_handle =
+								StringTable::getOrInternStringHandle(
+									struct_parsing_context_stack_.back().struct_name);
+							if (auto active_struct_it = getTypesByNameMap().find(active_struct_handle);
+								active_struct_it != getTypesByNameMap().end() &&
+								active_struct_it->second != nullptr) {
+								is_current_instantiation_owner =
+									classify_current_instantiation_owner(
+										active_struct_it->second->registeredTypeIndex());
+							}
+						}
+						if (!is_current_instantiation_owner &&
+							(!struct_parsing_context_stack_.empty() ||
+							 !member_function_context_stack_.empty())) {
+							record.owner_kind =
+								TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization;
+						}
+
+						append_suffix_chain(record);
+						return record;
+					};
+					std::optional<TypeInfo::DependentQualifiedNameRecord> dependent_record =
+						make_alias_target_dependent_record();
 					StringHandle target_member_handle = StringTable::getOrInternStringHandle(
 						StringBuilder()
 							.append(StringTable::getStringView(alias_target_info->name()))
@@ -1205,6 +1317,12 @@ ParseResult Parser::parse_type_specifier() {
 					auto existing_target_member = getTypesByNameMap().find(target_member_handle);
 					TypeIndex target_member_index;
 					if (existing_target_member != getTypesByNameMap().end()) {
+						if (dependent_record.has_value() &&
+							existing_target_member->second != nullptr &&
+							existing_target_member->second->isDependentMemberType() &&
+							!existing_target_member->second->hasDependentQualifiedName()) {
+							existing_target_member->second->setDependentQualifiedName(*dependent_record);
+						}
 						target_member_index = existing_target_member->second->registeredTypeIndex();
 					} else {
 						TypeInfo& placeholder_type = add_empty_type_entry();
@@ -1212,6 +1330,9 @@ ParseResult Parser::parse_type_specifier() {
 						placeholder_type.name_ = target_member_handle;
 						placeholder_type.is_incomplete_instantiation_ = true;
 						placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+						if (dependent_record.has_value()) {
+							placeholder_type.setDependentQualifiedName(*dependent_record);
+						}
 						if (alias_target_info->isTemplateInstantiation()) {
 							placeholder_type.setTemplateInstantiationInfo(
 								alias_target_info->base_template_,
@@ -1261,22 +1382,71 @@ ParseResult Parser::parse_type_specifier() {
 			}
 
 			if (is_dependent_qualified_type) {
+				const TypeInfo* owner_type_info = nullptr;
+				TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind =
+					TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter;
+				InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments;
+				StringHandle owner_name_handle =
+					StringTable::getOrInternStringHandle(base_part);
+				TypeIndex owner_type_index{};
+				if (auto owner_it = getTypesByNameMap().find(owner_name_handle);
+					owner_it != getTypesByNameMap().end() &&
+					owner_it->second != nullptr) {
+					owner_type_info = owner_it->second;
+					owner_type_index = owner_type_info->registeredTypeIndex();
+					if (owner_type_info->isTemplateInstantiation()) {
+						owner_kind =
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
+						owner_name_handle = owner_type_info->baseTemplateName();
+						StringHandle qualified_owner_name =
+							gNamespaceRegistry.buildQualifiedIdentifier(
+								owner_type_info->sourceNamespace(),
+								owner_type_info->baseTemplateName());
+						if (qualified_owner_name.isValid() &&
+							!StringTable::getStringView(qualified_owner_name).empty()) {
+							owner_name_handle = qualified_owner_name;
+						}
+						owner_template_arguments = owner_type_info->templateArgs();
+					}
+				}
 				if (auto typename_error = diagnoseMissingTypenameForDependentOwner(
-						TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
+						owner_kind,
 						last_qualified_token,
 						false);
 					typename_error.has_value()) {
 					return *typename_error;
 				}
 				StringHandle type_handle = StringTable::getOrInternStringHandle(type_name);
-				StringHandle owner_handle =
-					StringTable::getOrInternStringHandle(base_part);
-				TypeIndex owner_type_index{};
-				if (auto owner_it = getTypesByNameMap().find(owner_handle);
-					owner_it != getTypesByNameMap().end() &&
-					owner_it->second != nullptr) {
-					owner_type_index = owner_it->second->registeredTypeIndex();
-				}
+				auto make_simple_dependent_record =
+					[&]() -> TypeInfo::DependentQualifiedNameRecord {
+					if (owner_type_info != nullptr &&
+						owner_type_info->hasDependentQualifiedName()) {
+						TypeInfo::DependentQualifiedNameRecord record =
+							*owner_type_info->dependentQualifiedName();
+						for (std::string_view component :
+							 splitDependentMemberPathComponents(
+								 type_name.substr(type_name.find("::") + 2))) {
+							if (component.empty()) {
+								continue;
+							}
+							if (size_t template_marker = component.find('<');
+								template_marker != std::string_view::npos) {
+								component = component.substr(0, template_marker);
+							}
+							TypeInfo::DependentQualifiedNameRecord::Member member;
+							member.name = StringTable::getOrInternStringHandle(component);
+							record.member_chain.push_back(std::move(member));
+						}
+						return record;
+					}
+					return makeDependentQualifiedNameRecord(
+						owner_name_handle,
+						owner_type_index,
+						owner_kind,
+						owner_template_arguments,
+						type_name.substr(type_name.find("::") + 2),
+						{});
+				};
 				auto type_it = getTypesByNameMap().find(type_handle);
 				TypeIndex type_idx;
 				if (type_it == getTypesByNameMap().end()) {
@@ -1286,13 +1456,16 @@ ParseResult Parser::parse_type_specifier() {
 					placeholder_type.is_incomplete_instantiation_ = true;
 					placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
 					placeholder_type.setDependentQualifiedName(
-						makeDependentQualifiedNameRecord(
-							owner_handle,
-							owner_type_index,
-							TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
-							InlineVector<TypeInfo::TemplateArgInfo, 4>{},
-							type_name.substr(type_name.find("::") + 2),
-							{}));
+						make_simple_dependent_record());
+					if (owner_type_info != nullptr &&
+						owner_type_info->hasInstantiationContext()) {
+						const TypeInfo::InstantiationContext* owner_context =
+							owner_type_info->instantiationContext();
+						placeholder_type.setInstantiationContext(
+							owner_context->param_names,
+							owner_context->param_args,
+							owner_context->parent);
+					}
 					getTypesByNameMap()[type_handle] = &placeholder_type;
 					type_idx = placeholder_type.type_index_;
 				} else {
@@ -1300,13 +1473,18 @@ ParseResult Parser::parse_type_specifier() {
 						type_it->second->isDependentMemberType() &&
 						!type_it->second->hasDependentQualifiedName()) {
 						type_it->second->setDependentQualifiedName(
-							makeDependentQualifiedNameRecord(
-								owner_handle,
-								owner_type_index,
-								TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter,
-								InlineVector<TypeInfo::TemplateArgInfo, 4>{},
-								type_name.substr(type_name.find("::") + 2),
-								{}));
+							make_simple_dependent_record());
+					}
+					if (type_it->second != nullptr &&
+						owner_type_info != nullptr &&
+						!type_it->second->hasInstantiationContext() &&
+						owner_type_info->hasInstantiationContext()) {
+						const TypeInfo::InstantiationContext* owner_context =
+							owner_type_info->instantiationContext();
+						type_it->second->setInstantiationContext(
+							owner_context->param_names,
+							owner_context->param_args,
+							owner_context->parent);
 					}
 					type_idx = type_it->second->type_index_;
 				}
@@ -1448,6 +1626,30 @@ ParseResult Parser::parse_type_specifier() {
 							placeholder_type.name_ = qualified_member_handle;
 							placeholder_type.is_incomplete_instantiation_ = true;
 							placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+							if (auto base_type_it = getTypesByNameMap().find(
+									StringTable::getOrInternStringHandle(base_type_name));
+								base_type_it != getTypesByNameMap().end() &&
+								base_type_it->second != nullptr &&
+								base_type_it->second->isTemplateInstantiation()) {
+								const TypeInfo& base_type_info = *base_type_it->second;
+								StringHandle owner_name = base_type_info.baseTemplateName();
+								if (!owner_name.isValid()) {
+									owner_name = base_type_info.name();
+								}
+								InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments =
+									base_type_info.templateArgs();
+								DependentMemberSegmentInfo terminal_segment_info;
+								placeholder_type.setDependentQualifiedName(
+									makeDependentQualifiedNameRecord(
+										owner_name,
+										base_type_info.registeredTypeIndex(),
+										TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation,
+										std::move(owner_template_arguments),
+										member_name,
+										std::span<const DependentMemberSegmentInfo>(
+											&terminal_segment_info,
+											1)));
+							}
 							getTypesByNameMap()[qualified_member_handle] = &placeholder_type;
 							return placeholder_type;
 						}
@@ -1688,6 +1890,15 @@ ParseResult Parser::parse_type_specifier() {
 									instantiated_type = resolveTypeInfoToTypeSpec(
 										*materialized_target.resolved_type_info, instantiated_type);
 								}
+							}
+						} else {
+							ASTNode substituted_alias_target = substituteTemplateParameters(
+								ASTNode::emplace_node<TypeSpecifierNode>(alias_node.target_type_node()),
+								alias_node.template_parameters(),
+								*template_args);
+							if (substituted_alias_target.is<TypeSpecifierNode>()) {
+								instantiated_type =
+									substituted_alias_target.as<TypeSpecifierNode>();
 							}
 						}
 					}
@@ -2833,6 +3044,60 @@ ParseResult Parser::parse_type_specifier() {
 								instantiated_type = resolveTypeInfoToTypeSpec(
 									*materialized_member_alias_target,
 									instantiated_type);
+							} else {
+								ASTNode substituted_member_alias_target = substituteTemplateParameters(
+									ASTNode::emplace_node<TypeSpecifierNode>(alias_node.target_type_node()),
+									alias_node.template_parameters(),
+									*member_template_args);
+								if (substituted_member_alias_target.is<TypeSpecifierNode>()) {
+									instantiated_type =
+										substituted_member_alias_target.as<TypeSpecifierNode>();
+								}
+							}
+							if (instantiated_type.type_index().is_valid()) {
+								if (TypeInfo* instantiated_type_info =
+										tryGetTypeInfoMut(instantiated_type.type_index());
+									instantiated_type_info != nullptr &&
+									instantiated_type_info->isDependentMemberType() &&
+									instantiated_type_info->hasDependentQualifiedName()) {
+									InlineVector<StringHandle, 4> merged_param_names;
+									InlineVector<TypeInfo::TemplateArgInfo, 4> merged_param_args;
+									if (instantiated_type_info->hasInstantiationContext()) {
+										const TypeInfo::InstantiationContext* existing_context =
+											instantiated_type_info->instantiationContext();
+										merged_param_names = existing_context->param_names;
+										merged_param_args = existing_context->param_args;
+									}
+									const auto alias_arg_infos =
+										convertToTemplateArgInfo(*member_template_args);
+									const size_t alias_pair_count = std::min(
+										alias_node.template_parameters().size(),
+										alias_arg_infos.size());
+									for (size_t i = 0; i < alias_pair_count; ++i) {
+										const StringHandle alias_param_name =
+											alias_node.template_parameters()[i].nameHandle();
+										auto existing_name_it = std::find(
+											merged_param_names.begin(),
+											merged_param_names.end(),
+											alias_param_name);
+										if (existing_name_it == merged_param_names.end()) {
+											merged_param_names.push_back(alias_param_name);
+											merged_param_args.push_back(alias_arg_infos[i]);
+										} else {
+											const size_t existing_index =
+												static_cast<size_t>(std::distance(
+													merged_param_names.begin(),
+													existing_name_it));
+											merged_param_args[existing_index] = alias_arg_infos[i];
+										}
+									}
+									if (!merged_param_names.empty() && !merged_param_args.empty()) {
+										instantiated_type_info->setInstantiationContext(
+											std::move(merged_param_names),
+											std::move(merged_param_args),
+											nullptr);
+									}
+								}
 							}
 
 							return ParseResult::success(emplace_node<TypeSpecifierNode>(instantiated_type));

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -53,6 +53,27 @@ InlineVector<std::string_view, 4> splitDependentMemberPathComponents(
 	return components;
 }
 
+// Split a dependent member path (e.g. "Inner::type") into components, strip any
+// trailing template-argument list from each, and append them to the record's
+// member chain. Centralizes logic shared by the dependent-record builders and
+// keeps the path splitting bounds-safe.
+void appendDependentMemberPathComponents(
+	TypeInfo::DependentQualifiedNameRecord& record,
+	std::string_view member_path) {
+	for (std::string_view component : splitDependentMemberPathComponents(member_path)) {
+		if (component.empty()) {
+			continue;
+		}
+		if (size_t template_marker = component.find('<');
+			template_marker != std::string_view::npos) {
+			component = component.substr(0, template_marker);
+		}
+		TypeInfo::DependentQualifiedNameRecord::Member member;
+		member.name = StringTable::getOrInternStringHandle(component);
+		record.member_chain.push_back(std::move(member));
+	}
+}
+
 TypeInfo::DependentQualifiedNameRecord makeDependentQualifiedNameRecord(
 	StringHandle owner_name,
 	TypeIndex owner_type,
@@ -1212,18 +1233,7 @@ ParseResult Parser::parse_type_specifier() {
 
 						auto append_suffix_chain =
 							[&](TypeInfo::DependentQualifiedNameRecord& record) {
-							for (std::string_view component : splitDependentMemberPathComponents(suffix_path)) {
-								if (component.empty()) {
-									continue;
-								}
-								if (size_t template_marker = component.find('<');
-									template_marker != std::string_view::npos) {
-									component = component.substr(0, template_marker);
-								}
-								TypeInfo::DependentQualifiedNameRecord::Member member;
-								member.name = StringTable::getOrInternStringHandle(component);
-								record.member_chain.push_back(std::move(member));
-							}
+							appendDependentMemberPathComponents(record, suffix_path);
 						};
 
 						if (alias_target_info->hasDependentQualifiedName()) {
@@ -1423,20 +1433,12 @@ ParseResult Parser::parse_type_specifier() {
 						owner_type_info->hasDependentQualifiedName()) {
 						TypeInfo::DependentQualifiedNameRecord record =
 							*owner_type_info->dependentQualifiedName();
-						for (std::string_view component :
-							 splitDependentMemberPathComponents(
-								 type_name.substr(type_name.find("::") + 2))) {
-							if (component.empty()) {
-								continue;
-							}
-							if (size_t template_marker = component.find('<');
-								template_marker != std::string_view::npos) {
-								component = component.substr(0, template_marker);
-							}
-							TypeInfo::DependentQualifiedNameRecord::Member member;
-							member.name = StringTable::getOrInternStringHandle(component);
-							record.member_chain.push_back(std::move(member));
+						std::string_view member_path;
+						if (size_t owner_sep = type_name.find("::");
+							owner_sep != std::string_view::npos) {
+							member_path = type_name.substr(owner_sep + 2);
 						}
+						appendDependentMemberPathComponents(record, member_path);
 						return record;
 					}
 					return makeDependentQualifiedNameRecord(

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -1267,6 +1267,32 @@ inline bool typeAliasPreservesSurfaceModifiers(const TypeInfo& type_info) {
 		   alias_spec->has_function_signature();
 }
 
+// A TypeInfo is a concrete alias semantic source when it resolves to a fully
+// materialized, non-dependent type that can stand in as the terminal type of an
+// alias chain. Placeholders, dependent members, and types still carrying
+// dependent placeholders are rejected so callers don't latch onto an unresolved
+// stand-in.
+inline bool isConcreteAliasSemanticSource(const TypeInfo* type_info) {
+	if (type_info == nullptr) {
+		return false;
+	}
+	if (type_info->isTemplatePlaceholder() ||
+		type_info->isDependentPlaceholder() ||
+		(type_info->is_incomplete_instantiation_ &&
+		 type_info->isDependentMemberType())) {
+		return false;
+	}
+	const TypeIndex registered_index =
+		type_info->registeredTypeIndex().withCategory(type_info->typeEnum());
+	if (!registered_index.is_valid()) {
+		return false;
+	}
+	if (typeIndexContainsDependentPlaceholder(registered_index)) {
+		return false;
+	}
+	return true;
+}
+
 // Convenience wrapper: resolve a TypeInfo through its alias chain, compose outer
 // modifiers from `outer_spec`, and convert the result to a TypeSpecifierNode.
 // This is the most common pattern in alias-template substitution paths.

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -1246,6 +1246,27 @@ inline TemplateTypeArg resolveTypeInfoToTemplateArg(
 		TemplateTypeArg(outer_spec));
 }
 
+// A member type alias such as `using type = T;` instantiated with `T = int*`
+// stores the terminal type (`int`) in its TypeIndex while keeping the pointer,
+// reference, cv, array, or function-signature indirection in its aliasTypeSpecifier.
+// Collapsing such an alias to its terminal type would silently drop those surface
+// modifiers, so callers that resolve dependent member aliases must keep the alias
+// itself whenever this returns true.
+inline bool typeAliasPreservesSurfaceModifiers(const TypeInfo& type_info) {
+	if (!type_info.isTypeAlias()) {
+		return false;
+	}
+	const TypeSpecifierNode* alias_spec = type_info.aliasTypeSpecifier();
+	if (alias_spec == nullptr) {
+		return false;
+	}
+	return alias_spec->pointer_depth() != 0 ||
+		   alias_spec->reference_qualifier() != ReferenceQualifier::None ||
+		   alias_spec->cv_qualifier() != CVQualifier::None ||
+		   alias_spec->is_array() ||
+		   alias_spec->has_function_signature();
+}
+
 // Convenience wrapper: resolve a TypeInfo through its alias chain, compose outer
 // modifiers from `outer_spec`, and convert the result to a TypeSpecifierNode.
 // This is the most common pattern in alias-template substitution paths.


### PR DESCRIPTION
## Summary

This PR advances the template-argument infrastructure toward C++20-conformant dependent-member handling. Dependent member alias resolution now flows through semantic metadata instead of a textual `base::member` fallback, surface modifiers (pointer/reference/cv/array/function) are preserved across alias chains, and the shared resolution helpers are deduplicated.

The full Windows test suite is green on this branch.

## What changed

### Semantic dependent-member alias resolution
- `src/Parser_Templates_Inst_Deduction.cpp`
  - Removes the textual `base::member` fallback in `resolveDependentMemberAlias()`; resolution is now semantic-only.
- `src/Parser_TypeSpecifiers.cpp`
  - Preserves/propagates `DependentQualifiedNameRecord` when creating dependent placeholders from alias targets like `self_type::Mid`, and classifies current-instantiation owners in that path.
  - In `finalizeInstantiatedAliasType`, returns a fully-materialized terminal type directly (e.g. builtin `int` or canonical native `longlong`) instead of fabricating a bogus size-0 `name::member` placeholder when the base does not declare the member.
- `src/Parser_Templates_Inst_Substitution.cpp`
  - Continues dependent member-template chain materialization through alias materialization paths instead of aborting early in dependent cases.
- `src/Parser_Templates_Params.cpp`
  - Fixes explicit-template-argument classification so qualified dependent type arguments are not misclassified as template-template arguments.

### Surface-modifier preservation across alias chains
- A shared `typeAliasPreservesSurfaceModifiers()` helper (in `src/TemplateRegistry_Types.h`) is used by `ExpressionSubstitutor.cpp` and the substitution path so that pointer/reference/cv/array/function indirection on a member alias is not silently dropped when collapsing an alias to its terminal type.

### Cleanup / deduplication (from PR review feedback)
- Extracts a shared `appendDependentMemberPathComponents()` helper in `Parser_TypeSpecifiers.cpp`, removing duplicated dependent-member path splitting and making the owner `::` split bounds-safe.
- Promotes the identical `isConcreteAliasSemanticSource()` helper (previously duplicated across `Parser_Templates_Inst_ClassTemplate.cpp` and `Parser_Templates_Inst_Substitution.cpp`) into `TemplateRegistry_Types.h` as a shared inline helper, and updates all call sites.
- Replaces a `StringTable::getStringView()` string comparison with a direct O(1) `StringHandle ==` comparison.
- Consolidates duplicated template-argument dependency checks.

## Validation

Previously-failing dependent member aliasing tests now pass:
- ✅ `tests/test_template_member_alias_preserves_pointer_ret0.cpp`
- ✅ `tests/test_dependent_sizeof_alignof_template_arg_ret0.cpp`
- ✅ `tests/test_alias_chain_dependent_bool_sizeof_ret0.cpp`

Full Windows suite: **2606 passed, 0 failures, 0 return mismatches, 188 expected-fails correct.**
