### PR TITLE
Templates: tighten replay attachment evidence

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -46,8 +46,8 @@ attachment evidence-driven rather than shape-driven.
   owner/member-chain records, active template bindings, and inherited
   member-template lookup; the hard-coded constexpr scan for matching generated
   member-template names is gone
-- out-of-line member-template replay no longer treats failed replay attachment
-  as recoverable: if replay identity plus substituted-signature evidence cannot
+- out-of-line member replay no longer treats failed replay attachment as
+  recoverable: if replay identity plus substituted-signature evidence cannot
   attach the definition, instantiation now fails instead of silently
   continuing into later template instantiation paths
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -46,6 +46,10 @@ attachment evidence-driven rather than shape-driven.
   owner/member-chain records, active template bindings, and inherited
   member-template lookup; the hard-coded constexpr scan for matching generated
   member-template names is gone
+- out-of-line member-template replay no longer treats failed replay attachment
+  as recoverable: if replay identity plus substituted-signature evidence cannot
+  attach the definition, instantiation now fails instead of silently
+  continuing into later template instantiation paths
 
 ## Main remaining architectural gap
 
@@ -72,7 +76,9 @@ evidence. Tightening those is the next best cleanup target.
 2. Keep replay attachment evidence-driven.
    Continue tightening declaration replay so attachment succeeds because source
    identity and canonical substituted signatures match, not because a fallback
-   scan guessed correctly.
+   scan guessed correctly. The next likely slice is the remaining plain-member
+   and unresolved-signature acceptance paths that still tolerate shape-first
+   replay attachment.
 
 3. Extend dependent-name modeling only where it unlocks step 2.
    Richer current-instantiation and unknown-specialization handling still

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -34,6 +34,9 @@ Move FlashCpp toward a sema-owned template system where:
 - dependent nested member-template static constexpr chains now reuse typed
   owner/member-chain records, active template bindings, and inherited
   member-template lookup instead of hard-coded constexpr name scans
+- out-of-line member-template replay attachment now fails instantiation when
+  replay identity plus substituted-signature evidence cannot attach the
+  definition, instead of silently continuing into later template instantiation
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type
@@ -62,6 +65,8 @@ unknown-specialization modeling only where it unblocks those paths.
 
 2. Continue tightening replay attachment so valid cases succeed via source
    identity plus canonical substituted-signature evidence, not fallback scans.
+   The next slice is likely the remaining plain-member or unresolved-signature
+   acceptance paths where replay can still succeed without enough evidence.
 
 3. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks step 2.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -34,9 +34,9 @@ Move FlashCpp toward a sema-owned template system where:
 - dependent nested member-template static constexpr chains now reuse typed
   owner/member-chain records, active template bindings, and inherited
   member-template lookup instead of hard-coded constexpr name scans
-- out-of-line member-template replay attachment now fails instantiation when
-  replay identity plus substituted-signature evidence cannot attach the
-  definition, instead of silently continuing into later template instantiation
+- out-of-line member replay attachment now fails instantiation when replay
+  identity plus substituted-signature evidence cannot attach the definition,
+  instead of silently continuing into later template instantiation
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -57,10 +57,9 @@ FlashCpp follows a parse -> sema -> IR pipeline:
   owner/member-chain records, active template bindings, inherited
   member-template lookup, and replayed static-initializer substitution instead
   of hard-coded constexpr name scans
-- out-of-line member-template replay attachment now fails the instantiation
-  when replay identity plus substituted-signature evidence cannot attach the
-  definition, instead of logging and continuing into later template
-  instantiation paths
+- out-of-line member replay attachment now fails the instantiation when replay
+  identity plus substituted-signature evidence cannot attach the definition,
+  instead of logging and continuing into later template instantiation paths
 
 ## Main remaining gaps
 

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -57,6 +57,10 @@ FlashCpp follows a parse -> sema -> IR pipeline:
   owner/member-chain records, active template bindings, inherited
   member-template lookup, and replayed static-initializer substitution instead
   of hard-coded constexpr name scans
+- out-of-line member-template replay attachment now fails the instantiation
+  when replay identity plus substituted-signature evidence cannot attach the
+  definition, instead of logging and continuing into later template
+  instantiation paths
 
 ## Main remaining gaps
 
@@ -83,8 +87,8 @@ The next template task is narrower and more architectural:
 
 - keep declaration replay attached by source identity plus canonical
   substituted-signature evidence
-- continue shrinking name/arity or shape-driven replay attachment where it
-  still exists
+- continue shrinking plain-member and unresolved-signature replay acceptance
+  where name/shape still wins without enough evidence
 - expand current-instantiation and unknown-specialization handling only where
   it unblocks those replay paths
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -12107,7 +12107,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (force_eager) {
 							throw InternalError(error_msg);
 						}
-						return std::nullopt;
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 				}
 			}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -15154,8 +15154,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		}
 
 		if (!found_match) {
-			FLASH_LOG(Templates, Warning, "Out-of-line member function ", decl.identifier_token().value(),
-					  " not found in instantiated struct");
+			std::string error_msg = std::string(StringBuilder()
+				.append("Out-of-line member function '")
+				.append(decl.identifier_token().value())
+				.append("' could not be attached in instantiated struct '")
+				.append(instantiated_name)
+				.append("'")
+				.commit());
+			if (force_eager) {
+				throw InternalError(error_msg);
+			}
+			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 		}
 	}
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2247,6 +2247,25 @@ static bool shouldAcceptReplaySubstitutedSignatureMatch(
 		return false;
 	}
 
+	const bool instantiated_preserves_member_template_identity =
+		typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
+			original_instantiated_type);
+	const bool out_of_line_preserves_member_template_identity =
+		typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
+			original_out_of_line_type);
+	if (instantiated_preserves_member_template_identity ||
+		out_of_line_preserves_member_template_identity) {
+		if (!instantiated_preserves_member_template_identity ||
+			!out_of_line_preserves_member_template_identity) {
+			return false;
+		}
+		return dependentTemplatePlaceholderNamesMatch(
+			original_instantiated_type,
+			original_out_of_line_type,
+			instantiated_template_params,
+			out_of_line_template_params);
+	}
+
 	if (!typeSpecifierLooksLikeDependentSignaturePlaceholder(original_instantiated_type) ||
 		!typeSpecifierLooksLikeDependentSignaturePlaceholder(original_out_of_line_type)) {
 		return true;
@@ -2541,7 +2560,7 @@ static bool isMatchingMemberTemplate(
 		func_decl->parameter_nodes().size() == ool_function_param_count;
 }
 
-static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
+static bool nestedOutOfLineMemberTemplateMatchesCandidate(
 	Parser& parser,
 	const ASTNode& candidate_member,
 	const FunctionDeclarationNode& out_of_line_decl,
@@ -2563,7 +2582,7 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		return false;
 	}
 
-	return declarationsMatchAfterTemplateSubstitution(
+	std::optional<bool> signature_match = declarationsMatchAfterTemplateSubstitution(
 		parser,
 		candidate_template.function_decl_node(),
 		out_of_line_decl,
@@ -2572,6 +2591,7 @@ static std::optional<bool> nestedOutOfLineMemberTemplateMatchesCandidate(
 		owner_type_name,
 		candidate_inner_template_params,
 		out_of_line_inner_template_params);
+	return signature_match.has_value() && *signature_match;
 }
 
 static std::optional<bool> outOfLineConstructorTemplateMatchesCandidate(
@@ -8163,8 +8183,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							relevant_source_member_templates.push_back(&source_member);
 						}
 					}
-					const size_t relevant_member_template_count =
-						relevant_source_member_templates.size();
 					FunctionDeclarationNode* inst_func_decl = nullptr;
 					for (const StructMemberFunctionDecl* source_member :
 						 relevant_source_member_templates) {
@@ -8179,25 +8197,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (matched_stub == nullptr || !matched_stub->is<TemplateFunctionDeclarationNode>()) {
 							continue;
 						}
-						if (relevant_member_template_count > 1) {
-							std::optional<bool> signature_match =
-								nestedOutOfLineMemberTemplateMatchesCandidate(
-									*this,
-									source_member->function_declaration,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										template_params.data(),
-										template_params.size()),
-									std::span<const TemplateTypeArg>(
-										template_args_for_pattern.data(),
-										template_args_for_pattern.size()),
-									instantiated_name,
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.inner_template_params.data(),
-										out_of_line_member.inner_template_params.size()));
-							if (!signature_match.has_value() || !*signature_match) {
-								continue;
-							}
+						if (!nestedOutOfLineMemberTemplateMatchesCandidate(
+								*this,
+								source_member->function_declaration,
+								ool_func,
+								std::span<const TemplateParameterNode>(
+									template_params.data(),
+									template_params.size()),
+								std::span<const TemplateTypeArg>(
+									template_args_for_pattern.data(),
+									template_args_for_pattern.size()),
+								instantiated_name,
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.inner_template_params.data(),
+									out_of_line_member.inner_template_params.size()))) {
+							continue;
 						}
 						inst_func_decl = get_function_decl_node_mut(*matched_stub);
 						if (inst_func_decl == nullptr) {
@@ -8235,14 +8249,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							"Set body position on partial-spec nested template member: ",
 							ool_func_name);
 					} else {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Could not attach partial-spec nested out-of-line member template '",
-							ool_func_name,
-							"' for instantiated class '",
-							instantiated_name,
-							"' via replay identity map");
+						std::string error_msg = std::string(StringBuilder()
+							.append("Could not attach partial-spec nested out-of-line member template '")
+							.append(ool_func_name)
+							.append("' for instantiated class '")
+							.append(instantiated_name)
+							.append("' via replay identity map")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					continue;
 				}
@@ -12008,9 +12025,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::string_view ool_func_name =
 						ool_func.decl_node().identifier_token().value();
 
-					// Pre-count same-name same-arity candidates without a body so that
-					// we can gate signature matching on overload ambiguity (mirrors the
-					// pattern used at the partial-spec and primary-template call sites).
+					// Collect same-name/same-shape candidates, then require a positive
+					// substituted-signature match before replay attachment.
 					InlineVector<const StructMemberFunctionDecl*, 4> same_name_candidates;
 					const size_t ool_inner_template_param_count =
 						out_of_line_member.inner_template_params.size();
@@ -12031,7 +12047,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 
-					const size_t relevant_member_template_count = same_name_candidates.size();
 					FunctionDeclarationNode* matched_nested_func_decl = nullptr;
 					for (const StructMemberFunctionDecl* source_member : same_name_candidates) {
 						ASTNode* matched_stub = findSourceMemberStubByIdentity(
@@ -12041,25 +12056,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							!matched_stub->is<TemplateFunctionDeclarationNode>()) {
 							continue;
 						}
-						if (relevant_member_template_count > 1) {
-							std::optional<bool> signature_match =
-								nestedOutOfLineMemberTemplateMatchesCandidate(
-									*this,
-									source_member->function_declaration,
-									ool_func,
-									std::span<const TemplateParameterNode>(
-										template_params.data(),
-										template_params.size()),
-									std::span<const TemplateTypeArg>(
-										template_args_to_use.data(),
-										template_args_to_use.size()),
-									qualified_name,
-									std::span<const TemplateParameterNode>(
-										out_of_line_member.inner_template_params.data(),
-										out_of_line_member.inner_template_params.size()));
-							if (!signature_match.has_value() || !*signature_match) {
-								continue;
-							}
+						if (!nestedOutOfLineMemberTemplateMatchesCandidate(
+								*this,
+								source_member->function_declaration,
+								ool_func,
+								std::span<const TemplateParameterNode>(
+									template_params.data(),
+									template_params.size()),
+								std::span<const TemplateTypeArg>(
+									template_args_to_use.data(),
+									template_args_to_use.size()),
+								qualified_name,
+								std::span<const TemplateParameterNode>(
+									out_of_line_member.inner_template_params.data(),
+									out_of_line_member.inner_template_params.size()))) {
+							continue;
 						}
 						matched_nested_func_decl = get_function_decl_node_mut(*matched_stub);
 						if (matched_nested_func_decl == nullptr) {
@@ -12084,16 +12095,19 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							"Set body position on nested struct template member: ",
 							ool_func_name);
 					} else {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Could not attach nested out-of-line member template '",
-							ool_func_name,
-							"' for nested struct '",
-							nested_struct.name().view(),
-							"' in instantiated class '",
-							StringTable::getStringView(qualified_name),
-							"'");
+						std::string error_msg = std::string(StringBuilder()
+							.append("Could not attach nested out-of-line member template '")
+							.append(ool_func_name)
+							.append("' for nested struct '")
+							.append(nested_struct.name().view())
+							.append("' in instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return std::nullopt;
 					}
 				}
 			}
@@ -14474,19 +14488,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			FLASH_LOG(Templates, Debug, "Processing nested template out-of-line member: ", ool_func_name);
 
 			bool found = false;
-			size_t relevant_member_template_count = 0;
 			const size_t ool_inner_template_param_count =
 				out_of_line_member.inner_template_params.size();
 			const size_t ool_function_param_count = ool_func.parameter_nodes().size();
-			for (const auto& mem_func : effective_member_functions) {
-				if (isMatchingMemberTemplate(
-						mem_func,
-						ool_func_name,
-						ool_inner_template_param_count,
-						ool_function_param_count)) {
-					++relevant_member_template_count;
-				}
-			}
 			if (out_of_line_ctor_stub) {
 				OutOfLineConstructorStubResolution ctor_resolution =
 					findOutOfLineConstructorTemplateStubByIdentity(
@@ -14609,8 +14613,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (matched_template_func_decl->has_template_body_position()) {
 					continue;
 				}
-				if (relevant_member_template_count > 1) {
-					std::optional<bool> signature_match = nestedOutOfLineMemberTemplateMatchesCandidate(
+				if (!nestedOutOfLineMemberTemplateMatchesCandidate(
 						*this,
 						source_member.function_declaration,
 						ool_func,
@@ -14623,10 +14626,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						instantiated_name,
 						std::span<const TemplateParameterNode>(
 							out_of_line_member.inner_template_params.data(),
-							out_of_line_member.inner_template_params.size()));
-					if (!signature_match.has_value() || !*signature_match) {
-						continue;
-					}
+							out_of_line_member.inner_template_params.size()))) {
+					continue;
 				}
 				inst_func_decl = matched_template_func_decl;
 				if (inst_func_decl == nullptr) {
@@ -14719,7 +14720,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (force_eager) {
 					throw InternalError(error_msg);
 				}
-				FLASH_LOG(Templates, Error, error_msg);
+				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
 
 			continue;

--- a/tests/test_template_ool_member_template_single_candidate_alias_target_mismatch_fail.cpp
+++ b/tests/test_template_ool_member_template_single_candidate_alias_target_mismatch_fail.cpp
@@ -1,0 +1,25 @@
+struct SingleCandidateAliasMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct SingleCandidateAliasMismatch {
+	template<class U>
+	int pick(typename T::template AddPtr<int>::type value);
+};
+
+template<class T>
+template<class U>
+int SingleCandidateAliasMismatch<T>::pick(
+	typename T::template AddPtr<long>::type value) {
+	return static_cast<int>(sizeof(*value));
+}
+
+int main() {
+	int value = 0;
+	SingleCandidateAliasMismatch<SingleCandidateAliasMismatchTag> instance;
+	return instance.pick<int>(&value);
+}

--- a/tests/test_template_ool_plain_member_single_candidate_alias_target_mismatch_fail.cpp
+++ b/tests/test_template_ool_plain_member_single_candidate_alias_target_mismatch_fail.cpp
@@ -1,0 +1,23 @@
+struct PlainSingleCandidateAliasMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct PlainSingleCandidateAliasMismatch {
+	int pick(typename T::template AddPtr<int>::type value);
+};
+
+template<class T>
+int PlainSingleCandidateAliasMismatch<T>::pick(
+	typename T::template AddPtr<long>::type value) {
+	return static_cast<int>(sizeof(*value));
+}
+
+int main() {
+	int value = 0;
+	PlainSingleCandidateAliasMismatch<PlainSingleCandidateAliasMismatchTag> instance;
+	return instance.pick(&value);
+}


### PR DESCRIPTION
## Summary
This PR tightens template replay attachment so out-of-line replay only succeeds when replay identity and substituted-signature evidence can actually attach the definition.

It includes two focused slices:
- member-template replay now requires positive substituted-signature evidence even for single-candidate same-name matches
- failed out-of-line replay attachment is no longer warning-only for member-template or plain-member paths; instantiation now fails instead of silently continuing

## Code changes
- tightened `nestedOutOfLineMemberTemplateMatchesCandidate(...)` to require a positive substituted-signature match instead of treating `std::nullopt` as acceptable evidence
- removed the overload-count gate from the nested/partial-spec/member-template replay sites so replay attachment always requires positive signature evidence
- prevented substituted-signature acceptance from treating dependent member-template placeholders without preserved identity as a positive match
- converted unresolved replay attachment in both nested member-template and plain out-of-line member paths into hard instantiation failure rather than warning-and-continue behavior

## Regressions
Added expected-fail coverage for invalid single-candidate replay cases that were previously accepted:
- `test_template_ool_member_template_single_candidate_alias_target_mismatch_fail.cpp`
- `test_template_ool_plain_member_single_candidate_alias_target_mismatch_fail.cpp`

Full suite result:
- 2608 regular tests passed
- 190 expected-fail tests failed as expected

## Follow-up
The next replay-tightening candidate is the remaining single-candidate plain-member acceptance path in `findPlainOutOfLineMemberStubByIdentity(...)` when `declarationsMatchAfterTemplateSubstitution(...)` returns `std::nullopt` rather than positive evidence.