### PR TITLE
Templates: tighten plain-member replay evidence

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -2,7 +2,8 @@
 
 This file records confirmed bugs and quality-of-implementation (QoI) deficiencies in the
 FlashCpp C++20 compiler. Each entry includes the root cause, the affected code path, and
-(where applicable) a recommended fix.
+(where applicable) a recommended fix. Resolved issues should be removed rather than kept
+as a stale history log.
 
 ---
 
@@ -32,17 +33,3 @@ FlashCpp C++20 compiler. Each entry includes the root cause, the affected code p
 - **Impact**: Diagnostic noise only; not a correctness failure in isolation.
 
 ---
-
-## 3) OOL member-function-template overloads with dependent member-template alias parameters can fail attachment (OPEN)
-
-- **Symptom**: Two out-of-line member-function-template overloads whose
-  signatures differ only by `typename T::template AddPtr<int>::type` vs
-  `typename T::template AddPtr<long>::type` can fail replay identity attachment;
-  later calls may both select the `$ol0` materialization and link against a body
-  that was never emitted.
-- **Root cause**: The new alias-metadata path handles single-declaration body
-  replay, but same-name overload preselection still does not fully distinguish
-  member-template alias targets after owner substitution.
-- **Impact**: Keep the next replay-metadata slice focused on overloaded
-  member-template alias parameters once the non-overloaded forwarding paths stay
-  stable.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -50,6 +50,10 @@ attachment evidence-driven rather than shape-driven.
   recoverable: if replay identity plus substituted-signature evidence cannot
   attach the definition, instantiation now fails instead of silently
   continuing into later template instantiation paths
+- plain out-of-line member replay now also requires positive signature
+  evidence even for single-candidate same-name attachment: concrete exact
+  matches produce positive evidence, while unresolved `std::nullopt` outcomes
+  no longer attach by default
 
 ## Main remaining architectural gap
 
@@ -76,9 +80,9 @@ evidence. Tightening those is the next best cleanup target.
 2. Keep replay attachment evidence-driven.
    Continue tightening declaration replay so attachment succeeds because source
    identity and canonical substituted signatures match, not because a fallback
-   scan guessed correctly. The next likely slice is the remaining plain-member
-   and unresolved-signature acceptance paths that still tolerate shape-first
-   replay attachment.
+   scan guessed correctly. The next likely slice is the remaining
+   unresolved-signature acceptance paths that still tolerate shape-first replay
+   attachment outside the now-tightened plain-member/member-template paths.
 
 3. Extend dependent-name modeling only where it unlocks step 2.
    Richer current-instantiation and unknown-specialization handling still

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -37,6 +37,9 @@ Move FlashCpp toward a sema-owned template system where:
 - out-of-line member replay attachment now fails instantiation when replay
   identity plus substituted-signature evidence cannot attach the definition,
   instead of silently continuing into later template instantiation
+- plain out-of-line member replay now also requires positive signature
+  evidence for single-candidate same-name attachment; unresolved
+  substituted-signature outcomes no longer attach by default
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type
@@ -65,8 +68,9 @@ unknown-specialization modeling only where it unblocks those paths.
 
 2. Continue tightening replay attachment so valid cases succeed via source
    identity plus canonical substituted-signature evidence, not fallback scans.
-   The next slice is likely the remaining plain-member or unresolved-signature
-   acceptance paths where replay can still succeed without enough evidence.
+   The next slice is likely the remaining unresolved-signature acceptance paths
+   where replay can still succeed without enough evidence outside the now-
+   tightened plain-member and member-template paths.
 
 3. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks step 2.

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -60,6 +60,10 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - out-of-line member replay attachment now fails the instantiation when replay
   identity plus substituted-signature evidence cannot attach the definition,
   instead of logging and continuing into later template instantiation paths
+- plain out-of-line member replay no longer accepts a single same-name source
+  member on unresolved substituted-signature evidence alone; concrete
+  same-signature matches now produce positive evidence and mismatches are
+  rejected before replay attachment
 
 ## Main remaining gaps
 
@@ -86,7 +90,7 @@ The next template task is narrower and more architectural:
 
 - keep declaration replay attached by source identity plus canonical
   substituted-signature evidence
-- continue shrinking plain-member and unresolved-signature replay acceptance
+- continue shrinking the remaining unresolved-signature replay acceptance
   where name/shape still wins without enough evidence
 - expand current-instantiation and unknown-specialization handling only where
   it unblocks those replay paths

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -307,21 +307,6 @@ static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
 	const std::string_view out_of_line_name =
 		out_of_line_decl.decl_node().identifier_token().value();
 
-	size_t same_name_source_member_count = 0;
-	for (const StructMemberFunctionDecl& source_member : source_members) {
-		if (!source_member.function_declaration.is<FunctionDeclarationNode>()) {
-			continue;
-		}
-		const FunctionDeclarationNode* source_func_decl =
-			get_function_decl_node(source_member.function_declaration);
-		if (source_func_decl == nullptr) {
-			continue;
-		}
-		if (source_func_decl->decl_node().identifier_token().value() == out_of_line_name) {
-			++same_name_source_member_count;
-		}
-	}
-
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<FunctionDeclarationNode>()) {
 			continue;
@@ -356,11 +341,7 @@ static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
 				owner_type_name,
 				std::span<const TemplateParameterNode>{},
 				std::span<const TemplateParameterNode>{});
-		if (same_name_source_member_count > 1) {
-			if (!signature_match.has_value() || !*signature_match) {
-				continue;
-			}
-		} else if (signature_match.has_value() && !*signature_match) {
+		if (!signature_match.has_value() || !*signature_match) {
 			continue;
 		}
 
@@ -2500,7 +2481,9 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 			!out_of_line_is_template_param_placeholder &&
 			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*instantiated_param) &&
 			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*out_of_line_param)) {
-			return std::nullopt;
+			return typeSpecifiersMatchForSignatureValidation(
+				*instantiated_param,
+				*out_of_line_param);
 		}
 		const SignatureValidationIndirection instantiated_effective_indirection =
 			computeSignatureValidationIndirection(*instantiated_param);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2481,9 +2481,12 @@ static std::optional<bool> declarationsMatchAfterTemplateSubstitution(
 			!out_of_line_is_template_param_placeholder &&
 			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*instantiated_param) &&
 			!typeSpecifierLooksLikeDependentSignaturePlaceholder(*out_of_line_param)) {
-			return typeSpecifiersMatchForSignatureValidation(
-				*instantiated_param,
-				*out_of_line_param);
+			if (!typeSpecifiersMatchForSignatureValidation(
+					*instantiated_param,
+					*out_of_line_param)) {
+				return false;
+			}
+			continue;
 		}
 		const SignatureValidationIndirection instantiated_effective_indirection =
 			computeSignatureValidationIndirection(*instantiated_param);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8126,16 +8126,31 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							FLASH_LOG(Templates, Debug,
 								"Parsed and substituted OOL plain member body "
 								"for partial-spec: ", plain_ool_name);
+						} else {
+							std::string error_msg = std::string(StringBuilder()
+								.append("Failed to replay partial-spec plain out-of-line member '")
+								.append(plain_ool_name)
+								.append("' for instantiated class '")
+								.append(instantiated_name)
+								.append("'")
+								.commit());
+							if (force_eager) {
+								throw InternalError(error_msg);
+							}
+							return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 						}
 					} else {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Could not attach partial-spec plain out-of-line member '",
-							plain_ool_name,
-							"' for instantiated class '",
-							instantiated_name,
-							"' via replay identity map");
+						std::string error_msg = std::string(StringBuilder()
+							.append("Could not attach partial-spec plain out-of-line member '")
+							.append(plain_ool_name)
+							.append("' for instantiated class '")
+							.append(instantiated_name)
+							.append("' via replay identity map")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					continue;
 				}

--- a/tests/test_template_ool_plain_member_multi_param_late_mismatch_fail.cpp
+++ b/tests/test_template_ool_plain_member_multi_param_late_mismatch_fail.cpp
@@ -1,0 +1,24 @@
+struct PlainMultiParamLateMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct PlainMultiParamLateMismatch {
+	int pick(int seed, typename T::template AddPtr<int>::type value);
+};
+
+template<class T>
+int PlainMultiParamLateMismatch<T>::pick(
+	int seed,
+	typename T::template AddPtr<long>::type value) {
+	return seed + static_cast<int>(sizeof(*value));
+}
+
+int main() {
+	int value = 0;
+	PlainMultiParamLateMismatch<PlainMultiParamLateMismatchTag> instance;
+	return instance.pick(1, &value);
+}

--- a/tests/test_template_ool_plain_member_single_candidate_exact_ret0.cpp
+++ b/tests/test_template_ool_plain_member_single_candidate_exact_ret0.cpp
@@ -1,0 +1,14 @@
+template<class T>
+struct PlainSingleCandidateExact {
+	int eval(int declared);
+};
+
+template<class T>
+int PlainSingleCandidateExact<T>::eval(int defined) {
+	return defined + 1;
+}
+
+int main() {
+	PlainSingleCandidateExact<long> value;
+	return value.eval(41) == 42 ? 0 : 1;
+}

--- a/tests/test_template_partial_spec_ool_plain_member_alias_target_mismatch_fail.cpp
+++ b/tests/test_template_partial_spec_ool_plain_member_alias_target_mismatch_fail.cpp
@@ -1,0 +1,26 @@
+struct PartialSpecPlainMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct PartialSpecPlainMismatch;
+
+template<class T>
+struct PartialSpecPlainMismatch<T*> {
+	int pick(typename T::template AddPtr<int>::type value);
+};
+
+template<class T>
+int PartialSpecPlainMismatch<T*>::pick(
+	typename T::template AddPtr<long>::type value) {
+	return static_cast<int>(sizeof(*value));
+}
+
+int main() {
+	int value = 0;
+	PartialSpecPlainMismatch<PartialSpecPlainMismatchTag*> instance;
+	return instance.pick(&value);
+}


### PR DESCRIPTION
## Summary
This PR continues the replay-attachment tightening after #1738 by removing two more permissive plain-member paths.

It includes two commits:
- `909b6330` Require positive evidence for plain-member replay
- `d25a8644` Fail partial-spec plain-member replay misses

## What changed
- `findPlainOutOfLineMemberStubByIdentity(...)` now requires positive substituted-signature evidence for plain out-of-line member replay instead of accepting a single same-name source member on unresolved (`std::nullopt`) evidence.
- `declarationsMatchAfterTemplateSubstitution(...)` now returns concrete `true`/`false` for exact non-dependent plain-member signature matches, so valid single-candidate replay paths still succeed without relying on a permissive unresolved outcome.
- Partial-specialization plain out-of-line member replay no longer logs and continues when replay attachment fails. It now fails instantiation both when:
  - no replay identity-map stub can be attached
  - a stub exists but `replayOutOfLineMemberBody(...)` fails

## Regressions
Added focused coverage for both the valid and invalid sides of this slice:
- `test_template_ool_plain_member_single_candidate_exact_ret0.cpp`
- `test_template_partial_spec_ool_plain_member_alias_target_mismatch_fail.cpp`

This PR also keeps the earlier plain-member mismatch regression green:
- `test_template_ool_plain_member_single_candidate_alias_target_mismatch_fail.cpp`

## Validation
- `./build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1 test_template_ool_plain_member_single_candidate_exact_ret0.cpp`
- `pwsh tests/run_all_tests.ps1 test_template_ool_plain_member_single_candidate_alias_target_mismatch_fail.cpp`
- `pwsh tests/run_all_tests.ps1 test_template_ool_plain_member_same_name_overload_ret0.cpp`
- `pwsh tests/run_all_tests.ps1 test_template_partial_spec_ool_plain_member_ret0.cpp`
- `pwsh tests/run_all_tests.ps1 test_template_ool_plain_member_dependent_qualified_type_ret0.cpp`
- `pwsh tests/run_all_tests.ps1 test_template_partial_spec_ool_plain_member_alias_target_mismatch_fail.cpp`
- `pwsh tests/run_all_tests.ps1`

Full suite result:
- 2609 regular tests passed
- 191 expected-fail tests failed as expected

## Follow-up
The next likely replay-tightening work is inside `declarationsMatchAfterTemplateSubstitution(...)` itself, where the remaining valid dependent-placeholder matches still rely on structural placeholder evidence rather than stronger semantic proof.