### PR TITLE
Templates: fail constructor-template replay misses directly

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -54,6 +54,9 @@ attachment evidence-driven rather than shape-driven.
   evidence even for single-candidate same-name attachment: concrete exact
   matches produce positive evidence, while unresolved `std::nullopt` outcomes
   no longer attach by default
+- nested and partial-specialization out-of-line constructor-template replay
+  now treats attachment misses as instantiation failures, matching the ordinary
+  constructor and member-function replay paths
 
 ## Main remaining architectural gap
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -40,6 +40,9 @@ Move FlashCpp toward a sema-owned template system where:
 - plain out-of-line member replay now also requires positive signature
   evidence for single-candidate same-name attachment; unresolved
   substituted-signature outcomes no longer attach by default
+- nested and partial-specialization constructor-template replay now fails
+  directly when replay identity plus substituted-signature evidence cannot
+  attach the out-of-line definition
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -64,6 +64,9 @@ FlashCpp follows a parse -> sema -> IR pipeline:
   member on unresolved substituted-signature evidence alone; concrete
   same-signature matches now produce positive evidence and mismatches are
   rejected before replay attachment
+- nested and partial-specialization out-of-line constructor-template replay
+  misses now fail instantiation directly instead of logging and continuing to
+  later lazy-constructor failures
 
 ## Main remaining gaps
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8304,26 +8304,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							out_of_line_member.inner_template_params.data(),
 							out_of_line_member.inner_template_params.size()));
 				if (ctor_resolution.ambiguous) {
-					FLASH_LOG(
-						Templates,
-						Error,
-						"Ambiguous replay-first attachment for partial-spec out-of-line constructor template '",
-						ool_func_name,
-						"' in instantiated class '",
-						instantiated_name,
-						"'");
-					continue;
+					std::string error_msg = std::string(StringBuilder()
+						.append("Ambiguous replay-first attachment for partial-spec out-of-line constructor template '")
+						.append(ool_func_name)
+						.append("' in instantiated class '")
+						.append(instantiated_name)
+						.append("'")
+						.commit());
+					if (force_eager) {
+						throw InternalError(error_msg);
+					}
+					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
 				if (ctor_resolution.ctor == nullptr) {
-					FLASH_LOG(
-						Templates,
-						Error,
-						"Could not attach partial-spec out-of-line constructor template '",
-						ool_func_name,
-						"' for instantiated class '",
-						instantiated_name,
-						"' via replay identity map");
-					continue;
+					std::string error_msg = std::string(StringBuilder()
+						.append("Could not attach partial-spec out-of-line constructor template '")
+						.append(ool_func_name)
+						.append("' for instantiated class '")
+						.append(instantiated_name)
+						.append("' via replay identity map")
+						.commit());
+					if (force_eager) {
+						throw InternalError(error_msg);
+					}
+					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
 
 				ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
@@ -11901,14 +11905,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								out_of_line_member.inner_template_params.size()));
 
 					if (ctor_resolution.ambiguous) {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Ambiguous replay-first attachment for nested out-of-line constructor template '",
-							out_of_line_ctor_decl.name(),
-							"' in instantiated class '",
-							StringTable::getStringView(qualified_name),
-							"'");
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
+							.append(out_of_line_ctor_decl.name())
+							.append("' in instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					} else if (ctor_resolution.ctor != nullptr) {
 						ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;
 						setOutOfLineConstructorTemplateReplayMetadata(
@@ -11918,14 +11925,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							ctor_decl.parameter_nodes(),
 							out_of_line_ctor_decl.parameter_nodes());
 					} else {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Could not attach nested out-of-line constructor template '",
-							out_of_line_ctor_decl.name(),
-							"' for instantiated class '",
-							StringTable::getStringView(qualified_name),
-							"' via replay identity map");
+						std::string error_msg = std::string(StringBuilder()
+							.append("Could not attach nested out-of-line constructor template '")
+							.append(out_of_line_ctor_decl.name())
+							.append("' for instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("' via replay identity map")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					continue;
 				}
@@ -11957,26 +11967,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								out_of_line_member.inner_template_params.data(),
 								out_of_line_member.inner_template_params.size()));
 					if (ctor_resolution.ambiguous) {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Ambiguous replay-first attachment for nested out-of-line constructor template '",
-							out_of_line_ctor_stub_decl.decl_node().identifier_token().value(),
-							"' in instantiated class '",
-							StringTable::getStringView(qualified_name),
-							"'");
-						continue;
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
+							.append(out_of_line_ctor_stub_decl.decl_node().identifier_token().value())
+							.append("' in instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					if (ctor_resolution.ctor == nullptr) {
-						FLASH_LOG(
-							Templates,
-							Error,
-							"Could not attach nested out-of-line constructor template '",
-							out_of_line_ctor_stub_decl.decl_node().identifier_token().value(),
-							"' for instantiated class '",
-							StringTable::getStringView(qualified_name),
-							"' via replay identity map");
-						continue;
+						std::string error_msg = std::string(StringBuilder()
+							.append("Could not attach nested out-of-line constructor template '")
+							.append(out_of_line_ctor_stub_decl.decl_node().identifier_token().value())
+							.append("' for instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("' via replay identity map")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 
 					ConstructorDeclarationNode& ctor_decl = *ctor_resolution.ctor;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8312,7 +8312,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						.append("'")
 						.commit());
 					if (force_eager) {
-						throw InternalError(error_msg);
+						throw CompileError(error_msg);
 					}
 					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
@@ -8325,7 +8325,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						.append("' via replay identity map")
 						.commit());
 					if (force_eager) {
-						throw InternalError(error_msg);
+						throw CompileError(error_msg);
 					}
 					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
@@ -11909,11 +11909,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
 							.append(out_of_line_ctor_decl.name())
 							.append("' in instantiated class '")
-							.append(StringTable::getStringView(qualified_name))
+							.append(qualified_name)
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					} else if (ctor_resolution.ctor != nullptr) {
@@ -11929,11 +11929,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("Could not attach nested out-of-line constructor template '")
 							.append(out_of_line_ctor_decl.name())
 							.append("' for instantiated class '")
-							.append(StringTable::getStringView(qualified_name))
+							.append(qualified_name)
 							.append("' via replay identity map")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -11971,11 +11971,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
 							.append(out_of_line_ctor_stub_decl.decl_node().identifier_token().value())
 							.append("' in instantiated class '")
-							.append(StringTable::getStringView(qualified_name))
+							.append(qualified_name)
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -11984,11 +11984,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("Could not attach nested out-of-line constructor template '")
 							.append(out_of_line_ctor_stub_decl.decl_node().identifier_token().value())
 							.append("' for instantiated class '")
-							.append(StringTable::getStringView(qualified_name))
+							.append(qualified_name)
 							.append("' via replay identity map")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}

--- a/tests/test_template_nested_ool_ctor_template_alias_target_mismatch_fail.cpp
+++ b/tests/test_template_nested_ool_ctor_template_alias_target_mismatch_fail.cpp
@@ -1,0 +1,32 @@
+struct NestedCtorTemplateAliasMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct NestedCtorTemplateAliasMismatchOuter {
+	struct Inner {
+		template<class U>
+		Inner(typename T::template AddPtr<int>::type value, U seed);
+	};
+};
+
+template<class T>
+template<class U>
+NestedCtorTemplateAliasMismatchOuter<T>::Inner::Inner(
+	typename T::template AddPtr<long>::type value,
+	U seed) {
+	(void)value;
+	(void)seed;
+}
+
+int main() {
+	int value = 0;
+	NestedCtorTemplateAliasMismatchOuter<NestedCtorTemplateAliasMismatchTag>::Inner instance(
+		&value,
+		0);
+	(void)instance;
+	return 0;
+}

--- a/tests/test_template_partial_spec_ool_ctor_template_alias_target_mismatch_fail.cpp
+++ b/tests/test_template_partial_spec_ool_ctor_template_alias_target_mismatch_fail.cpp
@@ -1,0 +1,31 @@
+struct PartialCtorTemplateAliasMismatchTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct PartialCtorTemplateAliasMismatch;
+
+template<class T>
+struct PartialCtorTemplateAliasMismatch<T*> {
+	template<class U>
+	PartialCtorTemplateAliasMismatch(typename T::template AddPtr<int>::type value, U seed);
+};
+
+template<class T>
+template<class U>
+PartialCtorTemplateAliasMismatch<T*>::PartialCtorTemplateAliasMismatch(
+	typename T::template AddPtr<long>::type value,
+	U seed) {
+	(void)value;
+	(void)seed;
+}
+
+int main() {
+	int value = 0;
+	PartialCtorTemplateAliasMismatch<PartialCtorTemplateAliasMismatchTag*> instance(&value, 0);
+	(void)instance;
+	return 0;
+}


### PR DESCRIPTION
## Summary
Tightens template replay behavior so nested and partial-specialization out-of-line constructor-template replay misses fail instantiation immediately, instead of logging and continuing into later lazy-constructor failures.

## What changed
- Converted constructor-template replay miss/ambiguity branches in 	try_instantiate_class_template(...) to return failTemplateInstantiation(...) (or throw in eager mode), matching existing ordinary constructor/member replay behavior.
- Added focused negative regressions:
  - tests/test_template_partial_spec_ool_ctor_template_alias_target_mismatch_fail.cpp
  - tests/test_template_nested_ool_ctor_template_alias_target_mismatch_fail.cpp
- Updated planning docs to record this stricter replay invariant:
  - docs/SEMANTIC_ANALYSIS_STATUS.md
  - docs/2026-05-12-template-argument-architecture-audit.md
  - docs/2026-05-12-template-argument-standard-conformance-investigation.md

Full suite result:
- 2609 regular tests passed
- 194 expected-fail tests failed as expected