### PR TITLE
Templates: tighten constructor StructTypeInfo replay evidence

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -57,6 +57,9 @@ attachment evidence-driven rather than shape-driven.
 - nested and partial-specialization out-of-line constructor-template replay
   now treats attachment misses as instantiation failures, matching the ordinary
   constructor and member-function replay paths
+- constructor replay sync into StructTypeInfo now requires signature-validation
+  evidence and no longer falls back to token/name shape equivalence for
+  mismatched parameter types
 
 ## Main remaining architectural gap
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -43,6 +43,9 @@ Move FlashCpp toward a sema-owned template system where:
 - nested and partial-specialization constructor-template replay now fails
   directly when replay identity plus substituted-signature evidence cannot
   attach the out-of-line definition
+- constructor replay sync into StructTypeInfo now requires
+  `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
+  treats token/name shape fallback as a valid equivalence
 - `materializeAliasTemplateInstance` now falls back to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -67,6 +67,9 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - nested and partial-specialization out-of-line constructor-template replay
   misses now fail instantiation directly instead of logging and continuing to
   later lazy-constructor failures
+- StructTypeInfo constructor-template sync now requires positive
+  `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
+  accepts token/name shape-only fallback equivalence
 
 ## Main remaining gaps
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -493,36 +493,7 @@ static bool constructorDeclarationsHaveEquivalentInstantiatedSignature(
 		if (lhs_param == nullptr || rhs_param == nullptr) {
 			return false;
 		}
-		if (typeSpecifiersMatchForSignatureValidation(*lhs_param, *rhs_param)) {
-			continue;
-		}
-
-		auto identity_name = [](const TypeSpecifierNode& type_spec) {
-			if (type_spec.type_index().is_valid()) {
-				if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
-					std::string_view type_name = StringTable::getStringView(type_info->name());
-					if (!type_name.empty()) {
-						return type_name;
-					}
-				}
-			}
-			return type_spec.token().value();
-		};
-		if (lhs_param->pointer_depth() != rhs_param->pointer_depth() ||
-			lhs_param->reference_qualifier() != rhs_param->reference_qualifier() ||
-			lhs_param->cv_qualifier() != rhs_param->cv_qualifier() ||
-			lhs_param->pointer_levels().size() != rhs_param->pointer_levels().size()) {
-			return false;
-		}
-		for (size_t pointer_level_index = 0;
-			 pointer_level_index < lhs_param->pointer_levels().size();
-			 ++pointer_level_index) {
-			if (lhs_param->pointer_levels()[pointer_level_index].cv_qualifier !=
-				rhs_param->pointer_levels()[pointer_level_index].cv_qualifier) {
-				return false;
-			}
-		}
-		if (identity_name(*lhs_param) != identity_name(*rhs_param)) {
+		if (!typeSpecifiersMatchForSignatureValidation(*lhs_param, *rhs_param)) {
 			return false;
 		}
 	}

--- a/tests/test_template_ool_ctor_template_dependent_member_template_alias_overload_ret0.cpp
+++ b/tests/test_template_ool_ctor_template_dependent_member_template_alias_overload_ret0.cpp
@@ -1,0 +1,58 @@
+// Regression: out-of-line constructor-template replay and StructTypeInfo sync
+// must not treat dependent member-template alias overloads as shape-equivalent.
+// The int and long alias-target overloads must each retain their own body.
+struct CtorTemplateDependentMemberTemplateAliasOverloadTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct CtorTemplateDependentMemberTemplateAliasOverload {
+	int which = 0;
+
+	template<class U>
+	CtorTemplateDependentMemberTemplateAliasOverload(
+		U seed,
+		typename T::template AddPtr<int>::type value);
+
+	template<class U>
+	CtorTemplateDependentMemberTemplateAliasOverload(
+		U seed,
+		typename T::template AddPtr<long>::type value);
+};
+
+template<class T>
+template<class U>
+CtorTemplateDependentMemberTemplateAliasOverload<T>::
+	CtorTemplateDependentMemberTemplateAliasOverload(
+		U seed,
+		typename T::template AddPtr<long>::type value)
+	: which(static_cast<int>(sizeof(*value)) + seed + 10) {}
+
+template<class T>
+template<class U>
+CtorTemplateDependentMemberTemplateAliasOverload<T>::
+	CtorTemplateDependentMemberTemplateAliasOverload(
+		U seed,
+		typename T::template AddPtr<int>::type value)
+	: which(static_cast<int>(sizeof(*value)) + seed + 20) {}
+
+int main() {
+	int int_value = 0;
+	long long_value = 0;
+	CtorTemplateDependentMemberTemplateAliasOverload<
+		CtorTemplateDependentMemberTemplateAliasOverloadTag>
+		from_int_ptr(1, &int_value);
+	if (from_int_ptr.which != 25) {
+		return 1;
+	}
+	CtorTemplateDependentMemberTemplateAliasOverload<
+		CtorTemplateDependentMemberTemplateAliasOverloadTag>
+		from_long_ptr(2, &long_value);
+	if (from_long_ptr.which != static_cast<int>(sizeof(long_value)) + 12) {
+		return 2;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary
Tightens constructor replay attachment by removing the remaining token/name shape fallback in StructTypeInfo constructor sync and requiring positive signature-validation evidence.

## What changed
- constructorDeclarationsHaveEquivalentInstantiatedSignature(...) now requires typeSpecifiersMatchForSignatureValidation(...) for parameter equivalence.
- Removed the prior token/name fallback path that could treat mismatched dependent placeholder spellings as equivalent during constructor StructTypeInfo sync.
- Added regression:
  - tests/test_template_ool_ctor_template_dependent_member_template_alias_overload_ret0.cpp
- Updated planning/status docs to reflect the stricter constructor replay invariant:
  - docs/SEMANTIC_ANALYSIS_STATUS.md
  - docs/2026-05-12-template-argument-architecture-audit.md
  - docs/2026-05-12-template-argument-standard-conformance-investigation.md

- Full suite:
  - pwsh tests/run_all_tests.ps1
  - 2610 regular tests passed
  - 194 expected-fail tests failed as expected