### PR TITLE
Tighten replay evidence handling for plain and nested member attachment

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -63,6 +63,9 @@ attachment evidence-driven rather than shape-driven.
 - replay attachment loops that previously reduced matching to boolean now
   preserve `InsufficientEvidence` and fail instantiation directly for
   nested/partial member-template and constructor-stub paths
+- plain out-of-line member replay now also preserves `InsufficientEvidence`
+  and fails instantiation directly instead of degrading to generic
+  replay-attachment misses
 - constructor replay sync into StructTypeInfo now requires signature-validation
   evidence and no longer falls back to token/name shape equivalence for
   mismatched parameter types

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -49,6 +49,9 @@ Move FlashCpp toward a sema-owned template system where:
 - replay attachment loops that previously flattened matching to boolean now
   preserve `InsufficientEvidence` and fail instantiation directly for
   nested/partial member-template and constructor-stub routes
+- plain out-of-line member replay now also preserves `InsufficientEvidence`
+  and fails instantiation directly instead of degrading to generic
+  replay-attachment misses
 - constructor replay sync into StructTypeInfo now requires
   `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
   treats token/name shape fallback as a valid equivalence

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -73,6 +73,8 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - replay attachment sites that previously collapsed to boolean mismatch now
   preserve `InsufficientEvidence` and fail instantiation directly for
   nested/partial member-template and constructor-stub replay paths
+- nested member-template replay attachment now also fails explicitly on
+  ambiguous positive-evidence matches instead of accepting the first candidate
 - plain out-of-line member replay attachment now also preserves
   `InsufficientEvidence` and fails instantiation directly instead of falling
   through to generic attachment misses

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -73,6 +73,9 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - replay attachment sites that previously collapsed to boolean mismatch now
   preserve `InsufficientEvidence` and fail instantiation directly for
   nested/partial member-template and constructor-stub replay paths
+- plain out-of-line member replay attachment now also preserves
+  `InsufficientEvidence` and fails instantiation directly instead of falling
+  through to generic attachment misses
 - StructTypeInfo constructor-template sync now requires positive
   `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
   accepts token/name shape-only fallback equivalence

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8205,6 +8205,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					FunctionDeclarationNode* inst_func_decl = nullptr;
 					bool saw_insufficient_replay_evidence = false;
+					bool saw_ambiguous_replay_match = false;
 					for (const StructMemberFunctionDecl* source_member :
 						 relevant_source_member_templates) {
 						const FunctionDeclarationNode* source_func_decl =
@@ -8240,11 +8241,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (signature_match != ReplaySignatureMatchResult::Match) {
 							continue;
 						}
-						inst_func_decl = get_function_decl_node_mut(*matched_stub);
-						if (inst_func_decl == nullptr) {
+						FunctionDeclarationNode* matched_template_func_decl =
+							get_function_decl_node_mut(*matched_stub);
+						if (matched_template_func_decl == nullptr) {
 							continue;
 						}
-						break;
+						if (inst_func_decl != nullptr &&
+							inst_func_decl != matched_template_func_decl) {
+							saw_ambiguous_replay_match = true;
+							break;
+						}
+						inst_func_decl = matched_template_func_decl;
+					}
+					if (saw_ambiguous_replay_match) {
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous replay-first attachment for partial-spec nested out-of-line member template '")
+							.append(ool_func_name)
+							.append("' in instantiated class '")
+							.append(instantiated_name)
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					if (inst_func_decl != nullptr) {
 						inst_func_decl->set_template_body_position(out_of_line_member.body_start);
@@ -12135,6 +12155,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					FunctionDeclarationNode* matched_nested_func_decl = nullptr;
 					bool saw_insufficient_replay_evidence = false;
+					bool saw_ambiguous_replay_match = false;
 					for (const StructMemberFunctionDecl* source_member : same_name_candidates) {
 						ASTNode* matched_stub = findSourceMemberStubByIdentity(
 							nested_source_member_identity_maps,
@@ -12165,13 +12186,34 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (signature_match != ReplaySignatureMatchResult::Match) {
 							continue;
 						}
-						matched_nested_func_decl = get_function_decl_node_mut(*matched_stub);
-						if (matched_nested_func_decl == nullptr) {
+						FunctionDeclarationNode* matched_template_func_decl =
+							get_function_decl_node_mut(*matched_stub);
+						if (matched_template_func_decl == nullptr) {
 							continue;
 						}
-						break;
+						if (matched_nested_func_decl != nullptr &&
+							matched_nested_func_decl != matched_template_func_decl) {
+							saw_ambiguous_replay_match = true;
+							break;
+						}
+						matched_nested_func_decl = matched_template_func_decl;
 					}
 
+					if (saw_ambiguous_replay_match) {
+						std::string error_msg = std::string(StringBuilder()
+							.append("Ambiguous replay-first attachment for nested out-of-line member template '")
+							.append(ool_func_name)
+							.append("' for nested struct '")
+							.append(nested_struct.name().view())
+							.append("' in instantiated class '")
+							.append(StringTable::getStringView(qualified_name))
+							.append("'")
+							.commit());
+						if (force_eager) {
+							throw InternalError(error_msg);
+						}
+						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
+					}
 					if (matched_nested_func_decl != nullptr) {
 						matched_nested_func_decl->set_template_body_position(out_of_line_member.body_start);
 						copyDefinitionParameterIdentifiers(
@@ -14707,6 +14749,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// resolve to instantiated stubs via source_member_to_stub identity mapping.
 			FunctionDeclarationNode* inst_func_decl = nullptr;
 			bool saw_insufficient_replay_evidence = false;
+			bool saw_ambiguous_replay_match = false;
 			for (const auto& source_member : effective_member_functions) {
 				if (!isMatchingMemberTemplate(
 						source_member,
@@ -14754,11 +14797,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (signature_match != ReplaySignatureMatchResult::Match) {
 					continue;
 				}
-				inst_func_decl = matched_template_func_decl;
-				if (inst_func_decl == nullptr) {
-					continue;
+				if (inst_func_decl != nullptr &&
+					inst_func_decl != matched_template_func_decl) {
+					saw_ambiguous_replay_match = true;
+					break;
 				}
-				break;
+				inst_func_decl = matched_template_func_decl;
+			}
+
+			if (saw_ambiguous_replay_match) {
+				std::string error_msg = std::string(StringBuilder()
+					.append("Ambiguous replay-first attachment for nested out-of-line member template '")
+					.append(ool_func_name)
+					.append("' in instantiated class '")
+					.append(instantiated_name)
+					.append("'")
+					.commit());
+				if (force_eager) {
+					throw InternalError(error_msg);
+				}
+				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
 
 			if (inst_func_decl != nullptr) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -302,7 +302,12 @@ static ASTNode* findSourceMemberStubByIdentity(
 	return nullptr;
 }
 
-static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
+struct OutOfLineMemberStubResolution {
+	FunctionDeclarationNode* func = nullptr;
+	bool insufficient_evidence = false;
+};
+
+static OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 	Parser& parser,
 	SourceMemberIdentityMaps& identity_maps,
 	std::span<const StructMemberFunctionDecl> source_members,
@@ -312,6 +317,8 @@ static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
 	StringHandle owner_type_name) {
 	const std::string_view out_of_line_name =
 		out_of_line_decl.decl_node().identifier_token().value();
+	OutOfLineMemberStubResolution resolution;
+	InlineVector<FunctionDeclarationNode*, 4> resolved_matches;
 
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<FunctionDeclarationNode>()) {
@@ -347,14 +354,21 @@ static FunctionDeclarationNode* findPlainOutOfLineMemberStubByIdentity(
 				owner_type_name,
 				std::span<const TemplateParameterNode>{},
 				std::span<const TemplateParameterNode>{});
+		if (signature_match == ReplaySignatureMatchResult::InsufficientEvidence) {
+			resolution.insufficient_evidence = true;
+			continue;
+		}
 		if (signature_match != ReplaySignatureMatchResult::Match) {
 			continue;
 		}
 
-		return inst_func_decl;
+		resolved_matches.push_back(inst_func_decl);
 	}
 
-	return nullptr;
+	if (resolved_matches.size() == 1) {
+		resolution.func = resolved_matches.front();
+	}
+	return resolution;
 }
 
 struct OutOfLineConstructorStubResolution {
@@ -8049,7 +8063,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (is_plain_ctor_stub) {
 						continue;
 					}
-					FunctionDeclarationNode* inst_func = findPlainOutOfLineMemberStubByIdentity(
+					OutOfLineMemberStubResolution member_resolution =
+						findPlainOutOfLineMemberStubByIdentity(
 						*this,
 						source_member_identity_maps,
 						std::span<const StructMemberFunctionDecl>(
@@ -8063,6 +8078,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							template_args_for_pattern.data(),
 							template_args_for_pattern.size()),
 						instantiated_name);
+					FunctionDeclarationNode* inst_func = member_resolution.func;
 					if (inst_func != nullptr) {
 						// Copy definition-site parameter names so the body can reference them.
 						copyDefinitionParameterIdentifiers(
@@ -8128,13 +8144,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 						}
 					} else {
-						std::string error_msg = std::string(StringBuilder()
-							.append("Could not attach partial-spec plain out-of-line member '")
+						StringBuilder error_builder;
+						if (member_resolution.insufficient_evidence) {
+							error_builder
+								.append("Insufficient replay evidence to attach partial-spec plain out-of-line member '");
+						} else {
+							error_builder
+								.append("Could not attach partial-spec plain out-of-line member '");
+						}
+						error_builder
 							.append(plain_ool_name)
 							.append("' for instantiated class '")
-							.append(instantiated_name)
-							.append("' via replay identity map")
-							.commit());
+							.append(instantiated_name);
+						if (!member_resolution.insufficient_evidence) {
+							error_builder.append("' via replay identity map");
+						} else {
+							error_builder.append("'");
+						}
+						std::string error_msg = std::string(error_builder.commit());
 						if (force_eager) {
 							throw InternalError(error_msg);
 						}
@@ -14847,7 +14874,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// against source declarations, then resolve directly to the instantiated stub
 		// through source-member -> stub identity.
 		bool found_match = false;
-		if (FunctionDeclarationNode* inst_func = findPlainOutOfLineMemberStubByIdentity(
+		OutOfLineMemberStubResolution plain_member_resolution =
+			findPlainOutOfLineMemberStubByIdentity(
 				*this,
 				source_member_identity_maps,
 				std::span<const StructMemberFunctionDecl>(
@@ -14861,6 +14889,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					template_args_to_use.data(),
 					template_args_to_use.size()),
 				instantiated_name);
+		if (FunctionDeclarationNode* inst_func = plain_member_resolution.func;
 			inst_func != nullptr) {
 			const std::span<const ASTNode> inst_func_params = inst_func->parameter_nodes();
 			std::vector<ASTNode> definition_scope_params(
@@ -14956,6 +14985,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			decl.identifier_token().value(),
 			template_name,
 			template_base_name);
+		if (!out_of_line_ctor_stub &&
+			plain_member_resolution.insufficient_evidence) {
+			std::string error_msg = std::string(StringBuilder()
+				.append("Insufficient replay evidence to attach out-of-line member '")
+				.append(decl.identifier_token().value())
+				.append("' for instantiated class '")
+				.append(instantiated_name)
+				.append("'")
+				.commit());
+			if (force_eager) {
+				throw InternalError(error_msg);
+			}
+			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
+		}
 		if (out_of_line_ctor_stub) {
 			OutOfLineConstructorStubResolution ctor_resolution =
 				findPlainOutOfLineConstructorStubByIdentity(

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8142,7 +8142,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								.append("'")
 								.commit());
 							if (force_eager) {
-								throw InternalError(error_msg);
+								throw CompileError(error_msg);
 							}
 							return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 						}
@@ -8150,10 +8150,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						StringBuilder error_builder;
 						if (member_resolution.ambiguous) {
 							error_builder
-								.append("Ambiguous replay-first attachment for partial-spec plain out-of-line member '");
+								.append("Could not uniquely match partial-spec plain out-of-line member '");
 						} else if (member_resolution.insufficient_evidence) {
 							error_builder
-								.append("Insufficient replay evidence to attach partial-spec plain out-of-line member '");
+								.append("Could not match partial-spec plain out-of-line member '");
 						} else {
 							error_builder
 								.append("Could not attach partial-spec plain out-of-line member '");
@@ -8170,7 +8170,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 						std::string error_msg = std::string(error_builder.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -8255,14 +8255,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					if (saw_ambiguous_replay_match) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Ambiguous replay-first attachment for partial-spec nested out-of-line member template '")
+							.append("Could not uniquely match partial-spec nested out-of-line member template '")
 							.append(ool_func_name)
 							.append("' in instantiated class '")
 							.append(instantiated_name)
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -8297,14 +8297,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							ool_func_name);
 					} else if (saw_insufficient_replay_evidence) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Insufficient replay evidence to attach partial-spec nested out-of-line member template '")
+							.append("Could not match partial-spec nested out-of-line member template '")
 							.append(ool_func_name)
 							.append("' for instantiated class '")
 							.append(instantiated_name)
+							.append("' to exactly one declaration after template substitution")
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					} else {
@@ -8316,7 +8317,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("' via replay identity map")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -8363,7 +8364,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							out_of_line_member.inner_template_params.size()));
 				if (ctor_resolution.ambiguous) {
 					std::string error_msg = std::string(StringBuilder()
-						.append("Ambiguous replay-first attachment for partial-spec out-of-line constructor template '")
+						.append("Could not uniquely match partial-spec out-of-line constructor template '")
 						.append(ool_func_name)
 						.append("' in instantiated class '")
 						.append(instantiated_name)
@@ -8378,7 +8379,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					StringBuilder error_builder;
 					if (ctor_resolution.insufficient_evidence) {
 						error_builder
-							.append("Insufficient replay evidence to attach partial-spec out-of-line constructor template '");
+							.append("Could not match partial-spec out-of-line constructor template '");
 					} else {
 						error_builder
 							.append("Could not attach partial-spec out-of-line constructor template '");
@@ -11975,7 +11976,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					if (ctor_resolution.ambiguous) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
+							.append("Could not uniquely match nested out-of-line constructor template '")
 							.append(out_of_line_ctor_decl.name())
 							.append("' in instantiated class '")
 							.append(qualified_name)
@@ -11997,7 +11998,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						StringBuilder error_builder;
 						if (ctor_resolution.insufficient_evidence) {
 							error_builder
-								.append("Insufficient replay evidence to attach nested out-of-line constructor template '");
+								.append("Could not match nested out-of-line constructor template '");
 						} else {
 							error_builder
 								.append("Could not attach nested out-of-line constructor template '");
@@ -12048,7 +12049,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								out_of_line_member.inner_template_params.size()));
 					if (ctor_resolution.ambiguous) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Ambiguous replay-first attachment for nested out-of-line constructor template '")
+							.append("Could not uniquely match nested out-of-line constructor template '")
 							.append(out_of_line_ctor_stub_decl.decl_node().identifier_token().value())
 							.append("' in instantiated class '")
 							.append(qualified_name)
@@ -12063,7 +12064,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						StringBuilder error_builder;
 						if (ctor_resolution.insufficient_evidence) {
 							error_builder
-								.append("Insufficient replay evidence to attach nested out-of-line constructor template '");
+								.append("Could not match nested out-of-line constructor template '");
 						} else {
 							error_builder
 								.append("Could not attach nested out-of-line constructor template '");
@@ -12201,7 +12202,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					if (saw_ambiguous_replay_match) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Ambiguous replay-first attachment for nested out-of-line member template '")
+							.append("Could not uniquely match nested out-of-line member template '")
 							.append(ool_func_name)
 							.append("' for nested struct '")
 							.append(nested_struct.name().view())
@@ -12210,7 +12211,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -12231,16 +12232,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							ool_func_name);
 					} else if (saw_insufficient_replay_evidence) {
 						std::string error_msg = std::string(StringBuilder()
-							.append("Insufficient replay evidence to attach nested out-of-line member template '")
+							.append("Could not match nested out-of-line member template '")
 							.append(ool_func_name)
 							.append("' for nested struct '")
 							.append(nested_struct.name().view())
 							.append("' in instantiated class '")
 							.append(StringTable::getStringView(qualified_name))
+							.append("' to exactly one declaration after template substitution")
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					} else {
@@ -12254,7 +12256,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("'")
 							.commit());
 						if (force_eager) {
-							throw InternalError(error_msg);
+							throw CompileError(error_msg);
 						}
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
@@ -14661,14 +14663,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							out_of_line_member.inner_template_params.size()));
 				if (ctor_resolution.ambiguous) {
 					std::string error_msg = std::string(StringBuilder()
-						.append("Ambiguous replay-first attachment for out-of-line constructor template '")
+						.append("Could not uniquely match out-of-line constructor template '")
 						.append(ool_func_name)
 						.append("' in instantiated class '")
 						.append(instantiated_name)
 						.append("'")
 						.commit());
 					if (force_eager) {
-						throw InternalError(error_msg);
+						throw CompileError(error_msg);
 					}
 					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
@@ -14677,7 +14679,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					StringBuilder error_builder;
 					if (ctor_resolution.insufficient_evidence) {
 						error_builder
-							.append("Insufficient replay evidence to attach out-of-line constructor template stub '");
+							.append("Could not match out-of-line constructor template stub '");
 					} else {
 						error_builder
 							.append("Could not attach out-of-line constructor template stub '");
@@ -14693,7 +14695,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					std::string error_msg = std::string(error_builder.commit());
 					if (force_eager) {
-						throw InternalError(error_msg);
+						throw CompileError(error_msg);
 					}
 					return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 				}
@@ -14807,14 +14809,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			if (saw_ambiguous_replay_match) {
 				std::string error_msg = std::string(StringBuilder()
-					.append("Ambiguous replay-first attachment for nested out-of-line member template '")
+					.append("Could not uniquely match nested out-of-line member template '")
 					.append(ool_func_name)
 					.append("' in instantiated class '")
 					.append(instantiated_name)
 					.append("'")
 					.commit());
 				if (force_eager) {
-					throw InternalError(error_msg);
+					throw CompileError(error_msg);
 				}
 				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
@@ -14894,14 +14896,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			if (!found && saw_insufficient_replay_evidence) {
 				std::string error_msg = std::string(StringBuilder()
-					.append("Insufficient replay evidence to attach nested out-of-line member template '")
+					.append("Could not match nested out-of-line member template '")
 					.append(ool_func_name)
 					.append("' for instantiated class '")
 					.append(instantiated_name)
+					.append("' to exactly one declaration after template substitution")
 					.append("'")
 					.commit());
 				if (force_eager) {
-					throw InternalError(error_msg);
+					throw CompileError(error_msg);
 				}
 				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
@@ -14915,7 +14918,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					.append("' via replay identity map")
 					.commit());
 				if (force_eager) {
-					throw InternalError(error_msg);
+					throw CompileError(error_msg);
 				}
 				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
@@ -15053,28 +15056,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (!out_of_line_ctor_stub &&
 			plain_member_resolution.ambiguous) {
 			std::string error_msg = std::string(StringBuilder()
-				.append("Ambiguous replay-first attachment for out-of-line member '")
+				.append("Could not uniquely match out-of-line member '")
 				.append(decl.identifier_token().value())
 				.append("' in instantiated class '")
 				.append(instantiated_name)
 				.append("'")
 				.commit());
 			if (force_eager) {
-				throw InternalError(error_msg);
+				throw CompileError(error_msg);
 			}
 			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 		}
 		if (!out_of_line_ctor_stub &&
 			plain_member_resolution.insufficient_evidence) {
 			std::string error_msg = std::string(StringBuilder()
-				.append("Insufficient replay evidence to attach out-of-line member '")
+				.append("Could not match out-of-line member '")
 				.append(decl.identifier_token().value())
 				.append("' for instantiated class '")
 				.append(instantiated_name)
+				.append("' to exactly one declaration after template substitution")
 				.append("'")
 				.commit());
 			if (force_eager) {
-				throw InternalError(error_msg);
+				throw CompileError(error_msg);
 			}
 			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 		}
@@ -15096,14 +15100,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					instantiated_name);
 			if (ctor_resolution.ambiguous) {
 				std::string ambiguity_msg = std::string(StringBuilder()
-					.append("Ambiguous replay-first attachment for out-of-line constructor '")
+					.append("Could not uniquely match out-of-line constructor '")
 					.append(decl.identifier_token().value())
 					.append("' in instantiated class '")
 					.append(instantiated_name)
 					.append("'")
 					.commit());
 				if (force_eager) {
-					throw InternalError(ambiguity_msg);
+					throw CompileError(ambiguity_msg);
 				}
 				return failTemplateInstantiation(ambiguity_msg, nullptr, std::nullopt);
 			}
@@ -15111,7 +15115,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				StringBuilder error_builder;
 				if (ctor_resolution.insufficient_evidence) {
 					error_builder
-						.append("Insufficient replay evidence to attach out-of-line constructor stub '");
+						.append("Could not match out-of-line constructor stub '");
 				} else {
 					error_builder
 						.append("Could not attach out-of-line constructor stub '");
@@ -15127,7 +15131,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 				std::string error_msg = std::string(error_builder.commit());
 				if (force_eager) {
-					throw InternalError(error_msg);
+					throw CompileError(error_msg);
 				}
 				return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 			}
@@ -15400,7 +15404,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				.append("'")
 				.commit());
 			if (force_eager) {
-				throw InternalError(error_msg);
+				throw CompileError(error_msg);
 			}
 			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 		}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8135,7 +8135,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								"for partial-spec: ", plain_ool_name);
 						} else {
 							std::string error_msg = std::string(StringBuilder()
-								.append("Failed to replay partial-spec plain out-of-line member '")
+								.append("Failed to attach body for partial-spec plain out-of-line member '")
 								.append(plain_ool_name)
 								.append("' for instantiated class '")
 								.append(instantiated_name)
@@ -8164,7 +8164,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append(instantiated_name);
 						if (!member_resolution.insufficient_evidence &&
 							!member_resolution.ambiguous) {
-							error_builder.append("' via replay identity map");
+							error_builder.append("' via source-member identity mapping");
 						} else {
 							error_builder.append("'");
 						}
@@ -8302,7 +8302,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("' for instantiated class '")
 							.append(instantiated_name)
 							.append("' to exactly one declaration after template substitution")
-							.append("'")
 							.commit());
 						if (force_eager) {
 							throw CompileError(error_msg);
@@ -8314,7 +8313,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append(ool_func_name)
 							.append("' for instantiated class '")
 							.append(instantiated_name)
-							.append("' via replay identity map")
+							.append("' via source-member identity mapping")
 							.commit());
 						if (force_eager) {
 							throw CompileError(error_msg);
@@ -8389,7 +8388,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						.append("' for instantiated class '")
 						.append(instantiated_name);
 					if (!ctor_resolution.insufficient_evidence) {
-						error_builder.append("' via replay identity map");
+						error_builder.append("' via source-member identity mapping");
 					} else {
 						error_builder.append("'");
 					}
@@ -12008,7 +12007,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("' for instantiated class '")
 							.append(qualified_name);
 						if (!ctor_resolution.insufficient_evidence) {
-							error_builder.append("' via replay identity map");
+							error_builder.append("' via source-member identity mapping");
 						} else {
 							error_builder.append("'");
 						}
@@ -12074,7 +12073,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("' for instantiated class '")
 							.append(qualified_name);
 						if (!ctor_resolution.insufficient_evidence) {
-							error_builder.append("' via replay identity map");
+							error_builder.append("' via source-member identity mapping");
 						} else {
 							error_builder.append("'");
 						}
@@ -12239,7 +12238,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append("' in instantiated class '")
 							.append(StringTable::getStringView(qualified_name))
 							.append("' to exactly one declaration after template substitution")
-							.append("'")
 							.commit());
 						if (force_eager) {
 							throw CompileError(error_msg);
@@ -14689,7 +14687,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						.append("' for instantiated class '")
 						.append(instantiated_name);
 					if (!ctor_resolution.insufficient_evidence) {
-						error_builder.append("' via replay identity map");
+						error_builder.append("' via source-member identity mapping");
 					} else {
 						error_builder.append("'");
 					}
@@ -14901,7 +14899,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					.append("' for instantiated class '")
 					.append(instantiated_name)
 					.append("' to exactly one declaration after template substitution")
-					.append("'")
 					.commit());
 				if (force_eager) {
 					throw CompileError(error_msg);
@@ -14915,7 +14912,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					.append(ool_func_name)
 					.append("' for instantiated class '")
 					.append(instantiated_name)
-					.append("' via replay identity map")
+					.append("' via source-member identity mapping")
 					.commit());
 				if (force_eager) {
 					throw CompileError(error_msg);
@@ -15075,7 +15072,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				.append("' for instantiated class '")
 				.append(instantiated_name)
 				.append("' to exactly one declaration after template substitution")
-				.append("'")
 				.commit());
 			if (force_eager) {
 				throw CompileError(error_msg);
@@ -15125,7 +15121,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					.append("' for instantiated class '")
 					.append(instantiated_name);
 				if (!ctor_resolution.insufficient_evidence) {
-					error_builder.append("' via replay identity map");
+					error_builder.append("' via source-member identity mapping");
 				} else {
 					error_builder.append("'");
 				}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -304,6 +304,7 @@ static ASTNode* findSourceMemberStubByIdentity(
 
 struct OutOfLineMemberStubResolution {
 	FunctionDeclarationNode* func = nullptr;
+	bool ambiguous = false;
 	bool insufficient_evidence = false;
 };
 
@@ -367,6 +368,8 @@ static OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 
 	if (resolved_matches.size() == 1) {
 		resolution.func = resolved_matches.front();
+	} else if (resolved_matches.size() > 1) {
+		resolution.ambiguous = true;
 	}
 	return resolution;
 }
@@ -8145,7 +8148,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					} else {
 						StringBuilder error_builder;
-						if (member_resolution.insufficient_evidence) {
+						if (member_resolution.ambiguous) {
+							error_builder
+								.append("Ambiguous replay-first attachment for partial-spec plain out-of-line member '");
+						} else if (member_resolution.insufficient_evidence) {
 							error_builder
 								.append("Insufficient replay evidence to attach partial-spec plain out-of-line member '");
 						} else {
@@ -8156,7 +8162,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							.append(plain_ool_name)
 							.append("' for instantiated class '")
 							.append(instantiated_name);
-						if (!member_resolution.insufficient_evidence) {
+						if (!member_resolution.insufficient_evidence &&
+							!member_resolution.ambiguous) {
 							error_builder.append("' via replay identity map");
 						} else {
 							error_builder.append("'");
@@ -14985,6 +14992,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			decl.identifier_token().value(),
 			template_name,
 			template_base_name);
+		if (!out_of_line_ctor_stub &&
+			plain_member_resolution.ambiguous) {
+			std::string error_msg = std::string(StringBuilder()
+				.append("Ambiguous replay-first attachment for out-of-line member '")
+				.append(decl.identifier_token().value())
+				.append("' in instantiated class '")
+				.append(instantiated_name)
+				.append("'")
+				.commit());
+			if (force_eager) {
+				throw InternalError(error_msg);
+			}
+			return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
+		}
 		if (!out_of_line_ctor_stub &&
 			plain_member_resolution.insufficient_evidence) {
 			std::string error_msg = std::string(StringBuilder()


### PR DESCRIPTION
## Summary
This PR continues the replay-evidence tightening work by removing additional first-match/generic-miss behavior from out-of-line member replay attachment paths.

### 1. Plain out-of-line member replay now preserves evidence state
- Replaced raw pointer return from `findPlainOutOfLineMemberStubByIdentity(...)` with structured replay result state (`func`, `ambiguous`, `insufficient_evidence`).
- Plain-member replay attachment now:
  - fails explicitly on unresolved or non-unique post-substitution matches instead of degrading to generic attachment misses,
  - fails explicitly on ambiguous positive-evidence replay matches.

### 2. Nested member-template replay now rejects ambiguous positive matches
- In the primary-template, partial-specialization, and nested-struct nested-template replay loops, attachment no longer accepts the first matching candidate when multiple positive-evidence candidates exist.
- These paths now fail with explicit ambiguous replay diagnostics.

### 3. User-facing diagnostic wording cleanup
- Reworded replay-attachment failures from implementation-centric language to clearer user diagnostics:
  - `Could not match ...` for unresolved post-substitution attachment,
  - `Could not uniquely match ...` for ambiguous attachment.
- Eager replay-attachment failures that already map to `failTemplateInstantiation(...)` now surface as `CompileError` instead of `InternalError`.

### 4. Documentation updates
- Updated semantic status and template architecture/conformance docs to record:
  - plain-member replay hard-fail behavior on unresolved post-substitution matches,
  - explicit ambiguous-match failures for nested member-template replay.

## Validation
- `./build_flashcpp.bat`
- `pwsh tests/run_all_tests.ps1`
  - 2610 regular tests passed
  - 194 expected-fail tests behaved as expected

## Commits in this PR
- `e1c79fc0` Tighten plain member replay evidence handling
- `dad41fab` Report ambiguous plain-member replay attachments
- `bfb1dcca` Fail nested template replay on ambiguous matches
- `721eb4a6` Clarify replay-attachment error wording for users