### PR TITLE
Strengthen sema-owned dependent call resolution

### DIFF
--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -105,6 +105,14 @@ The direct-call reason table is gone. The remaining work is to remove the
 last non-normalized member-recovery paths so direct calls are sema-owned across
 the whole pipeline and unresolved calls fail with clear diagnostics/invariants.
 
+Near-term blocker in this area:
+
+- dependent-unqualified calls still keep a provisional parser-callee fallback
+  after POI lookup misses; removing it currently regresses
+  `test_dependent_identifier_template_call_ret0.cpp`,
+  `test_pack_expansion_in_template_body_ret0.cpp`, and
+  `test_template_builtin_addressof_substitution_ret0.cpp`
+
 Recommended next step:
 
 - continue the Phase 1 burn-down in

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2966,15 +2966,19 @@ private:
 // Unified call-expression node (consolidation plan step 1)
 // ============================================================================
 
+// Shared payload for call-lookup records captured during parsing.
+struct CallLookupRecordShared {
+	TemplateDefinitionLookupContext definition_context;
+	StringHandle callee_name{};
+};
+
 // Per-call semantic record for non-dependent function calls whose lookup was
 // completed in the template definition context.  The callee pointer follows the
 // same stable FunctionDeclarationNode identity already stored by
 // CalleeDescriptor; the definition context documents the lookup boundary used
 // to exclude later point-of-instantiation declarations.  For qualified calls,
 // the CallExprNode qualified_name records the qualifier and ADL is disabled.
-struct FunctionCallDefinitionLookupRecord {
-	TemplateDefinitionLookupContext definition_context;
-	StringHandle callee_name{};
+struct FunctionCallDefinitionLookupRecord : CallLookupRecordShared {
 	const FunctionDeclarationNode* resolved_function = nullptr;
 	StringHandle resolved_mangled_name{};
 	bool ordinary_lookup_included = true;
@@ -2984,10 +2988,10 @@ struct FunctionCallDefinitionLookupRecord {
 // Per-call semantic record for unresolved dependent unqualified calls whose
 // ordinary lookup must remain definition-bound while ADL completes at the point
 // of instantiation.
-struct DependentUnqualifiedCallLookupRecord {
-	TemplateDefinitionLookupContext definition_context;
-	StringHandle callee_name{};
+struct DependentUnqualifiedCallLookupRecord : CallLookupRecordShared {
 	bool argument_dependent_lookup_included = true;
+	const FunctionDeclarationNode* definition_bound_function = nullptr;
+	StringHandle definition_bound_mangled_name{};
 };
 
 // Describes what kind of call site this is.

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -32,7 +32,6 @@ struct CallInfo {
 
 	// Full function declaration (null when only a DeclarationNode is available).
 	const FunctionDeclarationNode* function_declaration;
-	const FunctionDeclarationNode* raw_function_declaration;
 
 	// Arguments (always present).
 	const ChunkedVector<ASTNode>* arguments;
@@ -59,7 +58,6 @@ struct CallInfo {
 		CallInfo info;
 		info.declaration           = &node.callee().declaration();
 		info.function_declaration  = getParserStoredDirectCallTarget(node);
-		info.raw_function_declaration = node.callee().function_declaration_or_null();
 		info.arguments             = &node.arguments();
 		info.called_from           = node.called_from();
 		info.receiver              = node.has_receiver() ? node.receiver() : ASTNode();

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1623,6 +1623,40 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			: makeDirectCallExpr(target_decl, std::move(args), called_from);
 		return gChunkedAnyStorage.emplace_back<ExpressionNode>(std::move(new_call));
 	};
+	auto materializeResolvedCallExpr = [&](
+		const FunctionDeclarationNode& target_func,
+		ChunkedVector<ASTNode>&& args,
+		const Token& called_from_token,
+		std::optional<std::string_view> qualified_call_name,
+		bool copy_template_arguments,
+		bool infer_qualified_name_from_parent) -> ASTNode {
+		ExpressionNode& new_expr = emplaceDirectCallExpr(
+			target_func.decl_node(),
+			&target_func,
+			std::move(args),
+			called_from_token);
+		CallMetadataCopyOptions copy_options;
+		copy_options.copy_template_arguments = copy_template_arguments;
+		copy_options.copy_dependent_unqualified_lookup_record = false;
+		copy_options.copy_dependent_qualified_lookup_record = false;
+		copyMetadataToExpr(new_expr, copy_options);
+		if (qualified_call_name.has_value() && !qualified_call_name->empty()) {
+			setCallQualifiedName(new_expr, *qualified_call_name);
+		} else if (infer_qualified_name_from_parent &&
+			!target_func.parent_struct_name().empty()) {
+			setCallQualifiedName(
+				new_expr,
+				StringBuilder()
+					.append(target_func.parent_struct_name())
+					.append("::")
+					.append(target_func.decl_node().identifier_token().value())
+					.commit());
+		}
+		if (target_func.has_mangled_name()) {
+			setCallMangledName(new_expr, target_func.mangled_name());
+		}
+		return ASTNode(&new_expr);
+	};
 	auto normalizePendingSemanticRoots = [&]() {
 		parser_.normalizePendingSemanticRoots();
 	};
@@ -2032,25 +2066,23 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					for (size_t i = 0; i < call.arguments().size(); ++i) {
 						substituted_args_nodes.push_back(substitute(call.arguments()[i]));
 					}
-
-					ExpressionNode& new_expr = emplaceDirectCallExpr(
-						func_decl.decl_node(),
-						&func_decl,
+					ASTNode resolved_call = materializeResolvedCallExpr(
+						func_decl,
 						std::move(substituted_args_nodes),
-						call.called_from());
-					CallMetadataCopyOptions copy_options;
-					copy_options.copy_template_arguments = false;
-					copyMetadataToExpr(new_expr, copy_options);
-					if (func_decl.has_mangled_name()) {
-						setCallMangledName(new_expr, func_decl.mangled_name());
-					}
+						call.called_from(),
+						std::nullopt,
+						false, // copy_template_arguments
+						false  // infer_qualified_name_from_parent
+					);
 					std::vector<ASTNode> substituted_template_arg_nodes;
 					substituted_template_arg_nodes.reserve(explicit_template_arg_nodes.size());
 					for (const auto& arg_node : explicit_template_arg_nodes) {
 						substituted_template_arg_nodes.push_back(substitute(arg_node));
 					}
-					setCallTemplateArguments(new_expr, std::move(substituted_template_arg_nodes));
-					return ASTNode(&new_expr);
+					setCallTemplateArguments(
+						resolved_call.as<ExpressionNode>(),
+						std::move(substituted_template_arg_nodes));
+					return resolved_call;
 				}
 			}
 
@@ -2226,16 +2258,14 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			FLASH_LOG(Templates, Debug, "  Successfully instantiated template function");
 
 			// Create a new direct CallExprNode with the instantiated function
-			ExpressionNode& new_expr = emplaceDirectCallExpr(
-				instantiated_func.decl_node(),
-				&instantiated_func,
+			return materializeResolvedCallExpr(
+				instantiated_func,
 				std::move(substituted_args),
-				call.called_from());
-			copyMetadataToExpr(new_expr);
-			if (instantiated_func.has_mangled_name()) {
-				setCallMangledName(new_expr, instantiated_func.mangled_name());
-			}
-			return ASTNode(&new_expr);
+				call.called_from(),
+				std::nullopt,
+				true,  // copy_template_arguments
+				false  // infer_qualified_name_from_parent
+			);
 		} else {
 			FLASH_LOG(Templates, Warning, "  Failed to instantiate template function: ", template_func_name);
 		}
@@ -2258,27 +2288,14 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				if (const FunctionDeclarationNode* target_func =
 						get_function_decl_node(*resolved_target);
 					target_func != nullptr) {
-					ExpressionNode& new_expr = emplaceDirectCallExpr(
-						target_func->decl_node(),
-						target_func,
+					return materializeResolvedCallExpr(
+						*target_func,
 						std::move(substituted_args),
-						call.called_from());
-					CallMetadataCopyOptions copy_options;
-					copy_options.copy_dependent_unqualified_lookup_record = false;
-					copyMetadataToExpr(new_expr, copy_options);
-					if (target_func->has_mangled_name()) {
-						setCallMangledName(new_expr, target_func->mangled_name());
-					}
-					if (!target_func->parent_struct_name().empty()) {
-						setCallQualifiedName(
-							new_expr,
-							StringBuilder()
-								.append(target_func->parent_struct_name())
-								.append("::")
-								.append(target_func->decl_node().identifier_token().value())
-								.commit());
-					}
-					return ASTNode(&new_expr);
+						call.called_from(),
+						std::nullopt,
+						true, // copy_template_arguments
+						true  // infer_qualified_name_from_parent
+					);
 				}
 			}
 		}
@@ -2352,23 +2369,20 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 								call.called_from().line(),
 								call.called_from().column(),
 								call.called_from().file_index());
-							ExpressionNode& new_expr = emplaceDirectCallExpr(
-								target_func->decl_node(),
-								target_func,
-								std::move(substituted_args),
-								called_from_token);
-							copyMetadataToExpr(new_expr);
-							setCallQualifiedName(
-								new_expr,
+							const std::string_view resolved_qualified_name =
 								StringBuilder()
 									.append(resolved_owner_name)
 									.append("::")
 									.append(resolved_member_name)
-									.commit());
-							if (target_func->has_mangled_name()) {
-								setCallMangledName(new_expr, target_func->mangled_name());
-							}
-							return ASTNode(&new_expr);
+									.commit();
+							return materializeResolvedCallExpr(
+								*target_func,
+								std::move(substituted_args),
+								called_from_token,
+								resolved_qualified_name,
+								true,  // copy_template_arguments
+								false  // infer_qualified_name_from_parent
+							);
 						}
 					}
 				}
@@ -2503,23 +2517,20 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 							call.called_from().line(),
 							call.called_from().column(),
 							call.called_from().file_index());
-						ExpressionNode& new_expr = emplaceDirectCallExpr(
-							target_func->decl_node(),
-							target_func,
-							std::move(substituted_args),
-							called_from_token);
-						copyMetadataToExpr(new_expr);
-						setCallQualifiedName(
-							new_expr,
+						const std::string_view materialized_qualified_name =
 							StringBuilder()
 								.append(materialized_owner_name)
 								.append("::")
 								.append(member_name)
-								.commit());
-						if (target_func->has_mangled_name()) {
-							setCallMangledName(new_expr, target_func->mangled_name());
-						}
-						return ASTNode(&new_expr);
+								.commit();
+						return materializeResolvedCallExpr(
+							*target_func,
+							std::move(substituted_args),
+							called_from_token,
+							materialized_qualified_name,
+							true,  // copy_template_arguments
+							false  // infer_qualified_name_from_parent
+						);
 					}
 				}
 			}
@@ -2595,17 +2606,14 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					return wrapOriginalCall();
 				}
 
-				ExpressionNode& new_expr = emplaceDirectCallExpr(
-					target_func->decl_node(),
-					target_func,
+				return materializeResolvedCallExpr(
+					*target_func,
 					std::move(substituted_args),
-					new_func_token);
-				copyMetadataToExpr(new_expr);
-				setCallQualifiedName(new_expr, new_func_name);
-				if (target_func && target_func->has_mangled_name()) {
-					setCallMangledName(new_expr, target_func->mangled_name());
-				}
-				return ASTNode(&new_expr);
+					new_func_token,
+					new_func_name,
+					true,  // copy_template_arguments
+					false  // infer_qualified_name_from_parent
+				);
 			}
 		}
 	}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -191,6 +191,31 @@ bool isEligibleDefinitionLookupCall(
 	return true;
 }
 
+template <typename LookupRecordT>
+void initializeCallLookupRecordCommon(
+	LookupRecordT& record,
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token) {
+	if (definition_context != nullptr && definition_context->is_valid()) {
+		record.definition_context = *definition_context;
+	}
+	record.callee_name = callee_token.handle();
+}
+
+void setDefinitionBoundFunction(
+	DependentUnqualifiedCallLookupRecord& record,
+	const FunctionDeclarationNode* definition_bound_function) {
+	if (definition_bound_function == nullptr) {
+		return;
+	}
+	record.definition_bound_function = definition_bound_function;
+	if (definition_bound_function->has_mangled_name()) {
+		record.definition_bound_mangled_name =
+			StringTable::getOrInternStringHandle(
+				definition_bound_function->mangled_name());
+	}
+}
+
 std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLookupRecord(
 	const TemplateDefinitionLookupContext* definition_context,
 	const Token& callee_token,
@@ -210,8 +235,7 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 
 	const FunctionDeclarationNode& func_decl = resolved_decl.as<FunctionDeclarationNode>();
 	FunctionCallDefinitionLookupRecord record;
-	record.definition_context = *definition_context;
-	record.callee_name = callee_token.handle();
+	initializeCallLookupRecordCommon(record, definition_context, callee_token);
 	record.resolved_function = &func_decl;
 	if (func_decl.has_mangled_name()) {
 		record.resolved_mangled_name =
@@ -225,18 +249,38 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 std::optional<DependentUnqualifiedCallLookupRecord> makeDependentUnqualifiedCallLookupRecord(
 	const TemplateDefinitionLookupContext* definition_context,
 	const Token& callee_token,
-	bool argument_dependent_lookup_included) {
+	bool argument_dependent_lookup_included,
+	const FunctionDeclarationNode* definition_bound_function) {
 	if (callee_token.type() != Token::Type::Identifier) {
 		return std::nullopt;
 	}
 
 	DependentUnqualifiedCallLookupRecord record;
-	if (definition_context != nullptr && definition_context->is_valid()) {
-		record.definition_context = *definition_context;
-	}
-	record.callee_name = callee_token.handle();
+	initializeCallLookupRecordCommon(record, definition_context, callee_token);
 	record.argument_dependent_lookup_included = argument_dependent_lookup_included;
+	setDefinitionBoundFunction(record, definition_bound_function);
 	return record;
+}
+
+std::optional<DependentUnqualifiedCallLookupRecord> makeDependentUnqualifiedCallLookupRecordFromResolvedDecl(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	bool argument_dependent_lookup_included,
+	const ASTNode& resolved_decl) {
+	if (const FunctionDeclarationNode* definition_bound_function =
+			get_function_decl_node(resolved_decl);
+		definition_bound_function != nullptr) {
+		return makeDependentUnqualifiedCallLookupRecord(
+			definition_context,
+			callee_token,
+			argument_dependent_lookup_included,
+			definition_bound_function);
+	}
+	return makeDependentUnqualifiedCallLookupRecord(
+		definition_context,
+		callee_token,
+		argument_dependent_lookup_included,
+		nullptr);
 }
 
 void appendUniqueOverloads(std::vector<ASTNode>& target, std::span<const ASTNode> source) {
@@ -1204,7 +1248,8 @@ void maybeAttachDependentUnqualifiedLookupRecord(
 	const Token& callee_token,
 	bool has_deferred_template_call_args,
 	const TemplateDefinitionLookupContext* definition_context,
-	bool argument_dependent_lookup_included) {
+	bool argument_dependent_lookup_included,
+	const FunctionDeclarationNode* definition_bound_function) {
 	if (!has_deferred_template_call_args) {
 		return;
 	}
@@ -1212,10 +1257,39 @@ void maybeAttachDependentUnqualifiedLookupRecord(
 			makeDependentUnqualifiedCallLookupRecord(
 				definition_context,
 				callee_token,
-				argument_dependent_lookup_included);
+				argument_dependent_lookup_included,
+				definition_bound_function);
 		record.has_value()) {
 		setCallDependentUnqualifiedLookupRecord(call_expr, *record);
 	}
+}
+
+void maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
+	ExpressionNode& call_expr,
+	const Token& callee_token,
+	bool has_deferred_template_call_args,
+	const TemplateDefinitionLookupContext* definition_context,
+	bool argument_dependent_lookup_included,
+	const ASTNode& resolved_decl) {
+	if (const FunctionDeclarationNode* definition_bound_function =
+			get_function_decl_node(resolved_decl);
+		definition_bound_function != nullptr) {
+		maybeAttachDependentUnqualifiedLookupRecord(
+			call_expr,
+			callee_token,
+			has_deferred_template_call_args,
+			definition_context,
+			argument_dependent_lookup_included,
+			definition_bound_function);
+		return;
+	}
+	maybeAttachDependentUnqualifiedLookupRecord(
+		call_expr,
+		callee_token,
+		has_deferred_template_call_args,
+		definition_context,
+		argument_dependent_lookup_included,
+		nullptr);
 }
 
 void syncTemplateArgumentNodeMetadata(
@@ -5272,7 +5346,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						identifier_token,
 						has_dependent_call_args,
 						current_template_definition_lookup_context_,
-						true);
+						true,
+						nullptr);
 					return ParseResult::success(*result);
 				}
 
@@ -5296,12 +5371,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 						}
 					}
-					maybeAttachDependentUnqualifiedLookupRecord(
+					maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 						result->as<ExpressionNode>(),
 						identifier_token,
 						has_dependent_call_args,
 						current_template_definition_lookup_context_,
-						true);
+						true,
+						*resolution.selected_overload);
 					return ParseResult::success(*result);
 				}
 				// Template instantiation failure is an expected substitution failure in
@@ -5713,15 +5789,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 					}
 					if (has_deferred_template_call_args) {
-						if (std::optional<DependentUnqualifiedCallLookupRecord> record =
-								makeDependentUnqualifiedCallLookupRecord(
-									current_template_definition_lookup_context_,
-									identifier_token,
-									argumentDependentLookupIncluded);
-							record.has_value()) {
-							setCallDependentUnqualifiedLookupRecord(
-								result->as<ExpressionNode>(),
-								*record);
+						std::optional<DependentUnqualifiedCallLookupRecord> record =
+							makeDependentUnqualifiedCallLookupRecordFromResolvedDecl(
+								current_template_definition_lookup_context_,
+								identifier_token,
+								argumentDependentLookupIncluded,
+								*identifierType);
+						if (record.has_value()) {
+							setCallDependentUnqualifiedLookupRecord(result->as<ExpressionNode>(), *record);
 						}
 					}
 					return ParseResult::success(*result);
@@ -5766,12 +5841,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
 						}
 					}
-					maybeAttachDependentUnqualifiedLookupRecord(
+					maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 						result->as<ExpressionNode>(),
 						identifier_token,
 						has_deferred_template_call_args,
 						current_template_definition_lookup_context_,
-						argumentDependentLookupIncluded);
+						argumentDependentLookupIncluded,
+						resolved_decl);
 					return ParseResult::success(*result);
 				};
 
@@ -5785,7 +5861,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							makeDependentUnqualifiedCallLookupRecord(
 								current_template_definition_lookup_context_,
 								identifier_token,
-								argumentDependentLookupIncluded);
+								argumentDependentLookupIncluded,
+								nullptr);
 						record.has_value()) {
 						setCallDependentUnqualifiedLookupRecord(
 							result->as<ExpressionNode>(),
@@ -8495,13 +8572,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 										}
 									}
-									maybeAttachDependentUnqualifiedLookupRecord(
+									maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 										result->as<ExpressionNode>(),
 										identifier_token,
 										argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 											argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
 										current_template_definition_lookup_context_,
-										true);
+										true,
+										*identifierType);
 									// Return early - we've created the call expression with the args
 									if (result.has_value())
 										return ParseResult::success(*result);
@@ -8720,13 +8798,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 											}
 										}
-										maybeAttachDependentUnqualifiedLookupRecord(
+										maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 											result->as<ExpressionNode>(),
 											identifier_token,
 											argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 												argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
 											current_template_definition_lookup_context_,
-											true);
+											true,
+											*instantiated_func);
 									} else if (has_dependent_template_args || defer_struct_member_template_instantiation) {
 										// Template arguments are dependent - this is a template-dependent expression
 										// Create a CallExprNode with a placeholder declaration that will be resolved during template instantiation
@@ -8852,13 +8931,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 													setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 												}
 											}
-											maybeAttachDependentUnqualifiedLookupRecord(
+											maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 												result->as<ExpressionNode>(),
 												identifier_token,
 												argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 													argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
 												current_template_definition_lookup_context_,
-												true);
+												true,
+												*instantiated_func);
 									} else {
 										bool has_dependent_call_args = argsHaveDeferredTemplateDependency(args, currentTemplateParamNames());
 										if (has_dependent_call_args ||
@@ -8932,13 +9012,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 														setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 													}
 												}
-												maybeAttachDependentUnqualifiedLookupRecord(
+												maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 													result->as<ExpressionNode>(),
 													identifier_token,
 													argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 														argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
 													current_template_definition_lookup_context_,
-													true);
+													true,
+													*instantiated_func);
 										} else {
 											bool has_dependent_call_args = argsHaveDeferredTemplateDependency(args, currentTemplateParamNames());
 											if (has_dependent_call_args ||
@@ -8987,13 +9068,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 													setCallQualifiedName(result->as<ExpressionNode>(), StringBuilder().append(func_decl.parent_struct_name()).append("::").append(func_decl.decl_node().identifier_token().value()).commit());
 												}
 											}
-											maybeAttachDependentUnqualifiedLookupRecord(
+											maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 												result->as<ExpressionNode>(),
 												identifier_token,
 												argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 													argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
 												current_template_definition_lookup_context_,
-												true);
+												true,
+												*resolution_result.selected_overload);
 										}
 									}
 								}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7584,6 +7584,26 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return nullptr;
 	};
+	auto resolveDefinitionLookupRecordTarget = [&]() -> const FunctionDeclarationNode* {
+		if (call_info.definition_lookup_record == nullptr ||
+			!call_info.definition_lookup_record->has_value()) {
+			return nullptr;
+		}
+		if (const FunctionDeclarationNode* resolved_function =
+				call_info.definition_lookup_record->value().resolved_function;
+			resolved_function != nullptr) {
+			return resolved_function;
+		}
+		return lookupFunctionByMangledName(
+			call_info.definition_lookup_record->value().resolved_mangled_name);
+	};
+	auto resolveDependentUnqualifiedRecordTarget =
+		[&](const DependentUnqualifiedCallLookupRecord& record) -> const FunctionDeclarationNode* {
+			if (record.definition_bound_function != nullptr) {
+				return record.definition_bound_function;
+			}
+			return lookupFunctionByMangledName(record.definition_bound_mangled_name);
+		};
 	struct QualifiedLookupTarget {
 		NamespaceHandle namespace_handle;
 		std::string_view identifier;
@@ -7712,6 +7732,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 
 		return nullptr;
 	}
+	if (call_info.function_declaration) {
+		return call_info.function_declaration;
+	}
 
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
 	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
@@ -7731,11 +7754,18 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (!call_info.has_receiver &&
 		call_info.dependent_unqualified_lookup_record != nullptr &&
 		call_info.dependent_unqualified_lookup_record->has_value()) {
+		const DependentUnqualifiedCallLookupRecord& dependent_record =
+			**call_info.dependent_unqualified_lookup_record;
+		if (const FunctionDeclarationNode* dependent_record_target =
+				resolveDependentUnqualifiedRecordTarget(dependent_record);
+			dependent_record_target != nullptr) {
+			return dependent_record_target;
+		}
 		std::vector<TypeSpecifierNode> arg_types;
 		if (parser().tryCollectFunctionCallArgTypes(arguments, arg_types)) {
 			if (std::optional<ASTNode> resolved_target =
 					parser().resolveDependentUnqualifiedCallAtPointOfInstantiation(
-						**call_info.dependent_unqualified_lookup_record,
+						dependent_record,
 						arguments,
 						arg_types);
 				resolved_target.has_value()) {
@@ -7746,24 +7776,18 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				}
 			}
 		}
-		if (call_info.raw_function_declaration != nullptr) {
-			return call_info.raw_function_declaration;
+		if (const FunctionDeclarationNode* definition_record_target =
+				resolveDefinitionLookupRecordTarget();
+			definition_record_target != nullptr) {
+			return definition_record_target;
 		}
 		return nullptr;
 	}
 
-	if (call_info.definition_lookup_record != nullptr &&
-		call_info.definition_lookup_record->has_value() &&
-		call_info.definition_lookup_record->value().resolved_function != nullptr) {
-		return call_info.definition_lookup_record->value().resolved_function;
-	}
-	if (call_info.definition_lookup_record != nullptr &&
-		call_info.definition_lookup_record->has_value()) {
-		if (const FunctionDeclarationNode* definition_mangled_candidate =
-				lookupFunctionByMangledName(
-					call_info.definition_lookup_record->value().resolved_mangled_name)) {
-			return definition_mangled_candidate;
-		}
+	if (const FunctionDeclarationNode* definition_record_target =
+			resolveDefinitionLookupRecordTarget();
+		definition_record_target != nullptr) {
+		return definition_record_target;
 	}
 
 	if (call_info.function_declaration)


### PR DESCRIPTION
## Summary
This PR strengthens sema-owned dependent call resolution while reducing duplicated call-rewrite logic.

### Key changes
- Added shared call-lookup payload (`CallLookupRecordShared`) for common record fields (`definition_context`, `callee_name`).
- Extended `DependentUnqualifiedCallLookupRecord` with definition-bound target identity:
  - `definition_bound_function`
  - `definition_bound_mangled_name`
- Updated parser record construction to populate those fields when a resolved function is available.
- Tightened semantic target resolution order for dependent-unqualified calls to prefer recorded target identity before additional POI probing.
- Refactored resolved-call materialization in `ExpressionSubstitutor` into one helper, and consistently clears dependent lookup records once a call is fully resolved.

### Why this helps
- Reduces reliance on broad name-based recovery paths.
- Preserves stable callee identity across parser -> substitution -> sema flow.
- Lowers duplication and metadata drift risk in call rewrite code.

## Validation
- `pwsh ./tests/run_all_tests.ps1`
- Result: 2611 regular tests passed, 194 expected-fail tests behaved as expected.