### PR TITLE
[codex] Fix template lookup and constexpr lambda captures

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -164,6 +164,13 @@ keeps lambda member-call receivers standards-aligned by:
   captures instead of assuming a local variable exists
 - preserving the referenced object's real size when loading through a
   by-reference capture
+- preserving receiver cv-qualification through constexpr synthetic `this`
+  bindings, including unqualified member calls from const member bodies
+
+Follow-up: the constexpr evaluator now applies the same const-aware selection
+rule in the receiver-based and current-struct paths, but the implementations are
+still structurally separate. The next cleanup should extract one shared
+member-candidate collector so future overload fixes cannot drift between paths.
 
 Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-02
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -12,8 +12,11 @@ highest-value cleanup should be.
 The template system has moved away from broad AST-only replay and toward
 owner-aware semantic records plus replay-first attachment. The legacy textual
 `base::member` dependent-alias path has now been removed; dependent member
-alias resolution is semantic-only. The biggest remaining gap is keeping replay
-attachment evidence-driven rather than shape-driven.
+alias resolution is semantic-only. The newest high-impact fix also moves
+normalized template-call overload lookup onto sema-owned argument typing, so
+replayed dependent member overloads no longer inherit stale parser-selected
+targets. The biggest remaining gap is keeping every replay/materialization path
+equally evidence-driven rather than shape-driven.
 
 ## What the current design can assume
 
@@ -27,6 +30,10 @@ attachment evidence-driven rather than shape-driven.
   materialization route in the covered cases
 - explicit member-template calls now carry call-argument information early
   enough to avoid caching obviously wrong overloads
+- sema-owned direct-call resolution for normalized template/member calls now
+  collects overload-resolution argument types from semantic expression typing
+  instead of parser-owned call-argument typing, so dependent out-of-line member
+  overloads resolve by the concrete substituted call signature seen during sema
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -34,7 +41,7 @@ attachment evidence-driven rather than shape-driven.
   `base::member` path in `resolveDependentMemberAlias(...)` has been removed,
   and resolution flows through the preserved `DependentQualifiedNameRecord`,
   instantiation-context bindings, and `materializeInstantiatedMemberAliasTarget`
-- `materializeAliasTemplateInstance` now has a fallback to
+- `materializeAliasTemplateInstance` now delegates to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias
   cases (`template<T> using id = T`) where `instantiated_name` is empty
   but the alias node is non-null
@@ -67,7 +74,7 @@ attachment evidence-driven rather than shape-driven.
   and fails instantiation directly instead of degrading to generic
   replay-attachment misses
 - constructor replay sync into StructTypeInfo now requires signature-validation
-  evidence and no longer falls back to token/name shape equivalence for
+  evidence and no longer accepts token/name shape equivalence for
   mismatched parameter types
 
 ## Main remaining architectural gap
@@ -82,9 +89,10 @@ parse/materialization time:
 - `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
 
 The remaining problem is no longer textual recovery. It is keeping replay
-attachment evidence-driven: a few declaration-replay paths still lean on
-name/arity shape rather than source identity plus canonical substituted-signature
-evidence. Tightening those is the next best cleanup target.
+attachment evidence-driven across the remaining declaration/materialization
+paths: a few routes still lean on name/arity shape or parser-carried bindings
+instead of source identity plus canonical substituted-signature evidence.
+Tightening those is the next best cleanup target.
 
 ## Recommended implementation order
 
@@ -94,17 +102,23 @@ evidence. Tightening those is the next best cleanup target.
 
 2. Keep replay attachment evidence-driven.
    Continue tightening declaration replay so attachment succeeds because source
-   identity and canonical substituted signatures match, not because a fallback
-   scan guessed correctly. The next likely slice is the remaining
+   identity and canonical substituted signatures match, not because a
+   shape-based repair scan guessed correctly. The next likely slice is the remaining
    unresolved-signature acceptance paths that still tolerate shape-first replay
    attachment outside the now-tightened plain-member/member-template paths.
 
-3. Extend dependent-name modeling only where it unlocks step 2.
+3. Extend sema-owned lookup unification where it unlocks step 2.
+   The recent member-call fix closed one concrete gap by replacing parser-owned
+   call-argument typing inside sema with normalized semantic argument typing.
+   The next useful expansion is to audit the remaining semantic call-resolution
+   sites that still do not share that collector.
+
+4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
    Richer current-instantiation and unknown-specialization handling still
    matters, but it should be pulled in to unblock concrete replay/alias gaps,
    not pursued as a detached refactor.
 
-4. Leave lower-priority uplift for later unless it blocks the above.
+5. Leave lower-priority uplift for later unless it blocks the above.
    This includes broader sema-owned ranking/deduction cleanup and sema-level
    modeling for aggregate-forwarding constructor cases.
 
@@ -117,6 +131,41 @@ evidence. Tightening those is the next best cleanup target.
   than rebuilding `owner::member` strings by hand
 - if a path cannot preserve enough metadata, document the gap explicitly and
   keep the compatibility surface narrow
+
+## Next steps
+
+1. Audit the remaining semantic call-resolution entry points that do not yet
+   share `tryCollectOverloadResolutionArgTypes(...)`, especially operator-call
+   and other normalized-call paths where parser-owned expression typing can
+   diverge from sema-owned substituted types.
+
+2. Tighten the remaining replay-attachment sites that can still succeed without
+   positive substituted-signature evidence outside the now-hardened plain-member,
+   member-template, and constructor-template routes.
+
+3. Expand current-instantiation / unknown-specialization modeling only for the
+   concrete cases that still block standards-conforming typed lookup after steps
+   1 and 2.
+
+## 2026-06-02 constexpr lambda capture-lowering note
+
+The updated constexpr-lambda tests exposed runtime-only closure-lowering gaps:
+compile-time evaluation already accepted the C++20 cases, but generated code
+mis-modeled captured `this` inside lambdas and nested lambdas. The current fix
+keeps lambda member-call receivers standards-aligned by:
+
+- treating `this->member()` inside `[this]` as a call on the captured enclosing
+  object pointer, not on the closure object
+- treating `this->member()` inside `[*this]` as a call on the closure's copied
+  object member
+- propagating nested `[this]` captures through the effective enclosing object
+  pointer, including when the enclosing object is a `[*this]` copy
+- taking the address of enclosing closure members for nested by-reference
+  captures instead of assuming a local variable exists
+- preserving the referenced object's real size when loading through a
+  by-reference capture
+
+Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-01
+**Last updated:** 2026-06-02
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -28,7 +28,11 @@ Move FlashCpp toward a sema-owned template system where:
   and replay cases
 - explicit member-template call handling now carries enough early argument
   information to avoid wrong cached overload reuse
-- dependent alias resolution is semantic-only: the textual fallback in
+- semantic direct-call resolution for normalized template/member calls now uses
+  sema-owned overload-resolution argument typing instead of parser-owned
+  argument collection, so dependent out-of-line member overloads are selected
+  from the concrete substituted call signature seen during semantic analysis
+- dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
 - dependent nested member-template static constexpr chains now reuse typed
@@ -54,8 +58,8 @@ Move FlashCpp toward a sema-owned template system where:
   replay-attachment misses
 - constructor replay sync into StructTypeInfo now requires
   `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
-  treats token/name shape fallback as a valid equivalence
-- `materializeAliasTemplateInstance` now falls back to
+  treats token/name shape equivalence as valid evidence
+- `materializeAliasTemplateInstance` now delegates to
   `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
   where the instantiated name resolves to a member type
 - member type aliases preserve surface modifiers (pointer/reference/cv/array/
@@ -73,7 +77,7 @@ now resolve through preserved semantic records:
 With textual recovery gone, the next conformance step is keeping replay
 attachment invariant-driven: tighten the remaining replay paths so valid cases
 succeed via source identity plus canonical substituted-signature evidence rather
-than name/arity fallback scans, and expand current-instantiation /
+than name/arity repair scans, and expand current-instantiation /
 unknown-specialization modeling only where it unblocks those paths.
 
 ## Priority order
@@ -82,15 +86,21 @@ unknown-specialization modeling only where it unblocks those paths.
    alias callers.~~ **Done** — the textual recovery path is removed.
 
 2. Continue tightening replay attachment so valid cases succeed via source
-   identity plus canonical substituted-signature evidence, not fallback scans.
+   identity plus canonical substituted-signature evidence, not shape-based
+   repair scans.
    The next slice is likely the remaining unresolved-signature acceptance paths
    where replay can still succeed without enough evidence outside the now-
    tightened plain-member and member-template paths.
 
-3. Expand current-instantiation, dependent-base, and unknown-specialization
-   handling only where that unblocks step 2.
+3. Unify the remaining semantic call-resolution entry points around the same
+   sema-owned overload-resolution argument collector now used for normalized
+   template/member direct calls. This is the shortest path to preventing stale
+   parser-selected targets from surviving semantic normalization.
 
-4. Leave broader cleanup for later unless it becomes a blocker:
+4. Expand current-instantiation, dependent-base, and unknown-specialization
+   handling only where that unblocks steps 2 and 3.
+
+5. Leave broader cleanup for later unless it becomes a blocker:
    sema-owned ranking/deduction expansion, remaining repair-path removal, and
    sema-level modeling for aggregate-forwarding constructor sequences.
 
@@ -103,6 +113,34 @@ unknown-specialization modeling only where it unblocks those paths.
 - treat codegen-side recovery as debt to remove, not a design tool; when a
   late retry is still needed, it should delegate to typed lookup such as
   `resolveBaseClassMemberTypeChain`
+
+## Next steps
+
+1. Apply the sema-owned overload-resolution argument collector to the remaining
+   semantic call-resolution sites that still rely on parser-owned expression
+   typing or reduced argument modeling.
+
+2. Continue deleting replay-attachment acceptance paths that still allow
+   insufficient substituted-signature evidence outside the now-hardened member
+   and constructor routes.
+
+3. Only after those are stable, extend current-instantiation and
+   unknown-specialization modeling for the specific unresolved cases that remain.
+
+## 2026-06-02 constexpr lambda conformance note
+
+The updated constexpr-lambda tests exposed runtime capture-lowering bugs rather
+than compile-time evaluation failures. Generated code now follows the C++20
+closure model for captured `this` and nested captures:
+
+- `[this]` member calls use the captured enclosing object pointer
+- `[*this]` member calls use the copied object stored in the closure
+- nested `[this]` captures propagate the effective enclosing object pointer,
+  including when the enclosing lambda captured `*this`
+- nested reference captures of enclosing closure members take the member's
+  address directly and preserve the referenced object's real size
+
+Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -139,6 +139,9 @@ closure model for captured `this` and nested captures:
   including when the enclosing lambda captured `*this`
 - nested reference captures of enclosing closure members take the member's
   address directly and preserve the referenced object's real size
+- constexpr member evaluation now preserves receiver cv-qualification through
+  synthetic `this` bindings and rejects stale lowered non-const targets when
+  evaluating calls from a const member body
 
 Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -103,10 +103,18 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - constexpr member evaluation now preserves receiver cv-qualification through
   synthetic `this` bindings and rejects stale lowered non-const targets when
   evaluating calls from const member bodies
+- constexpr member evaluation now accepts semantically attached lowered
+  member-template targets directly and normalizes internal materialized member
+  names before any remaining symbolic fallback lookup
 - runtime lambda lowering now treats captured `this` according to the C++20
   closure model: `[this]` calls use the captured object pointer, `[*this]`
   calls use the copied closure member, and nested captures propagate the
   effective enclosing object instead of the closure object
+- deferred generic-lambda `operator()` lowering no longer depends on a stale
+  parser/sema query key surviving AST cloning during normalization; codegen
+  now prefers the exact normalized call node and can derive the callable owner
+  type from the resolved `operator()` member when the auxiliary receiver-type
+  query was not materialized
 
 ## Main remaining gaps
 
@@ -146,7 +154,26 @@ Recommended next step:
   semantic call-resolution entry points that still rely on parser-owned
   expression typing or reduced argument modeling
 
-### 3. Keep template replay attachment evidence-driven
+### 3. Replace pointer-keyed semantic call identity with stable call identity
+
+Some sema facts are still keyed by `CallExprNode*`. That remains fragile across
+template substitution and generic-lambda normalization because cloned call
+nodes are semantically the same call but not the same address. The recent
+generic-lambda regression was fixed by preferring the exact normalized call
+node and by deriving callable-owner information from the selected member when
+possible, but that is still a recovery around the real architectural gap.
+
+Recommended next step:
+
+- introduce a stable semantic call identity that survives substitution,
+  normalization, and replay
+- key resolved-call, callable-operator, and call-result-type facts by that
+  stable identity instead of raw node address where normalized bodies rely on
+  sema-owned results
+- remove the remaining exact-node recovery logic once the stable identity is
+  propagated end-to-end
+
+### 4. Keep template replay attachment evidence-driven
 
 The dependent-alias cleanup is complete: semantic owner/member-chain records
 now carry the former blocker cases, the textual `base::member` path is gone,
@@ -162,7 +189,24 @@ The next template task is narrower and more architectural:
 - expand current-instantiation and unknown-specialization handling only where
   it unblocks those replay paths
 
-### 4. Keep normalized-body invariants getting stricter
+### 5. Prefer semantic call targets over reconstructed constexpr lookup
+
+Constexpr member-call evaluation is improved, but it still has mixed lookup
+modes: some paths execute directly from the semantically attached declaration,
+others reconstruct the target from member-name lookup on the receiver type.
+For member templates and lowered/materialized declarations, the standards-
+aligned endpoint is to use the semantic target first and perform member lookup
+only when no semantic target exists.
+
+Recommended next step:
+
+- make constexpr member-call evaluation consistently consume the attached
+  semantic declaration target first
+- reduce name-based re-lookup to a true missing-metadata recovery path
+- then tighten invariants so normalized constexpr calls fail only on missing
+  compiler-owned semantic facts, not on rediscovery mismatches
+
+### 6. Keep normalized-body invariants getting stricter
 
 Any normalized-body path that still succeeds via compatibility behavior should
 be converted to one of:

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -1,6 +1,6 @@
 # Semantic Analysis Status
 
-**Last Updated:** 2026-06-01
+**Last Updated:** 2026-06-02
 
 This document is intentionally forward-looking. It should capture the current
 ownership model, the invariants future work can rely on, and the next cleanup
@@ -62,6 +62,10 @@ FlashCpp follows a parse -> sema -> IR pipeline:
   `direct_call_unresolved_after_lookup`
 - receiver-member recovery has been removed from direct-call target resolution;
   receiver calls now require a concrete parser/sema-resolved member target
+- normalized template/member direct-call resolution now collects overload
+  argument types from sema-owned expression typing via
+  `tryCollectOverloadResolutionArgTypes(...)`, instead of reusing parser-owned
+  argument typing that can retain stale dependent-template targets
 - parser/template work now preserves substantially more owner/member-template
   identity for dependent aliases and replay-heavy paths before deduction-time
   resolution
@@ -96,6 +100,13 @@ FlashCpp follows a parse -> sema -> IR pipeline:
 - StructTypeInfo constructor-template sync now requires positive
   `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
   accepts token/name shape-only fallback equivalence
+- constexpr member evaluation now preserves receiver cv-qualification through
+  synthetic `this` bindings and rejects stale lowered non-const targets when
+  evaluating calls from const member bodies
+- runtime lambda lowering now treats captured `this` according to the C++20
+  closure model: `[this]` calls use the captured object pointer, `[*this]`
+  calls use the copied closure member, and nested captures propagate the
+  effective enclosing object instead of the closure object
 
 ## Main remaining gaps
 
@@ -118,7 +129,24 @@ Recommended next step:
 - continue the Phase 1 burn-down in
   `docs/2026-04-04-codegen-name-lookup-investigation.md`
 
-### 2. Keep template replay attachment evidence-driven
+### 2. Unify remaining member/call lookup helpers
+
+Several paths now apply the same standards rule independently: const receivers
+only see const-qualified non-static members, while non-const receivers prefer
+non-const overloads and then const overloads when no non-const match exists.
+This is true for receiver-based constexpr member calls, current-struct
+constexpr calls, and normalized template/member direct-call resolution, but the
+candidate collectors are still structurally separate.
+
+Recommended next step:
+
+- extract a shared const-aware member-candidate collector for constexpr
+  receiver-based lookup and current-struct lookup
+- apply the sema-owned overload-resolution argument collector to the remaining
+  semantic call-resolution entry points that still rely on parser-owned
+  expression typing or reduced argument modeling
+
+### 3. Keep template replay attachment evidence-driven
 
 The dependent-alias cleanup is complete: semantic owner/member-chain records
 now carry the former blocker cases, the textual `base::member` path is gone,
@@ -134,7 +162,7 @@ The next template task is narrower and more architectural:
 - expand current-instantiation and unknown-specialization handling only where
   it unblocks those replay paths
 
-### 3. Keep normalized-body invariants getting stricter
+### 4. Keep normalized-body invariants getting stricter
 
 Any normalized-body path that still succeeds via compatibility behavior should
 be converted to one of:

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -150,6 +150,10 @@ Recommended next step:
 
 - extract a shared const-aware member-candidate collector for constexpr
   receiver-based lookup and current-struct lookup
+- extend that shared member-lookup helper to cover sema member-call target
+  selection and constexpr member-call target selection, so const/static/member-
+  template filtering rules live in one standards-owned path instead of being
+  reimplemented across sema, constexpr evaluation, and IR-adjacent recovery
 - apply the sema-owned overload-resolution argument collector to the remaining
   semantic call-resolution entry points that still rely on parser-owned
   expression typing or reduced argument modeling

--- a/docs/TEST_RUNNER_FAILURE_REPORT.md
+++ b/docs/TEST_RUNNER_FAILURE_REPORT.md
@@ -18,12 +18,7 @@
 - `problem_statement_example.cpp`
 - `spaceship_default.cpp`
 - `test_complex_keywords.cpp`
-- `test_constexpr_lambda_copy_this_mutation_ret0.cpp`
 - `test_constexpr_lambda_immediate_ret0.cpp`
-- `test_constexpr_lambda_member_repeated_state_ret0.cpp`
-- `test_constexpr_lambda_nested_member_copy_this_ret0.cpp`
-- `test_constexpr_lambda_nested_state_ret0.cpp`
-- `test_constexpr_lambda_this_shared_mutation_ret0.cpp`
 - `test_constexpr_offsetof_nested_ret0.cpp`
 - `test_constexpr_offsetof_ret0.cpp`
 - `test_copy_assign_default_arg_ret42.cpp`
@@ -100,7 +95,7 @@
 
 ## Notes
 
-- Compile failures: 78 unique tests
+- Compile failures: 72 unique tests
 - Link failures: 0
 - Runtime crashes: 0
 - Return mismatches: 4 unique tests

--- a/docs/TEST_RUNNER_FAILURE_REPORT.md
+++ b/docs/TEST_RUNNER_FAILURE_REPORT.md
@@ -101,6 +101,114 @@
 - Return mismatches: 4 unique tests
 - `_fail` files that unexpectedly passed: 0
 
+## C++20 Reject Triage
+
+This is a first-pass triage using:
+
+```text
+clang++ --target=x86_64-unknown-linux-gnu -std=c++20 -pedantic-errors -fsyntax-only
+```
+
+The goal here is only to separate genuine standard C++20 reject cases from:
+
+- missing required standard headers
+- vendor extensions / target-specific ABI assumptions
+
+No test files were changed in this pass.
+
+### Ignored For Now: Missing Required Headers
+
+These are not interesting language-invalid cases yet; they need the right standard headers first.
+
+- `countof_test.cpp`: uses `size_t` without including a header that provides it.
+- `problem_statement_example.cpp`: defaulted spaceship requires `<compare>`.
+- `spaceship_default.cpp`: defaulted spaceship requires `<compare>`.
+- `test_friend_default_spaceship_ret0.cpp`: defaulted spaceship requires `<compare>`.
+- `test_rtti_basic_ret1.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_sizeof_template_param_default_ret4.cpp`: uses `size_t` without including a header that provides it.
+- `test_spaceship_3member_ret15.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_all_ops_ret255.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_inline_expr_ret17.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_longlong_ret15.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_mixed_types_ret3.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_multi_member_ret8.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_negative_ret31.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_nested_delegate_ret7.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_reversed_ret31.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_signed_cmp_ret127.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_synthesized_ret8.cpp`: defaulted spaceship requires `<compare>`.
+- `test_spaceship_template_ret127.cpp`: defaulted spaceship requires `<compare>`.
+- `test_std_forward.cpp`: uses `std::forward` without including the needed standard header.
+- `test_std_forward_observable.cpp`: uses `std::forward` without including the needed standard header.
+- `test_typeid_builtin_matches_type_ret0.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_typeid_expr_matches_type_ret0.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_typeid_non_polymorphic_expr_matches_type_ret0.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_typeid_runtime_ref_call_ret0.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_typeid_runtime_ref_member_evaluated_once_ret0.cpp`: uses `typeid` without including `<typeinfo>`.
+- `test_typeinfo_compare_ret2.cpp`: uses `typeid` / `type_info` without including `<typeinfo>`.
+
+### Ignored For Now: Extensions Or ABI-Specific Assumptions
+
+These are outside portable standard C++20 and should be tracked separately from real language-invalid tests.
+
+- `test_complex_keywords.cpp`: uses C99 `_Complex`, `__complex__`, and `_Imaginary`.
+- `test_declspec_class_ret0.cpp`: uses MSVC `__declspec(...)` syntax.
+- `test_declspec_dllimport_var_ret42.cpp`: uses MSVC `__declspec(dllimport)`.
+- `test_local_declspec_attribute_prefix_ret42.cpp`: uses MSVC `__declspec(align(...))`.
+- `test_stdlib_features_ret0.cpp`: relies on compiler intrinsic `__is_complete_or_unbounded`.
+- `test_toplevel_const_ptr_arg_ret0.cpp`: uses `__cdecl` and `unsigned __int64`.
+- `test_type_alias_callconv_function_pointer_noexcept_ret0.cpp`: uses `__stdcall`.
+- `test_va_float_args_ret0.cpp`: assumes a particular `va_list` / builtin varargs ABI model.
+- `test_va_implementation_ret60.cpp`: assumes a particular `va_list` / builtin varargs ABI model.
+- `test_va_large_struct_ret0.cpp`: assumes a particular `va_list` / builtin varargs ABI model.
+- `test_va_mixed_types_ret0.cpp`: assumes a particular `va_list` / builtin varargs ABI model.
+- `test_va_struct_args_ret0.cpp`: assumes a particular `va_list` / builtin varargs ABI model.
+- `test_varargs.cpp`: includes helper code that hardcodes a non-portable `va_list` representation.
+
+### Genuine C++20 Reject Cases
+
+These still reject after setting aside header omissions and extension-only cases.
+
+- `concept_comprehensive_ret15.cpp`: declares non-template concepts like `concept AlwaysTrue = true;`; a concept definition must be a template declaration.
+- `partial_spec_pattern_collision_ret0.cpp`: uses `friend class Accessor;` even though `Accessor` is a class template; that declaration is ill-formed and the expected friend access does not exist.
+- `test_constexpr_offsetof_nested_ret0.cpp`: uses `offsetof(PackedOuter, inner.value)`; nested member designators are rejected by this standard-library `offsetof` form.
+- `test_constexpr_offsetof_ret0.cpp`: uses `offsetof` without first making the macro available, so the token sequence is parsed as ordinary code and becomes invalid.
+- `test_copy_assign_default_arg_ret42.cpp`: adds a default argument to `operator=`, which is not allowed.
+- `test_ctor_string_literal_lvalue_ret0.cpp`: overload set makes the string-literal call bind to a deleted constructor.
+- `test_dependent_decltype_arrow_member_pointer_ret0.cpp`: forms a pointer to a reference type.
+- `test_dependent_decltype_member_pointer_local_ret0.cpp`: forms a pointer to a reference type.
+- `test_extern_template_does_not_instantiate_ret0.cpp`: assumes an `extern template` declaration can appear for a class template whose definition immediately hard-errors on instantiation; `clang` instantiates enough to trip the `static_assert`.
+- `test_identifier_binding_constexpr_function_call_member_access_prefers_static_member_function_ret42.cpp`: initializes a `constexpr` data member from a function call that is not accepted as a constant expression in this form.
+- `test_infer_expr_type_expansion_ret0.cpp`: uses `offsetof` without first making the macro available, so the expression is not parsed as an `offsetof` invocation.
+- `test_member_struct_partial_spec_ret1.cpp`: names a protected nested template from non-friend, non-derived code.
+- `test_member_template_nested_static_member_two_phase_definition_lookup_ret0.cpp`: requires a `constexpr` static member initializer that is not a core constant expression under `clang`.
+- `test_no_unique_address_empty_member_same_type_overlap_ret0.cpp`: uses `offsetof` without first making the macro available, so the expression is invalid as written.
+- `test_operator_addressof_overload_baseline_ret99.cpp`: expects built-in address-of behavior even though the overloaded `operator&` changes the expression type.
+- `test_operator_member_tiebreak_ret0.cpp`: both member and non-member `operator+` are viable and the call is ambiguous.
+- `test_outofline_nested_pack_ret0.cpp`: uses `offsetof(Wrapper<int>::Nested, x)` without making `offsetof` available.
+- `test_outofline_nested_union_ret0.cpp`: uses `offsetof(Wrapper<int>::Nested, a)` without making `offsetof` available.
+- `test_pack_expansion_comprehensive.cpp`: uses `decltype((declval<Args>()...))`, which is not a valid pack-expansion form.
+- `test_separator_chars.cpp`: contains `#if ABC, XYZ`; the comma operator is not valid in a preprocessor conditional expression.
+- `test_sizeof_offsetof.cpp`: uses `offsetof` without first making the macro available.
+- `test_spaceship_user_synth_ret255.cpp`: expects the relational operators to synthesize from a user-defined `operator<=>` returning `int`; that is not how C++20 synthesis works.
+- `test_static_constexpr_member_partial_spec_ret4.cpp`: names a protected nested template from non-friend, non-derived code.
+- `test_structured_binding_member_get_preferred_over_free_get_ret42.cpp`: provides an invalid `get` customization / specialization shape, so the intended structured-binding lookup does not match.
+- `test_template_arg_context_ambiguous_type_vs_value_ret0.cpp`: passes a non-type where a template type parameter is required.
+- `test_template_inclass_static_member_two_phase_lookup_ret0.cpp`: requires a `constexpr` static member initializer that is not a core constant expression under `clang`.
+- `test_template_nested_ool_member_template_outer_param_binding_ret0.cpp`: overload resolution finds multiple matching `add` candidates, so the call is ambiguous.
+- `test_template_qualified_phase1_fallback_ret0.cpp`: refers to `ns::late_compare` before any such member exists in that namespace.
+- `test_template_static_member_initializer_replay_metadata_invariant_ret0.cpp`: requires a `constexpr` static member initializer that is not a core constant expression under `clang`.
+- `test_template_static_member_lazy_forward_reference_ret42.cpp`: uses `later` before it has been declared.
+- `test_type_alias_in_sfinae_ret42.cpp`: uses `enable_if` in a way that is a hard constraint failure instead of a SFINAE-friendly substitution failure.
+- `test_variadic_overload.cpp`: overload resolution between the `print` candidates is ambiguous.
+
+### Not Reproduced As C++20 Rejects In This Pass
+
+These are still listed in the original failure report, but this syntax-only triage did not reject them as standard-invalid:
+
+- `test_constexpr_lambda_immediate_ret0.cpp`
+- `test_type_traits_intrinsics_ret147.cpp`
+
 ## Result
 
 `RESULT: FAILED`

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -1022,9 +1022,8 @@ private:
 		std::string_view body_error,
 		std::string_view return_error);
 	// Select the best constexpr-evaluable overload of operator_name from struct_info.
-	// When both const and non-const overloads exist, the const overload is preferred
-	// (constexpr evaluation is read-only so both produce identical results).
-	// Returns ambiguity when multiple viable const overloads exist.
+	// Constexpr evaluation still follows the receiver's cv-qualified overload set;
+	// it must not assume const/non-const bodies are interchangeable.
 	static ResolvedMemberFunctionCandidate findConstexprOperatorOverload(
 		const StructTypeInfo* struct_info,
 		StringHandle operator_name,

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -457,6 +457,7 @@ struct EvaluationContext {
 	const StructTypeInfo* struct_info = nullptr;
 	// Cached type index for the current struct (parallel to struct_info; avoids O(n) search in gTypeInfo).
 	TypeIndex struct_type_index{};
+	bool current_member_function_is_const = false;
 	std::unordered_map<std::string_view, EvalResult>* local_bindings = nullptr;
 
 	// Pointer to the innermost active block scope tracker (null at top level).

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -1008,6 +1008,15 @@ private:
 		MemberFunctionLookupMode lookup_mode,
 		bool require_static,
 		bool detect_ambiguity);
+	static ResolvedMemberFunctionCandidate findConstAwareMemberFunctionCandidate(
+		const StructTypeInfo* struct_info,
+		StringHandle function_name_handle,
+		size_t argument_count,
+		EvaluationContext& context,
+		MemberFunctionLookupMode lookup_mode,
+		bool require_static,
+		bool receiver_is_const,
+		bool detect_ambiguity);
 	// Invoke a constexpr member function with pre-evaluated arguments.
 	// Handles: this injection, argument binding, template context save/restore,
 	// recursion depth guard, struct context setup, evaluate_block_with_bindings.

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -97,6 +97,21 @@ bool should_preserve_exact_type(const TypeSpecifierNode& type_spec) {
 	return !isPlaceholderAutoType(type_spec.category());
 }
 
+std::string_view getConstexprReferenceBindingTargetName(const ASTNode& expr) {
+	if (const IdentifierNode* identifier = tryGetIdentifier(expr)) {
+		return identifier->name();
+	}
+
+	if (expr.is<ExpressionNode>()) {
+		const ExpressionNode& expression = expr.as<ExpressionNode>();
+		if (const auto* member_access = std::get_if<MemberAccessNode>(&expression)) {
+			return member_access->member_name();
+		}
+	}
+
+	return {};
+}
+
 struct SimpleConstexprTypeHelperPattern {
 	std::string_view helper_name;
 	std::string_view wrapper_template_name;
@@ -5468,6 +5483,16 @@ EvalResult Evaluator::bind_evaluated_arguments(
 		}
 
 		const DeclarationNode& param_decl = param_node.as<DeclarationNode>();
+		const TypeSpecifierNode& param_type = param_decl.type_specifier_node();
+		if (param_type.is_reference() || param_type.is_rvalue_reference()) {
+			std::string_view alias_target_name =
+				getConstexprReferenceBindingTargetName(arguments[i]);
+			if (!alias_target_name.empty()) {
+				EvalResult reference_alias = EvalResult::from_pointer(alias_target_name);
+				reference_alias.pointer_value_snapshot = {arg_result};
+				arg_result = std::move(reference_alias);
+			}
+		}
 		maybe_set_exact_type_from_declaration(arg_result, param_decl);
 		apply_uint_init_narrowing(arg_result);
 		bindings[param_decl.identifier_token().value()] = arg_result;

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -918,11 +918,6 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 	if (!lowered_func) {
 		return nullptr;
 	}
-	if (!lowered_func->has_outer_template_bindings() &&
-		!lowered_func->has_non_type_template_args() &&
-		!lowered_func->has_mangled_name()) {
-		return nullptr;
-	}
 	if (struct_info) {
 		for (const auto& member_func : struct_info->member_functions) {
 			if (!member_func.function_decl.is<FunctionDeclarationNode>()) {
@@ -954,10 +949,25 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 			require_static)) {
 		return nullptr;
 	}
+	if (struct_info && !lowered_func->parent_struct_name().empty()) {
+		const StringHandle lowered_owner =
+			StringTable::getOrInternStringHandle(lowered_func->parent_struct_name());
+		if (normalizeClassName(lowered_owner) != normalizeClassName(struct_info->name)) {
+			return nullptr;
+		}
+	}
 	return lowered_func;
 }
 
 namespace {
+
+std::string_view normalizeConstexprLookupName(std::string_view name) {
+	if (const size_t materialized_suffix = name.find('$');
+		materialized_suffix != std::string_view::npos) {
+		return name.substr(0, materialized_suffix);
+	}
+	return name;
+}
 
 std::optional<size_t> try_get_constexpr_pointer_upper_bound(
 	std::string_view var_name,
@@ -1914,7 +1924,8 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_operator_call(
 		return std::nullopt;
 	}
 
-	std::string_view func_name = call_info->function_declaration->decl_node().identifier_token().value();
+	std::string_view func_name = normalizeConstexprLookupName(
+		call_info->function_declaration->decl_node().identifier_token().value());
 	if (overloadableOperatorFromFunctionName(func_name) != OverloadableOperator::Call) {
 		return std::nullopt;
 	}
@@ -2439,6 +2450,18 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		!actual_func->is_const_member_function()) {
 		actual_func = nullptr;
 		actual_member = nullptr;
+	}
+	if (!actual_func &&
+		call_info->function_declaration &&
+		isConstexprMemberLookupCandidate(
+			*call_info->function_declaration,
+			call_info->arguments->size(),
+			context,
+			MemberFunctionLookupMode::LookupOnly,
+			false)) {
+		actual_func = call_info->function_declaration;
+		actual_member =
+			findMemberFunctionMetadataRecursive(bound_struct_info, *actual_func);
 	}
 	if (!actual_func) {
 		auto member_function_match = receiver_is_this
@@ -8391,7 +8414,8 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	if (!placeholder_func) {
 		return EvalResult::error("Constexpr member function call is missing a function declaration");
 	}
-	std::string_view func_name = placeholder_func->decl_node().identifier_token().value();
+	std::string_view func_name = normalizeConstexprLookupName(
+		placeholder_func->decl_node().identifier_token().value());
 
 	// For lambda calls (operator()), we need special handling
 	const bool is_operator_call = overloadableOperatorFromFunctionName(func_name) == OverloadableOperator::Call;
@@ -8727,6 +8751,17 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 		}
 		actual_member =
 			actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : nullptr;
+	}
+	if (!actual_func &&
+		isConstexprMemberLookupCandidate(
+			*placeholder_func,
+			arguments.size(),
+			context,
+			MemberFunctionLookupMode::LookupOnly,
+			false)) {
+		actual_func = placeholder_func;
+		actual_member =
+			findMemberFunctionMetadataRecursive(struct_info, *actual_func);
 	}
 	// Virtual dispatch: resolve to the final overrider in the dynamic type using
 	// is_virtual/is_override flags so that same-name non-overriding derived

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -2819,6 +2819,27 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	if (!bind_result.success()) {
 		return bind_result;
 	}
+	std::vector<std::string_view> pointer_target_writebacks;
+	std::vector<std::pair<std::string_view, EvalResult>> pointer_target_imports;
+	for (const auto& [param_name, param_value] : member_bindings) {
+		(void)param_name;
+		if (!param_value.pointer_to_var.isValid()) {
+			continue;
+		}
+		std::string_view target_name = StringTable::getStringView(param_value.pointer_to_var);
+		if (member_bindings.find(target_name) != member_bindings.end()) {
+			continue;
+		}
+		const EvalResult* outer_target = findBindingValue(target_name, bindings, context);
+		if (!outer_target) {
+			continue;
+		}
+		pointer_target_imports.push_back({target_name, *outer_target});
+		pointer_target_writebacks.push_back(target_name);
+	}
+	for (const auto& [target_name, target_value] : pointer_target_imports) {
+		member_bindings[target_name] = target_value;
+	}
 
 	// Inject a synthetic "this" binding so that member function bodies can access
 	// members by unqualified name (e.g. `return a + b;`).  EvalResult requires a
@@ -2921,6 +2942,15 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		// Remove the synthetic "this" injected above before writing member state
 		// back to the outer map, so "this" is not accidentally stored as a member.
 		member_bindings.erase("this");
+		for (std::string_view target_name : pointer_target_writebacks) {
+			auto local_it = member_bindings.find(target_name);
+			if (local_it == member_bindings.end()) {
+				continue;
+			}
+			if (EvalResult* outer_target = findMutableBindingValue(target_name, *mutable_bindings, context)) {
+				*outer_target = local_it->second;
+			}
+		}
 		if (write_back_to_object_binding) {
 			if (write_back_via_receiver_lvalue) {
 				EvalResult updated_object = pointed_object_result;
@@ -8980,9 +9010,34 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	bool receiver_is_const = false;
 	if (has_complex_object_result && complex_object_result.exact_type.has_value()) {
 		receiver_is_const = complex_object_result.exact_type->is_const();
-	} else if (var_decl) {
+	}
+	if (!receiver_is_const && var_decl) {
 		receiver_is_const = var_decl->declaration().type_specifier_node().is_const() ||
 			var_decl->is_constexpr();
+	}
+	if (!receiver_is_const) {
+		if (std::optional<TypeSpecifierNode> receiver_expr_type =
+				tryQueryExpressionType(object_expr, context);
+			receiver_expr_type.has_value()) {
+			receiver_is_const = receiver_expr_type->is_const();
+		}
+	}
+	if (!receiver_is_const && object_identifier && context.symbols) {
+		std::optional<ASTNode> object_symbol = lookup_identifier_symbol(
+			object_identifier,
+			object_identifier->name(),
+			*context.symbols);
+		if (!object_symbol.has_value() && context.global_symbols) {
+			object_symbol = lookup_identifier_symbol(
+				object_identifier,
+				object_identifier->name(),
+				*context.global_symbols);
+		}
+		if (object_symbol.has_value() && object_symbol->is<VariableDeclarationNode>()) {
+			const auto& object_var_decl = object_symbol->as<VariableDeclarationNode>();
+			receiver_is_const = object_var_decl.is_constexpr() ||
+				object_var_decl.declaration().type_specifier_node().is_const();
+		}
 	}
 
 	// Look up the actual member function in the struct's type info
@@ -9100,6 +9155,22 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 			: member_function_match.function;
 	const StructMemberFunction* actual_member =
 		actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : member_function_match.member;
+	if (actual_func &&
+		receiver_is_const &&
+		!actual_func->is_static() &&
+		!actual_func->is_const_member_function()) {
+		const bool fallback_is_const_compatible =
+			member_function_match.function != nullptr &&
+			(member_function_match.function->is_static() ||
+				member_function_match.function->is_const_member_function());
+		if (fallback_is_const_compatible) {
+			actual_func = member_function_match.function;
+			actual_member = member_function_match.member;
+		} else {
+			actual_func = nullptr;
+			actual_member = nullptr;
+		}
+	}
 	if (!actual_func) {
 		actual_func = try_get_lowered_constexpr_member_call_target(
 			call_expr,
@@ -9197,7 +9268,6 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 				" actual_member=", actual_member != nullptr);
 		}
 	}
-
 	if (!actual_func) {
 		return EvalResult::error("Member function not found: " + std::string(func_name));
 	}

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -26,11 +26,161 @@ const std::unordered_map<std::string_view, EvalResult>& emptyEvalBindings() {
 	return kEmpty;
 }
 
+std::string_view normalizeConstexprLookupName(std::string_view name) {
+	if (const size_t materialized_suffix = name.find('$');
+		materialized_suffix != std::string_view::npos) {
+		return name.substr(0, materialized_suffix);
+	}
+	return name;
+}
+
 bool isRecoverablePointerDerefFailure(const EvalResult& result) {
 	if (result.success()) {
 		return false;
 	}
 	return result.error_message.rfind("Cannot dereference constexpr pointer:", 0) == 0;
+}
+
+bool sameConstexprMemberParameterTypes(
+	const FunctionDeclarationNode& lhs,
+	const FunctionDeclarationNode& rhs) {
+	const auto& lhs_params = lhs.parameter_nodes();
+	const auto& rhs_params = rhs.parameter_nodes();
+	if (lhs_params.size() != rhs_params.size()) {
+		return false;
+	}
+	for (size_t i = 0; i < lhs_params.size(); ++i) {
+		if (!lhs_params[i].is<DeclarationNode>() || !rhs_params[i].is<DeclarationNode>()) {
+			return false;
+		}
+		const TypeSpecifierNode& lhs_type = lhs_params[i].as<DeclarationNode>().type_specifier_node();
+		const TypeSpecifierNode& rhs_type = rhs_params[i].as<DeclarationNode>().type_specifier_node();
+		if (lhs_type.category() != rhs_type.category() ||
+			lhs_type.cv_qualifier() != rhs_type.cv_qualifier() ||
+			lhs_type.reference_qualifier() != rhs_type.reference_qualifier() ||
+			lhs_type.pointer_levels().size() != rhs_type.pointer_levels().size() ||
+			!std::ranges::equal(lhs_type.array_dimensions(), rhs_type.array_dimensions())) {
+			return false;
+		}
+		for (size_t level = 0; level < lhs_type.pointer_levels().size(); ++level) {
+			if (lhs_type.pointer_levels()[level].cv_qualifier !=
+				rhs_type.pointer_levels()[level].cv_qualifier) {
+				return false;
+			}
+		}
+		TypeIndex lhs_index = lhs_type.type_index();
+		TypeIndex rhs_index = rhs_type.type_index();
+		if (lhs_index.needsTypeIndex() != rhs_index.needsTypeIndex()) {
+			return false;
+		}
+		if (lhs_index.needsTypeIndex() && rhs_index.needsTypeIndex() &&
+			lhs_index != rhs_index &&
+			lhs_type.token().value() != rhs_type.token().value()) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool matchesConstexprFunctionName(
+	const StructMemberFunction& member_func,
+	StringHandle function_name_handle) {
+	if (member_func.getName() == function_name_handle) {
+		return true;
+	}
+	return normalizeConstexprLookupName(StringTable::getStringView(member_func.getName())) ==
+		normalizeConstexprLookupName(StringTable::getStringView(function_name_handle));
+}
+
+bool sameConstexprFunctionIdentity(
+	const FunctionDeclarationNode& lhs,
+	const FunctionDeclarationNode& rhs) {
+	if (normalizeConstexprLookupName(lhs.parent_struct_name()) !=
+		normalizeConstexprLookupName(rhs.parent_struct_name())) {
+		return false;
+	}
+	if (normalizeConstexprLookupName(lhs.decl_node().identifier_token().value()) !=
+		normalizeConstexprLookupName(rhs.decl_node().identifier_token().value())) {
+		return false;
+	}
+	if (lhs.parameter_nodes().size() != rhs.parameter_nodes().size()) {
+		return false;
+	}
+	if (lhs.is_const_member_function() != rhs.is_const_member_function() ||
+		lhs.is_static() != rhs.is_static()) {
+		return false;
+	}
+	if (!sameConstexprMemberParameterTypes(lhs, rhs)) {
+		return false;
+	}
+	if (lhs.has_mangled_name() && rhs.has_mangled_name() &&
+		lhs.mangled_name() != rhs.mangled_name()) {
+		return false;
+	}
+	return true;
+}
+
+const FunctionDeclarationNode* findMatchingSymbolTableMemberDefinition(
+	const FunctionDeclarationNode& target_function,
+	EvaluationContext& context) {
+	if (!context.symbols) {
+		return nullptr;
+	}
+	const auto matches_candidate = [&](const FunctionDeclarationNode& candidate) {
+		return candidate.parent_struct_name() == target_function.parent_struct_name() &&
+			normalizeConstexprLookupName(candidate.decl_node().identifier_token().value()) ==
+				normalizeConstexprLookupName(target_function.decl_node().identifier_token().value()) &&
+			candidate.parameter_nodes().size() == target_function.parameter_nodes().size() &&
+			candidate.is_const_member_function() == target_function.is_const_member_function() &&
+			sameConstexprMemberParameterTypes(candidate, target_function);
+	};
+	const auto scan_owner_struct = [&](const SymbolTable& symbols) -> const FunctionDeclarationNode* {
+		StringHandle owner_handle = StringTable::getOrInternStringHandle(target_function.parent_struct_name());
+		std::optional<ASTNode> owner_symbol = symbols.lookup(owner_handle);
+		if (!owner_symbol.has_value() || !owner_symbol->is<StructDeclarationNode>()) {
+			return nullptr;
+		}
+		const auto& struct_node = owner_symbol->as<StructDeclarationNode>();
+		for (const auto& member_func_decl : struct_node.member_functions()) {
+			if (!member_func_decl.function_declaration.is<FunctionDeclarationNode>()) {
+				continue;
+			}
+			const auto& candidate = member_func_decl.function_declaration.as<FunctionDeclarationNode>();
+			if (matches_candidate(candidate)) {
+				return &candidate;
+			}
+		}
+		return nullptr;
+	};
+	if (const FunctionDeclarationNode* owner_candidate = scan_owner_struct(*context.symbols)) {
+		return owner_candidate;
+	}
+	if (context.global_symbols && context.global_symbols != context.symbols) {
+		if (const FunctionDeclarationNode* owner_candidate = scan_owner_struct(*context.global_symbols)) {
+			return owner_candidate;
+		}
+	}
+	auto overloads = context.symbols->lookup_all(target_function.decl_node().identifier_token().value());
+	for (const ASTNode& overload : overloads) {
+		if (overload.is<FunctionDeclarationNode>()) {
+			const auto& candidate = overload.as<FunctionDeclarationNode>();
+			if (matches_candidate(candidate)) {
+				return &candidate;
+			}
+		}
+	}
+	if (context.global_symbols && context.global_symbols != context.symbols) {
+		overloads = context.global_symbols->lookup_all(target_function.decl_node().identifier_token().value());
+		for (const ASTNode& overload : overloads) {
+			if (overload.is<FunctionDeclarationNode>()) {
+				const auto& candidate = overload.as<FunctionDeclarationNode>();
+				if (matches_candidate(candidate)) {
+					return &candidate;
+				}
+			}
+		}
+	}
+	return nullptr;
 }
 TypeSpecifierNode makeArrayTypeSpec(TypeIndex type_index, std::span<const size_t> array_dimensions);
 EvalResult materializeArrayInitializer(
@@ -116,6 +266,18 @@ const StructMemberFunction* findMemberFunctionMetadataRecursive(
 		if (&candidate == &target_function || &candidate.decl_node() == &target_function.decl_node()) {
 			return &member_func;
 		}
+		if (candidate.has_mangled_name() &&
+			target_function.has_mangled_name() &&
+			candidate.mangled_name() == target_function.mangled_name()) {
+			return &member_func;
+		}
+		if (normalizeConstexprLookupName(candidate.decl_node().identifier_token().value()) ==
+				normalizeConstexprLookupName(target_function.decl_node().identifier_token().value()) &&
+			candidate.parameter_nodes().size() == target_function.parameter_nodes().size() &&
+			candidate.is_const_member_function() == target_function.is_const_member_function() &&
+			candidate.parent_struct_name() == target_function.parent_struct_name()) {
+			return &member_func;
+		}
 	}
 
 	for (const auto& base_class : struct_info->base_classes) {
@@ -138,7 +300,7 @@ const StructMemberFunction* findMemberFunctionMetadataRecursive(
 
 // Find the final overrider of `base_virtual` in `dynamic_struct_info` and its
 // base classes.  Returns the most-derived StructMemberFunction that overrides
-// `base_virtual` (same name, same arity, and is_virtual/is_override), or
+// `base_virtual` (same name and signature), or
 // nullptr when no override exists (caller should keep the base declaration).
 const StructMemberFunction* findFinalOverrider(
 	const StructTypeInfo* dynamic_struct_info,
@@ -148,13 +310,18 @@ const StructMemberFunction* findFinalOverrider(
 		return nullptr;
 	}
 
+	const FunctionDeclarationNode* base_virtual_decl =
+		base_virtual.function_decl.is<FunctionDeclarationNode>()
+			? &base_virtual.function_decl.as<FunctionDeclarationNode>()
+			: nullptr;
+	if (base_virtual_decl &&
+		normalizeConstexprLookupName(base_virtual_decl->parent_struct_name()) ==
+			normalizeConstexprLookupName(StringTable::getStringView(dynamic_struct_info->name))) {
+		return nullptr;
+	}
+
 	for (const auto& mf : dynamic_struct_info->member_functions) {
 		if (mf.name != base_virtual.name) {
-			continue;
-		}
-		// Only consider functions that are virtual or explicitly override
-		// something - this avoids selecting a same-name non-overriding overload.
-		if (!mf.is_virtual && !mf.is_override) {
 			continue;
 		}
 		// Don't return the base virtual itself as its own "override".
@@ -165,7 +332,31 @@ const StructMemberFunction* findFinalOverrider(
 			continue;
 		}
 		const auto& fd = mf.function_decl.as<FunctionDeclarationNode>();
+		if (base_virtual_decl &&
+			sameConstexprFunctionIdentity(fd, *base_virtual_decl)) {
+			continue;
+		}
+		const std::string_view dynamic_owner_name =
+			normalizeConstexprLookupName(StringTable::getStringView(dynamic_struct_info->name));
+		const std::string_view candidate_owner_name =
+			normalizeConstexprLookupName(fd.parent_struct_name());
+		// Skip inherited/base declarations that are mirrored into the derived
+		// member list. Final overrider selection must only consider functions
+		// declared by the currently inspected dynamic class at this recursion step.
+		if (candidate_owner_name != dynamic_owner_name) {
+			continue;
+		}
 		if (fd.parameter_nodes().size() != param_count) {
+			continue;
+		}
+		if (!base_virtual.function_decl.is<FunctionDeclarationNode>()) {
+			continue;
+		}
+		const auto& base_fd = base_virtual.function_decl.as<FunctionDeclarationNode>();
+		if (fd.is_const_member_function() != base_fd.is_const_member_function()) {
+			continue;
+		}
+		if (!sameConstexprMemberParameterTypes(fd, base_fd)) {
 			continue;
 		}
 		return &mf;
@@ -939,6 +1130,12 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 				candidate.mangled_name() == lowered_func->mangled_name()) {
 				return &candidate;
 			}
+			if (normalizeConstexprLookupName(candidate.decl_node().identifier_token().value()) ==
+					normalizeConstexprLookupName(lowered_func->decl_node().identifier_token().value()) &&
+				candidate.parameter_nodes().size() == lowered_func->parameter_nodes().size() &&
+				candidate.is_const_member_function() == lowered_func->is_const_member_function()) {
+				return &candidate;
+			}
 		}
 	}
 	if (!isConstexprMemberLookupCandidate(
@@ -947,6 +1144,16 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 			context,
 			lookup_mode,
 			require_static)) {
+		return nullptr;
+	}
+	const bool lowered_func_has_replay_identity =
+		lowered_func->has_outer_template_bindings() ||
+		lowered_func->has_non_type_template_args() ||
+		lowered_func->has_mangled_name() ||
+		call_expr.has_template_arguments();
+	if (struct_info &&
+		findMemberFunctionMetadataRecursive(struct_info, *lowered_func) == nullptr &&
+		!lowered_func_has_replay_identity) {
 		return nullptr;
 	}
 	if (struct_info && !lowered_func->parent_struct_name().empty()) {
@@ -960,14 +1167,6 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 }
 
 namespace {
-
-std::string_view normalizeConstexprLookupName(std::string_view name) {
-	if (const size_t materialized_suffix = name.find('$');
-		materialized_suffix != std::string_view::npos) {
-		return name.substr(0, materialized_suffix);
-	}
-	return name;
-}
 
 std::optional<size_t> try_get_constexpr_pointer_upper_bound(
 	std::string_view var_name,
@@ -2300,7 +2499,8 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		return std::nullopt;
 	}
 
-	std::string_view func_name = call_info->function_declaration->decl_node().identifier_token().value();
+	std::string_view func_name = normalizeConstexprLookupName(
+		call_info->function_declaration->decl_node().identifier_token().value());
 	// operator() on a bound local struct object falls through to this function
 	// when try_evaluate_bound_member_operator_call could not resolve it via a
 	// stored lambda or callable_var_decl.  The caller returns early on the first
@@ -2429,20 +2629,60 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	}
 
 	StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
-	const FunctionDeclarationNode* actual_func = [&]() -> const FunctionDeclarationNode* {
-		if (const auto* call_expr = std::get_if<CallExprNode>(&expr)) {
-			return try_get_lowered_constexpr_member_call_target(
-				*call_expr,
-				bound_struct_info,
-				call_info->arguments->size(),
-				context,
-				MemberFunctionLookupMode::LookupOnly,
-				false);
-		}
-		return nullptr;
-	}();
+	auto lookup_sema_services =
+		context
+			.requireParserAttachedSema(kMemberFunctionMaterializationLookupOp)
+			.parserSemanticServices();
+	lookup_sema_services.ensureMemberFunctionMaterialized(
+		bound_struct_info->name,
+		func_name_handle,
+		std::nullopt);
+	if (call_info->function_declaration) {
+		lookup_sema_services.ensureMemberFunctionMaterialized(
+			bound_struct_info->name,
+			*call_info->function_declaration);
+	}
+	const CallExprNode* call_expr = std::get_if<CallExprNode>(&expr);
+	ResolvedFunctionQueryResult sema_resolved_direct_query =
+		lookup_sema_services.getResolvedDirectCallQuery(call_expr);
+	const FunctionDeclarationNode* actual_func =
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available
+			? sema_resolved_direct_query.function
+			: [&]() -> const FunctionDeclarationNode* {
+				if (call_expr) {
+					return try_get_lowered_constexpr_member_call_target(
+						*call_expr,
+						bound_struct_info,
+						call_info->arguments->size(),
+						context,
+						MemberFunctionLookupMode::LookupOnly,
+						false);
+				}
+				return nullptr;
+			}();
 	const StructMemberFunction* actual_member =
 		actual_func ? findMemberFunctionMetadataRecursive(bound_struct_info, *actual_func) : nullptr;
+	if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+		FLASH_LOG(ConstExpr, Debug,
+			"try_evaluate_bound_member_function_call: func='", func_name,
+			"' struct='", StringTable::getStringView(bound_struct_info->name),
+			"' type_index=", bound_type_index,
+			" sema_state=", static_cast<int>(sema_resolved_direct_query.state),
+			" actual_func=", actual_func != nullptr,
+			" actual_member=", actual_member != nullptr);
+		if (actual_func) {
+			FLASH_LOG(ConstExpr, Debug,
+				"  selected owner='", actual_func->parent_struct_name(),
+				"' name='", actual_func->decl_node().identifier_token().value(),
+				"' const=", actual_func->is_const_member_function());
+		}
+		for (const auto& [member_name, member_value] : member_bindings) {
+			FLASH_LOG(ConstExpr, Debug,
+				"  member binding '", member_name,
+				"' int=", member_value.success() ? member_value.as_int() : 0,
+				" object_type=", member_value.object_type_index);
+		}
+	}
 	if (actual_func &&
 		receiver_is_this &&
 		context.current_member_function_is_const &&
@@ -2450,18 +2690,6 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		!actual_func->is_const_member_function()) {
 		actual_func = nullptr;
 		actual_member = nullptr;
-	}
-	if (!actual_func &&
-		call_info->function_declaration &&
-		isConstexprMemberLookupCandidate(
-			*call_info->function_declaration,
-			call_info->arguments->size(),
-			context,
-			MemberFunctionLookupMode::LookupOnly,
-			false)) {
-		actual_func = call_info->function_declaration;
-		actual_member =
-			findMemberFunctionMetadataRecursive(bound_struct_info, *actual_func);
 	}
 	if (!actual_func) {
 		auto member_function_match = receiver_is_this
@@ -2487,6 +2715,33 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		actual_func = member_function_match.function;
 		actual_member = member_function_match.member;
 	}
+	if (!actual_func &&
+		call_info->function_declaration &&
+		isConstexprMemberLookupCandidate(
+			*call_info->function_declaration,
+			call_info->arguments->size(),
+			context,
+			MemberFunctionLookupMode::LookupOnly,
+			false)) {
+		const FunctionDeclarationNode* fallback_func = call_info->function_declaration;
+		const StructMemberFunction* fallback_member =
+			findMemberFunctionMetadataRecursive(bound_struct_info, *fallback_func);
+		const bool fallback_rejected_for_const_receiver =
+			receiver_is_this &&
+			context.current_member_function_is_const &&
+			!fallback_func->is_static() &&
+			!fallback_func->is_const_member_function();
+		if (!fallback_rejected_for_const_receiver) {
+			actual_func = fallback_func;
+			actual_member = fallback_member;
+		}
+	}
+	if (actual_member && actual_member->function_decl.is<FunctionDeclarationNode>() && actual_func) {
+		const auto& member_function_decl = actual_member->function_decl.as<FunctionDeclarationNode>();
+		if (!sameConstexprFunctionIdentity(member_function_decl, *actual_func)) {
+			actual_member = nullptr;
+		}
+	}
 	// Virtual dispatch: when the resolved function is virtual, find the final
 	// overrider in the dynamic type (bound_struct_info) rather than staying pinned
 	// to the sema-resolved static target.  This applies to all receiver kinds,
@@ -2501,6 +2756,35 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 			actual_member = override_member;
 		}
 	}
+	if (actual_func && !actual_func->get_definition().has_value()) {
+		if (const FunctionDeclarationNode* symbol_table_func =
+				findMatchingSymbolTableMemberDefinition(*actual_func, context);
+			symbol_table_func &&
+			sameConstexprFunctionIdentity(*symbol_table_func, *actual_func)) {
+			actual_func = symbol_table_func;
+		}
+	}
+	if (actual_func) {
+		if (!actual_func->get_definition().has_value()) {
+			const FunctionDeclarationNode* requested_func = actual_func;
+			StringHandle owner_name = bound_struct_info->name;
+			if (!actual_func->parent_struct_name().empty()) {
+				owner_name = StringTable::getOrInternStringHandle(actual_func->parent_struct_name());
+			}
+			auto replay_sema_services =
+				context
+					.requireParserAttachedSema(kMemberFunctionMaterializationReplayOp)
+					.parserSemanticServices();
+			if (std::optional<ASTNode> refreshed =
+					replay_sema_services.ensureMemberFunctionMaterialized(owner_name, *actual_func);
+				refreshed.has_value() && refreshed->is<FunctionDeclarationNode>()) {
+				const auto& refreshed_func = refreshed->as<FunctionDeclarationNode>();
+				if (sameConstexprFunctionIdentity(refreshed_func, *requested_func)) {
+					actual_func = &refreshed_func;
+				}
+			}
+		}
+	}
 	if (!actual_func) {
 		return EvalResult::error("Member function not found: " + std::string(func_name));
 	}
@@ -2513,6 +2797,16 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	const auto& definition = actual_func->get_definition();
 	if (!definition.has_value()) {
 		return EvalResult::error("Constexpr member function has no body: " + std::string(func_name));
+	}
+	if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug) && definition->is<BlockNode>()) {
+		const auto& stmts = definition->as<BlockNode>().get_statements();
+		if (!stmts.empty() && stmts[0].is<ReturnStatementNode>()) {
+			const auto& ret = stmts[0].as<ReturnStatementNode>();
+			if (ret.expression().has_value() && ret.expression()->is<ExpressionNode>()) {
+				FLASH_LOG(ConstExpr, Debug,
+					"  first return expr index=", ret.expression()->as<ExpressionNode>().index());
+			}
+		}
 	}
 
 	auto bind_result = bind_evaluated_arguments(
@@ -2602,6 +2896,12 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 		context,
 		"Member function body is not a block",
 		"Constexpr member function did not return a value");
+	if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+		FLASH_LOG(ConstExpr, Debug,
+			"  bound member body result success=", result.success(),
+			" int=", result.success() ? result.as_int() : 0,
+			" members=", member_bindings.size());
+	}
 	context.local_bindings = saved_local_bindings;
 	context.current_depth--;
 	context.return_type_info = saved_return_type_info;
@@ -2701,7 +3001,7 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 					}
 					for (const auto& member_func : target_struct->member_functions) {
 						if (member_func.is_constructor || member_func.is_destructor ||
-							member_func.getName() != func_name_handle ||
+							!matchesConstexprFunctionName(member_func, func_name_handle) ||
 							!member_func.function_decl.is<FunctionDeclarationNode>()) {
 							continue;
 						}
@@ -2904,7 +3204,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_member_function_candi
 
 	for (const auto& member_func : struct_info->member_functions) {
 		if (member_func.is_constructor || member_func.is_destructor ||
-			member_func.getName() != function_name_handle ||
+			!matchesConstexprFunctionName(member_func, function_name_handle) ||
 			!member_func.function_decl.is<FunctionDeclarationNode>()) {
 			continue;
 		}
@@ -3186,7 +3486,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 					}
 					for (const auto& member_func : target_struct->member_functions) {
 						if (member_func.is_constructor || member_func.is_destructor ||
-							member_func.getName() != function_name_handle ||
+							!matchesConstexprFunctionName(member_func, function_name_handle) ||
 							!member_func.function_decl.is<FunctionDeclarationNode>()) {
 							continue;
 						}
@@ -7408,10 +7708,25 @@ std::optional<EvalResult> Evaluator::resolve_constexpr_object_source(
 
 	bool resolved_from_local_object = false;
 	if (const EvalResult* local_object = findLocalBinding(object_name, context);
-		local_object && local_object->object_type_index.is_valid()) {
-		resolved_object.declared_type_index = local_object->object_type_index;
-		resolved_object.materialized_value = *local_object;
-		resolved_from_local_object = true;
+		local_object) {
+		if (local_object->object_type_index.is_valid()) {
+			resolved_object.declared_type_index = local_object->object_type_index;
+			resolved_object.materialized_value = *local_object;
+			resolved_from_local_object = true;
+		} else if (local_object->pointer_to_var.isValid() && context.local_bindings) {
+			EvalResult deref_result = deref_pointer_with_bindings(
+				*local_object,
+				*context.local_bindings,
+				context);
+			if (!deref_result.success()) {
+				return deref_result;
+			}
+			if (deref_result.object_type_index.is_valid()) {
+				resolved_object.declared_type_index = deref_result.object_type_index;
+				resolved_object.materialized_value = std::move(deref_result);
+				resolved_from_local_object = true;
+			}
+		}
 	}
 
 	// For local bound objects, still try to recover the original declaration
@@ -8673,6 +8988,21 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	// Look up the actual member function in the struct's type info
 	const auto& arguments = call_expr.arguments();
 	StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
+	auto lookup_sema_services =
+		context
+			.requireParserAttachedSema(kMemberFunctionMaterializationLookupOp)
+			.parserSemanticServices();
+	ResolvedFunctionQueryResult sema_resolved_direct_query =
+		lookup_sema_services.getResolvedDirectCallQuery(&call_expr);
+	if (placeholder_func) {
+		lookup_sema_services.ensureMemberFunctionMaterialized(
+			struct_info->name,
+			*placeholder_func);
+	}
+	lookup_sema_services.ensureMemberFunctionMaterialized(
+		struct_info->name,
+		func_name_handle,
+		std::nullopt);
 	auto findConstAwareMemberFunctionMatch =
 		[&](bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
 			auto collectCandidates =
@@ -8680,7 +9010,7 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 					ResolvedMemberFunctionCandidate result;
 					for (const auto& member_func : struct_info->member_functions) {
 						if (member_func.is_constructor || member_func.is_destructor ||
-							member_func.getName() != func_name_handle ||
+							!matchesConstexprFunctionName(member_func, func_name_handle) ||
 							!member_func.function_decl.is<FunctionDeclarationNode>()) {
 							continue;
 						}
@@ -8733,8 +9063,43 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	if (member_function_match.ambiguous) {
 		return EvalResult::error("Ambiguous member function overload in constant expression");
 	}
-	const FunctionDeclarationNode* actual_func = member_function_match.function;
-	const StructMemberFunction* actual_member = member_function_match.member;
+	if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+		FLASH_LOG(ConstExpr, Debug,
+			"evaluate_member_function_call: func='", func_name,
+			"' struct='", StringTable::getStringView(struct_info->name),
+			"' type_index=", type_index,
+			" sema_state=", static_cast<int>(sema_resolved_direct_query.state),
+			" placeholder=", placeholder_func != nullptr,
+			" matched=", member_function_match.function != nullptr);
+		if (placeholder_func) {
+			FLASH_LOG(ConstExpr, Debug,
+				"  placeholder name='", placeholder_func->decl_node().identifier_token().value(),
+				"' constexpr=", placeholder_func->is_constexpr(),
+				" materialized=", placeholder_func->is_materialized(),
+				" outer_template_bindings=", placeholder_func->has_outer_template_bindings(),
+				" non_type_template_args=", placeholder_func->has_non_type_template_args(),
+				" const_member=", placeholder_func->is_const_member_function(),
+				" params=", placeholder_func->parameter_nodes().size(),
+				" has_definition=", placeholder_func->get_definition().has_value());
+		}
+		for (const auto& member_func : struct_info->member_functions) {
+			if (!member_func.function_decl.is<FunctionDeclarationNode>()) {
+				continue;
+			}
+			const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
+			FLASH_LOG(ConstExpr, Debug,
+				"  candidate name='", func_decl.decl_node().identifier_token().value(),
+				"' const=", func_decl.is_const_member_function(),
+				" constexpr=", func_decl.is_constexpr(),
+				" materialized=", func_decl.is_materialized());
+		}
+	}
+	const FunctionDeclarationNode* actual_func =
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available
+			? sema_resolved_direct_query.function
+			: member_function_match.function;
+	const StructMemberFunction* actual_member =
+		actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : member_function_match.member;
 	if (!actual_func) {
 		actual_func = try_get_lowered_constexpr_member_call_target(
 			call_expr,
@@ -8743,25 +9108,31 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 			context,
 			MemberFunctionLookupMode::LookupOnly,
 			false);
+		actual_member =
+			actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : nullptr;
+		const bool should_enforce_const_receiver_on_lowered =
+			actual_func != nullptr &&
+			actual_member != nullptr;
 		if (actual_func != nullptr &&
 			receiver_is_const &&
+			should_enforce_const_receiver_on_lowered &&
 			!actual_func->is_static() &&
 			!actual_func->is_const_member_function()) {
 			actual_func = nullptr;
 		}
 		actual_member =
-			actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : nullptr;
+			actual_func ? actual_member : nullptr;
+		if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+			FLASH_LOG(ConstExpr, Debug,
+				"  after try_get_lowered: actual_func=", actual_func != nullptr,
+				" actual_member=", actual_member != nullptr);
+		}
 	}
-	if (!actual_func &&
-		isConstexprMemberLookupCandidate(
-			*placeholder_func,
-			arguments.size(),
-			context,
-			MemberFunctionLookupMode::LookupOnly,
-			false)) {
-		actual_func = placeholder_func;
-		actual_member =
-			findMemberFunctionMetadataRecursive(struct_info, *actual_func);
+	if (actual_member && actual_member->function_decl.is<FunctionDeclarationNode>() && actual_func) {
+		const auto& member_function_decl = actual_member->function_decl.as<FunctionDeclarationNode>();
+		if (!sameConstexprFunctionIdentity(member_function_decl, *actual_func)) {
+			actual_member = nullptr;
+		}
 	}
 	// Virtual dispatch: resolve to the final overrider in the dynamic type using
 	// is_virtual/is_override flags so that same-name non-overriding derived
@@ -8773,6 +9144,57 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 				actual_func->parameter_nodes().size())) {
 			actual_func = &override_member->function_decl.as<FunctionDeclarationNode>();
 			actual_member = override_member;
+		}
+	}
+	if (actual_func) {
+		if (const FunctionDeclarationNode* symbol_table_func =
+				findMatchingSymbolTableMemberDefinition(*actual_func, context);
+			symbol_table_func &&
+			sameConstexprFunctionIdentity(*symbol_table_func, *actual_func)) {
+			actual_func = symbol_table_func;
+		}
+	}
+	if (actual_func &&
+		!actual_func->get_definition().has_value()) {
+		const FunctionDeclarationNode* requested_func = actual_func;
+		StringHandle owner_name = struct_info->name;
+		if (!actual_func->parent_struct_name().empty()) {
+			owner_name = StringTable::getOrInternStringHandle(actual_func->parent_struct_name());
+		}
+		auto replay_sema_services =
+			context
+				.requireParserAttachedSema(kMemberFunctionMaterializationReplayOp)
+				.parserSemanticServices();
+		if (std::optional<ASTNode> refreshed =
+				replay_sema_services.ensureMemberFunctionMaterialized(owner_name, *actual_func);
+			refreshed.has_value() && refreshed->is<FunctionDeclarationNode>()) {
+			const auto& refreshed_func = refreshed->as<FunctionDeclarationNode>();
+			if (sameConstexprFunctionIdentity(refreshed_func, *requested_func)) {
+				actual_func = &refreshed_func;
+			}
+		}
+	}
+
+	if (!actual_func) {
+		if (placeholder_func &&
+			placeholder_func->get_definition().has_value()) {
+			const FunctionDeclarationNode* fallback_func = placeholder_func;
+			const StructMemberFunction* fallback_member =
+				findMemberFunctionMetadataRecursive(struct_info, *fallback_func);
+			const bool fallback_rejected_for_const_receiver =
+				receiver_is_const &&
+				fallback_member != nullptr &&
+				!fallback_func->is_static() &&
+				!fallback_func->is_const_member_function();
+			if (!fallback_rejected_for_const_receiver) {
+				actual_func = fallback_func;
+				actual_member = fallback_member;
+			}
+		}
+		if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+			FLASH_LOG(ConstExpr, Debug,
+				"  after placeholder fallback: actual_func=", actual_func != nullptr,
+				" actual_member=", actual_member != nullptr);
 		}
 	}
 
@@ -8925,7 +9347,20 @@ EvalResult Evaluator::materialize_constructor_object_value(
 	TypeIndex type_index = type_spec.type_index();
 	const TypeInfo* type_info = tryGetTypeInfo(type_index);
 	if (!type_info) {
-		return EvalResult::error("Constructor call has invalid struct/class type");
+		StringHandle type_name_handle = type_spec.token().handle();
+		if (!type_name_handle.isValid() && !type_spec.token().value().empty()) {
+			type_name_handle = StringTable::getOrInternStringHandle(type_spec.token().value());
+		}
+		auto type_it = getTypesByNameMap().find(type_name_handle);
+		if (type_it != getTypesByNameMap().end()) {
+			type_info = type_it->second;
+			if (type_info && !type_index.is_valid()) {
+				type_index = type_info->type_index_.withCategory(type_info->typeEnum());
+			}
+		}
+		if (!type_info) {
+			return EvalResult::error("Constructor call has invalid struct/class type");
+		}
 	}
 
 	const StructTypeInfo* struct_info = type_info->getStructInfo();

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -1726,10 +1726,10 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 			call_expr.arguments().size(),
 			context,
 			MemberFunctionLookupMode::ConstexprEvaluable,
-			true,
+			false,
 			true);
 		if (current_struct_match.ambiguous) {
-			return EvalResult::error("Ambiguous static member function overload in constant expression");
+			return EvalResult::error("Ambiguous member function overload in constant expression");
 		}
 		if (current_struct_match.function) {
 			if (!current_struct_match.function->is_static()) {
@@ -2432,6 +2432,14 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	}();
 	const StructMemberFunction* actual_member =
 		actual_func ? findMemberFunctionMetadataRecursive(bound_struct_info, *actual_func) : nullptr;
+	if (actual_func &&
+		receiver_is_this &&
+		context.current_member_function_is_const &&
+		!actual_func->is_static() &&
+		!actual_func->is_const_member_function()) {
+		actual_func = nullptr;
+		actual_member = nullptr;
+	}
 	if (!actual_func) {
 		auto member_function_match = receiver_is_this
 										 ? find_current_struct_member_function_candidate(
@@ -2502,6 +2510,15 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	EvalResult this_binding = EvalResult::from_int(0LL);
 	this_binding.object_type_index = bound_type_index;
 	this_binding.object_member_bindings = member_bindings;
+	if (const TypeInfo* bound_type = tryGetTypeInfo(bound_type_index)) {
+		TypeSpecifierNode this_type(
+			bound_type->type_index_.withCategory(TypeCategory::Struct),
+			bound_type->sizeInBits(),
+			Token{},
+			context.current_member_function_is_const ? CVQualifier::Const : CVQualifier::None,
+			ReferenceQualifier::None);
+		this_binding.set_exact_type(this_type);
+	}
 	member_bindings["this"] = std::move(this_binding);
 
 	auto saved_template_param_names = context.template_param_names;
@@ -2540,8 +2557,10 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 
 	auto saved_struct_info = context.struct_info;
 	auto saved_struct_type_index = context.struct_type_index;
+	bool saved_current_member_function_is_const = context.current_member_function_is_const;
 	context.struct_info = bound_struct_info;
 	context.struct_type_index = bound_type_index;
+	context.current_member_function_is_const = actual_func->is_const_member_function();
 	// Set return_type_info so that aggregate-initializer returns (return {x, y}) work correctly.
 	const TypeInfo* saved_return_type_info = context.return_type_info;
 	context.return_type_info = nullptr;
@@ -2565,6 +2584,7 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	context.return_type_info = saved_return_type_info;
 	context.struct_info = saved_struct_info;
 	context.struct_type_index = saved_struct_type_index;
+	context.current_member_function_is_const = saved_current_member_function_is_const;
 	if (!result.success() && (result.error_message == "Constexpr member function did not return a value" ||
 							  result.error_message == "Constexpr function return statement has no expression")) {
 		{
@@ -2744,6 +2764,7 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 	EvalResult this_binding = EvalResult::from_int(0LL);
 	this_binding.object_type_index = object.object_type_index;
 	this_binding.object_member_bindings = object.object_member_bindings;
+	this_binding.exact_type = object.exact_type;
 	member_bindings["this"] = std::move(this_binding);
 
 	// Load template type bindings, preferring function-level outer bindings when present.
@@ -2770,10 +2791,12 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 	auto saved_struct_type_index = context.struct_type_index;
 	const TypeInfo* saved_return_type_info = context.return_type_info;
 	auto* saved_local_bindings = context.local_bindings;
+	bool saved_current_member_function_is_const = context.current_member_function_is_const;
 	context.struct_info = struct_info;
 	context.struct_type_index = object.object_type_index;
 	context.return_type_info = nullptr;
 	context.local_bindings = &member_bindings;
+	context.current_member_function_is_const = match.function->is_const_member_function();
 	{
 		const TypeSpecifierNode& ret_spec = match.function->decl_node().type_specifier_node();
 		TypeIndex ret_idx = ret_spec.type_index();
@@ -2794,6 +2817,7 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 	context.return_type_info = saved_return_type_info;
 	context.struct_info = saved_struct_info;
 	context.struct_type_index = saved_struct_type_index;
+	context.current_member_function_is_const = saved_current_member_function_is_const;
 	context.template_param_names = std::move(saved_template_param_names);
 	context.template_args = std::move(saved_template_args);
 	context.template_environment = std::move(saved_template_environment);
@@ -3118,13 +3142,78 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 		.ensureMemberFunctionMaterialized(
 			context.struct_info->name, function_name_handle, std::nullopt);
 
-	result = find_member_function_candidate(
+	auto findConstAwareCurrentStructCandidate =
+		[&](const StructTypeInfo* target_struct, bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
+			if (require_static) {
+				return find_member_function_candidate(
+					target_struct,
+					function_name_handle,
+					argument_count,
+					context,
+					lookup_mode,
+					require_static,
+					detect_ambiguity);
+			}
+
+			auto collectCandidates =
+				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
+					ResolvedMemberFunctionCandidate collected;
+					if (!target_struct) {
+						return collected;
+					}
+					for (const auto& member_func : target_struct->member_functions) {
+						if (member_func.is_constructor || member_func.is_destructor ||
+							member_func.getName() != function_name_handle ||
+							!member_func.function_decl.is<FunctionDeclarationNode>()) {
+							continue;
+						}
+
+						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
+						if (!isConstexprMemberLookupCandidate(
+								func_decl,
+								argument_count,
+								context,
+								lookup_mode,
+								require_static)) {
+							continue;
+						}
+						if (!func_decl.is_static()) {
+							if (require_const_member) {
+								if (!func_decl.is_const_member_function()) {
+									continue;
+								}
+							} else if (func_decl.is_const_member_function()) {
+								continue;
+							}
+						}
+
+						if (collected.function && detect_ambiguity) {
+							collected.ambiguous = true;
+							return collected;
+						}
+
+						collected.function = &func_decl;
+						collected.member = &member_func;
+						if (!detect_ambiguity) {
+							break;
+						}
+					}
+					return collected;
+				};
+
+			if (context.current_member_function_is_const) {
+				return collectCandidates(true);
+			}
+
+			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
+			if (non_const_match.function || non_const_match.ambiguous) {
+				return non_const_match;
+			}
+			return collectCandidates(true);
+		};
+
+	result = findConstAwareCurrentStructCandidate(
 		context.struct_info,
-		function_name_handle,
-		argument_count,
-		context,
-		lookup_mode,
-		require_static,
 		detect_ambiguity_in_current_struct);
 	if (result.function && !result.function->is_materialized()) {
 		StringHandle owner_name = context.struct_info->name;
@@ -3135,13 +3224,8 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 			.requireParserAttachedSema(kMemberFunctionMaterializationReplayOp)
 			.parserSemanticServices()
 			.ensureMemberFunctionMaterialized(owner_name, *result.function);
-		result = find_member_function_candidate(
+		result = findConstAwareCurrentStructCandidate(
 			context.struct_info,
-			function_name_handle,
-			argument_count,
-			context,
-			lookup_mode,
-			require_static,
 			detect_ambiguity_in_current_struct);
 	}
 	if (result.function || result.ambiguous) {
@@ -3153,13 +3237,8 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 		const TypeInfo* struct_type = struct_type_it->second;
 		auto template_type_it = getTypesByNameMap().find(struct_type->baseTemplateName());
 		if (template_type_it != getTypesByNameMap().end() && template_type_it->second->isStruct()) {
-			return find_member_function_candidate(
+			return findConstAwareCurrentStructCandidate(
 				template_type_it->second->getStructInfo(),
-				function_name_handle,
-				argument_count,
-				context,
-				lookup_mode,
-				require_static,
 				false);
 		}
 	}
@@ -8735,8 +8814,10 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	}
 	auto saved_struct_info = context.struct_info;
 	auto saved_struct_type_index = context.struct_type_index;
+	bool saved_current_member_function_is_const = context.current_member_function_is_const;
 	context.struct_info = struct_info;
 	context.struct_type_index = type_index;
+	context.current_member_function_is_const = actual_func->is_const_member_function();
 	// Set return_type_info so that aggregate-initializer returns (return {x, y}) work correctly.
 	const TypeInfo* saved_return_type_info = context.return_type_info;
 	context.return_type_info = nullptr;
@@ -8764,6 +8845,7 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 	context.return_type_info = saved_return_type_info;
 	context.struct_info = saved_struct_info;
 	context.struct_type_index = saved_struct_type_index;
+	context.current_member_function_is_const = saved_current_member_function_is_const;
 	restore_template_bindings();
 	return result;
 }

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -2646,17 +2646,70 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 		return EvalResult::error("Object is not a struct type for member function '" + std::string(func_name) + "'");
 
 	StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
+	const bool object_is_const =
+		object.exact_type.has_value() && object.exact_type->is_const();
+	auto findConstAwareMemberCandidate =
+		[&](const StructTypeInfo* target_struct, bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
+			auto collectCandidates =
+				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
+					ResolvedMemberFunctionCandidate result;
+					if (!target_struct) {
+						return result;
+					}
+					for (const auto& member_func : target_struct->member_functions) {
+						if (member_func.is_constructor || member_func.is_destructor ||
+							member_func.getName() != func_name_handle ||
+							!member_func.function_decl.is<FunctionDeclarationNode>()) {
+							continue;
+						}
+
+						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
+						if (!isConstexprMemberLookupCandidate(
+								func_decl,
+								0,
+								context,
+								MemberFunctionLookupMode::LookupOnly,
+								false)) {
+							continue;
+						}
+						if (!func_decl.is_static()) {
+							if (require_const_member) {
+								if (!func_decl.is_const_member_function()) {
+									continue;
+								}
+							} else if (func_decl.is_const_member_function()) {
+								continue;
+							}
+						}
+
+						if (result.function && detect_ambiguity) {
+							result.ambiguous = true;
+							return result;
+						}
+
+						result.function = &func_decl;
+						result.member = &member_func;
+						if (!detect_ambiguity) {
+							break;
+						}
+					}
+					return result;
+				};
+
+			if (object_is_const) {
+				return collectCandidates(true);
+			}
+
+			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
+			if (non_const_match.function || non_const_match.ambiguous) {
+				return non_const_match;
+			}
+			return collectCandidates(true);
+		};
 
 	// Try instantiation's own member functions first, then fall back to the
 	// base template (same logic as find_current_struct_member_function_candidate).
-	auto match = find_member_function_candidate(
-		struct_info,
-		func_name_handle,
-		0,
-		context,
-		MemberFunctionLookupMode::LookupOnly,
-		false,
-		true);
+	auto match = findConstAwareMemberCandidate(struct_info, true);
 
 	if ((!match.function && !match.ambiguous) ||
 		(match.function && !match.function->is_materialized())) {
@@ -2666,13 +2719,8 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 			const TypeInfo* struct_type = struct_type_it->second;
 			auto template_type_it = getTypesByNameMap().find(struct_type->baseTemplateName());
 			if (template_type_it != getTypesByNameMap().end() && template_type_it->second->isStruct()) {
-				match = find_member_function_candidate(
+				match = findConstAwareMemberCandidate(
 					template_type_it->second->getStructInfo(),
-					func_name_handle,
-					0,
-					context,
-					MemberFunctionLookupMode::LookupOnly,
-					false,
 					false);
 			}
 		}
@@ -8511,32 +8559,95 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 		return EvalResult::error("Type is not a struct in member function call");
 	}
 
+	bool receiver_is_const = false;
+	if (has_complex_object_result && complex_object_result.exact_type.has_value()) {
+		receiver_is_const = complex_object_result.exact_type->is_const();
+	} else if (var_decl) {
+		receiver_is_const = var_decl->declaration().type_specifier_node().is_const() ||
+			var_decl->is_constexpr();
+	}
+
 	// Look up the actual member function in the struct's type info
 	const auto& arguments = call_expr.arguments();
 	StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
-	const FunctionDeclarationNode* actual_func = try_get_lowered_constexpr_member_call_target(
-		call_expr,
-		struct_info,
-		arguments.size(),
-		context,
-		MemberFunctionLookupMode::LookupOnly,
-		false);
-	const StructMemberFunction* actual_member =
-		actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : nullptr;
+	auto findConstAwareMemberFunctionMatch =
+		[&](bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
+			auto collectCandidates =
+				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
+					ResolvedMemberFunctionCandidate result;
+					for (const auto& member_func : struct_info->member_functions) {
+						if (member_func.is_constructor || member_func.is_destructor ||
+							member_func.getName() != func_name_handle ||
+							!member_func.function_decl.is<FunctionDeclarationNode>()) {
+							continue;
+						}
+
+						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
+						if (!isConstexprMemberLookupCandidate(
+								func_decl,
+								arguments.size(),
+								context,
+								MemberFunctionLookupMode::LookupOnly,
+								false)) {
+							continue;
+						}
+						if (!func_decl.is_static()) {
+							if (require_const_member) {
+								if (!func_decl.is_const_member_function()) {
+									continue;
+								}
+							} else if (func_decl.is_const_member_function()) {
+								continue;
+							}
+						}
+
+						if (result.function && detect_ambiguity) {
+							result.ambiguous = true;
+							return result;
+						}
+
+						result.function = &func_decl;
+						result.member = &member_func;
+						if (!detect_ambiguity) {
+							break;
+						}
+					}
+					return result;
+				};
+
+			if (receiver_is_const) {
+				return collectCandidates(true);
+			}
+
+			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
+			if (non_const_match.function || non_const_match.ambiguous) {
+				return non_const_match;
+			}
+			return collectCandidates(true);
+		};
+	ResolvedMemberFunctionCandidate member_function_match =
+		findConstAwareMemberFunctionMatch(true);
+	if (member_function_match.ambiguous) {
+		return EvalResult::error("Ambiguous member function overload in constant expression");
+	}
+	const FunctionDeclarationNode* actual_func = member_function_match.function;
+	const StructMemberFunction* actual_member = member_function_match.member;
 	if (!actual_func) {
-		auto member_function_match = find_member_function_candidate(
+		actual_func = try_get_lowered_constexpr_member_call_target(
+			call_expr,
 			struct_info,
-			func_name_handle,
 			arguments.size(),
 			context,
 			MemberFunctionLookupMode::LookupOnly,
-			false,
-			true);
-		if (member_function_match.ambiguous) {
-			return EvalResult::error("Ambiguous member function overload in constant expression");
+			false);
+		if (actual_func != nullptr &&
+			receiver_is_const &&
+			!actual_func->is_static() &&
+			!actual_func->is_const_member_function()) {
+			actual_func = nullptr;
 		}
-		actual_func = member_function_match.function;
-		actual_member = member_function_match.member;
+		actual_member =
+			actual_func ? findMemberFunctionMetadataRecursive(struct_info, *actual_func) : nullptr;
 	}
 	// Virtual dispatch: resolve to the final overrider in the dynamic type using
 	// is_virtual/is_override flags so that same-name non-overriding derived

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -3021,68 +3021,22 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 	StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
 	const bool object_is_const =
 		object.exact_type.has_value() && object.exact_type->is_const();
-	auto findConstAwareMemberCandidate =
+	auto findConstAwareMemberCandidateForStruct =
 		[&](const StructTypeInfo* target_struct, bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
-			auto collectCandidates =
-				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
-					ResolvedMemberFunctionCandidate result;
-					if (!target_struct) {
-						return result;
-					}
-					for (const auto& member_func : target_struct->member_functions) {
-						if (member_func.is_constructor || member_func.is_destructor ||
-							!matchesConstexprFunctionName(member_func, func_name_handle) ||
-							!member_func.function_decl.is<FunctionDeclarationNode>()) {
-							continue;
-						}
-
-						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-						if (!isConstexprMemberLookupCandidate(
-								func_decl,
-								0,
-								context,
-								MemberFunctionLookupMode::LookupOnly,
-								false)) {
-							continue;
-						}
-						if (!func_decl.is_static()) {
-							if (require_const_member) {
-								if (!func_decl.is_const_member_function()) {
-									continue;
-								}
-							} else if (func_decl.is_const_member_function()) {
-								continue;
-							}
-						}
-
-						if (result.function && detect_ambiguity) {
-							result.ambiguous = true;
-							return result;
-						}
-
-						result.function = &func_decl;
-						result.member = &member_func;
-						if (!detect_ambiguity) {
-							break;
-						}
-					}
-					return result;
-				};
-
-			if (object_is_const) {
-				return collectCandidates(true);
-			}
-
-			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
-			if (non_const_match.function || non_const_match.ambiguous) {
-				return non_const_match;
-			}
-			return collectCandidates(true);
+			return findConstAwareMemberFunctionCandidate(
+				target_struct,
+				func_name_handle,
+				0,
+				context,
+				MemberFunctionLookupMode::LookupOnly,
+				false,
+				object_is_const,
+				detect_ambiguity);
 		};
 
 	// Try instantiation's own member functions first, then fall back to the
 	// base template (same logic as find_current_struct_member_function_candidate).
-	auto match = findConstAwareMemberCandidate(struct_info, true);
+	auto match = findConstAwareMemberCandidateForStruct(struct_info, true);
 
 	if ((!match.function && !match.ambiguous) ||
 		(match.function && !match.function->is_materialized())) {
@@ -3092,7 +3046,7 @@ EvalResult Evaluator::call_constexpr_member_fn_on_object(
 			const TypeInfo* struct_type = struct_type_it->second;
 			auto template_type_it = getTypesByNameMap().find(struct_type->baseTemplateName());
 			if (template_type_it != getTypesByNameMap().end() && template_type_it->second->isStruct()) {
-				match = findConstAwareMemberCandidate(
+				match = findConstAwareMemberCandidateForStruct(
 					template_type_it->second->getStructInfo(),
 					false);
 			}
@@ -3265,6 +3219,83 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_member_function_candi
 	}
 
 	return result;
+}
+
+Evaluator::ResolvedMemberFunctionCandidate Evaluator::findConstAwareMemberFunctionCandidate(
+	const StructTypeInfo* struct_info,
+	StringHandle function_name_handle,
+	size_t argument_count,
+	EvaluationContext& context,
+	MemberFunctionLookupMode lookup_mode,
+	bool require_static,
+	bool receiver_is_const,
+	bool detect_ambiguity) {
+	if (require_static) {
+		return find_member_function_candidate(
+			struct_info,
+			function_name_handle,
+			argument_count,
+			context,
+			lookup_mode,
+			true,
+			detect_ambiguity);
+	}
+
+	auto collectCandidates =
+		[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
+			ResolvedMemberFunctionCandidate result;
+			if (!struct_info) {
+				return result;
+			}
+			for (const auto& member_func : struct_info->member_functions) {
+				if (member_func.is_constructor || member_func.is_destructor ||
+					!matchesConstexprFunctionName(member_func, function_name_handle) ||
+					!member_func.function_decl.is<FunctionDeclarationNode>()) {
+					continue;
+				}
+
+				const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
+				if (!isConstexprMemberLookupCandidate(
+						func_decl,
+						argument_count,
+						context,
+						lookup_mode,
+						false)) {
+					continue;
+				}
+				if (!func_decl.is_static()) {
+					if (require_const_member) {
+						if (!func_decl.is_const_member_function()) {
+							continue;
+						}
+					} else if (func_decl.is_const_member_function()) {
+						continue;
+					}
+				}
+
+				if (result.function && detect_ambiguity) {
+					result.ambiguous = true;
+					return result;
+				}
+
+				result.function = &func_decl;
+				result.member = &member_func;
+				if (!detect_ambiguity) {
+					break;
+				}
+			}
+			return result;
+		};
+
+	if (receiver_is_const) {
+		return collectCandidates(true);
+	}
+
+	ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
+	if (non_const_match.function || non_const_match.ambiguous) {
+		return non_const_match;
+	}
+	return collectCandidates(true);
 }
 
 Evaluator::ResolvedMemberFunctionCandidate Evaluator::findConstexprOperatorOverload(
@@ -3497,72 +3528,15 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::find_current_struct_member
 
 	auto findConstAwareCurrentStructCandidate =
 		[&](const StructTypeInfo* target_struct, bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
-			if (require_static) {
-				return find_member_function_candidate(
-					target_struct,
-					function_name_handle,
-					argument_count,
-					context,
-					lookup_mode,
-					require_static,
-					detect_ambiguity);
-			}
-
-			auto collectCandidates =
-				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
-					ResolvedMemberFunctionCandidate collected;
-					if (!target_struct) {
-						return collected;
-					}
-					for (const auto& member_func : target_struct->member_functions) {
-						if (member_func.is_constructor || member_func.is_destructor ||
-							!matchesConstexprFunctionName(member_func, function_name_handle) ||
-							!member_func.function_decl.is<FunctionDeclarationNode>()) {
-							continue;
-						}
-
-						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-						if (!isConstexprMemberLookupCandidate(
-								func_decl,
-								argument_count,
-								context,
-								lookup_mode,
-								require_static)) {
-							continue;
-						}
-						if (!func_decl.is_static()) {
-							if (require_const_member) {
-								if (!func_decl.is_const_member_function()) {
-									continue;
-								}
-							} else if (func_decl.is_const_member_function()) {
-								continue;
-							}
-						}
-
-						if (collected.function && detect_ambiguity) {
-							collected.ambiguous = true;
-							return collected;
-						}
-
-						collected.function = &func_decl;
-						collected.member = &member_func;
-						if (!detect_ambiguity) {
-							break;
-						}
-					}
-					return collected;
-				};
-
-			if (context.current_member_function_is_const) {
-				return collectCandidates(true);
-			}
-
-			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
-			if (non_const_match.function || non_const_match.ambiguous) {
-				return non_const_match;
-			}
-			return collectCandidates(true);
+			return findConstAwareMemberFunctionCandidate(
+				target_struct,
+				function_name_handle,
+				argument_count,
+				context,
+				lookup_mode,
+				require_static,
+				context.current_member_function_is_const,
+				detect_ambiguity);
 		};
 
 	result = findConstAwareCurrentStructCandidate(
@@ -9058,63 +9032,16 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 		struct_info->name,
 		func_name_handle,
 		std::nullopt);
-	auto findConstAwareMemberFunctionMatch =
-		[&](bool detect_ambiguity) -> ResolvedMemberFunctionCandidate {
-			auto collectCandidates =
-				[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
-					ResolvedMemberFunctionCandidate result;
-					for (const auto& member_func : struct_info->member_functions) {
-						if (member_func.is_constructor || member_func.is_destructor ||
-							!matchesConstexprFunctionName(member_func, func_name_handle) ||
-							!member_func.function_decl.is<FunctionDeclarationNode>()) {
-							continue;
-						}
-
-						const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-						if (!isConstexprMemberLookupCandidate(
-								func_decl,
-								arguments.size(),
-								context,
-								MemberFunctionLookupMode::LookupOnly,
-								false)) {
-							continue;
-						}
-						if (!func_decl.is_static()) {
-							if (require_const_member) {
-								if (!func_decl.is_const_member_function()) {
-									continue;
-								}
-							} else if (func_decl.is_const_member_function()) {
-								continue;
-							}
-						}
-
-						if (result.function && detect_ambiguity) {
-							result.ambiguous = true;
-							return result;
-						}
-
-						result.function = &func_decl;
-						result.member = &member_func;
-						if (!detect_ambiguity) {
-							break;
-						}
-					}
-					return result;
-				};
-
-			if (receiver_is_const) {
-				return collectCandidates(true);
-			}
-
-			ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
-			if (non_const_match.function || non_const_match.ambiguous) {
-				return non_const_match;
-			}
-			return collectCandidates(true);
-		};
 	ResolvedMemberFunctionCandidate member_function_match =
-		findConstAwareMemberFunctionMatch(true);
+		findConstAwareMemberFunctionCandidate(
+			struct_info,
+			func_name_handle,
+			arguments.size(),
+			context,
+			MemberFunctionLookupMode::LookupOnly,
+			false,
+			receiver_is_const,
+			true);
 	if (member_function_match.ambiguous) {
 		return EvalResult::error("Ambiguous member function overload in constant expression");
 	}

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -378,7 +378,7 @@ ExprResult AstToIr::generateCallExprIr(const CallExprNode& callExprNode, Express
 			copyCallMetadata(direct_static_call, callExprNode, copy_options);
 			return generateFunctionCallIr(direct_static_call, context, &callExprNode);
 		}
-		return generateMemberFunctionCallIr(callExprNode, context);
+		return generateMemberFunctionCallIr(callExprNode, context, &callExprNode);
 	}
 	return generateFunctionCallIr(callExprNode, context);
 }
@@ -588,7 +588,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 				*resolved_operator_call,
 				std::move(member_args),
 				callExprNode.called_from());
-			return generateMemberFunctionCallIr(member_call, context, sema_call_key);
+			return generateMemberFunctionCallIr(member_call, context);
 		}
 		if (sema_normalized_current_function_ &&
 			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -291,7 +291,18 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		object_node.is<ExpressionNode>()) {
 		std::optional<TypeSpecifierNode> callee_type;
 		ResolvedFunctionQueryResult resolved_op_call_query =
-			sema_services.getResolvedOpCallQuery(sema_call_key);
+			sema_call_key != nullptr
+				? sema_services.getResolvedOpCallQuery(sema_call_key)
+				: sema_services.getResolvedOpCallQuery(&callExprNode);
+		ResolvedFunctionQueryResult exact_call_query =
+			sema_services.getResolvedOpCallQuery(&callExprNode);
+		if (exact_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+			sema_services.ensureCallableOperatorResolved(callExprNode);
+			exact_call_query = sema_services.getResolvedOpCallQuery(&callExprNode);
+		}
+		if (!resolved_op_call_query.hasValue() && exact_call_query.hasValue()) {
+			resolved_op_call_query = exact_call_query;
+		}
 		const FunctionDeclarationNode* resolved_op_call =
 			resolved_op_call_query.state == ResolvedFunctionQueryResult::State::Available
 				? resolved_op_call_query.function
@@ -317,14 +328,43 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 				callee_type = *static_member_function_type;
 			}
 		}
+		if (isInconclusiveCallableType(callee_type)) {
+			const FunctionDeclarationNode* callable_target =
+				resolved_op_call != nullptr ? resolved_op_call : &member_func_decl;
+			if (callable_target != nullptr && !callable_target->parent_struct_name().empty()) {
+				const StringHandle owner_name =
+					StringTable::getOrInternStringHandle(callable_target->parent_struct_name());
+				if (auto owner_type_it = getTypesByNameMap().find(owner_name);
+					owner_type_it != getTypesByNameMap().end() &&
+					owner_type_it->second != nullptr) {
+					const TypeInfo* owner_type_info = owner_type_it->second;
+					TypeIndex owner_type_index =
+						owner_type_info->registeredTypeIndex().withCategory(owner_type_info->typeEnum());
+					if (!owner_type_index.is_valid()) {
+						owner_type_index =
+							owner_type_info->type_index_.withCategory(owner_type_info->typeEnum());
+					}
+					if (owner_type_index.is_valid()) {
+						callee_type.emplace(
+							owner_type_index.withCategory(TypeCategory::Struct),
+							owner_type_info->sizeInBits(),
+							callExprNode.called_from(),
+							CVQualifier::None,
+							ReferenceQualifier::None);
+					}
+				}
+			}
+		}
 		const bool callee_type_unusable_for_callable =
 			isInconclusiveCallableType(callee_type) ||
 			(callee_type.has_value() &&
 			 (callee_type->type() == TypeCategory::Invalid ||
 			  isPlaceholderAutoType(callee_type->type())));
+		const bool has_concrete_callable_member =
+			resolved_op_call != nullptr || !member_func_decl.parent_struct_name().empty();
 		// operator() callable type parser fallback. Probed 2026-05-20 across the full
 		// test corpus — never hit for any body. Sema now always resolves the callable type.
-		if (callee_type_unusable_for_callable && !resolved_op_call) {
+		if (callee_type_unusable_for_callable && !has_concrete_callable_member) {
 			const bool sema_query_not_yet_analyzed =
 				resolved_op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed ||
 				callee_type_query.state == TypeSpecifierQueryResult::State::NotYetAnalyzed;

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -5,15 +5,40 @@
 
 
 ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNode, ExpressionContext context) {
-	return generateMemberFunctionCallIr(callExprNode, context, &callExprNode);
+	return generateMemberFunctionCallIr(callExprNode, context, nullptr);
 }
 
 ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNode, ExpressionContext context, const void* sema_call_key) {
 	std::vector<IrOperand> irOperands;
 	irOperands.reserve(5 + callExprNode.arguments().size() * 4); // ret + name + this + ~4 per arg
 
-	const FunctionDeclarationNode& member_func_decl = *callExprNode.callee().function_declaration_or_null();
 	auto sema_services = sema_.parserSemanticServices();
+	const FunctionDeclarationNode* parser_member_func_decl =
+		callExprNode.callee().function_declaration_or_null();
+	ResolvedFunctionQueryResult sema_resolved_direct_query;
+	if (sema_call_key != nullptr) {
+		sema_resolved_direct_query =
+			sema_services.getResolvedDirectCallQuery(sema_call_key);
+	}
+	const FunctionDeclarationNode* sema_resolved_member_func =
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available
+			? sema_resolved_direct_query.function
+			: nullptr;
+	const bool has_sema_resolved_member_target =
+		sema_resolved_member_func != nullptr;
+	if (sema_call_key != nullptr &&
+		sema_normalized_current_function_ &&
+		parser_member_func_decl == nullptr &&
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		throw InternalError("Normalized member-call direct query remained NotYetAnalyzed");
+	}
+	if (parser_member_func_decl == nullptr && sema_resolved_member_func == nullptr) {
+		throw InternalError("CallExprNode with receiver is missing FunctionDeclarationNode");
+	}
+	const FunctionDeclarationNode& member_func_decl =
+		sema_resolved_member_func != nullptr
+			? *sema_resolved_member_func
+			: *parser_member_func_decl;
 
 	FLASH_LOG(Codegen, Debug, "=== generateMemberFunctionCallIr START ===");
 
@@ -558,32 +583,48 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		const IdentifierNode& object_ident = std::get<IdentifierNode>(*object_expr);
 		object_name = object_ident.name();
 
-		// Look up the object in both local and global symbol tables
-		std::optional<ASTNode> symbol = lookupSymbol(object_name);
-		if (symbol.has_value()) {
-			// Use helper to get DeclarationNode from either DeclarationNode or VariableDeclarationNode
-			object_decl = get_decl_from_symbol(*symbol);
-			if (object_decl) {
-				object_type = object_decl->type_specifier_node();
-				if (!object_type.type_index().is_valid()) {
-					StringHandle object_type_name = object_type.token().handle();
-					if (object_type_name.isValid()) {
-						auto object_type_it = getTypesByNameMap().find(object_type_name);
-						if (object_type_it != getTypesByNameMap().end() &&
-							object_type_it->second != nullptr) {
-							object_type.set_type_index(
-								object_type_it->second->type_index_.withCategory(
-									object_type_it->second->typeEnum()));
-							object_type.set_size_in_bits(
-								object_type_it->second->sizeInBits());
+		if (object_name == "this" &&
+			current_lambda_context_.isActive() &&
+			current_lambda_context_.enclosing_struct_type_index.is_valid() &&
+			(current_lambda_context_.has_this_pointer || current_lambda_context_.has_copy_this)) {
+			const TypeInfo* captured_this_type = tryGetTypeInfo(current_lambda_context_.enclosing_struct_type_index);
+			if (!captured_this_type || !captured_this_type->isStruct()) {
+				throw InternalError("Lambda captured-this receiver type was not registered");
+			}
+			object_type = TypeSpecifierNode(
+				captured_this_type->type_index_.withCategory(TypeCategory::Struct),
+				captured_this_type->sizeInBits(),
+				Token{},
+				CVQualifier::None,
+				ReferenceQualifier::None);
+		} else {
+			// Look up the object in both local and global symbol tables
+			std::optional<ASTNode> symbol = lookupSymbol(object_name);
+			if (symbol.has_value()) {
+				// Use helper to get DeclarationNode from either DeclarationNode or VariableDeclarationNode
+				object_decl = get_decl_from_symbol(*symbol);
+				if (object_decl) {
+					object_type = object_decl->type_specifier_node();
+					if (!object_type.type_index().is_valid()) {
+						StringHandle object_type_name = object_type.token().handle();
+						if (object_type_name.isValid()) {
+							auto object_type_it = getTypesByNameMap().find(object_type_name);
+							if (object_type_it != getTypesByNameMap().end() &&
+								object_type_it->second != nullptr) {
+								object_type.set_type_index(
+									object_type_it->second->type_index_.withCategory(
+										object_type_it->second->typeEnum()));
+								object_type.set_size_in_bits(
+									object_type_it->second->sizeInBits());
+							}
 						}
 					}
-				}
 
-				// If the type is 'auto', deduce the actual closure type from lambda initializer
-				if (isPlaceholderAutoType(object_type.type())) {
-					if (auto deduced = deduceLambdaClosureType(*symbol, object_decl->identifier_token())) {
-						object_type = *deduced;
+					// If the type is 'auto', deduce the actual closure type from lambda initializer
+					if (isPlaceholderAutoType(object_type.type())) {
+						if (auto deduced = deduceLambdaClosureType(*symbol, object_decl->identifier_token())) {
+							object_type = *deduced;
+						}
 					}
 				}
 			}
@@ -1075,7 +1116,8 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					break;
 				}
 			}
-			if (!called_member_func) {
+			if (!called_member_func &&
+				!has_sema_resolved_member_target) {
 				for (const auto& member_func : struct_info->member_functions) {
 					if (member_func.getName() == func_name_handle &&
 						member_func.function_decl.is<FunctionDeclarationNode>() &&
@@ -1113,17 +1155,19 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 											return; // Stop searching once found
 										}
 									}
-									for (const auto& member_func : base_struct_info->member_functions) {
-										if (member_func.getName() == func_name_handle &&
-											member_func.function_decl.is<FunctionDeclarationNode>() &&
-											isViableMemberOverload(member_func.function_decl.as<FunctionDeclarationNode>())) {
-											called_member_func = &member_func;
-											declaring_struct = base_struct_info;
-											if (member_func.is_virtual) {
-												is_virtual_call = true;
-												vtable_index = member_func.vtable_index;
+									if (!has_sema_resolved_member_target) {
+										for (const auto& member_func : base_struct_info->member_functions) {
+											if (member_func.getName() == func_name_handle &&
+												member_func.function_decl.is<FunctionDeclarationNode>() &&
+												isViableMemberOverload(member_func.function_decl.as<FunctionDeclarationNode>())) {
+												called_member_func = &member_func;
+												declaring_struct = base_struct_info;
+												if (member_func.is_virtual) {
+													is_virtual_call = true;
+													vtable_index = member_func.vtable_index;
+												}
+												return;
 											}
-											return;
 										}
 									}
 									// Recursively search base classes of this base class
@@ -1914,7 +1958,43 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		bool this_arg_is_pointer_value = false;
 		ValueStorage this_arg_storage = ValueStorage::ContainsData;
 		bool object_is_pointer_like = object_type.pointer_depth() > 0 || object_type.is_reference() || object_type.is_rvalue_reference();
-		if (object_name.empty()) {
+		bool object_is_lambda_captured_this = false;
+		if (object_expr && std::holds_alternative<IdentifierNode>(*object_expr)) {
+			const IdentifierNode& object_ident = std::get<IdentifierNode>(*object_expr);
+			object_is_lambda_captured_this =
+				object_ident.name() == "this" &&
+				current_lambda_context_.isActive() &&
+				current_lambda_context_.enclosing_struct_type_index.is_valid() &&
+				(current_lambda_context_.has_this_pointer || current_lambda_context_.has_copy_this);
+		}
+		if (object_is_lambda_captured_this) {
+			if (current_lambda_context_.has_copy_this) {
+				const StructTypeInfo* closure_struct = getCurrentClosureStruct();
+				const StructMember* copy_this_member = closure_struct ? closure_struct->findMember("__copy_this") : nullptr;
+				if (!copy_this_member) {
+					throw InternalError("Lambda [*this] member-call receiver missing __copy_this member");
+				}
+				TempVar this_addr = var_counter.next();
+				AddressOfMemberOp addr_op;
+				addr_op.result = this_addr;
+				addr_op.base_object = StringTable::getOrInternStringHandle("this"sv);
+				addr_op.member_offset = static_cast<int>(copy_this_member->offset);
+				addr_op.member_type_index = current_lambda_context_.enclosing_struct_type_index.withCategory(TypeCategory::Struct);
+				addr_op.member_size_in_bits = static_cast<int>(copy_this_member->size * 8);
+				ir_.addInstruction(IrInstruction(IrOpcode::AddressOfMember, std::move(addr_op), callExprNode.called_from()));
+				this_arg_value = IrValue(this_addr);
+				this_arg_is_pointer_value = true;
+				this_arg_storage = ValueStorage::ContainsAddress;
+			} else {
+				std::optional<TempVar> this_ptr = emitLoadThisPointer(callExprNode.called_from());
+				if (!this_ptr.has_value()) {
+					throw InternalError("Lambda [this] member-call receiver could not load captured object pointer");
+				}
+				this_arg_value = IrValue(*this_ptr);
+				this_arg_is_pointer_value = true;
+				this_arg_storage = ValueStorage::ContainsAddress;
+			}
+		} else if (object_name.empty()) {
 			// Object is a temporary expression result (e.g., getContainer().method())
 			// Evaluate the expression to get a TempVar, then take its address for the this pointer
 			ExprResult obj_result = visitExpressionNode(*object_expr);

--- a/src/IrGenerator_Expr_Primitives.cpp
+++ b/src/IrGenerator_Expr_Primitives.cpp
@@ -395,10 +395,10 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 	};
 	auto makeIdentifierResultFromTypeNode = [&](const TypeSpecifierNode& type_node, int size_bits, IrOperand value,
 												bool preserve_pointer_depth = false) -> ExprResult {
-			// Preserve the original direct-identifier encoding rule from these sites:
-			// semantic identity types carry type_index in ExprResult, while legacy slot-4 metadata
-			// keeps enum values identifiable after integral lowering and keeps enum pointers usable
-			// for still-unmigrated pointer-depth consumers.
+		// Preserve the original direct-identifier encoding rule from these sites:
+		// semantic identity types carry type_index in ExprResult, while legacy slot-4 metadata
+		// keeps enum values identifiable after integral lowering and keeps enum pointers usable
+		// for still-unmigrated pointer-depth consumers.
 		TypeCategory result_type = type_node.type();
 		if (isPlaceholderAutoType(result_type)) {
 			result_type = resolveCodegenTypeCategory(type_node, "identifier lowering");
@@ -421,10 +421,10 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 			carries_type_index ? type_node.type_index() : TypeIndex{},
 			pointer_depth);
 	};
-		// Check if this is a captured variable in a lambda.
-		// Explicit captures ([x], [&x]) have binding set at parse time.
-		// Capture-all ([=], [&]) variables are expanded at parse time into current_lambda_context_
-		// but keep Local binding, so we fall back to the runtime captures map for those.
+	// Check if this is a captured variable in a lambda.
+	// Explicit captures ([x], [&x]) have binding set at parse time.
+	// Capture-all ([=], [&]) variables are expanded at parse time into current_lambda_context_
+	// but keep Local binding, so we fall back to the runtime captures map for those.
 	StringHandle var_name_str = StringTable::getOrInternStringHandle(identifierNode.name());
 	auto preserveSemanticTypeIndex = [](TypeCategory type, TypeIndex type_index) {
 		return carriesSemanticTypeIndex(type) ? type_index : TypeIndex{};
@@ -455,8 +455,8 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 	bool is_implicit_capture = !is_explicit_capture && current_lambda_context_.isActive() &&
 							   current_lambda_context_.captures.find(var_name_str) != current_lambda_context_.captures.end();
 	if (is_explicit_capture || is_implicit_capture) {
-			// This is a captured variable - generate member access (this->x)
-			// Look up the closure struct type
+		// This is a captured variable - generate member access (this->x)
+		// Look up the closure struct type
 		auto type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
 		if (type_it != getTypesByNameMap().end() && type_it->second->isStruct()) {
 			TypeIndex closure_type_index = type_it->second->type_index_;
@@ -473,8 +473,8 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 				}
 
 				if (is_reference) {
-						// By-reference capture: member is a pointer, need to dereference
-						// First, load the pointer from the closure
+					// By-reference capture: member is a pointer, need to dereference
+					// First, load the pointer from the closure
 					TempVar ptr_temp = var_counter.next();
 					MemberLoadOp member_load;
 					member_load.result.value = ptr_temp;
@@ -488,30 +488,29 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 
 					ir_.addInstruction(IrInstruction(IrOpcode::MemberAccess, std::move(member_load), Token()));
 
-						// The ptr_temp now contains the address of the captured variable
-						// We need to dereference it using PointerDereference
+					// The ptr_temp now contains the address of the captured variable
+					// We need to dereference it using PointerDereference
 					auto capture_type_it = current_lambda_context_.capture_types.find(var_name_str);
-					if (capture_type_it != current_lambda_context_.capture_types.end()) {
-						const TypeSpecifierNode& orig_type = capture_type_it->second;
-
-							// Generate Dereference to load the value
-						TempVar result_temp = emitDereference(orig_type.category(), 64, 0, ptr_temp);
-
-							// Mark as lvalue with Indirect metadata for unified assignment handler
-							// This represents dereferencing a pointer: *ptr
-						LValueInfo lvalue_info(
-							LValueInfo::Kind::Indirect,
-							ptr_temp,  // The pointer temp var
-							0  // offset is 0 for dereference
-						);
-						setTempVarMetadata(result_temp, TempVarMetadata::makeLValue(lvalue_info, TypeCategory::Invalid, 0));
-
-						TypeIndex type_index = (orig_type.category() == TypeCategory::Struct) ? orig_type.type_index() : nativeTypeIndex(orig_type.type());
-						return makeIdentifierResult(orig_type.type(), static_cast<int>(orig_type.size_in_bits()), result_temp, type_index);
+					if (capture_type_it == current_lambda_context_.capture_types.end()) {
+						throw InternalError("Lambda by-reference capture missing captured object type");
 					}
+					const TypeSpecifierNode& orig_type = capture_type_it->second;
 
-						// Fallback: return the pointer temp
-					return makeExprResult(nativeTypeIndex(member->memberType()), SizeInBits{64}, IrOperand{ptr_temp}, PointerDepth{}, ValueStorage::ContainsData);
+					// Generate Dereference to load the referenced object, using the
+					// captured variable's object size rather than the pointer slot size.
+					TempVar result_temp = emitDereference(orig_type.category(), orig_type.size_in_bits(), 0, ptr_temp);
+
+					// Mark as lvalue with Indirect metadata for unified assignment handler
+					// This represents dereferencing a pointer: *ptr
+					LValueInfo lvalue_info(
+						LValueInfo::Kind::Indirect,
+						ptr_temp,  // The pointer temp var
+						0  // offset is 0 for dereference
+					);
+					setTempVarMetadata(result_temp, TempVarMetadata::makeLValue(lvalue_info, TypeCategory::Invalid, 0));
+
+					TypeIndex type_index = (orig_type.category() == TypeCategory::Struct) ? orig_type.type_index() : nativeTypeIndex(orig_type.type());
+					return makeIdentifierResult(orig_type.type(), static_cast<int>(orig_type.size_in_bits()), result_temp, type_index);
 				} else {
 						// By-value capture: direct member access
 					TempVar result_temp = var_counter.next();
@@ -547,7 +546,7 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 		}
 	}
 
-		// If we're inside a [*this] lambda, prefer resolving to members of the copied object
+	// If we're inside a [*this] lambda, prefer resolving to members of the copied object
 	if (isInCopyThisLambda() && current_lambda_context_.enclosing_struct_type_index.is_valid()) {
 		auto result = FlashCpp::gLazyMemberResolver.resolve(current_lambda_context_.enclosing_struct_type_index, var_name_str);
 		if (result) {
@@ -578,8 +577,8 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 		}
 	}
 
-		// Check if this is a static local variable FIRST (before any other lookups)
-		// Phase 4: Using StringHandle for lookup
+	// Check if this is a static local variable FIRST (before any other lookups)
+	// Phase 4: Using StringHandle for lookup
 	StringHandle identifier_handle = StringTable::getOrInternStringHandle(identifierNode.name());
 	auto static_local_it = static_local_names_.find(identifier_handle);
 	if (static_local_it != static_local_names_.end()) {
@@ -682,11 +681,11 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 					}
 					return makeIdentifierResultFromTypeNode(type_n, size_bits, result_temp, true);
 				}
-					// Other symbol types (FunctionDeclarationNode, etc.): fall through to cascade
+				// Other symbol types (FunctionDeclarationNode, etc.): fall through to cascade
 			}
-				// Not found by direct lookup: fall through to cascade (handles namespace-scoped globals)
+			// Not found by direct lookup: fall through to cascade (handles namespace-scoped globals)
 		}
-			// Has using override: fall through to cascade for correct qualified name resolution
+		// Has using override: fall through to cascade for correct qualified name resolution
 	}
 
 	auto resolveImplicitMember = [&](TypeIndex owner_type_index, StringHandle member_name)
@@ -777,10 +776,10 @@ ExprResult AstToIr::generateIdentifierIr(const IdentifierNode& identifierNode,
 		}
 	}
 
-		// Check using declarations from local scope FIRST, before local symbol table lookup
-		// This handles cases like: using ::globalValue; return globalValue;
-		// where globalValue should resolve to the global namespace version even if there's
-		// a namespace-scoped version with the same name
+	// Check using declarations from local scope FIRST, before local symbol table lookup
+	// This handles cases like: using ::globalValue; return globalValue;
+	// where globalValue should resolve to the global namespace version even if there's
+	// a namespace-scoped version with the same name
 	std::optional<ASTNode> symbol;
 	bool is_global = false;
 	std::optional<StringHandle> resolved_qualified_name;	 // Track the qualified name from using declaration

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -314,6 +314,23 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 				std::string_view var_name = capture.identifier_name();  // Already a persistent string_view from AST
 				StringHandle var_name_str = StringTable::getOrInternStringHandle(var_name);	// Single conversion for both uses below
 				const StructMember* member = struct_info->findMember(var_name);
+				auto findEnclosingCaptureOffset = [&](StringHandle capture_name) -> int {
+					auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
+					if (enclosing_type_it == getTypesByNameMap().end() ||
+						enclosing_type_it->second == nullptr) {
+						return -1;
+					}
+					const TypeInfo* enclosing_type = enclosing_type_it->second;
+					const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo();
+					if (!enclosing_struct) {
+						return -1;
+					}
+					const StructMember* enclosing_member = enclosing_struct->findMember(capture_name);
+					if (!enclosing_member) {
+						return -1;
+					}
+					return static_cast<int>(enclosing_member->offset);
+				};
 
 				if (member && (capture.has_initializer() || capture_index < lambda_info.captured_var_decls.size())) {
 					// Check if this variable is a captured variable from an enclosing lambda
@@ -410,36 +427,14 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 								member_load.object = StringTable::getOrInternStringHandle("this");
 								member_load.member_name = StringTable::getOrInternStringHandle(var_name);
 
-								int enclosing_offset = -1;
-								auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-								if (enclosing_type_it != getTypesByNameMap().end() &&
-									enclosing_type_it->second != nullptr) {
-									const TypeInfo* enclosing_type = enclosing_type_it->second;
-									if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
-										const StructMember* enclosing_member = enclosing_struct->findMember(var_name);
-										if (enclosing_member) {
-											enclosing_offset = static_cast<int>(enclosing_member->offset);
-										}
-									}
-								}
+								int enclosing_offset = findEnclosingCaptureOffset(var_name_str);
 								member_load.offset = enclosing_offset;
 								member_load.struct_type_info = nullptr;
 								member_load.ref_qualifier = CVReferenceQualifier::LValueReference;
 								ir_.addInstruction(IrInstruction(IrOpcode::MemberAccess, std::move(member_load), lambda.lambda_token()));
 							} else {
 								// Enclosing captured by value - need to get address of this->x
-								int enclosing_offset = -1;
-								auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-								if (enclosing_type_it != getTypesByNameMap().end() &&
-									enclosing_type_it->second != nullptr) {
-									const TypeInfo* enclosing_type = enclosing_type_it->second;
-									if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
-										const StructMember* enclosing_member = enclosing_struct->findMember(var_name_str);
-										if (enclosing_member) {
-											enclosing_offset = static_cast<int>(enclosing_member->offset);
-										}
-									}
-								}
+								int enclosing_offset = findEnclosingCaptureOffset(var_name_str);
 								if (enclosing_offset < 0) {
 									throw InternalError("Nested lambda reference capture could not resolve enclosing closure member");
 								}
@@ -492,18 +487,7 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 							member_load.object = StringTable::getOrInternStringHandle("this");
 							member_load.member_name = StringTable::getOrInternStringHandle(var_name);
 
-							int enclosing_offset = -1;
-							auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-							if (enclosing_type_it != getTypesByNameMap().end() &&
-								enclosing_type_it->second != nullptr) {
-								const TypeInfo* enclosing_type = enclosing_type_it->second;
-								if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
-									const StructMember* enclosing_member = enclosing_struct->findMember(var_name_str);
-									if (enclosing_member) {
-										enclosing_offset = static_cast<int>(enclosing_member->offset);
-									}
-								}
-							}
+							int enclosing_offset = findEnclosingCaptureOffset(var_name_str);
 							member_load.offset = enclosing_offset;
 							member_load.struct_type_info = nullptr;
 							member_load.ref_qualifier = CVReferenceQualifier::None;

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -161,14 +161,14 @@ LambdaInfo AstToIr::collectLambdaForDeferredGeneration(const LambdaExpressionNod
 }
 
 ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambda, std::string_view target_var_name) {
-		// Collect lambda information for deferred generation
-		// Following Clang's approach: generate closure class, operator(), __invoke, and conversion operator
-		// If target_var_name is provided, use it as the closure variable name (for variable declarations)
-		// Otherwise, create a temporary __closure_N variable
+	// Collect lambda information for deferred generation
+	// Following Clang's approach: generate closure class, operator(), __invoke, and conversion operator
+	// If target_var_name is provided, use it as the closure variable name (for variable declarations)
+	// Otherwise, create a temporary __closure_N variable
 
 	LambdaInfo lambda_info = collectLambdaForDeferredGeneration(lambda);
 
-		// Look up the closure type (registered during parsing)
+	// Look up the closure type (registered during parsing)
 	auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(lambda_info.closure_type_name));
 	if (type_it == getTypesByNameMap().end()) {
 			// Error: closure type not found
@@ -178,14 +178,14 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 
 	const TypeInfo* closure_type = type_it->second;
 
-		// Use target variable name if provided, otherwise create a temporary closure variable
+	// Use target variable name if provided, otherwise create a temporary closure variable
 	std::string_view closure_var_name;
 	if (!target_var_name.empty()) {
-			// Use the target variable name directly
-			// We MUST emit VariableDecl here before any MemberStore operations
+		// Use the target variable name directly
+		// We MUST emit VariableDecl here before any MemberStore operations
 		closure_var_name = target_var_name;
 
-			// Declare the closure variable with the target name
+		// Declare the closure variable with the target name
 		VariableDeclOp lambda_decl_op;
 		lambda_decl_op.type_index = nativeTypeIndex(TypeCategory::Struct);
 		lambda_decl_op.size_in_bits = SizeInBits{static_cast<int>(closure_type->getStructInfo()->sizeInBits().value)};
@@ -195,13 +195,13 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 		lambda_decl_op.is_array = false;
 		ir_.addInstruction(IrInstruction(IrOpcode::VariableDecl, std::move(lambda_decl_op), lambda.lambda_token()));
 	} else {
-			// Create a temporary closure variable name
+		// Create a temporary closure variable name
 		closure_var_name = StringBuilder()
 							   .append("__closure_")
 							   .append(static_cast<int64_t>(lambda_info.lambda_id))
 							   .commit();
 
-			// Declare the closure variable
+		// Declare the closure variable
 		VariableDeclOp lambda_decl_op;
 		lambda_decl_op.type_index = nativeTypeIndex(TypeCategory::Struct);
 		lambda_decl_op.size_in_bits = SizeInBits{static_cast<int>(closure_type->getStructInfo()->sizeInBits().value)};
@@ -212,9 +212,9 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 		ir_.addInstruction(IrInstruction(IrOpcode::VariableDecl, std::move(lambda_decl_op), lambda.lambda_token()));
 	}
 
-		// Now initialize captured members
-		// The key insight: we need to generate the initialization code that will be
-		// executed during IR conversion, after the variable has been added to scope
+	// Now initialize captured members
+	// The key insight: we need to generate the initialization code that will be
+	// executed during IR conversion, after the variable has been added to scope
 	if (!lambda_info.captures.empty()) {
 		const StructTypeInfo* struct_info = closure_type->getStructInfo();
 		if (struct_info) {
@@ -224,17 +224,39 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 					continue;
 				}
 
-					// Handle [this] capture - stores pointer to enclosing object
+				// Handle [this] capture - stores pointer to enclosing object
 				if (capture.kind() == LambdaCaptureNode::CaptureKind::This) {
 					const StructMember* member = struct_info->findMember("__this");
 					if (member) {
+						IrValue this_capture_value = StringTable::getOrInternStringHandle("this"sv);
+						if (current_lambda_context_.isActive()) {
+							if (auto this_ptr = emitLoadThisPointer(lambda.lambda_token())) {
+								this_capture_value = *this_ptr;
+							} else if (current_lambda_context_.has_copy_this) {
+								const StructTypeInfo* enclosing_closure = getCurrentClosureStruct();
+								const StructMember* copy_this_member = enclosing_closure ? enclosing_closure->findMember("__copy_this") : nullptr;
+								if (!copy_this_member) {
+									throw InternalError("Nested lambda [this] capture missing enclosing __copy_this member");
+								}
+								TempVar copy_this_addr = var_counter.next();
+								AddressOfMemberOp addr_op;
+								addr_op.result = copy_this_addr;
+								addr_op.base_object = StringTable::getOrInternStringHandle("this"sv);
+								addr_op.member_offset = static_cast<int>(copy_this_member->offset);
+								addr_op.member_type_index = current_lambda_context_.enclosing_struct_type_index.withCategory(TypeCategory::Struct);
+								addr_op.member_size_in_bits = static_cast<int>(copy_this_member->size * 8);
+								ir_.addInstruction(IrInstruction(IrOpcode::AddressOfMember, std::move(addr_op), lambda.lambda_token()));
+								this_capture_value = copy_this_addr;
+							} else {
+								throw InternalError("Nested lambda [this] capture could not resolve enclosing object");
+							}
+						}
 							// Store the enclosing 'this' pointer in the closure
-							// Use the 'this' variable name to properly resolve to the member function's this parameter
 						MemberStoreOp store_this;
 						store_this.value.setType(TypeCategory::Void);
 						store_this.value.ir_type = IrType::Void;
 						store_this.value.size_in_bits = SizeInBits{64};
-						store_this.value.value = StringTable::getOrInternStringHandle("this");
+						store_this.value.value = this_capture_value;
 						store_this.object = StringTable::getOrInternStringHandle(closure_var_name);
 						store_this.member_name = StringTable::getOrInternStringHandle("__this");
 						store_this.offset = static_cast<int>(member->offset);
@@ -245,20 +267,20 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 					continue;
 				}
 
-					// Handle [*this] capture - stores copy of entire enclosing object
+				// Handle [*this] capture - stores copy of entire enclosing object
 				if (capture.kind() == LambdaCaptureNode::CaptureKind::CopyThis) {
-						// For [*this], we need to copy the entire object into the closure
-						// The closure should have a member named "__copy_this" of the enclosing struct type
+					// For [*this], we need to copy the entire object into the closure
+					// The closure should have a member named "__copy_this" of the enclosing struct type
 					const StructMember* member = struct_info->findMember("__copy_this");
 					if (member && lambda_info.enclosing_struct_type_index.is_valid()) {
-							// Copy each member of the enclosing struct into __copy_this
+						// Copy each member of the enclosing struct into __copy_this
 						const TypeInfo* enclosing_type = tryGetTypeInfo(lambda_info.enclosing_struct_type_index);
 						if (enclosing_type && enclosing_type->getStructInfo()) {
 							const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo();
 							int copy_base_offset = static_cast<int>(member->offset);
 
 							for (const auto& enclosing_member : enclosing_struct->members) {
-									// Load from original 'this'
+								// Load from original 'this'
 								TempVar loaded_value = var_counter.next();
 								MemberLoadOp load_op;
 								load_op.result.value = loaded_value;
@@ -272,7 +294,7 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 								load_op.struct_type_info = nullptr;
 								ir_.addInstruction(IrInstruction(IrOpcode::MemberAccess, std::move(load_op), lambda.lambda_token()));
 
-									// Store into closure->__copy_this at the appropriate offset
+								// Store into closure->__copy_this at the appropriate offset
 								MemberStoreOp store_copy_this;
 								store_copy_this.value.setType(enclosing_member.type_index.category());
 								store_copy_this.value.size_in_bits = SizeInBits{static_cast<int>(enclosing_member.size * 8)};
@@ -294,17 +316,17 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 				const StructMember* member = struct_info->findMember(var_name);
 
 				if (member && (capture.has_initializer() || capture_index < lambda_info.captured_var_decls.size())) {
-						// Check if this variable is a captured variable from an enclosing lambda
+					// Check if this variable is a captured variable from an enclosing lambda
 					bool is_captured_from_enclosing = current_lambda_context_.isActive() &&
 													  current_lambda_context_.captures.count(var_name_str) > 0;
 
-						// Handle init-captures
+					// Handle init-captures
 					if (capture.has_initializer()) {
-							// Init-capture: evaluate the initializer expression and store it
+						// Init-capture: evaluate the initializer expression and store it
 						const ASTNode& init_node = *capture.initializer();
 						const ExpressionNode& init_expr = init_node.as<ExpressionNode>();
 
-							// For init-capture by reference [&y = x], we need to store the address of x
+						// For init-capture by reference [&y = x], we need to store the address of x
 						if (capture.kind() == LambdaCaptureNode::CaptureKind::ByReference) {
 							ExprResult address_result = materializeAddressResult(
 								init_expr,
@@ -315,7 +337,7 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 								continue;
 							}
 
-								// Store the address in the closure member
+							// Store the address in the closure member
 							MemberStoreOp member_store;
 							member_store.value.setType(member->memberType());
 							member_store.value.size_in_bits = SizeInBits{64}; // pointer size
@@ -329,12 +351,12 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 						} else {
 							ExprResult init_result = visitExpressionNode(init_expr);
 							IrOperand init_value = init_result.value;
-								// Init-capture by value [x = expr] - store the value directly
+							// Init-capture by value [x = expr] - store the value directly
 							MemberStoreOp member_store;
 							member_store.value.setType(member->type_index.category());
 							member_store.value.size_in_bits = SizeInBits{static_cast<int>(member->size * 8)};
 
-								// Convert IrOperand to IrValue
+							// Convert IrOperand to IrValue
 							if (const auto* temp_var_ptr = std::get_if<TempVar>(&init_value)) {
 								member_store.value.value = *temp_var_ptr;
 							} else if (const auto* int_val = std::get_if<int>(&init_value)) {
@@ -346,7 +368,7 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 							} else if (const auto* string = std::get_if<StringHandle>(&init_value)) {
 								member_store.value.value = *string;
 							} else {
-									// For other types, skip this capture
+								// For other types, skip this capture
 								continue;
 							}
 
@@ -358,11 +380,11 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 							ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(member_store), lambda.lambda_token()));
 						}
 
-							// Init-captures do not consume an entry from captured_var_decls.
+						// Init-captures do not consume an entry from captured_var_decls.
 						continue;
 					} else if (capture.kind() == LambdaCaptureNode::CaptureKind::ByReference) {
-							// By-reference: store the address of the variable
-							// Get the original variable type from captured_var_decls
+						// By-reference: store the address of the variable
+						// Get the original variable type from captured_var_decls
 						const ASTNode& var_decl = lambda_info.captured_var_decls[capture_index];
 						const DeclarationNode* decl = get_decl_from_symbol(var_decl);
 						if (!decl) {
@@ -374,13 +396,13 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 						TempVar addr_temp = var_counter.next();
 
 						if (is_captured_from_enclosing) {
-								// Variable is captured from enclosing lambda - need to get address from this->x
+							// Variable is captured from enclosing lambda - need to get address from this->x
 							auto enclosing_kind_it = current_lambda_context_.capture_kinds.find(var_name_str);
 							bool enclosing_is_ref = (enclosing_kind_it != current_lambda_context_.capture_kinds.end() &&
 													 enclosing_kind_it->second == LambdaCaptureNode::CaptureKind::ByReference);
 
 							if (enclosing_is_ref) {
-									// Enclosing captured by reference - it already holds a pointer, just copy it
+								// Enclosing captured by reference - it already holds a pointer, just copy it
 								MemberLoadOp member_load;
 								member_load.result.value = addr_temp;
 								member_load.result.setType(orig_type.category());
@@ -404,15 +426,30 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 								member_load.ref_qualifier = CVReferenceQualifier::LValueReference;
 								ir_.addInstruction(IrInstruction(IrOpcode::MemberAccess, std::move(member_load), lambda.lambda_token()));
 							} else {
-									// Enclosing captured by value - need to get address of this->x
-								AddressOfOp addr_op;
+								// Enclosing captured by value - need to get address of this->x
+								int enclosing_offset = -1;
+								auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
+								if (enclosing_type_it != getTypesByNameMap().end()) {
+									const TypeInfo* enclosing_type = enclosing_type_it->second;
+									if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
+										const StructMember* enclosing_member = enclosing_struct->findMember(var_name_str);
+										if (enclosing_member) {
+											enclosing_offset = static_cast<int>(enclosing_member->offset);
+										}
+									}
+								}
+								if (enclosing_offset < 0) {
+									throw InternalError("Nested lambda reference capture could not resolve enclosing closure member");
+								}
+								AddressOfMemberOp addr_op;
 								addr_op.result = addr_temp;
-								addr_op.operand.setType(orig_type.category());
-								addr_op.operand.ir_type = toIrType(orig_type.type());
-								addr_op.operand.size_in_bits = SizeInBits{orig_type.size_in_bits()};
-								addr_op.operand.pointer_depth = PointerDepth{};
-								addr_op.operand.value = StringTable::getOrInternStringHandle(var_name);
-								ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), lambda.lambda_token()));
+								addr_op.base_object = StringTable::getOrInternStringHandle("this"sv);
+								addr_op.member_offset = enclosing_offset;
+								addr_op.member_type_index = orig_type.type_index().is_valid()
+																? orig_type.type_index().withCategory(orig_type.category())
+																: nativeTypeIndex(orig_type.category());
+								addr_op.member_size_in_bits = orig_type.size_in_bits();
+								ir_.addInstruction(IrInstruction(IrOpcode::AddressOfMember, std::move(addr_op), lambda.lambda_token()));
 							}
 						} else {
 								// Regular variable - generate AddressOf directly
@@ -426,7 +463,7 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 							ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), lambda.lambda_token()));
 						}
 
-							// Store the address in the closure member
+						// Store the address in the closure member
 						MemberStoreOp member_store;
 						member_store.value.setType(member->type_index.category());
 						member_store.value.size_in_bits = SizeInBits{static_cast<int>(member->size * 8)};
@@ -438,13 +475,13 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 						member_store.struct_type_info = nullptr;
 						ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(member_store), lambda.lambda_token()));
 					} else {
-							// By-value: copy the value
+						// By-value: copy the value
 						MemberStoreOp member_store;
 						member_store.value.setType(member->type_index.category());
 						member_store.value.size_in_bits = SizeInBits{static_cast<int>(member->size * 8)};
 
 						if (is_captured_from_enclosing) {
-								// Variable is captured from enclosing lambda - load it via member access first
+							// Variable is captured from enclosing lambda - load it via member access first
 							TempVar loaded_value = var_counter.next();
 							MemberLoadOp member_load;
 							member_load.result.value = loaded_value;
@@ -489,12 +526,12 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 		}
 	}
 
-		// Return the closure variable representing the lambda
-		// Format: {type, size, value, type_index}
-		// - type: Type::Struct (the closure is a struct)
-		// - size: size of the closure in bits
-		// - value: closure_var_name (the allocated closure variable)
-		// - type_index: the type index for the closure struct
+	// Return the closure variable representing the lambda
+	// Format: {type, size, value, type_index}
+	// - type: Type::Struct (the closure is a struct)
+	// - size: size of the closure in bits
+	// - value: closure_var_name (the allocated closure variable)
+	// - type_index: the type index for the closure struct
 	int closure_size_bits = static_cast<int>(closure_type->getStructInfo()->sizeInBits().value);
 	TypeIndex closure_type_index = TypeIndex{closure_type->type_index_};
 	return makeExprResult(closure_type_index.withCategory(TypeCategory::Struct), SizeInBits{static_cast<int>(closure_size_bits)}, IrOperand{StringTable::getOrInternStringHandle(closure_var_name)}, PointerDepth{}, ValueStorage::ContainsData);

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -412,7 +412,8 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 
 								int enclosing_offset = -1;
 								auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-								if (enclosing_type_it != getTypesByNameMap().end()) {
+								if (enclosing_type_it != getTypesByNameMap().end() &&
+									enclosing_type_it->second != nullptr) {
 									const TypeInfo* enclosing_type = enclosing_type_it->second;
 									if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
 										const StructMember* enclosing_member = enclosing_struct->findMember(var_name);
@@ -493,7 +494,8 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 
 							int enclosing_offset = -1;
 							auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-							if (enclosing_type_it != getTypesByNameMap().end()) {
+							if (enclosing_type_it != getTypesByNameMap().end() &&
+								enclosing_type_it->second != nullptr) {
 								const TypeInfo* enclosing_type = enclosing_type_it->second;
 								if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
 									const StructMember* enclosing_member = enclosing_struct->findMember(var_name_str);

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -429,7 +429,8 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 								// Enclosing captured by value - need to get address of this->x
 								int enclosing_offset = -1;
 								auto enclosing_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
-								if (enclosing_type_it != getTypesByNameMap().end()) {
+								if (enclosing_type_it != getTypesByNameMap().end() &&
+									enclosing_type_it->second != nullptr) {
 									const TypeInfo* enclosing_type = enclosing_type_it->second;
 									if (const StructTypeInfo* enclosing_struct = enclosing_type->getStructInfo()) {
 										const StructMember* enclosing_member = enclosing_struct->findMember(var_name_str);

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -6,6 +6,7 @@
 #include "CompileContext.h"
 #include "ChunkedString.h"
 #include "TemplateTypes.h" // For FunctionSignatureKey
+#include "InlineVector.h"
 #include <vector>
 #include <optional>
 #include <unordered_map>
@@ -1376,9 +1377,9 @@ inline OverloadResolutionResult resolve_overload(
 
 	// Track the best match found so far
 	const ASTNode* best_match = nullptr;
-	std::vector<ArgumentConversionInfo> best_infos;
+	InlineVector<ArgumentConversionInfo, 4> best_infos;
 	int num_best_matches = 0;
-	std::vector<const ASTNode*> tied_candidates; // All candidates with best rank
+	InlineVector<const ASTNode*, 4> tied_candidates; // All candidates with best rank
 
 	// Evaluate each overload
 	for (const auto& overload : overloads) {
@@ -1411,7 +1412,7 @@ inline OverloadResolutionResult resolve_overload(
 		// Check if all provided arguments can be converted to parameters
 		// For variadic functions, only check the named parameters
 		// The variadic arguments (...) accept any type
-		std::vector<ArgumentConversionInfo> conversion_infos;
+		InlineVector<ArgumentConversionInfo, 4> conversion_infos;
 		bool all_convertible = true;
 
 		size_t params_to_check = std::min(parameters.size(), argument_types.size());
@@ -1461,7 +1462,7 @@ inline OverloadResolutionResult resolve_overload(
 				// Re-evaluate all previously accumulated tied/incomparable
 				// candidates against the new best ranks — any that are not
 				// strictly worse must be kept so that ambiguity is detected.
-				std::vector<const ASTNode*> old_tied = std::move(tied_candidates);
+				InlineVector<const ASTNode*, 4> old_tied = std::move(tied_candidates);
 				best_match = &overload;
 				best_infos = conversion_infos;
 				num_best_matches = 1;
@@ -1474,7 +1475,7 @@ inline OverloadResolutionResult resolve_overload(
 					const FunctionDeclarationNode* prev_func = &prev->as<FunctionDeclarationNode>();
 					const auto& prev_params = prev_func->parameter_nodes();
 					size_t prev_params_to_check = std::min(prev_params.size(), argument_types.size());
-					std::vector<ArgumentConversionInfo> prev_infos;
+					InlineVector<ArgumentConversionInfo, 4> prev_infos;
 					bool prev_valid = true;
 					for (size_t k = 0; k < prev_params_to_check; ++k) {
 						const auto& pt = prev_params[k].as<DeclarationNode>().type_specifier_node();

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -162,6 +162,11 @@ struct SourceMemberIdentityMaps {
 	std::unordered_map<uint64_t, ASTNode> by_location;
 };
 
+struct SourceMemberStructInfoIndexMaps {
+	std::unordered_map<const void*, size_t> by_node;
+	std::unordered_map<uint64_t, size_t> by_location;
+};
+
 enum class ReplaySignatureMatchResult {
 	Match,
 	Mismatch,
@@ -213,6 +218,72 @@ static const void* sourceMemberAstNodeKey(const ASTNode& node) {
 	if (node.is<DestructorDeclarationNode>())
 		return &node.as<DestructorDeclarationNode>();
 	return nullptr;
+}
+
+static void mixReplaySourceTokenKey(uint64_t& key, const Token& token) {
+	auto mix = [&](uint64_t value) {
+		key ^= value + 0x9E3779B97F4A7C15ull + (key << 6) + (key >> 2);
+	};
+	mix(static_cast<uint64_t>(token.file_index()));
+	mix(static_cast<uint64_t>(token.line()));
+	mix(static_cast<uint64_t>(token.column()));
+	mix(static_cast<uint64_t>(token.handle().handle));
+}
+
+static void mixReplaySourceParamKey(uint64_t& key, const ASTNode& param) {
+	if (!param.is<DeclarationNode>()) {
+		Token fallback_token(
+			Token::Type::Identifier,
+			std::string_view(param.type_name()),
+			0,
+			0,
+			0);
+		mixReplaySourceTokenKey(key, fallback_token);
+		return;
+	}
+
+	const DeclarationNode& decl = param.as<DeclarationNode>();
+	mixReplaySourceTokenKey(key, decl.type_specifier_node().token());
+	if (decl.type_specifier_node().type_index().is_valid()) {
+		auto mix = [&](uint64_t value) {
+			key ^= value + 0x9E3779B97F4A7C15ull + (key << 6) + (key >> 2);
+		};
+		mix(static_cast<uint64_t>(decl.type_specifier_node().type_index().index()));
+		mix(static_cast<uint64_t>(decl.type_specifier_node().pointer_depth()));
+		mix(static_cast<uint64_t>(decl.type_specifier_node().reference_qualifier()));
+	}
+}
+
+static std::optional<uint64_t> declarationReplaySourceKey(
+	const FunctionDeclarationNode& decl,
+	size_t template_param_count) {
+	uint64_t key = 0xCBF29CE484222325ull;
+	mixReplaySourceTokenKey(key, decl.decl_node().identifier_token());
+	auto mix = [&](uint64_t value) {
+		key ^= value + 0x9E3779B97F4A7C15ull + (key << 6) + (key >> 2);
+	};
+	mix(static_cast<uint64_t>(decl.parameter_nodes().size()));
+	mix(static_cast<uint64_t>(template_param_count));
+	for (const ASTNode& param : decl.parameter_nodes()) {
+		mixReplaySourceParamKey(key, param);
+	}
+	return key;
+}
+
+static std::optional<uint64_t> declarationReplaySourceKey(
+	const ConstructorDeclarationNode& decl,
+	size_t template_param_count) {
+	uint64_t key = 0xCBF29CE484222325ull;
+	mixReplaySourceTokenKey(key, decl.name_token());
+	auto mix = [&](uint64_t value) {
+		key ^= value + 0x9E3779B97F4A7C15ull + (key << 6) + (key >> 2);
+	};
+	mix(static_cast<uint64_t>(decl.parameter_nodes().size()));
+	mix(static_cast<uint64_t>(template_param_count));
+	for (const ASTNode& param : decl.parameter_nodes()) {
+		mixReplaySourceParamKey(key, param);
+	}
+	return key;
 }
 
 static std::optional<uint64_t> sourceMemberLocationKey(const ASTNode& member) {
@@ -302,8 +373,72 @@ static ASTNode* findSourceMemberStubByIdentity(
 	return nullptr;
 }
 
+static void registerSourceMemberStructInfoIndex(
+	SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode& source_member,
+	size_t struct_info_index) {
+	auto register_key = [&](const void* key) {
+		if (key != nullptr) {
+			index_maps.by_node[key] = struct_info_index;
+		}
+	};
+	register_key(sourceMemberAstNodeKey(source_member));
+	if (source_member.is<TemplateFunctionDeclarationNode>()) {
+		register_key(sourceMemberAstNodeKey(
+			source_member.as<TemplateFunctionDeclarationNode>().function_declaration()));
+	}
+	if (std::optional<uint64_t> location_key = sourceMemberLocationKey(source_member);
+		location_key.has_value()) {
+		index_maps.by_location[*location_key] = struct_info_index;
+	}
+}
+
+static FunctionDeclarationNode* findStructInfoFunctionBySourceMemberIdentity(
+	StructTypeInfo* struct_info,
+	const SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode& source_member) {
+	if (struct_info == nullptr) {
+		return nullptr;
+	}
+
+	auto find_index = [&](const void* key) -> std::optional<size_t> {
+		if (key == nullptr) {
+			return std::nullopt;
+		}
+		auto it = index_maps.by_node.find(key);
+		if (it == index_maps.by_node.end()) {
+			return std::nullopt;
+		}
+		return it->second;
+	};
+
+	std::optional<size_t> index = find_index(sourceMemberAstNodeKey(source_member));
+	if (!index.has_value() &&
+		source_member.is<TemplateFunctionDeclarationNode>()) {
+		index = find_index(sourceMemberAstNodeKey(
+			source_member.as<TemplateFunctionDeclarationNode>().function_declaration()));
+	}
+	if (!index.has_value()) {
+		if (std::optional<uint64_t> location_key = sourceMemberLocationKey(source_member);
+			location_key.has_value()) {
+			auto it = index_maps.by_location.find(*location_key);
+			if (it != index_maps.by_location.end()) {
+				index = it->second;
+			}
+		}
+	}
+	if (!index.has_value() ||
+		*index >= struct_info->member_functions.size()) {
+		return nullptr;
+	}
+
+	ASTNode& function_decl = struct_info->member_functions[*index].function_decl;
+	return get_function_decl_node_mut(function_decl);
+}
+
 struct OutOfLineMemberStubResolution {
 	FunctionDeclarationNode* func = nullptr;
+	const ASTNode* source_member = nullptr;
 	bool ambiguous = false;
 	bool insufficient_evidence = false;
 };
@@ -320,8 +455,12 @@ static OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 		out_of_line_decl.decl_node().identifier_token().value();
 	OutOfLineMemberStubResolution resolution;
 	InlineVector<FunctionDeclarationNode*, 4> resolved_matches;
+	const ASTNode* matched_source_member = nullptr;
 
-	for (const StructMemberFunctionDecl& source_member : source_members) {
+	for (size_t source_member_index = 0;
+		 source_member_index < source_members.size();
+		 ++source_member_index) {
+		const StructMemberFunctionDecl& source_member = source_members[source_member_index];
 		if (!source_member.function_declaration.is<FunctionDeclarationNode>()) {
 			continue;
 		}
@@ -364,10 +503,12 @@ static OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 		}
 
 		resolved_matches.push_back(inst_func_decl);
+		matched_source_member = &source_member.function_declaration;
 	}
 
 	if (resolved_matches.size() == 1) {
 		resolution.func = resolved_matches.front();
+		resolution.source_member = matched_source_member;
 	} else if (resolved_matches.size() > 1) {
 		resolution.ambiguous = true;
 	}
@@ -566,6 +707,10 @@ static OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
 	const ConstructorDeclarationNode& ctor_decl,
 	EligibleFn&& is_candidate_eligible) {
 	OutOfLineConstructorStubResolution resolution;
+	const std::optional<uint64_t> target_source_key =
+		declarationReplaySourceKey(
+			ctor_decl,
+			ctor_decl.template_parameters().size());
 
 	// Prefer direct node identity when the StructTypeInfo stores the same
 	// constructor node instance as the replay-attached declaration.
@@ -579,6 +724,37 @@ static OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
 			if (is_candidate_eligible(info_ctor)) {
 				resolution.ctor = &info_ctor;
 			}
+			return resolution;
+		}
+	}
+
+	if (target_source_key.has_value()) {
+		for (auto& info_func : struct_info.member_functions) {
+			if (!info_func.is_constructor ||
+				!info_func.function_decl.is<ConstructorDeclarationNode>()) {
+				continue;
+			}
+
+			auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
+			if (!is_candidate_eligible(info_ctor)) {
+				continue;
+			}
+			const std::optional<uint64_t> info_source_key =
+				declarationReplaySourceKey(
+					info_ctor,
+					info_ctor.template_parameters().size());
+			if (!info_source_key.has_value() ||
+				*info_source_key != *target_source_key) {
+				continue;
+			}
+			if (resolution.ctor != nullptr) {
+				resolution.ambiguous = true;
+				resolution.ctor = nullptr;
+				return resolution;
+			}
+			resolution.ctor = &info_ctor;
+		}
+		if (resolution.ctor != nullptr || resolution.ambiguous) {
 			return resolution;
 		}
 	}
@@ -617,31 +793,69 @@ static OutOfLineFunctionStubResolution findMatchingFunctionInStructInfo(
 	const FunctionDeclarationNode& func_decl,
 	EligibleFn&& is_candidate_eligible) {
 	OutOfLineFunctionStubResolution resolution;
+	const std::optional<uint64_t> target_source_key =
+		declarationReplaySourceKey(func_decl, 0);
 
 	for (auto& info_func : struct_info.member_functions) {
-		if (info_func.is_constructor ||
-			!info_func.function_decl.is<FunctionDeclarationNode>()) {
+		if (info_func.is_constructor) {
 			continue;
 		}
-		auto& info_decl = info_func.function_decl.as<FunctionDeclarationNode>();
-		if (&info_decl == &func_decl) {
-			if (is_candidate_eligible(info_decl)) {
-				resolution.func = &info_decl;
+		FunctionDeclarationNode* info_decl =
+			get_function_decl_node_mut(info_func.function_decl);
+		if (info_decl == nullptr) {
+			continue;
+		}
+		if (info_decl == &func_decl) {
+			if (is_candidate_eligible(*info_decl)) {
+				resolution.func = info_decl;
 			}
 			return resolution;
 		}
 	}
 
+	if (target_source_key.has_value()) {
+		for (auto& info_func : struct_info.member_functions) {
+			if (info_func.is_constructor) {
+				continue;
+			}
+
+			FunctionDeclarationNode* info_decl =
+				get_function_decl_node_mut(info_func.function_decl);
+			if (info_decl == nullptr) {
+				continue;
+			}
+			if (!is_candidate_eligible(*info_decl)) {
+				continue;
+			}
+			const std::optional<uint64_t> info_source_key =
+				declarationReplaySourceKey(*info_decl, 0);
+			if (!info_source_key.has_value() ||
+				*info_source_key != *target_source_key) {
+				continue;
+			}
+			if (resolution.func != nullptr) {
+				resolution.ambiguous = true;
+				resolution.func = nullptr;
+				return resolution;
+			}
+			resolution.func = info_decl;
+		}
+		if (resolution.func != nullptr || resolution.ambiguous) {
+			return resolution;
+		}
+	}
+
 	for (auto& info_func : struct_info.member_functions) {
-		if (info_func.is_constructor ||
-			!info_func.function_decl.is<FunctionDeclarationNode>()) {
+		if (info_func.is_constructor) {
 			continue;
 		}
 
-		auto& info_decl = info_func.function_decl.as<FunctionDeclarationNode>();
-		if (!is_candidate_eligible(info_decl) ||
+		FunctionDeclarationNode* info_decl =
+			get_function_decl_node_mut(info_func.function_decl);
+		if (info_decl == nullptr ||
+			!is_candidate_eligible(*info_decl) ||
 			!functionDeclarationsHaveEquivalentInstantiatedSignature(
-				info_decl,
+				*info_decl,
 				func_decl)) {
 			continue;
 		}
@@ -650,7 +864,7 @@ static OutOfLineFunctionStubResolution findMatchingFunctionInStructInfo(
 			resolution.ambiguous = true;
 			return resolution;
 		}
-		resolution.func = &info_decl;
+		resolution.func = info_decl;
 	}
 
 	return resolution;
@@ -2666,6 +2880,42 @@ void Parser::copyDefinitionParameterTypes(
 	}
 }
 
+static void materializeReplayAttachedFunctionParameterTypesFromDefinition(
+	Parser& parser,
+	std::span<ASTNode> instantiated_params,
+	std::span<const ASTNode> definition_params,
+	std::span<const TemplateParameterNode> outer_template_params,
+	std::span<const TemplateTypeArg> outer_template_args,
+	StringHandle owner_type_name) {
+	if (instantiated_params.size() != definition_params.size()) {
+		return;
+	}
+
+	for (size_t param_index = 0; param_index < instantiated_params.size(); ++param_index) {
+		DeclarationNode* instantiated_decl =
+			const_cast<DeclarationNode*>(
+				get_decl_from_symbol(instantiated_params[param_index]));
+		const DeclarationNode* definition_decl =
+			get_decl_from_symbol(definition_params[param_index]);
+		if (instantiated_decl == nullptr || definition_decl == nullptr) {
+			continue;
+		}
+
+		std::optional<TypeSpecifierNode> substituted_definition_type =
+			substituteOutOfLineSignatureType(
+				parser,
+				definition_decl->type_specifier_node(),
+				outer_template_params,
+				outer_template_args,
+				owner_type_name);
+		if (!substituted_definition_type.has_value()) {
+			continue;
+		}
+
+		instantiated_decl->set_type_node(*substituted_definition_type);
+	}
+}
+
 void Parser::syncOutOfLineConstructorTemplateParameters(
 	std::span<ASTNode> instantiated_params,
 	std::span<const ASTNode> definition_params) {
@@ -2757,57 +3007,16 @@ bool Parser::replayOutOfLineMemberBody(
 static OutOfLineFunctionStubResolution findReplayedOutOfLineMemberInStructInfo(
 	StructTypeInfo* struct_info,
 	FunctionDeclarationNode& replayed_func) {
-	OutOfLineFunctionStubResolution resolution;
 	if (struct_info == nullptr) {
-		return resolution;
+		return {};
 	}
 
-	OutOfLineFunctionStubResolution info_func_resolution =
-		findMatchingFunctionInStructInfo(
-			*struct_info,
-			replayed_func,
-			[](const FunctionDeclarationNode& info_func) {
-				return !info_func.is_materialized();
-			});
-	if (info_func_resolution.func != nullptr || info_func_resolution.ambiguous) {
-		return info_func_resolution;
-	}
-
-	for (auto& info_func : struct_info->member_functions) {
-		if (info_func.is_constructor ||
-			!info_func.function_decl.is<FunctionDeclarationNode>()) {
-			continue;
-		}
-		auto& info_decl = info_func.function_decl.as<FunctionDeclarationNode>();
-		FLASH_LOG(
-			Templates,
-			Debug,
-			"StructTypeInfo replay sync candidate: name=",
-			info_decl.decl_node().identifier_token().value(),
-			", params=",
-			static_cast<size_t>(info_decl.parameter_nodes().size()),
-			", materialized=",
-			info_decl.is_materialized());
-		if (info_decl.is_materialized() ||
-			info_decl.decl_node().identifier_token().value() !=
-				replayed_func.decl_node().identifier_token().value() ||
-			info_decl.parameter_nodes().size() != replayed_func.parameter_nodes().size() ||
-			info_decl.is_static() != replayed_func.is_static() ||
-			info_decl.is_const_member_function() != replayed_func.is_const_member_function() ||
-			info_decl.is_volatile_member_function() != replayed_func.is_volatile_member_function()) {
-			continue;
-		}
-		if (resolution.func != nullptr) {
-			resolution.ambiguous = true;
-			resolution.func = nullptr;
-			return resolution;
-		}
-		resolution.func = &info_decl;
-	}
-	if (resolution.func != nullptr || resolution.ambiguous) {
-		return resolution;
-	}
-	return info_func_resolution;
+	return findMatchingFunctionInStructInfo(
+		*struct_info,
+		replayed_func,
+		[](const FunctionDeclarationNode& info_func) {
+			return !info_func.is_materialized();
+		});
 }
 
 // Resolve any stored template arguments on a deferred base member-type chain after a class
@@ -6251,7 +6460,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						true,  // Preserve declared parameter cv-qualifier in this path
 						false, // Do not re-apply bound metadata to full substitution
 						false, // Do not force resolved TypeIndex onto full AST substitutions
-						false);// Plain member path does not need dependent member-template signature preservation
+						true); // Preserve dependent member-template signature identity for replay
 
 					copy_function_properties(new_func_ref, orig_func);
 					// Ensure is_const_member_function is set from pattern so propagateAstProperties derives cv_qualifier.
@@ -7889,7 +8098,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						true,  // Preserve declared parameter cv-qualifier in this path
 						false, // Do not re-apply bound metadata to full substitution
 						true,  // Force resolved TypeIndex onto full AST substitutions
-						false); // Plain member path does not need dependent member-template signature preservation
+						true); // Preserve dependent member-template signature identity for replay
 					std::unordered_map<std::string_view, TemplateTypeArg> deduced_args;
 					for (size_t i = 0; i < template_params.size() && i < template_args_for_pattern.size(); ++i) {
 						std::string_view pname = template_params[i].name();
@@ -8087,6 +8296,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						copyDefinitionParameterIdentifiers(
 							inst_func->parameter_nodes(),
 							plain_ool_func.parameter_nodes());
+						materializeReplayAttachedFunctionParameterTypesFromDefinition(
+							*this,
+							std::span<ASTNode>(
+								inst_func->parameter_nodes().data(),
+								inst_func->parameter_nodes().size()),
+							std::span<const ASTNode>(
+								plain_ool_func.parameter_nodes().data(),
+								plain_ool_func.parameter_nodes().size()),
+							std::span<const TemplateParameterNode>(
+								template_params.data(),
+								template_params.size()),
+							std::span<const TemplateTypeArg>(
+								template_args_for_pattern.data(),
+								template_args_for_pattern.size()),
+							instantiated_name);
 
 						const std::span<const ASTNode> inst_func_params =
 							inst_func->parameter_nodes();
@@ -8125,6 +8349,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								copyDefinitionParameterIdentifiers(
 									info_func_resolution.func->parameter_nodes(),
 									plain_ool_func.parameter_nodes());
+								materializeReplayAttachedFunctionParameterTypesFromDefinition(
+									*this,
+									std::span<ASTNode>(
+										info_func_resolution.func->parameter_nodes().data(),
+										info_func_resolution.func->parameter_nodes().size()),
+									std::span<const ASTNode>(
+										plain_ool_func.parameter_nodes().data(),
+										plain_ool_func.parameter_nodes().size()),
+									std::span<const TemplateParameterNode>(
+										template_params.data(),
+										template_params.size()),
+									std::span<const TemplateTypeArg>(
+										template_args_for_pattern.data(),
+										template_args_for_pattern.size()),
+									instantiated_name);
 								info_func_resolution.func->set_definition(*inst_func->get_definition());
 								finalize_function_after_definition(*info_func_resolution.func, true);
 							}
@@ -13217,6 +13456,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Slice 3: map from original template member node (by raw pointer) to the instantiated stub node.
 	// Used by deferred-body replay and nested out-of-line attachment to avoid name-based scanning.
 	SourceMemberIdentityMaps source_member_identity_maps;
+	SourceMemberStructInfoIndexMaps struct_info_member_identity_maps;
 	TypeIndex instantiated_member_owner_type_index{};
 	if (auto instantiated_owner_it = getTypesByNameMap().find(instantiated_name);
 		instantiated_owner_it != getTypesByNameMap().end()) {
@@ -13367,7 +13607,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					true,  // Preserve declared parameter cv-qualifier in this path
 					false, // Do not re-apply bound metadata to full substitution
 					true,  // Force resolved TypeIndex onto full AST substitutions
-					false); // Plain member path does not need dependent member-template signature preservation
+					true); // Preserve dependent member-template signature identity for replay
 				pack_param_info_.resize(saved_pack_info);
 
 				// Copy function properties but DO NOT set definition. Delay mangling until
@@ -13397,6 +13637,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_pure_virtual,
 						mem_func.is_override,
 						mem_func.is_final);
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
+						mem_func.function_declaration,
+						struct_info_ptr->member_functions.size() - 1);
 				}
 				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
 
@@ -13458,7 +13702,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					true,  // Preserve declared parameter cv-qualifier in this path
 					false, // Do not re-apply bound metadata to full substitution
 					true,  // Force resolved TypeIndex onto full AST substitutions
-					false); // Plain member path does not need dependent member-template signature preservation
+					true); // Preserve dependent member-template signature identity for replay
 
 				// Get the function body - either from definition or by re-parsing from saved position
 				std::optional<ASTNode> body_to_substitute;
@@ -13603,6 +13847,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_pure_virtual,
 						mem_func.is_override,
 						mem_func.is_final);
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
+						mem_func.function_declaration,
+						struct_info_ptr->member_functions.size() - 1);
 				}
 				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
 
@@ -13648,7 +13896,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					false, // Declaration-only path: strip only top-level by-value cv-qualifiers
 					false, // Do not re-apply bound metadata to full substitution
 					true,  // Force resolved TypeIndex onto full AST substitutions
-					false); // Plain member path does not need dependent member-template signature preservation
+					true); // Preserve dependent member-template signature identity for replay
 				pack_param_info_.resize(saved_pack_info);
 
 				// Copy other function properties
@@ -13728,6 +13976,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_pure_virtual,
 						mem_func.is_override,
 						mem_func.is_final);
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
+						mem_func.function_declaration,
+						struct_info_ptr->member_functions.size() - 1);
 				}
 				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
 
@@ -14956,6 +15208,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				instantiated_name);
 		if (FunctionDeclarationNode* inst_func = plain_member_resolution.func;
 			inst_func != nullptr) {
+			materializeReplayAttachedFunctionParameterTypesFromDefinition(
+				*this,
+				std::span<ASTNode>(
+					inst_func->parameter_nodes().data(),
+					inst_func->parameter_nodes().size()),
+				std::span<const ASTNode>(
+					func_decl.parameter_nodes().data(),
+					func_decl.parameter_nodes().size()),
+				std::span<const TemplateParameterNode>(
+					out_of_line_member.template_params.data(),
+					out_of_line_member.template_params.size()),
+				std::span<const TemplateTypeArg>(
+					template_args_to_use.data(),
+					template_args_to_use.size()),
+				instantiated_name);
 			const std::span<const ASTNode> inst_func_params = inst_func->parameter_nodes();
 			std::vector<ASTNode> definition_scope_params(
 				inst_func_params.begin(),
@@ -14995,10 +15262,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				"primary-template",
 				decl.identifier_token().value());
 			if (found_match) {
-				OutOfLineFunctionStubResolution info_func_resolution =
-					findReplayedOutOfLineMemberInStructInfo(
-						struct_info_ptr,
-						*inst_func);
+				FunctionDeclarationNode* struct_info_func =
+					plain_member_resolution.source_member != nullptr
+						? findStructInfoFunctionBySourceMemberIdentity(
+							  struct_info_ptr,
+							  struct_info_member_identity_maps,
+							  *plain_member_resolution.source_member)
+						: nullptr;
+				OutOfLineFunctionStubResolution info_func_resolution;
+				if (struct_info_func != nullptr) {
+					info_func_resolution.func = struct_info_func;
+				} else {
+					info_func_resolution =
+						findReplayedOutOfLineMemberInStructInfo(
+							struct_info_ptr,
+							*inst_func);
+				}
 				if (info_func_resolution.ambiguous) {
 					std::string error_msg = std::string(StringBuilder()
 						.append("Ambiguous StructTypeInfo sync for out-of-line member '")
@@ -15013,30 +15292,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					FLASH_LOG(Templates, Error, error_msg);
 				} else if (info_func_resolution.func != nullptr &&
 					inst_func->is_materialized()) {
-					FLASH_LOG(
-						Templates,
-						Debug,
-						"Syncing replayed out-of-line member into StructTypeInfo: ",
-						decl.identifier_token().value());
 					copyDefinitionParameterIdentifiers(
 						info_func_resolution.func->parameter_nodes(),
 						func_decl.parameter_nodes());
-					copyDefinitionParameterTypes(
-						info_func_resolution.func->parameter_nodes(),
-						inst_func->parameter_nodes());
+					materializeReplayAttachedFunctionParameterTypesFromDefinition(
+						*this,
+						std::span<ASTNode>(
+							info_func_resolution.func->parameter_nodes().data(),
+							info_func_resolution.func->parameter_nodes().size()),
+						std::span<const ASTNode>(
+							func_decl.parameter_nodes().data(),
+							func_decl.parameter_nodes().size()),
+						std::span<const TemplateParameterNode>(
+							out_of_line_member.template_params.data(),
+							out_of_line_member.template_params.size()),
+						std::span<const TemplateTypeArg>(
+							template_args_to_use.data(),
+							template_args_to_use.size()),
+						instantiated_name);
 					info_func_resolution.func->set_definition(*inst_func->get_definition());
 					finalize_function_after_definition(*info_func_resolution.func, true);
-				} else {
-					FLASH_LOG(
-						Templates,
-						Debug,
-						"Skipped StructTypeInfo sync for replayed out-of-line member '",
-						decl.identifier_token().value(),
-						"' (matched=",
-						info_func_resolution.func != nullptr,
-						", materialized=",
-						inst_func->is_materialized(),
-						")");
 				}
 				registerLateMaterializedOwningStructRoot(instantiated_name);
 				normalizePendingSemanticRoots();

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7195,6 +7195,9 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 
 	if (call_info.has_receiver)
 		return;
+	if (call_info.declaration == nullptr) {
+		throw InternalError("tryResolveCallableOperatorImpl received null callee declaration");
+	}
 
 	const DeclarationNode& callee_decl = *call_info.declaration;
 	const StringHandle callee_name = callee_decl.identifier_token().handle();
@@ -7587,6 +7590,10 @@ void SemanticAnalysis::annotateResolvedCallArgConversions(const void* call_key,
 const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(const CallInfo& call_info,
 																				const void* call_key) {
 	const ChunkedVector<ASTNode>& arguments = *call_info.arguments;
+	if (call_info.declaration == nullptr) {
+		throw InternalError("resolveCallArgAnnotationTarget received null callee declaration");
+	}
+	const DeclarationNode& callee_decl = *call_info.declaration;
 	auto appendUniqueOverload = [](std::vector<ASTNode>& target, const ASTNode& candidate) {
 		auto it = std::find_if(target.begin(), target.end(), [&](const ASTNode& existing) {
 			return existing.raw_pointer() == candidate.raw_pointer();
@@ -7780,7 +7787,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		};
 		if (const StructTypeInfo* receiver_struct_info = resolveReceiverStructInfo()) {
 			const StringHandle member_name_handle =
-				call_info.declaration->identifier_token().handle();
+				callee_decl.identifier_token().handle();
 			std::vector<ASTNode> member_overloads;
 			auto collectVisibleMemberOverloads =
 				[&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
@@ -7980,7 +7987,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (call_info.function_declaration)
 		return call_info.function_declaration;
 
-	const DeclarationNode& decl = *call_info.declaration;
+	const DeclarationNode& decl = callee_decl;
 
 	const std::string_view name = call_info.qualified_name.isValid()
 									  ? call_info.qualified_name.view()
@@ -8226,13 +8233,17 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 														 const void* call_key,
 														 const char* context_description) {
 	analyzed_direct_call_queries_.insert(call_key);
+	if (call_info.declaration == nullptr) {
+		throw InternalError("tryAnnotateCallArgConversionsImpl received null callee declaration");
+	}
+	const DeclarationNode& callee_decl = *call_info.declaration;
 
 	const FunctionDeclarationNode* func_decl = resolveCallArgAnnotationTarget(call_info, call_key);
 	if (!func_decl) {
 		const bool normalized_call_expr = hasNormalizedAstNode(call_expr_node);
 		const std::string_view call_name = call_info.qualified_name.isValid()
 											   ? call_info.qualified_name.view()
-											   : call_info.declaration->identifier_token().value();
+											   : callee_decl.identifier_token().value();
 		if (!call_info.is_indirect && normalized_call_expr) {
 			throw InternalError(std::string(
 				StringBuilder()

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -34,6 +34,13 @@ bool isFunctionCandidateViableForArgCount(const FunctionDeclarationNode& candida
 	return argument_count >= min_required && argument_count <= max_accepted;
 }
 
+const DeclarationNode& requireCallDeclaration(const CallInfo& call_info, const char* operation) {
+	if (call_info.declaration == nullptr) {
+		throw InternalError(std::string(operation) + " received null callee declaration");
+	}
+	return *call_info.declaration;
+}
+
 } // namespace
 
 void applyDeclarationArrayBoundsToTypeSpec(
@@ -7195,11 +7202,8 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 
 	if (call_info.has_receiver)
 		return;
-	if (call_info.declaration == nullptr) {
-		throw InternalError("tryResolveCallableOperatorImpl received null callee declaration");
-	}
 
-	const DeclarationNode& callee_decl = *call_info.declaration;
+	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "tryResolveCallableOperatorImpl");
 	const StringHandle callee_name = callee_decl.identifier_token().handle();
 	if (!callee_name.isValid())
 		return;
@@ -7590,10 +7594,7 @@ void SemanticAnalysis::annotateResolvedCallArgConversions(const void* call_key,
 const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(const CallInfo& call_info,
 																				const void* call_key) {
 	const ChunkedVector<ASTNode>& arguments = *call_info.arguments;
-	if (call_info.declaration == nullptr) {
-		throw InternalError("resolveCallArgAnnotationTarget received null callee declaration");
-	}
-	const DeclarationNode& callee_decl = *call_info.declaration;
+	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "resolveCallArgAnnotationTarget");
 	auto appendUniqueOverload = [](std::vector<ASTNode>& target, const ASTNode& candidate) {
 		auto it = std::find_if(target.begin(), target.end(), [&](const ASTNode& existing) {
 			return existing.raw_pointer() == candidate.raw_pointer();
@@ -8233,10 +8234,7 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 														 const void* call_key,
 														 const char* context_description) {
 	analyzed_direct_call_queries_.insert(call_key);
-	if (call_info.declaration == nullptr) {
-		throw InternalError("tryAnnotateCallArgConversionsImpl received null callee declaration");
-	}
-	const DeclarationNode& callee_decl = *call_info.declaration;
+	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "tryAnnotateCallArgConversionsImpl");
 
 	const FunctionDeclarationNode* func_decl = resolveCallArgAnnotationTarget(call_info, call_key);
 	if (!func_decl) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -1487,6 +1487,10 @@ const FunctionDeclarationNode* ParserSemanticServices::getResolvedOpCall(const C
 	return owner_->getResolvedOpCall(key);
 }
 
+void ParserSemanticServices::ensureCallableOperatorResolved(const CallExprNode& call_node) {
+	owner_->ensureCallableOperatorResolved(call_node);
+}
+
 ResolvedFunctionQueryResult ParserSemanticServices::getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const {
 	return owner_->getResolvedOpSubscriptQuery(key);
 }
@@ -4488,6 +4492,12 @@ ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpCallQuery(const CallE
 
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedOpCall(const CallExprNode* key) const {
 	return getResolvedOpCall(static_cast<const void*>(key));
+}
+
+void SemanticAnalysis::ensureCallableOperatorResolved(const CallExprNode& call_node) {
+	if (getResolvedOpCallQuery(&call_node).state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		tryResolveCallableOperator(call_node);
+	}
 }
 
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7831,17 +7831,16 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 						appendUniqueOverload(preferred_member_overloads, candidate_node);
 					}
 				}
+				InlineVector<TypeSpecifierNode, 6> member_arg_types;
+				const bool has_member_arg_types =
+					tryCollectOverloadResolutionArgTypes(arguments, member_arg_types);
 				auto tryResolveMemberOverloadSet =
 					[&](std::span<const ASTNode> overload_set) -> const FunctionDeclarationNode* {
-						if (overload_set.empty()) {
-							return nullptr;
-						}
-						InlineVector<TypeSpecifierNode, 6> arg_types;
-						if (!tryCollectOverloadResolutionArgTypes(arguments, arg_types)) {
+						if (overload_set.empty() || !has_member_arg_types) {
 							return nullptr;
 						}
 						const OverloadResolutionResult result =
-							resolve_overload(overload_set, arg_types);
+							resolve_overload(overload_set, member_arg_types);
 						if (!result.has_match ||
 							result.is_ambiguous ||
 							result.selected_overload == nullptr) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -5987,6 +5987,22 @@ std::optional<TypeSpecifierNode> SemanticAnalysis::buildOverloadResolutionArgTyp
 	return std::nullopt;
 }
 
+bool SemanticAnalysis::tryCollectOverloadResolutionArgTypes(
+	const ChunkedVector<ASTNode>& arguments,
+	InlineVector<TypeSpecifierNode, 6>& arg_types_out) {
+	arg_types_out.clear();
+	arg_types_out.reserve(arguments.size());
+	for (const ASTNode& argument : arguments) {
+		auto arg_type = buildOverloadResolutionArgType(argument, nullptr);
+		if (!arg_type.has_value() || arg_type->category() == TypeCategory::Invalid) {
+			arg_types_out.clear();
+			return false;
+		}
+		arg_types_out.push_back(*arg_type);
+	}
+	return true;
+}
+
 // --- Scoped enum diagnostic helper ---
 // C++11+: scoped enums (enum class) do not allow implicit conversion to other types.
 
@@ -7726,6 +7742,168 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 	if (call_info.has_receiver) {
+		auto resolveReceiverStructInfo = [&]() -> const StructTypeInfo* {
+			const CanonicalTypeId receiver_type_id = inferExpressionType(call_info.receiver);
+			if (!receiver_type_id) {
+				return nullptr;
+			}
+			const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
+			const TypeInfo* receiver_type_info = nullptr;
+			if (receiver_desc.category() == TypeCategory::Struct ||
+				receiver_desc.category() == TypeCategory::UserDefined) {
+				receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
+				if (!receiver_type_info &&
+					receiver_desc.category() == TypeCategory::UserDefined &&
+					receiver_desc.type_index.is_valid()) {
+					const ResolvedAliasTypeInfo resolved_alias =
+						resolveAliasTypeInfo(receiver_desc.type_index);
+					receiver_type_info = resolved_alias.terminal_type_info;
+				}
+			}
+			if (receiver_type_info == nullptr) {
+				return nullptr;
+			}
+			if (const TypeInfo* resolved_owner = resolveStructOwnerType(receiver_type_info)) {
+				return resolved_owner->getStructInfo();
+			}
+			return nullptr;
+		};
+		if (const StructTypeInfo* receiver_struct_info = resolveReceiverStructInfo()) {
+			const StringHandle member_name_handle =
+				call_info.declaration->identifier_token().handle();
+			std::vector<ASTNode> member_overloads;
+			auto collectVisibleMemberOverloads =
+				[&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
+				if (!current_struct_info) {
+					return;
+				}
+				bool has_local_overload = false;
+				for (const auto& member_func : current_struct_info->member_functions) {
+					if (member_func.is_constructor ||
+						member_func.is_destructor ||
+						member_func.getName() != member_name_handle ||
+						!member_func.function_decl.is<FunctionDeclarationNode>()) {
+						continue;
+					}
+					appendUniqueOverload(member_overloads, member_func.function_decl);
+					has_local_overload = true;
+				}
+				if (has_local_overload) {
+					return;
+				}
+				for (const auto& base_spec : current_struct_info->base_classes) {
+					if (const StructTypeInfo* base_struct = tryGetStructTypeInfo(base_spec.type_index)) {
+						self(base_struct, self);
+					}
+				}
+			};
+			collectVisibleMemberOverloads(receiver_struct_info, collectVisibleMemberOverloads);
+			if (!member_overloads.empty()) {
+				const std::optional<TypeSpecifierNode> receiver_arg_type =
+					buildOverloadResolutionArgType(call_info.receiver, nullptr);
+				const bool receiver_is_const =
+					receiver_arg_type.has_value() && receiver_arg_type->is_const();
+				std::vector<ASTNode> preferred_member_overloads;
+				std::vector<ASTNode> compatible_member_overloads;
+				preferred_member_overloads.reserve(member_overloads.size());
+				compatible_member_overloads.reserve(member_overloads.size());
+				for (const ASTNode& candidate_node : member_overloads) {
+					const FunctionDeclarationNode* candidate =
+						getCallTargetFunctionCandidate(candidate_node);
+					if (candidate == nullptr) {
+						continue;
+					}
+					if (candidate->is_static()) {
+						appendUniqueOverload(preferred_member_overloads, candidate_node);
+						appendUniqueOverload(compatible_member_overloads, candidate_node);
+						continue;
+					}
+					if (receiver_is_const) {
+						if (!candidate->is_const_member_function()) {
+							continue;
+						}
+						appendUniqueOverload(preferred_member_overloads, candidate_node);
+						appendUniqueOverload(compatible_member_overloads, candidate_node);
+						continue;
+					}
+					appendUniqueOverload(compatible_member_overloads, candidate_node);
+					if (!candidate->is_const_member_function()) {
+						appendUniqueOverload(preferred_member_overloads, candidate_node);
+					}
+				}
+				auto tryResolveMemberOverloadSet =
+					[&](std::span<const ASTNode> overload_set) -> const FunctionDeclarationNode* {
+						if (overload_set.empty()) {
+							return nullptr;
+						}
+						InlineVector<TypeSpecifierNode, 6> arg_types;
+						if (!tryCollectOverloadResolutionArgTypes(arguments, arg_types)) {
+							return nullptr;
+						}
+						const OverloadResolutionResult result =
+							resolve_overload(overload_set, arg_types);
+						if (!result.has_match ||
+							result.is_ambiguous ||
+							result.selected_overload == nullptr) {
+							return nullptr;
+						}
+						return getCallTargetFunctionCandidate(*result.selected_overload);
+					};
+				auto sameOverloadSet =
+					[](std::span<const ASTNode> lhs, std::span<const ASTNode> rhs) -> bool {
+						if (lhs.size() != rhs.size()) {
+							return false;
+						}
+						for (size_t i = 0; i < lhs.size(); ++i) {
+							if (lhs[i].raw_pointer() != rhs[i].raw_pointer()) {
+								return false;
+							}
+						}
+						return true;
+					};
+				if (const FunctionDeclarationNode* resolved_candidate =
+						tryResolveMemberOverloadSet(preferred_member_overloads);
+					resolved_candidate != nullptr) {
+					return resolved_candidate;
+				}
+				if (!sameOverloadSet(preferred_member_overloads, compatible_member_overloads)) {
+					if (const FunctionDeclarationNode* resolved_candidate =
+							tryResolveMemberOverloadSet(compatible_member_overloads);
+						resolved_candidate != nullptr) {
+						return resolved_candidate;
+					}
+				}
+				std::vector<ASTNode> ordered_member_overloads = preferred_member_overloads;
+				appendUniqueOverloads(ordered_member_overloads, compatible_member_overloads);
+				if (call_info.function_declaration) {
+					for (const ASTNode& candidate_node : ordered_member_overloads) {
+						const FunctionDeclarationNode* candidate =
+							getCallTargetFunctionCandidate(candidate_node);
+						if (candidate == nullptr) {
+							continue;
+						}
+						if (candidate == call_info.function_declaration ||
+							&candidate->decl_node() == &call_info.function_declaration->decl_node()) {
+							return candidate;
+						}
+						if (candidate->has_mangled_name() &&
+							call_info.function_declaration->has_mangled_name() &&
+							candidate->mangled_name() ==
+								call_info.function_declaration->mangled_name()) {
+							return candidate;
+						}
+					}
+				}
+				for (const ASTNode& candidate_node : ordered_member_overloads) {
+					if (const FunctionDeclarationNode* candidate =
+							getCallTargetFunctionCandidate(candidate_node);
+						candidate != nullptr &&
+						isFunctionCandidateViableForArgCount(*candidate, arguments.size())) {
+						return candidate;
+					}
+				}
+			}
+		}
 		if (call_info.function_declaration) {
 			return call_info.function_declaration;
 		}
@@ -7761,8 +7939,8 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			dependent_record_target != nullptr) {
 			return dependent_record_target;
 		}
-		std::vector<TypeSpecifierNode> arg_types;
-		if (parser().tryCollectFunctionCallArgTypes(arguments, arg_types)) {
+		InlineVector<TypeSpecifierNode, 6> arg_types;
+		if (tryCollectOverloadResolutionArgTypes(arguments, arg_types)) {
 			if (std::optional<ASTNode> resolved_target =
 					parser().resolveDependentUnqualifiedCallAtPointOfInstantiation(
 						dependent_record,
@@ -7827,8 +8005,8 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			}
 		}
 	}
-	std::vector<TypeSpecifierNode> arg_types;
-	const bool arg_types_collected = parser().tryCollectFunctionCallArgTypes(arguments, arg_types);
+	InlineVector<TypeSpecifierNode, 6> arg_types;
+	const bool arg_types_collected = tryCollectOverloadResolutionArgTypes(arguments, arg_types);
 	if (arg_types_collected &&
 		!arg_types.empty() &&
 		!call_info.qualified_name.isValid()) {
@@ -8071,8 +8249,7 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 	const FunctionDeclarationNode* resolved_op_call = resolved_op_call_query.hasValue() ? resolved_op_call_query.function : nullptr;
 	const bool cache_as_direct_call =
 		!resolved_op_call &&
-		(!call_info.has_receiver ||
-		 (func_decl && func_decl->is_static()));
+		func_decl != nullptr;
 	if (cache_as_direct_call) {
 		resolved_direct_call_table_[call_key] = func_decl;
 	} else {

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -446,6 +446,9 @@ private:
 	std::optional<TypeSpecifierNode> buildOverloadResolutionArgType(
 		const ASTNode& arg,
 		CanonicalTypeId* inferred_type_id = nullptr);
+	bool tryCollectOverloadResolutionArgTypes(
+		const ChunkedVector<ASTNode>& arguments,
+		InlineVector<TypeSpecifierNode, 6>& arg_types_out);
 
 	// Allocate a new ImplicitCastInfo entry and return its 1-based index.
 	CastInfoIndex allocateCastInfo(const ImplicitCastInfo& info);

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -99,6 +99,7 @@ public:
 	ResolvedFunctionQueryResult getResolvedOpCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
+	void ensureCallableOperatorResolved(const CallExprNode& call_node);
 	ResolvedFunctionQueryResult getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const;
 	const FunctionDeclarationNode* getResolvedOpSubscript(const ArraySubscriptNode* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
@@ -243,6 +244,7 @@ public:
 	const FunctionDeclarationNode* getResolvedOpCall(const void* key) const;
 
 	const FunctionDeclarationNode* getResolvedOpCall(const CallExprNode* key) const;
+	void ensureCallableOperatorResolved(const CallExprNode& call_node);
 	ResolvedFunctionQueryResult getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const;
 	const FunctionDeclarationNode* getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;

--- a/tests/test_constexpr_const_this_overload_ret0.cpp
+++ b/tests/test_constexpr_const_this_overload_ret0.cpp
@@ -1,0 +1,33 @@
+struct ConstThisOverload {
+	int value;
+
+	constexpr int pick() { return 1; }
+	constexpr int pick() const { return value; }
+
+	constexpr int implicitThis() const {
+		return pick();
+	}
+
+	constexpr int explicitThis() const {
+		return this->pick();
+	}
+};
+
+constexpr int testImplicitThis() {
+	ConstThisOverload value{20};
+	return value.implicitThis();
+}
+
+constexpr int testExplicitThis() {
+	ConstThisOverload value{30};
+	return value.explicitThis();
+}
+
+static_assert(testImplicitThis() == 20);
+static_assert(testExplicitThis() == 30);
+
+int main() {
+	if (testImplicitThis() != 20) return 1;
+	if (testExplicitThis() != 30) return 2;
+	return 0;
+}

--- a/tests/test_constexpr_lambda_const_this_overload_ret0.cpp
+++ b/tests/test_constexpr_lambda_const_this_overload_ret0.cpp
@@ -1,0 +1,25 @@
+struct LambdaConstThisOverload {
+	int value;
+
+	constexpr int pick() { return 1; }
+	constexpr int pick() const { return value; }
+
+	constexpr int run() const {
+		auto lambda = [this]() {
+			return this->pick();
+		};
+		return lambda();
+	}
+};
+
+constexpr int testLambdaConstThis() {
+	LambdaConstThisOverload value{60};
+	return value.run();
+}
+
+static_assert(testLambdaConstThis() == 60);
+
+int main() {
+	if (testLambdaConstThis() != 60) return 1;
+	return 0;
+}

--- a/tests/test_constexpr_lambda_copy_this_mutation_ret0.cpp
+++ b/tests/test_constexpr_lambda_copy_this_mutation_ret0.cpp
@@ -14,9 +14,14 @@ struct CopyThisMutationExample {
 	}
 };
 
-constexpr CopyThisMutationExample example{40};
-static_assert(example.testCopyThisMutation() == 124);
+constexpr int testCopyThisMutation() {
+	CopyThisMutationExample example{40};
+	return example.testCopyThisMutation();
+}
+static_assert(testCopyThisMutation() == 124);
 
 int main() {
+	CopyThisMutationExample example{40};
+	if (example.testCopyThisMutation() != 124) return 1;
 	return 0;
 }

--- a/tests/test_constexpr_lambda_immediate_ret0.cpp
+++ b/tests/test_constexpr_lambda_immediate_ret0.cpp
@@ -1,15 +1,25 @@
 // Test immediate constexpr lambda invocation
 
-static_assert([]() { return 42; }() == 42,
+constexpr int testImmediateLambda() {
+	auto f = []() { return 42; };
+	return f();
+}
+static_assert(testImmediateLambda() == 42,
 			  "immediately-invoked constexpr lambda should work");
 
-constexpr int base = 40;
-static_assert([base]() {
-	int y = 2;
-	return base + y;
-}() == 42,
+constexpr int testImmediateLambdaCapture() {
+	constexpr int base = 40;
+	auto f = [base]() {
+		int y = 2;
+		return base + y;
+	};
+	return f();
+}
+static_assert(testImmediateLambdaCapture() == 42,
 			  "immediately-invoked constexpr lambda should support captures and local variables");
 
 int main() {
+	if (testImmediateLambda() != 42) return 1;
+	if (testImmediateLambdaCapture() != 42) return 1;
 	return 0;
 }

--- a/tests/test_constexpr_lambda_member_repeated_state_ret0.cpp
+++ b/tests/test_constexpr_lambda_member_repeated_state_ret0.cpp
@@ -18,10 +18,25 @@ struct MemberRepeatedStateExample {
 	}
 };
 
-constexpr MemberRepeatedStateExample example{40};
-static_assert(example.sharedThisState() == 130);
-static_assert(example.copiedThisState() == 126);
+constexpr int sharedThisState() {
+	MemberRepeatedStateExample example{40};
+	return example.sharedThisState();
+}
+constexpr int copiedThisState() {
+	MemberRepeatedStateExample example{40};
+	return example.copiedThisState();
+}
+static_assert(sharedThisState() == 130);
+static_assert(copiedThisState() == 126);
 
 int main() {
+	{
+		MemberRepeatedStateExample example{40};
+		if (example.sharedThisState() != 130) return 1;
+	}
+	{
+		MemberRepeatedStateExample example{40};
+		if (example.copiedThisState() != 126) return 2;
+	}
 	return 0;
 }

--- a/tests/test_constexpr_lambda_nested_member_copy_this_ret0.cpp
+++ b/tests/test_constexpr_lambda_nested_member_copy_this_ret0.cpp
@@ -24,10 +24,25 @@ struct NestedMemberCopyThisExample {
 	}
 };
 
-constexpr NestedMemberCopyThisExample example{40};
-static_assert(example.sharedNested() == 174);
-static_assert(example.copiedNested() == 170);
+constexpr int sharedNested() {
+	NestedMemberCopyThisExample example{40};
+	return example.sharedNested();
+}
+constexpr int copiedNested() {
+	NestedMemberCopyThisExample example{40};
+	return example.copiedNested();
+}
+static_assert(sharedNested() == 174);
+static_assert(copiedNested() == 170);
 
 int main() {
+	{
+		NestedMemberCopyThisExample example{40};
+		if (example.sharedNested() != 174) return 1;
+	}
+	{
+		NestedMemberCopyThisExample example{40};
+		if (example.copiedNested() != 170) return 2;
+	}
 	return 0;
 }

--- a/tests/test_constexpr_lambda_nested_state_ret0.cpp
+++ b/tests/test_constexpr_lambda_nested_state_ret0.cpp
@@ -24,10 +24,15 @@ struct NestedMemberLambdaStateExample {
 	}
 };
 
-constexpr NestedMemberLambdaStateExample example{40};
+constexpr int run() {
+	NestedMemberLambdaStateExample example{40};
+	return example.run();
+}
 static_assert(nested_outer_closure_state() == 172);
-static_assert(example.run() == 172);
+static_assert(run() == 172);
 
 int main() {
+	NestedMemberLambdaStateExample example{40};
+	if (example.run() != 172) return 1;
 	return 0;
 }

--- a/tests/test_constexpr_lambda_this_shared_mutation_ret0.cpp
+++ b/tests/test_constexpr_lambda_this_shared_mutation_ret0.cpp
@@ -14,9 +14,14 @@ struct ThisSharedMutationExample {
 	}
 };
 
-constexpr ThisSharedMutationExample example{40};
-static_assert(example.testThisMutation() == 123);
+constexpr int testThisMutation() {
+	ThisSharedMutationExample example{40};
+	return example.testThisMutation();
+}
+static_assert(testThisMutation() == 123);
 
 int main() {
+	ThisSharedMutationExample example{40};
+	if (example.testThisMutation() != 123) return 1;
 	return 0;
 }

--- a/tests/test_constexpr_template_const_this_overload_ret0.cpp
+++ b/tests/test_constexpr_template_const_this_overload_ret0.cpp
@@ -1,0 +1,34 @@
+template <typename T>
+struct TemplateConstThisOverload {
+	T value;
+
+	constexpr T pick() { return T{1}; }
+	constexpr T pick() const { return value; }
+
+	constexpr T implicitThis() const {
+		return pick();
+	}
+
+	constexpr T explicitThis() const {
+		return this->pick();
+	}
+};
+
+constexpr int testTemplateImplicitThis() {
+	TemplateConstThisOverload<int> value{40};
+	return value.implicitThis();
+}
+
+constexpr int testTemplateExplicitThis() {
+	TemplateConstThisOverload<int> value{50};
+	return value.explicitThis();
+}
+
+static_assert(testTemplateImplicitThis() == 40);
+static_assert(testTemplateExplicitThis() == 50);
+
+int main() {
+	if (testTemplateImplicitThis() != 40) return 1;
+	if (testTemplateExplicitThis() != 50) return 2;
+	return 0;
+}

--- a/tests/test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp
+++ b/tests/test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp
@@ -1,0 +1,41 @@
+// Regression: replayed plain out-of-line member sync into StructTypeInfo must
+// resolve by source declaration identity, not by same-name/same-arity shape.
+// The int and long dependent alias-target overloads must each keep their own body.
+struct OolPlainMemberDependentMemberTemplateAliasOverloadTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct OolPlainMemberDependentMemberTemplateAliasOverload {
+	int pick(typename T::template AddPtr<int>::type value);
+	int pick(typename T::template AddPtr<long>::type value);
+};
+
+template<class T>
+int OolPlainMemberDependentMemberTemplateAliasOverload<T>::pick(
+	typename T::template AddPtr<long>::type value) {
+	return static_cast<int>(sizeof(*value)) + 10;
+}
+
+template<class T>
+int OolPlainMemberDependentMemberTemplateAliasOverload<T>::pick(
+	typename T::template AddPtr<int>::type value) {
+	return static_cast<int>(sizeof(*value)) + 20;
+}
+
+int main() {
+	int int_value = 0;
+	long long_value = 0;
+	OolPlainMemberDependentMemberTemplateAliasOverload<
+		OolPlainMemberDependentMemberTemplateAliasOverloadTag> value;
+	if (value.pick(&int_value) != 24) {
+		return 1;
+	}
+	if (value.pick(&long_value) != static_cast<int>(sizeof(long_value)) + 10) {
+		return 2;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

This PR continues the template-argument infrastructure refactor and fixes the runtime/runtime-constexpr gaps exposed by the updated constexpr lambda tests.

The template side moves normalized member/direct call overload argument collection into sema-owned expression typing, tightens dependent member replay evidence, and adds a regression for out-of-line dependent member-template alias overload selection. This avoids carrying stale parser-selected overload targets through normalized template replay.

The constexpr/lambda side fixes C++20 closure semantics for captured `this`: `[this]` member calls now use the captured object pointer, `[*this]` calls use the copied closure member, nested `[this]` captures propagate the effective enclosing object, and nested reference captures address enclosing closure members directly. A review pass also found that constexpr synthetic `this` bindings could drop receiver cv-qualification, so this PR preserves that exact type and rejects stale lowered non-const targets when evaluating const member bodies.

## Tests

- `./build_flashcpp.bat`
- `pwsh ./tests/run_all_tests.ps1 test_constexpr_const_this_overload_ret0.cpp test_constexpr_template_const_this_overload_ret0.cpp test_constexpr_lambda_const_this_overload_ret0.cpp`
- `pwsh ./tests/run_all_tests.ps1 @tests` where `@tests` is all `tests/*constexpr_lambda*.cpp` files
- `pwsh ./tests/run_all_tests.ps1 test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp test_template_ool_plain_member_dependent_qualified_type_ret0.cpp test_template_ool_member_template_dependent_member_template_alias_overload_ret0.cpp test_template_holder_const_nonconst_get_ret0.cpp`

## Notes

`docs/SEMANTIC_ANALYSIS_STATUS.md` and the two template architecture docs were updated with the current invariants and next steps. The remaining architectural cleanup is to unify the structurally separate const-aware member-candidate collectors so receiver-based constexpr lookup and current-struct lookup cannot drift again.