### PR TITLE
Finish standards refactor callable/constexpr fallout

### DIFF
--- a/FlashCpp.vcxproj
+++ b/FlashCpp.vcxproj
@@ -486,6 +486,7 @@
     <ClInclude Include="src\LazyMemberResolver.h" />
     <ClInclude Include="src\Lexer.h" />
     <ClInclude Include="src\Log.h" />
+    <ClInclude Include="src\MemberFunctionLookupShared.h" />
     <ClInclude Include="src\NameMangling.h" />
     <ClInclude Include="src\NamespaceRegistry.h" />
     <ClInclude Include="src\ObjFileWriter.h" />

--- a/FlashCpp.vcxproj.filters
+++ b/FlashCpp.vcxproj.filters
@@ -356,6 +356,9 @@
     <ClInclude Include="src\Log.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\MemberFunctionLookupShared.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\NameMangling.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -458,6 +458,7 @@
     <ClInclude Include="src\LazyMemberResolver.h" />
     <ClInclude Include="src\Lexer.h" />
     <ClInclude Include="src\Log.h" />
+    <ClInclude Include="src\MemberFunctionLookupShared.h" />
     <ClInclude Include="src\NameMangling.h" />
     <ClInclude Include="src\NamespaceRegistry.h" />
     <ClInclude Include="src\ObjFileWriter.h" />

--- a/FlashCppMSVC.vcxproj.filters
+++ b/FlashCppMSVC.vcxproj.filters
@@ -362,6 +362,9 @@
     <ClInclude Include="src\Log.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\MemberFunctionLookupShared.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\NameMangling.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -183,6 +183,42 @@ Validated with:
 - `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
+## 2026-06-04 callable/operator() standards follow-up note
+
+Continuing the standards-callable cleanup exposed three coupled regressions in
+normalized/deferred lambda call paths:
+
+- nested generic-lambda closures could place callable and scalar captures at the
+  same offset when callable capture size metadata remained unresolved
+- normalized direct-call lowering failed too early when sema-owned target
+  metadata was absent, even though the call still had enough typed context for
+  late/deferred lookup resolution
+- unresolved callable-reference recursive self calls (`self(self, ...)`) could
+  lower with mismatched self-argument qualifier expectations, breaking mangled
+  target resolution
+
+The fix now:
+
+- backfills unresolved by-value capture size/alignment from capture-member type
+  information and recalculates closure layout before emission
+- keeps strict sema-owned direct-call target behavior when metadata exists, and
+  constrains compatibility behavior to an explicit metadata-missing boundary
+- aligns unresolved callable-reference recursive self lowering with the ordinary
+  recursive self path (including lvalue-reference self argument handling)
+
+Remaining debt:
+
+- the metadata-missing direct-call compatibility boundary is still temporary and
+  should be removed once sema always materializes owned direct-call targets for
+  these normalized/deferred paths
+
+Validated with:
+
+- `test_generic_lambda_callable_nested_clone_ret0.cpp`
+- `test_generic_lambda_recursive_self_ret0.cpp`
+- `test_lambda_cpp20_comprehensive_ret135.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
 ## 2026-06-02 constexpr lambda capture-lowering note
 
 The updated constexpr-lambda tests exposed runtime-only closure-lowering gaps:

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-02
+**Last updated:** 2026-06-04
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -15,7 +15,10 @@ owner-aware semantic records plus replay-first attachment. The legacy textual
 alias resolution is semantic-only. The newest high-impact fix also moves
 normalized template-call overload lookup onto sema-owned argument typing, so
 replayed dependent member overloads no longer inherit stale parser-selected
-targets. The biggest remaining gap is keeping every replay/materialization path
+targets. A concrete follow-up now brings semantic `operator[]` resolution onto
+that same receiver-aware, sema-owned argument-typing path, so const receivers
+and lvalue/rvalue index overloads no longer depend on reduced parser-shaped
+typing. The biggest remaining gap is keeping every replay/materialization path
 equally evidence-driven rather than shape-driven.
 
 ## What the current design can assume
@@ -34,6 +37,10 @@ equally evidence-driven rather than shape-driven.
   collects overload-resolution argument types from semantic expression typing
   instead of parser-owned call-argument typing, so dependent out-of-line member
   overloads resolve by the concrete substituted call signature seen during sema
+- semantic `operator[]` resolution now shares sema-owned overload-resolution
+  argument typing and the same receiver-const candidate partitioning used by
+  direct member-call lookup, so normalized subscripts no longer bind non-const
+  members through const receivers or lose lvalue/rvalue index evidence
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -109,9 +116,11 @@ Tightening those is the next best cleanup target.
 
 3. Extend sema-owned lookup unification where it unlocks step 2.
    The recent member-call fix closed one concrete gap by replacing parser-owned
-   call-argument typing inside sema with normalized semantic argument typing.
-   The next useful expansion is to audit the remaining semantic call-resolution
-   sites that still do not share that collector.
+   call-argument typing inside sema with normalized semantic argument typing,
+   and the 2026-06-04 follow-up applied the same model to semantic
+   `operator[]` resolution. The next useful expansion is to audit the remaining
+   semantic call-resolution sites that still do not share that collector or the
+   receiver-aware candidate partitioning around it.
 
 4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
    Richer current-instantiation and unknown-specialization handling still
@@ -135,9 +144,9 @@ Tightening those is the next best cleanup target.
 ## Next steps
 
 1. Audit the remaining semantic call-resolution entry points that do not yet
-   share `tryCollectOverloadResolutionArgTypes(...)`, especially operator-call
-   and other normalized-call paths where parser-owned expression typing can
-   diverge from sema-owned substituted types.
+   share `tryCollectOverloadResolutionArgTypes(...)` or the shared
+   receiver-aware candidate partitioning, especially callable-operator and
+   other normalized-call paths beyond the now-fixed `operator[]` route.
 
 2. Tighten the remaining replay-attachment sites that can still succeed without
    positive substituted-signature evidence outside the now-hardened plain-member,
@@ -146,6 +155,33 @@ Tightening those is the next best cleanup target.
 3. Expand current-instantiation / unknown-specialization modeling only for the
    concrete cases that still block standards-conforming typed lookup after steps
    1 and 2.
+
+## 2026-06-04 semantic operator[] note
+
+Auditing the remaining semantic call-resolution entry points found one
+standards-visible live bug in `SemanticAnalysis::tryResolveSubscriptOperator`:
+subscript overload resolution still used reduced expression typing and did not
+filter member candidates by receiver constness before fallback selection. That
+allowed const objects to bind non-const `operator[]` members and could erase
+lvalue/rvalue index evidence needed for overload selection.
+
+The fix now:
+
+- partitions `operator[]` candidates with the same receiver-const rule used by
+  ordinary member-call lookup
+- resolves the subscript index through sema-owned overload-resolution argument
+  typing rather than raw `inferExpressionType(...)`
+- shares the small overload-set helpers with ordinary member-call resolution so
+  future receiver-sensitive fixes cannot drift between the two paths
+
+Validated with:
+
+- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_subscript_const_ambiguity_fail.cpp`
+- `test_operator_subscript_const_ret42.cpp`
+- `test_operator_subscript_overloads_ret42.cpp`
+- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
 ## 2026-06-02 constexpr lambda capture-lowering note
 
@@ -179,6 +215,10 @@ Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 When changing this area, always rerun:
 
 - the focused regression that motivated the slice
+- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
+  `test_operator_subscript_const_ambiguity_fail.cpp` and
+  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` when touching
+  semantic subscript resolution or receiver-sensitive normalized-call lookup
 - the three former textual-path blockers listed above when touching dependent
   alias ownership (they now exercise the semantic-only route)
 - the dependent member-template static constexpr regressions when touching

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-02
+**Last updated:** 2026-06-04
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -32,6 +32,10 @@ Move FlashCpp toward a sema-owned template system where:
   sema-owned overload-resolution argument typing instead of parser-owned
   argument collection, so dependent out-of-line member overloads are selected
   from the concrete substituted call signature seen during semantic analysis
+- semantic `operator[]` resolution now also uses sema-owned
+  overload-resolution argument typing plus receiver-const candidate filtering,
+  so normalized subscripts preserve lvalue/rvalue index evidence and do not
+  bind non-const members through const receivers
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -94,8 +98,11 @@ unknown-specialization modeling only where it unblocks those paths.
 
 3. Unify the remaining semantic call-resolution entry points around the same
    sema-owned overload-resolution argument collector now used for normalized
-   template/member direct calls. This is the shortest path to preventing stale
-   parser-selected targets from surviving semantic normalization.
+   template/member direct calls. A 2026-06-04 follow-up closed the concrete
+   `operator[]` gap by sharing receiver-aware candidate filtering plus sema-
+   owned index typing with direct member-call resolution. This is still the
+   shortest path to preventing stale parser-selected targets from surviving
+   semantic normalization.
 
 4. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks steps 2 and 3.
@@ -116,9 +123,10 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Apply the sema-owned overload-resolution argument collector to the remaining
-   semantic call-resolution sites that still rely on parser-owned expression
-   typing or reduced argument modeling.
+1. Apply the sema-owned overload-resolution argument collector and the shared
+   receiver-aware candidate partitioning to the remaining semantic
+   call-resolution sites that still rely on parser-owned expression typing or
+   reduced argument modeling beyond the now-fixed `operator[]` route.
 
 2. Continue deleting replay-attachment acceptance paths that still allow
    insufficient substituted-signature evidence outside the now-hardened member
@@ -126,6 +134,33 @@ unknown-specialization modeling only where it unblocks those paths.
 
 3. Only after those are stable, extend current-instantiation and
    unknown-specialization modeling for the specific unresolved cases that remain.
+
+## 2026-06-04 semantic operator[] conformance note
+
+Auditing the remaining sema call-resolution entry points found a live C++20
+conformance bug in semantic `operator[]` resolution: the overload set was
+still classified from reduced expression typing and fallback selection ignored
+receiver constness. That made two ordinary language rules unstable in normalized
+subscript calls:
+
+- a const receiver must not bind a non-const `operator[]`
+- lvalue and prvalue index expressions must preserve the overload-resolution
+  categories seen by ordinary member-call lookup
+
+`SemanticAnalysis::tryResolveSubscriptOperator` now reuses the same
+receiver-aware candidate partitioning and sema-owned overload-resolution
+argument typing already used by normalized member-call resolution. This keeps
+the semantic subscript path aligned with the broader sema-owned call model
+instead of depending on reduced parser-shaped typing.
+
+Validated with:
+
+- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_subscript_const_ambiguity_fail.cpp`
+- `test_operator_subscript_const_ret42.cpp`
+- `test_operator_subscript_overloads_ret42.cpp`
+- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
 ## 2026-06-02 constexpr lambda conformance note
 
@@ -150,6 +185,10 @@ Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 For work in this area:
 
 - add a focused regression first when a new gap is identified
+- rerun `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
+  `test_operator_subscript_const_ambiguity_fail.cpp` and
+  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` when touching
+  semantic subscript resolution or receiver-sensitive normalized-call lookup
 - rerun the three former dependent-alias blocker tests when touching alias
   ownership or current-instantiation handling (they now exercise the
   semantic-only route)

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -162,6 +162,41 @@ Validated with:
 - `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
+## 2026-06-04 callable/operator() conformance note
+
+The remaining standards-callable regressions in normalized/deferred paths were:
+
+- nested generic-lambda callable captures could remain zero-sized in closure
+  layout, causing overlap with subsequent captures
+- normalized direct-call lowering could hard-fail when sema-owned target
+  metadata was missing, even for late/deferred call paths that still had typed
+  lookup evidence
+- unresolved callable-reference recursive self calls could miss the correct
+  mangled target because self-argument qualifier handling diverged from ordinary
+  recursive self lowering
+
+The fix now:
+
+- backfills unresolved by-value capture size/alignment from capture member type
+  info and recalculates closure layout before emission
+- preserves strict sema-owned direct-call target use when available, and limits
+  compatibility behavior to an explicit metadata-missing boundary
+- unifies unresolved callable-reference recursive self-call lowering with the
+  ordinary recursive self path, including lvalue-reference self-argument
+  qualifier treatment
+
+Conformance debt to remove next:
+
+- delete the metadata-missing direct-call compatibility boundary once sema
+  always provides owned direct-call targets for these normalized/deferred calls
+
+Validated with:
+
+- `test_generic_lambda_callable_nested_clone_ret0.cpp`
+- `test_generic_lambda_recursive_self_ret0.cpp`
+- `test_lambda_cpp20_comprehensive_ret135.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
 ## 2026-06-02 constexpr lambda conformance note
 
 The updated constexpr-lambda tests exposed runtime capture-lowering bugs rather

--- a/docs/SEMANTIC_ANALYSIS_STATUS.md
+++ b/docs/SEMANTIC_ANALYSIS_STATUS.md
@@ -1,6 +1,6 @@
 # Semantic Analysis Status
 
-**Last Updated:** 2026-06-02
+**Last Updated:** 2026-06-04
 
 This document is intentionally forward-looking. It should capture the current
 ownership model, the invariants future work can rely on, and the next cleanup
@@ -115,6 +115,18 @@ FlashCpp follows a parse -> sema -> IR pipeline:
   now prefers the exact normalized call node and can derive the callable owner
   type from the resolved `operator()` member when the auxiliary receiver-type
   query was not materialized
+- deferred nested-generic-lambda closure layout now backfills unresolved
+  by-value capture size/alignment from the capture member type and recalculates
+  closure layout before emission, so callable captures and value captures cannot
+  overlap in generated closure storage
+- normalized direct-call lowering now keeps strict sema-owned target usage when
+  metadata is present, but uses one temporary metadata-missing compatibility
+  boundary for unresolved normalized calls that still rely on late/deferred
+  lookup surfaces
+- unresolved callable-reference recursive generic-lambda self calls now use the
+  same self-forward detection and lvalue-reference self-argument qualifier model
+  as the ordinary recursive path, so mangled-call lookup matches C++20
+  deduction behavior
 
 ## Main remaining gaps
 
@@ -131,6 +143,10 @@ Near-term blocker in this area:
   `test_dependent_identifier_template_call_ret0.cpp`,
   `test_pack_expansion_in_template_body_ret0.cpp`, and
   `test_template_builtin_addressof_substitution_ret0.cpp`
+- normalized direct-call lowering still has one explicit metadata-missing
+  compatibility boundary (sema target absent, deferred/late-instantiated call
+  still resolvable by typed lookup). This should be deleted once sema
+  consistently materializes owned direct-call targets for these paths.
 
 Recommended next step:
 

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -22,6 +22,7 @@ struct TypeInfo;
 class Parser;  // For template instantiation
 class SemanticAnalysis;
 class QualifiedIdentifierNode;
+struct ConstAwareMemberCandidateSet;
 
 /// @file ConstExprEvaluator.h
 /// @brief Constant expression evaluation for static_assert, constexpr variables, etc.
@@ -1026,6 +1027,23 @@ private:
 		bool require_static,
 		bool receiver_is_const,
 		bool detect_ambiguity);
+	static bool tryCollectConstexprOverloadResolutionArgTypes(
+		const ChunkedVector<ASTNode>& arguments,
+		EvaluationContext& context,
+		InlineVector<TypeSpecifierNode, 6>& arg_types_out);
+	static ResolvedMemberFunctionCandidate resolveConstexprMemberCallCandidateFromCollectedSets(
+		const ConstAwareMemberCandidateSet& candidate_sets,
+		const ChunkedVector<ASTNode>& arguments,
+		EvaluationContext& context);
+	static ResolvedMemberFunctionCandidate resolveConstAwareConstexprMemberFunctionCallCandidate(
+		const StructTypeInfo* struct_info,
+		StringHandle function_name_handle,
+		const ChunkedVector<ASTNode>& arguments,
+		EvaluationContext& context,
+		MemberFunctionLookupMode lookup_mode,
+		bool require_static,
+		bool receiver_is_const,
+		bool stop_at_first_local_name_set);
 	// Invoke a constexpr member function with pre-evaluated arguments.
 	// Handles: this injection, argument binding, template context save/restore,
 	// recursion depth guard, struct context setup, evaluate_block_with_bindings.

--- a/src/ConstExprEvaluator_Members.cpp
+++ b/src/ConstExprEvaluator_Members.cpp
@@ -3,6 +3,7 @@
 #include "BuiltinListInitNarrowing.h"
 #include "CallNodeHelpers.h"
 #include "ExpressionSubstitutor.h"
+#include "MemberFunctionLookupShared.h"
 #include "OverloadResolution.h"
 #include "SemanticAnalysis.h"
 #include "TypeTraitEvaluator.h"
@@ -119,6 +120,166 @@ bool sameConstexprFunctionIdentity(
 	}
 	return true;
 }
+
+const StructMemberFunction* findCollectedMemberFunctionByIdentity(
+	std::span<const StructMemberFunction* const> candidates,
+	const FunctionDeclarationNode& target_function) {
+	for (const StructMemberFunction* candidate_member : candidates) {
+		if (candidate_member == nullptr ||
+			!candidate_member->function_decl.is<FunctionDeclarationNode>()) {
+			continue;
+		}
+		const auto& candidate =
+			candidate_member->function_decl.as<FunctionDeclarationNode>();
+		if (sameConstexprFunctionIdentity(candidate, target_function)) {
+			return candidate_member;
+		}
+	}
+	return nullptr;
+}
+}
+
+bool Evaluator::tryCollectConstexprOverloadResolutionArgTypes(
+	const ChunkedVector<ASTNode>& arguments,
+	EvaluationContext& context,
+	InlineVector<TypeSpecifierNode, 6>& arg_types_out) {
+	arg_types_out.clear();
+	arg_types_out.reserve(arguments.size());
+
+	auto sema_services =
+		context
+			.requireParserAttachedSema(kMemberFunctionMaterializationLookupOp)
+			.parserSemanticServices();
+	for (const ASTNode& argument : arguments) {
+		std::optional<TypeSpecifierNode> arg_type =
+			sema_services.getOverloadResolutionArgType(argument);
+		if (!arg_type.has_value() || arg_type->category() == TypeCategory::Invalid) {
+			arg_types_out.clear();
+			return false;
+		}
+		arg_types_out.push_back(*arg_type);
+	}
+	return true;
+}
+
+Evaluator::ResolvedMemberFunctionCandidate Evaluator::resolveConstexprMemberCallCandidateFromCollectedSets(
+	const ConstAwareMemberCandidateSet& candidate_sets,
+	const ChunkedVector<ASTNode>& arguments,
+	EvaluationContext& context) {
+	Evaluator::ResolvedMemberFunctionCandidate result;
+	if (candidate_sets.compatible.empty()) {
+		return result;
+	}
+
+	InlineVector<ASTNode, 8> preferred_overloads;
+	InlineVector<ASTNode, 8> compatible_overloads;
+	appendUniqueMemberFunctionOverloadNodes(preferred_overloads, candidate_sets.preferred);
+	appendUniqueMemberFunctionOverloadNodes(compatible_overloads, candidate_sets.compatible);
+
+	InlineVector<TypeSpecifierNode, 6> arg_types;
+	const bool has_arg_types =
+		tryCollectConstexprOverloadResolutionArgTypes(arguments, context, arg_types);
+	auto tryResolveCollectedSet =
+		[&](std::span<const ASTNode> overloads,
+			std::span<const StructMemberFunction* const> members,
+			bool* ambiguous_out) -> Evaluator::ResolvedMemberFunctionCandidate {
+			Evaluator::ResolvedMemberFunctionCandidate candidate_result;
+			if (ambiguous_out != nullptr) {
+				*ambiguous_out = false;
+			}
+			if (overloads.empty()) {
+				return candidate_result;
+			}
+
+			if (!has_arg_types) {
+				if (members.size() == 1 &&
+					members.front() != nullptr &&
+					members.front()->function_decl.is<FunctionDeclarationNode>()) {
+					candidate_result.member = members.front();
+					candidate_result.function =
+						&members.front()->function_decl.as<FunctionDeclarationNode>();
+					return candidate_result;
+				}
+				if (ambiguous_out != nullptr && members.size() > 1) {
+					*ambiguous_out = true;
+				}
+				return candidate_result;
+			}
+
+			const OverloadResolutionResult overload_result =
+				resolve_overload(overloads, arg_types);
+			if (overload_result.is_ambiguous) {
+				if (ambiguous_out != nullptr) {
+					*ambiguous_out = true;
+				}
+				return candidate_result;
+			}
+			if (!overload_result.has_match || overload_result.selected_overload == nullptr ||
+				!overload_result.selected_overload->is<FunctionDeclarationNode>()) {
+				return candidate_result;
+			}
+
+			const auto& resolved_function =
+				overload_result.selected_overload->as<FunctionDeclarationNode>();
+			candidate_result.function = &resolved_function;
+			candidate_result.member =
+				findCollectedMemberFunctionByIdentity(members, resolved_function);
+			return candidate_result;
+		};
+
+	bool preferred_ambiguous = false;
+	result = tryResolveCollectedSet(
+		preferred_overloads,
+		candidate_sets.preferred,
+		&preferred_ambiguous);
+	if (result.function != nullptr || preferred_ambiguous) {
+		result.ambiguous = preferred_ambiguous;
+		return result;
+	}
+
+	if (!sameMemberCandidateSet(candidate_sets.preferred, candidate_sets.compatible)) {
+		bool compatible_ambiguous = false;
+		result = tryResolveCollectedSet(
+			compatible_overloads,
+			candidate_sets.compatible,
+			&compatible_ambiguous);
+		result.ambiguous = compatible_ambiguous;
+	}
+
+	return result;
+}
+
+Evaluator::ResolvedMemberFunctionCandidate Evaluator::resolveConstAwareConstexprMemberFunctionCallCandidate(
+	const StructTypeInfo* struct_info,
+	StringHandle function_name_handle,
+	const ChunkedVector<ASTNode>& arguments,
+	EvaluationContext& context,
+	MemberFunctionLookupMode lookup_mode,
+	bool require_static,
+	bool receiver_is_const,
+	bool stop_at_first_local_name_set) {
+	const ConstAwareMemberCandidateSet candidate_sets =
+		collectConstAwareVisibleMemberFunctionCandidates(
+			struct_info,
+			function_name_handle,
+			receiver_is_const,
+			stop_at_first_local_name_set,
+			[&](const StructMemberFunction& member_func, const FunctionDeclarationNode& func_decl) {
+				return matchesConstexprFunctionName(member_func, function_name_handle) &&
+					isConstexprMemberLookupCandidate(
+						func_decl,
+						arguments.size(),
+						context,
+						lookup_mode,
+						require_static);
+			});
+	return resolveConstexprMemberCallCandidateFromCollectedSets(
+		candidate_sets,
+		arguments,
+		context);
+}
+
+namespace {
 
 const FunctionDeclarationNode* findMatchingSymbolTableMemberDefinition(
 	const FunctionDeclarationNode& target_function,
@@ -271,11 +432,7 @@ const StructMemberFunction* findMemberFunctionMetadataRecursive(
 			candidate.mangled_name() == target_function.mangled_name()) {
 			return &member_func;
 		}
-		if (normalizeConstexprLookupName(candidate.decl_node().identifier_token().value()) ==
-				normalizeConstexprLookupName(target_function.decl_node().identifier_token().value()) &&
-			candidate.parameter_nodes().size() == target_function.parameter_nodes().size() &&
-			candidate.is_const_member_function() == target_function.is_const_member_function() &&
-			candidate.parent_struct_name() == target_function.parent_struct_name()) {
+		if (sameConstexprFunctionIdentity(candidate, target_function)) {
 			return &member_func;
 		}
 	}
@@ -1130,10 +1287,7 @@ const FunctionDeclarationNode* Evaluator::try_get_lowered_constexpr_member_call_
 				candidate.mangled_name() == lowered_func->mangled_name()) {
 				return &candidate;
 			}
-			if (normalizeConstexprLookupName(candidate.decl_node().identifier_token().value()) ==
-					normalizeConstexprLookupName(lowered_func->decl_node().identifier_token().value()) &&
-				candidate.parameter_nodes().size() == lowered_func->parameter_nodes().size() &&
-				candidate.is_const_member_function() == lowered_func->is_const_member_function()) {
+			if (sameConstexprFunctionIdentity(candidate, *lowered_func)) {
 				return &candidate;
 			}
 		}
@@ -1930,12 +2084,14 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 
 	if (!call_expr.has_qualified_name() && context.struct_info) {
 		StringHandle func_name_handle = StringTable::getOrInternStringHandle(func_name);
-		auto current_struct_match = find_current_struct_member_function_candidate(
+		auto current_struct_match = resolveConstAwareConstexprMemberFunctionCallCandidate(
+			context.struct_info,
 			func_name_handle,
-			call_expr.arguments().size(),
+			call_expr.arguments(),
 			context,
 			MemberFunctionLookupMode::ConstexprEvaluable,
 			false,
+			context.current_member_function_is_const,
 			true);
 		if (current_struct_match.ambiguous) {
 			return EvalResult::error("Ambiguous member function overload in constant expression");
@@ -2516,6 +2672,7 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	bool write_back_to_object_binding = false;
 	bool write_back_through_pointer = false;
 	bool write_back_via_receiver_lvalue = false;
+	bool bound_receiver_is_const = receiver_is_this && context.current_member_function_is_const;
 	std::string_view object_name;
 	EvalResult pointed_object_result;
 
@@ -2597,6 +2754,11 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 			}
 			bound_type_index = pointed_object_result.object_type_index;
 			member_bindings = pointed_object_result.object_member_bindings;
+			bound_receiver_is_const =
+				(pointed_object_result.exact_type.has_value() &&
+				 pointed_object_result.exact_type->is_const()) ||
+				(object_value->exact_type.has_value() &&
+				 object_value->exact_type->is_const());
 			if (is_reference_alias_receiver) {
 				// Local reference variables are alias bindings (pointer + reference-qualified type).
 				// Write back through the receiver lvalue to update the alias target, avoiding
@@ -2613,6 +2775,9 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 			}
 			bound_type_index = object_value->object_type_index;
 			member_bindings = object_value->object_member_bindings;
+			bound_receiver_is_const =
+				object_value->exact_type.has_value() &&
+				object_value->exact_type->is_const();
 			// Enable write-back when the receiver is a named identifier OR when the
 			// complex receiver resolved to a named binding (e.g. ternary -> identifier).
 			write_back_to_object_binding = object_identifier != nullptr || !resolved_binding_name.empty();
@@ -2693,20 +2858,23 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 	}
 	if (!actual_func) {
 		auto member_function_match = receiver_is_this
-										 ? find_current_struct_member_function_candidate(
+										 ? resolveConstAwareConstexprMemberFunctionCallCandidate(
+											   context.struct_info,
 											   func_name_handle,
-											   call_info->arguments->size(),
+											   *call_info->arguments,
 											   context,
 											   MemberFunctionLookupMode::LookupOnly,
 											   false,
+											   context.current_member_function_is_const,
 											   true)
-										 : find_member_function_candidate(
+										 : resolveConstAwareConstexprMemberFunctionCallCandidate(
 											   bound_struct_info,
 											   func_name_handle,
-											   call_info->arguments->size(),
+											   *call_info->arguments,
 											   context,
 											   MemberFunctionLookupMode::LookupOnly,
 											   false,
+											   bound_receiver_is_const,
 											   true);
 		if (member_function_match.ambiguous) {
 			return EvalResult::error("Ambiguous member function overload in constant expression");
@@ -2714,27 +2882,6 @@ std::optional<EvalResult> Evaluator::try_evaluate_bound_member_function_call(
 
 		actual_func = member_function_match.function;
 		actual_member = member_function_match.member;
-	}
-	if (!actual_func &&
-		call_info->function_declaration &&
-		isConstexprMemberLookupCandidate(
-			*call_info->function_declaration,
-			call_info->arguments->size(),
-			context,
-			MemberFunctionLookupMode::LookupOnly,
-			false)) {
-		const FunctionDeclarationNode* fallback_func = call_info->function_declaration;
-		const StructMemberFunction* fallback_member =
-			findMemberFunctionMetadataRecursive(bound_struct_info, *fallback_func);
-		const bool fallback_rejected_for_const_receiver =
-			receiver_is_this &&
-			context.current_member_function_is_const &&
-			!fallback_func->is_static() &&
-			!fallback_func->is_const_member_function();
-		if (!fallback_rejected_for_const_receiver) {
-			actual_func = fallback_func;
-			actual_member = fallback_member;
-		}
 	}
 	if (actual_member && actual_member->function_decl.is<FunctionDeclarationNode>() && actual_func) {
 		const auto& member_function_decl = actual_member->function_decl.as<FunctionDeclarationNode>();
@@ -3240,62 +3387,49 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::findConstAwareMemberFuncti
 			true,
 			detect_ambiguity);
 	}
-
-	auto collectCandidates =
-		[&](bool require_const_member) -> ResolvedMemberFunctionCandidate {
-			ResolvedMemberFunctionCandidate result;
-			if (!struct_info) {
-				return result;
-			}
-			for (const auto& member_func : struct_info->member_functions) {
-				if (member_func.is_constructor || member_func.is_destructor ||
-					!matchesConstexprFunctionName(member_func, function_name_handle) ||
-					!member_func.function_decl.is<FunctionDeclarationNode>()) {
-					continue;
-				}
-
-				const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-				if (!isConstexprMemberLookupCandidate(
+	const ConstAwareMemberCandidateSet candidate_sets =
+		collectConstAwareVisibleMemberFunctionCandidates(
+			struct_info,
+			function_name_handle,
+			receiver_is_const,
+			false,
+			[&](const StructMemberFunction& member_func, const FunctionDeclarationNode& func_decl) {
+				return matchesConstexprFunctionName(member_func, function_name_handle) &&
+					isConstexprMemberLookupCandidate(
 						func_decl,
 						argument_count,
 						context,
 						lookup_mode,
-						false)) {
-					continue;
-				}
-				if (!func_decl.is_static()) {
-					if (require_const_member) {
-						if (!func_decl.is_const_member_function()) {
-							continue;
-						}
-					} else if (func_decl.is_const_member_function()) {
-						continue;
-					}
-				}
+						false);
+			});
 
-				if (result.function && detect_ambiguity) {
-					result.ambiguous = true;
-					return result;
-				}
-
-				result.function = &func_decl;
-				result.member = &member_func;
-				if (!detect_ambiguity) {
-					break;
-				}
+	auto selectUniqueCandidate =
+		[&](std::span<const StructMemberFunction* const> members) -> ResolvedMemberFunctionCandidate {
+			ResolvedMemberFunctionCandidate result;
+			if (members.empty()) {
+				return result;
+			}
+			result.member = members.front();
+			result.function =
+				result.member != nullptr &&
+					result.member->function_decl.is<FunctionDeclarationNode>()
+					? &result.member->function_decl.as<FunctionDeclarationNode>()
+					: nullptr;
+			if (detect_ambiguity && members.size() > 1) {
+				result.ambiguous = true;
 			}
 			return result;
 		};
 
-	if (receiver_is_const) {
-		return collectCandidates(true);
+	ResolvedMemberFunctionCandidate result =
+		selectUniqueCandidate(candidate_sets.preferred);
+	if (result.function != nullptr || result.ambiguous) {
+		return result;
 	}
-
-	ResolvedMemberFunctionCandidate non_const_match = collectCandidates(false);
-	if (non_const_match.function || non_const_match.ambiguous) {
-		return non_const_match;
+	if (!sameMemberCandidateSet(candidate_sets.preferred, candidate_sets.compatible)) {
+		result = selectUniqueCandidate(candidate_sets.compatible);
 	}
-	return collectCandidates(true);
+	return result;
 }
 
 Evaluator::ResolvedMemberFunctionCandidate Evaluator::findConstexprOperatorOverload(
@@ -8768,13 +8902,15 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 			true);
 		if (!matched_function) {
 			StringHandle fn_handle = StringTable::getOrInternStringHandle(func_name);
-			auto current_match = find_current_struct_member_function_candidate(
+			auto current_match = resolveConstAwareConstexprMemberFunctionCallCandidate(
+				context.struct_info,
 				fn_handle,
-				call_expr.arguments().size(),
+				call_expr.arguments(),
 				context,
 				MemberFunctionLookupMode::ConstexprEvaluable,
 				true,
-				false);
+				context.current_member_function_is_const,
+				true);
 			matched_function = current_match.function;
 		}
 
@@ -9033,10 +9169,10 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 		func_name_handle,
 		std::nullopt);
 	ResolvedMemberFunctionCandidate member_function_match =
-		findConstAwareMemberFunctionCandidate(
+		resolveConstAwareConstexprMemberFunctionCallCandidate(
 			struct_info,
 			func_name_handle,
-			arguments.size(),
+			arguments,
 			context,
 			MemberFunctionLookupMode::LookupOnly,
 			false,
@@ -9173,27 +9309,10 @@ EvalResult Evaluator::evaluate_member_function_call(const CallExprNode& call_exp
 		}
 	}
 
-	if (!actual_func) {
-		if (placeholder_func &&
-			placeholder_func->get_definition().has_value()) {
-			const FunctionDeclarationNode* fallback_func = placeholder_func;
-			const StructMemberFunction* fallback_member =
-				findMemberFunctionMetadataRecursive(struct_info, *fallback_func);
-			const bool fallback_rejected_for_const_receiver =
-				receiver_is_const &&
-				fallback_member != nullptr &&
-				!fallback_func->is_static() &&
-				!fallback_func->is_const_member_function();
-			if (!fallback_rejected_for_const_receiver) {
-				actual_func = fallback_func;
-				actual_member = fallback_member;
-			}
-		}
-		if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
-			FLASH_LOG(ConstExpr, Debug,
-				"  after placeholder fallback: actual_func=", actual_func != nullptr,
-				" actual_member=", actual_member != nullptr);
-		}
+	if (!actual_func && IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
+		FLASH_LOG(ConstExpr, Debug,
+			"  after canonical member lookup: actual_func=", actual_func != nullptr,
+			" actual_member=", actual_member != nullptr);
 	}
 	if (!actual_func) {
 		return EvalResult::error("Member function not found: " + std::string(func_name));

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -740,7 +740,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 						// Don't call visitExpressionNode which would dereference it
 						call_op.args.push_back(makeTypedValue(TypeCategory::Struct, SizeInBits{64}, IrValue(func_name)));
 
-							// Type for mangling is rvalue reference to closure type
+						// Type for mangling is lvalue reference to closure type
 						TypeSpecifierNode self_type(closure_type_index.withCategory(TypeCategory::Struct), 8, Token(), CVQualifier::None, ReferenceQualifier::None);
 						self_type.set_reference_qualifier(ReferenceQualifier::LValueReference);
 						arg_types.push_back(self_type);

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -588,7 +588,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 				*resolved_operator_call,
 				std::move(member_args),
 				callExprNode.called_from());
-			return generateMemberFunctionCallIr(member_call, context);
+			return generateMemberFunctionCallIr(member_call, context, sema_call_key);
 		}
 		if (sema_normalized_current_function_ &&
 			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
@@ -658,12 +658,26 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		}
 
 		bool is_recursive_lambda_self = false;
-		if (current_lambda_context_.isActive() && func_type.category() == TypeCategory::Struct &&
-			func_type.is_rvalue_reference()) {
+		if (current_lambda_context_.isActive() &&
+			(func_type.is_rvalue_reference() || func_type.is_reference())) {
 			auto closure_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
 			if (closure_type_it != getTypesByNameMap().end() &&
 				func_type.type_index() == closure_type_it->second->type_index_) {
 				is_recursive_lambda_self = true;
+			}
+			if (!is_recursive_lambda_self &&
+				(!func_type.type_index().is_valid() || !func_type.type_index().isStruct())) {
+				bool self_forward_pattern = false;
+				const auto call_args = callExprNode.arguments();
+				if (call_args.size() > 0 && call_args[0].is<ExpressionNode>()) {
+					const ExpressionNode& first_arg_expr = call_args[0].as<ExpressionNode>();
+					if (const auto* first_arg_id = std::get_if<IdentifierNode>(&first_arg_expr)) {
+						self_forward_pattern = first_arg_id->name() == func_name_view;
+					}
+				}
+				if (self_forward_pattern) {
+					is_recursive_lambda_self = true;
+				}
 			}
 		}
 
@@ -728,7 +742,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 
 							// Type for mangling is rvalue reference to closure type
 						TypeSpecifierNode self_type(closure_type_index.withCategory(TypeCategory::Struct), 8, Token(), CVQualifier::None, ReferenceQualifier::None);
-						self_type.set_reference_qualifier(ReferenceQualifier::RValueReference);
+						self_type.set_reference_qualifier(ReferenceQualifier::LValueReference);
 						arg_types.push_back(self_type);
 					} else {
 						// Normal argument - visit the expression
@@ -1074,15 +1088,23 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	// hatches. Semantically normalized ordinary direct calls should now either
 	// provide a sema-owned target or fail during sema annotation.
 	const bool ordinary_direct_call = !callExprNode.callee().is_indirect();
+	const bool sema_has_owned_direct_target =
+		parser_resolved_direct_target != nullptr ||
+		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available;
 	if (!matched_func_decl &&
 		ordinary_direct_call &&
 		sema_normalized_current_function_ &&
-		!parser_resolved_direct_target &&
+		!sema_has_owned_direct_target &&
 		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
-		throw InternalError("Normalized direct-call query remained NotYetAnalyzed");
+		FLASH_LOG_FORMAT(
+			Codegen,
+			Debug,
+			"Phase 1 compatibility fallback: direct-call query remained NotYetAnalyzed for '{}'",
+			func_name_view);
 	}
 	const bool allow_lookup_recovery =
-		!sema_normalized_current_function_; // body not tracked by normalized_bodies_
+		!sema_normalized_current_function_ ||
+		!sema_has_owned_direct_target;
 
 	// For sema-normalized ordinary direct calls, lowering must consume the sema-owned
 	// callee selection instead of rescanning symbol tables and member hierarchies again.

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -295,14 +295,12 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 			sema_call_key != nullptr
 				? sema_services.getResolvedOpCallQuery(sema_call_key)
 				: sema_services.getResolvedOpCallQuery(&callExprNode);
-		ResolvedFunctionQueryResult exact_call_query =
-			sema_services.getResolvedOpCallQuery(&callExprNode);
-		if (exact_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		if (resolved_op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 			sema_services.ensureCallableOperatorResolved(callExprNode);
-			exact_call_query = sema_services.getResolvedOpCallQuery(&callExprNode);
-		}
-		if (!resolved_op_call_query.hasValue() && exact_call_query.hasValue()) {
-			resolved_op_call_query = exact_call_query;
+			resolved_op_call_query =
+				sema_call_key != nullptr
+					? sema_services.getResolvedOpCallQuery(sema_call_key)
+					: sema_services.getResolvedOpCallQuery(&callExprNode);
 		}
 		const FunctionDeclarationNode* resolved_op_call =
 			resolved_op_call_query.state == ResolvedFunctionQueryResult::State::Available
@@ -327,33 +325,6 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 						identifier.nameHandle());
 				static_member_function_type.has_value()) {
 				callee_type = *static_member_function_type;
-			}
-		}
-		if (isInconclusiveCallableType(callee_type)) {
-			const FunctionDeclarationNode* callable_target =
-				resolved_op_call != nullptr ? resolved_op_call : &member_func_decl;
-			if (callable_target != nullptr && !callable_target->parent_struct_name().empty()) {
-				const StringHandle owner_name =
-					StringTable::getOrInternStringHandle(callable_target->parent_struct_name());
-				if (auto owner_type_it = getTypesByNameMap().find(owner_name);
-					owner_type_it != getTypesByNameMap().end() &&
-					owner_type_it->second != nullptr) {
-					const TypeInfo* owner_type_info = owner_type_it->second;
-					TypeIndex owner_type_index =
-						owner_type_info->registeredTypeIndex().withCategory(owner_type_info->typeEnum());
-					if (!owner_type_index.is_valid()) {
-						owner_type_index =
-							owner_type_info->type_index_.withCategory(owner_type_info->typeEnum());
-					}
-					if (owner_type_index.is_valid()) {
-						callee_type.emplace(
-							owner_type_index.withCategory(TypeCategory::Struct),
-							owner_type_info->sizeInBits(),
-							callExprNode.called_from(),
-							CVQualifier::None,
-							ReferenceQualifier::None);
-					}
-				}
 			}
 		}
 		const bool callee_type_unusable_for_callable =
@@ -622,7 +593,31 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 
 	if (object_expr && std::holds_alternative<IdentifierNode>(*object_expr)) {
 		const IdentifierNode& object_ident = std::get<IdentifierNode>(*object_expr);
-		object_name = object_ident.name();
+		const StringHandle object_name_handle = object_ident.nameHandle().isValid()
+			? object_ident.nameHandle()
+			: StringTable::getOrInternStringHandle(object_ident.name());
+		const bool is_explicit_lambda_capture =
+			object_ident.binding() == IdentifierBinding::CapturedByValue ||
+			object_ident.binding() == IdentifierBinding::CapturedByRef;
+		const bool is_implicit_lambda_capture =
+			!is_explicit_lambda_capture &&
+			current_lambda_context_.isActive() &&
+			current_lambda_context_.captures.find(object_name_handle) != current_lambda_context_.captures.end();
+		const bool object_is_lambda_capture =
+			is_explicit_lambda_capture ||
+			is_implicit_lambda_capture;
+		if (!object_is_lambda_capture) {
+			object_name = object_ident.name();
+		} else {
+			auto capture_type_it = current_lambda_context_.capture_types.find(object_name_handle);
+			if (capture_type_it != current_lambda_context_.capture_types.end()) {
+				if (auto resolved_capture_type = normalizeResolvedStructType(capture_type_it->second); resolved_capture_type.has_value()) {
+					object_type = *resolved_capture_type;
+				} else {
+					object_type = capture_type_it->second;
+				}
+			}
+		}
 
 		if (object_name == "this" &&
 			current_lambda_context_.isActive() &&
@@ -2000,13 +1995,38 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		ValueStorage this_arg_storage = ValueStorage::ContainsData;
 		bool object_is_pointer_like = object_type.pointer_depth() > 0 || object_type.is_reference() || object_type.is_rvalue_reference();
 		bool object_is_lambda_captured_this = false;
+		bool object_is_lambda_capture = false;
+		bool object_is_lambda_capture_by_reference = false;
 		if (object_expr && std::holds_alternative<IdentifierNode>(*object_expr)) {
 			const IdentifierNode& object_ident = std::get<IdentifierNode>(*object_expr);
+			const StringHandle object_name_handle = object_ident.nameHandle().isValid()
+				? object_ident.nameHandle()
+				: StringTable::getOrInternStringHandle(object_ident.name());
 			object_is_lambda_captured_this =
 				object_ident.name() == "this" &&
 				current_lambda_context_.isActive() &&
 				current_lambda_context_.enclosing_struct_type_index.is_valid() &&
 				(current_lambda_context_.has_this_pointer || current_lambda_context_.has_copy_this);
+			const bool is_explicit_lambda_capture =
+				object_ident.binding() == IdentifierBinding::CapturedByValue ||
+				object_ident.binding() == IdentifierBinding::CapturedByRef;
+			const bool is_implicit_lambda_capture =
+				!is_explicit_lambda_capture &&
+				current_lambda_context_.isActive() &&
+				current_lambda_context_.captures.find(object_name_handle) != current_lambda_context_.captures.end();
+			object_is_lambda_capture =
+				!object_is_lambda_captured_this &&
+				(is_explicit_lambda_capture || is_implicit_lambda_capture);
+			if (object_is_lambda_capture) {
+				object_is_lambda_capture_by_reference =
+					object_ident.binding() == IdentifierBinding::CapturedByRef;
+				if (!object_is_lambda_capture_by_reference && is_implicit_lambda_capture) {
+					auto capture_kind_it = current_lambda_context_.capture_kinds.find(object_name_handle);
+					object_is_lambda_capture_by_reference =
+						capture_kind_it != current_lambda_context_.capture_kinds.end() &&
+						capture_kind_it->second == LambdaCaptureNode::CaptureKind::ByReference;
+				}
+			}
 		}
 		if (object_is_lambda_captured_this) {
 			if (current_lambda_context_.has_copy_this) {
@@ -2032,6 +2052,55 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					throw InternalError("Lambda [this] member-call receiver could not load captured object pointer");
 				}
 				this_arg_value = IrValue(*this_ptr);
+				this_arg_is_pointer_value = true;
+				this_arg_storage = ValueStorage::ContainsAddress;
+			}
+		} else if (object_is_lambda_capture && object_expr &&
+				   std::holds_alternative<IdentifierNode>(*object_expr)) {
+			const IdentifierNode& object_ident = std::get<IdentifierNode>(*object_expr);
+			const StringHandle object_name_handle = object_ident.nameHandle().isValid()
+				? object_ident.nameHandle()
+				: StringTable::getOrInternStringHandle(object_ident.name());
+			auto closure_type_it = getTypesByNameMap().find(current_lambda_context_.closure_type);
+			if (closure_type_it == getTypesByNameMap().end() || !closure_type_it->second->isStruct()) {
+				throw InternalError("Lambda capture receiver missing closure type info");
+			}
+			const auto capture_result = FlashCpp::gLazyMemberResolver.resolve(
+				closure_type_it->second->type_index_,
+				object_name_handle);
+			if (!capture_result || capture_result.member == nullptr) {
+				throw InternalError("Lambda capture receiver missing closure member");
+			}
+
+			if (object_is_lambda_capture_by_reference) {
+				TempVar capture_ptr_temp = var_counter.next();
+				MemberLoadOp member_load;
+				member_load.result.value = capture_ptr_temp;
+				member_load.result.setType(capture_result.member->type_index.category());
+				member_load.result.size_in_bits = SizeInBits{64};
+				member_load.object = StringTable::getOrInternStringHandle("this"sv);
+				member_load.member_name = capture_result.member->getName();
+				member_load.offset = static_cast<int>(capture_result.adjusted_offset);
+				member_load.ref_qualifier = capture_result.member->is_rvalue_reference()
+					? CVReferenceQualifier::RValueReference
+					: capture_result.member->is_reference()
+						? CVReferenceQualifier::LValueReference
+						: CVReferenceQualifier::None;
+				member_load.struct_type_info = nullptr;
+				ir_.addInstruction(IrInstruction(IrOpcode::MemberAccess, std::move(member_load), callExprNode.called_from()));
+				this_arg_value = IrValue(capture_ptr_temp);
+				this_arg_is_pointer_value = true;
+				this_arg_storage = ValueStorage::ContainsAddress;
+			} else {
+				TempVar capture_addr_temp = var_counter.next();
+				AddressOfMemberOp addr_op;
+				addr_op.result = capture_addr_temp;
+				addr_op.base_object = StringTable::getOrInternStringHandle("this"sv);
+				addr_op.member_offset = static_cast<int>(capture_result.adjusted_offset);
+				addr_op.member_type_index = object_type.type_index();
+				addr_op.member_size_in_bits = static_cast<int>(object_type.size_in_bits());
+				ir_.addInstruction(IrInstruction(IrOpcode::AddressOfMember, std::move(addr_op), callExprNode.called_from()));
+				this_arg_value = IrValue(capture_addr_temp);
 				this_arg_is_pointer_value = true;
 				this_arg_storage = ValueStorage::ContainsAddress;
 			}

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -89,7 +89,16 @@ LambdaInfo AstToIr::collectLambdaForDeferredGeneration(const LambdaExpressionNod
 		std::optional<ASTNode> var_symbol = symbol_table.lookup(var_name);
 
 		if (var_symbol.has_value()) {
-			info.captured_var_decls.push_back(*var_symbol);
+			if (std::optional<TypeSpecifierNode> deduced_lambda_closure_type =
+					deduceLambdaClosureType(*var_symbol, capture.identifier_token());
+				deduced_lambda_closure_type.has_value()) {
+				ASTNode deduced_type_node = ASTNode::emplace_node<TypeSpecifierNode>(*deduced_lambda_closure_type);
+				DeclarationNode& synthetic_decl =
+					gChunkedAnyStorage.emplace_back<DeclarationNode>(deduced_type_node, capture.identifier_token());
+				info.captured_var_decls.push_back(ASTNode::emplace_node<DeclarationNode>(synthetic_decl));
+			} else {
+				info.captured_var_decls.push_back(*var_symbol);
+			}
 		} else if (current_lambda_context_.isActive()) {
 			StringHandle var_name_handle = StringTable::getOrInternStringHandle(var_name);
 			auto capture_type_it = current_lambda_context_.capture_types.find(var_name_handle);
@@ -176,7 +185,91 @@ ExprResult AstToIr::generateLambdaExpressionIr(const LambdaExpressionNode& lambd
 		return makeExprResult(nativeTypeIndex(TypeCategory::Int), SizeInBits{32}, IrOperand{dummy}, PointerDepth{}, ValueStorage::ContainsData);
 	}
 
-	const TypeInfo* closure_type = type_it->second;
+	TypeInfo* closure_type = type_it->second;
+	StructTypeInfo* closure_struct_info = closure_type != nullptr ? closure_type->getStructInfo() : nullptr;
+
+	// Generic lambda instantiation can materialize concrete capture types after the
+	// closure was first registered with dependent placeholder member sizes.
+	// Backfill any unresolved by-value capture member shape before emitting stores.
+	if (closure_struct_info != nullptr) {
+		bool layout_changed = false;
+		size_t capture_decl_index = 0;
+		for (const auto& capture : lambda_info.captures) {
+			if (capture.is_capture_all() ||
+				capture.kind() == LambdaCaptureNode::CaptureKind::This ||
+				capture.kind() == LambdaCaptureNode::CaptureKind::CopyThis ||
+				capture.has_initializer()) {
+				continue;
+			}
+
+			if (capture_decl_index >= lambda_info.captured_var_decls.size()) {
+				break;
+			}
+
+			const DeclarationNode* capture_decl = get_decl_from_symbol(lambda_info.captured_var_decls[capture_decl_index]);
+			capture_decl_index++;
+			if (capture_decl == nullptr || capture.kind() == LambdaCaptureNode::CaptureKind::ByReference) {
+				continue;
+			}
+
+			const StringHandle capture_name = StringTable::getOrInternStringHandle(capture.identifier_name());
+			StructMember* capture_member = nullptr;
+			for (auto& member : closure_struct_info->members) {
+				if (member.getName() == capture_name) {
+					capture_member = &member;
+					break;
+				}
+			}
+			if (capture_member == nullptr || capture_member->size != 0) {
+				continue;
+			}
+
+			const TypeSpecifierNode& capture_type = capture_decl->type_specifier_node();
+			size_t resolved_size = capture_type.size_in_bits() / 8;
+			size_t resolved_alignment = resolved_size > 0
+										 ? get_type_alignment(capture_type.type(), resolved_size)
+										 : 1;
+			if (capture_type.type_index().is_valid()) {
+				if (const TypeInfo* capture_type_info = tryGetTypeInfo(capture_type.type_index())) {
+					if (resolved_size == 0 && capture_type_info->hasStoredSize()) {
+						resolved_size = toSizeT(capture_type_info->sizeInBytes());
+					}
+					if (const StructTypeInfo* capture_struct_info = capture_type_info->getStructInfo()) {
+						if (resolved_size == 0) {
+							resolved_size = toSizeT(capture_struct_info->sizeInBytes());
+						}
+						if (capture_struct_info->alignment > 0) {
+							resolved_alignment = capture_struct_info->alignment;
+						}
+					}
+				}
+			}
+			if (resolved_size == 0 && is_builtin_type(capture_type.type())) {
+				resolved_size = get_type_size_bits(capture_type.type()) / 8;
+			}
+			if (resolved_size == 0) {
+				continue;
+			}
+			if (resolved_alignment == 0) {
+				resolved_alignment = 1;
+			}
+
+			capture_member->size = resolved_size;
+			capture_member->alignment = resolved_alignment;
+			capture_member->referenced_size_bits = std::max(capture_member->referenced_size_bits, resolved_size * 8);
+			if (capture_member->type_index.category() == TypeCategory::Invalid) {
+				TypeIndex resolved_member_type_index = capture_type.type_index();
+				if (!resolved_member_type_index.is_valid()) {
+					resolved_member_type_index = nativeTypeIndex(capture_type.type());
+				}
+				capture_member->type_index = resolved_member_type_index.withCategory(capture_type.type());
+			}
+			layout_changed = true;
+		}
+		if (layout_changed) {
+			closure_struct_info->recalculateLayout();
+		}
+	}
 
 	// Use target variable name if provided, otherwise create a temporary closure variable
 	std::string_view closure_var_name;

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -2,6 +2,7 @@
 
 #include "AstNodeTypes_DeclNodes.h"
 #include "InlineVector.h"
+#include <algorithm>
 #include <ranges>
 #include <span>
 
@@ -62,9 +63,7 @@ ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
 		if (current_struct_info == nullptr) {
 			return;
 		}
-		if (std::ranges::any_of(visited, [current_struct_info](const StructTypeInfo* existing) {
-				return existing == current_struct_info;
-			})) {
+		if (std::ranges::find(visited, current_struct_info) != visited.end()) {
 			return;
 		}
 		visited.push_back(current_struct_info);

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "AstNodeTypes_DeclNodes.h"
+#include "InlineVector.h"
+#include <ranges>
+#include <span>
+#include <unordered_set>
+
+struct ConstAwareMemberCandidateSet {
+	InlineVector<const StructMemberFunction*, 8> preferred;
+	InlineVector<const StructMemberFunction*, 8> compatible;
+};
+
+inline void appendUniqueMemberFunctionCandidate(
+	InlineVector<const StructMemberFunction*, 8>& target,
+	const StructMemberFunction* candidate) {
+	if (candidate == nullptr) {
+		return;
+	}
+	if (std::ranges::none_of(target, [&](const StructMemberFunction* existing) {
+		return existing == candidate;
+	})) {
+		target.push_back(candidate);
+	}
+}
+
+inline bool sameMemberCandidateSet(
+	std::span<const StructMemberFunction* const> lhs,
+	std::span<const StructMemberFunction* const> rhs) {
+	return std::ranges::equal(lhs, rhs);
+}
+
+inline void appendUniqueMemberFunctionOverloadNodes(
+	InlineVector<ASTNode, 8>& target,
+	std::span<const StructMemberFunction* const> members) {
+	for (const StructMemberFunction* member : members) {
+		if (member == nullptr) {
+			continue;
+		}
+		const ASTNode& function_decl = member->function_decl;
+		if (std::ranges::none_of(target, [&](const ASTNode& existing) {
+			return existing.raw_pointer() == function_decl.raw_pointer();
+		})) {
+			target.push_back(function_decl);
+		}
+	}
+}
+
+template <typename AcceptFn>
+ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
+	const StructTypeInfo* root_struct_info,
+	StringHandle member_name_handle,
+	bool receiver_is_const,
+	bool stop_at_first_local_name_set,
+	AcceptFn&& accept_candidate) {
+	ConstAwareMemberCandidateSet result;
+	if (root_struct_info == nullptr) {
+		return result;
+	}
+
+	std::unordered_set<const StructTypeInfo*> visited;
+	auto recurse = [&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
+		if (current_struct_info == nullptr ||
+			!visited.insert(current_struct_info).second) {
+			return;
+		}
+
+		bool found_local_overload = false;
+		for (const auto& member_func : current_struct_info->member_functions) {
+			if (member_func.is_constructor ||
+				member_func.is_destructor ||
+				member_func.getName() != member_name_handle ||
+				!member_func.function_decl.is<FunctionDeclarationNode>()) {
+				continue;
+			}
+
+			const auto& func_decl =
+				member_func.function_decl.as<FunctionDeclarationNode>();
+			if (!accept_candidate(member_func, func_decl)) {
+				continue;
+			}
+
+			found_local_overload = true;
+			if (func_decl.is_static()) {
+				appendUniqueMemberFunctionCandidate(result.preferred, &member_func);
+				appendUniqueMemberFunctionCandidate(result.compatible, &member_func);
+				continue;
+			}
+			if (receiver_is_const) {
+				if (!func_decl.is_const_member_function()) {
+					continue;
+				}
+				appendUniqueMemberFunctionCandidate(result.preferred, &member_func);
+				appendUniqueMemberFunctionCandidate(result.compatible, &member_func);
+				continue;
+			}
+
+			appendUniqueMemberFunctionCandidate(result.compatible, &member_func);
+			if (!func_decl.is_const_member_function()) {
+				appendUniqueMemberFunctionCandidate(result.preferred, &member_func);
+			}
+		}
+
+		if (found_local_overload && stop_at_first_local_name_set) {
+			return;
+		}
+
+		for (const auto& base_spec : current_struct_info->base_classes) {
+			if (const StructTypeInfo* base_struct =
+					tryGetStructTypeInfo(base_spec.type_index)) {
+				self(base_struct, self);
+			}
+		}
+	};
+
+	recurse(root_struct_info, recurse);
+	return result;
+}

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -4,7 +4,6 @@
 #include "InlineVector.h"
 #include <ranges>
 #include <span>
-#include <unordered_set>
 
 struct ConstAwareMemberCandidateSet {
 	InlineVector<const StructMemberFunction*, 8> preferred;
@@ -58,12 +57,17 @@ ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
 		return result;
 	}
 
-	std::unordered_set<const StructTypeInfo*> visited;
+	InlineVector<const StructTypeInfo*, 8> visited;
 	auto recurse = [&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
-		if (current_struct_info == nullptr ||
-			!visited.insert(current_struct_info).second) {
+		if (current_struct_info == nullptr) {
 			return;
 		}
+		if (std::ranges::any_of(visited, [current_struct_info](const StructTypeInfo* existing) {
+				return existing == current_struct_info;
+			})) {
+			return;
+		}
+		visited.push_back(current_struct_info);
 
 		bool found_local_overload = false;
 		for (const auto& member_func : current_struct_info->member_functions) {

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -1314,8 +1314,27 @@ ParseResult Parser::parse_lambda_expression() {
 				member_alignment = 8;
 			} else {
 				// By-value capture: store the actual value
-				member_size = var_type.size_in_bits() / 8;
-				member_alignment = member_size;	// Simple alignment = size
+				MemberSizeAndAlignment member_layout =
+					calculateResolvedMemberSizeAndAlignment(var_type, var_type.type_index());
+				member_size = member_layout.size;
+				member_alignment = member_layout.alignment;
+				if (member_size == 0 && var_type.type_index().is_valid()) {
+					if (const TypeInfo* captured_type_info = tryGetTypeInfo(var_type.type_index());
+						captured_type_info != nullptr) {
+						if (const StructTypeInfo* captured_struct_info = captured_type_info->getStructInfo()) {
+							const size_t struct_size = toSizeT(captured_struct_info->sizeInBytes());
+							if (struct_size > 0) {
+								member_size = struct_size;
+								member_alignment = captured_struct_info->alignment > 0
+									? captured_struct_info->alignment
+									: 1;
+							}
+						}
+					}
+				}
+				if (member_alignment == 0) {
+					member_alignment = member_size > 0 ? member_size : 1;
+				}
 			}
 
 			// Resolve type category and type index from the captured variable's type.

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -15,6 +15,7 @@
 #include "Parser_FunctionTypeHelpers.h"
 #include "ParserInternal.h"
 #include "NameMangling.h"
+#include "MemberFunctionLookupShared.h"
 #include <algorithm>
 #include <limits>
 
@@ -26,12 +27,101 @@ void requireParserSemanticServicesAttachment(const SemanticAnalysis& sema, const
 	}
 }
 
+const FunctionDeclarationNode* getCallTargetFunctionCandidate(const ASTNode& overload);
+
 bool isFunctionCandidateViableForArgCount(const FunctionDeclarationNode& candidate, size_t argument_count) {
 	const size_t min_required = countMinRequiredArgs(candidate);
 	const size_t max_accepted = candidate.is_variadic()
 		? std::numeric_limits<size_t>::max()
 		: candidate.parameter_nodes().size();
 	return argument_count >= min_required && argument_count <= max_accepted;
+}
+
+template <typename OverloadContainer>
+void appendUniqueOverload(OverloadContainer& target, const ASTNode& candidate) {
+	if (std::ranges::none_of(target, [&](const ASTNode& existing) {
+		return existing.raw_pointer() == candidate.raw_pointer();
+	})) {
+		target.push_back(candidate);
+	}
+}
+
+template <typename OverloadContainer>
+void appendUniqueOverloads(OverloadContainer& target, std::span<const ASTNode> source) {
+	for (const ASTNode& candidate : source) {
+		appendUniqueOverload(target, candidate);
+	}
+}
+
+bool sameOverloadSet(std::span<const ASTNode> lhs, std::span<const ASTNode> rhs) {
+	auto rawPointer = [](const ASTNode& node) { return node.raw_pointer(); };
+	return std::ranges::equal(
+		lhs,
+		rhs,
+		{},
+		rawPointer,
+		rawPointer);
+}
+
+template <typename OverloadContainer>
+void partitionMemberOverloadsByReceiverConstness(
+	std::span<const ASTNode> member_overloads,
+	bool receiver_is_const,
+	OverloadContainer& preferred_member_overloads,
+	OverloadContainer& compatible_member_overloads) {
+	preferred_member_overloads.clear();
+	compatible_member_overloads.clear();
+	preferred_member_overloads.reserve(member_overloads.size());
+	compatible_member_overloads.reserve(member_overloads.size());
+
+	for (const ASTNode& candidate_node : member_overloads) {
+		const FunctionDeclarationNode* candidate =
+			getCallTargetFunctionCandidate(candidate_node);
+		if (candidate == nullptr) {
+			continue;
+		}
+		if (candidate->is_static()) {
+			appendUniqueOverload(preferred_member_overloads, candidate_node);
+			appendUniqueOverload(compatible_member_overloads, candidate_node);
+			continue;
+		}
+		if (receiver_is_const) {
+			if (!candidate->is_const_member_function()) {
+				continue;
+			}
+			appendUniqueOverload(preferred_member_overloads, candidate_node);
+			appendUniqueOverload(compatible_member_overloads, candidate_node);
+			continue;
+		}
+		appendUniqueOverload(compatible_member_overloads, candidate_node);
+		if (!candidate->is_const_member_function()) {
+			appendUniqueOverload(preferred_member_overloads, candidate_node);
+		}
+	}
+}
+
+const FunctionDeclarationNode* tryResolveUniqueOverloadByArgTypes(
+	std::span<const ASTNode> overload_set,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool* is_ambiguous_out = nullptr) {
+	if (is_ambiguous_out != nullptr) {
+		*is_ambiguous_out = false;
+	}
+	if (overload_set.empty()) {
+		return nullptr;
+	}
+
+	const OverloadResolutionResult result = resolve_overload(overload_set, arg_types);
+	if (result.is_ambiguous) {
+		if (is_ambiguous_out != nullptr) {
+			*is_ambiguous_out = true;
+		}
+		return nullptr;
+	}
+	if (!result.has_match || result.selected_overload == nullptr) {
+		return nullptr;
+	}
+	return getCallTargetFunctionCandidate(*result.selected_overload);
 }
 
 const DeclarationNode& requireCallDeclaration(const CallInfo& call_info, const char* operation) {
@@ -7168,10 +7258,11 @@ void SemanticAnalysis::tryAnnotateContextualBool(const ASTNode& expr_node) {
 
 // Helper: collect operator candidates of op_kind from current_struct and all reachable
 // base classes, using visited to avoid revisiting in diamond inheritance hierarchies.
+template <typename CandidateContainer>
 static void collectOperatorCandidatesRecursive(
 	const StructTypeInfo* current_struct,
 	OverloadableOperator op_kind,
-	std::vector<ASTNode>& candidates,
+	CandidateContainer& candidates,
 	std::unordered_set<const StructTypeInfo*>& visited) {
 	if (!visited.insert(current_struct).second)
 		return;
@@ -7199,6 +7290,9 @@ static void collectOperatorCandidatesRecursive(
 
 void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info, const void* call_key) {
 	analyzed_op_call_queries_.insert(call_key);
+	const bool normalized_call =
+		call_key != nullptr &&
+		normalized_ast_nodes_.count(call_key) > 0;
 
 	if (call_info.has_receiver)
 		return;
@@ -7225,7 +7319,7 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 
 	const ChunkedVector<ASTNode>& arguments = *call_info.arguments;
 	const size_t arg_count = arguments.size();
-	std::vector<ASTNode> candidates;
+	InlineVector<ASTNode, 8> candidates;
 	std::unordered_set<const StructTypeInfo*> visited;
 	collectOperatorCandidatesRecursive(struct_info, OverloadableOperator::Call, candidates, visited);
 	if (candidates.empty())
@@ -7253,6 +7347,11 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 		}
 		if (result.is_ambiguous) {
 			explicitly_ambiguous = true;
+		}
+	}
+	if (normalized_call || explicitly_ambiguous) {
+		if (!best_match) {
+			return;
 		}
 	}
 
@@ -7359,31 +7458,61 @@ void SemanticAnalysis::tryResolveSubscriptOperator(const ArraySubscriptNode& sub
 
 	// Collect all operator[] candidates from this struct and its base classes.
 	// Use a visited set to avoid collecting duplicate candidates in diamond inheritance.
-	std::vector<ASTNode> candidates;
+	InlineVector<ASTNode, 8> candidates;
 	std::unordered_set<const StructTypeInfo*> visited;
 	collectOperatorCandidatesRecursive(struct_info, OverloadableOperator::Subscript, candidates, visited);
 
 	if (candidates.empty())
 		return;
 
-	// Try overload resolution with the index argument type.
-	const CanonicalTypeId index_type_id = inferExpressionType(subscript_node.index_expr());
+	const std::optional<TypeSpecifierNode> receiver_arg_type =
+		getOverloadResolutionArgType(subscript_node.array_expr());
+	const bool receiver_is_const =
+		receiver_arg_type.has_value() && receiver_arg_type->is_const();
+	InlineVector<ASTNode, 8> preferred_candidates;
+	InlineVector<ASTNode, 8> compatible_candidates;
+	partitionMemberOverloadsByReceiverConstness(
+		candidates,
+		receiver_is_const,
+		preferred_candidates,
+		compatible_candidates);
+
+	// Try overload resolution with the sema-owned index argument type so
+	// subscript overloads see the same lvalue/rvalue-sensitive argument view as
+	// ordinary member-call resolution.
+	const std::optional<TypeSpecifierNode> index_arg_type =
+		getOverloadResolutionArgType(subscript_node.index_expr());
 	const FunctionDeclarationNode* best_match = nullptr;
 	bool explicitly_ambiguous = false;
 
-	if (index_type_id) {
-		const TypeSpecifierNode index_type_spec = materializeTypeSpecifier(type_context_.get(index_type_id));
-		std::vector<TypeSpecifierNode> arg_types = {index_type_spec};
-		const OverloadResolutionResult result = resolve_overload(candidates, arg_types);
-		if (result.has_match && !result.is_ambiguous)
-			best_match = &result.selected_overload->as<FunctionDeclarationNode>();
-		if (result.is_ambiguous)
-			explicitly_ambiguous = true;
+	if (index_arg_type.has_value()) {
+		TypeSpecifierNode arg_type = *index_arg_type;
+		std::span<const TypeSpecifierNode> arg_types(&arg_type, 1);
+		bool preferred_ambiguous = false;
+		best_match = tryResolveUniqueOverloadByArgTypes(
+			preferred_candidates,
+			arg_types,
+			&preferred_ambiguous);
+		explicitly_ambiguous = preferred_ambiguous;
+
+		if (!best_match &&
+			!explicitly_ambiguous &&
+			!sameOverloadSet(preferred_candidates, compatible_candidates)) {
+			bool compatible_ambiguous = false;
+			best_match = tryResolveUniqueOverloadByArgTypes(
+				compatible_candidates,
+				arg_types,
+				&compatible_ambiguous);
+			explicitly_ambiguous = compatible_ambiguous;
+		}
 	}
 
 	if (!best_match && !explicitly_ambiguous) {
-		// Fallback: arity-based selection (single param matching).
-		for (const auto& candidate_node : candidates) {
+		// Preserve the legacy arity recovery only after receiver-const filtering
+		// so `const` objects cannot silently bind non-const member subscripts.
+		InlineVector<ASTNode, 8> ordered_candidates = preferred_candidates;
+		appendUniqueOverloads(ordered_candidates, compatible_candidates);
+		for (const auto& candidate_node : ordered_candidates) {
 			const auto& candidate = candidate_node.as<FunctionDeclarationNode>();
 			if (candidate.parameter_nodes().size() == 1) {
 				best_match = &candidate;
@@ -7595,19 +7724,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 																				const void* call_key) {
 	const ChunkedVector<ASTNode>& arguments = *call_info.arguments;
 	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "resolveCallArgAnnotationTarget");
-	auto appendUniqueOverload = [](std::vector<ASTNode>& target, const ASTNode& candidate) {
-		auto it = std::find_if(target.begin(), target.end(), [&](const ASTNode& existing) {
-			return existing.raw_pointer() == candidate.raw_pointer();
-		});
-		if (it == target.end()) {
-			target.push_back(candidate);
-		}
-	};
-	auto appendUniqueOverloads = [&](std::vector<ASTNode>& target, std::span<const ASTNode> source) {
-		for (const ASTNode& candidate : source) {
-			appendUniqueOverload(target, candidate);
-		}
-	};
+	const bool normalized_call =
+		call_key != nullptr &&
+		normalized_ast_nodes_.count(call_key) > 0;
 	auto lookupFunctionByMangledName = [&](StringHandle mangled_name) -> const FunctionDeclarationNode* {
 		if (!mangled_name.isValid()) {
 			return nullptr;
@@ -7789,66 +7908,28 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		if (const StructTypeInfo* receiver_struct_info = resolveReceiverStructInfo()) {
 			const StringHandle member_name_handle =
 				callee_decl.identifier_token().handle();
-			std::vector<ASTNode> member_overloads;
-			auto collectVisibleMemberOverloads =
-				[&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
-				if (!current_struct_info) {
-					return;
-				}
-				bool has_local_overload = false;
-				for (const auto& member_func : current_struct_info->member_functions) {
-					if (member_func.is_constructor ||
-						member_func.is_destructor ||
-						member_func.getName() != member_name_handle ||
-						!member_func.function_decl.is<FunctionDeclarationNode>()) {
-						continue;
-					}
-					appendUniqueOverload(member_overloads, member_func.function_decl);
-					has_local_overload = true;
-				}
-				if (has_local_overload) {
-					return;
-				}
-				for (const auto& base_spec : current_struct_info->base_classes) {
-					if (const StructTypeInfo* base_struct = tryGetStructTypeInfo(base_spec.type_index)) {
-						self(base_struct, self);
-					}
-				}
-			};
-			collectVisibleMemberOverloads(receiver_struct_info, collectVisibleMemberOverloads);
-			if (!member_overloads.empty()) {
-				const std::optional<TypeSpecifierNode> receiver_arg_type =
-					buildOverloadResolutionArgType(call_info.receiver, nullptr);
-				const bool receiver_is_const =
-					receiver_arg_type.has_value() && receiver_arg_type->is_const();
-				std::vector<ASTNode> preferred_member_overloads;
-				std::vector<ASTNode> compatible_member_overloads;
-				preferred_member_overloads.reserve(member_overloads.size());
-				compatible_member_overloads.reserve(member_overloads.size());
-				for (const ASTNode& candidate_node : member_overloads) {
-					const FunctionDeclarationNode* candidate =
-						getCallTargetFunctionCandidate(candidate_node);
-					if (candidate == nullptr) {
-						continue;
-					}
-					if (candidate->is_static()) {
-						appendUniqueOverload(preferred_member_overloads, candidate_node);
-						appendUniqueOverload(compatible_member_overloads, candidate_node);
-						continue;
-					}
-					if (receiver_is_const) {
-						if (!candidate->is_const_member_function()) {
-							continue;
-						}
-						appendUniqueOverload(preferred_member_overloads, candidate_node);
-						appendUniqueOverload(compatible_member_overloads, candidate_node);
-						continue;
-					}
-					appendUniqueOverload(compatible_member_overloads, candidate_node);
-					if (!candidate->is_const_member_function()) {
-						appendUniqueOverload(preferred_member_overloads, candidate_node);
-					}
-				}
+			const std::optional<TypeSpecifierNode> receiver_arg_type =
+				buildOverloadResolutionArgType(call_info.receiver, nullptr);
+			const bool receiver_is_const =
+				receiver_arg_type.has_value() && receiver_arg_type->is_const();
+			const ConstAwareMemberCandidateSet member_candidates =
+				collectConstAwareVisibleMemberFunctionCandidates(
+					receiver_struct_info,
+					member_name_handle,
+					receiver_is_const,
+					true,
+					[](const StructMemberFunction&, const FunctionDeclarationNode&) {
+						return true;
+					});
+			if (!member_candidates.compatible.empty()) {
+				InlineVector<ASTNode, 8> preferred_member_overloads;
+				InlineVector<ASTNode, 8> compatible_member_overloads;
+				appendUniqueMemberFunctionOverloadNodes(
+					preferred_member_overloads,
+					member_candidates.preferred);
+				appendUniqueMemberFunctionOverloadNodes(
+					compatible_member_overloads,
+					member_candidates.compatible);
 				InlineVector<TypeSpecifierNode, 6> member_arg_types;
 				const bool has_member_arg_types =
 					tryCollectOverloadResolutionArgTypes(arguments, member_arg_types);
@@ -7857,26 +7938,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 						if (overload_set.empty() || !has_member_arg_types) {
 							return nullptr;
 						}
-						const OverloadResolutionResult result =
-							resolve_overload(overload_set, member_arg_types);
-						if (!result.has_match ||
-							result.is_ambiguous ||
-							result.selected_overload == nullptr) {
-							return nullptr;
-						}
-						return getCallTargetFunctionCandidate(*result.selected_overload);
-					};
-				auto sameOverloadSet =
-					[](std::span<const ASTNode> lhs, std::span<const ASTNode> rhs) -> bool {
-						if (lhs.size() != rhs.size()) {
-							return false;
-						}
-						for (size_t i = 0; i < lhs.size(); ++i) {
-							if (lhs[i].raw_pointer() != rhs[i].raw_pointer()) {
-								return false;
-							}
-						}
-						return true;
+						return tryResolveUniqueOverloadByArgTypes(overload_set, member_arg_types);
 					};
 				if (const FunctionDeclarationNode* resolved_candidate =
 						tryResolveMemberOverloadSet(preferred_member_overloads);
@@ -7890,7 +7952,11 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 						return resolved_candidate;
 					}
 				}
-				std::vector<ASTNode> ordered_member_overloads = preferred_member_overloads;
+				if (normalized_call) {
+					return nullptr;
+				}
+				InlineVector<ASTNode, 8> ordered_member_overloads =
+					preferred_member_overloads;
 				appendUniqueOverloads(ordered_member_overloads, compatible_member_overloads);
 				if (call_info.function_declaration) {
 					for (const ASTNode& candidate_node : ordered_member_overloads) {
@@ -7921,13 +7987,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				}
 			}
 		}
-		if (call_info.function_declaration) {
+		if (!normalized_call && call_info.function_declaration) {
 			return call_info.function_declaration;
 		}
 
 		return nullptr;
 	}
-	if (call_info.function_declaration) {
+	if (!normalized_call && call_info.function_declaration) {
 		return call_info.function_declaration;
 	}
 
@@ -7941,12 +8007,15 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (func_decl)
 		return func_decl;
 
-	if (const FunctionDeclarationNode* mangled_candidate =
-			lookupFunctionByMangledName(call_info.mangled_name)) {
-		return mangled_candidate;
+	if (!normalized_call) {
+		if (const FunctionDeclarationNode* mangled_candidate =
+				lookupFunctionByMangledName(call_info.mangled_name)) {
+			return mangled_candidate;
+		}
 	}
 
-	if (!call_info.has_receiver &&
+	if (!normalized_call &&
+		!call_info.has_receiver &&
 		call_info.dependent_unqualified_lookup_record != nullptr &&
 		call_info.dependent_unqualified_lookup_record->has_value()) {
 		const DependentUnqualifiedCallLookupRecord& dependent_record =
@@ -7979,13 +8048,15 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 
-	if (const FunctionDeclarationNode* definition_record_target =
-			resolveDefinitionLookupRecordTarget();
-		definition_record_target != nullptr) {
-		return definition_record_target;
+	if (!normalized_call) {
+		if (const FunctionDeclarationNode* definition_record_target =
+				resolveDefinitionLookupRecordTarget();
+			definition_record_target != nullptr) {
+			return definition_record_target;
+		}
 	}
 
-	if (call_info.function_declaration)
+	if (!normalized_call && call_info.function_declaration)
 		return call_info.function_declaration;
 
 	const DeclarationNode& decl = callee_decl;
@@ -8046,6 +8117,12 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				return resolved_candidate;
 			}
 		}
+	}
+	if (normalized_call) {
+		if (!call_info.is_indirect) {
+			++stats_.direct_call_unresolved_after_overload;
+		}
+		return nullptr;
 	}
 
 	for (const auto& overload : overloads) {
@@ -8243,12 +8320,11 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 											   ? call_info.qualified_name.view()
 											   : callee_decl.identifier_token().value();
 		if (!call_info.is_indirect && normalized_call_expr) {
-			throw InternalError(std::string(
-				StringBuilder()
-					.append("Phase 1: sema-normalized direct call missing resolved target for '")
-					.append(call_name)
-					.append("'")
-					.commit()));
+			FLASH_LOG_FORMAT(
+				General,
+				Debug,
+				"Phase 1 compatibility fallback: sema-normalized direct call has no resolved target for '{}'",
+				call_name);
 		}
 		for (const ASTNode& arg : *call_info.arguments) {
 			buildOverloadResolutionArgType(arg, nullptr);

--- a/tests/test_constexpr_member_call_const_nonconst_collector_ret0.cpp
+++ b/tests/test_constexpr_member_call_const_nonconst_collector_ret0.cpp
@@ -1,0 +1,39 @@
+template <typename T>
+struct ReceiverSelector {
+	constexpr ReceiverSelector() = default;
+
+	constexpr int selected() {
+		return value();
+	}
+
+	constexpr int selected() const {
+		return value();
+	}
+
+	constexpr int value() {
+		return 1;
+	}
+
+	constexpr int value() const {
+		return 2;
+	}
+};
+
+static_assert(ReceiverSelector<int>{}.selected() == 1);
+
+constexpr ReceiverSelector<int> const_selector{};
+static_assert(const_selector.selected() == 2);
+
+int main() {
+	ReceiverSelector<int> selector;
+	if (selector.selected() != 1) {
+		return 1;
+	}
+
+	const ReceiverSelector<int> const_runtime_selector{};
+	if (const_runtime_selector.selected() != 2) {
+		return 2;
+	}
+
+	return 0;
+}

--- a/tests/test_constexpr_template_member_same_arity_overload_binding_ret0.cpp
+++ b/tests/test_constexpr_template_member_same_arity_overload_binding_ret0.cpp
@@ -1,0 +1,27 @@
+template <typename T>
+struct OverloadClone {
+	constexpr int pick(int) const {
+		return 10;
+	}
+
+	constexpr int pick(long) const {
+		return 20;
+	}
+
+	constexpr int eval() const {
+		return pick(T{});
+	}
+};
+
+static_assert(OverloadClone<int>{}.eval() == 10);
+static_assert(OverloadClone<long>{}.eval() == 20);
+
+int main() {
+	if (OverloadClone<int>{}.eval() != 10) {
+		return 1;
+	}
+	if (OverloadClone<long>{}.eval() != 20) {
+		return 2;
+	}
+	return 0;
+}

--- a/tests/test_constexpr_virtual_dispatch_nonoverriding_same_arity_ret0.cpp
+++ b/tests/test_constexpr_virtual_dispatch_nonoverriding_same_arity_ret0.cpp
@@ -1,0 +1,25 @@
+struct BaseDispatch {
+	virtual constexpr int value(int) const {
+		return 1;
+	}
+};
+
+struct DerivedDispatch : BaseDispatch {
+	constexpr int value(int) const override {
+		return 42;
+	}
+
+	constexpr int value(long) const {
+		return 7;
+	}
+};
+
+constexpr int callBase(const BaseDispatch& base) {
+	return base.value(0);
+}
+
+static_assert(callBase(DerivedDispatch{}) == 42);
+
+int main() {
+	return callBase(DerivedDispatch{}) == 42 ? 0 : 1;
+}

--- a/tests/test_generic_lambda_callable_nested_clone_ret0.cpp
+++ b/tests/test_generic_lambda_callable_nested_clone_ret0.cpp
@@ -1,0 +1,18 @@
+struct Adder {
+	int bias;
+
+	constexpr int operator()(int value) const {
+		return bias + value;
+	}
+};
+
+int main() {
+	auto outer = []<typename Callable>(Callable callable, int value) {
+		auto inner = [=]() {
+			return callable(value);
+		};
+		return inner();
+	};
+
+	return outer(Adder{2}, 40) == 42 ? 0 : 1;
+}

--- a/tests/test_operator_call_sema_receiver_and_arg_overload_ret0.cpp
+++ b/tests/test_operator_call_sema_receiver_and_arg_overload_ret0.cpp
@@ -1,0 +1,46 @@
+struct ReceiverSensitiveCallable {
+	int operator()(int value) {
+		return value + 1;
+	}
+
+	int operator()(int value) const {
+		return value + 10;
+	}
+};
+
+struct ArgSensitiveCallable {
+	int operator()(int& value) const {
+		return value + 100;
+	}
+
+	int operator()(int&& value) const {
+		return value + 200;
+	}
+};
+
+int callConst(const ReceiverSensitiveCallable& callable) {
+	return callable(2);
+}
+
+int main() {
+	ReceiverSensitiveCallable receiver_sensitive;
+	const ReceiverSensitiveCallable const_receiver_sensitive{};
+	ArgSensitiveCallable arg_sensitive;
+
+	int value = 3;
+
+	if (receiver_sensitive(2) != 3) {
+		return 1;
+	}
+	if (callConst(const_receiver_sensitive) != 12) {
+		return 2;
+	}
+	if (arg_sensitive(value) != 103) {
+		return 3;
+	}
+	if (arg_sensitive(4) != 204) {
+		return 4;
+	}
+
+	return 0;
+}

--- a/tests/test_operator_subscript_const_ambiguity_fail.cpp
+++ b/tests/test_operator_subscript_const_ambiguity_fail.cpp
@@ -1,0 +1,18 @@
+struct AmbiguousSubscript {
+	int operator[](long) {
+		return 1;
+	}
+
+	int operator[](unsigned) {
+		return 2;
+	}
+
+	int operator[](short) const {
+		return 3;
+	}
+};
+
+int main() {
+	AmbiguousSubscript subscriptable;
+	return subscriptable[0];
+}

--- a/tests/test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp
+++ b/tests/test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp
@@ -1,0 +1,48 @@
+struct ReceiverSensitiveSubscript {
+	int value;
+
+	int& operator[](int) {
+		return value;
+	}
+
+	int operator[](int) const {
+		return value + 10;
+	}
+};
+
+struct ArgSensitiveSubscript {
+	int operator[](int& index) const {
+		return index + 100;
+	}
+
+	int operator[](int&& index) const {
+		return index + 200;
+	}
+};
+
+int readConst(const ReceiverSensitiveSubscript& subscriptable) {
+	return subscriptable[0];
+}
+
+int main() {
+	ReceiverSensitiveSubscript receiver_sensitive{5};
+	const ReceiverSensitiveSubscript const_receiver_sensitive{7};
+	ArgSensitiveSubscript arg_sensitive;
+
+	int index = 8;
+
+	if (receiver_sensitive[0] != 5) {
+		return 1;
+	}
+	if (readConst(const_receiver_sensitive) != 17) {
+		return 2;
+	}
+	if (arg_sensitive[index] != 108) {
+		return 3;
+	}
+	if (arg_sensitive[9] != 209) {
+		return 4;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Problem
This PR finishes the remaining fallout from the template/member/constexpr/operator() standards-conformance refactor.

The major remaining regressions were:
1. Nested generic lambda callable captures could overlap in closure layout (inner callable/value capture collision), causing incorrect runtime behavior.
2. Some normalized direct-call paths failed too aggressively when sema-owned target metadata was missing, breaking deferred/late-instantiated call scenarios that previously worked.
3. Recursive generic-lambda self-calls in unresolved callable-reference paths could lower with mismatched mangling/qualifiers, leading to wrong symbol resolution and downstream codegen failures.

## Root-cause notes
- The nested callable failure was ultimately a closure member layout issue: a by-value callable capture could remain zero-sized in certain unresolved/deferred paths, so a subsequent capture was placed at the same offset.
- The direct-call failures were boundary/ownership strictness issues after refactor tightening: strict behavior is valid when owned metadata exists, but missing metadata needed explicit compatibility handling rather than hard failure.
- The recursive lambda failures came from incomplete self-call recognition and qualifier handling in unresolved callable-reference lowering/mangling.

## What changed
### 1. Lambda capture layout correctness (parser + IR)
- Hardened by-value lambda capture member size/alignment resolution in parser-side capture member construction.
- Added codegen-side closure-member backfill for unresolved capture sizes and enforced layout recalculation before emission.
- Ensured nested generic lambda closures receive non-overlapping member offsets in deferred/instantiated paths.

### 2. Direct-call normalized ownership handling
- Kept strict sema-normalized direct-call ownership behavior when sema/parser owned target metadata is present.
- Reintroduced compatibility fallback only for metadata-missing paths to preserve previous valid behavior and unblock late-instantiated/deferred scenarios without reintroducing pointer-guessing behavior.

### 3. Recursive generic lambda self-call lowering
- Expanded self-call detection for unresolved callable-reference forms (e.g. self-forward patterns).
- Corrected self-argument qualifier treatment used for mangling/lookup so symbol resolution matches C++20 deduction behavior in these call forms.

### 4. Standards regression coverage
Added and wired new regression tests for:
- nested generic lambda callable capture behavior
- constexpr template/member same-arity overload binding behavior
- constexpr virtual dispatch non-overriding same-arity behavior
- constexpr member-call const/non-const collector behavior
- operator() receiver/argument overload behavior
- operator[] receiver/argument overload behavior + const ambiguity fail path

Project files were updated so the new tests are included in Visual Studio configurations.

## Validation
- `build_flashcpp.bat`
- Focused regression runs for the standards-refactor test set listed above
- Full Windows suite: `pwsh tests/run_all_tests.ps1`
  - Regular tests: 2621 compile/link/run passed
  - Expected-fail tests: 195 failed as expected

## Outcome
This restores the previously green behavior for the standards-refactor area while preserving the intended architectural direction:
- stable semantic call identity
- no pointer-keyed operator() recovery paths
- const-aware member candidate collection and constexpr member lookup hardening
- standards-oriented direct-call handling with explicit compatibility boundary where metadata is absent