### PR TITLE
[codex] Tighten dependent callable operator resolution

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -23,8 +23,10 @@ trailing return clauses against materialized parameter declarations and keeps
 bound member-pointer metadata intact in the non-explicit parameter
 materialization path, so dependent trailing-return `decltype` no longer drops
 reference qualification or pointer-to-member owner identity. The biggest
-remaining gap is keeping every replay/materialization path equally
-evidence-driven rather than shape-driven.
+remaining gaps are (1) keeping every replay/materialization path equally
+evidence-driven rather than shape-driven and (2) finishing the last hard
+diagnostic cleanup around no-viable dependent callable-object `operator()`
+cases.
 
 ## What the current design can assume
 
@@ -46,6 +48,11 @@ evidence-driven rather than shape-driven.
   argument typing and the same receiver-const candidate partitioning used by
   direct member-call lookup, so normalized subscripts no longer bind non-const
   members through const receivers or lose lvalue/rvalue index evidence
+- semantic receiverless callable `operator()` resolution for dependent/local
+  callable objects now also shares sema-owned overload-resolution argument
+  typing plus receiver-const candidate partitioning, so template-instantiated
+  functors no longer depend on reduced expression typing for lvalue/rvalue or
+  const overload selection
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -129,9 +136,11 @@ Tightening those is the next best cleanup target.
 3. Extend sema-owned lookup unification where it unlocks step 2.
    The recent member-call fix closed one concrete gap by replacing parser-owned
    call-argument typing inside sema with normalized semantic argument typing,
-   and the 2026-06-04 follow-up applied the same model to semantic
-   `operator[]` resolution. The next useful expansion is to audit the remaining
-   semantic call-resolution sites that still do not share that collector or the
+   and the 2026-06-04 follow-ups applied the same model to semantic
+   `operator[]` and dependent/local callable `operator()` resolution. The next
+   useful expansion is to finish the remaining hard diagnostic cleanup around
+   no-viable dependent callable objects, then audit any other semantic
+   call-resolution sites that still do not share that collector or the
    receiver-aware candidate partitioning around it.
 
 4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
@@ -157,16 +166,22 @@ Tightening those is the next best cleanup target.
 
 1. Audit the remaining semantic call-resolution entry points that do not yet
    share `tryCollectOverloadResolutionArgTypes(...)` or the shared
-   receiver-aware candidate partitioning, especially callable-operator and
-   other normalized-call paths beyond the now-fixed `operator[]` route.
+   receiver-aware candidate partitioning beyond the now-fixed `operator[]` and
+   dependent/local callable `operator()` routes.
 
-2. Tighten the remaining replay-attachment sites that can still succeed without
+2. Finish the hard diagnostic follow-up for dependent callable objects: a local
+   scratch `const Callable& c; c(...)` negative case still found an older path
+   that compiled after sema declined to resolve a viable `operator()`, so the
+   next callable slice should make that failure sema-owned and add a stable
+   `_fail` regression.
+
+3. Tighten the remaining replay-attachment sites that can still succeed without
    positive substituted-signature evidence outside the now-hardened plain-member,
    member-template, and constructor-template routes.
 
-3. Expand current-instantiation / unknown-specialization modeling only for the
+4. Expand current-instantiation / unknown-specialization modeling only for the
    concrete cases that still block standards-conforming typed lookup after steps
-   1 and 2.
+   1-3.
 
 ## 2026-06-04 dependent decltype trailing-return note
 
@@ -265,6 +280,42 @@ Validated with:
 - `test_generic_lambda_recursive_self_ret0.cpp`
 - `test_lambda_cpp20_comprehensive_ret135.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
+## 2026-06-04 dependent callable operator() sema note
+
+Continuing the same call-resolution audit found that receiverless dependent
+callable-object resolution still lagged behind direct member calls and
+`operator[]`: `SemanticAnalysis::tryResolveCallableOperatorImpl` still used
+reduced expression typing and did not partition candidates by receiver
+constness before fallback selection. That left template-instantiated functor
+calls vulnerable to stale lvalue/rvalue collapse and const/non-const drift even
+though the concrete callable type was already known in sema.
+
+This slice now:
+
+- routes dependent/local callable `operator()` overload selection through
+  sema-owned overload-resolution argument typing
+- partitions callable candidates with the same receiver-const rule already used
+  by direct member calls and semantic `operator[]`
+- keeps the codegen-side callable hard-stop narrow enough to preserve recursive
+  lambda self forwarding while still treating sema-analyzed absent struct
+  callable targets as invalid in the covered path
+
+Validated with:
+
+- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_callable_sema_resolved_ret0.cpp`
+- `test_template_out_of_line_operator_call_ret0.cpp`
+- `test_generic_lambda_recursive_self_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
+Remaining debt:
+
+- a local scratch negative case (`const Callable& c; c(...)` with only a
+  non-const call operator) still found an older compile-through path, so the
+  next callable follow-up should add a sema-owned hard diagnostic and land a
+  stable `_fail` regression for that case
 
 ## 2026-06-02 constexpr lambda capture-lowering note
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -36,6 +36,11 @@ Move FlashCpp toward a sema-owned template system where:
   overload-resolution argument typing plus receiver-const candidate filtering,
   so normalized subscripts preserve lvalue/rvalue index evidence and do not
   bind non-const members through const receivers
+- semantic receiverless callable `operator()` resolution for dependent/local
+  callable objects now also uses sema-owned overload-resolution argument typing
+  plus receiver-const candidate filtering, so template-instantiated functors no
+  longer rely on reduced expression typing for const or lvalue/rvalue overload
+  selection
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -103,11 +108,12 @@ unknown-specialization modeling only where it unblocks those paths.
 
 3. Unify the remaining semantic call-resolution entry points around the same
    sema-owned overload-resolution argument collector now used for normalized
-   template/member direct calls. A 2026-06-04 follow-up closed the concrete
-   `operator[]` gap by sharing receiver-aware candidate filtering plus sema-
-   owned index typing with direct member-call resolution. This is still the
-   shortest path to preventing stale parser-selected targets from surviving
-   semantic normalization.
+   template/member direct calls. The 2026-06-04 follow-ups closed the concrete
+   `operator[]` and dependent/local callable `operator()` gaps by sharing
+   receiver-aware candidate filtering plus sema-owned argument typing with
+   direct member-call resolution. The next step here is the remaining hard
+   diagnostic cleanup for no-viable dependent callable objects, then any other
+   residual semantic call sites still outside that model.
 
 4. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks steps 2 and 3.
@@ -131,13 +137,19 @@ unknown-specialization modeling only where it unblocks those paths.
 1. Apply the sema-owned overload-resolution argument collector and the shared
    receiver-aware candidate partitioning to the remaining semantic
    call-resolution sites that still rely on parser-owned expression typing or
-   reduced argument modeling beyond the now-fixed `operator[]` route.
+   reduced argument modeling beyond the now-fixed `operator[]` and
+   dependent/local callable `operator()` routes.
 
-2. Continue deleting replay-attachment acceptance paths that still allow
+2. Add a sema-owned hard diagnostic and `_fail` regression for the remaining
+   dependent callable-object no-viable case discovered in this slice:
+   `const Callable& c; c(...)` can still compile through an older path after
+   sema declines to resolve a viable `operator()`.
+
+3. Continue deleting replay-attachment acceptance paths that still allow
    insufficient substituted-signature evidence outside the now-hardened member
    and constructor routes.
 
-3. Only after those are stable, extend current-instantiation and
+4. Only after those are stable, extend current-instantiation and
    unknown-specialization modeling for the specific unresolved cases that remain.
 
 ## 2026-06-04 dependent decltype conformance note
@@ -241,6 +253,41 @@ Validated with:
 - `test_generic_lambda_recursive_self_ret0.cpp`
 - `test_lambda_cpp20_comprehensive_ret135.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
+## 2026-06-04 dependent callable operator() conformance note
+
+The next live callable conformance gap was not another parser issue. It was the
+late semantic resolution path for receiverless dependent/local callable objects:
+`SemanticAnalysis::tryResolveCallableOperatorImpl` still classified overloads
+from reduced expression typing and did not partition candidates by receiver
+constness before fallback selection. That meant a template-instantiated functor
+call could preserve the wrong overload category even after the concrete
+callable type was known.
+
+The fix now:
+
+- reuses sema-owned overload-resolution argument typing for dependent/local
+  callable `operator()` calls
+- applies the same receiver-const candidate filtering used by ordinary member
+  calls and semantic `operator[]`
+- preserves recursive lambda self forwarding while treating sema-analyzed
+  absent struct-callable targets as invalid in the covered codegen path
+
+Validated with:
+
+- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_callable_sema_resolved_ret0.cpp`
+- `test_template_out_of_line_operator_call_ret0.cpp`
+- `test_generic_lambda_recursive_self_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
+
+Remaining conformance debt:
+
+- a local scratch negative case (`const Callable& c; c(...)` with only a
+  non-const call operator) still compiles through an older path, so this slice
+  deliberately stops short of adding the `_fail` regression until that
+  diagnostic is made fully sema-owned
 
 ## 2026-06-04 non-standard template test cleanup
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -33,6 +33,15 @@ still accepted.
   A `_fail` regression (`test_copy_assign_default_arg_fail.cpp`) was tried and
   unexpectedly compiled; keep this tracked here until parser/sema rejects it.
 
+## Alias-backed callable objects can bypass missing `operator()` diagnostics
+Calls through local aliases/typedefs to non-callable struct types are not
+consistently rejected yet. A reduced case like `using Alias = NotCallable;
+Alias a; a(1);` can still compile instead of diagnosing that no matching
+`operator()` exists. The review-driven helper refactor in PR #1753 narrowed the
+semantic duplication around local callable lookup, but the remaining acceptance
+bug still needs a parser/sema/codegen follow-up before a stable `_fail`
+regression can be landed.
+
 ## Constructor overload selection mismatch (string literal/lvalue case)
 The original `tests/test_ctor_string_literal_lvalue_ret0.cpp` shape exposed a
 wrong overload pick around string-literal binding vs deleted rvalue-reference

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -568,17 +568,26 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 
 	if (func_ptr_decl) {
 		const auto& func_type = func_ptr_decl->type_specifier_node();
-		const ResolvedFunctionQueryResult resolved_operator_call_query =
+		const TypeInfo* callable_owner_type_info =
+			(func_type.type_index().is_valid() &&
+			 !func_type.is_function_pointer() &&
+			 !func_type.has_function_signature())
+				? resolveToConcreteStructTypeInfo(func_type.type_index())
+				: nullptr;
+		const bool callee_is_struct_callable =
+			callable_owner_type_info != nullptr &&
+			callable_owner_type_info->getStructInfo() != nullptr;
+		ResolvedFunctionQueryResult resolved_operator_call_query =
 			sema_services.getResolvedOpCallQuery(sema_call_key);
+		if (callee_is_struct_callable &&
+			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+			sema_services.ensureCallableOperatorResolved(callExprNode);
+			resolved_operator_call_query = sema_services.getResolvedOpCallQuery(sema_call_key);
+		}
 		const FunctionDeclarationNode* resolved_operator_call =
 			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::Available
 				? resolved_operator_call_query.function
 				: nullptr;
-		const bool callee_is_struct_callable =
-			(func_type.category() == TypeCategory::Struct ||
-			 func_type.category() == TypeCategory::UserDefined) &&
-			!func_type.is_function_pointer() &&
-			!func_type.has_function_signature();
 		const bool recursive_self_forward_pattern = [&]() {
 			if (!current_lambda_context_.isActive()) {
 				return false;

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -574,6 +574,24 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::Available
 				? resolved_operator_call_query.function
 				: nullptr;
+		const bool callee_is_struct_callable =
+			(func_type.category() == TypeCategory::Struct ||
+			 func_type.category() == TypeCategory::UserDefined) &&
+			!func_type.is_function_pointer() &&
+			!func_type.has_function_signature();
+		const bool recursive_self_forward_pattern = [&]() {
+			if (!current_lambda_context_.isActive()) {
+				return false;
+			}
+			const auto call_args = callExprNode.arguments();
+			if (call_args.size() == 0 || !call_args[0].is<ExpressionNode>()) {
+				return false;
+			}
+			const ExpressionNode& first_arg_expr = call_args[0].as<ExpressionNode>();
+			const auto* first_arg_id = std::get_if<IdentifierNode>(&first_arg_expr);
+			return first_arg_id != nullptr &&
+				first_arg_id->name() == func_name_view;
+		}();
 
 		if (resolved_operator_call) {
 			ChunkedVector<ASTNode> member_args;
@@ -593,6 +611,15 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		if (sema_normalized_current_function_ &&
 			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 			throw InternalError("Normalized direct operator() query remained NotYetAnalyzed");
+		}
+		if (!resolved_operator_call &&
+			resolved_operator_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent &&
+			callee_is_struct_callable &&
+			!recursive_self_forward_pattern) {
+			throw CompileError(
+				std::string("callable object '") +
+				std::string(func_name_view) +
+				"' has no matching operator()");
 		}
 
 		// Check if this is a function pointer or a substituted function type carrying

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7344,13 +7344,10 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 		return;
 
 	const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
-	if (callee_desc.category() != TypeCategory::Struct)
+	if (callee_desc.category() != TypeCategory::Struct &&
+		callee_desc.category() != TypeCategory::UserDefined)
 		return;
-	const TypeInfo* callee_type_info = tryGetTypeInfo(callee_desc.type_index);
-	if (!callee_type_info)
-		return;
-
-	const StructTypeInfo* struct_info = callee_type_info->getStructInfo();
+	const StructTypeInfo* struct_info = tryResolveLocalCallableStructInfo(callee_name);
 	if (!struct_info)
 		return;
 
@@ -7827,20 +7824,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			qualified_name.substr(scope_sep + 2)
 		};
 	};
-	auto resolveStructOwnerType = [&](const TypeInfo* type_info) -> const TypeInfo* {
-		constexpr size_t kMaxAliasDepth = 100;
-		for (size_t alias_depth = 0; type_info && alias_depth < kMaxAliasDepth; ++alias_depth) {
-			if (type_info->getStructInfo()) {
-				return type_info;
-			}
-			const TypeInfo* underlying = tryGetTypeInfo(type_info->type_index_);
-			if (!underlying || underlying == type_info) {
-				break;
-			}
-			type_info = underlying;
-		}
-		return nullptr;
-	};
 	auto appendOwnerMemberOverloads = [&](const TypeInfo* owner_type,
 										  std::string_view member_name,
 										  std::vector<ASTNode>& target) {
@@ -7872,7 +7855,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		if (!owner_type) {
 			return;
 		}
-		if (const TypeInfo* resolved_owner = resolveStructOwnerType(owner_type)) {
+		if (const TypeInfo* resolved_owner = tryResolveStructOwnerTypeInfo(owner_type)) {
 			appendFromStruct(resolved_owner->getStructInfo());
 			if (resolved_owner->isTemplateInstantiation()) {
 				auto pattern_it = getTypesByNameMap().find(resolved_owner->baseTemplateName());
@@ -7889,7 +7872,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				**call_info.dependent_qualified_lookup_record;
 			if (dependent_record.owner_type.is_valid()) {
 				if (const TypeInfo* owner_from_record = tryGetTypeInfo(dependent_record.owner_type)) {
-					return resolveStructOwnerType(owner_from_record);
+					return tryResolveStructOwnerTypeInfo(owner_from_record);
 				}
 			}
 		}
@@ -7924,40 +7907,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		if (!type_info) {
 			type_info = resolve_type_info(StringTable::getOrInternStringHandle(owner_name));
 		}
-		return resolveStructOwnerType(type_info);
+		return tryResolveStructOwnerTypeInfo(type_info);
 	};
 	auto resolveLocalCallableStructInfo = [&]() -> const StructTypeInfo* {
 		if (call_info.has_receiver) {
 			return nullptr;
 		}
-		const StringHandle callee_name = callee_decl.identifier_token().handle();
-		if (!callee_name.isValid()) {
-			return nullptr;
-		}
-		const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
-		if (!callee_type_id) {
-			return nullptr;
-		}
-		const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
-		const TypeInfo* callee_type_info = nullptr;
-		if (callee_desc.category() == TypeCategory::Struct ||
-			callee_desc.category() == TypeCategory::UserDefined) {
-			callee_type_info = tryGetTypeInfo(callee_desc.type_index);
-			if (!callee_type_info &&
-				callee_desc.category() == TypeCategory::UserDefined &&
-				callee_desc.type_index.is_valid()) {
-				const ResolvedAliasTypeInfo resolved_alias =
-					resolveAliasTypeInfo(callee_desc.type_index);
-				callee_type_info = resolved_alias.terminal_type_info;
-			}
-		}
-		if (callee_type_info == nullptr) {
-			return nullptr;
-		}
-		if (const TypeInfo* resolved_owner = resolveStructOwnerType(callee_type_info)) {
-			return resolved_owner->getStructInfo();
-		}
-		return nullptr;
+		return tryResolveLocalCallableStructInfo(callee_decl.identifier_token().handle());
 	};
 	if (call_info.is_indirect) {
 		return nullptr;
@@ -7984,7 +7940,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			if (receiver_type_info == nullptr) {
 				return nullptr;
 			}
-			if (const TypeInfo* resolved_owner = resolveStructOwnerType(receiver_type_info)) {
+			if (const TypeInfo* resolved_owner = tryResolveStructOwnerTypeInfo(receiver_type_info)) {
 				return resolved_owner->getStructInfo();
 			}
 			return nullptr;
@@ -8394,6 +8350,51 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	return result;
 }
 
+const TypeInfo* SemanticAnalysis::tryResolveStructOwnerTypeInfo(const TypeInfo* type_info) const {
+	constexpr size_t kMaxAliasDepth = 100;
+	for (size_t alias_depth = 0; type_info && alias_depth < kMaxAliasDepth; ++alias_depth) {
+		if (type_info->getStructInfo()) {
+			return type_info;
+		}
+		const TypeInfo* underlying = tryGetTypeInfo(type_info->type_index_);
+		if (!underlying || underlying == type_info) {
+			break;
+		}
+		type_info = underlying;
+	}
+	return nullptr;
+}
+
+const StructTypeInfo* SemanticAnalysis::tryResolveLocalCallableStructInfo(StringHandle callee_name) const {
+	if (!callee_name.isValid()) {
+		return nullptr;
+	}
+	const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
+	if (!callee_type_id) {
+		return nullptr;
+	}
+	const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
+	const TypeInfo* callee_type_info = nullptr;
+	if (callee_desc.category() == TypeCategory::Struct ||
+		callee_desc.category() == TypeCategory::UserDefined) {
+		callee_type_info = tryGetTypeInfo(callee_desc.type_index);
+		if (!callee_type_info &&
+			callee_desc.category() == TypeCategory::UserDefined &&
+			callee_desc.type_index.is_valid()) {
+			const ResolvedAliasTypeInfo resolved_alias =
+				resolveAliasTypeInfo(callee_desc.type_index);
+			callee_type_info = resolved_alias.terminal_type_info;
+		}
+	}
+	if (callee_type_info == nullptr) {
+		return nullptr;
+	}
+	if (const TypeInfo* resolved_owner = tryResolveStructOwnerTypeInfo(callee_type_info)) {
+		return resolved_owner->getStructInfo();
+	}
+	return nullptr;
+}
+
 void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_expr_node,
 														 const CallInfo& call_info,
 														 const void* call_key,
@@ -8413,28 +8414,7 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 				return false;
 			}
 			const StringHandle callee_name = callee_decl.identifier_token().handle();
-			if (!callee_name.isValid()) {
-				return false;
-			}
-			const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
-			if (!callee_type_id) {
-				return false;
-			}
-			const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
-			const TypeInfo* callee_type_info = nullptr;
-			if (callee_desc.category() == TypeCategory::Struct ||
-				callee_desc.category() == TypeCategory::UserDefined) {
-				callee_type_info = tryGetTypeInfo(callee_desc.type_index);
-				if (!callee_type_info &&
-					callee_desc.category() == TypeCategory::UserDefined &&
-					callee_desc.type_index.is_valid()) {
-					const ResolvedAliasTypeInfo resolved_alias =
-						resolveAliasTypeInfo(callee_desc.type_index);
-					callee_type_info = resolved_alias.terminal_type_info;
-				}
-			}
-			if (callee_type_info == nullptr ||
-				callee_type_info->getStructInfo() == nullptr) {
+			if (tryResolveLocalCallableStructInfo(callee_name) == nullptr) {
 				return false;
 			}
 			InlineVector<TypeSpecifierNode, 6> arg_types;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7362,28 +7362,40 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 	if (candidates.empty())
 		return;
 
-	std::vector<TypeSpecifierNode> arg_types;
-	arg_types.reserve(arg_count);
-	bool all_types_known = true;
-	for (const ASTNode& arg : arguments) {
-		const CanonicalTypeId arg_type_id = inferExpressionType(arg);
-		if (arg_type_id) {
-			arg_types.push_back(materializeTypeSpecifier(type_context_.get(arg_type_id)));
-		} else {
-			all_types_known = false;
-			break;
-		}
-	}
+	const bool receiver_is_const =
+		(static_cast<uint8_t>(callee_desc.base_cv) &
+		 static_cast<uint8_t>(CVQualifier::Const)) != 0;
+	InlineVector<ASTNode, 8> preferred_candidates;
+	InlineVector<ASTNode, 8> compatible_candidates;
+	partitionMemberOverloadsByReceiverConstness(
+		candidates,
+		receiver_is_const,
+		preferred_candidates,
+		compatible_candidates);
 
 	const FunctionDeclarationNode* best_match = nullptr;
 	bool explicitly_ambiguous = false;
-	if (all_types_known) {
-		const OverloadResolutionResult result = resolve_overload(candidates, arg_types);
-		if (result.has_match && !result.is_ambiguous) {
-			best_match = &result.selected_overload->as<FunctionDeclarationNode>();
-		}
-		if (result.is_ambiguous) {
-			explicitly_ambiguous = true;
+
+	InlineVector<TypeSpecifierNode, 6> arg_types;
+	const bool arg_types_collected =
+		tryCollectOverloadResolutionArgTypes(arguments, arg_types);
+	if (arg_types_collected) {
+		bool preferred_ambiguous = false;
+		best_match = tryResolveUniqueOverloadByArgTypes(
+			preferred_candidates,
+			arg_types,
+			&preferred_ambiguous);
+		explicitly_ambiguous = preferred_ambiguous;
+
+		if (!best_match &&
+			!explicitly_ambiguous &&
+			!sameOverloadSet(preferred_candidates, compatible_candidates)) {
+			bool compatible_ambiguous = false;
+			best_match = tryResolveUniqueOverloadByArgTypes(
+				compatible_candidates,
+				arg_types,
+				&compatible_ambiguous);
+			explicitly_ambiguous = compatible_ambiguous;
 		}
 	}
 	if (normalized_call || explicitly_ambiguous) {
@@ -7393,9 +7405,11 @@ void SemanticAnalysis::tryResolveCallableOperatorImpl(const CallInfo& call_info,
 	}
 
 	if (!best_match && !explicitly_ambiguous) {
+		InlineVector<ASTNode, 8> ordered_candidates = preferred_candidates;
+		appendUniqueOverloads(ordered_candidates, compatible_candidates);
 		const FunctionDeclarationNode* default_argument_match = nullptr;
 		bool default_argument_match_ambiguous = false;
-		for (const auto& candidate_node : candidates) {
+		for (const auto& candidate_node : ordered_candidates) {
 			const auto& candidate = candidate_node.as<FunctionDeclarationNode>();
 			if (!candidate.is_variadic() && candidate.parameter_nodes().size() == arg_count) {
 				best_match = &candidate;
@@ -7912,6 +7926,39 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return resolveStructOwnerType(type_info);
 	};
+	auto resolveLocalCallableStructInfo = [&]() -> const StructTypeInfo* {
+		if (call_info.has_receiver) {
+			return nullptr;
+		}
+		const StringHandle callee_name = callee_decl.identifier_token().handle();
+		if (!callee_name.isValid()) {
+			return nullptr;
+		}
+		const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
+		if (!callee_type_id) {
+			return nullptr;
+		}
+		const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
+		const TypeInfo* callee_type_info = nullptr;
+		if (callee_desc.category() == TypeCategory::Struct ||
+			callee_desc.category() == TypeCategory::UserDefined) {
+			callee_type_info = tryGetTypeInfo(callee_desc.type_index);
+			if (!callee_type_info &&
+				callee_desc.category() == TypeCategory::UserDefined &&
+				callee_desc.type_index.is_valid()) {
+				const ResolvedAliasTypeInfo resolved_alias =
+					resolveAliasTypeInfo(callee_desc.type_index);
+				callee_type_info = resolved_alias.terminal_type_info;
+			}
+		}
+		if (callee_type_info == nullptr) {
+			return nullptr;
+		}
+		if (const TypeInfo* resolved_owner = resolveStructOwnerType(callee_type_info)) {
+			return resolved_owner->getStructInfo();
+		}
+		return nullptr;
+	};
 	if (call_info.is_indirect) {
 		return nullptr;
 	}
@@ -8043,6 +8090,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 	if (func_decl)
 		return func_decl;
+	if (resolveLocalCallableStructInfo() != nullptr &&
+		op_call_query.state != ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+		return nullptr;
+	}
 
 	if (!normalized_call) {
 		if (const FunctionDeclarationNode* mangled_candidate =
@@ -8352,6 +8403,50 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 
 	const FunctionDeclarationNode* func_decl = resolveCallArgAnnotationTarget(call_info, call_key);
 	if (!func_decl) {
+		auto hasDiagnosableLocalCallableMiss = [&]() -> bool {
+			if (call_info.has_receiver || call_info.is_indirect) {
+				return false;
+			}
+			const ResolvedFunctionQueryResult op_call_query =
+				getResolvedOpCallQuery(call_key);
+			if (op_call_query.state != ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
+				return false;
+			}
+			const StringHandle callee_name = callee_decl.identifier_token().handle();
+			if (!callee_name.isValid()) {
+				return false;
+			}
+			const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
+			if (!callee_type_id) {
+				return false;
+			}
+			const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
+			const TypeInfo* callee_type_info = nullptr;
+			if (callee_desc.category() == TypeCategory::Struct ||
+				callee_desc.category() == TypeCategory::UserDefined) {
+				callee_type_info = tryGetTypeInfo(callee_desc.type_index);
+				if (!callee_type_info &&
+					callee_desc.category() == TypeCategory::UserDefined &&
+					callee_desc.type_index.is_valid()) {
+					const ResolvedAliasTypeInfo resolved_alias =
+						resolveAliasTypeInfo(callee_desc.type_index);
+					callee_type_info = resolved_alias.terminal_type_info;
+				}
+			}
+			if (callee_type_info == nullptr ||
+				callee_type_info->getStructInfo() == nullptr) {
+				return false;
+			}
+			InlineVector<TypeSpecifierNode, 6> arg_types;
+			return tryCollectOverloadResolutionArgTypes(*call_info.arguments, arg_types);
+		};
+		if (hasDiagnosableLocalCallableMiss()) {
+			throw CompileError(
+				std::string("callable object '") +
+				std::string(callee_decl.identifier_token().value()) +
+				"' has no matching operator()");
+		}
+
 		const bool normalized_call_expr = hasNormalizedAstNode(call_expr_node);
 		const std::string_view call_name = call_info.qualified_name.isValid()
 											   ? call_info.qualified_name.view()
@@ -8368,6 +8463,33 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 		}
 		resolved_direct_call_table_.erase(call_key);
 		return;
+	}
+	auto localCallableReceiverIsConst = [&]() -> bool {
+		if (call_info.has_receiver || call_info.is_indirect) {
+			return false;
+		}
+		const StringHandle callee_name = callee_decl.identifier_token().handle();
+		if (!callee_name.isValid()) {
+			return false;
+		}
+		const CanonicalTypeId callee_type_id = lookupLocalType(callee_name);
+		if (!callee_type_id) {
+			return false;
+		}
+		const CanonicalTypeDesc& callee_desc = type_context_.get(callee_type_id);
+		return (static_cast<uint8_t>(callee_desc.base_cv) &
+				static_cast<uint8_t>(CVQualifier::Const)) != 0;
+	};
+	if (!call_info.has_receiver &&
+		!call_info.is_indirect &&
+		!func_decl->parent_struct_name().empty() &&
+		!func_decl->is_static() &&
+		!func_decl->is_const_member_function() &&
+		localCallableReceiverIsConst()) {
+		throw CompileError(
+			std::string("callable object '") +
+			std::string(callee_decl.identifier_token().value()) +
+			"' cannot call non-const operator() through a const receiver");
 	}
 
 	// Phase 5 Slices B & C: if the selected call target is a lazily-registered

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -548,6 +548,8 @@ private:
 										   const char* context_description);
 	const FunctionDeclarationNode* resolveCallArgAnnotationTarget(const CallInfo& call_info,
 																 const void* call_key);
+	const TypeInfo* tryResolveStructOwnerTypeInfo(const TypeInfo* type_info) const;
+	const StructTypeInfo* tryResolveLocalCallableStructInfo(StringHandle callee_name) const;
 	struct ResolvedMemberAccessInfo {
 		TypeIndex owner_type_index{};
 		size_t member_index = 0;

--- a/tests/test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp
+++ b/tests/test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp
@@ -1,0 +1,48 @@
+// Regression: dependent callable-object operator() resolution in sema must
+// preserve receiver constness and lvalue/rvalue argument categories after
+// template substitution.
+
+struct ReceiverSensitiveCallable {
+	int operator()(int value) {
+		return value + 1;
+	}
+
+	int operator()(int value) const {
+		return value + 10;
+	}
+};
+
+struct ArgSensitiveCallable {
+	int operator()(int& value) const {
+		return value + 100;
+	}
+
+	int operator()(int&& value) const {
+		return value + 200;
+	}
+};
+
+template <typename Callable>
+int callConst(const Callable& callable) {
+	return callable(2);
+}
+
+template <typename Callable>
+int callArgSensitive(const Callable& callable) {
+	int value = 3;
+	return callable(value) + callable(4);
+}
+
+int main() {
+	ReceiverSensitiveCallable receiver_sensitive;
+	ArgSensitiveCallable arg_sensitive;
+
+	if (callConst(receiver_sensitive) != 12) {
+		return 1;
+	}
+	if (callArgSensitive(arg_sensitive) != 307) {
+		return 2;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
This continues the template-infrastructure refactor by moving receiverless callable-object resolution further onto shared sema-owned logic.

This PR now:
- reuses one alias-aware helper for local callable struct lookup instead of duplicating that logic in multiple callable paths
- lets sema treat local `UserDefined` callable objects the same way as direct structs when resolving `operator()`
- makes direct-call lowering re-query sema for struct-callable aliases before falling back

## Why
The previous slice fixed dependent/local callable `operator()` overload selection, but review feedback was correct that alias/typedef-backed callable objects still relied on duplicated, narrower lookup code. That was the wrong shape for a standards-conformance refactor because it invites drift between equivalent callable paths.

## Follow-up
While checking the review comment, I also confirmed a separate remaining bug: an alias-backed local object without `operator()` can still be accepted in some paths. I did not force a brittle `_fail` test into this PR. That issue is now documented in `docs/KNOWN_ISSUES.md` for the next callable follow-up.
