### PR TITLE
[codex] Reject alias-backed non-callable operator() calls

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -33,15 +33,6 @@ still accepted.
   A `_fail` regression (`test_copy_assign_default_arg_fail.cpp`) was tried and
   unexpectedly compiled; keep this tracked here until parser/sema rejects it.
 
-## Alias-backed callable objects can bypass missing `operator()` diagnostics
-Calls through local aliases/typedefs to non-callable struct types are not
-consistently rejected yet. A reduced case like `using Alias = NotCallable;
-Alias a; a(1);` can still compile instead of diagnosing that no matching
-`operator()` exists. The review-driven helper refactor in PR #1753 narrowed the
-semantic duplication around local callable lookup, but the remaining acceptance
-bug still needs a parser/sema/codegen follow-up before a stable `_fail`
-regression can be landed.
-
 ## Constructor overload selection mismatch (string literal/lvalue case)
 The original `tests/test_ctor_string_literal_lvalue_ret0.cpp` shape exposed a
 wrong overload pick around string-literal binding vs deleted rvalue-reference

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3332,8 +3332,19 @@ private:	 // Resume private methods
 		const Token& paren_token,
 		ChunkedVector<ASTNode>&& args,
 		std::vector<TypeSpecifierNode>&& arg_types);
+	struct ConcreteCallOperatorResolution {
+		enum class State : uint8_t {
+			Unavailable,
+			Resolved,
+			NoViableMatch,
+			Ambiguous,
+		};
+
+		State state = State::Unavailable;
+		const FunctionDeclarationNode* function = nullptr;
+	};
 	const FunctionDeclarationNode* tryResolveConcreteMemberFunction(const std::optional<ASTNode>& object_expr, std::string_view member_name);
-	const FunctionDeclarationNode* tryResolveConcreteCallOperator(
+	ConcreteCallOperatorResolution tryResolveConcreteCallOperator(
 		const std::optional<ASTNode>& object_expr,
 		std::span<const TypeSpecifierNode> arg_types,
 		size_t argument_count,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -22,12 +22,10 @@ void setResolvedMemberCallMetadata(ExpressionNode& call_expr, const FunctionDecl
 	}
 }
 
-const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_spec) {
+const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_spec, bool allow_pointers) {
 	if (type_spec.is_function_pointer() ||
 		type_spec.has_function_signature() ||
-		type_spec.pointer_depth() > 0 ||
-		type_spec.is_reference() ||
-		type_spec.is_rvalue_reference() ||
+		(!allow_pointers && type_spec.pointer_depth() > 0) ||
 		type_spec.is_array() ||
 		!type_spec.type_index().is_valid()) {
 		return nullptr;
@@ -41,8 +39,7 @@ const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_
 
 	const ResolvedAliasTypeInfo resolved_alias =
 		resolveAliasTypeInfo(type_spec.type_index().withCategory(type_spec.category()));
-	if (resolved_alias.pointer_depth != 0 ||
-		resolved_alias.reference_qualifier != ReferenceQualifier::None ||
+	if ((!allow_pointers && resolved_alias.pointer_depth != 0) ||
 		resolved_alias.function_signature.has_value() ||
 		resolved_alias.isArray() ||
 		resolved_alias.terminal_type_info == nullptr ||
@@ -66,7 +63,7 @@ std::optional<ASTNode> Parser::tryResolveMemberFunctionTemplate(
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
 		return std::nullopt;
-	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt, true);
 	if (!type_info)
 		return std::nullopt;
 	if (type_info->is_incomplete_instantiation_) {
@@ -100,7 +97,7 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
 		return nullptr;
-	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt, true);
 	if (!type_info)
 		return nullptr;
 	if (type_info->is_incomplete_instantiation_) {
@@ -164,7 +161,7 @@ Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
 		return {};
-	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt, false);
 	if (!type_info)
 		return {};
 	if (type_info->is_incomplete_instantiation_) {

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -21,6 +21,37 @@ void setResolvedMemberCallMetadata(ExpressionNode& call_expr, const FunctionDecl
 		setCallQualifiedName(call_expr, qualified_name_builder.commit());
 	}
 }
+
+const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_spec) {
+	if (type_spec.is_function_pointer() ||
+		type_spec.has_function_signature() ||
+		type_spec.pointer_depth() > 0 ||
+		type_spec.is_reference() ||
+		type_spec.is_rvalue_reference() ||
+		type_spec.is_array() ||
+		!type_spec.type_index().is_valid()) {
+		return nullptr;
+	}
+
+	if (const TypeInfo* direct_type_info = tryGetTypeInfo(type_spec.type_index());
+		direct_type_info != nullptr &&
+		direct_type_info->getStructInfo() != nullptr) {
+		return direct_type_info;
+	}
+
+	const ResolvedAliasTypeInfo resolved_alias =
+		resolveAliasTypeInfo(type_spec.type_index().withCategory(type_spec.category()));
+	if (resolved_alias.pointer_depth != 0 ||
+		resolved_alias.reference_qualifier != ReferenceQualifier::None ||
+		resolved_alias.function_signature.has_value() ||
+		resolved_alias.isArray() ||
+		resolved_alias.terminal_type_info == nullptr ||
+		resolved_alias.terminal_type_info->getStructInfo() == nullptr) {
+		return nullptr;
+	}
+
+	return resolved_alias.terminal_type_info;
+}
 } // namespace
 
 // Helper: resolve object type from expression and try to instantiate member function template.
@@ -35,11 +66,7 @@ std::optional<ASTNode> Parser::tryResolveMemberFunctionTemplate(
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
 		return std::nullopt;
-	const auto& type_spec = *type_opt;
-	if (!is_struct_type(type_spec.category()))
-		return std::nullopt;
-	TypeIndex type_idx = type_spec.type_index();
-	const TypeInfo* type_info = tryGetTypeInfo(type_idx);
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
 	if (!type_info)
 		return std::nullopt;
 	if (type_info->is_incomplete_instantiation_) {
@@ -73,11 +100,7 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
 		return nullptr;
-	const auto& type_spec = *type_opt;
-	if (!is_struct_type(type_spec.category()))
-		return nullptr;
-	TypeIndex type_idx = type_spec.type_index();
-	const TypeInfo* type_info = tryGetTypeInfo(type_idx);
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
 	if (!type_info)
 		return nullptr;
 	if (type_info->is_incomplete_instantiation_) {
@@ -131,35 +154,31 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteMemberFunction(
 	return match;
 }
 
-const FunctionDeclarationNode* Parser::tryResolveConcreteCallOperator(
+Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 	const std::optional<ASTNode>& object_expr,
 	std::span<const TypeSpecifierNode> arg_types,
 	size_t argument_count,
 	bool all_arg_types_known) {
 	if (!object_expr.has_value())
-		return nullptr;
+		return {};
 	auto type_opt = get_expression_type(*object_expr);
 	if (!type_opt.has_value())
-		return nullptr;
-	const auto& type_spec = *type_opt;
-	if (!is_struct_type(type_spec.category()))
-		return nullptr;
-	TypeIndex type_idx = type_spec.type_index();
-	const TypeInfo* type_info = tryGetTypeInfo(type_idx);
+		return {};
+	const TypeInfo* type_info = tryResolveConcreteStructOwnerType(*type_opt);
 	if (!type_info)
-		return nullptr;
+		return {};
 	if (type_info->is_incomplete_instantiation_) {
 		instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
 		type_info = findTypeByName(type_info->name());
 		if (!type_info || type_info->is_incomplete_instantiation_) {
-			return nullptr;
+			return {};
 		}
 	}
 
 	instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
 	const StructTypeInfo* struct_info = type_info->getStructInfo();
 	if (!struct_info)
-		return nullptr;
+		return {};
 
 	std::vector<ASTNode> call_candidates;
 	std::unordered_set<const StructTypeInfo*> visited;
@@ -194,16 +213,19 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteCallOperator(
 	collect_visible_call_operators(struct_info, collect_visible_call_operators);
 
 	if (call_candidates.empty()) {
-		return nullptr;
+		return {ConcreteCallOperatorResolution::State::NoViableMatch, nullptr};
 	}
 
 	if (all_arg_types_known) {
 		const OverloadResolutionResult op_result = resolve_overload(call_candidates, arg_types);
 		if (op_result.has_match && !op_result.is_ambiguous && op_result.selected_overload != nullptr) {
-			return &op_result.selected_overload->as<FunctionDeclarationNode>();
+			return {
+				ConcreteCallOperatorResolution::State::Resolved,
+				&op_result.selected_overload->as<FunctionDeclarationNode>()
+			};
 		}
 		if (op_result.is_ambiguous) {
-			return nullptr;
+			return {ConcreteCallOperatorResolution::State::Ambiguous, nullptr};
 		}
 	}
 
@@ -225,10 +247,13 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteCallOperator(
 		same_arity_candidate = &candidate;
 	}
 	if (same_arity_candidate != nullptr && !ambiguous_same_arity) {
-		return same_arity_candidate;
+		return {ConcreteCallOperatorResolution::State::Resolved, same_arity_candidate};
 	}
 	if (call_candidates.size() == 1) {
-		return &call_candidates.front().as<FunctionDeclarationNode>();
+		return {
+			ConcreteCallOperatorResolution::State::Resolved,
+			&call_candidates.front().as<FunctionDeclarationNode>()
+		};
 	}
 
 	if (all_arg_types_known) {
@@ -239,11 +264,14 @@ const FunctionDeclarationNode* Parser::tryResolveConcreteCallOperator(
 				arg_types);
 			instantiated_operator.has_value() &&
 			instantiated_operator->is<FunctionDeclarationNode>()) {
-			return &instantiated_operator->as<FunctionDeclarationNode>();
+			return {
+				ConcreteCallOperatorResolution::State::Resolved,
+				&instantiated_operator->as<FunctionDeclarationNode>()
+			};
 		}
 	}
 
-	return nullptr;
+	return {ConcreteCallOperatorResolution::State::NoViableMatch, nullptr};
 }
 
 void Parser::finalizePostfixCallExpression(
@@ -313,11 +341,18 @@ void Parser::finalizePostfixCallExpression(
 		paren_token.column(),
 		paren_token.file_index());
 	const bool all_arg_types_known = arg_types.size() == args.size();
-	const FunctionDeclarationNode* func_ref = tryResolveConcreteCallOperator(
+	const ConcreteCallOperatorResolution call_operator_resolution = tryResolveConcreteCallOperator(
 		result,
 		arg_types,
 		args.size(),
 		all_arg_types_known);
+	const FunctionDeclarationNode* func_ref = call_operator_resolution.function;
+	if (call_operator_resolution.state == ConcreteCallOperatorResolution::State::Ambiguous) {
+		throw CompileError("call to overloaded operator() is ambiguous");
+	}
+	if (call_operator_resolution.state == ConcreteCallOperatorResolution::State::NoViableMatch) {
+		throw CompileError("callable object has no matching operator()");
+	}
 	if (!func_ref) {
 		// Keep the deferred member-call representation for unresolved/dependent
 		// callable objects so sema can handle the remaining compatibility cases.

--- a/tests/test_alias_pointer_member_call_ret0.cpp
+++ b/tests/test_alias_pointer_member_call_ret0.cpp
@@ -1,0 +1,13 @@
+struct Box {
+	int value() const {
+		return 42;
+	}
+};
+
+using Alias = Box;
+
+int main() {
+	Alias box;
+	Alias* ptr = &box;
+	return ptr->value() == 42 ? 0 : 1;
+}

--- a/tests/test_callable_alias_missing_operator_fail.cpp
+++ b/tests/test_callable_alias_missing_operator_fail.cpp
@@ -1,0 +1,8 @@
+struct NotCallable {};
+
+using Alias = NotCallable;
+
+int main() {
+	Alias a;
+	return a(1);
+}

--- a/tests/test_callable_alias_reference_ret0.cpp
+++ b/tests/test_callable_alias_reference_ret0.cpp
@@ -1,0 +1,16 @@
+struct Callable {
+	int operator()(int x) const {
+		return x + 1;
+	}
+};
+
+using Alias = Callable;
+
+int call_ref(const Alias& callable) {
+	return callable(41);
+}
+
+int main() {
+	Alias callable;
+	return call_ref(callable) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
This fixes a parser-side acceptance bug for alias-backed non-callable objects.

A reduced case like:

```cpp
struct NotCallable {};
using Alias = NotCallable;
int main() {
	Alias a;
	return a(1);
}
```

used to compile by falling through the deferred callable-object path and later synthesizing a bogus `operator()` call target.

## What changed
- make parser-side concrete member/callable lookup chase aliases to a concrete struct owner before deciding whether to defer
- split concrete `operator()` lookup results into `Resolved`, `NoViableMatch`, `Ambiguous`, and `Unavailable`
- reject concrete non-callable objects immediately instead of reusing the deferred/dependent callable fallback
- add `_fail` coverage for the alias-backed repro
- remove the fixed issue from `docs/KNOWN_ISSUES.md`

## Validation
- `./build_flashcpp.bat`
- `pwsh ./tests/run_all_tests.ps1 test_callable_alias_missing_operator_fail.cpp`
- `pwsh ./tests/run_all_tests.ps1 test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
- `pwsh ./tests/run_all_tests.ps1 test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
