### PR TITLE
Tighten template callable and subscript lowering paths

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-08
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -22,11 +22,14 @@ typing. The latest template-`decltype` fix now also reparses function-template
 trailing return clauses against materialized parameter declarations and keeps
 bound member-pointer metadata intact in the non-explicit parameter
 materialization path, so dependent trailing-return `decltype` no longer drops
-reference qualification or pointer-to-member owner identity. The biggest
-remaining gaps are (1) keeping every replay/materialization path equally
-evidence-driven rather than shape-driven and (2) finishing the last hard
-diagnostic cleanup around no-viable dependent callable-object `operator()`
-cases.
+reference qualification or pointer-to-member owner identity. The most recent
+callable follow-up now also makes the dependent `const Callable& c; c(...)`
+negative case sema-owned, so parser-selected non-const `operator()` targets no
+longer compile through const receivers after sema has already found no viable
+const-compatible callable target. The biggest remaining gap is keeping every
+replay/materialization path equally evidence-driven rather than shape-driven
+while continuing to narrow the remaining compatibility fallbacks around
+semantic call resolution.
 
 ## What the current design can assume
 
@@ -53,6 +56,10 @@ cases.
   typing plus receiver-const candidate partitioning, so template-instantiated
   functors no longer depend on reduced expression typing for lvalue/rvalue or
   const overload selection
+- sema now also rejects parser-selected non-const `operator()` targets on
+  const dependent/local callable receivers once semantic lookup has shown there
+  is no viable const-compatible overload, so this negative path no longer
+  compiles through fallback attachment
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -137,11 +144,13 @@ Tightening those is the next best cleanup target.
    The recent member-call fix closed one concrete gap by replacing parser-owned
    call-argument typing inside sema with normalized semantic argument typing,
    and the 2026-06-04 follow-ups applied the same model to semantic
-   `operator[]` and dependent/local callable `operator()` resolution. The next
-   useful expansion is to finish the remaining hard diagnostic cleanup around
-   no-viable dependent callable objects, then audit any other semantic
-   call-resolution sites that still do not share that collector or the
-   receiver-aware candidate partitioning around it.
+   `operator[]` and dependent/local callable `operator()` resolution. The
+   2026-06-08 follow-up closes the documented const-receiver no-viable
+   callable diagnostic hole; the next useful expansion is to audit any other
+   semantic call-resolution sites that still do not share that collector or the
+   receiver-aware candidate partitioning around it, and then remove the
+   temporary compatibility fallbacks that remain once typed sema evidence is
+   present.
 
 4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
    Richer current-instantiation and unknown-specialization handling still
@@ -169,15 +178,13 @@ Tightening those is the next best cleanup target.
    receiver-aware candidate partitioning beyond the now-fixed `operator[]` and
    dependent/local callable `operator()` routes.
 
-2. Finish the hard diagnostic follow-up for dependent callable objects: a local
-   scratch `const Callable& c; c(...)` negative case still found an older path
-   that compiled after sema declined to resolve a viable `operator()`, so the
-   next callable slice should make that failure sema-owned and add a stable
-   `_fail` regression.
-
-3. Tighten the remaining replay-attachment sites that can still succeed without
+2. Tighten the remaining replay-attachment sites that can still succeed without
    positive substituted-signature evidence outside the now-hardened plain-member,
    member-template, and constructor-template routes.
+
+3. Audit the remaining semantic call compatibility fallbacks that still reuse
+   parser-selected targets after typed sema evidence is available, and remove
+   each fallback once the owning semantic path is fully covered.
 
 4. Expand current-instantiation / unknown-specialization modeling only for the
    concrete cases that still block standards-conforming typed lookup after steps
@@ -310,12 +317,31 @@ Validated with:
 - `test_generic_lambda_recursive_self_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
-Remaining debt:
+## 2026-06-08 dependent callable const-receiver diagnostic note
 
-- a local scratch negative case (`const Callable& c; c(...)` with only a
-  non-const call operator) still found an older compile-through path, so the
-  next callable follow-up should add a sema-owned hard diagnostic and land a
-  stable `_fail` regression for that case
+The next callable audit slice closed the remaining documented compile-through
+case for dependent/local callable objects: a templated `const Callable& c;
+c(...)` could still compile when the parser had already attached a non-const
+`operator()` target, even though sema's const-aware member lookup found no
+viable const-compatible overload.
+
+This slice now:
+
+- blocks the stale parser-selected member-call target from being reused once
+  semantic lookup has proven that a const receiver has no const-compatible
+  `operator()` candidate to bind
+- raises the failure from sema as an explicit callable diagnostic rather than
+  allowing the member-call fallback to continue
+- locks the case down with a stable template-instantiation `_fail` regression
+
+Validated with:
+
+- `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_template_callable_operator_const_receiver_explicit_member_fail.cpp`
+- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_callable_operator_default_arg_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-08
 
 ## 2026-06-02 constexpr lambda capture-lowering note
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-04
+**Last updated:** 2026-06-08
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -41,6 +41,10 @@ Move FlashCpp toward a sema-owned template system where:
   plus receiver-const candidate filtering, so template-instantiated functors no
   longer rely on reduced expression typing for const or lvalue/rvalue overload
   selection
+- sema now also rejects parser-selected non-const `operator()` targets on
+  const dependent/local callable receivers once semantic lookup has shown there
+  is no viable const-compatible overload, so this standards-visible negative
+  case no longer compiles through member-call fallback
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -111,9 +115,11 @@ unknown-specialization modeling only where it unblocks those paths.
    template/member direct calls. The 2026-06-04 follow-ups closed the concrete
    `operator[]` and dependent/local callable `operator()` gaps by sharing
    receiver-aware candidate filtering plus sema-owned argument typing with
-   direct member-call resolution. The next step here is the remaining hard
-   diagnostic cleanup for no-viable dependent callable objects, then any other
-   residual semantic call sites still outside that model.
+   direct member-call resolution, and the 2026-06-08 follow-up closes the
+   documented const-receiver no-viable callable diagnostic hole. The next step
+   here is auditing any residual semantic call sites still outside that model,
+   then removing the temporary parser-target compatibility fallbacks that
+   remain once typed sema evidence is available.
 
 4. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks steps 2 and 3.
@@ -140,14 +146,13 @@ unknown-specialization modeling only where it unblocks those paths.
    reduced argument modeling beyond the now-fixed `operator[]` and
    dependent/local callable `operator()` routes.
 
-2. Add a sema-owned hard diagnostic and `_fail` regression for the remaining
-   dependent callable-object no-viable case discovered in this slice:
-   `const Callable& c; c(...)` can still compile through an older path after
-   sema declines to resolve a viable `operator()`.
-
-3. Continue deleting replay-attachment acceptance paths that still allow
+2. Continue deleting replay-attachment acceptance paths that still allow
    insufficient substituted-signature evidence outside the now-hardened member
    and constructor routes.
+
+3. Audit the remaining semantic call compatibility fallbacks that still reuse
+   parser-selected targets after typed sema evidence is available, and remove
+   them incrementally as each owning semantic path becomes complete.
 
 4. Only after those are stable, extend current-instantiation and
    unknown-specialization modeling for the specific unresolved cases that remain.
@@ -282,12 +287,29 @@ Validated with:
 - `test_generic_lambda_recursive_self_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-04
 
-Remaining conformance debt:
+## 2026-06-08 dependent callable const-receiver conformance note
 
-- a local scratch negative case (`const Callable& c; c(...)` with only a
-  non-const call operator) still compiles through an older path, so this slice
-  deliberately stops short of adding the `_fail` regression until that
-  diagnostic is made fully sema-owned
+The documented remaining callable negative case is now closed: a dependent
+`const Callable& c; c(...)` with only a non-const `operator()` used to compile
+because the parser-selected member-call target could survive even after sema's
+const-aware lookup found no viable callable overload.
+
+The fix now:
+
+- blocks reuse of that stale parser-selected non-const `operator()` target for
+  const receivers once sema has no const-compatible callable candidate
+- emits the failure from sema as a hard callable diagnostic instead of
+  continuing through member-call fallback
+- adds a stable template-instantiation `_fail` regression for the covered case
+
+Validated with:
+
+- `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_template_callable_operator_const_receiver_explicit_member_fail.cpp`
+- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_callable_operator_default_arg_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-08
 
 ## 2026-06-04 non-standard template test cleanup
 

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -2536,17 +2536,18 @@ int32_t IrToObjConverter<TWriterClass>::getStackOffsetFromTempVar(TempVar tempVa
 }
 
 template <class TWriterClass>
-int IrToObjConverter<TWriterClass>::getStackVariableLoadSizeBits(StringHandle variable_name, int fallback_size_in_bits) const {
+SizeInBits IrToObjConverter<TWriterClass>::getStackVariableLoadSizeBits(StringHandle variable_name) const {
 	for (auto scope_it = variable_scopes.rbegin(); scope_it != variable_scopes.rend(); ++scope_it) {
 		auto variable_it = scope_it->variables.find(variable_name);
 		if (variable_it == scope_it->variables.end() || variable_it->second.offset == INT_MIN) {
 			continue;
 		}
 		if (variable_it->second.size_in_bits.value > 0) {
-			return variable_it->second.size_in_bits.value;
+			return variable_it->second.size_in_bits;
 		}
+		break;
 	}
-	return fallback_size_in_bits;
+	throw InternalError("Named stack variable is missing a recorded size");
 }
 
 template <class TWriterClass>
@@ -12456,7 +12457,7 @@ void IrToObjConverter<TWriterClass>::handleArrayAccess(const IrInstruction& inst
 		auto index_it = variable_scopes.back().variables.find(index_var_name_handle);
 		assert(index_it != variable_scopes.back().variables.end() && "Index variable not found");
 		int64_t index_var_offset = index_it->second.offset;
-		int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name_handle, op.index.size_in_bits.value);
+		SizeInBits index_size_in_bits = getStackVariableLoadSizeBits(index_var_name_handle);
 
 			// Allocate a second register for the index
 		X64Register index_reg = allocateRegisterWithSpilling();
@@ -12621,7 +12622,7 @@ void IrToObjConverter<TWriterClass>::handleArrayElementAddress(const IrInstructi
 				return;
 			}
 			int64_t index_offset = it->second.offset;
-			int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name, op.index.size_in_bits.value);
+			SizeInBits index_size_in_bits = getStackVariableLoadSizeBits(index_var_name);
 
 				// Load index: source (sized stack slot) -> dest (64-bit RCX)
 			emitMovFromFrameSized(
@@ -14194,7 +14195,7 @@ void IrToObjConverter<TWriterClass>::handleComputeAddress(const IrInstruction& i
 				return;
 			}
 			int64_t index_offset = it->second.offset;
-			int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name, arr_idx.index_size_bits.value);
+			SizeInBits index_size_in_bits = getStackVariableLoadSizeBits(index_var_name);
 
 				// Load index into RCX with proper size and sign extension
 			bool is_signed = isSignedType(arr_idx.indexType());

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -2536,6 +2536,20 @@ int32_t IrToObjConverter<TWriterClass>::getStackOffsetFromTempVar(TempVar tempVa
 }
 
 template <class TWriterClass>
+int IrToObjConverter<TWriterClass>::getStackVariableLoadSizeBits(StringHandle variable_name, int fallback_size_in_bits) const {
+	for (auto scope_it = variable_scopes.rbegin(); scope_it != variable_scopes.rend(); ++scope_it) {
+		auto variable_it = scope_it->variables.find(variable_name);
+		if (variable_it == scope_it->variables.end() || variable_it->second.offset == INT_MIN) {
+			continue;
+		}
+		if (variable_it->second.size_in_bits.value > 0) {
+			return variable_it->second.size_in_bits.value;
+		}
+	}
+	return fallback_size_in_bits;
+}
+
+template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::flushAllDirtyRegisters() {
 	regAlloc.flushAllDirtyRegisters([this](X64Register reg, int32_t stackVariableOffset, int size_in_bits) {
 				// Always flush dirty registers to stack, regardless of offset alignment.
@@ -12442,6 +12456,7 @@ void IrToObjConverter<TWriterClass>::handleArrayAccess(const IrInstruction& inst
 		auto index_it = variable_scopes.back().variables.find(index_var_name_handle);
 		assert(index_it != variable_scopes.back().variables.end() && "Index variable not found");
 		int64_t index_var_offset = index_it->second.offset;
+		int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name_handle, op.index.size_in_bits.value);
 
 			// Allocate a second register for the index
 		X64Register index_reg = allocateRegisterWithSpilling();
@@ -12470,7 +12485,7 @@ void IrToObjConverter<TWriterClass>::handleArrayAccess(const IrInstruction& inst
 		bool is_signed = isSignedType(op.index.typeEnum());
 		emitMovFromFrameSized(
 			SizedRegister{index_reg, 64, false},
-			SizedStackSlot{static_cast<int32_t>(index_var_offset), op.index.size_in_bits.value, is_signed});
+			SizedStackSlot{static_cast<int32_t>(index_var_offset), index_size_in_bits, is_signed});
 
 		emitMultiplyRegByElementSize(textSectionData, index_reg, element_size_bytes);
 		emitAddRegs(textSectionData, base_reg, index_reg);
@@ -12606,11 +12621,12 @@ void IrToObjConverter<TWriterClass>::handleArrayElementAddress(const IrInstructi
 				return;
 			}
 			int64_t index_offset = it->second.offset;
+			int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name, op.index.size_in_bits.value);
 
 				// Load index: source (sized stack slot) -> dest (64-bit RCX)
 			emitMovFromFrameSized(
 				SizedRegister{X64Register::RCX, 64, false},	// dest: 64-bit register
-				SizedStackSlot{static_cast<int32_t>(index_offset), op.index.size_in_bits.value, isSignedType(op.index.typeEnum())}  // source: index from stack
+				SizedStackSlot{static_cast<int32_t>(index_offset), index_size_in_bits, isSignedType(op.index.typeEnum())}  // source: index from stack
 			);
 
 				// Multiply index by element size
@@ -14178,12 +14194,13 @@ void IrToObjConverter<TWriterClass>::handleComputeAddress(const IrInstruction& i
 				return;
 			}
 			int64_t index_offset = it->second.offset;
+			int index_size_in_bits = getStackVariableLoadSizeBits(index_var_name, arr_idx.index_size_bits.value);
 
 				// Load index into RCX with proper size and sign extension
 			bool is_signed = isSignedType(arr_idx.indexType());
 			emitMovFromFrameSized(
 				SizedRegister{X64Register::RCX, 64, false},
-				SizedStackSlot{static_cast<int32_t>(index_offset), arr_idx.index_size_bits.value, is_signed});
+				SizedStackSlot{static_cast<int32_t>(index_offset), index_size_in_bits, is_signed});
 
 				// Multiply RCX by element size
 			emitMultiplyRCXByElementSize(textSectionData, element_size_bytes);

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -206,6 +206,7 @@ private:
 	// - Extends scope_stack_space if the offset exceeds current tracked allocation
 	// - Registers the TempVar in variables for consistent subsequent lookups
 	int32_t getStackOffsetFromTempVar(TempVar tempVar, int size_in_bits = 64);
+	int getStackVariableLoadSizeBits(StringHandle variable_name, int fallback_size_in_bits) const;
 
 	void flushAllDirtyRegisters();
 

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -206,7 +206,7 @@ private:
 	// - Extends scope_stack_space if the offset exceeds current tracked allocation
 	// - Registers the TempVar in variables for consistent subsequent lookups
 	int32_t getStackOffsetFromTempVar(TempVar tempVar, int size_in_bits = 64);
-	int getStackVariableLoadSizeBits(StringHandle variable_name, int fallback_size_in_bits) const;
+	SizeInBits getStackVariableLoadSizeBits(StringHandle variable_name) const;
 
 	void flushAllDirtyRegisters();
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7572,6 +7572,9 @@ void SemanticAnalysis::tryResolveSubscriptOperator(const ArraySubscriptNode& sub
 	if (!best_match)
 		return;
 
+	best_match = tryMaterializeLazyReceiverMemberTarget(
+		best_match,
+		subscript_node.array_expr());
 	op_subscript_table_[&subscript_node] = best_match;
 
 	FLASH_LOG_FORMAT(General, Debug,
@@ -8282,29 +8285,35 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	const FunctionDeclarationNode* func_decl,
 	const CallInfo& call_info) {
+	if (!call_info.has_receiver || !call_info.receiver.has_value()) {
+		return tryMaterializeLazyCallTarget(func_decl);
+	}
+	return tryMaterializeLazyReceiverMemberTarget(func_decl, call_info.receiver);
+}
+
+const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyReceiverMemberTarget(
+	const FunctionDeclarationNode* func_decl,
+	const ASTNode& receiver) {
 	// First run the base marker (intra-instantiation remap + pattern-parent
 	// lazy materialization).
 	const FunctionDeclarationNode* result = tryMaterializeLazyCallTarget(func_decl);
-	if (!func_decl) {
+	if (!func_decl || !receiver.has_value()) {
 		return result;
 	}
+
 	// Phase 5 Slice G item #4 blockers (5)/(6): when the resolver returns a
 	// member-function decl whose parent_struct_name is empty (using-decl pack
 	// or static-like overload pick) or points at a template pattern (pattern
 	// member reached via an instantiation receiver), derive the concrete
-	// instantiated owner from the call's receiver type and mark that lazy
+	// instantiated owner from the receiver type and mark that lazy
 	// member ODR-used so drain pass-2 materialises it.
-	if (!call_info.has_receiver || !call_info.receiver.has_value()) {
-		return result;
-	}
-
 	const std::string_view parent_sv = func_decl->parent_struct_name();
 	// Note: parent_sv may be empty for member calls whose resolver picked a
 	// non-member-view of the decl (e.g. using-decl pack statics, certain
 	// static-member / free-function overload candidates). In that case we
 	// derive the instantiated owner purely from the receiver type below.
 	const TypeInfo* receiver_type_info =
-		tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
+		tryResolveStructOwnerTypeInfoForExpression(receiver);
 	// Fallback: if receiver type inference failed (e.g. unresolved `this`
 	// in a late-materialised dependent member body), use the innermost
 	// member-context. That is the struct whose body we are currently

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7921,33 +7921,12 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 	if (call_info.has_receiver) {
-		auto resolveReceiverStructInfo = [&]() -> const StructTypeInfo* {
-			const CanonicalTypeId receiver_type_id = inferExpressionType(call_info.receiver);
-			if (!receiver_type_id) {
-				return nullptr;
-			}
-			const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
-			const TypeInfo* receiver_type_info = nullptr;
-			if (receiver_desc.category() == TypeCategory::Struct ||
-				receiver_desc.category() == TypeCategory::UserDefined) {
-				receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
-				if (!receiver_type_info &&
-					receiver_desc.category() == TypeCategory::UserDefined &&
-					receiver_desc.type_index.is_valid()) {
-					const ResolvedAliasTypeInfo resolved_alias =
-						resolveAliasTypeInfo(receiver_desc.type_index);
-					receiver_type_info = resolved_alias.terminal_type_info;
-				}
-			}
-			if (receiver_type_info == nullptr) {
-				return nullptr;
-			}
-			if (const TypeInfo* resolved_owner = tryResolveStructOwnerTypeInfo(receiver_type_info)) {
-				return resolved_owner->getStructInfo();
-			}
-			return nullptr;
-		};
-		if (const StructTypeInfo* receiver_struct_info = resolveReceiverStructInfo()) {
+		if (const TypeInfo* receiver_owner_type_info =
+				tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
+			receiver_owner_type_info != nullptr &&
+			receiver_owner_type_info->getStructInfo() != nullptr) {
+			const StructTypeInfo* receiver_struct_info =
+				receiver_owner_type_info->getStructInfo();
 			const StringHandle member_name_handle =
 				callee_decl.identifier_token().handle();
 			const std::optional<TypeSpecifierNode> receiver_arg_type =
@@ -8324,19 +8303,8 @@ const FunctionDeclarationNode* SemanticAnalysis::tryMaterializeLazyCallTarget(
 	// non-member-view of the decl (e.g. using-decl pack statics, certain
 	// static-member / free-function overload candidates). In that case we
 	// derive the instantiated owner purely from the receiver type below.
-	const CanonicalTypeId receiver_type_id = inferExpressionType(call_info.receiver);
-	const TypeInfo* receiver_type_info = nullptr;
-	if (receiver_type_id) {
-		const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
-		if (receiver_desc.category() == TypeCategory::Struct ||
-			receiver_desc.category() == TypeCategory::UserDefined) {
-			receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
-			if (!receiver_type_info && receiver_desc.category() == TypeCategory::UserDefined) {
-				const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(receiver_desc.type_index);
-				receiver_type_info = resolved_alias.terminal_type_info;
-			}
-		}
-	}
+	const TypeInfo* receiver_type_info =
+		tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
 	// Fallback: if receiver type inference failed (e.g. unresolved `this`
 	// in a late-materialised dependent member body), use the innermost
 	// member-context. That is the struct whose body we are currently
@@ -8373,6 +8341,32 @@ const TypeInfo* SemanticAnalysis::tryResolveStructOwnerTypeInfo(const TypeInfo* 
 		type_info = underlying;
 	}
 	return nullptr;
+}
+
+const TypeInfo* SemanticAnalysis::tryResolveStructOwnerTypeInfoForExpression(const ASTNode& expr) {
+	const CanonicalTypeId expr_type_id = inferExpressionType(expr);
+	if (!expr_type_id) {
+		return nullptr;
+	}
+
+	const CanonicalTypeDesc& expr_desc = type_context_.get(expr_type_id);
+	const TypeInfo* expr_type_info = nullptr;
+	if (expr_desc.category() == TypeCategory::Struct ||
+		expr_desc.category() == TypeCategory::UserDefined) {
+		expr_type_info = tryGetTypeInfo(expr_desc.type_index);
+		if (!expr_type_info &&
+			expr_desc.category() == TypeCategory::UserDefined &&
+			expr_desc.type_index.is_valid()) {
+			const ResolvedAliasTypeInfo resolved_alias =
+				resolveAliasTypeInfo(expr_desc.type_index);
+			expr_type_info = resolved_alias.terminal_type_info;
+		}
+	}
+	if (expr_type_info == nullptr) {
+		return nullptr;
+	}
+
+	return tryResolveStructOwnerTypeInfo(expr_type_info);
 }
 
 const StructTypeInfo* SemanticAnalysis::tryResolveLocalCallableStructInfo(StringHandle callee_name) const {
@@ -8446,36 +8440,15 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			if (!receiver_arg_type.has_value() || !receiver_arg_type->is_const()) {
 				return std::nullopt;
 			}
-			const CanonicalTypeId receiver_type_id =
-				inferExpressionType(call_info.receiver);
-			if (!receiver_type_id) {
-				return std::nullopt;
-			}
-			const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
-			const TypeInfo* receiver_type_info = nullptr;
-			if (receiver_desc.category() == TypeCategory::Struct ||
-				receiver_desc.category() == TypeCategory::UserDefined) {
-				receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
-				if (!receiver_type_info &&
-					receiver_desc.category() == TypeCategory::UserDefined &&
-					receiver_desc.type_index.is_valid()) {
-					const ResolvedAliasTypeInfo resolved_alias =
-						resolveAliasTypeInfo(receiver_desc.type_index);
-					receiver_type_info = resolved_alias.terminal_type_info;
-				}
-			}
-			if (receiver_type_info == nullptr) {
-				return std::nullopt;
-			}
-			const TypeInfo* resolved_owner =
-				tryResolveStructOwnerTypeInfo(receiver_type_info);
-			if (resolved_owner == nullptr ||
-				resolved_owner->getStructInfo() == nullptr) {
+			const TypeInfo* receiver_owner_type_info =
+				tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
+			if (receiver_owner_type_info == nullptr ||
+				receiver_owner_type_info->getStructInfo() == nullptr) {
 				return std::nullopt;
 			}
 			const ConstAwareMemberCandidateSet member_candidates =
 				collectConstAwareVisibleMemberFunctionCandidates(
-					resolved_owner->getStructInfo(),
+					receiver_owner_type_info->getStructInfo(),
 					callee_decl.identifier_token().handle(),
 					true,
 					true,

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7775,6 +7775,8 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	const bool normalized_call =
 		call_key != nullptr &&
 		normalized_ast_nodes_.count(call_key) > 0;
+	const bool is_callable_operator =
+		callee_decl.identifier_token().value() == "operator()"sv;
 	auto lookupFunctionByMangledName = [&](StringHandle mangled_name) -> const FunctionDeclarationNode* {
 		if (!mangled_name.isValid()) {
 			return nullptr;
@@ -8025,6 +8027,14 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 						return candidate;
 					}
 				}
+			}
+			if (is_callable_operator &&
+				receiver_is_const &&
+				member_candidates.compatible.empty() &&
+				call_info.function_declaration != nullptr &&
+				!call_info.function_declaration->is_static() &&
+				!call_info.function_declaration->is_const_member_function()) {
+				return nullptr;
 			}
 		}
 		if (!normalized_call && call_info.function_declaration) {
@@ -8401,6 +8411,8 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 														 const char* context_description) {
 	analyzed_direct_call_queries_.insert(call_key);
 	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "tryAnnotateCallArgConversionsImpl");
+	const bool is_callable_operator =
+		callee_decl.identifier_token().value() == "operator()"sv;
 
 	const FunctionDeclarationNode* func_decl = resolveCallArgAnnotationTarget(call_info, call_key);
 	if (!func_decl) {
@@ -8420,11 +8432,84 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			InlineVector<TypeSpecifierNode, 6> arg_types;
 			return tryCollectOverloadResolutionArgTypes(*call_info.arguments, arg_types);
 		};
+		auto diagnosableConstReceiverCallableName = [&]() -> std::optional<std::string> {
+			if (!call_info.has_receiver ||
+				call_info.is_indirect ||
+				!is_callable_operator ||
+				call_info.function_declaration == nullptr ||
+				call_info.function_declaration->is_static() ||
+				call_info.function_declaration->is_const_member_function()) {
+				return std::nullopt;
+			}
+			const std::optional<TypeSpecifierNode> receiver_arg_type =
+				buildOverloadResolutionArgType(call_info.receiver, nullptr);
+			if (!receiver_arg_type.has_value() || !receiver_arg_type->is_const()) {
+				return std::nullopt;
+			}
+			const CanonicalTypeId receiver_type_id =
+				inferExpressionType(call_info.receiver);
+			if (!receiver_type_id) {
+				return std::nullopt;
+			}
+			const CanonicalTypeDesc& receiver_desc = type_context_.get(receiver_type_id);
+			const TypeInfo* receiver_type_info = nullptr;
+			if (receiver_desc.category() == TypeCategory::Struct ||
+				receiver_desc.category() == TypeCategory::UserDefined) {
+				receiver_type_info = tryGetTypeInfo(receiver_desc.type_index);
+				if (!receiver_type_info &&
+					receiver_desc.category() == TypeCategory::UserDefined &&
+					receiver_desc.type_index.is_valid()) {
+					const ResolvedAliasTypeInfo resolved_alias =
+						resolveAliasTypeInfo(receiver_desc.type_index);
+					receiver_type_info = resolved_alias.terminal_type_info;
+				}
+			}
+			if (receiver_type_info == nullptr) {
+				return std::nullopt;
+			}
+			const TypeInfo* resolved_owner =
+				tryResolveStructOwnerTypeInfo(receiver_type_info);
+			if (resolved_owner == nullptr ||
+				resolved_owner->getStructInfo() == nullptr) {
+				return std::nullopt;
+			}
+			const ConstAwareMemberCandidateSet member_candidates =
+				collectConstAwareVisibleMemberFunctionCandidates(
+					resolved_owner->getStructInfo(),
+					callee_decl.identifier_token().handle(),
+					true,
+					true,
+					[](const StructMemberFunction&, const FunctionDeclarationNode&) {
+						return true;
+					});
+			if (!member_candidates.compatible.empty()) {
+				return std::nullopt;
+			}
+			if (call_info.receiver.is<ExpressionNode>()) {
+				const ExpressionNode& receiver_expr = call_info.receiver.as<ExpressionNode>();
+				if (const auto* ident = std::get_if<IdentifierNode>(&receiver_expr)) {
+					return std::string(ident->name());
+				}
+			}
+			return std::string{};
+		};
 		if (hasDiagnosableLocalCallableMiss()) {
 			throw CompileError(
 				std::string("callable object '") +
 				std::string(callee_decl.identifier_token().value()) +
 				"' has no matching operator()");
+		}
+		if (std::optional<std::string> receiver_name =
+				diagnosableConstReceiverCallableName();
+			receiver_name.has_value()) {
+			if (!receiver_name->empty()) {
+				throw CompileError(
+					std::string("callable object '") +
+					*receiver_name +
+					"' cannot call non-const operator() through a const receiver");
+			}
+			throw CompileError(
+				"callable object cannot call non-const operator() through a const receiver");
 		}
 
 		const bool normalized_call_expr = hasNormalizedAstNode(call_expr_node);

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -549,6 +549,7 @@ private:
 	const FunctionDeclarationNode* resolveCallArgAnnotationTarget(const CallInfo& call_info,
 																 const void* call_key);
 	const TypeInfo* tryResolveStructOwnerTypeInfo(const TypeInfo* type_info) const;
+	const TypeInfo* tryResolveStructOwnerTypeInfoForExpression(const ASTNode& expr);
 	const StructTypeInfo* tryResolveLocalCallableStructInfo(StringHandle callee_name) const;
 	struct ResolvedMemberAccessInfo {
 		TypeIndex owner_type_index{};

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -574,6 +574,10 @@ private:
 	const FunctionDeclarationNode* tryMaterializeLazyCallTarget(
 		const FunctionDeclarationNode* func_decl);
 
+	const FunctionDeclarationNode* tryMaterializeLazyReceiverMemberTarget(
+		const FunctionDeclarationNode* func_decl,
+		const ASTNode& receiver);
+
 	// Phase 5 Slice G item #4: receiver-aware variant. When the resolved
 	// `func_decl` carries a template-pattern parent_struct_name (e.g.
 	// `Box` rather than `Box$hash`), the receiver's TypeInfo gives us the

--- a/tests/test_template_callable_operator_const_receiver_explicit_member_fail.cpp
+++ b/tests/test_template_callable_operator_const_receiver_explicit_member_fail.cpp
@@ -1,0 +1,15 @@
+template<typename Callable>
+int invokeConst(const Callable& callable) {
+	return callable.operator()(1);
+}
+
+struct MutableOnlyCallable {
+	int operator()(int value) {
+		return value + 1;
+	}
+};
+
+int main() {
+	MutableOnlyCallable callable;
+	return invokeConst(callable);
+}

--- a/tests/test_template_callable_operator_const_receiver_fail.cpp
+++ b/tests/test_template_callable_operator_const_receiver_fail.cpp
@@ -1,0 +1,15 @@
+template<typename Callable>
+int invokeConst(const Callable& callable) {
+	return callable(1);
+}
+
+struct MutableOnlyCallable {
+	int operator()(int value) {
+		return value + 1;
+	}
+};
+
+int main() {
+	MutableOnlyCallable callable;
+	return invokeConst(callable);
+}


### PR DESCRIPTION
## Summary
This branch continues the template-infrastructure refactoring from the May 12 audits by removing a few high-impact fallback paths and tightening the boundary between parser guesses, semantic evidence, and backend lowering.

The first change closes a callable conformance gap: a const dependent or local callable can no longer compile through a stale parser-selected non-const `operator()` target once semantic analysis has already proven there is no const-compatible candidate.

The branch also reduces semantic duplication by extracting the shared receiver-expression to concrete struct-owner resolution used by member-call target resolution, const-receiver callable diagnostics, and lazy call-target materialization.

On the subscript side, semantic `operator[]` results now go through the same receiver-aware lazy member materialization path as ordinary member calls, so out-of-line template subscript bodies materialize the instantiated member target instead of falling back to a template-pattern target.

Finally, the branch fixes a Linux-only backend bug that still caused `test_template_out_of_line_subscript_operator_ret42.cpp` to segfault: named array indices in several address-lowering paths were being reloaded using widened payload size instead of the authoritative stack-slot width, which could turn a stored 32-bit `int` index into a garbage 64-bit load. Those paths now use the recorded stack-variable width, producing the correct sign-extending load.

## Changes
- Tightened const callable operator diagnostics so semantic analysis rejects stale non-const callable fallback paths once const-compatibility has been disproven.
- Extracted shared semantic receiver-owner lookup logic to reduce duplication across member-call and callable resolution paths.
- Materialized semantic subscript targets through the same receiver-aware lazy member path used for member calls.
- Fixed Linux named-index load-width handling in backend array/address lowering.
- Added and validated focused regressions around callable diagnostics and template subscript behavior.
- Updated the template-argument audit docs with the landed slice and the next follow-up work.

## Next Steps
The next highest-impact item remains replay-attachment hardening: remove the remaining out-of-line template member attachment paths that still accept shape matches without positive substituted-signature evidence.