### PR TITLE
[codex] Tighten template call fallback and pack substitution

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -501,6 +501,39 @@ member-candidate collector so future overload fixes cannot drift between paths.
 
 Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 
+## 2026-06-09 direct-call pack-substitution sema note
+
+Returning to the remaining non-receiver/direct-call compatibility surface
+showed that one active route was no longer a semantic lookup hole in
+`SemanticAnalysis`, but an earlier substitution gap in
+`ExpressionSubstitutor`: when a substituted direct call still carried a
+`PackExpansionExprNode` in its argument list, the dependent-unqualified
+point-of-instantiation replay could not collect concrete argument types and the
+later direct-call compatibility branch remained live.
+
+This slice now:
+
+- preserves call-site pack expansion while rebuilding substituted constructor,
+  direct-call, and receiver-call argument lists inside `ExpressionSubstitutor`
+- lets dependent-unqualified direct calls materialize concrete argument types
+  before point-of-instantiation lookup, covering the active
+  `add(readValue(__builtin_addressof(args))...)` route
+- removes the confirmed live traffic from the remaining non-receiver
+  compatibility branch without widening semantic fallback
+
+Validated with:
+
+- `test_template_builtin_addressof_substitution_ret0.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+Next step:
+
+- re-audit `resolveCallArgAnnotationTarget(...)` / direct-call compatibility
+  now that this pack-substitution gap is closed, and remove or narrow the
+  remaining non-receiver fallback only where typed sema evidence is complete
+
 ## Validation guidance
 
 When changing this area, always rerun:

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -34,8 +34,11 @@ members are explicitly excluded by requiring real member-function ownership
 before raising the diagnostic. The next receiver-member follow-up now also
 blocks parser-selected fallback after typed sema has already proven a dependent
 member call ambiguous, so replay/materialization remains the biggest remaining
-gap while semantic-call fallback debt narrows toward the non-receiver/direct-call
-cases that still have temporary compatibility behavior.
+gap. The newest replay follow-up closes one active weak-evidence route in
+partial-specialization plain-member `StructTypeInfo` sync by preserving
+source-member identity there too, so the remaining replay cleanup is now
+narrower: the residual `StructTypeInfo` sync helpers that still fall back to
+signature equivalence when identity metadata is missing.
 
 ## What the current design can assume
 
@@ -73,6 +76,9 @@ cases that still have temporary compatibility behavior.
 - sema now also rejects parser-selected ordinary member-call fallback once
   shared typed overload resolution has already proven the dependent receiver
   call ambiguous
+- partial-specialization plain out-of-line member replay now also syncs its
+  `StructTypeInfo` copy through source-member identity instead of dropping to
+  signature-equivalent matching
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -192,9 +198,10 @@ Tightening those is the next best cleanup target.
    negative cases are closed for `operator[]`, callable `operator()`, and
    ordinary member functions.
 
-2. Tighten the remaining replay-attachment sites that can still succeed without
-   positive substituted-signature evidence outside the now-hardened plain-member,
-   member-template, and constructor-template routes.
+2. Tighten the remaining replay/`StructTypeInfo` sync helpers that still fall
+   back to signature-equivalent matching when source replay identity was not
+   preserved, now that the partial-specialization plain-member route is
+   identity-driven too.
 
 3. Audit the remaining semantic call compatibility fallbacks that still reuse
    parser-selected targets after typed sema evidence is available, and remove
@@ -255,6 +262,37 @@ Validated with:
 - `test_template_member_call_const_receiver_fail.cpp`
 - `test_funcptr_nested_template_struct_ret0.cpp`
 - `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 partial-specialization StructTypeInfo replay-sync note
+
+Moving to the next active replay slice found that one weak-evidence route still
+survived outside the hardened replay-attachment helpers: partial-specialization
+plain out-of-line member replay attached the instantiated stub correctly by
+source-member identity, but the later `StructTypeInfo` sync path could still
+drop to signature-equivalent matching because the partial-specialization
+`StructTypeInfo` copy never recorded source-member -> struct-info-member
+identity for ordinary member functions.
+
+This slice now:
+
+- records source-member -> `StructTypeInfo` member index identity for ordinary
+  function copies in the partial-specialization struct-info build path
+- reuses that identity in partial-specialization plain out-of-line member sync
+  before any `StructTypeInfo` signature-equivalence fallback is considered
+- removes the active dependence on weak signature-equivalent sync for the
+  covered same-name overload route
+
+Validated with:
+
+- `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
+- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
+- `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## 2026-06-04 dependent decltype trailing-return note

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -37,8 +37,10 @@ member call ambiguous, so replay/materialization remains the biggest remaining
 gap. The newest replay follow-up closes one active weak-evidence route in
 partial-specialization plain-member `StructTypeInfo` sync by preserving
 source-member identity there too, so the remaining replay cleanup is now
-narrower: the residual `StructTypeInfo` sync helpers that still fall back to
-signature equivalence when identity metadata is missing.
+narrower still: the residual signature-equivalent `StructTypeInfo` sync branch
+was probed across the full suite, found dead on the current corpus, and then
+deleted. The next highest-value task is back on the semantic-call side unless a
+new replay route proves it still loses identity metadata.
 
 ## What the current design can assume
 
@@ -79,6 +81,8 @@ signature equivalence when identity metadata is missing.
 - partial-specialization plain out-of-line member replay now also syncs its
   `StructTypeInfo` copy through source-member identity instead of dropping to
   signature-equivalent matching
+- the last shared signature-equivalent `StructTypeInfo` sync fallback in the
+  current corpus has been removed after a full-suite probe showed it was dead
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -192,16 +196,15 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Audit the remaining non-receiver / direct-call compatibility branches that
-   still allow ordinary calls to continue after typed sema evidence has
+1. Return to the remaining non-receiver / direct-call compatibility branches
+   that still allow ordinary calls to continue after typed sema evidence has
    produced no viable target or an ambiguity, now that the receiver-sensitive
-   negative cases are closed for `operator[]`, callable `operator()`, and
-   ordinary member functions.
+   negative cases are closed and the dead signature-equivalent
+   `StructTypeInfo` sync branch is gone.
 
-2. Tighten the remaining replay/`StructTypeInfo` sync helpers that still fall
-   back to signature-equivalent matching when source replay identity was not
-   preserved, now that the partial-specialization plain-member route is
-   identity-driven too.
+2. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
+   source replay identity into that path rather than reintroducing any
+   signature-equivalent fallback.
 
 3. Audit the remaining semantic call compatibility fallbacks that still reuse
    parser-selected targets after typed sema evidence is available, and remove
@@ -294,6 +297,29 @@ Validated with:
 - `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
 - `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 dead signature-equivalent StructTypeInfo sync cleanup note
+
+After the partial-specialization fix, the remaining shared
+`findMatchingFunctionInStructInfo(...)` /
+`findMatchingConstructorInStructInfo(...)` signature-equivalent fallback was
+probed directly with hard-fail guards across the full suite. No current test
+hit that branch.
+
+This slice now:
+
+- deletes the dead signature-equivalent `StructTypeInfo` sync fallback from the
+  shared constructor/function helpers
+- leaves those helpers consuming only stronger evidence already preserved in the
+  current design: direct node identity and replay source keys
+- keeps the docs honest by moving the next recommended task back to the live
+  semantic-call compatibility boundary instead of implying this dead replay
+  branch still needed root-fixing
+
+Validated with:
+
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09 under the hard-fail probe
+- full `pwsh tests/run_all_tests.ps1` again after deleting the dead fallback
 
 ## 2026-06-04 dependent decltype trailing-return note
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -31,10 +31,11 @@ the same const-receiver hole for dependent `const T& obj; obj.member(...)`
 calls, so stale parser-selected non-const member targets no longer compile once
 shared sema lookup has found no const-compatible overload; function-pointer
 members are explicitly excluded by requiring real member-function ownership
-before raising the diagnostic. The biggest remaining gap is keeping every
-replay/materialization path equally evidence-driven rather than shape-driven
-while continuing to narrow the remaining compatibility fallbacks around
-semantic call resolution.
+before raising the diagnostic. The next receiver-member follow-up now also
+blocks parser-selected fallback after typed sema has already proven a dependent
+member call ambiguous, so replay/materialization remains the biggest remaining
+gap while semantic-call fallback debt narrows toward the non-receiver/direct-call
+cases that still have temporary compatibility behavior.
 
 ## What the current design can assume
 
@@ -69,6 +70,9 @@ semantic call resolution.
   targets on const dependent/member-call receivers once shared const-aware
   lookup has shown there is no const-compatible overload, while leaving
   function-pointer member calls on the indirect-call path
+- sema now also rejects parser-selected ordinary member-call fallback once
+  shared typed overload resolution has already proven the dependent receiver
+  call ambiguous
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -182,11 +186,11 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Audit the remaining semantic call-resolution entry points and compatibility
-   branches that still allow normalized ordinary calls to continue after typed
-   sema evidence has produced no viable target or an ambiguity, now that the
-   const-receiver negative cases are closed for `operator[]`, callable
-   `operator()`, and ordinary member functions.
+1. Audit the remaining non-receiver / direct-call compatibility branches that
+   still allow ordinary calls to continue after typed sema evidence has
+   produced no viable target or an ambiguity, now that the receiver-sensitive
+   negative cases are closed for `operator[]`, callable `operator()`, and
+   ordinary member functions.
 
 2. Tighten the remaining replay-attachment sites that can still succeed without
    positive substituted-signature evidence outside the now-hardened plain-member,
@@ -224,6 +228,31 @@ Validated with:
 
 - `test_template_member_call_const_receiver_fail.cpp`
 - `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_funcptr_nested_template_struct_ret0.cpp`
+- `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 ordinary member ambiguity sema note
+
+Continuing the same fallback audit found a second receiver-member hole: a
+dependent member call that became ambiguous at instantiation could still
+compile because sema reduced the typed overload result to "no unique target"
+and then fell back to the parser-selected member candidate.
+
+This slice now:
+
+- preserves ambiguity information across the shared receiver-member typed
+  overload helper instead of collapsing it to a generic miss
+- blocks parser-selected fallback once shared sema has already proven the
+  receiver-member call ambiguous
+- raises the covered ambiguity from the shared call-annotation path as a hard
+  member-call diagnostic
+
+Validated with:
+
+- `test_template_member_call_ambiguous_fail.cpp`
+- `test_template_member_call_no_viable_overload_fail.cpp`
+- `test_template_member_call_const_receiver_fail.cpp`
 - `test_funcptr_nested_template_struct_ret0.cpp`
 - `test_typedef_function_ptr_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-09
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -26,7 +26,12 @@ reference qualification or pointer-to-member owner identity. The most recent
 callable follow-up now also makes the dependent `const Callable& c; c(...)`
 negative case sema-owned, so parser-selected non-const `operator()` targets no
 longer compile through const receivers after sema has already found no viable
-const-compatible callable target. The biggest remaining gap is keeping every
+const-compatible callable target. The next ordinary-member follow-up now closes
+the same const-receiver hole for dependent `const T& obj; obj.member(...)`
+calls, so stale parser-selected non-const member targets no longer compile once
+shared sema lookup has found no const-compatible overload; function-pointer
+members are explicitly excluded by requiring real member-function ownership
+before raising the diagnostic. The biggest remaining gap is keeping every
 replay/materialization path equally evidence-driven rather than shape-driven
 while continuing to narrow the remaining compatibility fallbacks around
 semantic call resolution.
@@ -60,6 +65,10 @@ semantic call resolution.
   const dependent/local callable receivers once semantic lookup has shown there
   is no viable const-compatible overload, so this negative path no longer
   compiles through fallback attachment
+- sema now also rejects parser-selected non-const ordinary member-function
+  targets on const dependent/member-call receivers once shared const-aware
+  lookup has shown there is no const-compatible overload, while leaving
+  function-pointer member calls on the indirect-call path
 - nested member-template alias materialization now preserves substantially more
   outer owner/member-template metadata through parsing, rebinding, and
   materialization
@@ -145,12 +154,12 @@ Tightening those is the next best cleanup target.
    call-argument typing inside sema with normalized semantic argument typing,
    and the 2026-06-04 follow-ups applied the same model to semantic
    `operator[]` and dependent/local callable `operator()` resolution. The
-   2026-06-08 follow-up closes the documented const-receiver no-viable
-   callable diagnostic hole; the next useful expansion is to audit any other
-   semantic call-resolution sites that still do not share that collector or the
-   receiver-aware candidate partitioning around it, and then remove the
-   temporary compatibility fallbacks that remain once typed sema evidence is
-   present.
+   2026-06-08/2026-06-09 follow-ups close the documented const-receiver
+   no-viable callable and ordinary-member diagnostic holes; the next useful
+   expansion is to audit any other semantic call-resolution sites that still do
+   not share that collector or the receiver-aware candidate partitioning around
+   it, and then remove the temporary compatibility fallbacks that remain once
+   typed sema evidence is present.
 
 4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
    Richer current-instantiation and unknown-specialization handling still
@@ -173,10 +182,11 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Audit the remaining semantic call-resolution entry points that do not yet
-   share `tryCollectOverloadResolutionArgTypes(...)` or the shared
-   receiver-aware candidate partitioning beyond the now-fixed `operator[]` and
-   dependent/local callable `operator()` routes.
+1. Audit the remaining semantic call-resolution entry points and compatibility
+   branches that still allow normalized ordinary calls to continue after typed
+   sema evidence has produced no viable target or an ambiguity, now that the
+   const-receiver negative cases are closed for `operator[]`, callable
+   `operator()`, and ordinary member functions.
 
 2. Tighten the remaining replay-attachment sites that can still succeed without
    positive substituted-signature evidence outside the now-hardened plain-member,
@@ -189,6 +199,34 @@ Tightening those is the next best cleanup target.
 4. Expand current-instantiation / unknown-specialization modeling only for the
    concrete cases that still block standards-conforming typed lookup after steps
    1-3.
+
+## 2026-06-09 ordinary member const-receiver sema note
+
+Continuing the semantic-call fallback audit found that the shared
+`resolveCallArgAnnotationTarget(...)` / `tryAnnotateCallArgConversionsImpl(...)`
+path still left one standards-visible ordinary member-call hole open: a
+dependent `const T& obj; obj.member(...)` could compile when the parser had
+already attached a non-const member target, even though sema's const-aware
+member lookup found no viable const-compatible overload.
+
+This slice now:
+
+- blocks reuse of that stale parser-selected non-const member target once
+  shared const-aware lookup has proven the receiver has no const-compatible
+  overload for the named member
+- raises the failure from the shared sema call-annotation path as a hard member
+  call diagnostic instead of letting normalized/template calls continue into
+  codegen fallback
+- keeps function-pointer member calls valid by requiring actual member-function
+  ownership before applying the const-receiver diagnostic guard
+
+Validated with:
+
+- `test_template_member_call_const_receiver_fail.cpp`
+- `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_funcptr_nested_template_struct_ret0.cpp`
+- `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## 2026-06-04 dependent decltype trailing-return note
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -52,6 +52,9 @@ Move FlashCpp toward a sema-owned template system where:
 - sema now also rejects parser-selected ordinary member-call fallback once
   typed receiver-member overload resolution has already proven the dependent
   call ambiguous
+- partial-specialization plain out-of-line member replay now also syncs its
+  `StructTypeInfo` copy through source-member identity instead of
+  signature-equivalent matching
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -153,9 +156,9 @@ unknown-specialization modeling only where it unblocks those paths.
    cases are closed for `operator[]`, callable `operator()`, and ordinary
    member functions.
 
-2. Continue deleting replay-attachment acceptance paths that still allow
-   insufficient substituted-signature evidence outside the now-hardened member
-   and constructor routes.
+2. Continue deleting replay/`StructTypeInfo` sync paths that still allow
+   signature-equivalent fallback when source replay identity was not preserved,
+   now that the partial-specialization plain-member route is identity-driven.
 
 3. Audit the remaining semantic call compatibility fallbacks that still reuse
    parser-selected targets after typed sema evidence is available, and remove
@@ -213,6 +216,38 @@ Validated with:
 - `test_template_member_call_const_receiver_fail.cpp`
 - `test_funcptr_nested_template_struct_ret0.cpp`
 - `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 partial-specialization StructTypeInfo replay-sync conformance note
+
+The next active standards-relevant replay gap was no longer initial attachment;
+that part was already identity-driven. The remaining weakness was the later
+`StructTypeInfo` sync for partial-specialization plain out-of-line members:
+the instantiated stub was attached by source-member identity, but the parallel
+`StructTypeInfo` copy could still be rediscovered only by signature-equivalent
+matching because the partial-specialization copy path never preserved
+source-member -> struct-info-member identity for ordinary functions.
+
+The fix now:
+
+- records source-member -> `StructTypeInfo` member index identity for ordinary
+  function copies in the partial-specialization struct-info build path
+- uses that identity first during partial-specialization plain-member replay
+  sync instead of rediscovering the `StructTypeInfo` target by equivalent
+  signature
+- removes the active same-name overload dependence on weak signature-shaped
+  sync in the covered route
+
+Validated with:
+
+- `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_plain_member_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
+- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
+- `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## 2026-06-04 dependent decltype conformance note

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-08
+**Last updated:** 2026-06-09
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -45,6 +45,10 @@ Move FlashCpp toward a sema-owned template system where:
   const dependent/local callable receivers once semantic lookup has shown there
   is no viable const-compatible overload, so this standards-visible negative
   case no longer compiles through member-call fallback
+- sema now also rejects parser-selected non-const ordinary member-function
+  targets on const dependent/member-call receivers once const-aware lookup has
+  shown there is no viable const-compatible overload, while leaving
+  function-pointer member calls on their ordinary indirect-call path
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -115,11 +119,11 @@ unknown-specialization modeling only where it unblocks those paths.
    template/member direct calls. The 2026-06-04 follow-ups closed the concrete
    `operator[]` and dependent/local callable `operator()` gaps by sharing
    receiver-aware candidate filtering plus sema-owned argument typing with
-   direct member-call resolution, and the 2026-06-08 follow-up closes the
-   documented const-receiver no-viable callable diagnostic hole. The next step
-   here is auditing any residual semantic call sites still outside that model,
-   then removing the temporary parser-target compatibility fallbacks that
-   remain once typed sema evidence is available.
+   direct member-call resolution, and the 2026-06-08/2026-06-09 follow-ups
+   close the documented const-receiver no-viable callable and ordinary-member
+   diagnostic holes. The next step here is auditing any residual semantic call
+   sites still outside that model, then removing the temporary parser-target
+   compatibility fallbacks that remain once typed sema evidence is available.
 
 4. Expand current-instantiation, dependent-base, and unknown-specialization
    handling only where that unblocks steps 2 and 3.
@@ -140,11 +144,11 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Apply the sema-owned overload-resolution argument collector and the shared
-   receiver-aware candidate partitioning to the remaining semantic
-   call-resolution sites that still rely on parser-owned expression typing or
-   reduced argument modeling beyond the now-fixed `operator[]` and
-   dependent/local callable `operator()` routes.
+1. Remove the remaining normalized-call compatibility branches that still let
+   ordinary calls continue after typed sema evidence has produced no viable
+   target or an ambiguity, now that the const-receiver negative cases are
+   closed for `operator[]`, callable `operator()`, and ordinary member
+   functions.
 
 2. Continue deleting replay-attachment acceptance paths that still allow
    insufficient substituted-signature evidence outside the now-hardened member
@@ -156,6 +160,32 @@ unknown-specialization modeling only where it unblocks those paths.
 
 4. Only after those are stable, extend current-instantiation and
    unknown-specialization modeling for the specific unresolved cases that remain.
+
+## 2026-06-09 ordinary member const-receiver conformance note
+
+The next live standards-visible call gap was the ordinary member-call analogue
+of the already-fixed callable case: a dependent `const T& obj; obj.member(...)`
+could still compile when the parser had attached a non-const member target,
+even though sema's const-aware member lookup found no viable const-compatible
+overload.
+
+The fix now:
+
+- blocks reuse of that stale parser-selected non-const member target in the
+  shared sema call-annotation path once const-aware lookup has shown there is
+  no const-compatible overload
+- emits a hard member-call diagnostic for the covered path instead of letting
+  normalized/template calls continue toward codegen fallback
+- preserves valid function-pointer member calls by requiring actual
+  member-function ownership before applying the const-receiver diagnostic
+
+Validated with:
+
+- `test_template_member_call_const_receiver_fail.cpp`
+- `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_funcptr_nested_template_struct_ret0.cpp`
+- `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## 2026-06-04 dependent decltype conformance note
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -478,6 +478,41 @@ closure model for captured `this` and nested captures:
 
 Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
 
+## 2026-06-09 direct-call pack-substitution conformance note
+
+The next live ordinary-call conformance blocker after the receiver-side fixes
+was narrower than expected: the remaining non-receiver compatibility path was
+still being exercised by a substitution gap, not by a fundamentally missing
+semantic lookup rule. When `ExpressionSubstitutor` rebuilt a substituted direct
+call and left a `PackExpansionExprNode` in the argument list, the dependent
+unqualified call could not collect concrete argument types at the point of
+instantiation, so the later compatibility branch still had to recover the
+call.
+
+The fix now:
+
+- preserves pack expansion while rebuilding substituted constructor, direct,
+  and receiver-call argument lists inside `ExpressionSubstitutor`
+- allows dependent-unqualified direct calls to arrive at point-of-instantiation
+  lookup with concrete argument types in the covered path
+- removes the active standards-visible fallback route exercised by
+  `add(readValue(__builtin_addressof(args))...)` without restoring any broad
+  parser-target recovery
+
+Validated with:
+
+- `test_template_builtin_addressof_substitution_ret0.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+Next step:
+
+- audit the residual non-receiver compatibility logic in
+  `resolveCallArgAnnotationTarget(...)` again and remove or narrow the
+  remaining branch only after each surviving direct-call route is proven to
+  reach typed semantic lookup with complete argument evidence
+
 ## Validation guidance
 
 For work in this area:

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -55,6 +55,8 @@ Move FlashCpp toward a sema-owned template system where:
 - partial-specialization plain out-of-line member replay now also syncs its
   `StructTypeInfo` copy through source-member identity instead of
   signature-equivalent matching
+- the dead shared signature-equivalent `StructTypeInfo` sync fallback is now
+  removed; current sync paths consume only preserved identity evidence
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -153,12 +155,11 @@ unknown-specialization modeling only where it unblocks those paths.
 1. Remove the remaining non-receiver / direct-call compatibility branches that
    still let ordinary calls continue after typed sema evidence has produced no
    viable target or an ambiguity, now that the receiver-sensitive negative
-   cases are closed for `operator[]`, callable `operator()`, and ordinary
-   member functions.
+   cases are closed and the dead shared `StructTypeInfo` sync fallback is gone.
 
-2. Continue deleting replay/`StructTypeInfo` sync paths that still allow
-   signature-equivalent fallback when source replay identity was not preserved,
-   now that the partial-specialization plain-member route is identity-driven.
+2. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
+   source replay identity into that path rather than restoring any
+   signature-equivalent fallback.
 
 3. Audit the remaining semantic call compatibility fallbacks that still reuse
    parser-selected targets after typed sema evidence is available, and remove
@@ -249,6 +250,26 @@ Validated with:
 - `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
 - `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 dead shared StructTypeInfo sync fallback cleanup note
+
+After the partial-specialization replay-sync fix, the remaining shared
+signature-equivalent `StructTypeInfo` sync fallback was probed directly with
+hard-fail guards across the full suite. No current test depended on it.
+
+The cleanup now:
+
+- deletes that dead signature-equivalent fallback from the shared constructor
+  and function `StructTypeInfo` sync helpers
+- leaves those helpers keyed only by stronger replay evidence already preserved
+  in the current architecture: direct node identity and replay source keys
+- reclassifies the next standards-facing task back to the live direct-call
+  compatibility boundary instead of to a dead replay branch
+
+Validated with:
+
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09 with the hard-fail probe
+- full `pwsh tests/run_all_tests.ps1` again after removing the dead fallback
 
 ## 2026-06-04 dependent decltype conformance note
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -49,6 +49,9 @@ Move FlashCpp toward a sema-owned template system where:
   targets on const dependent/member-call receivers once const-aware lookup has
   shown there is no viable const-compatible overload, while leaving
   function-pointer member calls on their ordinary indirect-call path
+- sema now also rejects parser-selected ordinary member-call fallback once
+  typed receiver-member overload resolution has already proven the dependent
+  call ambiguous
 - dependent alias resolution is semantic-only: the textual recovery path in
   `resolveDependentMemberAlias(...)` has been removed in favor of preserved
   owner/member-chain records and instantiation-context bindings
@@ -144,11 +147,11 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Remove the remaining normalized-call compatibility branches that still let
-   ordinary calls continue after typed sema evidence has produced no viable
-   target or an ambiguity, now that the const-receiver negative cases are
-   closed for `operator[]`, callable `operator()`, and ordinary member
-   functions.
+1. Remove the remaining non-receiver / direct-call compatibility branches that
+   still let ordinary calls continue after typed sema evidence has produced no
+   viable target or an ambiguity, now that the receiver-sensitive negative
+   cases are closed for `operator[]`, callable `operator()`, and ordinary
+   member functions.
 
 2. Continue deleting replay-attachment acceptance paths that still allow
    insufficient substituted-signature evidence outside the now-hardened member
@@ -183,6 +186,31 @@ Validated with:
 
 - `test_template_member_call_const_receiver_fail.cpp`
 - `test_template_callable_operator_const_receiver_fail.cpp`
+- `test_funcptr_nested_template_struct_ret0.cpp`
+- `test_typedef_function_ptr_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-09 ordinary member ambiguity conformance note
+
+The next live standards-visible gap in the same family was ambiguity handling
+for dependent ordinary member calls: once instantiation made the receiver call
+ambiguous, sema could still degrade that typed result to "no unique target"
+and continue by reusing a parser-selected member candidate.
+
+The fix now:
+
+- preserves explicit ambiguity in the shared receiver-member typed overload
+  helper instead of collapsing it to a generic miss
+- blocks parser-selected fallback once sema has already proven the receiver
+  call ambiguous
+- emits a hard member-call ambiguity diagnostic from the shared call-annotation
+  path for the covered cases
+
+Validated with:
+
+- `test_template_member_call_ambiguous_fail.cpp`
+- `test_template_member_call_no_viable_overload_fail.cpp`
+- `test_template_member_call_const_receiver_fail.cpp`
 - `test_funcptr_nested_template_struct_ret0.cpp`
 - `test_typedef_function_ptr_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -531,10 +531,8 @@ ASTNode ExpressionSubstitutor::substituteConstructorCall(const ConstructorCallNo
 
 	// Create new ConstructorCallNode with substituted type
 	// First, we need to copy the arguments
-	ChunkedVector<ASTNode> substituted_args;
-	for (size_t i = 0; i < ctor.arguments().size(); ++i) {
-		substituted_args.push_back(substitute(ctor.arguments()[i]));
-	}
+	ChunkedVector<ASTNode> substituted_args =
+		substituteCallArgumentsPreservingPackExpansion(ctor.arguments());
 
 	// Create new TypeSpecifierNode and ConstructorCallNode
 	TypeSpecifierNode& new_type = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(substituted_type);
@@ -546,6 +544,96 @@ ASTNode ExpressionSubstitutor::substituteConstructorCall(const ConstructorCallNo
 	// Wrap in ExpressionNode
 	ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_ctor);
 	return ASTNode(&new_expr);
+}
+
+void ExpressionSubstitutor::substituteCallArgumentPreservingPackExpansion(
+	const ASTNode& arg,
+	ChunkedVector<ASTNode>& out) {
+	if (arg.is<ExpressionNode>()) {
+		const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
+		if (const auto* pack_expansion_expr = std::get_if<PackExpansionExprNode>(&arg_expr)) {
+			InlineVector<TemplateParameterNode, 4> template_params;
+			InlineVector<TemplateTypeArg, 4> template_args;
+			template_params.reserve(environment_.bindings.size());
+			for (const TemplateBinding& binding : environment_.bindings) {
+				if (!binding.name.isValid()) {
+					continue;
+				}
+				Token param_token(
+					Token::Type::Identifier,
+					StringTable::getStringView(binding.name),
+					0,
+					0,
+					0);
+				TemplateParameterNode template_param;
+				switch (binding.kind) {
+				case TemplateParameterKind::Type:
+					template_param = TemplateParameterNode(binding.name, param_token);
+					break;
+				case TemplateParameterKind::NonType: {
+					TypeSpecifierNode parameter_type;
+					if (!binding.args.empty()) {
+						const TemplateTypeArg& bound_arg = binding.args.front();
+						if (bound_arg.type_index.is_valid()) {
+							parameter_type = TypeSpecifierNode(
+								bound_arg.type_index,
+								computeTypeSizeInBits(bound_arg.type_index),
+								param_token,
+								CVQualifier::None,
+								ReferenceQualifier::None);
+						} else if (bound_arg.typeEnum() != TypeCategory::Invalid) {
+							parameter_type = TypeSpecifierNode(
+								bound_arg.typeEnum(),
+								TypeQualifier::None,
+								get_type_size_bits(bound_arg.typeEnum()),
+								param_token,
+								CVQualifier::None);
+						}
+					}
+					template_param = TemplateParameterNode(binding.name, parameter_type, param_token);
+					break;
+				}
+				case TemplateParameterKind::Template:
+					template_param = TemplateParameterNode(
+						binding.name,
+						std::span<const TemplateParameterNode>{},
+						param_token);
+					break;
+				default:
+					throw InternalError("Unsupported template parameter kind while preserving pack expansion during call substitution");
+				}
+				template_param.set_variadic(binding.is_pack);
+				template_params.push_back(std::move(template_param));
+				if (binding.is_pack) {
+					for (const TemplateTypeArg& pack_arg : binding.args) {
+						template_args.push_back(pack_arg);
+					}
+				} else if (!binding.args.empty()) {
+					template_args.push_back(binding.args.front());
+				}
+			}
+
+			if (!template_params.empty() &&
+				parser_.expandPackExpansionArgs(
+					*pack_expansion_expr,
+					std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
+					std::span<const TemplateTypeArg>(template_args.data(), template_args.size()),
+					out)) {
+				return;
+			}
+		}
+	}
+
+	out.push_back(substitute(arg));
+}
+
+ChunkedVector<ASTNode> ExpressionSubstitutor::substituteCallArgumentsPreservingPackExpansion(
+	const ChunkedVector<ASTNode>& args) {
+	ChunkedVector<ASTNode> substituted_args;
+	for (const ASTNode& arg : args) {
+		substituteCallArgumentPreservingPackExpansion(arg, substituted_args);
+	}
+	return substituted_args;
 }
 
 std::vector<TemplateTypeArg> ExpressionSubstitutor::collectCurrentBoundTemplateArgs(std::string_view use_site) const {
@@ -1982,11 +2070,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				return false;
 			};
 			auto makeSubstitutedCallArguments = [&]() {
-				ChunkedVector<ASTNode> substituted_args;
-				for (size_t i = 0; i < call.arguments().size(); ++i) {
-					substituted_args.push_back(substitute(call.arguments()[i]));
-				}
-				return substituted_args;
+				return substituteCallArgumentsPreservingPackExpansion(call.arguments());
 			};
 			// First try function template instantiation to obtain accurate return type
 			std::optional<ASTNode> instantiated_template = std::nullopt;
@@ -2062,10 +2146,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				if (instantiated_template->is<FunctionDeclarationNode>()) {
 					const FunctionDeclarationNode& func_decl = instantiated_template->as<FunctionDeclarationNode>();
 
-					substituted_args_nodes.clear();
-					for (size_t i = 0; i < call.arguments().size(); ++i) {
-						substituted_args_nodes.push_back(substitute(call.arguments()[i]));
-					}
+					substituted_args_nodes =
+						substituteCallArgumentsPreservingPackExpansion(call.arguments());
 					ASTNode resolved_call = materializeResolvedCallExpr(
 						func_decl,
 						std::move(substituted_args_nodes),
@@ -2165,10 +2247,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					ReferenceQualifier::None);
 
 				// Create a ConstructorCallNode instead of an ordinary CallExprNode
-				substituted_args_nodes.clear();
-				for (size_t i = 0; i < call.arguments().size(); ++i) {
-					substituted_args_nodes.push_back(substitute(call.arguments()[i]));
-				}
+				substituted_args_nodes =
+					substituteCallArgumentsPreservingPackExpansion(call.arguments());
 				ConstructorCallNode& new_ctor = gChunkedAnyStorage.emplace_back<ConstructorCallNode>(
 					ASTNode(&new_type),
 					std::move(substituted_args_nodes),
@@ -2213,10 +2293,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					FLASH_LOG(Templates, Debug, "  Type was substituted, creating ConstructorCallNode");
 
 					// Create a ConstructorCallNode instead of an ordinary CallExprNode
-					ChunkedVector<ASTNode> substituted_args_nodes;
-					for (size_t i = 0; i < call.arguments().size(); ++i) {
-						substituted_args_nodes.push_back(substitute(call.arguments()[i]));
-					}
+					ChunkedVector<ASTNode> substituted_args_nodes =
+						substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 					TypeSpecifierNode& new_type = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(substituted_type);
 					ConstructorCallNode& new_ctor = gChunkedAnyStorage.emplace_back<ConstructorCallNode>(
@@ -2239,11 +2317,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	if (symbol_opt.has_value() && symbol_opt->is<TemplateFunctionDeclarationNode>()) {
 		FLASH_LOG(Templates, Debug, "  Function is a template: ", template_func_name);
 
-		ChunkedVector<ASTNode> substituted_args;
-		for (size_t i = 0; i < call.arguments().size(); ++i) {
-			ASTNode substituted_arg = substitute(call.arguments()[i]);
-			substituted_args.push_back(substituted_arg);
-		}
+		ChunkedVector<ASTNode> substituted_args =
+			substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 		std::optional<ASTNode> instantiated_opt = parser_.tryInstantiateTemplateFromCallArguments(
 			call.has_qualified_name() ? call.qualified_name() : std::string_view(),
@@ -2272,10 +2347,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	}
 
 	if (call.has_dependent_unqualified_lookup_record()) {
-		ChunkedVector<ASTNode> substituted_args;
-		for (size_t i = 0; i < call.arguments().size(); ++i) {
-			substituted_args.push_back(substitute(call.arguments()[i]));
-		}
+		ChunkedVector<ASTNode> substituted_args =
+			substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 		std::vector<TypeSpecifierNode> substituted_arg_types;
 		if (parser_.tryCollectFunctionCallArgTypes(substituted_args, substituted_arg_types)) {
@@ -2332,10 +2405,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					const std::string_view resolved_member_name =
 						resolved_qual_id->name();
 					if (!resolved_owner_name.empty()) {
-						ChunkedVector<ASTNode> substituted_args;
-						for (size_t i = 0; i < call.arguments().size(); ++i) {
-							substituted_args.push_back(substitute(call.arguments()[i]));
-						}
+						ChunkedVector<ASTNode> substituted_args =
+							substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 						const FunctionDeclarationNode* target_func = nullptr;
 						std::string_view mutable_resolved_owner_name =
@@ -2421,10 +2492,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			}
 
 			if (!materialized_owner_name.empty()) {
-					ChunkedVector<ASTNode> substituted_args;
-					for (size_t i = 0; i < call.arguments().size(); ++i) {
-						substituted_args.push_back(substitute(call.arguments()[i]));
-					}
+					ChunkedVector<ASTNode> substituted_args =
+						substituteCallArgumentsPreservingPackExpansion(call.arguments());
 					const FunctionDeclarationNode* target_func = nullptr;
 
 					std::optional<ASTNode> instantiated_member =
@@ -2573,10 +2642,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 									 call.called_from().line(), call.called_from().column(), call.called_from().file_index());
 
 				// Substitute arguments
-				ChunkedVector<ASTNode> substituted_args;
-				for (size_t i = 0; i < call.arguments().size(); ++i) {
-					substituted_args.push_back(substitute(call.arguments()[i]));
-				}
+				ChunkedVector<ASTNode> substituted_args =
+					substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 				// Try to trigger lazy member function instantiation for the target
 				parser_.instantiateLazyMemberForCanonicalOwner(
@@ -2620,10 +2687,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 
 	// Return with substituted children preserved.
 	FLASH_LOG(Templates, Debug, "  Returning function call as-is");
-	ChunkedVector<ASTNode> substituted_fallback_args;
-	for (size_t i = 0; i < call.arguments().size(); ++i) {
-		substituted_fallback_args.push_back(substitute(call.arguments()[i]));
-	}
+	ChunkedVector<ASTNode> substituted_fallback_args =
+		substituteCallArgumentsPreservingPackExpansion(call.arguments());
 	return materializeSubstitutedUnresolvedCall(std::move(substituted_fallback_args));
 }
 
@@ -2633,10 +2698,8 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 	}
 
 	ASTNode substituted_receiver = substitute(call.receiver());
-	ChunkedVector<ASTNode> substituted_args;
-	for (size_t i = 0; i < call.arguments().size(); ++i) {
-		substituted_args.push_back(substitute(call.arguments()[i]));
-	}
+	ChunkedVector<ASTNode> substituted_args =
+		substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
 	if ((call.callee().is_member() || call.callee().is_static_member()) &&
 		call.called_from().kind().is_identifier()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2069,9 +2069,6 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 				return false;
 			};
-			auto makeSubstitutedCallArguments = [&]() {
-				return substituteCallArgumentsPreservingPackExpansion(call.arguments());
-			};
 			// First try function template instantiation to obtain accurate return type
 			std::optional<ASTNode> instantiated_template = std::nullopt;
 			if (!qualified_name.empty()) {
@@ -2216,7 +2213,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				FLASH_LOG(Templates, Debug,
 					"  Preserving unresolved dependent call after explicit template/variable-template instantiation miss: ",
 					!qualified_name.empty() ? qualified_name : func_name);
-				return materializeSubstitutedUnresolvedCall(makeSubstitutedCallArguments());
+				return materializeSubstitutedUnresolvedCall(
+					substituteCallArgumentsPreservingPackExpansion(call.arguments()));
 			}
 
 			Parser::AliasTemplateMaterializationResult materialized_type =
@@ -2262,7 +2260,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				if (has_variable_template_candidate) {
 					FLASH_LOG(Templates, Debug,
 						"  Variable-template candidate instantiation failed; preserving explicit unresolved call");
-					return materializeSubstitutedUnresolvedCall(makeSubstitutedCallArguments());
+					return materializeSubstitutedUnresolvedCall(
+						substituteCallArgumentsPreservingPackExpansion(call.arguments()));
 				}
 			}
 		}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -294,6 +294,7 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 	Parser& parser)
 	: param_map_(param_map), parser_(parser) {
 	rebuildEnvironmentFromCurrentBindings();
+	captureParserPackState();
 }
 
 ExpressionSubstitutor::ExpressionSubstitutor(
@@ -302,6 +303,7 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 	std::span<const std::string_view> template_param_order)
 	: param_map_(param_map), parser_(parser), template_param_order_(template_param_order.begin(), template_param_order.end()) {
 	rebuildEnvironmentFromCurrentBindings();
+	captureParserPackState();
 }
 
 ExpressionSubstitutor::ExpressionSubstitutor(
@@ -310,6 +312,7 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 	Parser& parser)
 	: param_map_(param_map), pack_map_(pack_map), parser_(parser) {
 	rebuildEnvironmentFromCurrentBindings();
+	captureParserPackState();
 }
 
 ExpressionSubstitutor::ExpressionSubstitutor(
@@ -319,6 +322,7 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 	std::span<const std::string_view> template_param_order)
 	: param_map_(param_map), pack_map_(pack_map), parser_(parser), template_param_order_(template_param_order.begin(), template_param_order.end()) {
 	rebuildEnvironmentFromCurrentBindings();
+	captureParserPackState();
 }
 
 ExpressionSubstitutor::ExpressionSubstitutor(
@@ -367,12 +371,17 @@ ExpressionSubstitutor::ExpressionSubstitutor(
 	};
 	append_environment(append_environment, &environment);
 	rebuildEnvironmentFromCurrentBindings();
+	captureParserPackState();
 }
 
 ExpressionSubstitutor::ExpressionSubstitutor(
 	const TemplateInstantiationContext& context,
 	Parser& parser)
 	: ExpressionSubstitutor(context.environment, parser) {
+}
+
+void ExpressionSubstitutor::captureParserPackState() {
+	captured_pack_param_info_ = parser_.pack_param_info_;
 }
 
 void ExpressionSubstitutor::rebuildEnvironmentFromCurrentBindings() {
@@ -618,6 +627,9 @@ void ExpressionSubstitutor::substituteCallArgumentPreservingPackExpansion(
 					*pack_expansion_expr,
 					std::span<const TemplateParameterNode>(template_params.data(), template_params.size()),
 					std::span<const TemplateTypeArg>(template_args.data(), template_args.size()),
+					std::span<const Parser::PackParamInfo>(
+						captured_pack_param_info_.data(),
+						captured_pack_param_info_.size()),
 					out)) {
 				return;
 			}

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -138,6 +138,11 @@ private:
 	ASTNode substituteTypeTraitExpr(const TypeTraitExprNode& trait_expr);
 	ASTNode substituteStaticCast(const StaticCastNode& cast_node);
 	ASTNode substituteLiteral(const ASTNode& literal);
+	void substituteCallArgumentPreservingPackExpansion(
+		const ASTNode& arg,
+		ChunkedVector<ASTNode>& out);
+	ChunkedVector<ASTNode> substituteCallArgumentsPreservingPackExpansion(
+		const ChunkedVector<ASTNode>& args);
 
 	// Helper: substitute in a type specifier with template args
 	TypeSpecifierNode substituteInType(const TypeSpecifierNode& type);

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -138,6 +138,7 @@ private:
 	ASTNode substituteTypeTraitExpr(const TypeTraitExprNode& trait_expr);
 	ASTNode substituteStaticCast(const StaticCastNode& cast_node);
 	ASTNode substituteLiteral(const ASTNode& literal);
+	void captureParserPackState();
 	void substituteCallArgumentPreservingPackExpansion(
 		const ASTNode& arg,
 		ChunkedVector<ASTNode>& out);
@@ -190,6 +191,7 @@ private:
 	Parser& parser_;
 	std::vector<std::string_view> template_param_order_;
 	TemplateEnvironment environment_;
+	std::vector<Parser::PackParamInfo> captured_pack_param_info_;
 	StringHandle current_owner_type_name_{};
 	// Cycle-detection guard for materializeStoredTemplateArgs:
 	// tracks TypeInfo pointers currently being materialized to prevent

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3294,6 +3294,12 @@ private:	 // Resume private methods
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
 		ChunkedVector<ASTNode>& out_args);
+	bool expandPackExpansionArgs(
+		const PackExpansionExprNode& pack_expansion,
+		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
+		std::span<const PackParamInfo> function_pack_infos,
+		ChunkedVector<ASTNode>& out_args);
 
 	void substituteArgWithPackExpansion(
 		const ASTNode& arg,

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -706,25 +706,6 @@ inline OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
 		}
 	}
 
-	for (auto& info_func : struct_info.member_functions) {
-		if (!info_func.is_constructor ||
-			!info_func.function_decl.is<ConstructorDeclarationNode>()) {
-			continue;
-		}
-
-		auto& info_ctor = info_func.function_decl.as<ConstructorDeclarationNode>();
-		if (!is_candidate_eligible(info_ctor) ||
-			!constructorDeclarationsHaveEquivalentInstantiatedSignature(
-				info_ctor,
-				ctor_decl)) {
-			continue;
-		}
-		if (resolution.ctor != nullptr) {
-			resolution.ambiguous = true;
-			return resolution;
-		}
-		resolution.ctor = &info_ctor;
-	}
 	return resolution;
 }
 
@@ -789,27 +770,6 @@ inline OutOfLineFunctionStubResolution findMatchingFunctionInStructInfo(
 		if (resolution.func != nullptr || resolution.ambiguous) {
 			return resolution;
 		}
-	}
-
-	for (auto& info_func : struct_info.member_functions) {
-		if (info_func.is_constructor) {
-			continue;
-		}
-
-		FunctionDeclarationNode* info_decl =
-			get_function_decl_node_mut(info_func.function_decl);
-		if (info_decl == nullptr ||
-			!is_candidate_eligible(*info_decl) ||
-			!functionDeclarationsHaveEquivalentInstantiatedSignature(
-				*info_decl,
-				func_decl)) {
-			continue;
-		}
-		if (resolution.func != nullptr) {
-			resolution.ambiguous = true;
-			return resolution;
-		}
-		resolution.func = info_decl;
 	}
 
 	return resolution;

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -719,7 +719,6 @@ inline OutOfLineConstructorStubResolution findMatchingConstructorInStructInfo(
 				ctor_decl)) {
 			continue;
 		}
-
 		if (resolution.ctor != nullptr) {
 			resolution.ambiguous = true;
 			return resolution;
@@ -806,7 +805,6 @@ inline OutOfLineFunctionStubResolution findMatchingFunctionInStructInfo(
 				func_decl)) {
 			continue;
 		}
-
 		if (resolution.func != nullptr) {
 			resolution.ambiguous = true;
 			return resolution;
@@ -3996,5 +3994,3 @@ inline const StructDeclarationNode* getCachedTemplateStructDecl(const ASTNode* c
 	}
 	return &cached_node->as<StructDeclarationNode>();
 }
-
-

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -778,12 +778,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								 const ASTNode& arg,
 								 std::vector<ASTNode>& out,
 								 const auto& tmpl_params,
-								 const auto& tmpl_args) {
+								 const auto& tmpl_args,
+								 std::span<const PackParamInfo> function_pack_infos) {
 		if (arg.is<ExpressionNode>()) {
 			const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
 			if (const auto* pack_exp = std::get_if<PackExpansionExprNode>(&arg_expr)) {
 				ChunkedVector<ASTNode> expanded;
-				if (expandPackExpansionArgs(*pack_exp, tmpl_params, tmpl_args, expanded)) {
+				if (expandPackExpansionArgs(*pack_exp, tmpl_params, tmpl_args, function_pack_infos, expanded)) {
 					for (size_t ei = 0; ei < expanded.size(); ++ei) {
 						out.push_back(expanded[ei]);
 					}
@@ -800,7 +801,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 											 const ConstructorDeclarationNode& orig_ctor,
 											 ConstructorDeclarationNode& new_ctor,
 											 const auto& tmpl_params,
-											 const auto& tmpl_args) {
+											 const auto& tmpl_args,
+											 std::span<const PackParamInfo> function_pack_infos) {
 		for (const auto& [name, expr] : orig_ctor.member_initializers()) {
 			new_ctor.add_member_initializer(name, substituteTemplateParameters(expr, tmpl_params, tmpl_args));
 		}
@@ -808,7 +810,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::vector<ASTNode> substituted_args;
 			substituted_args.reserve(init.arguments.size());
 			for (const auto& arg : init.arguments) {
-				substituteInitArg(arg, substituted_args, tmpl_params, tmpl_args);
+				substituteInitArg(arg, substituted_args, tmpl_params, tmpl_args, function_pack_infos);
 			}
 			new_ctor.add_base_initializer(
 				resolveBaseInitializerNameForTemplateArgs(init.getBaseClassName(), tmpl_params, tmpl_args),
@@ -819,7 +821,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::vector<ASTNode> substituted_del_args;
 			substituted_del_args.reserve(del_init.arguments.size());
 			for (const auto& arg : del_init.arguments) {
-				substituteInitArg(arg, substituted_del_args, tmpl_params, tmpl_args);
+				substituteInitArg(arg, substituted_del_args, tmpl_params, tmpl_args, function_pack_infos);
 			}
 			new_ctor.set_delegating_initializer(std::move(substituted_del_args));
 		}
@@ -2360,11 +2362,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								pattern_struct.name(),
 								struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct))
 							: std::nullopt);
+					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 					substituteAndCopyInitializers(
 						orig_ctor,
 						new_ctor_ref,
 						template_params,
-						template_args_for_member_copy);
+						template_args_for_member_copy,
+						std::span<const PackParamInfo>(
+							ctor_pack_param_info.data(),
+							ctor_pack_param_info.size()));
 					if (orig_ctor.is_materialized()) {
 						new_ctor_ref.set_definition(substituteTemplateParameters(
 							*orig_ctor.get_definition(),
@@ -3695,9 +3701,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								pattern_struct.name(),
 								struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct))
 							: std::nullopt);
+					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 
 					// Copy initializers (member, base, delegating)
-					substituteAndCopyInitializers(orig_ctor, new_ctor_ref, template_params, template_args_for_pattern);
+					substituteAndCopyInitializers(
+						orig_ctor,
+						new_ctor_ref,
+						template_params,
+						template_args_for_pattern,
+						std::span<const PackParamInfo>(
+							ctor_pack_param_info.data(),
+							ctor_pack_param_info.size()));
 
 					// Copy definition if present (with template parameter substitution)
 					if (orig_ctor.is_materialized()) {
@@ -10007,6 +10021,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// so that pack expansions in the body and initializers resolve correctly.
 					size_t saved_pack_info = pack_param_info_.size();
 					substituteAndCopyParams(ctor_decl.parameter_nodes(), new_ctor_ref, template_params, template_args_to_use);
+					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 
 					std::optional<ASTNode> substituted_body;
 					if (ctor_decl.is_materialized()) {
@@ -10017,7 +10032,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 
 					// Copy all initializers (member, base, delegating) with template parameter substitution
-					substituteAndCopyInitializers(ctor_decl, new_ctor_ref, template_params, template_args_to_use);
+					substituteAndCopyInitializers(
+						ctor_decl,
+						new_ctor_ref,
+						template_params,
+						template_args_to_use,
+						std::span<const PackParamInfo>(
+							ctor_pack_param_info.data(),
+							ctor_pack_param_info.size()));
 					new_ctor_ref.set_is_implicit(ctor_decl.is_implicit());
 					new_ctor_ref.set_is_explicitly_defaulted(ctor_decl.is_explicitly_defaulted());
 					new_ctor_ref.set_noexcept(ctor_decl.is_noexcept());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2328,6 +2328,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 
 			SourceMemberIdentityMaps struct_info_source_member_identity_maps;
+			SourceMemberStructInfoIndexMaps struct_info_member_identity_maps;
 
 			// Copy member functions from pattern
 			for (StructMemberFunctionDecl& mem_func : pattern_struct.member_functions()) {
@@ -2465,6 +2466,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_pure_virtual,
 						mem_func.is_override,
 						mem_func.is_final);
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
+						mem_func.function_declaration,
+						struct_info->member_functions.size() - 1);
 					// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
 				}
 			}
@@ -4302,10 +4307,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									template_args_for_pattern.size()),
 								"partial-spec",
 								plain_ool_name)) {
-							OutOfLineFunctionStubResolution info_func_resolution =
-								findReplayedOutOfLineMemberInStructInfo(
-									struct_type_info.getStructInfo(),
-									*inst_func);
+							FunctionDeclarationNode* struct_info_func =
+								member_resolution.source_member != nullptr
+									? findStructInfoFunctionBySourceMemberIdentity(
+										  struct_type_info.getStructInfo(),
+										  struct_info_member_identity_maps,
+										  *member_resolution.source_member)
+									: nullptr;
+							OutOfLineFunctionStubResolution info_func_resolution;
+							if (struct_info_func != nullptr) {
+								info_func_resolution.func = struct_info_func;
+							} else {
+								info_func_resolution =
+									findReplayedOutOfLineMemberInStructInfo(
+										struct_type_info.getStructInfo(),
+										*inst_func);
+							}
 							if (info_func_resolution.ambiguous) {
 								FLASH_LOG(
 									Templates,

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -2122,67 +2122,125 @@ bool Parser::expandPackExpansionArgs(
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	ChunkedVector<ASTNode>& out_args) {
+	return expandPackExpansionArgs(
+		pack_expansion,
+		template_params,
+		template_args,
+		std::span<const PackParamInfo>(pack_param_info_.data(), pack_param_info_.size()),
+		out_args);
+}
 
+bool Parser::expandPackExpansionArgs(
+	const PackExpansionExprNode& pack_expansion,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	std::span<const PackParamInfo> function_pack_infos,
+	ChunkedVector<ASTNode>& out_args) {
 	const ASTNode& pattern = pack_expansion.pattern();
+	InlineVector<std::pair<size_t, size_t>, 4> template_param_arg_ranges;
+	template_param_arg_ranges.reserve(template_params.size());
+	size_t variadic_template_param_count = 0;
 
-	// Find the variadic template parameter and count non-variadic params
-	size_t variadic_param_idx = SIZE_MAX;
-	size_t non_variadic_count = 0;
-	for (size_t p = 0; p < template_params.size(); ++p) {
-		const auto& tparam = template_params[p];
-		if (tparam.is_variadic())
-			variadic_param_idx = p;
-		else
-			non_variadic_count++;
+	size_t total_non_variadic = 0;
+	for (const TemplateParameterNode& param : template_params) {
+		if (!param.is_variadic()) {
+			++total_non_variadic;
+		} else {
+			++variadic_template_param_count;
+		}
 	}
 
-	size_t num_pack_elements = 0;
-	bool found_pack_context = false;
-	if (variadic_param_idx != SIZE_MAX && template_args.size() >= non_variadic_count) {
-		found_pack_context = true;
-		num_pack_elements = template_args.size() - non_variadic_count;
+	size_t arg_cursor = 0;
+	size_t non_variadic_seen = 0;
+	for (const TemplateParameterNode& param : template_params) {
+		if (!param.is_variadic()) {
+			template_param_arg_ranges.push_back({arg_cursor, arg_cursor < template_args.size() ? 1u : 0u});
+			if (arg_cursor < template_args.size()) {
+				++arg_cursor;
+			}
+			++non_variadic_seen;
+			continue;
+		}
+
+		size_t required_after = total_non_variadic - non_variadic_seen;
+		size_t remaining = arg_cursor < template_args.size() ? template_args.size() - arg_cursor : 0;
+		size_t pack_size = remaining > required_after ? remaining - required_after : 0;
+		template_param_arg_ranges.push_back({arg_cursor, pack_size});
+		arg_cursor += pack_size;
+	}
+
+	std::optional<size_t> num_pack_elements;
+	for (size_t p = 0; p < template_params.size(); ++p) {
+		const TemplateParameterNode& tparam = template_params[p];
+		if (!tparam.is_variadic() || !exprContainsIdentifier(pattern, tparam.name())) {
+			continue;
+		}
+		const size_t pack_size = template_param_arg_ranges[p].second;
+		if (!num_pack_elements.has_value()) {
+			num_pack_elements = pack_size;
+		} else if (*num_pack_elements != pack_size) {
+			throw InternalError("Mismatched template parameter pack sizes while expanding call arguments");
+		}
+	}
+	if (!num_pack_elements.has_value() && variadic_template_param_count == 1) {
+		for (size_t p = 0; p < template_params.size(); ++p) {
+			if (template_params[p].is_variadic()) {
+				num_pack_elements = template_param_arg_ranges[p].second;
+				break;
+			}
+		}
 	}
 
 	// Also check pack_param_info_ for function parameter packs. Match the pack
 	// name against the pattern so empty packs are still recognized and consumed
 	// instead of leaking a PackExpansionExprNode across the parser/sema boundary.
-	std::string_view func_pack_name;
-	for (const auto& pack_info : pack_param_info_) {
+	InlineVector<std::string_view, 4> matched_function_pack_names;
+	for (const auto& pack_info : function_pack_infos) {
 		if (exprContainsIdentifier(pattern, pack_info.original_name)) {
-			found_pack_context = true;
-			func_pack_name = pack_info.original_name;
-			num_pack_elements = pack_info.pack_size;
-			break;
+			matched_function_pack_names.push_back(pack_info.original_name);
+			if (!num_pack_elements.has_value()) {
+				num_pack_elements = pack_info.pack_size;
+			} else if (*num_pack_elements != pack_info.pack_size) {
+				throw InternalError("Mismatched function parameter pack sizes while expanding call arguments");
+			}
 		}
 	}
 
-	if (!found_pack_context)
+	if (!num_pack_elements.has_value())
 		return false;
-	if (num_pack_elements == 0) {
+	if (*num_pack_elements == 0) {
 		FLASH_LOG(Templates, Debug, "Expanding PackExpansionExprNode in function call args: empty pack");
 		return true;
 	}
 
-	FLASH_LOG(Templates, Debug, "Expanding PackExpansionExprNode in function call args: ", num_pack_elements, " elements");
-	for (size_t pi = 0; pi < num_pack_elements; ++pi) {
+	FLASH_LOG(Templates, Debug, "Expanding PackExpansionExprNode in function call args: ", *num_pack_elements, " elements");
+	for (size_t pi = 0; pi < *num_pack_elements; ++pi) {
 		// Build substitution params for this single pack element
 		InlineVector<TemplateParameterNode, 4> subst_params;
 		InlineVector<TemplateTypeArg, 4> subst_args;
 		for (size_t p = 0; p < template_params.size(); ++p) {
 			const auto& tparam = template_params[p];
 			if (tparam.is_variadic()) {
-				TemplateParameterNode single_tparam(tparam.nameHandle(), tparam.token());
+				const auto& [pack_start, pack_size] = template_param_arg_ranges[p];
+				if (pi >= pack_size) {
+					continue;
+				}
+				TemplateParameterNode single_tparam = tparam;
+				single_tparam.set_variadic(false);
 				subst_params.push_back(single_tparam);
-				subst_args.push_back(template_args[non_variadic_count + pi]);
-			} else if (p < template_args.size()) {
+				subst_args.push_back(template_args[pack_start + pi]);
+			} else if (template_param_arg_ranges[p].second != 0) {
 				subst_params.push_back(template_params[p]);
-				subst_args.push_back(template_args[p]);
+				subst_args.push_back(template_args[template_param_arg_ranges[p].first]);
 			}
 		}
 
 		// Replace the function parameter pack identifier (e.g., "args") with
 		// the expanded element name (e.g., "args_0") in the pattern before substitution
-		ASTNode expanded_pattern = replacePackIdentifierInExpr(pattern, func_pack_name, pi);
+		ASTNode expanded_pattern = pattern;
+		for (std::string_view func_pack_name : matched_function_pack_names) {
+			expanded_pattern = replacePackIdentifierInExpr(expanded_pattern, func_pack_name, pi);
+		}
 		ASTNode substituted = substituteTemplateParameters(expanded_pattern, std::span<const TemplateParameterNode>(subst_params.data(), subst_params.size()), std::span<const TemplateTypeArg>(subst_args.data(), subst_args.size()));
 		out_args.push_back(substituted);
 	}

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -220,11 +220,17 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 	if (!expr.has_value() || pack_name.empty()) {
 		return false;
 	}
+	if (expr.is<TypeSpecifierNode>()) {
+		const TypeSpecifierNode& type_spec = expr.as<TypeSpecifierNode>();
+		return type_spec.token().value() == pack_name;
+	}
 
 	return AstTraversal::visitExpressionNode(expr, [&](const auto& node) -> bool {
 		using T = std::decay_t<decltype(node)>;
 		if constexpr (std::is_same_v<T, IdentifierNode>) {
 			return node.name() == pack_name;
+		} else if constexpr (std::is_same_v<T, TemplateParameterReferenceNode>) {
+			return StringTable::getStringView(node.param_name()) == pack_name;
 		} else if constexpr (std::is_same_v<T, CallExprNode>) {
 			if (node.has_receiver() && exprContainsIdentifier(node.receiver(), pack_name))
 				return true;
@@ -279,7 +285,6 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 							 std::is_same_v<T, NewExpressionNode> ||
 							 std::is_same_v<T, DeleteExpressionNode> ||
 							 std::is_same_v<T, LambdaExpressionNode> ||
-							 std::is_same_v<T, TemplateParameterReferenceNode> ||
 							 std::is_same_v<T, FoldExpressionNode> ||
 							 std::is_same_v<T, PackExpansionExprNode> ||
 							 std::is_same_v<T, PseudoDestructorCallNode> ||

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -124,6 +124,36 @@ const FunctionDeclarationNode* tryResolveUniqueOverloadByArgTypes(
 	return getCallTargetFunctionCandidate(*result.selected_overload);
 }
 
+struct MemberOverloadResolutionByArgTypesResult {
+	const FunctionDeclarationNode* function = nullptr;
+	bool ambiguous = false;
+};
+
+inline MemberOverloadResolutionByArgTypesResult resolveConstAwareMemberOverloadByArgTypes(
+	std::span<const ASTNode> preferred_overloads,
+	std::span<const ASTNode> compatible_overloads,
+	std::span<const TypeSpecifierNode> arg_types) {
+	MemberOverloadResolutionByArgTypesResult result;
+	bool preferred_ambiguous = false;
+	result.function = tryResolveUniqueOverloadByArgTypes(
+		preferred_overloads,
+		arg_types,
+		&preferred_ambiguous);
+	if (result.function != nullptr || preferred_ambiguous) {
+		result.ambiguous = preferred_ambiguous;
+		return result;
+	}
+	if (!sameOverloadSet(preferred_overloads, compatible_overloads)) {
+		bool compatible_ambiguous = false;
+		result.function = tryResolveUniqueOverloadByArgTypes(
+			compatible_overloads,
+			arg_types,
+			&compatible_ambiguous);
+		result.ambiguous = compatible_ambiguous;
+	}
+	return result;
+}
+
 const DeclarationNode& requireCallDeclaration(const CallInfo& call_info, const char* operation) {
 	if (call_info.declaration == nullptr) {
 		throw InternalError(std::string(operation) + " received null callee declaration");
@@ -7955,23 +7985,17 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				InlineVector<TypeSpecifierNode, 6> member_arg_types;
 				const bool has_member_arg_types =
 					tryCollectOverloadResolutionArgTypes(arguments, member_arg_types);
-				auto tryResolveMemberOverloadSet =
-					[&](std::span<const ASTNode> overload_set) -> const FunctionDeclarationNode* {
-						if (overload_set.empty() || !has_member_arg_types) {
-							return nullptr;
-						}
-						return tryResolveUniqueOverloadByArgTypes(overload_set, member_arg_types);
-					};
-				if (const FunctionDeclarationNode* resolved_candidate =
-						tryResolveMemberOverloadSet(preferred_member_overloads);
-					resolved_candidate != nullptr) {
-					return resolved_candidate;
-				}
-				if (!sameOverloadSet(preferred_member_overloads, compatible_member_overloads)) {
-					if (const FunctionDeclarationNode* resolved_candidate =
-							tryResolveMemberOverloadSet(compatible_member_overloads);
-						resolved_candidate != nullptr) {
-						return resolved_candidate;
+				if (has_member_arg_types) {
+					const MemberOverloadResolutionByArgTypesResult overload_resolution =
+						resolveConstAwareMemberOverloadByArgTypes(
+							preferred_member_overloads,
+							compatible_member_overloads,
+							member_arg_types);
+					if (overload_resolution.function != nullptr) {
+						return overload_resolution.function;
+					}
+					if (overload_resolution.ambiguous) {
+						return nullptr;
 					}
 				}
 				if (normalized_call) {
@@ -8474,6 +8498,51 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			}
 			return std::string(callee_decl.identifier_token().value());
 		};
+		auto hasDiagnosableAmbiguousReceiverMemberCall = [&]() -> bool {
+			if (!call_info.has_receiver || call_info.is_indirect) {
+				return false;
+			}
+			const TypeInfo* receiver_owner_type_info =
+				tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
+			if (receiver_owner_type_info == nullptr ||
+				receiver_owner_type_info->getStructInfo() == nullptr) {
+				return false;
+			}
+			const std::optional<TypeSpecifierNode> receiver_arg_type =
+				buildOverloadResolutionArgType(call_info.receiver, nullptr);
+			const bool receiver_is_const =
+				receiver_arg_type.has_value() && receiver_arg_type->is_const();
+			const ConstAwareMemberCandidateSet member_candidates =
+				collectConstAwareVisibleMemberFunctionCandidates(
+					receiver_owner_type_info->getStructInfo(),
+					callee_decl.identifier_token().handle(),
+					receiver_is_const,
+					true,
+					[](const StructMemberFunction&, const FunctionDeclarationNode&) {
+						return true;
+					});
+			if (member_candidates.compatible.empty()) {
+				return false;
+			}
+			InlineVector<TypeSpecifierNode, 6> member_arg_types;
+			if (!tryCollectOverloadResolutionArgTypes(*call_info.arguments, member_arg_types)) {
+				return false;
+			}
+			InlineVector<ASTNode, 8> preferred_member_overloads;
+			InlineVector<ASTNode, 8> compatible_member_overloads;
+			appendUniqueMemberFunctionOverloadNodes(
+				preferred_member_overloads,
+				member_candidates.preferred);
+			appendUniqueMemberFunctionOverloadNodes(
+				compatible_member_overloads,
+				member_candidates.compatible);
+			const MemberOverloadResolutionByArgTypesResult overload_resolution =
+				resolveConstAwareMemberOverloadByArgTypes(
+					preferred_member_overloads,
+					compatible_member_overloads,
+					member_arg_types);
+			return overload_resolution.ambiguous;
+		};
 		if (hasDiagnosableLocalCallableMiss()) {
 			throw CompileError(
 				std::string("callable object '") +
@@ -8498,8 +8567,14 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 				*member_name +
 				"' cannot be called through a const receiver");
 		}
-
 		const bool normalized_call_expr = hasNormalizedAstNode(call_expr_node);
+		if (hasDiagnosableAmbiguousReceiverMemberCall()) {
+			throw CompileError(
+				std::string("Ambiguous member function overload for '") +
+				std::string(callee_decl.identifier_token().value()) +
+				"'");
+		}
+
 		const std::string_view call_name = call_info.qualified_name.isValid()
 											   ? call_info.qualified_name.view()
 											   : callee_decl.identifier_token().value();

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7778,8 +7778,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	const bool normalized_call =
 		call_key != nullptr &&
 		normalized_ast_nodes_.count(call_key) > 0;
-	const bool is_callable_operator =
-		callee_decl.identifier_token().value() == "operator()"sv;
 	auto lookupFunctionByMangledName = [&](StringHandle mangled_name) -> const FunctionDeclarationNode* {
 		if (!mangled_name.isValid()) {
 			return nullptr;
@@ -8010,8 +8008,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 					}
 				}
 			}
-			if (is_callable_operator &&
-				receiver_is_const &&
+			if (receiver_is_const &&
 				member_candidates.compatible.empty() &&
 				call_info.function_declaration != nullptr &&
 				!call_info.function_declaration->is_static() &&
@@ -8435,11 +8432,11 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			InlineVector<TypeSpecifierNode, 6> arg_types;
 			return tryCollectOverloadResolutionArgTypes(*call_info.arguments, arg_types);
 		};
-		auto diagnosableConstReceiverCallableName = [&]() -> std::optional<std::string> {
+		auto diagnosableConstReceiverMemberName = [&]() -> std::optional<std::string> {
 			if (!call_info.has_receiver ||
 				call_info.is_indirect ||
-				!is_callable_operator ||
 				call_info.function_declaration == nullptr ||
+				call_info.function_declaration->parent_struct_name().empty() ||
 				call_info.function_declaration->is_static() ||
 				call_info.function_declaration->is_const_member_function()) {
 				return std::nullopt;
@@ -8467,13 +8464,15 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			if (!member_candidates.compatible.empty()) {
 				return std::nullopt;
 			}
-			if (call_info.receiver.is<ExpressionNode>()) {
+			if (is_callable_operator &&
+				call_info.receiver.is<ExpressionNode>()) {
 				const ExpressionNode& receiver_expr = call_info.receiver.as<ExpressionNode>();
 				if (const auto* ident = std::get_if<IdentifierNode>(&receiver_expr)) {
 					return std::string(ident->name());
 				}
+				return std::string{};
 			}
-			return std::string{};
+			return std::string(callee_decl.identifier_token().value());
 		};
 		if (hasDiagnosableLocalCallableMiss()) {
 			throw CompileError(
@@ -8481,17 +8480,23 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 				std::string(callee_decl.identifier_token().value()) +
 				"' has no matching operator()");
 		}
-		if (std::optional<std::string> receiver_name =
-				diagnosableConstReceiverCallableName();
-			receiver_name.has_value()) {
-			if (!receiver_name->empty()) {
+		if (std::optional<std::string> member_name =
+				diagnosableConstReceiverMemberName();
+			member_name.has_value()) {
+			if (is_callable_operator) {
+				if (!member_name->empty()) {
+					throw CompileError(
+						std::string("callable object '") +
+						*member_name +
+						"' cannot call non-const operator() through a const receiver");
+				}
 				throw CompileError(
-					std::string("callable object '") +
-					*receiver_name +
-					"' cannot call non-const operator() through a const receiver");
+					"callable object cannot call non-const operator() through a const receiver");
 			}
 			throw CompileError(
-				"callable object cannot call non-const operator() through a const receiver");
+				std::string("member function '") +
+				*member_name +
+				"' cannot be called through a const receiver");
 		}
 
 		const bool normalized_call_expr = hasNormalizedAstNode(call_expr_node);
@@ -8537,6 +8542,20 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 			std::string("callable object '") +
 			std::string(callee_decl.identifier_token().value()) +
 			"' cannot call non-const operator() through a const receiver");
+	}
+	if (call_info.has_receiver &&
+		!call_info.is_indirect &&
+		!func_decl->parent_struct_name().empty() &&
+		!func_decl->is_static() &&
+		!func_decl->is_const_member_function()) {
+		const std::optional<TypeSpecifierNode> receiver_arg_type =
+			buildOverloadResolutionArgType(call_info.receiver, nullptr);
+		if (receiver_arg_type.has_value() && receiver_arg_type->is_const()) {
+			throw CompileError(
+				std::string("member function '") +
+				std::string(callee_decl.identifier_token().value()) +
+				"' cannot be called through a const receiver");
+		}
 	}
 
 	// Phase 5 Slices B & C: if the selected call target is a lazily-registered

--- a/tests/test_call_template_arg_pack_expansion_before_deduced_tail_ret0.cpp
+++ b/tests/test_call_template_arg_pack_expansion_before_deduced_tail_ret0.cpp
@@ -1,0 +1,34 @@
+int add3(int a, int b, int tail) {
+	return a + b + tail;
+}
+
+int tailKind(long) {
+	return 12;
+}
+
+template <typename T>
+int typeCode();
+
+template <>
+int typeCode<char>() {
+	return 10;
+}
+
+template <>
+int typeCode<short>() {
+	return 20;
+}
+
+template <>
+int typeCode<long>() {
+	return 99;
+}
+
+template <typename T, typename... Rest, typename U>
+int sumRestCodes(T, Rest..., U tail) {
+	return add3(typeCode<Rest>()..., tailKind(tail));
+}
+
+int main() {
+	return sumRestCodes<int, char, short>(1, 'a', static_cast<short>(2), 0L) == 42 ? 0 : 1;
+}

--- a/tests/test_nontype_call_pack_expansion_before_deduced_tail_ret0.cpp
+++ b/tests/test_nontype_call_pack_expansion_before_deduced_tail_ret0.cpp
@@ -1,0 +1,16 @@
+int add3(int a, int b, int tail) {
+	return a + b + tail;
+}
+
+int tailKind(long) {
+	return 12;
+}
+
+template <int Prefix, int... Ns, typename U>
+int sumValues(U tail) {
+	return add3(Ns..., tailKind(tail)) - Prefix;
+}
+
+int main() {
+	return sumValues<0, 10, 20>(0L) == 42 ? 0 : 1;
+}

--- a/tests/test_template_member_call_ambiguous_fail.cpp
+++ b/tests/test_template_member_call_ambiguous_fail.cpp
@@ -1,0 +1,19 @@
+template<typename Value>
+int callAmbiguous(Value& value) {
+	return value.pick(1, 2);
+}
+
+struct AmbiguousMember {
+	int pick(int lhs, double rhs) {
+		return lhs + static_cast<int>(rhs);
+	}
+
+	int pick(double lhs, int rhs) {
+		return static_cast<int>(lhs) + rhs;
+	}
+};
+
+int main() {
+	AmbiguousMember value;
+	return callAmbiguous(value);
+}

--- a/tests/test_template_member_call_const_receiver_fail.cpp
+++ b/tests/test_template_member_call_const_receiver_fail.cpp
@@ -1,0 +1,15 @@
+template<typename Value>
+int callThroughConst(const Value& value) {
+	return value.bump(41);
+}
+
+struct MutableOnly {
+	int bump(int input) {
+		return input + 1;
+	}
+};
+
+int main() {
+	MutableOnly value;
+	return callThroughConst(value);
+}

--- a/tests/test_template_member_call_no_viable_overload_fail.cpp
+++ b/tests/test_template_member_call_no_viable_overload_fail.cpp
@@ -1,0 +1,15 @@
+template<typename Value>
+int callMissing(Value& value) {
+	return value.pick("bad");
+}
+
+struct IntOnlyMember {
+	int pick(int value) {
+		return value + 1;
+	}
+};
+
+int main() {
+	IntOnlyMember value;
+	return callMissing(value);
+}


### PR DESCRIPTION
## Summary
This branch continues the template-argument infrastructure refactor by removing several remaining compatibility paths in template call handling and replay synchronization that were letting stale parser-era or signature-shaped matches survive after stronger semantic evidence was available.

The first set of changes tightens ordinary dependent member-call behavior in semantic analysis. Calls that become invalid for const receivers or become ambiguous at instantiation are no longer allowed to keep compiling by falling back to parser-selected member targets. Instead, the shared semantic call path preserves the stronger typed result and rejects the stale fallback.

The next set of changes hardens replay and `StructTypeInfo` synchronization for partial specializations. Source-member to instantiated-member identity is preserved into the plain out-of-line member replay path so synchronization no longer depends on signature-equivalent rediscovery. With that identity-driven path in place, the now-dead replay sync signature fallback could be removed entirely.

The remaining changes close active direct-call pack-substitution gaps that turned out to be caused by earlier substitution and pack bookkeeping rather than missing semantic lookup. Substituted call rebuilding now preserves pack expansion across constructor, direct-call, and receiver-call argument lists, snapshots the relevant pack state instead of relying on ambient parser state, and expands pack arguments from the correct template-argument slice instead of assuming a trailing-pack layout. The branch also fixes pack detection when the pack only appears inside explicit template arguments, covering cases such as `typeCode<Rest>()...` and `__builtin_addressof(args)...` in standards-valid pack-before-tail call patterns.

Overall, the branch narrows the remaining template call compatibility surface, shifts more behavior onto sema-owned typed evidence, and removes weak signature-shaped repair paths that were masking unresolved infrastructure gaps.

## Impact
This makes the compiler more C++20-conforming in a few high-impact areas of template infrastructure:

- dependent ordinary member calls now fail correctly when constness or ambiguity makes the instantiated call invalid
- partial-specialization replay is more deterministic because source identity is preserved through sync instead of being reconstructed later
- dependent direct calls with substituted pack-expanded arguments now resolve with stable pack bookkeeping, including standards-valid pack-before-tail cases that previously leaked `PackExpansionExprNode` or relied on stale parser state

These changes also reduce future maintenance cost by making the remaining fallback boundaries smaller and easier to audit.

## Follow-up
The next step is to re-audit the remaining non-receiver compatibility logic in `resolveCallArgAnnotationTarget(...)` now that the live pack-substitution routes have been removed, and then eliminate or further narrow any surviving direct-call fallback only where typed semantic evidence is complete.
