### PR TITLE
[codex] Tighten direct-call viability and indirect call typing

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -39,8 +39,14 @@ partial-specialization plain-member `StructTypeInfo` sync by preserving
 source-member identity there too, so the remaining replay cleanup is now
 narrower still: the residual signature-equivalent `StructTypeInfo` sync branch
 was probed across the full suite, found dead on the current corpus, and then
-deleted. The next highest-value task is back on the semantic-call side unless a
-new replay route proves it still loses identity metadata.
+deleted. The newest direct-call follow-up closes the standards-visible
+ordinary-call blocker that was still distorting the remaining template audit:
+shared overload viability no longer accepts concrete struct-to-scalar calls
+without a real conversion path, and indirect-call argument typing now preserves
+the callee return type instead of collapsing `fp(args...)` back to the function
+pointer type during parser-side overload ranking. The next highest-value task
+is back on the residual semantic-call compatibility surface unless a new replay
+route proves it still loses identity metadata.
 
 ## What the current design can assume
 
@@ -125,6 +131,13 @@ new replay route proves it still loses identity metadata.
 - constructor replay sync into StructTypeInfo now requires signature-validation
   evidence and no longer accepts token/name shape equivalence for
   mismatched parameter types
+- ordinary overload viability now requires a real conversion path before a
+  concrete struct argument can match a scalar parameter, instead of letting
+  parser-side `Struct -> scalar` optimism survive into normal direct-call
+  ranking
+- parser-side indirect/direct call argument typing now preserves the return
+  type of function-pointer and function-reference calls, so downstream overload
+  ranking no longer sees `fp(args...)` as the pointer type itself
 - function-template trailing-return reparse now happens after parameter
   materialization when a saved `->` position exists, so dependent
   `decltype(param_expr)` sees the same concrete parameter declarations used by
@@ -196,11 +209,11 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Return to the remaining non-receiver / direct-call compatibility branches
-   that still allow ordinary calls to continue after typed sema evidence has
-   produced no viable target or an ambiguity, now that the receiver-sensitive
-   negative cases are closed and the dead signature-equivalent
-   `StructTypeInfo` sync branch is gone.
+1. Re-audit the remaining non-receiver / direct-call compatibility branches in
+   `resolveCallArgAnnotationTarget(...)` now that the active ordinary-call
+   blocker was not fallback at all, but ordinary overload viability plus
+   indirect-call argument typing. Remove or narrow only the branches that are
+   now truly dead after typed parser/sema evidence is complete.
 
 2. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
    source replay identity into that path rather than reintroducing any
@@ -533,6 +546,42 @@ Next step:
 - re-audit `resolveCallArgAnnotationTarget(...)` / direct-call compatibility
   now that this pack-substitution gap is closed, and remove or narrow the
   remaining non-receiver fallback only where typed sema evidence is complete
+
+## 2026-06-09 ordinary direct-call viability note
+
+Continuing that direct-call audit exposed a broader standards-visible blocker
+than template fallback alone: a plain ordinary call could still accept a
+concrete struct argument for a scalar parameter even when no conversion
+operator or converting constructor existed, and the same bug then reproduced
+through dependent direct calls in instantiated template bodies. Tightening that
+path also surfaced a second parser-typing gap: indirect calls such as
+`sumBig(fp(10))` were being ranked as though `fp(10)` had function-pointer type
+instead of the callee return type.
+
+This slice now:
+
+- keeps `TypeSpecifierNode` identity through parser-side reference unwrapping in
+  overload viability instead of degrading concrete types to coarse
+  `TypeCategory` pairs
+- requires a real conversion path before a concrete struct argument can match a
+  scalar parameter in ordinary overload ranking, while still preserving the
+  existing incomplete-type optimism for genuinely unresolved parse-time cases
+- teaches parser-side call typing to recover the return type from
+  function-pointer / function-reference signatures, so indirect calls feed the
+  right argument type into later overload resolution
+
+Validated with:
+
+- `test_overload_resolution_struct_without_conversion_to_int_fail.cpp`
+- `test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_funcptr_large_struct_return_direct_use_ret0.cpp`
+- `test_implicit_conversion_arg_ret42.cpp`
+- `test_func_arg_conv_ctor_sema_ret42.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- `test_template_builtin_addressof_substitution_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -94,6 +94,13 @@ Move FlashCpp toward a sema-owned template system where:
   template pattern
 - non-explicit template-parameter materialization now preserves full
   pointer-to-member metadata for bound type arguments
+- ordinary overload viability now requires a real conversion path before a
+  concrete struct argument can match a scalar parameter, instead of accepting a
+  parser-only `Struct -> scalar` guess
+- parser-side indirect call typing now preserves the callee return type when a
+  function pointer or function reference is called, so ordinary overload
+  ranking sees `fp(args...)` as the returned object type rather than the pointer
+  itself
 
 ## Highest-value remaining standards gap
 
@@ -152,10 +159,11 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Remove the remaining non-receiver / direct-call compatibility branches that
-   still let ordinary calls continue after typed sema evidence has produced no
-   viable target or an ambiguity, now that the receiver-sensitive negative
-   cases are closed and the dead shared `StructTypeInfo` sync fallback is gone.
+1. Re-audit the remaining non-receiver / direct-call compatibility branches in
+   `resolveCallArgAnnotationTarget(...)` now that the last active blocker in
+   this area was ordinary overload viability plus indirect-call typing, not a
+   missing template-only fallback. Remove or narrow only the branches that are
+   now demonstrably dead once typed parser/sema evidence is complete.
 
 2. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
    source replay identity into that path rather than restoring any
@@ -512,6 +520,41 @@ Next step:
   `resolveCallArgAnnotationTarget(...)` again and remove or narrow the
   remaining branch only after each surviving direct-call route is proven to
   reach typed semantic lookup with complete argument evidence
+
+## 2026-06-09 ordinary direct-call viability conformance note
+
+The next live ordinary-call conformance blocker after the pack-substitution
+follow-up was not a template-only replay issue anymore. A plain call such as
+`pick(NotInt{})` could still compile even though `NotInt` had no conversion
+operator or converting constructor for `int`, and the same false viability then
+reappeared through instantiated dependent direct calls. Tightening that path
+also exposed a second parser typing bug: indirect calls like `sumBig(fp(10))`
+were being ranked as though `fp(10)` had function-pointer type instead of the
+return type `Big`.
+
+The fix now:
+
+- preserves concrete `TypeSpecifierNode` identity through parser-side
+  reference-unwrapping during overload viability instead of reducing those
+  comparisons to coarse `TypeCategory` pairs
+- requires a real conversion path before a concrete struct argument can match a
+  scalar parameter in ordinary overload resolution, while preserving the
+  existing incomplete-type optimism for genuinely unresolved parse-time cases
+- recovers indirect-call return types from function-pointer and
+  function-reference signatures so parser-side argument typing feeds the real
+  returned object type into later overload ranking
+
+Validated with:
+
+- `test_overload_resolution_struct_without_conversion_to_int_fail.cpp`
+- `test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_funcptr_large_struct_return_direct_use_ret0.cpp`
+- `test_implicit_conversion_arg_ret42.cpp`
+- `test_func_arg_conv_ctor_sema_ret42.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
 
 ## Validation guidance
 

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -586,6 +586,32 @@ inline bool hasImplicitConvertingConstructorForArgument(TypeIndex target_idx, co
 //   • Set is_lvalue_reference(true) on 'from' for lvalue expressions (named variables, etc.)
 //   • Leave 'from' as non-reference for rvalue expressions (literals, temporaries, etc.)
 inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const TypeSpecifierNode& to) {
+	auto stripReferenceQualifier = [](TypeSpecifierNode spec) {
+		spec.set_reference_qualifier(ReferenceQualifier::None);
+		return spec;
+	};
+	auto effectiveCategory = [](const TypeSpecifierNode& spec) -> TypeCategory {
+		TypeCategory category = spec.category();
+		if (spec.type_index().is_valid()) {
+			if (const TypeInfo* type_info = tryGetTypeInfo(spec.type_index())) {
+				if (const TypeCategory concrete = type_info->typeEnum();
+					concrete != TypeCategory::Invalid) {
+					category = concrete;
+				}
+			}
+		}
+		return category;
+	};
+	auto hasCompleteStructInfo = [](TypeIndex type_index) -> bool {
+		if (!type_index.is_valid() || type_index.index() >= getTypeInfoCount()) {
+			return false;
+		}
+		if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
+			return type_info->getStructInfo() != nullptr;
+		}
+		return false;
+	};
+
 	// String literals and other array expressions can reach overload resolution as
 	// array-only types. Identifier arrays may already carry pointer metadata plus
 	// retained array extents from earlier decay paths; !from.is_pointer() keeps
@@ -761,7 +787,9 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				// rvalue reference can bind to a temporary materialized from an xvalue when
 				// a standard conversion is required.
 				if (!to_is_rvalue && to.is_const()) {
-					auto plan = buildConversionPlan(from_base_category, to_base_category);
+					auto plan = buildConversionPlan(
+						stripReferenceQualifier(from),
+						stripReferenceQualifier(to));
 					if (plan.is_valid) {
 						// C++20 [over.ics.rank]/3.2.3 prefers binding an rvalue to T&& over
 						// binding it to const T& when the implied conversion sequences are
@@ -772,7 +800,9 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 					}
 				}
 				if (from_is_rvalue && to_is_rvalue) {
-					auto plan = buildConversionPlan(from_base_category, to_base_category);
+					auto plan = buildConversionPlan(
+						stripReferenceQualifier(from),
+						stripReferenceQualifier(to));
 					if (plan.is_valid) {
 						return plan;
 					}
@@ -805,7 +835,9 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				if (!types_match) {
 					// Allow conversions for const lvalue refs and rvalue refs by
 					// materializing a temporary of the referred-to type.
-					auto plan = buildConversionPlan(from_base_category, to_base_category);
+					auto plan = buildConversionPlan(
+						stripReferenceQualifier(from),
+						stripReferenceQualifier(to));
 					if ((!to_is_rvalue && to_is_const && plan.is_valid) ||
 						(to_is_rvalue && plan.is_valid)) {
 						// Const lvalue ref can bind to values that can be converted
@@ -875,25 +907,42 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				return {ConversionRank::Conversion, StandardConversionKind::None, true};
 			}
 			// Try conversion of the referenced type to target type
-			return buildConversionPlan(from_resolved_category, to_resolved_category);
+			return buildConversionPlan(
+				stripReferenceQualifier(from),
+				stripReferenceQualifier(to));
 		}
 	}
 
 	// Check for user-defined conversion operators
-	// If 'from' is a struct type and 'to' is a different type, assume conversion might be possible
-	// The actual conversion operator existence will be checked during CodeGen
-	if (from.category() == TypeCategory::Struct && to.category() != TypeCategory::Struct) {
-		// For struct-to-primitive conversions, optimistically assume a conversion operator exists
-		// CodeGen will verify and generate the actual call
-		return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+	// For concrete struct/scalar conversions, require a real conversion path once
+	// the relevant type metadata exists. Keep optimistic acceptance only for
+	// genuinely incomplete parse-time types.
+	const TypeCategory effective_from_category = effectiveCategory(from);
+	const TypeCategory effective_to_category = effectiveCategory(to);
+	if (effective_from_category == TypeCategory::Struct &&
+		effective_to_category != TypeCategory::Struct) {
+		if (from.type_index().is_valid() &&
+			hasConversionOperator(from.type_index(), effective_to_category, to.type_index())) {
+			return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+		}
+		if (!hasCompleteStructInfo(from.type_index())) {
+			return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+		}
+		return ConversionPlan::no_match();
 	}
 
 	// Check for user-defined conversions in reverse: if 'to' is Struct and 'from' is not
-	// This handles constructor conversions (not conversion operators, but similar concept)
-	if (to.category() == TypeCategory::Struct && from.category() != TypeCategory::Struct) {
-		// Could be a converting constructor in 'to' struct - accept it tentatively
-		// CodeGen will handle the actual constructor call
-		return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+	// This handles constructor conversions (not conversion operators, but similar concept).
+	if (effective_to_category == TypeCategory::Struct &&
+		effective_from_category != TypeCategory::Struct) {
+		if (to.type_index().is_valid() &&
+			hasImplicitConvertingConstructorForArgument(to.type_index(), from)) {
+			return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+		}
+		if (!hasCompleteStructInfo(to.type_index())) {
+			return {ConversionRank::UserDefined, StandardConversionKind::UserDefined, true};
+		}
+		return ConversionPlan::no_match();
 	}
 
 	// Handle UserDefined type aliases:

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -11,6 +11,7 @@
 #include "InstantiationQueue.h"
 #include "RebindStaticMemberAst.h"
 #include "SemanticAnalysis.h"
+#include "Parser_FunctionTypeHelpers.h"
 #include "TemplateEnvironment.h"
 #include <atomic> // Include atomic for constrained partial specialization counter
 #include <string_view> // Include string_view header
@@ -431,6 +432,14 @@ void Parser::appendFunctionCallArgType(const ASTNode& arg_node, std::vector<Type
 					arg_type = ret_node.template as<TypeSpecifierNode>();
 					return;
 				}
+			}
+			if (auto indirect_return_type =
+					FlashCpp::ParserFunctionTypeHelpers::tryGetReturnTypeFromFunctionType(
+						inner.callee().declaration().type_specifier_node(),
+						inner.called_from());
+				indirect_return_type.has_value()) {
+				arg_type = *indirect_return_type;
+				return;
 			}
 			arg_type = TypeSpecifierNode(TypeCategory::Invalid, TypeQualifier::None, 0, Token(), CVQualifier::None);
 		} else if constexpr (std::is_same_v<T, ConstructorCallNode>) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2705,6 +2705,12 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 		TypeSpecifierNode return_type;
 		if (call_info.function_declaration) {
 			return_type = call_info.function_declaration->decl_node().type_specifier_node();
+		} else if (auto indirect_return_type =
+					   FlashCpp::ParserFunctionTypeHelpers::tryGetReturnTypeFromFunctionType(
+						   callee_decl.type_specifier_node(),
+						   call_info.called_from);
+				   indirect_return_type.has_value()) {
+			return_type = *indirect_return_type;
 		} else {
 			return_type = callee_decl.type_specifier_node();
 		}

--- a/src/Parser_FunctionTypeHelpers.h
+++ b/src/Parser_FunctionTypeHelpers.h
@@ -53,6 +53,55 @@ inline TypeSpecifierNode buildFunctionPointerTypeFromFunctionDeclaration(const F
 	return fp_type;
 }
 
+inline std::optional<TypeSpecifierNode> tryGetReturnTypeFromFunctionType(
+	const TypeSpecifierNode& function_like_type,
+	const Token& source_token) {
+	if (!function_like_type.has_function_signature()) {
+		return std::nullopt;
+	}
+
+	const FunctionSignature& sig = function_like_type.function_signature();
+	TypeIndex return_type_index = sig.return_type_index;
+	TypeCategory return_category = sig.returnType();
+	if (return_type_index.is_valid()) {
+		return_type_index = return_type_index.withCategory(return_category);
+	}
+
+	SizeInBits return_size_bits{};
+	if (sig.return_pointer_depth > 0 ||
+		return_category == TypeCategory::FunctionPointer ||
+		return_category == TypeCategory::MemberFunctionPointer ||
+		return_category == TypeCategory::MemberObjectPointer) {
+		return_size_bits = SizeInBits{64};
+	} else if (return_type_index.is_valid()) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(return_type_index)) {
+			if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
+				return_size_bits = struct_info->sizeInBits();
+			} else if (type_info->hasStoredSize()) {
+				return_size_bits = type_info->sizeInBits();
+			}
+		}
+	}
+	if (!return_size_bits.is_set() &&
+		return_category != TypeCategory::Invalid &&
+		return_category != TypeCategory::Void) {
+		return_size_bits = SizeInBits{get_type_size_bits(return_category)};
+	}
+
+	TypeSpecifierNode return_type(
+		return_category,
+		TypeQualifier::None,
+		return_size_bits.is_set() ? return_size_bits.value : 0,
+		source_token,
+		CVQualifier::None);
+	if (return_type_index.is_valid()) {
+		return_type.set_type_index(return_type_index);
+	}
+	return_type.set_reference_qualifier(sig.return_reference_qualifier);
+	return_type.add_pointer_levels(sig.return_pointer_depth);
+	return return_type;
+}
+
 inline std::optional<TypeSpecifierNode> tryGetBareFunctionIdentifierType(const ASTNode& arg_node) {
 	if (!arg_node.is<ExpressionNode>()) {
 		return std::nullopt;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7949,13 +7949,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return tryResolveLocalCallableStructInfo(callee_decl.identifier_token().handle());
 	};
-	auto fallbackToParserSelectedTarget = [&]() -> const FunctionDeclarationNode* {
+	auto fallbackToEarlyParserSelectedTarget = [&]() -> const FunctionDeclarationNode* {
 		if (normalized_call) {
 			return nullptr;
 		}
 		return call_info.function_declaration;
 	};
-	auto fallbackToNonNormalizedLookupTarget = [&]() -> const FunctionDeclarationNode* {
+	auto fallbackToLateNonNormalizedCompatibilityTarget = [&]() -> const FunctionDeclarationNode* {
 		if (normalized_call) {
 			return nullptr;
 		}
@@ -8069,7 +8069,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 	if (const FunctionDeclarationNode* parser_selected_target =
-			fallbackToParserSelectedTarget();
+			fallbackToEarlyParserSelectedTarget();
 		parser_selected_target != nullptr) {
 		return parser_selected_target;
 	}
@@ -8130,7 +8130,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 
 	if (const FunctionDeclarationNode* compatibility_target =
-			fallbackToNonNormalizedLookupTarget();
+			fallbackToLateNonNormalizedCompatibilityTarget();
 		compatibility_target != nullptr) {
 		return compatibility_target;
 	}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7818,26 +7818,27 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return nullptr;
 	};
+	auto resolveBoundFunctionTarget =
+		[&](const FunctionDeclarationNode* resolved_function,
+			StringHandle mangled_name) -> const FunctionDeclarationNode* {
+			if (resolved_function != nullptr) {
+				return resolved_function;
+			}
+			return lookupFunctionByMangledName(mangled_name);
+		};
 	auto resolveDefinitionLookupRecordTarget = [&]() -> const FunctionDeclarationNode* {
 		if (call_info.definition_lookup_record == nullptr ||
 			!call_info.definition_lookup_record->has_value()) {
 			return nullptr;
 		}
-		if (const FunctionDeclarationNode* resolved_function =
-				call_info.definition_lookup_record->value().resolved_function;
-			resolved_function != nullptr) {
-			return resolved_function;
-		}
-		return lookupFunctionByMangledName(
-			call_info.definition_lookup_record->value().resolved_mangled_name);
+		const FunctionCallDefinitionLookupRecord& record =
+			call_info.definition_lookup_record->value();
+		return resolveBoundFunctionTarget(
+			record.resolved_function,
+			record.resolved_mangled_name);
 	};
-	auto resolveDependentUnqualifiedRecordTarget =
-		[&](const DependentUnqualifiedCallLookupRecord& record) -> const FunctionDeclarationNode* {
-			if (record.definition_bound_function != nullptr) {
-				return record.definition_bound_function;
-			}
-			return lookupFunctionByMangledName(record.definition_bound_mangled_name);
-		};
+	const FunctionDeclarationNode* definition_lookup_record_target =
+		resolveDefinitionLookupRecordTarget();
 	struct QualifiedLookupTarget {
 		NamespaceHandle namespace_handle;
 		std::string_view identifier;
@@ -7948,6 +7949,27 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return tryResolveLocalCallableStructInfo(callee_decl.identifier_token().handle());
 	};
+	auto fallbackToParserSelectedTarget = [&]() -> const FunctionDeclarationNode* {
+		if (normalized_call) {
+			return nullptr;
+		}
+		return call_info.function_declaration;
+	};
+	auto fallbackToNonNormalizedLookupTarget = [&]() -> const FunctionDeclarationNode* {
+		if (normalized_call) {
+			return nullptr;
+		}
+		if (definition_lookup_record_target != nullptr) {
+			return definition_lookup_record_target;
+		}
+		return call_info.function_declaration;
+	};
+
+	// Resolution order:
+	// 1. receiver-member direct lookup
+	// 2. callable operator / local callable resolution
+	// 3. non-receiver compatibility metadata (mangled / definition-bound / POI)
+	// 4. fresh overload lookup + ranking
 	if (call_info.is_indirect) {
 		return nullptr;
 	}
@@ -8046,8 +8068,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 
 		return nullptr;
 	}
-	if (!normalized_call && call_info.function_declaration) {
-		return call_info.function_declaration;
+	if (const FunctionDeclarationNode* parser_selected_target =
+			fallbackToParserSelectedTarget();
+		parser_selected_target != nullptr) {
+		return parser_selected_target;
 	}
 
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
@@ -8078,7 +8102,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		const DependentUnqualifiedCallLookupRecord& dependent_record =
 			**call_info.dependent_unqualified_lookup_record;
 		if (const FunctionDeclarationNode* dependent_record_target =
-				resolveDependentUnqualifiedRecordTarget(dependent_record);
+				resolveBoundFunctionTarget(
+					dependent_record.definition_bound_function,
+					dependent_record.definition_bound_mangled_name);
 			dependent_record_target != nullptr) {
 			return dependent_record_target;
 		}
@@ -8097,24 +8123,17 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				}
 			}
 		}
-		if (const FunctionDeclarationNode* definition_record_target =
-				resolveDefinitionLookupRecordTarget();
-			definition_record_target != nullptr) {
-			return definition_record_target;
+		if (definition_lookup_record_target != nullptr) {
+			return definition_lookup_record_target;
 		}
 		return nullptr;
 	}
 
-	if (!normalized_call) {
-		if (const FunctionDeclarationNode* definition_record_target =
-				resolveDefinitionLookupRecordTarget();
-			definition_record_target != nullptr) {
-			return definition_record_target;
-		}
+	if (const FunctionDeclarationNode* compatibility_target =
+			fallbackToNonNormalizedLookupTarget();
+		compatibility_target != nullptr) {
+		return compatibility_target;
 	}
-
-	if (!normalized_call && call_info.function_declaration)
-		return call_info.function_declaration;
 
 	const DeclarationNode& decl = callee_decl;
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7949,6 +7949,31 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return tryResolveLocalCallableStructInfo(callee_decl.identifier_token().handle());
 	};
+	auto matchesParserSelectedTarget =
+		[&](const FunctionDeclarationNode& candidate) -> bool {
+			if (call_info.function_declaration == nullptr) {
+				return false;
+			}
+			if (&candidate == call_info.function_declaration ||
+				&candidate.decl_node() == &call_info.function_declaration->decl_node()) {
+				return true;
+			}
+			return candidate.has_mangled_name() &&
+				   call_info.function_declaration->has_mangled_name() &&
+				   candidate.mangled_name() == call_info.function_declaration->mangled_name();
+		};
+	auto findViableTargetByArgCount =
+		[&](std::span<const ASTNode> overloads) -> const FunctionDeclarationNode* {
+			for (const ASTNode& overload : overloads) {
+				if (const FunctionDeclarationNode* candidate =
+						getCallTargetFunctionCandidate(overload);
+					candidate != nullptr &&
+					isFunctionCandidateViableForArgCount(*candidate, arguments.size())) {
+					return candidate;
+				}
+			}
+			return nullptr;
+		};
 	auto fallbackToEarlyParserSelectedTarget = [&]() -> const FunctionDeclarationNode* {
 		if (normalized_call) {
 			return nullptr;
@@ -8030,28 +8055,16 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 					for (const ASTNode& candidate_node : ordered_member_overloads) {
 						const FunctionDeclarationNode* candidate =
 							getCallTargetFunctionCandidate(candidate_node);
-						if (candidate == nullptr) {
-							continue;
-						}
-						if (candidate == call_info.function_declaration ||
-							&candidate->decl_node() == &call_info.function_declaration->decl_node()) {
-							return candidate;
-						}
-						if (candidate->has_mangled_name() &&
-							call_info.function_declaration->has_mangled_name() &&
-							candidate->mangled_name() ==
-								call_info.function_declaration->mangled_name()) {
+						if (candidate != nullptr &&
+							matchesParserSelectedTarget(*candidate)) {
 							return candidate;
 						}
 					}
 				}
-				for (const ASTNode& candidate_node : ordered_member_overloads) {
-					if (const FunctionDeclarationNode* candidate =
-							getCallTargetFunctionCandidate(candidate_node);
-						candidate != nullptr &&
-						isFunctionCandidateViableForArgCount(*candidate, arguments.size())) {
-						return candidate;
-					}
+				if (const FunctionDeclarationNode* viable_member_target =
+						findViableTargetByArgCount(ordered_member_overloads);
+					viable_member_target != nullptr) {
+					return viable_member_target;
 				}
 			}
 			if (receiver_is_const &&
@@ -8062,8 +8075,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				return nullptr;
 			}
 		}
-		if (!normalized_call && call_info.function_declaration) {
-			return call_info.function_declaration;
+		if (const FunctionDeclarationNode* parser_selected_target =
+				fallbackToEarlyParserSelectedTarget();
+			parser_selected_target != nullptr) {
+			return parser_selected_target;
 		}
 
 		return nullptr;
@@ -8222,20 +8237,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 
 	if (!func_decl) {
-		auto find_by_arg_count = [&]() -> const FunctionDeclarationNode* {
-			for (const auto& overload : overloads) {
-				if (const FunctionDeclarationNode* candidate = getCallTargetFunctionCandidate(overload)) {
-					if (isFunctionCandidateViableForArgCount(*candidate, arguments.size())) {
-						return candidate;
-					}
-				}
-			}
-			return nullptr;
-		};
 		if (overloads.size() == 1) {
 			func_decl = getCallTargetFunctionCandidate(overloads[0]);
 		} else {
-			func_decl = find_by_arg_count();
+			func_decl = findViableTargetByArgCount(overloads);
 		}
 	}
 

--- a/tests/test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp
+++ b/tests/test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp
@@ -1,0 +1,9 @@
+int pick(int) {
+	return 0;
+}
+
+struct NotInt {};
+
+int main() {
+	return pick(NotInt{});
+}

--- a/tests/test_overload_resolution_struct_without_conversion_to_int_fail.cpp
+++ b/tests/test_overload_resolution_struct_without_conversion_to_int_fail.cpp
@@ -1,0 +1,10 @@
+int pick(int) {
+	return 0;
+}
+
+struct NotInt {};
+
+int main() {
+	NotInt value;
+	return pick(value);
+}

--- a/tests/test_template_dependent_unqualified_direct_call_nonviable_fail.cpp
+++ b/tests/test_template_dependent_unqualified_direct_call_nonviable_fail.cpp
@@ -1,0 +1,15 @@
+int pick(int) {
+	return 0;
+}
+
+template <typename T>
+int callPick(T value) {
+	return pick(value);
+}
+
+struct NotInt {};
+
+int main() {
+	NotInt value;
+	return callPick(value);
+}


### PR DESCRIPTION
## Summary
This follow-up closes the remaining live direct-call blocker that was still obscuring the template call audit. The root problem was no longer template replay by itself: ordinary overload viability could still accept concrete struct-to-scalar calls without a real conversion path, and parser-side typing for indirect calls could collapse `fp(args...)` back to the function-pointer type instead of the callee return type. Both issues then leaked into dependent direct-call behavior inside instantiated template bodies.

The core change tightens parser-side overload viability so concrete struct arguments only match scalar parameters when a real conversion path exists, while keeping the existing incomplete-type optimism for genuinely unresolved parse-time cases. In the same area, parser call typing now recovers return types from function-pointer and function-reference signatures, so indirect calls participate in downstream overload ranking with the correct object type instead of a pointer-shaped placeholder.

On the regression side, the branch adds direct and template `_fail` coverage for invalid `struct -> int` ordinary calls, and it keeps the existing positive conversion paths working for user-defined conversion operators and converting constructors. The function-pointer large-struct return case is also explicitly covered because the viability tightening exposed that parser argument typing bug during validation.

The audit documents are updated to reflect that this slice removed a broader ordinary-call blocker rather than just narrowing template fallback. They now point the next task back at the residual non-receiver/direct-call compatibility branches in `resolveCallArgAnnotationTarget(...)`, which should be re-audited now that ordinary overload viability and indirect-call typing are no longer distorting the evidence.