### PR TITLE
Tighten sema direct-call target recovery for template calls

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -3,661 +3,128 @@
 **Date:** 2026-05-12  
 **Last updated:** 2026-06-11
 
-This document is not a release log. It should explain what the current template
-architecture can assume, what is still structurally wrong, and what the next
-highest-value cleanup should be.
+This document is a planning aid for the remaining template-infrastructure work.
+It should describe the current architectural baseline, the highest-value
+remaining gaps, and the next tasks to execute. It is intentionally not a
+chronological work log.
 
-## Executive summary
+## Current architectural baseline
 
-The template system has moved away from broad AST-only replay and toward
-owner-aware semantic records plus replay-first attachment. The legacy textual
-`base::member` dependent-alias path has now been removed; dependent member
-alias resolution is semantic-only. The newest high-impact fix also moves
-normalized template-call overload lookup onto sema-owned argument typing, so
-replayed dependent member overloads no longer inherit stale parser-selected
-targets. A concrete follow-up now brings semantic `operator[]` resolution onto
-that same receiver-aware, sema-owned argument-typing path, so const receivers
-and lvalue/rvalue index overloads no longer depend on reduced parser-shaped
-typing. The latest template-`decltype` fix now also reparses function-template
-trailing return clauses against materialized parameter declarations and keeps
-bound member-pointer metadata intact in the non-explicit parameter
-materialization path, so dependent trailing-return `decltype` no longer drops
-reference qualification or pointer-to-member owner identity. The most recent
-callable follow-up now also makes the dependent `const Callable& c; c(...)`
-negative case sema-owned, so parser-selected non-const `operator()` targets no
-longer compile through const receivers after sema has already found no viable
-const-compatible callable target. The next ordinary-member follow-up now closes
-the same const-receiver hole for dependent `const T& obj; obj.member(...)`
-calls, so stale parser-selected non-const member targets no longer compile once
-shared sema lookup has found no const-compatible overload; function-pointer
-members are explicitly excluded by requiring real member-function ownership
-before raising the diagnostic. The next receiver-member follow-up now also
-blocks parser-selected fallback after typed sema has already proven a dependent
-member call ambiguous, so replay/materialization remains the biggest remaining
-gap. The newest replay follow-up closes one active weak-evidence route in
-partial-specialization plain-member `StructTypeInfo` sync by preserving
-source-member identity there too, so the remaining replay cleanup is now
-narrower still: the residual signature-equivalent `StructTypeInfo` sync branch
-was probed across the full suite, found dead on the current corpus, and then
-deleted. The newest direct-call follow-up closes the standards-visible
-ordinary-call blocker that was still distorting the remaining template audit:
-shared overload viability no longer accepts concrete struct-to-scalar calls
-without a real conversion path, and indirect-call argument typing now preserves
-the callee return type instead of collapsing `fp(args...)` back to the function
-pointer type during parser-side overload ranking. The newest non-receiver
-direct-call follow-up now also narrows the remaining compatibility surface:
-ordinary direct calls no longer reuse bare parser-selected targets up front
-when no definition-bound lookup record exists, while preserved
-definition-context call records still short-circuit non-dependent two-phase
-lookup exactly where the standard requires. Fresh typed sema lookup now owns
-ordinary non-receiver direct-call selection across the covered paths, with the
-parser-selected target kept only as the last compatibility resort after typed
-lookup has already had its chance. The next highest-value task is therefore the
-remaining last-resort direct-call fallback surface unless a new replay route
-proves it still loses identity metadata.
-
-## What the current design can assume
+The template system is now substantially more sema-owned than parser-owned in
+the areas that were previously blocking standards-visible behavior:
 
 - covered non-dependent template-body lookup preserves definition-context
   binding
-- major out-of-line replay paths now prefer source-member identity plus
-  substituted-signature evidence over name/arity scans
-- constructor and member-template replay are increasingly owner-aware and
-  evidence-driven rather than shape-driven
-- dependent owner/member-template chains already have a shared semantic
-  materialization route in the covered cases
-- explicit member-template calls now carry call-argument information early
-  enough to avoid caching obviously wrong overloads
-- sema-owned direct-call resolution for normalized template/member calls now
-  collects overload-resolution argument types from semantic expression typing
-  instead of parser-owned call-argument typing, so dependent out-of-line member
-  overloads resolve by the concrete substituted call signature seen during sema
-- ordinary non-receiver direct calls now also defer bare parser-selected target
-  reuse until after preserved definition-context records and fresh typed lookup
-  have both had a chance to resolve the call, so non-dependent two-phase lookup
-  remains definition-bound while ordinary direct-call fallback is narrower
-- semantic `operator[]` resolution now shares sema-owned overload-resolution
-  argument typing and the same receiver-const candidate partitioning used by
-  direct member-call lookup, so normalized subscripts no longer bind non-const
-  members through const receivers or lose lvalue/rvalue index evidence
-- semantic receiverless callable `operator()` resolution for dependent/local
-  callable objects now also shares sema-owned overload-resolution argument
-  typing plus receiver-const candidate partitioning, so template-instantiated
-  functors no longer depend on reduced expression typing for lvalue/rvalue or
-  const overload selection
-- sema now also rejects parser-selected non-const `operator()` targets on
-  const dependent/local callable receivers once semantic lookup has shown there
-  is no viable const-compatible overload, so this negative path no longer
-  compiles through fallback attachment
-- sema now also rejects parser-selected non-const ordinary member-function
-  targets on const dependent/member-call receivers once shared const-aware
-  lookup has shown there is no const-compatible overload, while leaving
-  function-pointer member calls on the indirect-call path
-- sema now also rejects parser-selected ordinary member-call fallback once
-  shared typed overload resolution has already proven the dependent receiver
-  call ambiguous
-- partial-specialization plain out-of-line member replay now also syncs its
-  `StructTypeInfo` copy through source-member identity instead of dropping to
-  signature-equivalent matching
-- the last shared signature-equivalent `StructTypeInfo` sync fallback in the
-  current corpus has been removed after a full-suite probe showed it was dead
-- nested member-template alias materialization now preserves substantially more
-  outer owner/member-template metadata through parsing, rebinding, and
-  materialization
-- dependent alias resolution is now semantic-only: the legacy textual
-  `base::member` path in `resolveDependentMemberAlias(...)` has been removed,
-  and resolution flows through the preserved `DependentQualifiedNameRecord`,
-  instantiation-context bindings, and `materializeInstantiatedMemberAliasTarget`
-- `materializeAliasTemplateInstance` now delegates to
-  `materializeInstantiatedMemberAliasTarget` for direct-parameter alias
-  cases (`template<T> using id = T`) where `instantiated_name` is empty
-  but the alias node is non-null
-- member type aliases preserve surface modifiers (pointer/reference/cv/array/
-  function) across alias chains via the shared
-  `typeAliasPreservesSurfaceModifiers()` helper, so collapsing an alias to its
-  terminal type no longer silently drops indirection
-- dependent member-template static constexpr chains are resolved through typed
-  owner/member-chain records, active template bindings, and inherited
-  member-template lookup; the hard-coded constexpr scan for matching generated
-  member-template names is gone
-- out-of-line member replay no longer treats failed replay attachment as
-  recoverable: if replay identity plus substituted-signature evidence cannot
-  attach the definition, instantiation now fails instead of silently
-  continuing into later template instantiation paths
-- plain out-of-line member replay now also requires positive signature
-  evidence even for single-candidate same-name attachment: concrete exact
-  matches produce positive evidence, while unresolved `std::nullopt` outcomes
-  no longer attach by default
-- nested and partial-specialization out-of-line constructor-template replay
-  now treats attachment misses as instantiation failures, matching the ordinary
-  constructor and member-function replay paths
-- replay signature matching now uses explicit result states
-  (`Match`/`Mismatch`/`InsufficientEvidence`) so attachment sites consume
-  positive evidence only
-- replay attachment loops that previously reduced matching to boolean now
-  preserve `InsufficientEvidence` and fail instantiation directly for
-  nested/partial member-template and constructor-stub paths
-- plain out-of-line member replay now also preserves `InsufficientEvidence`
-  and fails instantiation directly instead of degrading to generic
-  replay-attachment misses
-- constructor replay sync into StructTypeInfo now requires signature-validation
-  evidence and no longer accepts token/name shape equivalence for
-  mismatched parameter types
-- ordinary overload viability now requires a real conversion path before a
-  concrete struct argument can match a scalar parameter, instead of letting
-  parser-side `Struct -> scalar` optimism survive into normal direct-call
-  ranking
-- parser-side indirect/direct call argument typing now preserves the return
-  type of function-pointer and function-reference calls, so downstream overload
-  ranking no longer sees `fp(args...)` as the pointer type itself
-- function-template trailing-return reparse now happens after parameter
-  materialization when a saved `->` position exists, so dependent
-  `decltype(param_expr)` sees the same concrete parameter declarations used by
-  the instantiated function body
-- non-explicit function-template parameter materialization now preserves full
-  bound type metadata for pointer-to-member arguments instead of collapsing
-  them to the pointee/base type
-
-## Main remaining architectural gap
-
-The residual textual `base::member` path in `resolveDependentMemberAlias(...)`
-has been removed. The previously-blocking recordless cases now resolve through
-semantic owner/member-chain records that are preserved end-to-end at
-parse/materialization time:
-
-- `test_member_template_alias_preserves_outer_metadata_ret0.cpp`
-- `test_alias_template_nested_member_value_ret42.cpp`
-- `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
-
-The remaining problem is no longer textual recovery. It is keeping replay
-attachment evidence-driven across the remaining declaration/materialization
-paths: a few routes still lean on name/arity shape or parser-carried bindings
-instead of source identity plus canonical substituted-signature evidence.
-Tightening those is the next best cleanup target.
-
-## Recommended implementation order
-
-1. ~~Remove the last recordless dependent-alias routes.~~ **Done.**
-   Semantic owner/member-chain records are now preserved in the three former
-   blocker cases and the textual `base::member` path has been deleted.
-
-2. Keep replay attachment evidence-driven.
-   Continue tightening declaration replay so attachment succeeds because source
-   identity and canonical substituted signatures match, not because a
-   shape-based repair scan guessed correctly. The next likely slice is the remaining
-   unresolved-signature acceptance paths that still tolerate shape-first replay
-   attachment outside the now-tightened plain-member/member-template paths.
-
-3. Extend sema-owned lookup unification where it unlocks step 2.
-   The recent member-call fix closed one concrete gap by replacing parser-owned
-   call-argument typing inside sema with normalized semantic argument typing,
-   and the 2026-06-04 follow-ups applied the same model to semantic
-   `operator[]` and dependent/local callable `operator()` resolution. The
-   2026-06-08/2026-06-09 follow-ups close the documented const-receiver
-   no-viable callable and ordinary-member diagnostic holes; the next useful
-   expansion is to audit any other semantic call-resolution sites that still do
-   not share that collector or the receiver-aware candidate partitioning around
-   it, and then remove the temporary compatibility fallbacks that remain once
-   typed sema evidence is present.
-
-4. Extend dependent-name modeling only where it unlocks steps 2 and 3.
-   Richer current-instantiation and unknown-specialization handling still
-   matters, but it should be pulled in to unblock concrete replay/alias gaps,
-   not pursued as a detached refactor.
-
-5. Leave lower-priority uplift for later unless it blocks the above.
-   This includes broader sema-owned ranking/deduction cleanup and sema-level
-   modeling for aggregate-forwarding constructor cases.
-
-## Architectural rules for follow-up work
-
-- prefer semantic records over textual reconstruction
-- prefer replay-first source identity over instantiated-member scans
-- do not add new broad repair paths for unresolved replay attachment
-- route any remaining late materialization through typed lookup helpers rather
-  than rebuilding `owner::member` strings by hand
-- if a path cannot preserve enough metadata, document the gap explicitly and
-  keep the compatibility surface narrow
-
-## Next steps
-
-1. Audit why some instantiated ordinary direct calls still lose
-   `FunctionCallDefinitionLookupRecord` / `DependentUnqualifiedCallLookupRecord`
-   while preserving an authoritative mangled target. The new mangled-name
-   overload scan keeps those calls definition-bound, but the real goal is to
-   preserve the owning semantic replay metadata so that compatibility recovery
-   becomes unnecessary.
-
-2. Continue removing the remaining final parser-selected non-receiver fallback
-   in `resolveCallArgAnnotationTarget(...)` only where replay/materialization
-   now preserves enough typed evidence to make that route provably dead.
-
-3. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
-   source replay identity into that path rather than reintroducing any
-   signature-equivalent fallback.
-
-4. Expand current-instantiation / unknown-specialization modeling only for the
-   concrete cases that still block standards-conforming typed lookup after steps
-   1-3.
-
-## 2026-06-09 ordinary member const-receiver sema note
-
-Continuing the semantic-call fallback audit found that the shared
-`resolveCallArgAnnotationTarget(...)` / `tryAnnotateCallArgConversionsImpl(...)`
-path still left one standards-visible ordinary member-call hole open: a
-dependent `const T& obj; obj.member(...)` could compile when the parser had
-already attached a non-const member target, even though sema's const-aware
-member lookup found no viable const-compatible overload.
-
-This slice now:
-
-- blocks reuse of that stale parser-selected non-const member target once
-  shared const-aware lookup has proven the receiver has no const-compatible
-  overload for the named member
-- raises the failure from the shared sema call-annotation path as a hard member
-  call diagnostic instead of letting normalized/template calls continue into
-  codegen fallback
-- keeps function-pointer member calls valid by requiring actual member-function
-  ownership before applying the const-receiver diagnostic guard
-
-Validated with:
-
-- `test_template_member_call_const_receiver_fail.cpp`
-- `test_template_callable_operator_const_receiver_fail.cpp`
-- `test_funcptr_nested_template_struct_ret0.cpp`
-- `test_typedef_function_ptr_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 ordinary member ambiguity sema note
-
-Continuing the same fallback audit found a second receiver-member hole: a
-dependent member call that became ambiguous at instantiation could still
-compile because sema reduced the typed overload result to "no unique target"
-and then fell back to the parser-selected member candidate.
-
-This slice now:
-
-- preserves ambiguity information across the shared receiver-member typed
-  overload helper instead of collapsing it to a generic miss
-- blocks parser-selected fallback once shared sema has already proven the
-  receiver-member call ambiguous
-- raises the covered ambiguity from the shared call-annotation path as a hard
-  member-call diagnostic
-
-Validated with:
-
-- `test_template_member_call_ambiguous_fail.cpp`
-- `test_template_member_call_no_viable_overload_fail.cpp`
-- `test_template_member_call_const_receiver_fail.cpp`
-- `test_funcptr_nested_template_struct_ret0.cpp`
-- `test_typedef_function_ptr_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 partial-specialization StructTypeInfo replay-sync note
-
-Moving to the next active replay slice found that one weak-evidence route still
-survived outside the hardened replay-attachment helpers: partial-specialization
-plain out-of-line member replay attached the instantiated stub correctly by
-source-member identity, but the later `StructTypeInfo` sync path could still
-drop to signature-equivalent matching because the partial-specialization
-`StructTypeInfo` copy never recorded source-member -> struct-info-member
-identity for ordinary member functions.
-
-This slice now:
-
-- records source-member -> `StructTypeInfo` member index identity for ordinary
-  function copies in the partial-specialization struct-info build path
-- reuses that identity in partial-specialization plain out-of-line member sync
-  before any `StructTypeInfo` signature-equivalence fallback is considered
-- removes the active dependence on weak signature-equivalent sync for the
-  covered same-name overload route
-
-Validated with:
-
-- `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
-- `test_template_ool_plain_member_same_name_overload_ret0.cpp`
-- `test_template_ool_ctor_same_name_overload_ret0.cpp`
-- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
-- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
-- `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 dead signature-equivalent StructTypeInfo sync cleanup note
-
-After the partial-specialization fix, the remaining shared
-`findMatchingFunctionInStructInfo(...)` /
-`findMatchingConstructorInStructInfo(...)` signature-equivalent fallback was
-probed directly with hard-fail guards across the full suite. No current test
-hit that branch.
-
-This slice now:
-
-- deletes the dead signature-equivalent `StructTypeInfo` sync fallback from the
-  shared constructor/function helpers
-- leaves those helpers consuming only stronger evidence already preserved in the
-  current design: direct node identity and replay source keys
-- keeps the docs honest by moving the next recommended task back to the live
-  semantic-call compatibility boundary instead of implying this dead replay
-  branch still needed root-fixing
-
-Validated with:
-
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09 under the hard-fail probe
-- full `pwsh tests/run_all_tests.ps1` again after deleting the dead fallback
-
-## 2026-06-04 dependent decltype trailing-return note
-
-Auditing the template-argument conformance backlog found a standards-visible gap
-in function-template trailing return materialization: dependent
-`decltype(...)` clauses could be reparsed before the instantiated parameter list
-existed, and the non-explicit parameter-materialization path could flatten a
-bound pointer-to-member template argument to its pointee type. Together those
-bugs lost lvalue-reference qualification in cases like
-`decltype(wrapped.get())`, lost member-pointer owner metadata in
-`decltype(wrapped.get().*pmd)`, and allowed invalid pointer-to-reference forms
-to compile.
-
-The fix now:
-
-- reparses saved trailing return clauses after free-function template parameter
-  materialization and against the instantiated parameter declarations
-- copies the saved trailing-return/template positions onto the instantiated
-  function before that reparse
-- rebuilds non-explicit bound parameter types through the full substituted
-  type-specifier path instead of a TypeIndex-only substitution
-- preserves pointer-to-member owner metadata when reconstructing a
-  `TypeSpecifierNode` from bound template-argument records
-
-Validated with:
-
-- `test_dependent_decltype_member_call_ref_ret0.cpp`
-- `test_dependent_decltype_member_pointer_local_ret0.cpp`
-- `test_dependent_decltype_member_pointer_local_fail.cpp`
-- `test_dependent_decltype_arrow_member_pointer_ret0.cpp`
-- `test_dependent_decltype_arrow_member_pointer_fail.cpp`
-- `test_template_trailing_return_decltype_nttp_ret0.cpp`
-- `test_template_trailing_return_namespace_lookup_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04, with only the pre-existing
-  lambda-linking failures remaining outside this area
-
-## 2026-06-04 semantic operator[] note
-
-Auditing the remaining semantic call-resolution entry points found one
-standards-visible live bug in `SemanticAnalysis::tryResolveSubscriptOperator`:
-subscript overload resolution still used reduced expression typing and did not
-filter member candidates by receiver constness before fallback selection. That
-allowed const objects to bind non-const `operator[]` members and could erase
-lvalue/rvalue index evidence needed for overload selection.
-
-The fix now:
-
-- partitions `operator[]` candidates with the same receiver-const rule used by
-  ordinary member-call lookup
-- resolves the subscript index through sema-owned overload-resolution argument
-  typing rather than raw `inferExpressionType(...)`
-- shares the small overload-set helpers with ordinary member-call resolution so
-  future receiver-sensitive fixes cannot drift between the two paths
-
-Validated with:
-
-- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_subscript_const_ambiguity_fail.cpp`
-- `test_operator_subscript_const_ret42.cpp`
-- `test_operator_subscript_overloads_ret42.cpp`
-- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-04 callable/operator() standards follow-up note
-
-Continuing the standards-callable cleanup exposed three coupled regressions in
-normalized/deferred lambda call paths:
-
-- nested generic-lambda closures could place callable and scalar captures at the
-  same offset when callable capture size metadata remained unresolved
-- normalized direct-call lowering failed too early when sema-owned target
-  metadata was absent, even though the call still had enough typed context for
-  late/deferred lookup resolution
-- unresolved callable-reference recursive self calls (`self(self, ...)`) could
-  lower with mismatched self-argument qualifier expectations, breaking mangled
-  target resolution
-
-The fix now:
-
-- backfills unresolved by-value capture size/alignment from capture-member type
-  information and recalculates closure layout before emission
-- keeps strict sema-owned direct-call target behavior when metadata exists, and
-  constrains compatibility behavior to an explicit metadata-missing boundary
-- aligns unresolved callable-reference recursive self lowering with the ordinary
-  recursive self path (including lvalue-reference self argument handling)
-
-Remaining debt:
-
-- the metadata-missing direct-call compatibility boundary is still temporary and
-  should be removed once sema always materializes owned direct-call targets for
-  these normalized/deferred paths
-
-Validated with:
-
-- `test_generic_lambda_callable_nested_clone_ret0.cpp`
-- `test_generic_lambda_recursive_self_ret0.cpp`
-- `test_lambda_cpp20_comprehensive_ret135.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-04 dependent callable operator() sema note
-
-Continuing the same call-resolution audit found that receiverless dependent
-callable-object resolution still lagged behind direct member calls and
-`operator[]`: `SemanticAnalysis::tryResolveCallableOperatorImpl` still used
-reduced expression typing and did not partition candidates by receiver
-constness before fallback selection. That left template-instantiated functor
-calls vulnerable to stale lvalue/rvalue collapse and const/non-const drift even
-though the concrete callable type was already known in sema.
-
-This slice now:
-
-- routes dependent/local callable `operator()` overload selection through
-  sema-owned overload-resolution argument typing
-- partitions callable candidates with the same receiver-const rule already used
-  by direct member calls and semantic `operator[]`
-- keeps the codegen-side callable hard-stop narrow enough to preserve recursive
-  lambda self forwarding while still treating sema-analyzed absent struct
-  callable targets as invalid in the covered path
-
-Validated with:
-
-- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_callable_sema_resolved_ret0.cpp`
-- `test_template_out_of_line_operator_call_ret0.cpp`
-- `test_generic_lambda_recursive_self_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-08 dependent callable const-receiver diagnostic note
-
-The next callable audit slice closed the remaining documented compile-through
-case for dependent/local callable objects: a templated `const Callable& c;
-c(...)` could still compile when the parser had already attached a non-const
-`operator()` target, even though sema's const-aware member lookup found no
-viable const-compatible overload.
-
-This slice now:
-
-- blocks the stale parser-selected member-call target from being reused once
-  semantic lookup has proven that a const receiver has no const-compatible
-  `operator()` candidate to bind
-- raises the failure from sema as an explicit callable diagnostic rather than
-  allowing the member-call fallback to continue
-- locks the case down with a stable template-instantiation `_fail` regression
-
-Validated with:
-
-- `test_template_callable_operator_const_receiver_fail.cpp`
-- `test_template_callable_operator_const_receiver_explicit_member_fail.cpp`
-- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_callable_operator_default_arg_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-08
-
-## 2026-06-02 constexpr lambda capture-lowering note
-
-The updated constexpr-lambda tests exposed runtime-only closure-lowering gaps:
-compile-time evaluation already accepted the C++20 cases, but generated code
-mis-modeled captured `this` inside lambdas and nested lambdas. The current fix
-keeps lambda member-call receivers standards-aligned by:
-
-- treating `this->member()` inside `[this]` as a call on the captured enclosing
-  object pointer, not on the closure object
-- treating `this->member()` inside `[*this]` as a call on the closure's copied
-  object member
-- propagating nested `[this]` captures through the effective enclosing object
-  pointer, including when the enclosing object is a `[*this]` copy
-- taking the address of enclosing closure members for nested by-reference
-  captures instead of assuming a local variable exists
-- preserving the referenced object's real size when loading through a
-  by-reference capture
-- preserving receiver cv-qualification through constexpr synthetic `this`
-  bindings, including unqualified member calls from const member bodies
-
-Follow-up: the constexpr evaluator now applies the same const-aware selection
-rule in the receiver-based and current-struct paths, but the implementations are
-still structurally separate. The next cleanup should extract one shared
-member-candidate collector so future overload fixes cannot drift between paths.
-
-Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
-
-## 2026-06-09 direct-call pack-substitution sema note
-
-Returning to the remaining non-receiver/direct-call compatibility surface
-showed that one active route was no longer a semantic lookup hole in
-`SemanticAnalysis`, but an earlier substitution gap in
-`ExpressionSubstitutor`: when a substituted direct call still carried a
-`PackExpansionExprNode` in its argument list, the dependent-unqualified
-point-of-instantiation replay could not collect concrete argument types and the
-later direct-call compatibility branch remained live.
-
-This slice now:
-
-- preserves call-site pack expansion while rebuilding substituted constructor,
-  direct-call, and receiver-call argument lists inside `ExpressionSubstitutor`
-- lets dependent-unqualified direct calls materialize concrete argument types
-  before point-of-instantiation lookup, covering the active
-  `add(readValue(__builtin_addressof(args))...)` route
-- removes the confirmed live traffic from the remaining non-receiver
-  compatibility branch without widening semantic fallback
-
-Validated with:
-
-- `test_template_builtin_addressof_substitution_ret0.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-Next step:
-
-- re-audit `resolveCallArgAnnotationTarget(...)` / direct-call compatibility
-  now that this pack-substitution gap is closed, and remove or narrow the
-  remaining non-receiver fallback only where typed sema evidence is complete
-
-## 2026-06-09 ordinary direct-call viability note
-
-Continuing that direct-call audit exposed a broader standards-visible blocker
-than template fallback alone: a plain ordinary call could still accept a
-concrete struct argument for a scalar parameter even when no conversion
-operator or converting constructor existed, and the same bug then reproduced
-through dependent direct calls in instantiated template bodies. Tightening that
-path also surfaced a second parser-typing gap: indirect calls such as
-`sumBig(fp(10))` were being ranked as though `fp(10)` had function-pointer type
-instead of the callee return type.
-
-This slice now:
-
-- keeps `TypeSpecifierNode` identity through parser-side reference unwrapping in
-  overload viability instead of degrading concrete types to coarse
-  `TypeCategory` pairs
-- requires a real conversion path before a concrete struct argument can match a
-  scalar parameter in ordinary overload ranking, while still preserving the
-  existing incomplete-type optimism for genuinely unresolved parse-time cases
-- teaches parser-side call typing to recover the return type from
-  function-pointer / function-reference signatures, so indirect calls feed the
-  right argument type into later overload resolution
-
-Validated with:
-
-- `test_overload_resolution_struct_without_conversion_to_int_fail.cpp`
-- `test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_funcptr_large_struct_return_direct_use_ret0.cpp`
-- `test_implicit_conversion_arg_ret42.cpp`
-- `test_func_arg_conv_ctor_sema_ret42.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- `test_template_builtin_addressof_substitution_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-11 non-receiver direct-call compatibility note
-
-Re-auditing `resolveCallArgAnnotationTarget(...)` showed that the live
-non-receiver compatibility branch was broader than the remaining standards
-debt warranted: ordinary direct calls still returned the parser-selected target
-immediately, before sema even attempted a fresh typed overload lookup. That
-was no longer needed for the covered ordinary-call paths after the recent
-argument-typing and overload-viability fixes, but non-dependent template-body
-calls still had to preserve definition-context binding.
-
-This slice now:
-
-- returns preserved `FunctionCallDefinitionLookupRecord` targets immediately for
-  non-receiver direct calls, so non-dependent two-phase lookup remains
-  definition-bound
-- stops reusing bare parser-selected non-receiver direct-call targets before
-  fresh typed lookup when no definition-bound record exists
-- recovers authoritative non-receiver direct-call targets from the preserved
-  mangled name even when the instantiated call dropped its definition/dependent
-  lookup records, preventing sema from falling back to a fresh later-overload
-  scan
-- keeps parser-selected target reuse only as the final compatibility boundary
-  after typed overload lookup and ordinary overload-set recovery still cannot
-  decide the call
-- fixes a full-suite regression in struct-to-pointer built-in subscript
-  normalization by deriving conversion-operator element types without the
-  brittle `CanonicalTypeDesc` pointer-level pop path that could assert on
-  `test_subscript_pointer_conversion_template_ret42.cpp`
-
-Validated with:
-
-- `template_lookup_non_dependent_no_rebind_ret0.cpp`
-- `test_template_two_phase_nondependent_later_better_overload_ret42.cpp`
-- `test_template_two_phase_member_func_template_ret42.cpp`
-- `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
-- `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
-- `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
-- `test_template_two_phase_explicit_nondependent_later_overload_ret42.cpp`
-- `test_template_two_phase_nondependent_later_function_template_overload_ret42.cpp`
-- `test_template_qualified_phase1_fallback_ret0.cpp`
-- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- `test_template_builtin_addressof_substitution_ret0.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_subscript_pointer_conversion_template_ret42.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-11
+- dependent alias resolution is semantic-only; the old textual
+  `base::member` reconstruction path is gone
+- replay/materialization paths are increasingly source-identity-driven instead
+  of shape-driven
+- normalized template/member direct-call resolution uses sema-owned
+  overload-resolution argument typing rather than parser-owned argument typing
+- semantic receiver-sensitive lookup for ordinary member calls, `operator[]`,
+  and callable `operator()` now shares the same const-aware candidate
+  partitioning model
+- parser-selected direct/member-call targets are no longer trusted early once
+  sema has enough typed evidence to decide or reject the call
+- direct-call viability now requires real conversion paths instead of accepting
+  parser-only optimistic struct-to-scalar matches
+- function-pointer/function-reference call typing preserves the callee return
+  type during overload ranking
+- replay attachment in the covered out-of-line member and constructor paths now
+  expects positive identity/signature evidence rather than silently accepting
+  unresolved shape-based matches
+
+## Architectural invariants to preserve
+
+Follow-up work in this area should preserve these rules:
+
+- preserve semantic identity end-to-end; do not rebuild meaning from text if a
+  structured record can be carried instead
+- prefer replay-first attachment using source identity plus canonical
+  substituted-signature evidence
+- treat parser-selected compatibility paths as temporary debt, not as a normal
+  resolution mechanism
+- when sema has enough typed evidence to decide, reject broad parser/codegen
+  fallback instead of letting it continue
+- if a path still lacks enough metadata, narrow the compatibility surface and
+  document the gap explicitly
+
+## Highest-value remaining architectural gaps
+
+### 1. Direct-call metadata loss across replay/materialization
+
+Some instantiated ordinary direct calls still lose their preserved
+`FunctionCallDefinitionLookupRecord` /
+`DependentUnqualifiedCallLookupRecord` while keeping an authoritative mangled
+target. The current mangled-name recovery in sema is acceptable as a narrow
+compatibility boundary, but it is not the desired end state.
+
+Desired end state:
+
+- the instantiated call preserves the original semantic lookup record
+- sema does not need mangled-name recovery to stay definition-bound
+- the final parser-selected fallback in `resolveCallArgAnnotationTarget(...)`
+  becomes removable
+
+### 2. Residual replay/`StructTypeInfo` sync gaps
+
+The broad signature-equivalent sync fallback is gone from the currently-covered
+paths, but future failures in replay-heavy areas will likely still come from
+metadata loss between source declarations and instantiated `StructTypeInfo`
+copies.
+
+Desired end state:
+
+- every replay/sync path preserves source-member identity directly
+- `StructTypeInfo` repair scans are not used to rediscover targets by name or
+  arity when identity could have been preserved
+
+### 3. Remaining semantic call compatibility fallback
+
+The ordinary non-receiver direct-call path is much narrower now, but one final
+parser-selected compatibility route still exists after typed lookup. That
+fallback should only survive where replay/materialization still drops decisive
+semantic evidence.
+
+Desired end state:
+
+- sema-owned typed lookup resolves or rejects ordinary direct calls directly
+- parser-selected direct-call fallback disappears from normalized flows
+
+### 4. Current-instantiation / unknown-specialization precision
+
+This is no longer the first task, but it remains the next structural lever once
+the direct-call and replay-identity gaps above are smaller. Expand it only
+where it unblocks real replay or typed-lookup failures.
+
+## Recommended task order
+
+1. Preserve direct-call lookup records across replay/materialization in the
+   remaining instantiated-call paths that still fall back to mangled-name
+   recovery.
+
+2. Remove the remaining final parser-selected non-receiver direct-call fallback
+   in `resolveCallArgAnnotationTarget(...)` once step 1 proves the owning paths
+   carry enough semantic evidence.
+
+3. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
+   in that path instead of restoring any signature-equivalent recovery logic.
+
+4. Only after steps 1-3 are stable, expand
+   current-instantiation/unknown-specialization modeling for the concrete cases
+   that still block standards-conforming typed lookup.
 
 ## Validation guidance
 
 When changing this area, always rerun:
 
 - the focused regression that motivated the slice
-- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
-  `test_operator_subscript_const_ambiguity_fail.cpp` and
-  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` and
-  `test_subscript_pointer_conversion_template_ret42.cpp` when touching
-  semantic subscript resolution, pointer-conversion discovery, or
-  receiver-sensitive normalized-call lookup
-- the three former textual-path blockers listed above when touching dependent
-  alias ownership (they now exercise the semantic-only route)
-- the dependent member-template static constexpr regressions when touching
-  nested qualified-id replay, inherited member-template lookup, or static member
-  initializer emission
-- `pwsh tests/run_all_tests.ps1` before closing the slice
+- `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
+- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_subscript_const_ambiguity_fail.cpp`
+- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
+- `test_subscript_pointer_conversion_template_ret42.cpp`
+- full `pwsh tests/run_all_tests.ps1` before closing the slice

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-09
+**Last updated:** 2026-06-11
 
 This document is not a release log. It should explain what the current template
 architecture can assume, what is still structurally wrong, and what the next
@@ -44,9 +44,17 @@ ordinary-call blocker that was still distorting the remaining template audit:
 shared overload viability no longer accepts concrete struct-to-scalar calls
 without a real conversion path, and indirect-call argument typing now preserves
 the callee return type instead of collapsing `fp(args...)` back to the function
-pointer type during parser-side overload ranking. The next highest-value task
-is back on the residual semantic-call compatibility surface unless a new replay
-route proves it still loses identity metadata.
+pointer type during parser-side overload ranking. The newest non-receiver
+direct-call follow-up now also narrows the remaining compatibility surface:
+ordinary direct calls no longer reuse bare parser-selected targets up front
+when no definition-bound lookup record exists, while preserved
+definition-context call records still short-circuit non-dependent two-phase
+lookup exactly where the standard requires. Fresh typed sema lookup now owns
+ordinary non-receiver direct-call selection across the covered paths, with the
+parser-selected target kept only as the last compatibility resort after typed
+lookup has already had its chance. The next highest-value task is therefore the
+remaining last-resort direct-call fallback surface unless a new replay route
+proves it still loses identity metadata.
 
 ## What the current design can assume
 
@@ -64,6 +72,10 @@ route proves it still loses identity metadata.
   collects overload-resolution argument types from semantic expression typing
   instead of parser-owned call-argument typing, so dependent out-of-line member
   overloads resolve by the concrete substituted call signature seen during sema
+- ordinary non-receiver direct calls now also defer bare parser-selected target
+  reuse until after preserved definition-context records and fresh typed lookup
+  have both had a chance to resolve the call, so non-dependent two-phase lookup
+  remains definition-bound while ordinary direct-call fallback is narrower
 - semantic `operator[]` resolution now shares sema-owned overload-resolution
   argument typing and the same receiver-const candidate partitioning used by
   direct member-call lookup, so normalized subscripts no longer bind non-const
@@ -209,11 +221,10 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Re-audit the remaining non-receiver / direct-call compatibility branches in
-   `resolveCallArgAnnotationTarget(...)` now that the active ordinary-call
-   blocker was not fallback at all, but ordinary overload viability plus
-   indirect-call argument typing. Remove or narrow only the branches that are
-   now truly dead after typed parser/sema evidence is complete.
+1. Audit the remaining last-resort non-receiver direct-call fallback in
+   `resolveCallArgAnnotationTarget(...)` and remove each surviving parser-
+   selected route only after the owning replay/materialization path preserves
+   enough typed overload evidence to make that fallback dead.
 
 2. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
    source replay identity into that path rather than reintroducing any
@@ -582,6 +593,41 @@ Validated with:
 - `test_pack_expansion_in_template_body_ret0.cpp`
 - `test_template_builtin_addressof_substitution_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-11 non-receiver direct-call compatibility note
+
+Re-auditing `resolveCallArgAnnotationTarget(...)` showed that the live
+non-receiver compatibility branch was broader than the remaining standards
+debt warranted: ordinary direct calls still returned the parser-selected target
+immediately, before sema even attempted a fresh typed overload lookup. That
+was no longer needed for the covered ordinary-call paths after the recent
+argument-typing and overload-viability fixes, but non-dependent template-body
+calls still had to preserve definition-context binding.
+
+This slice now:
+
+- returns preserved `FunctionCallDefinitionLookupRecord` targets immediately for
+  non-receiver direct calls, so non-dependent two-phase lookup remains
+  definition-bound
+- stops reusing bare parser-selected non-receiver direct-call targets before
+  fresh typed lookup when no definition-bound record exists
+- keeps parser-selected target reuse only as the final compatibility boundary
+  after typed overload lookup and ordinary overload-set recovery still cannot
+  decide the call
+
+Validated with:
+
+- `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_two_phase_nondependent_later_better_overload_ret42.cpp`
+- `test_template_two_phase_member_func_template_ret42.cpp`
+- `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
+- `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
+- `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
+- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- `test_template_builtin_addressof_substitution_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-11
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -221,18 +221,20 @@ Tightening those is the next best cleanup target.
 
 ## Next steps
 
-1. Audit the remaining last-resort non-receiver direct-call fallback in
-   `resolveCallArgAnnotationTarget(...)` and remove each surviving parser-
-   selected route only after the owning replay/materialization path preserves
-   enough typed overload evidence to make that fallback dead.
+1. Audit why some instantiated ordinary direct calls still lose
+   `FunctionCallDefinitionLookupRecord` / `DependentUnqualifiedCallLookupRecord`
+   while preserving an authoritative mangled target. The new mangled-name
+   overload scan keeps those calls definition-bound, but the real goal is to
+   preserve the owning semantic replay metadata so that compatibility recovery
+   becomes unnecessary.
 
-2. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
+2. Continue removing the remaining final parser-selected non-receiver fallback
+   in `resolveCallArgAnnotationTarget(...)` only where replay/materialization
+   now preserves enough typed evidence to make that route provably dead.
+
+3. If another replay/`StructTypeInfo` sync gap appears, prefer preserving
    source replay identity into that path rather than reintroducing any
    signature-equivalent fallback.
-
-3. Audit the remaining semantic call compatibility fallbacks that still reuse
-   parser-selected targets after typed sema evidence is available, and remove
-   each fallback once the owning semantic path is fully covered.
 
 4. Expand current-instantiation / unknown-specialization modeling only for the
    concrete cases that still block standards-conforming typed lookup after steps
@@ -611,9 +613,17 @@ This slice now:
   definition-bound
 - stops reusing bare parser-selected non-receiver direct-call targets before
   fresh typed lookup when no definition-bound record exists
+- recovers authoritative non-receiver direct-call targets from the preserved
+  mangled name even when the instantiated call dropped its definition/dependent
+  lookup records, preventing sema from falling back to a fresh later-overload
+  scan
 - keeps parser-selected target reuse only as the final compatibility boundary
   after typed overload lookup and ordinary overload-set recovery still cannot
   decide the call
+- fixes a full-suite regression in struct-to-pointer built-in subscript
+  normalization by deriving conversion-operator element types without the
+  brittle `CanonicalTypeDesc` pointer-level pop path that could assert on
+  `test_subscript_pointer_conversion_template_ret42.cpp`
 
 Validated with:
 
@@ -623,10 +633,15 @@ Validated with:
 - `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
 - `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
 - `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
+- `test_template_two_phase_explicit_nondependent_later_overload_ret42.cpp`
+- `test_template_two_phase_nondependent_later_function_template_overload_ret42.cpp`
+- `test_template_qualified_phase1_fallback_ret0.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_dependent_identifier_template_call_ret0.cpp`
 - `test_pack_expansion_in_template_body_ret0.cpp`
 - `test_template_builtin_addressof_substitution_ret0.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_subscript_pointer_conversion_template_ret42.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-11
 
 ## Validation guidance
@@ -636,8 +651,10 @@ When changing this area, always rerun:
 - the focused regression that motivated the slice
 - `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
   `test_operator_subscript_const_ambiguity_fail.cpp` and
-  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` when touching
-  semantic subscript resolution or receiver-sensitive normalized-call lookup
+  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` and
+  `test_subscript_pointer_conversion_template_ret42.cpp` when touching
+  semantic subscript resolution, pointer-conversion discovery, or
+  receiver-sensitive normalized-call lookup
 - the three former textual-path blockers listed above when touching dependent
   alias ownership (they now exercise the semantic-only route)
 - the dependent member-template static constexpr regressions when touching

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -3,624 +3,129 @@
 **Date:** 2026-05-12  
 **Last updated:** 2026-06-11
 
-This document tracks the standards-facing endpoint for template argument and
-dependent-name work. It should describe the intended model and the shortest path
-from the current implementation to that model, not a full branch history.
+This document tracks the standards-facing target for the remaining template
+infrastructure work. It should describe the intended semantic model, the
+highest-value remaining conformance gaps, and the next tasks required to close
+them. It is intentionally not a branch diary.
 
-## Goal
+## Target model
 
-Move FlashCpp toward a sema-owned template system where:
+Move FlashCpp toward a template implementation where:
 
 - dependency classification is explicit
-- template arguments are classified against the actual target parameter
+- non-dependent lookup remains definition-bound through instantiation
 - dependent names preserve semantic identity end-to-end
-- substitution, deduction, ranking, and materialization stay separate
-- replay-heavy paths become invariant-driven instead of repair-driven
+- substitution, deduction, ranking, and replay/materialization stay separate
+- semantic analysis, not parser leftovers, owns final call-target selection in
+  normalized flows
+- replay succeeds because invariant evidence matches, not because a repair scan
+  guessed correctly
 
-## What is already true enough to build on
+## Current conformance baseline
 
-- semantic lookup records cover the main template lookup paths
-- covered non-dependent template-body lookup preserves definition-context
-  binding
-- several replay paths already preserve source identity and enough context to
-  avoid AST-only intent recovery
-- owner/member-template chains are preserved semantically in many covered alias
-  and replay cases
-- explicit member-template call handling now carries enough early argument
-  information to avoid wrong cached overload reuse
-- semantic direct-call resolution for normalized template/member calls now uses
-  sema-owned overload-resolution argument typing instead of parser-owned
-  argument collection, so dependent out-of-line member overloads are selected
-  from the concrete substituted call signature seen during semantic analysis
-- ordinary non-receiver direct calls now also defer bare parser-selected target
-  reuse until after preserved definition-context records and fresh typed lookup
-  have both had a chance to resolve the call, so non-dependent two-phase
-  lookup remains definition-bound while the ordinary fallback surface is
-  smaller
-- semantic `operator[]` resolution now also uses sema-owned
-  overload-resolution argument typing plus receiver-const candidate filtering,
-  so normalized subscripts preserve lvalue/rvalue index evidence and do not
-  bind non-const members through const receivers
-- semantic receiverless callable `operator()` resolution for dependent/local
-  callable objects now also uses sema-owned overload-resolution argument typing
-  plus receiver-const candidate filtering, so template-instantiated functors no
-  longer rely on reduced expression typing for const or lvalue/rvalue overload
-  selection
-- sema now also rejects parser-selected non-const `operator()` targets on
-  const dependent/local callable receivers once semantic lookup has shown there
-  is no viable const-compatible overload, so this standards-visible negative
-  case no longer compiles through member-call fallback
-- sema now also rejects parser-selected non-const ordinary member-function
-  targets on const dependent/member-call receivers once const-aware lookup has
-  shown there is no viable const-compatible overload, while leaving
-  function-pointer member calls on their ordinary indirect-call path
-- sema now also rejects parser-selected ordinary member-call fallback once
-  typed receiver-member overload resolution has already proven the dependent
-  call ambiguous
-- partial-specialization plain out-of-line member replay now also syncs its
-  `StructTypeInfo` copy through source-member identity instead of
-  signature-equivalent matching
-- the dead shared signature-equivalent `StructTypeInfo` sync fallback is now
-  removed; current sync paths consume only preserved identity evidence
-- dependent alias resolution is semantic-only: the textual recovery path in
-  `resolveDependentMemberAlias(...)` has been removed in favor of preserved
-  owner/member-chain records and instantiation-context bindings
-- dependent nested member-template static constexpr chains now reuse typed
-  owner/member-chain records, active template bindings, and inherited
-  member-template lookup instead of hard-coded constexpr name scans
-- out-of-line member replay attachment now fails instantiation when replay
-  identity plus substituted-signature evidence cannot attach the definition,
-  instead of silently continuing into later template instantiation
-- plain out-of-line member replay now also requires positive signature
-  evidence for single-candidate same-name attachment; unresolved
-  substituted-signature outcomes no longer attach by default
-- nested and partial-specialization constructor-template replay now fails
-  directly when replay identity plus substituted-signature evidence cannot
-  attach the out-of-line definition
-- replay signature matching now reports explicit
-  `Match`/`Mismatch`/`InsufficientEvidence` outcomes; attachment paths treat
-  only `Match` as valid evidence
-- replay attachment loops that previously flattened matching to boolean now
-  preserve `InsufficientEvidence` and fail instantiation directly for
-  nested/partial member-template and constructor-stub routes
-- plain out-of-line member replay now also preserves `InsufficientEvidence`
-  and fails instantiation directly instead of degrading to generic
-  replay-attachment misses
-- constructor replay sync into StructTypeInfo now requires
-  `typeSpecifiersMatchForSignatureValidation(...)` evidence and no longer
-  treats token/name shape equivalence as valid evidence
-- `materializeAliasTemplateInstance` now delegates to
-  `materializeInstantiatedMemberAliasTarget` for direct-parameter alias cases
-  where the instantiated name resolves to a member type
-- member type aliases preserve surface modifiers (pointer/reference/cv/array/
-  function) across alias chains rather than collapsing to the terminal type
-- function-template trailing return `decltype(...)` reparsing now runs against
-  the instantiated parameter declarations rather than the pre-materialized
-  template pattern
-- non-explicit template-parameter materialization now preserves full
-  pointer-to-member metadata for bound type arguments
-- ordinary overload viability now requires a real conversion path before a
-  concrete struct argument can match a scalar parameter, instead of accepting a
-  parser-only `Struct -> scalar` guess
-- parser-side indirect call typing now preserves the callee return type when a
-  function pointer or function reference is called, so ordinary overload
-  ranking sees `fp(args...)` as the returned object type rather than the pointer
-  itself
+The compiler now has a workable standards-facing baseline in several previously
+blocking areas:
 
-## Highest-value remaining standards gap
+- covered non-dependent template-body lookup remains definition-bound
+- dependent alias resolution no longer relies on textual reconstruction
+- normalized direct-call resolution for template/member calls uses sema-owned
+  overload-resolution argument typing
+- semantic const-aware lookup for ordinary member calls, `operator[]`, and
+  callable `operator()` now rejects stale non-const parser-selected targets
+  once sema has typed evidence
+- direct-call viability now requires real conversion paths
+- indirect call typing preserves the returned object type during overload
+  ranking
+- replay attachment in the covered routes now expects positive
+  identity/signature evidence rather than accepting unresolved
+  shape-based matches
 
-The textual dependent-alias recovery path has been deleted; the former blockers
-now resolve through preserved semantic records:
+## Highest-value remaining standards gaps
 
-- `test_member_template_alias_preserves_outer_metadata_ret0.cpp`
-- `test_alias_template_nested_member_value_ret42.cpp`
-- `test_template_current_instantiation_alias_qualified_deeper_member_ret0.cpp`
+### 1. Compatibility recovery is still covering direct-call metadata loss
 
-With textual recovery gone, the next conformance step is keeping replay
-attachment invariant-driven: tighten the remaining replay paths so valid cases
-succeed via source identity plus canonical substituted-signature evidence rather
-than name/arity repair scans, and expand current-instantiation /
-unknown-specialization modeling only where it unblocks those paths.
+Some instantiated ordinary direct calls still lose their preserved
+definition-bound lookup record while retaining an authoritative mangled target.
+Sema now recovers that target, which prevents standards-visible rebinding to a
+later overload, but the standards-conforming endpoint is to preserve the
+semantic lookup record itself.
+
+Why this matters:
+
+- a preserved mangled target is only a compatibility boundary
+- the real semantic model should still know *why* the call is definition-bound
+- removing the final parser-selected fallback depends on closing this metadata
+  gap first
+
+### 2. Replay must stay invariant-driven
+
+The remaining standards risk is no longer textual dependent-name recovery. It
+is replay/materialization paths that may still succeed or sync through weak
+name/arity evidence instead of source identity plus canonical substituted
+signatures.
+
+Why this matters:
+
+- replay that succeeds through shape-based repair can silently select the wrong
+  declaration
+- those weak paths tend to reopen non-conforming fallback behavior later in
+  sema or codegen
+
+### 3. Final parser-selected ordinary direct-call fallback
+
+The remaining ordinary non-receiver compatibility route should disappear from
+normalized flows once replay/materialization preserves enough typed evidence.
+
+Why this matters:
+
+- as long as the fallback exists, sema is not yet the sole owner of final
+  ordinary direct-call target selection
+- the standard model is cleaner when typed sema evidence resolves or rejects
+  the call directly
+
+### 4. Current-instantiation / unknown-specialization coverage
+
+This is still necessary, but it is no longer the immediate next task. Expand
+it only for concrete unresolved cases that block steps 1-3.
 
 ## Priority order
 
-1. ~~Preserve semantic owner/member-chain records in the remaining dependent
-   alias callers.~~ **Done** — the textual recovery path is removed.
+1. Preserve direct-call lookup records across the remaining replay and
+   materialization paths that currently rely on mangled-name recovery.
 
-2. Continue tightening replay attachment so valid cases succeed via source
-   identity plus canonical substituted-signature evidence, not shape-based
-   repair scans.
-   The next slice is likely the remaining unresolved-signature acceptance paths
-   where replay can still succeed without enough evidence outside the now-
-   tightened plain-member and member-template paths.
+2. Remove the final parser-selected non-receiver direct-call fallback in
+   `resolveCallArgAnnotationTarget(...)` once step 1 is complete for the
+   remaining live paths.
 
-3. Unify the remaining semantic call-resolution entry points around the same
-   sema-owned overload-resolution argument collector now used for normalized
-   template/member direct calls. The 2026-06-04 follow-ups closed the concrete
-   `operator[]` and dependent/local callable `operator()` gaps by sharing
-   receiver-aware candidate filtering plus sema-owned argument typing with
-   direct member-call resolution, and the 2026-06-08/2026-06-09 follow-ups
-   close the documented const-receiver no-viable callable and ordinary-member
-   diagnostic holes. The next step here is auditing any residual semantic call
-   sites still outside that model, then removing the temporary parser-target
-   compatibility fallbacks that remain once typed sema evidence is available.
+3. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
+   identity rather than restoring any signature-equivalent or textual repair
+   logic.
 
-4. Expand current-instantiation, dependent-base, and unknown-specialization
-   handling only where that unblocks steps 2 and 3.
-
-5. Leave broader cleanup for later unless it becomes a blocker:
-   sema-owned ranking/deduction expansion, remaining repair-path removal, and
-   sema-level modeling for aggregate-forwarding constructor sequences.
+4. Expand current-instantiation and unknown-specialization handling only where
+   it unblocks concrete replay or typed-lookup failures still remaining after
+   steps 1-3.
 
 ## Standards rules for follow-up work
 
 - do not normalize textual reconstruction as acceptable semantics
-- prefer invariant failures or proper diagnostics over silent repair in
-  normalized flows
+- prefer hard failure or proper diagnostics over silent repair in normalized
+  semantic flows
 - keep compatibility behavior explicit, narrow, and temporary
-- treat codegen-side recovery as debt to remove, not a design tool; when a
-  late retry is still needed, it should delegate to typed lookup such as
-  `resolveBaseClassMemberTypeChain`
-
-## Next steps
-
-1. Audit why some instantiated ordinary direct calls still lose
-   `FunctionCallDefinitionLookupRecord` / `DependentUnqualifiedCallLookupRecord`
-   while preserving an authoritative mangled target. The current mangled-name
-   recovery is a compatibility boundary, not the desired end state.
-
-2. Continue removing the final parser-selected non-receiver fallback in
-   `resolveCallArgAnnotationTarget(...)` only after the owning replay or
-   materialization path preserves enough typed evidence to make that route
-   unnecessary.
-
-3. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
-   source replay identity into that path rather than restoring any
-   signature-equivalent fallback.
-
-4. Only after those are stable, extend current-instantiation and
-   unknown-specialization modeling for the specific unresolved cases that remain.
-
-## 2026-06-09 ordinary member const-receiver conformance note
-
-The next live standards-visible call gap was the ordinary member-call analogue
-of the already-fixed callable case: a dependent `const T& obj; obj.member(...)`
-could still compile when the parser had attached a non-const member target,
-even though sema's const-aware member lookup found no viable const-compatible
-overload.
-
-The fix now:
-
-- blocks reuse of that stale parser-selected non-const member target in the
-  shared sema call-annotation path once const-aware lookup has shown there is
-  no const-compatible overload
-- emits a hard member-call diagnostic for the covered path instead of letting
-  normalized/template calls continue toward codegen fallback
-- preserves valid function-pointer member calls by requiring actual
-  member-function ownership before applying the const-receiver diagnostic
-
-Validated with:
-
-- `test_template_member_call_const_receiver_fail.cpp`
-- `test_template_callable_operator_const_receiver_fail.cpp`
-- `test_funcptr_nested_template_struct_ret0.cpp`
-- `test_typedef_function_ptr_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 ordinary member ambiguity conformance note
-
-The next live standards-visible gap in the same family was ambiguity handling
-for dependent ordinary member calls: once instantiation made the receiver call
-ambiguous, sema could still degrade that typed result to "no unique target"
-and continue by reusing a parser-selected member candidate.
-
-The fix now:
-
-- preserves explicit ambiguity in the shared receiver-member typed overload
-  helper instead of collapsing it to a generic miss
-- blocks parser-selected fallback once sema has already proven the receiver
-  call ambiguous
-- emits a hard member-call ambiguity diagnostic from the shared call-annotation
-  path for the covered cases
-
-Validated with:
-
-- `test_template_member_call_ambiguous_fail.cpp`
-- `test_template_member_call_no_viable_overload_fail.cpp`
-- `test_template_member_call_const_receiver_fail.cpp`
-- `test_funcptr_nested_template_struct_ret0.cpp`
-- `test_typedef_function_ptr_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 partial-specialization StructTypeInfo replay-sync conformance note
-
-The next active standards-relevant replay gap was no longer initial attachment;
-that part was already identity-driven. The remaining weakness was the later
-`StructTypeInfo` sync for partial-specialization plain out-of-line members:
-the instantiated stub was attached by source-member identity, but the parallel
-`StructTypeInfo` copy could still be rediscovered only by signature-equivalent
-matching because the partial-specialization copy path never preserved
-source-member -> struct-info-member identity for ordinary functions.
-
-The fix now:
-
-- records source-member -> `StructTypeInfo` member index identity for ordinary
-  function copies in the partial-specialization struct-info build path
-- uses that identity first during partial-specialization plain-member replay
-  sync instead of rediscovering the `StructTypeInfo` target by equivalent
-  signature
-- removes the active same-name overload dependence on weak signature-shaped
-  sync in the covered route
-
-Validated with:
-
-- `test_template_partial_spec_ool_plain_member_same_name_overload_ret0.cpp`
-- `test_template_ool_plain_member_same_name_overload_ret0.cpp`
-- `test_template_ool_ctor_same_name_overload_ret0.cpp`
-- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_ool_ctor_same_name_overload_template_default_arg_ret0.cpp`
-- `test_template_ool_ctor_template_nullopt_single_candidate_no_attach_ret0.cpp`
-- `test_template_ool_plain_member_dependent_member_template_alias_overload_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-09 dead shared StructTypeInfo sync fallback cleanup note
-
-After the partial-specialization replay-sync fix, the remaining shared
-signature-equivalent `StructTypeInfo` sync fallback was probed directly with
-hard-fail guards across the full suite. No current test depended on it.
-
-The cleanup now:
-
-- deletes that dead signature-equivalent fallback from the shared constructor
-  and function `StructTypeInfo` sync helpers
-- leaves those helpers keyed only by stronger replay evidence already preserved
-  in the current architecture: direct node identity and replay source keys
-- reclassifies the next standards-facing task back to the live direct-call
-  compatibility boundary instead of to a dead replay branch
-
-Validated with:
-
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09 with the hard-fail probe
-- full `pwsh tests/run_all_tests.ps1` again after removing the dead fallback
-
-## 2026-06-04 dependent decltype conformance note
-
-The remaining pointer-to-member `decltype` failures were not primarily member
-access bugs. The deeper standards gap was that free-function template trailing
-return clauses were being reparsed before the instantiated parameter list
-existed, and non-explicit parameter materialization could erase bound
-pointer-to-member structure by reducing a template argument like `int Box::*`
-to `int`.
-
-The fix now:
-
-- reparses saved free-function trailing return clauses after parameter
-  materialization, with the concrete instantiated parameter declarations in
-  scope
-- copies the saved trailing-return/template parse positions onto the
-  instantiated function before replay
-- materializes non-explicit bound parameter types through the full substituted
-  type-specifier path so member-pointer category/owner data survive deduction
-- preserves member-pointer owner metadata when converting stored bound template
-  arguments back into `TypeSpecifierNode`s
-
-Standards-visible result:
-
-- `decltype(wrapped.get())` in a function-template trailing return now
-  preserves `T&`
-- `decltype(wrapped.get().*pmd)` likewise preserves the lvalue reference and no
-  longer admits invalid `Result*` forms
-
-Validated with:
-
-- `test_dependent_decltype_member_call_ref_ret0.cpp`
-- `test_dependent_decltype_member_pointer_local_ret0.cpp`
-- `test_dependent_decltype_member_pointer_local_fail.cpp`
-- `test_dependent_decltype_arrow_member_pointer_ret0.cpp`
-- `test_dependent_decltype_arrow_member_pointer_fail.cpp`
-- `test_template_trailing_return_decltype_nttp_ret0.cpp`
-- `test_template_trailing_return_namespace_lookup_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04, with only the unrelated
-  pre-existing lambda-link failures remaining
-
-## 2026-06-04 semantic operator[] conformance note
-
-Auditing the remaining sema call-resolution entry points found a live C++20
-conformance bug in semantic `operator[]` resolution: the overload set was
-still classified from reduced expression typing and fallback selection ignored
-receiver constness. That made two ordinary language rules unstable in normalized
-subscript calls:
-
-- a const receiver must not bind a non-const `operator[]`
-- lvalue and prvalue index expressions must preserve the overload-resolution
-  categories seen by ordinary member-call lookup
-
-`SemanticAnalysis::tryResolveSubscriptOperator` now reuses the same
-receiver-aware candidate partitioning and sema-owned overload-resolution
-argument typing already used by normalized member-call resolution. This keeps
-the semantic subscript path aligned with the broader sema-owned call model
-instead of depending on reduced parser-shaped typing.
-
-Validated with:
-
-- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_subscript_const_ambiguity_fail.cpp`
-- `test_operator_subscript_const_ret42.cpp`
-- `test_operator_subscript_overloads_ret42.cpp`
-- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-04 callable/operator() conformance note
-
-The remaining standards-callable regressions in normalized/deferred paths were:
-
-- nested generic-lambda callable captures could remain zero-sized in closure
-  layout, causing overlap with subsequent captures
-- normalized direct-call lowering could hard-fail when sema-owned target
-  metadata was missing, even for late/deferred call paths that still had typed
-  lookup evidence
-- unresolved callable-reference recursive self calls could miss the correct
-  mangled target because self-argument qualifier handling diverged from ordinary
-  recursive self lowering
-
-The fix now:
-
-- backfills unresolved by-value capture size/alignment from capture member type
-  info and recalculates closure layout before emission
-- preserves strict sema-owned direct-call target use when available, and limits
-  compatibility behavior to an explicit metadata-missing boundary
-- unifies unresolved callable-reference recursive self-call lowering with the
-  ordinary recursive self path, including lvalue-reference self-argument
-  qualifier treatment
-
-Conformance debt to remove next:
-
-- delete the metadata-missing direct-call compatibility boundary once sema
-  always provides owned direct-call targets for these normalized/deferred calls
-
-Validated with:
-
-- `test_generic_lambda_callable_nested_clone_ret0.cpp`
-- `test_generic_lambda_recursive_self_ret0.cpp`
-- `test_lambda_cpp20_comprehensive_ret135.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-04 dependent callable operator() conformance note
-
-The next live callable conformance gap was not another parser issue. It was the
-late semantic resolution path for receiverless dependent/local callable objects:
-`SemanticAnalysis::tryResolveCallableOperatorImpl` still classified overloads
-from reduced expression typing and did not partition candidates by receiver
-constness before fallback selection. That meant a template-instantiated functor
-call could preserve the wrong overload category even after the concrete
-callable type was known.
-
-The fix now:
-
-- reuses sema-owned overload-resolution argument typing for dependent/local
-  callable `operator()` calls
-- applies the same receiver-const candidate filtering used by ordinary member
-  calls and semantic `operator[]`
-- preserves recursive lambda self forwarding while treating sema-analyzed
-  absent struct-callable targets as invalid in the covered codegen path
-
-Validated with:
-
-- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_callable_sema_resolved_ret0.cpp`
-- `test_template_out_of_line_operator_call_ret0.cpp`
-- `test_generic_lambda_recursive_self_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-04
-
-## 2026-06-08 dependent callable const-receiver conformance note
-
-The documented remaining callable negative case is now closed: a dependent
-`const Callable& c; c(...)` with only a non-const `operator()` used to compile
-because the parser-selected member-call target could survive even after sema's
-const-aware lookup found no viable callable overload.
-
-The fix now:
-
-- blocks reuse of that stale parser-selected non-const `operator()` target for
-  const receivers once sema has no const-compatible callable candidate
-- emits the failure from sema as a hard callable diagnostic instead of
-  continuing through member-call fallback
-- adds a stable template-instantiation `_fail` regression for the covered case
-
-Validated with:
-
-- `test_template_callable_operator_const_receiver_fail.cpp`
-- `test_template_callable_operator_const_receiver_explicit_member_fail.cpp`
-- `test_template_callable_operator_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_call_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_callable_operator_default_arg_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-08
-
-## 2026-06-04 non-standard template test cleanup
-
-A focused cleanup pass converted template-focused non-standard tests from
-`docs/TEST_RUNNER_FAILURE_REPORT.md` to valid C++20 forms while preserving test
-intent (friend declarations for class templates, protected-access setup, pack
-expansion form, forward declarations, overload ambiguity trigger, and constexpr
-initializer requirements).
-
-Result: all updated tests pass `clang++ --target=x86_64-unknown-linux-gnu
--std=c++20 -pedantic-errors -fsyntax-only` and also pass targeted
-`pwsh tests/run_all_tests.ps1` runs. No new missing-feature entry was required
-for this subset.
-
-## 2026-06-04 wider non-standard C++20 cleanup (non-extension set)
-
-A wider pass converted the remaining non-extension non-standard tests to
-portable C++20 forms and verified them with `clang++ -std=c++20
--pedantic-errors -fsyntax-only`. (Per repo preference, test edits avoid
-`#include <cstddef>`.)
-
-Now-passing tests from this wider pass were removed from
-`docs/TEST_RUNNER_FAILURE_REPORT.md`.
-
-Remaining blockers in FlashCpp for the edited non-extension set are now grouped
-as implementation gaps rather than language-invalid test input:
-
-- Standard library header/template ingestion gaps (`<compare>`, `<utility>`,
-  `<typeinfo>`) affecting spaceship, forwarding, and RTTI test families.
-- `constexpr` member-call binding in
-  `test_identifier_binding_constexpr_function_call_member_access_prefers_static_member_function_ret42.cpp`.
-- Structured-binding tuple customization lookup in
-  `test_structured_binding_member_get_preferred_over_free_get_ret42.cpp`.
-- `no_unique_address` and several `offsetof`/layout tests under the current
-  header-ingestion/runtime-layout path.
-
-## 2026-06-02 constexpr lambda conformance note
-
-The updated constexpr-lambda tests exposed runtime capture-lowering bugs rather
-than compile-time evaluation failures. Generated code now follows the C++20
-closure model for captured `this` and nested captures:
-
-- `[this]` member calls use the captured enclosing object pointer
-- `[*this]` member calls use the copied object stored in the closure
-- nested `[this]` captures propagate the effective enclosing object pointer,
-  including when the enclosing lambda captured `*this`
-- nested reference captures of enclosing closure members take the member's
-  address directly and preserve the referenced object's real size
-- constexpr member evaluation now preserves receiver cv-qualification through
-  synthetic `this` bindings and rejects stale lowered non-const targets when
-  evaluating calls from a const member body
-
-Validated with all `tests/*constexpr_lambda*.cpp` tests on 2026-06-02.
-
-## 2026-06-09 direct-call pack-substitution conformance note
-
-The next live ordinary-call conformance blocker after the receiver-side fixes
-was narrower than expected: the remaining non-receiver compatibility path was
-still being exercised by a substitution gap, not by a fundamentally missing
-semantic lookup rule. When `ExpressionSubstitutor` rebuilt a substituted direct
-call and left a `PackExpansionExprNode` in the argument list, the dependent
-unqualified call could not collect concrete argument types at the point of
-instantiation, so the later compatibility branch still had to recover the
-call.
-
-The fix now:
-
-- preserves pack expansion while rebuilding substituted constructor, direct,
-  and receiver-call argument lists inside `ExpressionSubstitutor`
-- allows dependent-unqualified direct calls to arrive at point-of-instantiation
-  lookup with concrete argument types in the covered path
-- removes the active standards-visible fallback route exercised by
-  `add(readValue(__builtin_addressof(args))...)` without restoring any broad
-  parser-target recovery
-
-Validated with:
-
-- `test_template_builtin_addressof_substitution_ret0.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-Next step:
-
-- audit the residual non-receiver compatibility logic in
-  `resolveCallArgAnnotationTarget(...)` again and remove or narrow the
-  remaining branch only after each surviving direct-call route is proven to
-  reach typed semantic lookup with complete argument evidence
-
-## 2026-06-09 ordinary direct-call viability conformance note
-
-The next live ordinary-call conformance blocker after the pack-substitution
-follow-up was not a template-only replay issue anymore. A plain call such as
-`pick(NotInt{})` could still compile even though `NotInt` had no conversion
-operator or converting constructor for `int`, and the same false viability then
-reappeared through instantiated dependent direct calls. Tightening that path
-also exposed a second parser typing bug: indirect calls like `sumBig(fp(10))`
-were being ranked as though `fp(10)` had function-pointer type instead of the
-return type `Big`.
-
-The fix now:
-
-- preserves concrete `TypeSpecifierNode` identity through parser-side
-  reference-unwrapping during overload viability instead of reducing those
-  comparisons to coarse `TypeCategory` pairs
-- requires a real conversion path before a concrete struct argument can match a
-  scalar parameter in ordinary overload resolution, while preserving the
-  existing incomplete-type optimism for genuinely unresolved parse-time cases
-- recovers indirect-call return types from function-pointer and
-  function-reference signatures so parser-side argument typing feeds the real
-  returned object type into later overload ranking
-
-Validated with:
-
-- `test_overload_resolution_struct_without_conversion_to_int_fail.cpp`
-- `test_overload_resolution_struct_temporary_without_conversion_to_int_fail.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_funcptr_large_struct_return_direct_use_ret0.cpp`
-- `test_implicit_conversion_arg_ret42.cpp`
-- `test_func_arg_conv_ctor_sema_ret42.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-09
-
-## 2026-06-11 non-receiver direct-call compatibility conformance note
-
-The next direct-call cleanup slice after the ordinary viability fix was no
-longer a broad overload-rule bug. It was a remaining compatibility decision in
-`resolveCallArgAnnotationTarget(...)`: for ordinary non-receiver direct calls,
-the resolver still accepted the parser-selected target before sema had tried a
-fresh typed lookup. That was too broad for standards-conforming ordinary-call
-behavior, but preserved definition-context records still had to remain
-authoritative for non-dependent template-body calls.
-
-The fix now:
-
-- returns preserved `FunctionCallDefinitionLookupRecord` targets immediately for
-  non-receiver direct calls so non-dependent two-phase lookup stays
-  definition-bound
-- stops reusing bare parser-selected non-receiver targets before fresh typed
-  lookup when no definition-bound record exists
-- recovers authoritative non-receiver direct-call targets from preserved
-  mangled metadata when an instantiated call no longer carries the original
-  definition/dependent lookup record, avoiding a later ordinary-lookup rebound
-- keeps parser-selected target reuse only as the final compatibility boundary
-  after typed overload lookup and ordinary overload-set recovery still cannot
-  determine the call
-- fixes a validation regression in struct-to-pointer built-in subscripting by
-  deriving conversion-operator element types without mutating a copied
-  canonical pointer-level container that could assert at runtime
-
-Validated with:
-
-- `template_lookup_non_dependent_no_rebind_ret0.cpp`
-- `test_template_two_phase_nondependent_later_better_overload_ret42.cpp`
-- `test_template_two_phase_member_func_template_ret42.cpp`
-- `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
-- `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
-- `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
-- `test_template_two_phase_explicit_nondependent_later_overload_ret42.cpp`
-- `test_template_two_phase_nondependent_later_function_template_overload_ret42.cpp`
-- `test_template_qualified_phase1_fallback_ret0.cpp`
-- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
-- `test_dependent_identifier_template_call_ret0.cpp`
-- `test_pack_expansion_in_template_body_ret0.cpp`
-- `test_template_builtin_addressof_substitution_ret0.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_subscript_pointer_conversion_template_ret42.cpp`
-- full `pwsh tests/run_all_tests.ps1` on 2026-06-11
+- treat codegen-side recovery as debt to remove, not as architecture
+- when a late retry is still necessary, route it through typed semantic lookup
+  instead of rebuilding intent from strings or shallow shape matches
 
 ## Validation guidance
 
-For work in this area:
+For work in this area, rerun:
 
-- add a focused regression first when a new gap is identified
-- rerun `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
-  `test_operator_subscript_const_ambiguity_fail.cpp` and
-  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` and
-  `test_subscript_pointer_conversion_template_ret42.cpp` when touching
-  semantic subscript resolution, pointer-conversion discovery, or
-  receiver-sensitive normalized-call lookup
-- rerun the three former dependent-alias blocker tests when touching alias
-  ownership or current-instantiation handling (they now exercise the
-  semantic-only route)
-- rerun the dependent member-template static constexpr regressions when touching
-  nested owner/member-chain replay or static member initializer materialization
-- run `pwsh tests/run_all_tests.ps1` before considering the slice complete
+- the focused regression that motivated the slice
+- `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
+- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
+- `test_operator_subscript_const_ambiguity_fail.cpp`
+- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
+- `test_subscript_pointer_conversion_template_ret42.cpp`
+- full `pwsh tests/run_all_tests.ps1` before considering the slice complete

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-09
+**Last updated:** 2026-06-11
 
 This document tracks the standards-facing endpoint for template argument and
 dependent-name work. It should describe the intended model and the shortest path
@@ -32,6 +32,11 @@ Move FlashCpp toward a sema-owned template system where:
   sema-owned overload-resolution argument typing instead of parser-owned
   argument collection, so dependent out-of-line member overloads are selected
   from the concrete substituted call signature seen during semantic analysis
+- ordinary non-receiver direct calls now also defer bare parser-selected target
+  reuse until after preserved definition-context records and fresh typed lookup
+  have both had a chance to resolve the call, so non-dependent two-phase
+  lookup remains definition-bound while the ordinary fallback surface is
+  smaller
 - semantic `operator[]` resolution now also uses sema-owned
   overload-resolution argument typing plus receiver-const candidate filtering,
   so normalized subscripts preserve lvalue/rvalue index evidence and do not
@@ -159,11 +164,10 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Re-audit the remaining non-receiver / direct-call compatibility branches in
-   `resolveCallArgAnnotationTarget(...)` now that the last active blocker in
-   this area was ordinary overload viability plus indirect-call typing, not a
-   missing template-only fallback. Remove or narrow only the branches that are
-   now demonstrably dead once typed parser/sema evidence is complete.
+1. Audit the remaining last-resort non-receiver direct-call fallback in
+   `resolveCallArgAnnotationTarget(...)` and remove each surviving parser-
+   selected route only after the owning replay/materialization path preserves
+   enough typed overload evidence to make that fallback unnecessary.
 
 2. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
    source replay identity into that path rather than restoring any
@@ -555,6 +559,41 @@ Validated with:
 - `test_dependent_identifier_template_call_ret0.cpp`
 - `test_pack_expansion_in_template_body_ret0.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-09
+
+## 2026-06-11 non-receiver direct-call compatibility conformance note
+
+The next direct-call cleanup slice after the ordinary viability fix was no
+longer a broad overload-rule bug. It was a remaining compatibility decision in
+`resolveCallArgAnnotationTarget(...)`: for ordinary non-receiver direct calls,
+the resolver still accepted the parser-selected target before sema had tried a
+fresh typed lookup. That was too broad for standards-conforming ordinary-call
+behavior, but preserved definition-context records still had to remain
+authoritative for non-dependent template-body calls.
+
+The fix now:
+
+- returns preserved `FunctionCallDefinitionLookupRecord` targets immediately for
+  non-receiver direct calls so non-dependent two-phase lookup stays
+  definition-bound
+- stops reusing bare parser-selected non-receiver targets before fresh typed
+  lookup when no definition-bound record exists
+- keeps parser-selected target reuse only as the final compatibility boundary
+  after typed overload lookup and ordinary overload-set recovery still cannot
+  determine the call
+
+Validated with:
+
+- `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_two_phase_nondependent_later_better_overload_ret42.cpp`
+- `test_template_two_phase_member_func_template_ret42.cpp`
+- `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
+- `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
+- `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
+- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
+- `test_dependent_identifier_template_call_ret0.cpp`
+- `test_pack_expansion_in_template_body_ret0.cpp`
+- `test_template_builtin_addressof_substitution_ret0.cpp`
+- full `pwsh tests/run_all_tests.ps1` on 2026-06-11
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -164,18 +164,19 @@ unknown-specialization modeling only where it unblocks those paths.
 
 ## Next steps
 
-1. Audit the remaining last-resort non-receiver direct-call fallback in
-   `resolveCallArgAnnotationTarget(...)` and remove each surviving parser-
-   selected route only after the owning replay/materialization path preserves
-   enough typed overload evidence to make that fallback unnecessary.
+1. Audit why some instantiated ordinary direct calls still lose
+   `FunctionCallDefinitionLookupRecord` / `DependentUnqualifiedCallLookupRecord`
+   while preserving an authoritative mangled target. The current mangled-name
+   recovery is a compatibility boundary, not the desired end state.
 
-2. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
+2. Continue removing the final parser-selected non-receiver fallback in
+   `resolveCallArgAnnotationTarget(...)` only after the owning replay or
+   materialization path preserves enough typed evidence to make that route
+   unnecessary.
+
+3. If another replay/`StructTypeInfo` sync gap turns up, fix it by preserving
    source replay identity into that path rather than restoring any
    signature-equivalent fallback.
-
-3. Audit the remaining semantic call compatibility fallbacks that still reuse
-   parser-selected targets after typed sema evidence is available, and remove
-   them incrementally as each owning semantic path becomes complete.
 
 4. Only after those are stable, extend current-instantiation and
    unknown-specialization modeling for the specific unresolved cases that remain.
@@ -577,9 +578,15 @@ The fix now:
   definition-bound
 - stops reusing bare parser-selected non-receiver targets before fresh typed
   lookup when no definition-bound record exists
+- recovers authoritative non-receiver direct-call targets from preserved
+  mangled metadata when an instantiated call no longer carries the original
+  definition/dependent lookup record, avoiding a later ordinary-lookup rebound
 - keeps parser-selected target reuse only as the final compatibility boundary
   after typed overload lookup and ordinary overload-set recovery still cannot
   determine the call
+- fixes a validation regression in struct-to-pointer built-in subscripting by
+  deriving conversion-operator element types without mutating a copied
+  canonical pointer-level container that could assert at runtime
 
 Validated with:
 
@@ -589,10 +596,15 @@ Validated with:
 - `test_template_out_of_line_member_two_phase_lookup_ret0.cpp`
 - `test_template_out_of_line_ctor_two_phase_lookup_ret0.cpp`
 - `test_template_ool_member_template_deferred_base_two_phase_lookup_ret0.cpp`
+- `test_template_two_phase_explicit_nondependent_later_overload_ret42.cpp`
+- `test_template_two_phase_nondependent_later_function_template_overload_ret42.cpp`
+- `test_template_qualified_phase1_fallback_ret0.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_dependent_identifier_template_call_ret0.cpp`
 - `test_pack_expansion_in_template_body_ret0.cpp`
 - `test_template_builtin_addressof_substitution_ret0.cpp`
+- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
+- `test_subscript_pointer_conversion_template_ret42.cpp`
 - full `pwsh tests/run_all_tests.ps1` on 2026-06-11
 
 ## Validation guidance
@@ -602,8 +614,10 @@ For work in this area:
 - add a focused regression first when a new gap is identified
 - rerun `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp` and
   `test_operator_subscript_const_ambiguity_fail.cpp` and
-  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` when touching
-  semantic subscript resolution or receiver-sensitive normalized-call lookup
+  `test_constexpr_operator_bracket_const_nonconst_ret0.cpp` and
+  `test_subscript_pointer_conversion_template_ret42.cpp` when touching
+  semantic subscript resolution, pointer-conversion discovery, or
+  receiver-sensitive normalized-call lookup
 - rerun the three former dependent-alias blocker tests when touching alias
   ownership or current-instantiation handling (they now exercise the
   semantic-only route)

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -479,6 +479,19 @@ static bool hasTopLevelPackExpansionInConstructorInitializers(const ConstructorD
 	return false;
 }
 
+void setMaterializedTypeSpecifierSize(TypeSpecifierNode& type_node) {
+	int size_bits = 0;
+	if (type_node.reference_qualifier() != ReferenceQualifier::None ||
+		type_node.pointer_depth() > 0) {
+		size_bits = 64;
+	} else if (type_node.category() == TypeCategory::Invalid) {
+		size_bits = 0;
+	} else {
+		size_bits = getTypeSpecSizeBits(type_node);
+	}
+	type_node.set_size_in_bits(size_bits);
+}
+
 TypeSpecifierNode materializeTypeSpecifier(const CanonicalTypeDesc& desc) {
 	TypeSpecifierNode type_node(desc.type_index.withCategory(desc.category()), 0, Token{}, CVQualifier::None, ReferenceQualifier::None);
 	type_node.set_cv_qualifier(desc.base_cv);
@@ -493,16 +506,16 @@ TypeSpecifierNode materializeTypeSpecifier(const CanonicalTypeDesc& desc) {
 	if (desc.function_signature.has_value()) {
 		type_node.set_function_signature(*desc.function_signature);
 	}
+	setMaterializedTypeSpecifierSize(type_node);
+	return type_node;
+}
 
-	int size_bits = 0;
-	if (desc.ref_qualifier != ReferenceQualifier::None || !desc.pointer_levels.empty()) {
-		size_bits = 64;
-	} else if (desc.category() == TypeCategory::Invalid) {
-		size_bits = 0;
-	} else {
-		size_bits = getTypeSpecSizeBits(type_node);
-	}
-	type_node.set_size_in_bits(size_bits);
+TypeSpecifierNode materializeTypeSpecifierWithMaxPointerDepth(
+	const CanonicalTypeDesc& desc,
+	size_t max_pointer_depth) {
+	TypeSpecifierNode type_node = materializeTypeSpecifier(desc);
+	type_node.limit_pointer_depth(max_pointer_depth);
+	setMaterializedTypeSpecifierSize(type_node);
 	return type_node;
 }
 
@@ -609,17 +622,10 @@ std::optional<PointerConversionInfo> findStructPointerConversionOperator(
 			}
 		}
 
-		TypeSpecifierNode element_type = materializeTypeSpecifier(return_desc);
-		const size_t pointer_depth = element_type.pointer_depth();
-		if (pointer_depth == 0) {
-			continue;
-		}
-		element_type.limit_pointer_depth(pointer_depth - 1);
-		if (pointer_depth > 1) {
-			element_type.set_size_in_bits(64);
-		} else {
-			element_type.set_size_in_bits(getTypeSpecSizeBits(element_type));
-		}
+		TypeSpecifierNode element_type =
+			materializeTypeSpecifierWithMaxPointerDepth(
+				return_desc,
+				return_desc.pointer_levels.size() - 1);
 		const CanonicalTypeId element_type_id =
 			sema.canonicalizeTypeForImplicitConversion(element_type);
 		return PointerConversionInfo{conv_op_return_type_id, element_type_id, &function_decl};
@@ -691,17 +697,10 @@ static void collectAllStructPointerConversionOperators(
 		if (return_desc.pointer_levels.empty() || !return_desc.array_dimensions.empty())
 			continue;
 
-		TypeSpecifierNode element_type = materializeTypeSpecifier(return_desc);
-		const size_t pointer_depth = element_type.pointer_depth();
-		if (pointer_depth == 0) {
-			continue;
-		}
-		element_type.limit_pointer_depth(pointer_depth - 1);
-		if (pointer_depth > 1) {
-			element_type.set_size_in_bits(64);
-		} else {
-			element_type.set_size_in_bits(getTypeSpecSizeBits(element_type));
-		}
+		TypeSpecifierNode element_type =
+			materializeTypeSpecifierWithMaxPointerDepth(
+				return_desc,
+				return_desc.pointer_levels.size() - 1);
 		const CanonicalTypeId element_type_id =
 			sema.canonicalizeTypeForImplicitConversion(element_type);
 		out_ops.push_back({conv_op_return_type_id, element_type_id, &function_decl});

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -609,9 +609,19 @@ std::optional<PointerConversionInfo> findStructPointerConversionOperator(
 			}
 		}
 
-		CanonicalTypeDesc element_desc = return_desc;
-		element_desc.pointer_levels.pop_back();
-		const CanonicalTypeId element_type_id = sema.canonicalizeTypeForImplicitConversion(materializeTypeSpecifier(element_desc));
+		TypeSpecifierNode element_type = materializeTypeSpecifier(return_desc);
+		const size_t pointer_depth = element_type.pointer_depth();
+		if (pointer_depth == 0) {
+			continue;
+		}
+		element_type.limit_pointer_depth(pointer_depth - 1);
+		if (pointer_depth > 1) {
+			element_type.set_size_in_bits(64);
+		} else {
+			element_type.set_size_in_bits(getTypeSpecSizeBits(element_type));
+		}
+		const CanonicalTypeId element_type_id =
+			sema.canonicalizeTypeForImplicitConversion(element_type);
 		return PointerConversionInfo{conv_op_return_type_id, element_type_id, &function_decl};
 	}
 
@@ -681,10 +691,19 @@ static void collectAllStructPointerConversionOperators(
 		if (return_desc.pointer_levels.empty() || !return_desc.array_dimensions.empty())
 			continue;
 
-		CanonicalTypeDesc element_desc = return_desc;
-		element_desc.pointer_levels.pop_back();
+		TypeSpecifierNode element_type = materializeTypeSpecifier(return_desc);
+		const size_t pointer_depth = element_type.pointer_depth();
+		if (pointer_depth == 0) {
+			continue;
+		}
+		element_type.limit_pointer_depth(pointer_depth - 1);
+		if (pointer_depth > 1) {
+			element_type.set_size_in_bits(64);
+		} else {
+			element_type.set_size_in_bits(getTypeSpecSizeBits(element_type));
+		}
 		const CanonicalTypeId element_type_id =
-			sema.canonicalizeTypeForImplicitConversion(materializeTypeSpecifier(element_desc));
+			sema.canonicalizeTypeForImplicitConversion(element_type);
 		out_ops.push_back({conv_op_return_type_id, element_type_id, &function_decl});
 	}
 
@@ -7788,7 +7807,6 @@ void SemanticAnalysis::annotateResolvedCallArgConversions(const void* call_key,
 		if (!param_type_node.has_value() || !param_type_node.is<TypeSpecifierNode>())
 			continue;
 		const TypeSpecifierNode& param_type = param_type_node.as<TypeSpecifierNode>();
-
 		if (param_type.is_reference() || param_type.is_rvalue_reference()) {
 			if (auto binding = buildCallArgReferenceBinding(arg, param_type, context_description)) {
 				ref_bindings[i] = *binding;
@@ -7816,15 +7834,30 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			mangled_symbol.has_value()) {
 			return getCallTargetFunctionCandidate(*mangled_symbol);
 		}
+		for (const ASTNode& overload :
+			 symbols_.lookup_all(callee_decl.identifier_token().value())) {
+			const FunctionDeclarationNode* candidate =
+				getCallTargetFunctionCandidate(overload);
+			if (candidate != nullptr &&
+				candidate->has_mangled_name() &&
+				candidate->mangled_name() == mangled_name.view()) {
+				return candidate;
+			}
+		}
 		return nullptr;
 	};
 	auto resolveBoundFunctionTarget =
 		[&](const FunctionDeclarationNode* resolved_function,
 			StringHandle mangled_name) -> const FunctionDeclarationNode* {
+			if (const FunctionDeclarationNode* canonical_function =
+					lookupFunctionByMangledName(mangled_name);
+				canonical_function != nullptr) {
+				return canonical_function;
+			}
 			if (resolved_function != nullptr) {
 				return resolved_function;
 			}
-			return lookupFunctionByMangledName(mangled_name);
+			return nullptr;
 		};
 	auto resolveDefinitionLookupRecordTarget = [&]() -> const FunctionDeclarationNode* {
 		if (call_info.definition_lookup_record == nullptr ||
@@ -7980,7 +8013,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return call_info.function_declaration;
 	};
-
 	// Resolution order:
 	// 1. receiver-member direct lookup
 	// 2. callable operator / local callable resolution
@@ -8074,12 +8106,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 
 		return nullptr;
 	}
-	if (const FunctionDeclarationNode* parser_selected_target =
-			fallbackToEarlyParserSelectedTarget();
-		parser_selected_target != nullptr) {
-		return parser_selected_target;
-	}
-
 	if (!normalized_call &&
 		!call_info.is_indirect &&
 		!call_info.has_receiver &&
@@ -8099,13 +8125,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (resolveLocalCallableStructInfo() != nullptr &&
 		op_call_query.state != ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 		return nullptr;
-	}
-
-	if (!normalized_call) {
-		if (const FunctionDeclarationNode* mangled_candidate =
-				lookupFunctionByMangledName(call_info.mangled_name)) {
-			return mangled_candidate;
-		}
 	}
 
 	if (!normalized_call &&
@@ -8140,6 +8159,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			return definition_lookup_record_target;
 		}
 		return nullptr;
+	}
+
+	if (!normalized_call) {
+		if (const FunctionDeclarationNode* mangled_candidate =
+				lookupFunctionByMangledName(call_info.mangled_name)) {
+			return mangled_candidate;
+		}
 	}
 
 	const DeclarationNode& decl = callee_decl;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7980,15 +7980,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return call_info.function_declaration;
 	};
-	auto fallbackToLateNonNormalizedCompatibilityTarget = [&]() -> const FunctionDeclarationNode* {
-		if (normalized_call) {
-			return nullptr;
-		}
-		if (definition_lookup_record_target != nullptr) {
-			return definition_lookup_record_target;
-		}
-		return call_info.function_declaration;
-	};
 
 	// Resolution order:
 	// 1. receiver-member direct lookup
@@ -8089,6 +8080,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return parser_selected_target;
 	}
 
+	if (!normalized_call &&
+		!call_info.is_indirect &&
+		!call_info.has_receiver &&
+		definition_lookup_record_target != nullptr) {
+		return definition_lookup_record_target;
+	}
+
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
 	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
 	if (!func_decl && op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
@@ -8144,12 +8142,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 
-	if (const FunctionDeclarationNode* compatibility_target =
-			fallbackToLateNonNormalizedCompatibilityTarget();
-		compatibility_target != nullptr) {
-		return compatibility_target;
-	}
-
 	const DeclarationNode& decl = callee_decl;
 
 	const std::string_view name = call_info.qualified_name.isValid()
@@ -8194,6 +8186,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		appendUniqueOverloads(overloads, adl_candidates);
 	}
 	if (overloads.empty()) {
+		if (!normalized_call &&
+			call_info.function_declaration != nullptr) {
+			return call_info.function_declaration;
+		}
 		if (!call_info.is_indirect) {
 			++stats_.direct_call_unresolved_after_lookup;
 		}
@@ -8242,6 +8238,11 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		} else {
 			func_decl = findViableTargetByArgCount(overloads);
 		}
+	}
+	if (!func_decl &&
+		!normalized_call &&
+		call_info.function_declaration != nullptr) {
+		func_decl = call_info.function_declaration;
 	}
 
 	if (!func_decl && !call_info.is_indirect) {

--- a/tests/test_template_dependent_unqualified_mangled_recovery_ret0.cpp
+++ b/tests/test_template_dependent_unqualified_mangled_recovery_ret0.cpp
@@ -1,0 +1,21 @@
+// Regression: dependent unqualified call completion can materialize a resolved
+// direct call that preserves the authoritative mangled target while losing the
+// original lookup record. Sema must still recover that bound target instead of
+// rebinding to a later ordinary overload.
+
+int lookup_probe(long) {
+	return 1;
+}
+
+template <typename T>
+int use_dependent_lookup() {
+	return lookup_probe(T{});
+}
+
+int lookup_probe(int) {
+	return 2;
+}
+
+int main() {
+	return use_dependent_lookup<int>() - 1;
+}

--- a/tests/test_template_qualified_direct_call_inner_return_overload_ret0.cpp
+++ b/tests/test_template_qualified_direct_call_inner_return_overload_ret0.cpp
@@ -1,0 +1,31 @@
+namespace QualifiedDirectCallInnerReturn {
+	struct Big {
+		long long first;
+		long long second;
+	};
+
+	int make(int) {
+		return 7;
+	}
+
+	Big make(long) {
+		return Big{1, 2};
+	}
+}
+
+int classify(int) {
+	return 1;
+}
+
+int classify(QualifiedDirectCallInnerReturn::Big) {
+	return 2;
+}
+
+template<typename T>
+int runQualifiedDirectCall(T value) {
+	return classify(QualifiedDirectCallInnerReturn::make(value));
+}
+
+int main() {
+	return runQualifiedDirectCall<long>(0L) == 2 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- narrow ordinary non-receiver direct-call compatibility in semantic call-target resolution so definition-bound template lookup wins before broad parser-selected fallback paths
- recover authoritative direct-call targets from preserved mangled metadata when instantiated calls no longer carry their original lookup records, preventing rebinding to later ordinary overloads
- refactor pointer-conversion element-type materialization in semantic subscript handling into explicit shared helpers and update the template-argument architecture/conformance docs with the completed slice and next steps

## Tests Added
- `tests/test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
- `tests/test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
