### PR TITLE
[codex] Tighten template direct-call semantic ownership

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -34,9 +34,11 @@ the areas that were previously blocking standards-visible behavior:
   expects positive identity/signature evidence rather than silently accepting
   unresolved shape-based matches
 - resolved direct-call materialization now preserves
-  `DependentUnqualifiedCallLookupRecord` when the instantiated target still
-  matches the definition-bound ordinary lookup, covering replay-heavy member
-  instantiations without relying on sema mangled-name recovery
+  `DependentUnqualifiedCallLookupRecord` both when the instantiated target
+  stays definition-bound and when dependent-unqualified POI completion selects
+  a different final function, so sema/constexpr can reuse structured call
+  metadata instead of re-running parser lookup or relying on mangled-name
+  recovery in those paths
 
 ## Architectural invariants to preserve
 
@@ -55,23 +57,25 @@ Follow-up work in this area should preserve these rules:
 
 ## Highest-value remaining architectural gaps
 
-### 1. Remaining non-definition-bound direct-call metadata loss
+### 1. Remaining direct-call metadata loss outside dependent-unqualified completion
 
-The definition-bound dependent-unqualified replay path is now preserved through
-resolved-call materialization, but some instantiated ordinary direct calls can
-still reach sema with only an authoritative mangled target when the final
-point-of-instantiation result is not representable by the current preserved
-record alone (for example, ADL-completed dependent-unqualified calls).
+Dependent-unqualified direct-call completion now preserves both the
+definition-bound ordinary lookup and the final point-of-instantiation target
+through resolved-call materialization. The remaining direct-call metadata risk
+is therefore narrower: other instantiated ordinary direct-call paths may still
+reach sema with only mangled or parser-selected compatibility evidence instead
+of preserved structured lookup metadata.
 
-The current mangled-name recovery in sema remains an acceptable narrow
-compatibility boundary there, but it is not the desired end state.
+The current mangled-name recovery and parser-selected compatibility boundary in
+sema remain acceptable narrow transitions there, but they are not the desired
+end state.
 
 Desired end state:
 
-- the instantiated call preserves enough structured semantic evidence to
-  recover the final point-of-instantiation result directly
-- sema does not need mangled-name recovery to stay definition-bound or to
-  reuse a completed dependent-unqualified result
+- every instantiated ordinary direct call preserves enough structured semantic
+  evidence to recover its final target directly
+- sema does not need mangled-name recovery or parser-selected compatibility to
+  reuse a completed replay/materialization result
 - the final parser-selected fallback in `resolveCallArgAnnotationTarget(...)`
   becomes removable
 
@@ -108,19 +112,15 @@ where it unblocks real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Extend the preserved direct-call metadata so non-definition-bound
-   point-of-instantiation results (especially ADL-completed
-   dependent-unqualified calls) survive replay/materialization without
-   mangled-name recovery.
+1. Remove the remaining final parser-selected non-receiver direct-call fallback
+   in `resolveCallArgAnnotationTarget(...)`. Any regression it exposes should
+   be fixed by preserving semantic metadata in the owning replay/materialization
+   path rather than restoring the fallback.
 
-2. Remove the remaining final parser-selected non-receiver direct-call fallback
-   in `resolveCallArgAnnotationTarget(...)` once step 1 proves the owning paths
-   carry enough semantic evidence.
-
-3. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
+2. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
    in that path instead of restoring any signature-equivalent recovery logic.
 
-4. Only after steps 1-3 are stable, expand
+3. Only after steps 1-2 are stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
    that still block standards-conforming typed lookup.
 
@@ -132,6 +132,7 @@ When changing this area, always rerun:
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
+- `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
 - `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -33,6 +33,10 @@ the areas that were previously blocking standards-visible behavior:
 - replay attachment in the covered out-of-line member and constructor paths now
   expects positive identity/signature evidence rather than silently accepting
   unresolved shape-based matches
+- resolved direct-call materialization now preserves
+  `DependentUnqualifiedCallLookupRecord` when the instantiated target still
+  matches the definition-bound ordinary lookup, covering replay-heavy member
+  instantiations without relying on sema mangled-name recovery
 
 ## Architectural invariants to preserve
 
@@ -51,18 +55,23 @@ Follow-up work in this area should preserve these rules:
 
 ## Highest-value remaining architectural gaps
 
-### 1. Direct-call metadata loss across replay/materialization
+### 1. Remaining non-definition-bound direct-call metadata loss
 
-Some instantiated ordinary direct calls still lose their preserved
-`FunctionCallDefinitionLookupRecord` /
-`DependentUnqualifiedCallLookupRecord` while keeping an authoritative mangled
-target. The current mangled-name recovery in sema is acceptable as a narrow
-compatibility boundary, but it is not the desired end state.
+The definition-bound dependent-unqualified replay path is now preserved through
+resolved-call materialization, but some instantiated ordinary direct calls can
+still reach sema with only an authoritative mangled target when the final
+point-of-instantiation result is not representable by the current preserved
+record alone (for example, ADL-completed dependent-unqualified calls).
+
+The current mangled-name recovery in sema remains an acceptable narrow
+compatibility boundary there, but it is not the desired end state.
 
 Desired end state:
 
-- the instantiated call preserves the original semantic lookup record
-- sema does not need mangled-name recovery to stay definition-bound
+- the instantiated call preserves enough structured semantic evidence to
+  recover the final point-of-instantiation result directly
+- sema does not need mangled-name recovery to stay definition-bound or to
+  reuse a completed dependent-unqualified result
 - the final parser-selected fallback in `resolveCallArgAnnotationTarget(...)`
   becomes removable
 
@@ -99,9 +108,10 @@ where it unblocks real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Preserve direct-call lookup records across replay/materialization in the
-   remaining instantiated-call paths that still fall back to mangled-name
-   recovery.
+1. Extend the preserved direct-call metadata so non-definition-bound
+   point-of-instantiation results (especially ADL-completed
+   dependent-unqualified calls) survive replay/materialization without
+   mangled-name recovery.
 
 2. Remove the remaining final parser-selected non-receiver direct-call fallback
    in `resolveCallArgAnnotationTarget(...)` once step 1 proves the owning paths
@@ -121,6 +131,7 @@ When changing this area, always rerun:
 - the focused regression that motivated the slice
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
+- `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
 - `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -39,6 +39,10 @@ the areas that were previously blocking standards-visible behavior:
   a different final function, so sema/constexpr can reuse structured call
   metadata instead of re-running parser lookup or relying on mangled-name
   recovery in those paths
+- the final parser-selected non-receiver direct-call fallback in
+  `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
+  resolve through preserved semantic metadata, typed lookup, or explicit
+  unresolved terminals instead of reusing the parser-selected target late
 
 ## Architectural invariants to preserve
 
@@ -57,29 +61,7 @@ Follow-up work in this area should preserve these rules:
 
 ## Highest-value remaining architectural gaps
 
-### 1. Remaining direct-call metadata loss outside dependent-unqualified completion
-
-Dependent-unqualified direct-call completion now preserves both the
-definition-bound ordinary lookup and the final point-of-instantiation target
-through resolved-call materialization. The remaining direct-call metadata risk
-is therefore narrower: other instantiated ordinary direct-call paths may still
-reach sema with only mangled or parser-selected compatibility evidence instead
-of preserved structured lookup metadata.
-
-The current mangled-name recovery and parser-selected compatibility boundary in
-sema remain acceptable narrow transitions there, but they are not the desired
-end state.
-
-Desired end state:
-
-- every instantiated ordinary direct call preserves enough structured semantic
-  evidence to recover its final target directly
-- sema does not need mangled-name recovery or parser-selected compatibility to
-  reuse a completed replay/materialization result
-- the final parser-selected fallback in `resolveCallArgAnnotationTarget(...)`
-  becomes removable
-
-### 2. Residual replay/`StructTypeInfo` sync gaps
+### 1. Residual replay/`StructTypeInfo` sync gaps
 
 The broad signature-equivalent sync fallback is gone from the currently-covered
 paths, but future failures in replay-heavy areas will likely still come from
@@ -92,33 +74,37 @@ Desired end state:
 - `StructTypeInfo` repair scans are not used to rediscover targets by name or
   arity when identity could have been preserved
 
-### 3. Remaining semantic call compatibility fallback
+### 2. Remaining direct-call metadata loss outside dependent-unqualified completion
 
-The ordinary non-receiver direct-call path is much narrower now, but one final
-parser-selected compatibility route still exists after typed lookup. That
-fallback should only survive where replay/materialization still drops decisive
-semantic evidence.
+Dependent-unqualified direct-call completion now preserves both the
+definition-bound ordinary lookup and the final point-of-instantiation target
+through resolved-call materialization, and the final parser-selected
+non-receiver fallback is gone. The remaining direct-call metadata risk is
+therefore narrower: other instantiated ordinary direct-call paths may still
+reach sema with only mangled compatibility evidence instead of preserved
+structured lookup metadata.
 
 Desired end state:
 
-- sema-owned typed lookup resolves or rejects ordinary direct calls directly
-- parser-selected direct-call fallback disappears from normalized flows
+- every instantiated ordinary direct call preserves enough structured semantic
+  evidence to recover its final target directly
+- sema does not need mangled-name recovery to reuse a completed
+  replay/materialization result
 
-### 4. Current-instantiation / unknown-specialization precision
+### 3. Current-instantiation / unknown-specialization precision
 
 This is no longer the first task, but it remains the next structural lever once
-the direct-call and replay-identity gaps above are smaller. Expand it only
-where it unblocks real replay or typed-lookup failures.
+the replay-identity gaps above are smaller. Expand it only where it unblocks
+real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Remove the remaining final parser-selected non-receiver direct-call fallback
-   in `resolveCallArgAnnotationTarget(...)`. Any regression it exposes should
-   be fixed by preserving semantic metadata in the owning replay/materialization
-   path rather than restoring the fallback.
-
-2. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
+1. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
    in that path instead of restoring any signature-equivalent recovery logic.
+
+2. Tighten the next remaining mangled-name compatibility path by preserving
+   structured direct-call metadata in the owning replay/materialization path
+   instead of relying on mangled recovery.
 
 3. Only after steps 1-2 are stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -40,27 +40,28 @@ blocking areas:
   identity/signature evidence rather than accepting unresolved
   shape-based matches
 - resolved direct-call materialization now preserves
-  `DependentUnqualifiedCallLookupRecord` when the instantiated target still
-  matches the definition-bound ordinary lookup, reducing replay-heavy
-  template-member dependence on mangled-name recovery
+  `DependentUnqualifiedCallLookupRecord` both when the instantiated target
+  stays definition-bound and when dependent-unqualified POI completion selects
+  a different final function, reducing replay-heavy dependence on parser
+  reruns and mangled-name recovery in those paths
 
 ## Highest-value remaining standards gaps
 
-### 1. Compatibility recovery is still covering non-definition-bound direct-call metadata loss
+### 1. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
 
-The definition-bound dependent-unqualified replay path is now preserved through
-resolved-call materialization, but instantiated ordinary direct calls can still
-lose structured point-of-instantiation evidence when the final result is not
-the same function captured by the definition-bound ordinary lookup record.
-Those cases currently retain an authoritative mangled target, and sema recovers
-that target, but the standards-conforming endpoint is to preserve structured
-semantic evidence for the final result itself.
+Dependent-unqualified replay/materialization now preserves both the
+definition-bound ordinary lookup and the final point-of-instantiation target.
+The remaining compatibility risk is therefore narrower: other instantiated
+ordinary direct calls can still lose structured semantic evidence and fall back
+to mangled-name or parser-selected compatibility behavior instead of carrying
+their final lookup result directly.
 
 Why this matters:
 
 - a preserved mangled target is only a compatibility boundary
 - the real semantic model should still know why the call is definition-bound
-  or which point-of-instantiation completion selected it
+  and, when POI completion changes the winner, which final semantic target was
+  selected
 - removing the final parser-selected fallback depends on closing this metadata
   gap first
 
@@ -97,22 +98,18 @@ it only for concrete unresolved cases that block steps 1-3.
 
 ## Priority order
 
-1. Extend preserved direct-call metadata so non-definition-bound
-   point-of-instantiation results, especially ADL-completed
-   dependent-unqualified calls, survive replay/materialization without
-   mangled-name recovery.
+1. Remove the final parser-selected non-receiver direct-call fallback in
+   `resolveCallArgAnnotationTarget(...)`, and fix the first exposed regression
+   by preserving semantic metadata in the owning replay/materialization path
+   instead of reintroducing compatibility recovery.
 
-2. Remove the final parser-selected non-receiver direct-call fallback in
-   `resolveCallArgAnnotationTarget(...)` once step 1 is complete for the
-   remaining live paths.
-
-3. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
+2. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
    identity rather than restoring any signature-equivalent or textual repair
    logic.
 
-4. Expand current-instantiation and unknown-specialization handling only where
+3. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
-   steps 1-3.
+   steps 1-2.
 
 ## Standards rules for follow-up work
 
@@ -132,6 +129,7 @@ For work in this area, rerun:
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
+- `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
 - `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -39,21 +39,28 @@ blocking areas:
 - replay attachment in the covered routes now expects positive
   identity/signature evidence rather than accepting unresolved
   shape-based matches
+- resolved direct-call materialization now preserves
+  `DependentUnqualifiedCallLookupRecord` when the instantiated target still
+  matches the definition-bound ordinary lookup, reducing replay-heavy
+  template-member dependence on mangled-name recovery
 
 ## Highest-value remaining standards gaps
 
-### 1. Compatibility recovery is still covering direct-call metadata loss
+### 1. Compatibility recovery is still covering non-definition-bound direct-call metadata loss
 
-Some instantiated ordinary direct calls still lose their preserved
-definition-bound lookup record while retaining an authoritative mangled target.
-Sema now recovers that target, which prevents standards-visible rebinding to a
-later overload, but the standards-conforming endpoint is to preserve the
-semantic lookup record itself.
+The definition-bound dependent-unqualified replay path is now preserved through
+resolved-call materialization, but instantiated ordinary direct calls can still
+lose structured point-of-instantiation evidence when the final result is not
+the same function captured by the definition-bound ordinary lookup record.
+Those cases currently retain an authoritative mangled target, and sema recovers
+that target, but the standards-conforming endpoint is to preserve structured
+semantic evidence for the final result itself.
 
 Why this matters:
 
 - a preserved mangled target is only a compatibility boundary
-- the real semantic model should still know *why* the call is definition-bound
+- the real semantic model should still know why the call is definition-bound
+  or which point-of-instantiation completion selected it
 - removing the final parser-selected fallback depends on closing this metadata
   gap first
 
@@ -90,8 +97,10 @@ it only for concrete unresolved cases that block steps 1-3.
 
 ## Priority order
 
-1. Preserve direct-call lookup records across the remaining replay and
-   materialization paths that currently rely on mangled-name recovery.
+1. Extend preserved direct-call metadata so non-definition-bound
+   point-of-instantiation results, especially ADL-completed
+   dependent-unqualified calls, survive replay/materialization without
+   mangled-name recovery.
 
 2. Remove the final parser-selected non-receiver direct-call fallback in
    `resolveCallArgAnnotationTarget(...)` once step 1 is complete for the
@@ -122,6 +131,7 @@ For work in this area, rerun:
 - the focused regression that motivated the slice
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
+- `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
 - `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
 - `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -44,28 +44,14 @@ blocking areas:
   stays definition-bound and when dependent-unqualified POI completion selects
   a different final function, reducing replay-heavy dependence on parser
   reruns and mangled-name recovery in those paths
+- the final parser-selected non-receiver direct-call fallback in
+  `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
+  resolve through semantic metadata, typed lookup, or explicit unresolved
+  terminals instead of reusing the parser-selected target late
 
 ## Highest-value remaining standards gaps
 
-### 1. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
-
-Dependent-unqualified replay/materialization now preserves both the
-definition-bound ordinary lookup and the final point-of-instantiation target.
-The remaining compatibility risk is therefore narrower: other instantiated
-ordinary direct calls can still lose structured semantic evidence and fall back
-to mangled-name or parser-selected compatibility behavior instead of carrying
-their final lookup result directly.
-
-Why this matters:
-
-- a preserved mangled target is only a compatibility boundary
-- the real semantic model should still know why the call is definition-bound
-  and, when POI completion changes the winner, which final semantic target was
-  selected
-- removing the final parser-selected fallback depends on closing this metadata
-  gap first
-
-### 2. Replay must stay invariant-driven
+### 1. Replay must stay invariant-driven
 
 The remaining standards risk is no longer textual dependent-name recovery. It
 is replay/materialization paths that may still succeed or sync through weak
@@ -79,33 +65,36 @@ Why this matters:
 - those weak paths tend to reopen non-conforming fallback behavior later in
   sema or codegen
 
-### 3. Final parser-selected ordinary direct-call fallback
+### 2. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
 
-The remaining ordinary non-receiver compatibility route should disappear from
-normalized flows once replay/materialization preserves enough typed evidence.
+Dependent-unqualified replay/materialization now preserves both the
+definition-bound ordinary lookup and the final point-of-instantiation target.
+The remaining compatibility risk is therefore narrower: other instantiated
+ordinary direct calls can still lose structured semantic evidence and fall back
+to mangled-name recovery instead of carrying their final lookup result
+directly.
 
 Why this matters:
 
-- as long as the fallback exists, sema is not yet the sole owner of final
-  ordinary direct-call target selection
-- the standard model is cleaner when typed sema evidence resolves or rejects
-  the call directly
+- a preserved mangled target is only a compatibility boundary
+- the real semantic model should still know why the call is definition-bound
+  and, when POI completion changes the winner, which final semantic target was
+  selected
 
-### 4. Current-instantiation / unknown-specialization coverage
+### 3. Current-instantiation / unknown-specialization coverage
 
 This is still necessary, but it is no longer the immediate next task. Expand
-it only for concrete unresolved cases that block steps 1-3.
+it only for concrete unresolved cases that block steps 1-2.
 
 ## Priority order
 
-1. Remove the final parser-selected non-receiver direct-call fallback in
-   `resolveCallArgAnnotationTarget(...)`, and fix the first exposed regression
-   by preserving semantic metadata in the owning replay/materialization path
-   instead of reintroducing compatibility recovery.
-
-2. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
+1. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
    identity rather than restoring any signature-equivalent or textual repair
    logic.
+
+2. Tighten the next remaining mangled-name compatibility path by preserving
+   structured direct-call metadata in the owning replay/materialization path
+   instead of relying on mangled recovery.
 
 3. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2992,6 +2992,8 @@ struct DependentUnqualifiedCallLookupRecord : CallLookupRecordShared {
 	bool argument_dependent_lookup_included = true;
 	const FunctionDeclarationNode* definition_bound_function = nullptr;
 	StringHandle definition_bound_mangled_name{};
+	const FunctionDeclarationNode* point_of_instantiation_function = nullptr;
+	StringHandle point_of_instantiation_mangled_name{};
 };
 
 // Describes what kind of call site this is.

--- a/src/ConstExprEvaluator_Bindings.cpp
+++ b/src/ConstExprEvaluator_Bindings.cpp
@@ -500,6 +500,16 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 	}
 
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
+		const DependentUnqualifiedCallLookupRecord& dependent_record =
+			*call_expr.dependent_unqualified_lookup_record();
+		if (dependent_record.point_of_instantiation_function != nullptr) {
+			return evaluate_function_call_with_bindings(
+				*dependent_record.point_of_instantiation_function,
+				call_expr.arguments(),
+				bindings,
+				context,
+				mutable_bindings);
+		}
 		// POI resolution requires parser-owned context. Missing parser/sema is a
 		// contract violation and must hard-fail.
 		SemanticAnalysis& sema_ref =
@@ -539,7 +549,7 @@ EvalResult Evaluator::evaluate_function_call_with_outer_bindings(
 		}
 		std::optional<ASTNode> resolved_target =
 			parser.resolveDependentUnqualifiedCallAtPointOfInstantiation(
-				*call_expr.dependent_unqualified_lookup_record(),
+				dependent_record,
 				call_expr.arguments(),
 				arg_types);
 		if (!resolved_target.has_value()) {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4782,6 +4782,15 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 	}
 
 	if (call_expr.has_dependent_unqualified_lookup_record()) {
+		const DependentUnqualifiedCallLookupRecord& dependent_record =
+			*call_expr.dependent_unqualified_lookup_record();
+		if (dependent_record.point_of_instantiation_function != nullptr) {
+			return evaluate_resolved_function_call(
+				*dependent_record.point_of_instantiation_function,
+				call_expr.arguments(),
+				context,
+				nullptr);
+		}
 		// POI resolution requires parser-owned context. Missing parser/sema is a
 		// contract violation and must hard-fail.
 		SemanticAnalysis& sema_ref =
@@ -4820,7 +4829,7 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 		}
 		std::optional<ASTNode> resolved_target =
 			parser.resolveDependentUnqualifiedCallAtPointOfInstantiation(
-				*call_expr.dependent_unqualified_lookup_record(),
+				dependent_record,
 				call_expr.arguments(),
 				arg_types);
 		if (!resolved_target.has_value()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1730,6 +1730,23 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		std::optional<std::string_view> qualified_call_name,
 		bool copy_template_arguments,
 		bool infer_qualified_name_from_parent) -> ASTNode {
+		const auto matchesDefinitionBoundDependentRecordTarget = [&]() -> bool {
+			if (!call.has_dependent_unqualified_lookup_record()) {
+				return false;
+			}
+			const DependentUnqualifiedCallLookupRecord& record =
+				*call.dependent_unqualified_lookup_record();
+			if (record.definition_bound_function != nullptr &&
+				(&target_func == record.definition_bound_function ||
+				 &target_func.decl_node() ==
+					 &record.definition_bound_function->decl_node())) {
+				return true;
+			}
+			return record.definition_bound_mangled_name.isValid() &&
+				   target_func.has_mangled_name() &&
+				   target_func.mangled_name() ==
+					   record.definition_bound_mangled_name.view();
+		};
 		ExpressionNode& new_expr = emplaceDirectCallExpr(
 			target_func.decl_node(),
 			&target_func,
@@ -1738,23 +1755,21 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		CallMetadataCopyOptions copy_options;
 		copy_options.copy_template_arguments = copy_template_arguments;
 		copy_options.copy_dependent_unqualified_lookup_record =
-			call.has_dependent_unqualified_lookup_record() &&
-			[&]() {
-				const DependentUnqualifiedCallLookupRecord& record =
-					*call.dependent_unqualified_lookup_record();
-				if (record.definition_bound_function != nullptr &&
-					(&target_func == record.definition_bound_function ||
-					 &target_func.decl_node() ==
-						 &record.definition_bound_function->decl_node())) {
-					return true;
-				}
-				return record.definition_bound_mangled_name.isValid() &&
-					   target_func.has_mangled_name() &&
-					   target_func.mangled_name() ==
-						   record.definition_bound_mangled_name.view();
-			}();
+			matchesDefinitionBoundDependentRecordTarget();
 		copy_options.copy_dependent_qualified_lookup_record = false;
 		copyMetadataToExpr(new_expr, copy_options);
+		if (call.has_dependent_unqualified_lookup_record() &&
+			!copy_options.copy_dependent_unqualified_lookup_record) {
+			DependentUnqualifiedCallLookupRecord completed_record =
+				*call.dependent_unqualified_lookup_record();
+			completed_record.point_of_instantiation_function = &target_func;
+			if (target_func.has_mangled_name()) {
+				completed_record.point_of_instantiation_mangled_name =
+					StringTable::getOrInternStringHandle(
+						target_func.mangled_name());
+			}
+			setCallDependentUnqualifiedLookupRecord(new_expr, completed_record);
+		}
 		if (qualified_call_name.has_value() && !qualified_call_name->empty()) {
 			setCallQualifiedName(new_expr, *qualified_call_name);
 		} else if (infer_qualified_name_from_parent &&

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1737,7 +1737,22 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			called_from_token);
 		CallMetadataCopyOptions copy_options;
 		copy_options.copy_template_arguments = copy_template_arguments;
-		copy_options.copy_dependent_unqualified_lookup_record = false;
+		copy_options.copy_dependent_unqualified_lookup_record =
+			call.has_dependent_unqualified_lookup_record() &&
+			[&]() {
+				const DependentUnqualifiedCallLookupRecord& record =
+					*call.dependent_unqualified_lookup_record();
+				if (record.definition_bound_function != nullptr &&
+					(&target_func == record.definition_bound_function ||
+					 &target_func.decl_node() ==
+						 &record.definition_bound_function->decl_node())) {
+					return true;
+				}
+				return record.definition_bound_mangled_name.isValid() &&
+					   target_func.has_mangled_name() &&
+					   target_func.mangled_name() ==
+						   record.definition_bound_mangled_name.view();
+			}();
 		copy_options.copy_dependent_qualified_lookup_record = false;
 		copyMetadataToExpr(new_expr, copy_options);
 		if (qualified_call_name.has_value() && !qualified_call_name->empty()) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8218,10 +8218,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		appendUniqueOverloads(overloads, adl_candidates);
 	}
 	if (overloads.empty()) {
-		if (!normalized_call &&
-			call_info.function_declaration != nullptr) {
-			return call_info.function_declaration;
-		}
 		if (!call_info.is_indirect) {
 			++stats_.direct_call_unresolved_after_lookup;
 		}
@@ -8270,11 +8266,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		} else {
 			func_decl = findViableTargetByArgCount(overloads);
 		}
-	}
-	if (!func_decl &&
-		!normalized_call &&
-		call_info.function_declaration != nullptr) {
-		func_decl = call_info.function_declaration;
 	}
 
 	if (!func_decl && !call_info.is_indirect) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8132,6 +8132,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		call_info.dependent_unqualified_lookup_record->has_value()) {
 		const DependentUnqualifiedCallLookupRecord& dependent_record =
 			**call_info.dependent_unqualified_lookup_record;
+		if (const FunctionDeclarationNode* completed_poi_target =
+				resolveBoundFunctionTarget(
+					dependent_record.point_of_instantiation_function,
+					dependent_record.point_of_instantiation_mangled_name);
+			completed_poi_target != nullptr) {
+			return completed_poi_target;
+		}
 		if (const FunctionDeclarationNode* dependent_record_target =
 				resolveBoundFunctionTarget(
 					dependent_record.definition_bound_function,

--- a/tests/test_template_dependent_unqualified_member_replay_ret0.cpp
+++ b/tests/test_template_dependent_unqualified_member_replay_ret0.cpp
@@ -1,0 +1,26 @@
+// Regression: out-of-line class-template member replay can materialize a
+// dependent unqualified direct call that later gets resolved to the
+// definition-bound ordinary overload. Keep that binding through
+// replay/materialization instead of relying on late recovery.
+
+int lookup_probe(long) {
+	return 1;
+}
+
+template <typename T>
+struct Box {
+	int run();
+};
+
+template <typename T>
+int Box<T>::run() {
+	return lookup_probe(T{});
+}
+
+int lookup_probe(int) {
+	return 2;
+}
+
+int main() {
+	return Box<int>{}.run() - 1;
+}

--- a/tests/test_template_dependent_unqualified_poi_adl_record_ret42.cpp
+++ b/tests/test_template_dependent_unqualified_poi_adl_record_ret42.cpp
@@ -1,0 +1,25 @@
+// Regression: dependent unqualified call completion can materialize a resolved
+// direct call whose final point-of-instantiation target comes from ADL rather
+// than the definition-bound ordinary lookup. Preserve that completed target as
+// structured metadata instead of relying on late recovery.
+
+constexpr int adl_pick(long) {
+	return 1;
+}
+
+namespace N {
+	struct Tag {
+		friend constexpr int adl_pick(Tag) {
+			return 42;
+		}
+	};
+}
+
+template <typename T>
+int runAdlPick() {
+	return adl_pick(T{});
+}
+
+int main() {
+	return runAdlPick<N::Tag>();
+}


### PR DESCRIPTION
## What changed
This branch continues the template-infrastructure refactor around dependent and ordinary direct-call resolution.

It includes three connected slices:
- preserve definition-bound dependent-unqualified replay metadata during resolved-call materialization
- preserve completed point-of-instantiation targets for dependent-unqualified calls, including ADL-completed cases
- remove the final parser-selected non-receiver direct-call fallback from `resolveCallArgAnnotationTarget(...)`

## Why
The remaining template call pipeline still allowed some instantiated direct calls to fall back to parser-selected or mangled-name compatibility behavior after replay/materialization.

The goal of this branch is to move those paths closer to the C++20 model where:
- definition-bound lookup stays preserved through instantiation
- dependent-unqualified POI completion preserves the final semantic target structurally
- sema resolves ordinary direct calls from semantic metadata and typed lookup instead of reusing the parser-selected target late

## Impact
Ordinary direct-call target selection is now stricter and more sema-owned in normalized and replay-heavy template flows.

The branch also updates the template architecture/conformance docs so the next task is the next replay/`StructTypeInfo` identity gap and then the remaining mangled-name compatibility paths.

## Root cause
The compiler was still carrying transitional compatibility behavior where replay/materialization could drop decisive semantic call metadata, and `resolveCallArgAnnotationTarget(...)` could reuse the parser-selected target after typed lookup failed.

That kept the parser in the ownership chain longer than intended and obscured where metadata preservation was still incomplete.
