### PR TITLE
Tighten template replay identity and struct sync

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -92,6 +92,9 @@ Near-term remaining scope:
   source-member-to-`StructTypeInfo` index map as the primary-template path,
   and the nested/member-template replay sites that already preserve a matched
   source declaration now route through the shared identity-first helpers too
+- partial-specialization nested member-template replay now also syncs the
+  `StructTypeInfo` copy through the shared identity-first helper once the
+  matched source declaration is preserved
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites still recover through replay-source-key helper scans after the source
   declaration is already known

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -43,6 +43,10 @@ the areas that were previously blocking standards-visible behavior:
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
   unresolved terminals instead of reusing the parser-selected target late
+- primary-template out-of-line constructor replay now synchronizes the
+  `StructTypeInfo` constructor copy through preserved source-member identity
+  when that identity is already known, instead of always rescanning
+  `StructTypeInfo` constructors afterward
 
 ## Architectural invariants to preserve
 
@@ -74,6 +78,12 @@ Desired end state:
 - `StructTypeInfo` repair scans are not used to rediscover targets by name or
   arity when identity could have been preserved
 
+Near-term remaining scope:
+
+- remaining member-template and constructor-template `StructTypeInfo` sync
+  sites still recover through replay-source-key helper scans after the source
+  declaration is already known
+
 ### 2. Remaining direct-call metadata loss outside dependent-unqualified completion
 
 Dependent-unqualified direct-call completion now preserves both the
@@ -99,8 +109,9 @@ real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Fix the next replay/`StructTypeInfo` sync miss by preserving source identity
-   in that path instead of restoring any signature-equivalent recovery logic.
+1. Fix the next member-template or constructor-template `StructTypeInfo` sync
+   miss by preserving source identity in that path instead of recovering the
+   copy through a helper scan.
 
 2. Tighten the next remaining mangled-name compatibility path by preserving
    structured direct-call metadata in the owning replay/materialization path

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -84,6 +84,10 @@ Near-term remaining scope:
   `Parser::try_instantiate_class_template()` is now unified locally, so the
   next cleanup target in this area is the remaining out-of-line replay/sync
   helper duplication rather than more registration drift
+- top-level replay-driven `StructTypeInfo` sync now uses shared
+  identity-first helpers for plain members and constructors; the remaining
+  duplication is in nested/member-template-specific attachment paths that do
+  not all route through those helpers yet
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites still recover through replay-source-key helper scans after the source
   declaration is already known

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -88,6 +88,10 @@ Near-term remaining scope:
   identity-first helpers for plain members and constructors; the remaining
   duplication is in nested/member-template-specific attachment paths that do
   not all route through those helpers yet
+- partial-specialization constructor copies now use the same
+  source-member-to-`StructTypeInfo` index map as the primary-template path,
+  and the nested/member-template replay sites that already preserve a matched
+  source declaration now route through the shared identity-first helpers too
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites still recover through replay-source-key helper scans after the source
   declaration is already known

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -80,6 +80,10 @@ Desired end state:
 
 Near-term remaining scope:
 
+- in-loop member-function / constructor registration inside
+  `Parser::try_instantiate_class_template()` is now unified locally, so the
+  next cleanup target in this area is the remaining out-of-line replay/sync
+  helper duplication rather than more registration drift
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites still recover through replay-source-key helper scans after the source
   declaration is already known

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -78,6 +78,10 @@ Near-term remaining scope:
   identity-first helpers for plain members and constructors; the remaining
   duplication is in nested/member-template-specific attachment paths that do
   not all route through those helpers yet
+- partial-specialization constructor copies now use the same
+  source-member-to-`StructTypeInfo` index map as the primary-template path,
+  and the nested/member-template replay sites that already preserve a matched
+  source declaration now route through the shared identity-first helpers too
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites that still route through replay-source-key helper scans after the
   matched source declaration is already known

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -70,6 +70,10 @@ Why this matters:
 
 Near-term remaining scope:
 
+- in-loop member-function / constructor registration inside
+  `Parser::try_instantiate_class_template()` is now unified locally, so the
+  next cleanup target in this area is the remaining out-of-line replay/sync
+  helper duplication rather than more registration drift
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites that still route through replay-source-key helper scans after the
   matched source declaration is already known

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -82,6 +82,9 @@ Near-term remaining scope:
   source-member-to-`StructTypeInfo` index map as the primary-template path,
   and the nested/member-template replay sites that already preserve a matched
   source declaration now route through the shared identity-first helpers too
+- partial-specialization nested member-template replay now also syncs the
+  `StructTypeInfo` copy through the shared identity-first helper once the
+  matched source declaration is preserved
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites that still route through replay-source-key helper scans after the
   matched source declaration is already known

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -74,6 +74,10 @@ Near-term remaining scope:
   `Parser::try_instantiate_class_template()` is now unified locally, so the
   next cleanup target in this area is the remaining out-of-line replay/sync
   helper duplication rather than more registration drift
+- top-level replay-driven `StructTypeInfo` sync now uses shared
+  identity-first helpers for plain members and constructors; the remaining
+  duplication is in nested/member-template-specific attachment paths that do
+  not all route through those helpers yet
 - remaining member-template and constructor-template `StructTypeInfo` sync
   sites that still route through replay-source-key helper scans after the
   matched source declaration is already known

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -48,6 +48,9 @@ blocking areas:
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
   terminals instead of reusing the parser-selected target late
+- primary-template out-of-line constructor replay now synchronizes the
+  `StructTypeInfo` constructor copy through preserved source-member identity
+  when that identity is already known, instead of recovering it afterward
 
 ## Highest-value remaining standards gaps
 
@@ -64,6 +67,12 @@ Why this matters:
   declaration
 - those weak paths tend to reopen non-conforming fallback behavior later in
   sema or codegen
+
+Near-term remaining scope:
+
+- remaining member-template and constructor-template `StructTypeInfo` sync
+  sites that still route through replay-source-key helper scans after the
+  matched source declaration is already known
 
 ### 2. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
 
@@ -88,9 +97,9 @@ it only for concrete unresolved cases that block steps 1-2.
 
 ## Priority order
 
-1. Tighten the next replay/`StructTypeInfo` sync gap by preserving source
-   identity rather than restoring any signature-equivalent or textual repair
-   logic.
+1. Tighten the next member-template or constructor-template
+   `StructTypeInfo` sync gap by preserving source identity rather than routing
+   through a helper scan after the source declaration is already known.
 
 2. Tighten the next remaining mangled-name compatibility path by preserving
    structured direct-call metadata in the owning replay/materialization path

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1730,23 +1730,6 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		std::optional<std::string_view> qualified_call_name,
 		bool copy_template_arguments,
 		bool infer_qualified_name_from_parent) -> ASTNode {
-		const auto matchesDefinitionBoundDependentRecordTarget = [&]() -> bool {
-			if (!call.has_dependent_unqualified_lookup_record()) {
-				return false;
-			}
-			const DependentUnqualifiedCallLookupRecord& record =
-				*call.dependent_unqualified_lookup_record();
-			if (record.definition_bound_function != nullptr &&
-				(&target_func == record.definition_bound_function ||
-				 &target_func.decl_node() ==
-					 &record.definition_bound_function->decl_node())) {
-				return true;
-			}
-			return record.definition_bound_mangled_name.isValid() &&
-				   target_func.has_mangled_name() &&
-				   target_func.mangled_name() ==
-					   record.definition_bound_mangled_name.view();
-		};
 		ExpressionNode& new_expr = emplaceDirectCallExpr(
 			target_func.decl_node(),
 			&target_func,
@@ -1754,15 +1737,14 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			called_from_token);
 		CallMetadataCopyOptions copy_options;
 		copy_options.copy_template_arguments = copy_template_arguments;
-		copy_options.copy_dependent_unqualified_lookup_record =
-			matchesDefinitionBoundDependentRecordTarget();
+		copy_options.copy_dependent_unqualified_lookup_record = false;
 		copy_options.copy_dependent_qualified_lookup_record = false;
 		copyMetadataToExpr(new_expr, copy_options);
-		if (call.has_dependent_unqualified_lookup_record() &&
-			!copy_options.copy_dependent_unqualified_lookup_record) {
+		if (call.has_dependent_unqualified_lookup_record()) {
 			DependentUnqualifiedCallLookupRecord completed_record =
 				*call.dependent_unqualified_lookup_record();
 			completed_record.point_of_instantiation_function = &target_func;
+			completed_record.point_of_instantiation_mangled_name = StringHandle{};
 			if (target_func.has_mangled_name()) {
 				completed_record.point_of_instantiation_mangled_name =
 					StringTable::getOrInternStringHandle(

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -2972,6 +2972,64 @@ inline OutOfLineFunctionStubResolution findReplayedOutOfLineMemberInStructInfo(
 		});
 }
 
+template <typename EligibleFn>
+inline OutOfLineFunctionStubResolution findReplayedOutOfLineMemberInStructInfo(
+	StructTypeInfo* struct_info,
+	const SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode* source_member,
+	const FunctionDeclarationNode& replayed_func,
+	EligibleFn&& is_candidate_eligible) {
+	if (struct_info == nullptr) {
+		return {};
+	}
+
+	if (source_member != nullptr) {
+		FunctionDeclarationNode* struct_info_func =
+			findStructInfoFunctionBySourceMemberIdentity(
+				struct_info,
+				index_maps,
+				*source_member);
+		if (struct_info_func != nullptr &&
+			is_candidate_eligible(*struct_info_func)) {
+			return {.func = struct_info_func};
+		}
+	}
+
+	return findMatchingFunctionInStructInfo(
+		*struct_info,
+		replayed_func,
+		std::forward<EligibleFn>(is_candidate_eligible));
+}
+
+template <typename EligibleFn>
+inline OutOfLineConstructorStubResolution findReplayedOutOfLineConstructorInStructInfo(
+	StructTypeInfo* struct_info,
+	const SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode* source_member,
+	const ConstructorDeclarationNode& replayed_ctor,
+	EligibleFn&& is_candidate_eligible) {
+	if (struct_info == nullptr) {
+		return {};
+	}
+
+	if (source_member != nullptr) {
+		ConstructorDeclarationNode* struct_info_ctor =
+			findStructInfoConstructorBySourceMemberIdentity(
+				struct_info,
+				index_maps,
+				*source_member);
+		if (struct_info_ctor != nullptr &&
+			is_candidate_eligible(*struct_info_ctor)) {
+			return {.ctor = struct_info_ctor};
+		}
+	}
+
+	return findMatchingConstructorInStructInfo(
+		*struct_info,
+		replayed_ctor,
+		std::forward<EligibleFn>(is_candidate_eligible));
+}
+
 // Resolve any stored template arguments on a deferred base member-type chain after a class
 // template's substitution maps are available.
 // Returns std::nullopt when any pack expansion or concrete member argument cannot be resolved.

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -383,6 +383,51 @@ inline FunctionDeclarationNode* findStructInfoFunctionBySourceMemberIdentity(
 	return get_function_decl_node_mut(function_decl);
 }
 
+inline ConstructorDeclarationNode* findStructInfoConstructorBySourceMemberIdentity(
+	StructTypeInfo* struct_info,
+	const SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode& source_member) {
+	if (struct_info == nullptr) {
+		return nullptr;
+	}
+
+	auto find_index = [&](const void* key) -> std::optional<size_t> {
+		if (key == nullptr) {
+			return std::nullopt;
+		}
+		auto it = index_maps.by_node.find(key);
+		if (it == index_maps.by_node.end()) {
+			return std::nullopt;
+		}
+		return it->second;
+	};
+
+	std::optional<size_t> index = find_index(sourceMemberAstNodeKey(source_member));
+	if (!index.has_value() &&
+		source_member.is<TemplateFunctionDeclarationNode>()) {
+		index = find_index(sourceMemberAstNodeKey(
+			source_member.as<TemplateFunctionDeclarationNode>().function_declaration()));
+	}
+	if (!index.has_value()) {
+		if (std::optional<uint64_t> location_key = sourceMemberLocationKey(source_member);
+			location_key.has_value()) {
+			auto it = index_maps.by_location.find(*location_key);
+			if (it != index_maps.by_location.end()) {
+				index = it->second;
+			}
+		}
+	}
+	if (!index.has_value() ||
+		*index >= struct_info->member_functions.size()) {
+		return nullptr;
+	}
+
+	ASTNode& function_decl = struct_info->member_functions[*index].function_decl;
+	return function_decl.is<ConstructorDeclarationNode>()
+		? &function_decl.as<ConstructorDeclarationNode>()
+		: nullptr;
+}
+
 struct OutOfLineMemberStubResolution {
 	FunctionDeclarationNode* func = nullptr;
 	const ASTNode* source_member = nullptr;
@@ -464,6 +509,7 @@ inline OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 
 struct OutOfLineConstructorStubResolution {
 	ConstructorDeclarationNode* ctor = nullptr;
+	const ASTNode* source_member = nullptr;
 	bool ambiguous = false;
 	bool insufficient_evidence = false;
 };
@@ -478,6 +524,7 @@ inline OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 	StringHandle owner_type_name) {
 	OutOfLineConstructorStubResolution resolution;
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
+	const ASTNode* matched_source_member = nullptr;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -511,11 +558,13 @@ inline OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 
 		if (matches_candidate) {
 			resolved_matches.push_back(inst_ctor_decl);
+			matched_source_member = &source_member.function_declaration;
 		}
 	}
 
 	if (resolved_matches.size() == 1) {
 		resolution.ctor = resolved_matches.front();
+		resolution.source_member = matched_source_member;
 		return resolution;
 	}
 	if (resolved_matches.size() > 1) {
@@ -536,6 +585,7 @@ inline OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
 	OutOfLineConstructorStubResolution resolution;
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
+	const ASTNode* matched_source_member = nullptr;
 	for (const StructMemberFunctionDecl& source_member : source_members) {
 		if (!source_member.function_declaration.is<ConstructorDeclarationNode>()) {
 			continue;
@@ -584,10 +634,12 @@ inline OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 		}
 
 		resolved_matches.push_back(inst_ctor_decl);
+		matched_source_member = &source_member.function_declaration;
 	}
 
 	if (resolved_matches.size() == 1) {
 		resolution.ctor = resolved_matches.front();
+		resolution.source_member = matched_source_member;
 		return resolution;
 	}
 	if (resolved_matches.size() > 1) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -9508,6 +9508,56 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (mem_func.function_declaration.is<FunctionDeclarationNode>()) {
 			const FunctionDeclarationNode& func_decl = mem_func.function_declaration.as<FunctionDeclarationNode>();
 			const DeclarationNode& decl = func_decl.decl_node();
+			auto registerInstantiatedMemberFunction =
+				[&](ASTNode new_func_node, StringHandle effective_name, const FunctionDeclarationNode& new_func_ref) {
+					// Add the substituted function to the instantiated struct.
+					if (mem_func.operator_kind != OverloadableOperator::None) {
+						instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_func_node, mem_func.access);
+					} else {
+						instantiated_struct_ref.add_member_function(new_func_node, mem_func.access);
+					}
+
+					// Also add to struct_info so it can be found during codegen.
+					if (mem_func.operator_kind != OverloadableOperator::None) {
+						struct_info_ptr->addOperatorOverload(
+							mem_func.operator_kind,
+							new_func_node,
+							mem_func.access,
+							mem_func.is_virtual,
+							mem_func.is_pure_virtual,
+							mem_func.is_override,
+							mem_func.is_final);
+					} else {
+						FLASH_LOG(
+							Templates,
+							Debug,
+							"Adding member function '",
+							StringTable::getStringView(effective_name),
+							"' to struct_info for ",
+							instantiated_name,
+							", parent_struct_name='",
+							new_func_ref.parent_struct_name(),
+							"'");
+						struct_info_ptr->addMemberFunction(
+							effective_name,
+							new_func_node,
+							mem_func.access,
+							mem_func.is_virtual,
+							mem_func.is_pure_virtual,
+							mem_func.is_override,
+							mem_func.is_final);
+						registerSourceMemberStructInfoIndex(
+							struct_info_member_identity_maps,
+							mem_func.function_declaration,
+							struct_info_ptr->member_functions.size() - 1);
+					}
+
+					// Record the stub for identity-map lookup during deferred-body replay.
+					registerSourceMemberStubIdentity(
+						source_member_identity_maps,
+						mem_func.function_declaration,
+						new_func_node);
+				};
 
 			// For lazy instantiation, register function for later instantiation instead of instantiating now.
 			// Namespaced implicit instantiations intentionally use the same stub path; the
@@ -9612,39 +9662,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				new_func_ref.set_is_const_member_function(mem_func.is_const());
 				new_func_ref.set_is_volatile_member_function(mem_func.is_volatile());
 
-				// Add the signature-only function to the instantiated struct
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_func_node, mem_func.access);
-				} else {
-					instantiated_struct_ref.add_member_function(new_func_node, mem_func.access);
-				}
-
-				// Also add to struct_info so it can be found during codegen
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_func_node, mem_func.access,
-														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
-				} else {
-					StringHandle func_name_handle = shell.effective_name;
-					struct_info_ptr->addMemberFunction(
-						func_name_handle,
-						new_func_node,
-						mem_func.access,
-						mem_func.is_virtual,
-						mem_func.is_pure_virtual,
-						mem_func.is_override,
-						mem_func.is_final);
-					registerSourceMemberStructInfoIndex(
-						struct_info_member_identity_maps,
-						mem_func.function_declaration,
-						struct_info_ptr->member_functions.size() - 1);
-				}
-				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
-
-				// Slice 3: record lazy-path stub for identity-map lookup during deferred-body replay.
-				registerSourceMemberStubIdentity(
-					source_member_identity_maps,
-					mem_func.function_declaration,
-					new_func_node);
+				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties.
+				registerInstantiatedMemberFunction(new_func_node, shell.effective_name, new_func_ref);
 
 				StringBuilder qualified_name_builder;
 				qualified_name_builder.append(StringTable::getStringView(instantiated_name))
@@ -9820,41 +9839,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 				pack_param_info_.resize(saved_pack_info);
 
-				// Add the substituted function to the instantiated struct
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_func_node, mem_func.access);
-				} else {
-					instantiated_struct_ref.add_member_function(new_func_node, mem_func.access);
-				}
-
-				// Also add to struct_info so it can be found during codegen
-				// Phase 7B: Intern function name and use StringHandle overload
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_func_node, mem_func.access,
-														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
-				} else {
-					FLASH_LOG(Templates, Debug, "Adding member function '", StringTable::getStringView(effective_name),
-							  "' to struct_info for ", instantiated_name, ", parent_struct_name='", new_func_ref.parent_struct_name(), "'");
-					struct_info_ptr->addMemberFunction(
-						effective_name,
-						new_func_node,
-						mem_func.access,
-						mem_func.is_virtual,
-						mem_func.is_pure_virtual,
-						mem_func.is_override,
-						mem_func.is_final);
-					registerSourceMemberStructInfoIndex(
-						struct_info_member_identity_maps,
-						mem_func.function_declaration,
-						struct_info_ptr->member_functions.size() - 1);
-				}
-				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
-
-				// Slice 3: record eager-with-definition stub for identity-map lookup.
-				registerSourceMemberStubIdentity(
-					source_member_identity_maps,
-					mem_func.function_declaration,
-					new_func_node);
+				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties.
+				registerInstantiatedMemberFunction(new_func_node, effective_name, new_func_ref);
 			} else {
 				// No definition, but still need to substitute parameter types and return type
 
@@ -9951,39 +9937,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 				}
 
-				// Add the substituted function to the instantiated struct
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					instantiated_struct_ref.add_operator_overload(mem_func.operator_kind, new_func_node, mem_func.access);
-				} else {
-					instantiated_struct_ref.add_member_function(new_func_node, mem_func.access);
-				}
-
-				// Also add to struct_info so it can be found during codegen
-				// Intern function name and use StringHandle overload
-				if (mem_func.operator_kind != OverloadableOperator::None) {
-					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_func_node, mem_func.access,
-														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
-				} else {
-					struct_info_ptr->addMemberFunction(
-						effective_name,
-						new_func_node,
-						mem_func.access,
-						mem_func.is_virtual,
-						mem_func.is_pure_virtual,
-						mem_func.is_override,
-						mem_func.is_final);
-					registerSourceMemberStructInfoIndex(
-						struct_info_member_identity_maps,
-						mem_func.function_declaration,
-						struct_info_ptr->member_functions.size() - 1);
-				}
-				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
-
-				// record no-definition stub for identity-map lookup.
-				registerSourceMemberStubIdentity(
-					source_member_identity_maps,
-					mem_func.function_declaration,
-					new_func_node);
+				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties.
+				registerInstantiatedMemberFunction(new_func_node, effective_name, new_func_ref);
 			}
 		} else if (mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
 			const ConstructorDeclarationNode& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3967,6 +3967,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								mem_func.is_pure_virtual,
 								mem_func.is_override,
 								mem_func.is_final);
+							registerSourceMemberStructInfoIndex(
+								struct_info_member_identity_maps,
+								mem_func.function_declaration,
+								struct_type_info.getStructInfo()->member_functions.size() - 1);
 						}
 
 						registerMemberTemplateInRegistry(
@@ -4024,6 +4028,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								mem_func.is_pure_virtual,
 								mem_func.is_override,
 								mem_func.is_final);
+							registerSourceMemberStructInfoIndex(
+								struct_info_member_identity_maps,
+								mem_func.function_declaration,
+								struct_type_info.getStructInfo()->member_functions.size() - 1);
 						}
 
 						registerMemberTemplateInRegistry(
@@ -4435,6 +4443,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 					FunctionDeclarationNode* inst_func_decl = nullptr;
+					const ASTNode* matched_source_member = nullptr;
 					bool saw_insufficient_replay_evidence = false;
 					bool saw_ambiguous_replay_match = false;
 					for (const StructMemberFunctionDecl* source_member :
@@ -4483,6 +4492,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							break;
 						}
 						inst_func_decl = matched_template_func_decl;
+						matched_source_member = &source_member->function_declaration;
 					}
 					if (saw_ambiguous_replay_match) {
 						std::string error_msg = std::string(StringBuilder()
@@ -4498,6 +4508,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						return failTemplateInstantiation(error_msg, nullptr, std::nullopt);
 					}
 					if (inst_func_decl != nullptr) {
+						auto outer_params_span = std::span<const TemplateParameterNode>(
+							template_params.data(),
+							template_params.size());
+						auto outer_args_span = std::span<const TemplateTypeArg>(
+							template_args_for_pattern.data(),
+							template_args_for_pattern.size());
 						inst_func_decl->set_template_body_position(out_of_line_member.body_start);
 						copyDefinitionParameterIdentifiers(
 							inst_func_decl->parameter_nodes(),
@@ -4505,8 +4521,52 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						copyDefinitionParameterTypesForDependentMemberTemplateSegments(
 							inst_func_decl->parameter_nodes(),
 							ool_func.parameter_nodes());
+						syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+							*this,
+							inst_func_decl->parameter_nodes(),
+							ool_func.parameter_nodes(),
+							outer_params_span,
+							outer_args_span);
 						inst_func_decl->set_definition_lookup_context(
 							out_of_line_member.definition_lookup_context);
+						if (StructTypeInfo* info = struct_type_info.getStructInfo();
+							info != nullptr) {
+							OutOfLineFunctionStubResolution info_func_resolution =
+								findReplayedOutOfLineMemberInStructInfo(
+									info,
+									struct_info_member_identity_maps,
+									matched_source_member,
+									*inst_func_decl,
+									[](const FunctionDeclarationNode& info_func) {
+										return !info_func.has_template_body_position();
+									});
+							if (info_func_resolution.func != nullptr) {
+								info_func_resolution.func->set_template_body_position(out_of_line_member.body_start);
+								copyDefinitionParameterIdentifiers(
+									info_func_resolution.func->parameter_nodes(),
+									ool_func.parameter_nodes());
+								copyDefinitionParameterTypes(
+									info_func_resolution.func->parameter_nodes(),
+									inst_func_decl->parameter_nodes());
+								syncReplayAttachedMemberTemplateParameterTypesFromDefinition(
+									*this,
+									info_func_resolution.func->parameter_nodes(),
+									ool_func.parameter_nodes(),
+									outer_params_span,
+									outer_args_span);
+								info_func_resolution.func->set_definition_lookup_context(
+									out_of_line_member.definition_lookup_context);
+							} else if (info_func_resolution.ambiguous) {
+								FLASH_LOG(
+									Templates,
+									Error,
+									"Ambiguous StructTypeInfo sync for partial-spec nested out-of-line member template '",
+									ool_func_name,
+									"' in instantiated class '",
+									instantiated_name,
+									"'");
+							}
+						}
 						{
 							StringBuilder qualified_name_builder;
 							qualified_name_builder

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -4321,22 +4321,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									template_args_for_pattern.size()),
 								"partial-spec",
 								plain_ool_name)) {
-							FunctionDeclarationNode* struct_info_func =
-								member_resolution.source_member != nullptr
-									? findStructInfoFunctionBySourceMemberIdentity(
-										  struct_type_info.getStructInfo(),
-										  struct_info_member_identity_maps,
-										  *member_resolution.source_member)
-									: nullptr;
-							OutOfLineFunctionStubResolution info_func_resolution;
-							if (struct_info_func != nullptr) {
-								info_func_resolution.func = struct_info_func;
-							} else {
-								info_func_resolution =
-									findReplayedOutOfLineMemberInStructInfo(
-										struct_type_info.getStructInfo(),
-										*inst_func);
-							}
+							OutOfLineFunctionStubResolution info_func_resolution =
+								findReplayedOutOfLineMemberInStructInfo(
+									struct_type_info.getStructInfo(),
+									struct_info_member_identity_maps,
+									member_resolution.source_member,
+									*inst_func,
+									[](const FunctionDeclarationNode& info_func) {
+										return !info_func.is_materialized();
+									});
 							if (info_func_resolution.ambiguous) {
 								FLASH_LOG(
 									Templates,
@@ -10917,31 +10910,22 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ool_func.parameter_nodes());
 
 				if (struct_info_ptr != nullptr) {
-					ConstructorDeclarationNode* struct_info_ctor =
-						ctor_resolution.source_member != nullptr
-							? findStructInfoConstructorBySourceMemberIdentity(
-								  struct_info_ptr,
-								  struct_info_member_identity_maps,
-								  *ctor_resolution.source_member)
-							: nullptr;
-					OutOfLineConstructorStubResolution info_ctor_resolution;
-					if (struct_info_ctor == nullptr) {
-						info_ctor_resolution =
-							findMatchingConstructorInStructInfo(
-								*struct_info_ptr,
-								ctor_decl,
-								[](const ConstructorDeclarationNode& info_ctor) {
-									return !info_ctor.has_template_body_position();
-								});
-						struct_info_ctor = info_ctor_resolution.ctor;
-					}
+					OutOfLineConstructorStubResolution info_ctor_resolution =
+						findReplayedOutOfLineConstructorInStructInfo(
+							struct_info_ptr,
+							struct_info_member_identity_maps,
+							ctor_resolution.source_member,
+							ctor_decl,
+							[](const ConstructorDeclarationNode& info_ctor) {
+								return !info_ctor.has_template_body_position();
+							});
 
-					if (struct_info_ctor != nullptr) {
+					if (info_ctor_resolution.ctor != nullptr) {
 						setOutOfLineConstructorTemplateReplayMetadata(
-							*struct_info_ctor,
+							*info_ctor_resolution.ctor,
 							out_of_line_member);
 						syncOutOfLineConstructorTemplateParameters(
-							struct_info_ctor->parameter_nodes(),
+							info_ctor_resolution.ctor->parameter_nodes(),
 							ool_func.parameter_nodes());
 					} else if (info_ctor_resolution.ambiguous) {
 						std::string error_msg = std::string(StringBuilder()
@@ -11231,22 +11215,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				"primary-template",
 				decl.identifier_token().value());
 			if (found_match) {
-				FunctionDeclarationNode* struct_info_func =
-					plain_member_resolution.source_member != nullptr
-						? findStructInfoFunctionBySourceMemberIdentity(
-							  struct_info_ptr,
-							  struct_info_member_identity_maps,
-							  *plain_member_resolution.source_member)
-						: nullptr;
-				OutOfLineFunctionStubResolution info_func_resolution;
-				if (struct_info_func != nullptr) {
-					info_func_resolution.func = struct_info_func;
-				} else {
-					info_func_resolution =
-						findReplayedOutOfLineMemberInStructInfo(
-							struct_info_ptr,
-							*inst_func);
-				}
+				OutOfLineFunctionStubResolution info_func_resolution =
+					findReplayedOutOfLineMemberInStructInfo(
+						struct_info_ptr,
+						struct_info_member_identity_maps,
+						plain_member_resolution.source_member,
+						*inst_func,
+						[](const FunctionDeclarationNode& info_func) {
+							return !info_func.is_materialized();
+						});
 				if (info_func_resolution.ambiguous) {
 					std::string error_msg = std::string(StringBuilder()
 						.append("Ambiguous StructTypeInfo sync for out-of-line member '")
@@ -11593,29 +11570,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ctor.set_definition(substituted_body);
 					// Also update the StructTypeInfo's copy (used by codegen)
 					if (struct_type_info.struct_info_) {
-						ConstructorDeclarationNode* struct_info_ctor =
-							ctor_resolution.source_member != nullptr
-								? findStructInfoConstructorBySourceMemberIdentity(
-									  struct_type_info.struct_info_.get(),
-									  struct_info_member_identity_maps,
-									  *ctor_resolution.source_member)
-								: nullptr;
-						OutOfLineConstructorStubResolution info_ctor_resolution;
-						if (struct_info_ctor == nullptr) {
-							info_ctor_resolution =
-								findMatchingConstructorInStructInfo(
-									*struct_type_info.struct_info_,
-									ctor,
-									[](const ConstructorDeclarationNode& info_ctor) {
-										return !info_ctor.is_materialized();
-									});
-							struct_info_ctor = info_ctor_resolution.ctor;
-						}
-						if (struct_info_ctor != nullptr) {
+						OutOfLineConstructorStubResolution info_ctor_resolution =
+							findReplayedOutOfLineConstructorInStructInfo(
+								struct_type_info.struct_info_.get(),
+								struct_info_member_identity_maps,
+								ctor_resolution.source_member,
+								ctor,
+								[](const ConstructorDeclarationNode& info_ctor) {
+									return !info_ctor.is_materialized();
+								});
+						if (info_ctor_resolution.ctor != nullptr) {
 							copyDefinitionParameterIdentifiers(
-								struct_info_ctor->parameter_nodes(),
+								info_ctor_resolution.ctor->parameter_nodes(),
 								func_decl.parameter_nodes());
-							struct_info_ctor->set_definition(substituted_body);
+							info_ctor_resolution.ctor->set_definition(substituted_body);
 						} else if (info_ctor_resolution.ambiguous) {
 							std::string error_msg = std::string(StringBuilder()
 								.append("Ambiguous StructTypeInfo constructor sync for out-of-line constructor '")

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -9959,7 +9959,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 
 				// Also add to struct_info so it can be found during codegen
-				// Phase 7B: Intern function name and use StringHandle overload
+				// Intern function name and use StringHandle overload
 				if (mem_func.operator_kind != OverloadableOperator::None) {
 					struct_info_ptr->addOperatorOverload(mem_func.operator_kind, new_func_node, mem_func.access,
 														 mem_func.is_virtual, mem_func.is_pure_virtual, mem_func.is_override, mem_func.is_final);
@@ -9979,7 +9979,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 				// cv_qualifier and is_noexcept are now auto-derived by propagateAstProperties
 
-				// Slice 3: record no-definition stub for identity-map lookup.
+				// record no-definition stub for identity-map lookup.
 				registerSourceMemberStubIdentity(
 					source_member_identity_maps,
 					mem_func.function_declaration,
@@ -9987,6 +9987,26 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 		} else if (mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
 			const ConstructorDeclarationNode& ctor_decl = mem_func.function_declaration.as<ConstructorDeclarationNode>();
+			auto registerInstantiatedConstructor = [&](ASTNode new_ctor_node) {
+				// Add the constructor to the instantiated struct AST node.
+				instantiated_struct_ref.add_constructor(new_ctor_node, mem_func.access);
+
+				// Also add to struct_info so it can be found during codegen.
+				struct_info_ptr->addConstructor(new_ctor_node, mem_func.access);
+				registerSourceMemberStructInfoIndex(
+					struct_info_member_identity_maps,
+					mem_func.function_declaration,
+					struct_info_ptr->member_functions.size() - 1);
+
+				// map the original template-pattern key to the fresh
+				// instantiated stub so deferred-body-replay can find and
+				// materialise it later, regardless of whether this path already
+				// has a definition.
+				registerSourceMemberStubIdentity(
+					source_member_identity_maps,
+					mem_func.function_declaration,
+					new_ctor_node);
+			};
 
 			// NOTE: Constructors are ALWAYS eagerly instantiated (not lazy)
 			// because they're needed for object creation
@@ -10048,17 +10068,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					pack_param_info_.resize(saved_pack_info);
 
-					// Add the substituted constructor to the instantiated struct AST node
-					instantiated_struct_ref.add_constructor(new_ctor_node, mem_func.access);
-
-					// Also add to struct_info so it can be found during codegen
-					struct_info_ptr->addConstructor(new_ctor_node, mem_func.access);
-
-					// Slice 3: record constructor-with-definition stub.
-					registerSourceMemberStubIdentity(
-						source_member_identity_maps,
-						mem_func.function_declaration,
-						new_ctor_node);
+					// Centralize constructor registration so AST / StructTypeInfo /
+					// source-identity updates stay identical across constructor paths.
+					registerInstantiatedConstructor(new_ctor_node);
 
 					// Register lazy constructor stubs with deferred bodies in the lazy registry
 					// for on-demand materialization when odr-used. The stub carries
@@ -10131,16 +10143,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_ctor_ref.set_requires_clause(*ctor_decl.requires_clause());
 					}
 
-					// Add the fresh stub to the instantiated struct AST node and to struct_info.
-					instantiated_struct_ref.add_constructor(new_ctor_node, mem_func.access);
-					struct_info_ptr->addConstructor(new_ctor_node, mem_func.access);
-
-					// Slice 3: map original template-pattern key to fresh instantiated stub,
-					// so deferred-body-replay can find and materialise it later.
-					registerSourceMemberStubIdentity(
-						source_member_identity_maps,
-						mem_func.function_declaration,
-						new_ctor_node);
+					// Centralize constructor registration so AST / StructTypeInfo /
+					// source-identity updates stay identical across constructor paths.
+					registerInstantiatedConstructor(new_ctor_node);
 					if (is_implicit_instantiation &&
 						!ctor_decl.is_materialized() &&
 						shouldCommitTemplateInstantiationArtifacts()) {
@@ -10957,20 +10962,31 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ool_func.parameter_nodes());
 
 				if (struct_info_ptr != nullptr) {
-					OutOfLineConstructorStubResolution info_ctor_resolution =
-						findMatchingConstructorInStructInfo(
-							*struct_info_ptr,
-							ctor_decl,
-							[](const ConstructorDeclarationNode& info_ctor) {
-								return !info_ctor.has_template_body_position();
-							});
+					ConstructorDeclarationNode* struct_info_ctor =
+						ctor_resolution.source_member != nullptr
+							? findStructInfoConstructorBySourceMemberIdentity(
+								  struct_info_ptr,
+								  struct_info_member_identity_maps,
+								  *ctor_resolution.source_member)
+							: nullptr;
+					OutOfLineConstructorStubResolution info_ctor_resolution;
+					if (struct_info_ctor == nullptr) {
+						info_ctor_resolution =
+							findMatchingConstructorInStructInfo(
+								*struct_info_ptr,
+								ctor_decl,
+								[](const ConstructorDeclarationNode& info_ctor) {
+									return !info_ctor.has_template_body_position();
+								});
+						struct_info_ctor = info_ctor_resolution.ctor;
+					}
 
-					if (info_ctor_resolution.ctor != nullptr) {
+					if (struct_info_ctor != nullptr) {
 						setOutOfLineConstructorTemplateReplayMetadata(
-							*info_ctor_resolution.ctor,
+							*struct_info_ctor,
 							out_of_line_member);
 						syncOutOfLineConstructorTemplateParameters(
-							info_ctor_resolution.ctor->parameter_nodes(),
+							struct_info_ctor->parameter_nodes(),
 							ool_func.parameter_nodes());
 					} else if (info_ctor_resolution.ambiguous) {
 						std::string error_msg = std::string(StringBuilder()
@@ -11622,18 +11638,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					ctor.set_definition(substituted_body);
 					// Also update the StructTypeInfo's copy (used by codegen)
 					if (struct_type_info.struct_info_) {
-						OutOfLineConstructorStubResolution info_ctor_resolution =
-							findMatchingConstructorInStructInfo(
-								*struct_type_info.struct_info_,
-								ctor,
-								[](const ConstructorDeclarationNode& info_ctor) {
-									return !info_ctor.is_materialized();
-								});
-						if (info_ctor_resolution.ctor != nullptr) {
+						ConstructorDeclarationNode* struct_info_ctor =
+							ctor_resolution.source_member != nullptr
+								? findStructInfoConstructorBySourceMemberIdentity(
+									  struct_type_info.struct_info_.get(),
+									  struct_info_member_identity_maps,
+									  *ctor_resolution.source_member)
+								: nullptr;
+						OutOfLineConstructorStubResolution info_ctor_resolution;
+						if (struct_info_ctor == nullptr) {
+							info_ctor_resolution =
+								findMatchingConstructorInStructInfo(
+									*struct_type_info.struct_info_,
+									ctor,
+									[](const ConstructorDeclarationNode& info_ctor) {
+										return !info_ctor.is_materialized();
+									});
+							struct_info_ctor = info_ctor_resolution.ctor;
+						}
+						if (struct_info_ctor != nullptr) {
 							copyDefinitionParameterIdentifiers(
-								info_ctor_resolution.ctor->parameter_nodes(),
+								struct_info_ctor->parameter_nodes(),
 								func_decl.parameter_nodes());
-							info_ctor_resolution.ctor->set_definition(substituted_body);
+							struct_info_ctor->set_definition(substituted_body);
 						} else if (info_ctor_resolution.ambiguous) {
 							std::string error_msg = std::string(StringBuilder()
 								.append("Ambiguous StructTypeInfo constructor sync for out-of-line constructor '")

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2329,7 +2329,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					member_decl.is_no_unique_address);
 			}
 
-			SourceMemberIdentityMaps struct_info_source_member_identity_maps;
 			SourceMemberStructInfoIndexMaps struct_info_member_identity_maps;
 
 			// Copy member functions from pattern
@@ -2382,10 +2381,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_ctor_ref.set_is_explicitly_defaulted(orig_ctor.is_explicitly_defaulted());
 					new_ctor_ref.set_noexcept(orig_ctor.is_noexcept());
 					struct_info->addConstructor(new_ctor_node, mem_func.access);
-					registerSourceMemberStubIdentity(
-						struct_info_source_member_identity_maps,
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
 						mem_func.function_declaration,
-						new_ctor_node);
+						struct_info->member_functions.size() - 1);
 				} else if (mem_func.is_destructor) {
 					// Handle destructor
 					struct_info->addDestructor(
@@ -3740,18 +3739,16 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						instantiated_struct_ref.has_outer_template_bindings() ? &outer_parent_snapshot : nullptr);
 					if (lazy_registry_key.isValid() &&
 						instantiated_struct_info_mut != nullptr) {
-						OutOfLineConstructorStubResolution info_ctor_resolution =
-							findMatchingConstructorInStructInfo(
-								*instantiated_struct_info_mut,
-								new_ctor_ref,
-								[](const ConstructorDeclarationNode&) {
-									return true;
-								});
-						if (info_ctor_resolution.ctor != nullptr) {
-								info_ctor_resolution.ctor->set_lazy_member_registry_key(lazy_registry_key);
-							}
+						ConstructorDeclarationNode* struct_info_ctor =
+							findStructInfoConstructorBySourceMemberIdentity(
+								instantiated_struct_info_mut,
+								struct_info_member_identity_maps,
+								mem_func.function_declaration);
+						if (struct_info_ctor != nullptr) {
+							struct_info_ctor->set_lazy_member_registry_key(lazy_registry_key);
 						}
 					}
+				}
 				} else if (mem_func.is_destructor) {
 					// Handle destructor
 					instantiated_struct_ref.add_destructor(mem_func.function_declaration, mem_func.access, mem_func.is_virtual);
@@ -4644,23 +4641,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				if (StructTypeInfo* ctor_instantiated_struct_info = struct_type_info.getStructInfo();
 					ctor_instantiated_struct_info != nullptr) {
 					OutOfLineConstructorStubResolution info_ctor_resolution =
-						findOutOfLineConstructorTemplateStubByIdentity(
-							*this,
-							struct_info_source_member_identity_maps,
-							std::span<const StructMemberFunctionDecl>(
-								pattern_struct.member_functions().data(),
-								pattern_struct.member_functions().size()),
-							ool_func,
-							std::span<const TemplateParameterNode>(
-								template_params.data(),
-								template_params.size()),
-							std::span<const TemplateTypeArg>(
-								template_args_for_pattern.data(),
-								template_args_for_pattern.size()),
-							instantiated_name,
-							std::span<const TemplateParameterNode>(
-								out_of_line_member.inner_template_params.data(),
-								out_of_line_member.inner_template_params.size()));
+						findReplayedOutOfLineConstructorInStructInfo(
+							ctor_instantiated_struct_info,
+							struct_info_member_identity_maps,
+							ctor_resolution.source_member,
+							ctor_decl,
+							[](const ConstructorDeclarationNode& info_ctor) {
+								return !info_ctor.has_template_body_position();
+							});
 
 					if (info_ctor_resolution.ctor != nullptr) {
 						setOutOfLineConstructorTemplateReplayMetadata(
@@ -8176,11 +8164,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				nested_struct.member_functions();
 
 			SourceMemberIdentityMaps nested_source_member_identity_maps;
+			SourceMemberStructInfoIndexMaps nested_struct_info_member_identity_maps;
 			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
 				registerSourceMemberStubIdentity(
 					nested_source_member_identity_maps,
 					source_member.function_declaration,
 					source_member.function_declaration);
+			}
+			if (nested_struct_info != nullptr &&
+				nested_struct_info->member_functions.size() == nested_source_member_functions.size()) {
+				for (size_t i = 0; i < nested_source_member_functions.size(); ++i) {
+					registerSourceMemberStructInfoIndex(
+						nested_struct_info_member_identity_maps,
+						nested_source_member_functions[i].function_declaration,
+						i);
+				}
 			}
 
 			for (const auto& out_of_line_member : nested_out_of_line_members) {
@@ -8331,8 +8329,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					if (nested_struct_info != nullptr) {
 						OutOfLineConstructorStubResolution info_ctor_resolution =
-							findMatchingConstructorInStructInfo(
-								*nested_struct_info,
+							findReplayedOutOfLineConstructorInStructInfo(
+								nested_struct_info.get(),
+								nested_struct_info_member_identity_maps,
+								ctor_resolution.source_member,
 								ctor_decl,
 								[](const ConstructorDeclarationNode& info_ctor) {
 									return !info_ctor.has_template_body_position();
@@ -10953,6 +10953,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Replay-first attachment path: match against source template members and
 			// resolve to instantiated stubs via source_member_to_stub identity mapping.
 			FunctionDeclarationNode* inst_func_decl = nullptr;
+			const ASTNode* matched_source_member = nullptr;
 			bool saw_insufficient_replay_evidence = false;
 			bool saw_ambiguous_replay_match = false;
 			for (const auto& source_member : effective_member_functions) {
@@ -11008,6 +11009,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					break;
 				}
 				inst_func_decl = matched_template_func_decl;
+				matched_source_member = &source_member.function_declaration;
 			}
 
 			if (saw_ambiguous_replay_match) {
@@ -11049,8 +11051,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				inst_func_decl->set_definition_lookup_context(out_of_line_member.definition_lookup_context);
 				if (struct_info_ptr != nullptr) {
 					OutOfLineFunctionStubResolution info_func_resolution =
-						findMatchingFunctionInStructInfo(
-							*struct_info_ptr,
+						findReplayedOutOfLineMemberInStructInfo(
+							struct_info_ptr,
+							struct_info_member_identity_maps,
+							matched_source_member,
 							*inst_func_decl,
 							[](const FunctionDeclarationNode& info_func) {
 								return !info_func.has_template_body_position();


### PR DESCRIPTION
## Summary
- simplify dependent-unqualified call materialization by always preserving point-of-instantiation target metadata when a dependent lookup record exists
- unify repeated template member/constructor registration paths in `Parser::try_instantiate_class_template()` and centralize replay-driven `StructTypeInfo` sync through shared identity-first helpers
- tighten partial-specialization, nested, and out-of-line member-template / constructor-template replay so matched source-member identity is reused directly when syncing `StructTypeInfo`
- update the template-architecture audit docs with the narrower remaining replay/sync cleanup scope

## Notes
- Follow-up scope is now mostly limited to replay/sync paths that still fall back to helper scans because they do not yet preserve strong source-member provenance end-to-end.
