### PR TITLE
Continue template infrastructure identity and call-metadata refactor

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -47,6 +47,11 @@ the areas that were previously blocking standards-visible behavior:
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
   `StructTypeInfo` constructors afterward
+- copied member-function-template stubs now register source-member identity
+  into `StructTypeInfo` immediately in the primary-template and covered
+  specialization paths, including operator overloads, so later out-of-line
+  replay sync no longer has to recover those copies through replay-source-key
+  scans once the matched source declaration is already known
 
 ## Architectural invariants to preserve
 
@@ -95,9 +100,11 @@ Near-term remaining scope:
 - partial-specialization nested member-template replay now also syncs the
   `StructTypeInfo` copy through the shared identity-first helper once the
   matched source declaration is preserved
-- remaining member-template and constructor-template `StructTypeInfo` sync
-  sites still recover through replay-source-key helper scans after the source
-  declaration is already known
+- primary-template and covered specialization member-template copies now record
+  `StructTypeInfo` identity at insertion time, so the remaining sync debt in
+  this bucket is narrower: audit any still-uncovered constructor-template or
+  replay-driven nested attachment path that reaches shared sync helpers without
+  an identity index even after the matched source declaration is known
 
 ### 2. Remaining direct-call metadata loss outside dependent-unqualified completion
 
@@ -130,9 +137,10 @@ real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Fix the next member-template or constructor-template `StructTypeInfo` sync
-   miss by preserving source identity in that path instead of recovering the
-   copy through a helper scan.
+1. Audit the remaining constructor-template / nested replay `StructTypeInfo`
+   sync path that still reaches shared helpers without a preserved identity
+   index, and close it the same way this slice closed the member-template
+   copies.
 
 2. Tighten the next remaining mangled-name compatibility path by preserving
    structured direct-call metadata in the owning replay/materialization path
@@ -154,6 +162,7 @@ Next direct-call target:
 When changing this area, always rerun:
 
 - the focused regression that motivated the slice
+- `test_template_ool_member_template_operator_identity_ret0.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
@@ -165,3 +174,20 @@ When changing this area, always rerun:
 - `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
 - `test_subscript_pointer_conversion_template_ret42.cpp`
 - full `pwsh tests/run_all_tests.ps1` before closing the slice
+
+## Next steps
+
+1. Inspect the remaining constructor-template and replay-only nested sync
+   callers for any path that still reaches
+   `findReplayedOutOfLineConstructorInStructInfo(...)` without a populated
+   `SourceMemberStructInfoIndexMaps` entry after source matching succeeded.
+
+2. After the replay/sync identity coverage is closed, remove or narrow the
+   remaining generic ordinary-call
+   `lookupFunctionByMangledName(call_info.mangled_name)` compatibility path in
+   sema by preserving the structured direct-call target in the owning
+   materialization path.
+
+3. Only then spend complexity on current-instantiation /
+   unknown-specialization expansion, and only for concrete typed-lookup or
+   replay failures that remain after steps 1-2.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -52,6 +52,11 @@ the areas that were previously blocking standards-visible behavior:
   specialization paths, including operator overloads, so later out-of-line
   replay sync no longer has to recover those copies through replay-source-key
   scans once the matched source declaration is already known
+- nested class-template member-function population now happens before
+  nested out-of-line replay, with `StructTypeInfo` identity recorded at
+  insertion time and lazy-registration split from structural insertion, so the
+  nested constructor/member-template replay helpers no longer depend on
+  positional back-fill of `StructTypeInfo` indices in that path
 
 ## Architectural invariants to preserve
 
@@ -100,11 +105,10 @@ Near-term remaining scope:
 - partial-specialization nested member-template replay now also syncs the
   `StructTypeInfo` copy through the shared identity-first helper once the
   matched source declaration is preserved
-- primary-template and covered specialization member-template copies now record
-  `StructTypeInfo` identity at insertion time, so the remaining sync debt in
-  this bucket is narrower: audit any still-uncovered constructor-template or
-  replay-driven nested attachment path that reaches shared sync helpers without
-  an identity index even after the matched source declaration is known
+- the previously highest-impact nested replay/sync gap is now covered in the
+  primary nested-class path as well; remaining replay debt in this bucket is no
+  longer the obvious first task and should be handled opportunistically only if
+  a concrete uncovered attachment/sync failure appears
 
 ### 2. Remaining direct-call metadata loss outside dependent-unqualified completion
 
@@ -137,12 +141,7 @@ real replay or typed-lookup failures.
 
 ## Recommended task order
 
-1. Audit the remaining constructor-template / nested replay `StructTypeInfo`
-   sync path that still reaches shared helpers without a preserved identity
-   index, and close it the same way this slice closed the member-template
-   copies.
-
-2. Tighten the next remaining mangled-name compatibility path by preserving
+1. Tighten the next remaining mangled-name compatibility path by preserving
    structured direct-call metadata in the owning replay/materialization path
    instead of relying on mangled recovery.
 
@@ -153,7 +152,7 @@ Next direct-call target:
   identifying which parser/materialization path still arrives there without a
   trustworthy structured direct-call target
 
-3. Only after steps 1-2 are stable, expand
+2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
    that still block standards-conforming typed lookup.
 
@@ -163,6 +162,9 @@ When changing this area, always rerun:
 
 - the focused regression that motivated the slice
 - `test_template_ool_member_template_operator_identity_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
+- `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
@@ -177,17 +179,11 @@ When changing this area, always rerun:
 
 ## Next steps
 
-1. Inspect the remaining constructor-template and replay-only nested sync
-   callers for any path that still reaches
-   `findReplayedOutOfLineConstructorInStructInfo(...)` without a populated
-   `SourceMemberStructInfoIndexMaps` entry after source matching succeeded.
-
-2. After the replay/sync identity coverage is closed, remove or narrow the
-   remaining generic ordinary-call
+1. Remove or narrow the remaining generic ordinary-call
    `lookupFunctionByMangledName(call_info.mangled_name)` compatibility path in
    sema by preserving the structured direct-call target in the owning
    materialization path.
 
-3. Only then spend complexity on current-instantiation /
+2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or
-   replay failures that remain after steps 1-2.
+   replay failures that remain after step 1.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -200,6 +200,10 @@ When changing this area, always rerun:
    still-uncovered resolved-call paths that only stamp `mangled_name` or
    `qualified_name`, starting with the typed current-member-context /
    qualified-member materializers and then the untyped fallback branches.
+   Immediate follow-up: convert the `resolved_member_function_from_context`
+   fast path in `Parser_Expr_PrimaryExpr.cpp` to preserve
+   `FunctionCallDefinitionLookupRecord`, and add a focused regression that
+   proves later overloads cannot steal that replayed member call target.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-11
+**Last updated:** 2026-06-12
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -39,6 +39,10 @@ the areas that were previously blocking standards-visible behavior:
   a different final function, so sema/constexpr can reuse structured call
   metadata instead of re-running parser lookup or relying on mangled-name
   recovery in those paths
+- non-dependent ordinary overload-resolution and namespace-qualified direct
+  call materialization in the covered template/replay paths now preserve
+  `FunctionCallDefinitionLookupRecord`, so sema no longer has to recover those
+  definition-bound targets from `call_info.mangled_name`
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
@@ -125,6 +129,10 @@ Latest progress:
 - sema now prefers the structured `FunctionDeclarationNode*` already stored in
   definition-lookup and dependent-unqualified records, and only falls back to
   mangled-name canonicalization when that structured target is absent
+- the highest-traffic non-dependent ordinary direct-call branches now preserve
+  `FunctionCallDefinitionLookupRecord` instead of only stamping
+  `mangled_name`, including unqualified overload-resolution paths in template
+  bodies and namespace-qualified direct-call materialization
 
 Desired end state:
 
@@ -132,6 +140,14 @@ Desired end state:
   evidence to recover its final target directly
 - sema does not need mangled-name recovery to reuse a completed
   replay/materialization result
+
+Remaining near-term scope:
+
+- the remaining compatibility surface is now concentrated in parser paths that
+  still stamp only `mangled_name` or `qualified_name` without a typed
+  definition-lookup record, especially current-member-context shortcuts,
+  untyped fallback branches, some qualified member-template call materializers,
+  and the user-defined literal operator path
 
 ### 3. Current-instantiation / unknown-specialization precision
 
@@ -147,10 +163,10 @@ real replay or typed-lookup failures.
 
 Next direct-call target:
 
-- remove or narrow the remaining generic ordinary-call
-  `lookupFunctionByMangledName(call_info.mangled_name)` fallback in sema by
-  identifying which parser/materialization path still arrives there without a
-  trustworthy structured direct-call target
+- trace the remaining `Parser_Expr_PrimaryExpr.cpp` direct-call sites that
+  still attach only compatibility metadata, then either preserve a typed
+  `FunctionCallDefinitionLookupRecord` there or explicitly document why the
+  call cannot yet carry one
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -166,6 +182,7 @@ When changing this area, always rerun:
 - `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
 - `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -179,10 +196,10 @@ When changing this area, always rerun:
 
 ## Next steps
 
-1. Remove or narrow the remaining generic ordinary-call
-   `lookupFunctionByMangledName(call_info.mangled_name)` compatibility path in
-   sema by preserving the structured direct-call target in the owning
-   materialization path.
+1. Finish the remaining parser-side direct-call metadata preservation in the
+   still-uncovered resolved-call paths that only stamp `mangled_name` or
+   `qualified_name`, starting with the typed current-member-context /
+   qualified-member materializers and then the untyped fallback branches.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-11
+**Last updated:** 2026-06-12
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -44,6 +44,10 @@ blocking areas:
   stays definition-bound and when dependent-unqualified POI completion selects
   a different final function, reducing replay-heavy dependence on parser
   reruns and mangled-name recovery in those paths
+- non-dependent ordinary overload-resolution and namespace-qualified direct
+  call materialization in the covered template paths now also preserve
+  `FunctionCallDefinitionLookupRecord`, reducing the remaining standards risk
+  that sema will reconstruct definition-bound targets from mangled names alone
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
@@ -114,6 +118,9 @@ Latest progress:
 - sema now consumes the structured `FunctionDeclarationNode*` already stored in
   definition-lookup and dependent-unqualified records before considering
   mangled-name canonicalization
+- the highest-traffic non-dependent ordinary direct-call branches now preserve
+  `FunctionCallDefinitionLookupRecord` directly, including unqualified
+  overload-resolution in template bodies and namespace-qualified direct calls
 
 Why this matters:
 
@@ -121,6 +128,14 @@ Why this matters:
 - the real semantic model should still know why the call is definition-bound
   and, when POI completion changes the winner, which final semantic target was
   selected
+
+Remaining near-term scope:
+
+- the remaining compatibility boundary is now concentrated in parser
+  materialization paths that still carry only `mangled_name` or
+  `qualified_name`, especially current-member-context shortcuts, untyped
+  fallbacks, some qualified member-template call materializers, and the
+  user-defined literal operator path
 
 ### 3. Current-instantiation / unknown-specialization coverage
 
@@ -135,9 +150,9 @@ it only for concrete unresolved cases that block steps 1-2.
 
 Next direct-call target:
 
-- identify the remaining ordinary direct-call parser/materialization path that
-  still reaches sema with only `call_info.mangled_name`, then replace that
-  fallback with preserved structured target metadata
+- identify the remaining direct-call parser/materialization sites that still
+  reach sema with compatibility-only metadata, then replace each typed case
+  with preserved structured target metadata before touching the sema fallback
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -163,6 +178,7 @@ For work in this area, rerun:
 - `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
 - `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
+- `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -176,10 +192,9 @@ For work in this area, rerun:
 
 ## Next steps
 
-1. Trace the remaining ordinary direct-call path that still reaches sema with
-   only `call_info.mangled_name`, then preserve the structured semantic target
-   in that owning replay/materialization flow so the compatibility fallback can
-   be narrowed or removed.
+1. Continue eliminating compatibility-only parser metadata in the remaining
+   resolved direct-call sites, starting with the typed current-member-context
+   and qualified-member materializers and then the untyped fallback branches.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -51,6 +51,11 @@ blocking areas:
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
+- copied member-function-template stubs now preserve source-member identity in
+  `StructTypeInfo` at insertion time in the primary-template and covered
+  specialization paths, including operator overloads, so out-of-line replay
+  sync no longer depends on replay-source-key recovery there once semantic
+  matching already identified the source declaration
 
 ## Highest-value remaining standards gaps
 
@@ -85,9 +90,11 @@ Near-term remaining scope:
 - partial-specialization nested member-template replay now also syncs the
   `StructTypeInfo` copy through the shared identity-first helper once the
   matched source declaration is preserved
-- remaining member-template and constructor-template `StructTypeInfo` sync
-  sites that still route through replay-source-key helper scans after the
-  matched source declaration is already known
+- member-template `StructTypeInfo` copies in the covered primary/specialization
+  paths now carry source identity directly; the remaining work in this bucket
+  is to find any still-uncovered constructor-template or replay-only nested
+  path that reaches the shared sync helpers without a populated identity map
+  after source matching already succeeded
 
 ### 2. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
 
@@ -118,7 +125,7 @@ it only for concrete unresolved cases that block steps 1-2.
 
 ## Priority order
 
-1. Tighten the next member-template or constructor-template
+1. Tighten the next constructor-template or replay-only nested
    `StructTypeInfo` sync gap by preserving source identity rather than routing
    through a helper scan after the source declaration is already known.
 
@@ -151,6 +158,7 @@ Next direct-call target:
 For work in this area, rerun:
 
 - the focused regression that motivated the slice
+- `test_template_ool_member_template_operator_identity_ret0.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
@@ -162,3 +170,19 @@ For work in this area, rerun:
 - `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
 - `test_subscript_pointer_conversion_template_ret42.cpp`
 - full `pwsh tests/run_all_tests.ps1` before considering the slice complete
+
+## Next steps
+
+1. Audit the remaining constructor-template and replay-only nested sync callers
+   and ensure they populate `SourceMemberStructInfoIndexMaps` before invoking
+   shared `StructTypeInfo` replay sync helpers once a source declaration match
+   is known.
+
+2. Trace the remaining ordinary direct-call path that still reaches sema with
+   only `call_info.mangled_name`, then preserve the structured semantic target
+   in that owning replay/materialization flow so the compatibility fallback can
+   be narrowed or removed.
+
+3. Use any concrete failures left after steps 1-2 to drive the next
+   current-instantiation / unknown-specialization expansion rather than
+   widening that model preemptively.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -56,6 +56,11 @@ blocking areas:
   specialization paths, including operator overloads, so out-of-line replay
   sync no longer depends on replay-source-key recovery there once semantic
   matching already identified the source declaration
+- nested class-template member functions are now inserted into
+  `StructTypeInfo` before nested out-of-line replay with identity recorded at
+  insertion time, and lazy nested-member registration is split from that
+  structural insertion so nested constructor/member-template replay no longer
+  depends on positional `StructTypeInfo` back-filling in the covered path
 
 ## Highest-value remaining standards gaps
 
@@ -90,11 +95,10 @@ Near-term remaining scope:
 - partial-specialization nested member-template replay now also syncs the
   `StructTypeInfo` copy through the shared identity-first helper once the
   matched source declaration is preserved
-- member-template `StructTypeInfo` copies in the covered primary/specialization
-  paths now carry source identity directly; the remaining work in this bucket
-  is to find any still-uncovered constructor-template or replay-only nested
-  path that reaches the shared sync helpers without a populated identity map
-  after source matching already succeeded
+- the previously highest-value replay/sync identity gaps for covered
+  member-template and nested constructor-template replay are now closed; any
+  remaining work in this bucket should be driven by a concrete uncovered
+  attachment failure rather than treated as the default next slice
 
 ### 2. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
 
@@ -125,11 +129,7 @@ it only for concrete unresolved cases that block steps 1-2.
 
 ## Priority order
 
-1. Tighten the next constructor-template or replay-only nested
-   `StructTypeInfo` sync gap by preserving source identity rather than routing
-   through a helper scan after the source declaration is already known.
-
-2. Tighten the next remaining mangled-name compatibility path by preserving
+1. Tighten the next remaining mangled-name compatibility path by preserving
    structured direct-call metadata in the owning replay/materialization path
    instead of relying on mangled recovery.
 
@@ -139,9 +139,9 @@ Next direct-call target:
   still reaches sema with only `call_info.mangled_name`, then replace that
   fallback with preserved structured target metadata
 
-3. Expand current-instantiation and unknown-specialization handling only where
+2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
-   steps 1-2.
+   step 1.
 
 ## Standards rules for follow-up work
 
@@ -159,6 +159,9 @@ For work in this area, rerun:
 
 - the focused regression that motivated the slice
 - `test_template_ool_member_template_operator_identity_ret0.cpp`
+- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
+- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
+- `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
@@ -173,16 +176,11 @@ For work in this area, rerun:
 
 ## Next steps
 
-1. Audit the remaining constructor-template and replay-only nested sync callers
-   and ensure they populate `SourceMemberStructInfoIndexMaps` before invoking
-   shared `StructTypeInfo` replay sync helpers once a source declaration match
-   is known.
-
-2. Trace the remaining ordinary direct-call path that still reaches sema with
+1. Trace the remaining ordinary direct-call path that still reaches sema with
    only `call_info.mangled_name`, then preserve the structured semantic target
    in that owning replay/materialization flow so the compatibility fallback can
    be narrowed or removed.
 
-3. Use any concrete failures left after steps 1-2 to drive the next
+2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than
    widening that model preemptively.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -195,6 +195,10 @@ For work in this area, rerun:
 1. Continue eliminating compatibility-only parser metadata in the remaining
    resolved direct-call sites, starting with the typed current-member-context
    and qualified-member materializers and then the untyped fallback branches.
+   Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
+   `resolved_member_function_from_context` path and add a focused regression
+   for replayed member calls that would otherwise be vulnerable to later
+   same-name overloads.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -1,7 +1,7 @@
 #pragma once
 
 struct SourceMemberStructInfoIndexMaps;
-inline void registerSourceMemberStructInfoIndex(
+void registerSourceMemberStructInfoIndex(
 	SourceMemberStructInfoIndexMaps& index_maps,
 	const ASTNode& source_member,
 	size_t struct_info_index);

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -1,5 +1,11 @@
 #pragma once
 
+struct SourceMemberStructInfoIndexMaps;
+inline void registerSourceMemberStructInfoIndex(
+	SourceMemberStructInfoIndexMaps& index_maps,
+	const ASTNode& source_member,
+	size_t struct_info_index);
+
 ASTNode rebindStaticMemberInitializerFunctionCalls(
 	const ASTNode& node,
 	const StructTypeInfo* struct_info,
@@ -1239,10 +1245,77 @@ LazyMemberFunctionInfo buildLazyNestedMemberFunctionInfo(
 	return lazy_mem_info;
 }
 
-template <typename TParams, typename TArgs>
-void registerNestedMemberFunctionsForLazy(
+inline void addNestedMemberFunctionsToStructInfo(
 	const StructDeclarationNode& nested_struct,
 	StructTypeInfo& nested_struct_info,
+	SourceMemberStructInfoIndexMaps* struct_info_index_maps) {
+	for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
+		if (mem_func.is_constructor || mem_func.is_destructor) {
+			if (mem_func.is_constructor) {
+				nested_struct_info.addConstructor(
+					mem_func.function_declaration,
+					mem_func.access);
+			} else {
+				nested_struct_info.addDestructor(
+					mem_func.function_declaration,
+					mem_func.access,
+					mem_func.is_virtual);
+			}
+			if (struct_info_index_maps != nullptr) {
+				registerSourceMemberStructInfoIndex(
+					*struct_info_index_maps,
+					mem_func.function_declaration,
+					nested_struct_info.member_functions.size() - 1);
+			}
+			continue;
+		}
+
+		const FunctionDeclarationNode* func_decl =
+			get_function_decl_node(mem_func.function_declaration);
+		if (func_decl == nullptr) {
+			continue;
+		}
+
+		{
+			ASTNode fn_node = mem_func.function_declaration;
+			if (auto* fn = get_function_decl_node_mut(fn_node)) {
+				fn->set_is_const_member_function(mem_func.is_const());
+				fn->set_is_volatile_member_function(mem_func.is_volatile());
+			}
+		}
+
+		const DeclarationNode& decl = func_decl->decl_node();
+		if (mem_func.operator_kind != OverloadableOperator::None) {
+			nested_struct_info.addOperatorOverload(
+				mem_func.operator_kind,
+				mem_func.function_declaration,
+				mem_func.access,
+				mem_func.is_virtual,
+				mem_func.is_pure_virtual,
+				mem_func.is_override,
+				mem_func.is_final);
+		} else {
+			nested_struct_info.addMemberFunction(
+				decl.identifier_token().handle(),
+				mem_func.function_declaration,
+				mem_func.access,
+				mem_func.is_virtual,
+				mem_func.is_pure_virtual,
+				mem_func.is_override,
+				mem_func.is_final);
+		}
+		if (struct_info_index_maps != nullptr) {
+			registerSourceMemberStructInfoIndex(
+				*struct_info_index_maps,
+				mem_func.function_declaration,
+				nested_struct_info.member_functions.size() - 1);
+		}
+	}
+}
+
+template <typename TParams, typename TArgs>
+inline void registerNestedMemberFunctionsLazyEntries(
+	const StructDeclarationNode& nested_struct,
 	StringHandle class_template_name,
 	StringHandle qualified_name,
 	const TParams& template_params,
@@ -1251,11 +1324,6 @@ void registerNestedMemberFunctionsForLazy(
 	bool should_register_lazy_members) {
 	for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
 		if (mem_func.is_constructor || mem_func.is_destructor) {
-			if (mem_func.is_constructor)
-				nested_struct_info.addConstructor(mem_func.function_declaration, mem_func.access);
-			else
-				nested_struct_info.addDestructor(mem_func.function_declaration, mem_func.access, mem_func.is_virtual);
-
 			StringHandle member_function_name{};
 			if (mem_func.function_declaration.is<ConstructorDeclarationNode>()) {
 				member_function_name = mem_func.function_declaration.as<ConstructorDeclarationNode>().name();
@@ -1294,39 +1362,34 @@ void registerNestedMemberFunctionsForLazy(
 				LazyMemberInstantiationRegistry::getInstance().registerLazyMember(std::move(lazy_mem_info));
 			}
 
-			// Set is_const/volatile_member_function on the node so propagateAstProperties derives cv_qualifier.
-			{
-				ASTNode fn_node = mem_func.function_declaration;
-				if (auto* fn = get_function_decl_node_mut(fn_node)) {
-					fn->set_is_const_member_function(mem_func.is_const());
-					fn->set_is_volatile_member_function(mem_func.is_volatile());
-				}
-			}
-			if (mem_func.operator_kind != OverloadableOperator::None) {
-				nested_struct_info.addOperatorOverload(
-					mem_func.operator_kind,
-					mem_func.function_declaration,
-					mem_func.access,
-					mem_func.is_virtual,
-					mem_func.is_pure_virtual,
-					mem_func.is_override,
-					mem_func.is_final);
-			} else {
-				nested_struct_info.addMemberFunction(
-					decl.identifier_token().handle(),
-					mem_func.function_declaration,
-					mem_func.access,
-					mem_func.is_virtual,
-					mem_func.is_pure_virtual,
-					mem_func.is_override,
-					mem_func.is_final);
-			}
-			// cv_qualifier is now auto-derived by propagateAstProperties
-
 			FLASH_LOG(Templates, Debug, "Registered lazy member function for nested type: ",
 					  qualified_name, "::", decl.identifier_token().value());
 		}
 	}
+}
+
+template <typename TParams, typename TArgs>
+inline void registerNestedMemberFunctionsForLazy(
+	const StructDeclarationNode& nested_struct,
+	StructTypeInfo& nested_struct_info,
+	StringHandle class_template_name,
+	StringHandle qualified_name,
+	const TParams& template_params,
+	const TArgs& template_args,
+	const TemplateEnvironmentSnapshot* outer_parent_snapshot,
+	bool should_register_lazy_members) {
+	addNestedMemberFunctionsToStructInfo(
+		nested_struct,
+		nested_struct_info,
+		nullptr);
+	registerNestedMemberFunctionsLazyEntries(
+		nested_struct,
+		class_template_name,
+		qualified_name,
+		template_params,
+		template_args,
+		outer_parent_snapshot,
+		should_register_lazy_members);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -246,6 +246,67 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 	return record;
 }
 
+void attachResolvedOrdinaryDirectCallMetadata(
+	ExpressionNode& call_expr,
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const FunctionDeclarationNode& func_decl,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included,
+	std::optional<std::string_view> qualified_name_override) {
+	if (func_decl.has_mangled_name()) {
+		setCallMangledName(call_expr, func_decl.mangled_name());
+	}
+
+	if (qualified_name_override.has_value() && !qualified_name_override->empty()) {
+		setCallQualifiedName(call_expr, *qualified_name_override);
+	} else if (!func_decl.parent_struct_name().empty()) {
+		setCallQualifiedName(
+			call_expr,
+			StringBuilder()
+				.append(func_decl.parent_struct_name())
+				.append("::")
+				.append(func_decl.decl_node().identifier_token().value())
+				.commit());
+	}
+
+	if (std::optional<FunctionCallDefinitionLookupRecord> record =
+			makeFunctionCallDefinitionLookupRecord(
+				definition_context,
+				callee_token,
+				arg_types,
+				has_deferred_template_call_args,
+				ASTNode(&func_decl),
+				ordinary_lookup_included,
+				argument_dependent_lookup_included);
+		record.has_value()) {
+		setCallDefinitionLookupRecord(call_expr, *record);
+	}
+}
+
+void attachResolvedOrdinaryDirectCallMetadata(
+	ExpressionNode& call_expr,
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const FunctionDeclarationNode& func_decl,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included) {
+	attachResolvedOrdinaryDirectCallMetadata(
+		call_expr,
+		definition_context,
+		callee_token,
+		arg_types,
+		has_deferred_template_call_args,
+		func_decl,
+		ordinary_lookup_included,
+		argument_dependent_lookup_included,
+		std::nullopt);
+}
+
 std::optional<DependentUnqualifiedCallLookupRecord> makeDependentUnqualifiedCallLookupRecord(
 	const TemplateDefinitionLookupContext* definition_context,
 	const Token& callee_token,
@@ -4874,6 +4935,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					return ParseResult::error(args_result.error_message, args_result.error_token.value_or(current_token_));
 				}
 				ChunkedVector<ASTNode> args = std::move(args_result.args);
+				std::vector<TypeSpecifierNode> arg_types =
+					apply_lvalue_reference_deduction(args, args_result.arg_types);
+				const bool has_deferred_qualified_call_args =
+					argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 
 				if (!consume(")"_tok)) {
 					return ParseResult::error("Expected ')' after function call arguments", current_token_);
@@ -4883,7 +4949,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (!identifierType.has_value() && current_linkage_ != Linkage::C) {
 					// Build qualified template name
 					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
-					std::vector<TypeSpecifierNode> arg_types = apply_lvalue_reference_deduction(args, args_result.arg_types);
 
 					// If explicit template arguments were provided, use them for instantiation
 					if (template_args.has_value() && !template_args->empty()) {
@@ -4958,8 +5023,17 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (identifierType->is<FunctionDeclarationNode>()) {
 					const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
 					FLASH_LOG(Parser, Debug, "Namespace-qualified function has mangled name: {}, name: {}", func_decl.has_mangled_name(), func_decl.mangled_name());
+					attachResolvedOrdinaryDirectCallMetadata(
+						function_call_node.as<ExpressionNode>(),
+						current_template_definition_lookup_context_,
+						final_identifier,
+						arg_types,
+						has_deferred_qualified_call_args,
+						func_decl,
+						true,
+						false,
+						buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name()));
 					if (func_decl.has_mangled_name()) {
-						setCallMangledName(function_call_node.as<ExpressionNode>(), func_decl.mangled_name());
 						FLASH_LOG(Parser, Debug, "Set mangled name on namespace-qualified call expression: {}", func_decl.mangled_name());
 					}
 				}
@@ -5323,11 +5397,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				const auto& func = template_func_inst->as<FunctionDeclarationNode>();
 				auto function_call_node = emplace_node<ExpressionNode>(
 					makeResolvedCallExpr(func, std::move(args), identifier_token));
-
-				// Set the mangled name on the function call if the instantiated function has one
-				if (func.has_mangled_name()) {
-					setCallMangledName(function_call_node.as<ExpressionNode>(), func.mangled_name());
-				}
+				attachResolvedOrdinaryDirectCallMetadata(
+					function_call_node.as<ExpressionNode>(),
+					current_template_definition_lookup_context_,
+					identifier_token,
+					arg_types,
+					false,
+					func,
+					true,
+					true);
 
 				result = function_call_node;
 				return ParseResult::success(*result);
@@ -5367,9 +5445,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						makeCallExprFromNode(*resolution.selected_overload, std::move(args), identifier_token));
 					if (resolution.selected_overload->is<FunctionDeclarationNode>()) {
 						const auto& func_decl = resolution.selected_overload->as<FunctionDeclarationNode>();
-						if (func_decl.has_mangled_name()) {
-							setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-						}
+						attachResolvedOrdinaryDirectCallMetadata(
+							result->as<ExpressionNode>(),
+							current_template_definition_lookup_context_,
+							identifier_token,
+							arg_types,
+							has_dependent_call_args,
+							func_decl,
+							true,
+							true);
 					}
 					maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 						result->as<ExpressionNode>(),
@@ -5784,9 +5868,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					result = emplace_node<ExpressionNode>(makeCallExprFromNode(*identifierType, std::move(args_ref), identifier_token));
 					if (identifierType->is<FunctionDeclarationNode>()) {
 						const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
-						if (func_decl.has_mangled_name()) {
-							setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-						}
+						attachResolvedOrdinaryDirectCallMetadata(
+							result->as<ExpressionNode>(),
+							current_template_definition_lookup_context_,
+							identifier_token,
+							arg_types,
+							has_deferred_template_call_args,
+							func_decl,
+							true,
+							argumentDependentLookupIncluded);
 					}
 					if (has_deferred_template_call_args) {
 						std::optional<DependentUnqualifiedCallLookupRecord> record =
@@ -5822,24 +5912,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					result = emplace_node<ExpressionNode>(makeCallExprFromNode(resolved_decl, std::move(args_ref), identifier_token));
 					if (resolved_decl.is<FunctionDeclarationNode>()) {
 						const FunctionDeclarationNode& func_decl = resolved_decl.as<FunctionDeclarationNode>();
-						if (func_decl.has_mangled_name()) {
-							setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-						}
-						if (!func_decl.parent_struct_name().empty()) {
-							setCallQualifiedName(result->as<ExpressionNode>(), StringBuilder().append(func_decl.parent_struct_name()).append("::").append(func_decl.decl_node().identifier_token().value()).commit());
-						}
-						if (std::optional<FunctionCallDefinitionLookupRecord> record =
-								makeFunctionCallDefinitionLookupRecord(
-									current_template_definition_lookup_context_,
-									identifier_token,
-									arg_types,
-									has_deferred_template_call_args,
-									resolved_decl,
-									true,
-									argumentDependentLookupIncludedRuntime);
-							record.has_value()) {
-							setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
-						}
+						attachResolvedOrdinaryDirectCallMetadata(
+							result->as<ExpressionNode>(),
+							current_template_definition_lookup_context_,
+							identifier_token,
+							arg_types,
+							has_deferred_template_call_args,
+							func_decl,
+							true,
+							argumentDependentLookupIncludedRuntime);
 					}
 					maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 						result->as<ExpressionNode>(),
@@ -6175,10 +6256,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						const auto& func = template_func_inst->as<FunctionDeclarationNode>();
 						auto function_call_node = emplace_node<ExpressionNode>(
 							makeResolvedCallExpr(func, std::move(args), identifier_token));
-						// Set the mangled name so the IR generator emits the correct symbol.
-						if (func.has_mangled_name()) {
-							setCallMangledName(function_call_node.as<ExpressionNode>(), func.mangled_name());
-						}
+						attachResolvedOrdinaryDirectCallMetadata(
+							function_call_node.as<ExpressionNode>(),
+							current_template_definition_lookup_context_,
+							identifier_token,
+							arg_types,
+							false,
+							func,
+							true,
+							true);
 						result = function_call_node;
 						return ParseResult::success(*result);
 					} else {
@@ -8514,21 +8600,28 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								return *default_args_error;
 							}
 							result = emplace_node<ExpressionNode>(makeResolvedCallExpr(func_decl, std::move(args), identifier_token));
-							if (func_decl.has_mangled_name()) {
-								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-							}
 							std::string_view qualified_owner = func_decl.parent_struct_name();
 							if (qualified_owner.empty() && !member_function_context_stack_.empty()) {
 								qualified_owner = StringTable::getStringView(member_function_context_stack_.back().struct_name);
 							}
+							std::optional<std::string_view> qualified_call_name = std::nullopt;
+							std::string qualified_call_name_storage;
 							if (!qualified_owner.empty()) {
-								setCallQualifiedName(
-									result->as<ExpressionNode>(),
+								qualified_call_name_storage = std::string(
 									StringBuilder()
 										.append(qualified_owner)
 										.append("::")
 										.append(func_decl.decl_node().identifier_token().value())
 										.commit());
+								qualified_call_name = qualified_call_name_storage;
+							}
+							if (func_decl.has_mangled_name()) {
+								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
+							}
+							if (qualified_call_name.has_value() && !qualified_call_name->empty()) {
+								setCallQualifiedName(
+									result->as<ExpressionNode>(),
+									*qualified_call_name);
 							}
 							return ParseResult::success(*result);
 						}
@@ -8646,6 +8739,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									return argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
 										   argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 								};
+								const bool has_deferred_call_args =
+									deleted_call_has_dependent_arguments();
 
 								auto make_late_dependent_call_result = [&]() -> ParseResult {
 									FLASH_LOG(Templates, Debug, "Creating dependent call expression for deleted dependent call to '", identifier_token.value(), "'");
@@ -8744,7 +8839,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										// Check if the function is deleted
 										const FunctionDeclarationNode* func_check = get_function_decl_node(*instantiated_func);
 										if (func_check && func_check->is_deleted()) {
-											if (deleted_call_has_dependent_arguments()) {
+											if (has_deferred_call_args) {
 												return make_late_dependent_call_result();
 											}
 											return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "'", identifier_token);
@@ -8791,18 +8886,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											set_current_struct_qualified_name(struct_name_for_qual);
 										}
 
-										// Copy mangled name if available
 										if (instantiated_func->is<FunctionDeclarationNode>()) {
 											const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
-											if (func_decl.has_mangled_name()) {
-												setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-											}
+											attachResolvedOrdinaryDirectCallMetadata(
+												result->as<ExpressionNode>(),
+												current_template_definition_lookup_context_,
+												identifier_token,
+												arg_types,
+												false,
+												func_decl,
+												true,
+												true);
 										}
 										maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 											result->as<ExpressionNode>(),
 											identifier_token,
-											argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-												argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
+											has_deferred_call_args,
 											current_template_definition_lookup_context_,
 											true,
 											*instantiated_func);
@@ -8907,7 +9006,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											// Check if the function is deleted
 											const FunctionDeclarationNode* func_check = get_function_decl_node(*instantiated_func);
 											if (func_check && func_check->is_deleted()) {
-												if (deleted_call_has_dependent_arguments()) {
+												if (has_deferred_call_args) {
 													return make_late_dependent_call_result();
 												}
 												return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "'", identifier_token);
@@ -8924,25 +9023,27 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											}
 											result = emplace_node<ExpressionNode>(makeCallExprFromNode(*instantiated_func, std::move(args), identifier_token));
 
-											// Copy mangled name if available
 											if (instantiated_func->is<FunctionDeclarationNode>()) {
 												const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
-												if (func_decl.has_mangled_name()) {
-													setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-												}
+												attachResolvedOrdinaryDirectCallMetadata(
+													result->as<ExpressionNode>(),
+													current_template_definition_lookup_context_,
+													identifier_token,
+													arg_types,
+													false,
+													func_decl,
+													true,
+													true);
 											}
 											maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 												result->as<ExpressionNode>(),
 												identifier_token,
-												argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-													argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
+												has_deferred_call_args,
 												current_template_definition_lookup_context_,
 												true,
 												*instantiated_func);
 									} else {
-										bool has_dependent_call_args = argsHaveDeferredTemplateDependency(args, currentTemplateParamNames());
-										if (has_dependent_call_args ||
-											argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+										if (has_deferred_call_args) {
 											FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
 											auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 											auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
@@ -8993,7 +9094,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												// Check if the function is deleted
 												const FunctionDeclarationNode* func_check = get_function_decl_node(*instantiated_func);
 												if (func_check && func_check->is_deleted()) {
-													if (deleted_call_has_dependent_arguments()) {
+													if (has_deferred_call_args) {
 														return make_late_dependent_call_result();
 													}
 													return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "'", identifier_token);
@@ -9005,25 +9106,27 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												}
 												result = emplace_node<ExpressionNode>(makeCallExprFromNode(*instantiated_func, std::move(args), identifier_token));
 
-												// Copy mangled name if available
 												if (instantiated_func->is<FunctionDeclarationNode>()) {
 													const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
-													if (func_decl.has_mangled_name()) {
-														setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-													}
+													attachResolvedOrdinaryDirectCallMetadata(
+														result->as<ExpressionNode>(),
+														current_template_definition_lookup_context_,
+														identifier_token,
+														arg_types,
+														false,
+														func_decl,
+														true,
+														true);
 												}
 												maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 													result->as<ExpressionNode>(),
 													identifier_token,
-													argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-														argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
+													has_deferred_call_args,
 													current_template_definition_lookup_context_,
 													true,
 													*instantiated_func);
 										} else {
-											bool has_dependent_call_args = argsHaveDeferredTemplateDependency(args, currentTemplateParamNames());
-											if (has_dependent_call_args ||
-												argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames())) {
+											if (has_deferred_call_args) {
 												FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
 												auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
 												auto placeholder_decl = emplace_node<DeclarationNode>(type_node, identifier_token);
@@ -9061,18 +9164,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											// This is important for functions in namespaces accessed via using directives
 											if (resolution_result.selected_overload->is<FunctionDeclarationNode>()) {
 												const FunctionDeclarationNode& func_decl = resolution_result.selected_overload->as<FunctionDeclarationNode>();
-												if (func_decl.has_mangled_name()) {
-													setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-												}
-												if (!func_decl.parent_struct_name().empty()) {
-													setCallQualifiedName(result->as<ExpressionNode>(), StringBuilder().append(func_decl.parent_struct_name()).append("::").append(func_decl.decl_node().identifier_token().value()).commit());
-												}
+												attachResolvedOrdinaryDirectCallMetadata(
+													result->as<ExpressionNode>(),
+													current_template_definition_lookup_context_,
+													identifier_token,
+													arg_types,
+													has_deferred_call_args,
+													func_decl,
+													true,
+													true);
 											}
 											maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 												result->as<ExpressionNode>(),
 												identifier_token,
-												argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-													argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
+												has_deferred_call_args,
 												current_template_definition_lookup_context_,
 												true,
 												*resolution_result.selected_overload);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -8604,24 +8604,17 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							if (qualified_owner.empty() && !member_function_context_stack_.empty()) {
 								qualified_owner = StringTable::getStringView(member_function_context_stack_.back().struct_name);
 							}
-							std::optional<std::string_view> qualified_call_name = std::nullopt;
-							std::string qualified_call_name_storage;
+							if (func_decl.has_mangled_name()) {
+								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
+							}
 							if (!qualified_owner.empty()) {
-								qualified_call_name_storage = std::string(
+								setCallQualifiedName(
+									result->as<ExpressionNode>(),
 									StringBuilder()
 										.append(qualified_owner)
 										.append("::")
 										.append(func_decl.decl_node().identifier_token().value())
 										.commit());
-								qualified_call_name = qualified_call_name_storage;
-							}
-							if (func_decl.has_mangled_name()) {
-								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-							}
-							if (qualified_call_name.has_value() && !qualified_call_name->empty()) {
-								setCallQualifiedName(
-									result->as<ExpressionNode>(),
-									*qualified_call_name);
 							}
 							return ParseResult::success(*result);
 						}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2397,14 +2397,29 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					const TemplateFunctionDeclarationNode& tmpl_func = mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
 					const FunctionDeclarationNode& inner_func = tmpl_func.function_decl_node();
 					StringHandle func_name_handle = inner_func.decl_node().identifier_token().handle();
-					struct_info->addMemberFunction(
-						func_name_handle,
+					if (mem_func.operator_kind != OverloadableOperator::None) {
+						struct_info->addOperatorOverload(
+							mem_func.operator_kind,
+							mem_func.function_declaration,
+							mem_func.access,
+							mem_func.is_virtual,
+							mem_func.is_pure_virtual,
+							mem_func.is_override,
+							mem_func.is_final);
+					} else {
+						struct_info->addMemberFunction(
+							func_name_handle,
+							mem_func.function_declaration,
+							mem_func.access,
+							mem_func.is_virtual,
+							mem_func.is_pure_virtual,
+							mem_func.is_override,
+							mem_func.is_final);
+					}
+					registerSourceMemberStructInfoIndex(
+						struct_info_member_identity_maps,
 						mem_func.function_declaration,
-						mem_func.access,
-						mem_func.is_virtual,
-						mem_func.is_pure_virtual,
-						mem_func.is_override,
-						mem_func.is_final);
+						struct_info->member_functions.size() - 1);
 				} else {
 					const FunctionDeclarationNode& orig_func = mem_func.function_declaration.as<FunctionDeclarationNode>();
 					const DeclarationNode& orig_decl = orig_func.decl_node();
@@ -3967,11 +3982,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								mem_func.is_pure_virtual,
 								mem_func.is_override,
 								mem_func.is_final);
-							registerSourceMemberStructInfoIndex(
-								struct_info_member_identity_maps,
-								mem_func.function_declaration,
-								struct_type_info.getStructInfo()->member_functions.size() - 1);
 						}
+						registerSourceMemberStructInfoIndex(
+							struct_info_member_identity_maps,
+							mem_func.function_declaration,
+							struct_type_info.getStructInfo()->member_functions.size() - 1);
 
 						registerMemberTemplateInRegistry(
 							new_template_func,
@@ -4028,11 +4043,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								mem_func.is_pure_virtual,
 								mem_func.is_override,
 								mem_func.is_final);
-							registerSourceMemberStructInfoIndex(
-								struct_info_member_identity_maps,
-								mem_func.function_declaration,
-								struct_type_info.getStructInfo()->member_functions.size() - 1);
 						}
+						registerSourceMemberStructInfoIndex(
+							struct_info_member_identity_maps,
+							mem_func.function_declaration,
+							struct_type_info.getStructInfo()->member_functions.size() - 1);
 
 						registerMemberTemplateInRegistry(
 							new_template_func_no_subst,
@@ -10609,6 +10624,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_override,
 						mem_func.is_final);
 				}
+				registerSourceMemberStructInfoIndex(
+					struct_info_member_identity_maps,
+					mem_func.function_declaration,
+					struct_info_ptr->member_functions.size() - 1);
 
 				// Register with qualified name
 				StringBuilder qualified_name_builder;
@@ -10787,6 +10806,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_override,
 						mem_func.is_final);
 				}
+				registerSourceMemberStructInfoIndex(
+					struct_info_member_identity_maps,
+					mem_func.function_declaration,
+					struct_info_ptr->member_functions.size() - 1);
 
 				// Register with qualified name
 				StringBuilder qualified_name_builder;

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8240,20 +8240,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			SourceMemberIdentityMaps nested_source_member_identity_maps;
 			SourceMemberStructInfoIndexMaps nested_struct_info_member_identity_maps;
+			addNestedMemberFunctionsToStructInfo(
+				nested_struct,
+				*nested_struct_info,
+				&nested_struct_info_member_identity_maps);
 			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
 				registerSourceMemberStubIdentity(
 					nested_source_member_identity_maps,
 					source_member.function_declaration,
 					source_member.function_declaration);
-			}
-			if (nested_struct_info != nullptr &&
-				nested_struct_info->member_functions.size() == nested_source_member_functions.size()) {
-				for (size_t i = 0; i < nested_source_member_functions.size(); ++i) {
-					registerSourceMemberStructInfoIndex(
-						nested_struct_info_member_identity_maps,
-						nested_source_member_functions[i].function_declaration,
-						i);
-				}
 			}
 
 			for (const auto& out_of_line_member : nested_out_of_line_members) {
@@ -8586,9 +8581,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// top-level member functions of the parent template and would otherwise
 			// never be registered, causing link errors when called.
 			TemplateEnvironmentSnapshot outer_parent_snapshot{instantiated_nested_struct_ref.outer_template_environment_snapshot()};
-			registerNestedMemberFunctionsForLazy(
+			registerNestedMemberFunctionsLazyEntries(
 				nested_struct,
-				*nested_struct_info,
 				instantiated_name,
 				qualified_name,
 				effective_template_params,

--- a/tests/test_template_explicit_function_id_definition_bound_ret0.cpp
+++ b/tests/test_template_explicit_function_id_definition_bound_ret0.cpp
@@ -1,0 +1,21 @@
+// Regression: explicit template-id calls inside template bodies must preserve
+// their resolved semantic target through instantiation instead of relying on
+// mangled-name recovery in sema. A later non-template overload with the same
+// name must not steal the call.
+template<class T>
+int explicitTemplateTarget(T) {
+	return 1;
+}
+
+template<class T>
+int callExplicitTemplateTarget(T value) {
+	return explicitTemplateTarget<T>(value) - 1;
+}
+
+int explicitTemplateTarget(int) {
+	return 100;
+}
+
+int main() {
+	return callExplicitTemplateTarget(0);
+}

--- a/tests/test_template_ool_member_template_operator_identity_ret0.cpp
+++ b/tests/test_template_ool_member_template_operator_identity_ret0.cpp
@@ -1,0 +1,48 @@
+// Regression: out-of-line class-template member-template operator() overloads
+// must sync the StructTypeInfo copy through source-member identity instead of
+// replay-source-key recovery after the source declaration is already known.
+struct OolMemberTemplateOperatorIdentityTag {
+	template<class U>
+	struct AddPtr {
+		using type = U*;
+	};
+};
+
+template<class T>
+struct OolMemberTemplateOperatorIdentity {
+	template<class U>
+	int operator()(U seed, typename T::template AddPtr<int>::type value) const;
+
+	template<class U>
+	int operator()(U seed, typename T::template AddPtr<long>::type value) const;
+};
+
+template<class T>
+template<class U>
+int OolMemberTemplateOperatorIdentity<T>::operator()(
+	U seed,
+	typename T::template AddPtr<long>::type value) const {
+	return static_cast<int>(sizeof(*value)) + seed + 10;
+}
+
+template<class T>
+template<class U>
+int OolMemberTemplateOperatorIdentity<T>::operator()(
+	U seed,
+	typename T::template AddPtr<int>::type value) const {
+	return static_cast<int>(sizeof(*value)) + seed + 20;
+}
+
+int main() {
+	int int_value = 0;
+	long long_value = 0;
+	OolMemberTemplateOperatorIdentity<
+		OolMemberTemplateOperatorIdentityTag> value;
+	if (value(1, &int_value) != 25) {
+		return 1;
+	}
+	if (value(2, &long_value) != static_cast<int>(sizeof(long_value)) + 12) {
+		return 2;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary
This branch continues the C++20 template-infrastructure refactor in three connected areas:

- tighten replay identity and `StructTypeInfo` synchronization so covered replay paths stop repairing targets by shape when source-member identity is already known
- stabilize nested template member population so nested replay no longer depends on positional `StructTypeInfo` back-filling
- preserve structured direct-call metadata for more template-owned call materialization paths so sema can reuse definition-bound targets without rebuilding intent from mangled names

## What changed
### Replay / `StructTypeInfo` identity
- tightened top-level replay sync to prefer source-member identity for constructors and member templates
- added focused regression coverage for out-of-line member-template `operator()` identity preservation

### Nested template population
- moved nested class-template member-function population onto the shared insertion/registration path in `ParserTemplateClassShared.h`
- reduced nested replay dependence on late `StructTypeInfo` repair scans and positional index back-fill

### Direct-call metadata preservation
- added a shared helper in `src/Parser_Expr_PrimaryExpr.cpp` for attaching resolved ordinary direct-call metadata
- reused it across template-instantiation, overload-resolution, and namespace-qualified direct-call materializers that already have typed call arguments
- preserved `FunctionCallDefinitionLookupRecord` for these covered paths instead of relying only on `mangled_name`
- added a regression for explicit template-id calls inside template bodies so a later same-name overload cannot steal the definition-bound specialization

## Follow-up noted during review
- `src/Parser_Expr_PrimaryExpr.cpp`: the `resolved_member_function_from_context` fast path still returns with only `mangled_name` / `qualified_name` and does not yet attach `FunctionCallDefinitionLookupRecord`. That keeps one ordinary direct-call parser path outside the new structured-binding model and should be the next direct-call metadata slice.
