### PR TITLE
Continue template direct-call metadata refactor

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -43,6 +43,11 @@ the areas that were previously blocking standards-visible behavior:
   call materialization in the covered template/replay paths now preserve
   `FunctionCallDefinitionLookupRecord`, so sema no longer has to recover those
   definition-bound targets from `call_info.mangled_name`
+- current-member-context static direct-call replay now preserves
+  `FunctionCallDefinitionLookupRecord` in the
+  `resolved_member_function_from_context` fast path, so later recovery does
+  not have to rediscover those definition-bound member targets from
+  `mangled_name`/`qualified_name` compatibility data alone
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
@@ -145,7 +150,7 @@ Remaining near-term scope:
 
 - the remaining compatibility surface is now concentrated in parser paths that
   still stamp only `mangled_name` or `qualified_name` without a typed
-  definition-lookup record, especially current-member-context shortcuts,
+  definition-lookup record, especially qualified-member materializers,
   untyped fallback branches, some qualified member-template call materializers,
   and the user-defined literal operator path
 
@@ -166,7 +171,8 @@ Next direct-call target:
 - trace the remaining `Parser_Expr_PrimaryExpr.cpp` direct-call sites that
   still attach only compatibility metadata, then either preserve a typed
   `FunctionCallDefinitionLookupRecord` there or explicitly document why the
-  call cannot yet carry one
+  call cannot yet carry one; after the current-member-context fast path, the
+  next typed branch to tighten is the remaining qualified-member materializer
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -183,6 +189,7 @@ When changing this area, always rerun:
 - `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
+- `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -198,12 +205,13 @@ When changing this area, always rerun:
 
 1. Finish the remaining parser-side direct-call metadata preservation in the
    still-uncovered resolved-call paths that only stamp `mangled_name` or
-   `qualified_name`, starting with the typed current-member-context /
-   qualified-member materializers and then the untyped fallback branches.
-   Immediate follow-up: convert the `resolved_member_function_from_context`
-   fast path in `Parser_Expr_PrimaryExpr.cpp` to preserve
-   `FunctionCallDefinitionLookupRecord`, and add a focused regression that
-   proves later overloads cannot steal that replayed member call target.
+   `qualified_name`, starting with the remaining typed qualified-member
+   materializers and then the untyped fallback branches.
+   Immediate follow-up: convert the next qualified-member materializer in
+   `Parser_Expr_PrimaryExpr.cpp` to preserve
+   `FunctionCallDefinitionLookupRecord`, and keep using focused regressions
+   where hidden or later same-name overloads could otherwise steal replayed
+   call targets.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -95,6 +95,12 @@ the areas that were previously blocking standards-visible behavior:
   insertion time and lazy-registration split from structural insertion, so the
   nested constructor/member-template replay helpers no longer depend on
   positional back-fill of `StructTypeInfo` indices in that path
+- parser-side pack-expansion handling for ordinary identifier-call and shared
+  argument-list parsing no longer treats "no matching function-parameter pack
+  found" as a successful expansion; unmatched complex expansions now stay as
+  `PackExpansionExprNode` until substitution, and call-site substitution can
+  scalarize the active pack bindings element-by-element instead of silently
+  flattening `expr...` into a single ordinary argument
 
 ## Architectural invariants to preserve
 
@@ -183,6 +189,10 @@ Remaining near-term scope:
   where both `get_expression_type(...)` and `appendFunctionCallArgType(...)`
   still fail, plus any remaining niche qualified/member-template materializers
   outside the now-covered shared helpers
+- the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
+  now fixed at the parser/substitution boundary; future work here should keep
+  pack-expansion ownership at that boundary instead of reintroducing
+  call-specific explicit-template-argument repairs deeper in sema/codegen
 - the remaining sema/codegen boundary sync for direct calls should stay narrow;
   it now operates at whole-call granularity on the exact lowered AST, but the
   long-term target is still to remove even that hook once the remaining
@@ -254,6 +264,10 @@ When changing this area, always rerun:
    otherwise steal replayed call targets. After that, collapse the new
    whole-call sema synchronization hook by proving those paths carry their
    conversion annotations before lowering.
+   Also clean up the remaining legacy parser sites that still hand-roll
+   `expr...` handling (constructor/initializer parsing) so they share the same
+   "expand only when a real function pack matched, otherwise preserve the pack
+   node" rule now enforced in ordinary call parsing.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -69,6 +69,15 @@ the areas that were previously blocking standards-visible behavior:
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
   unresolved terminals instead of reusing the parser-selected target late
+- ordinary direct-call parsing now makes one last structured
+  `appendFunctionCallArgType(...)` pass before dropping to the
+  compatibility-only fallback when primary `get_expression_type(...)`
+  collection fails, shrinking the cases that still lose
+  `FunctionCallDefinitionLookupRecord` just because parser-side type
+  materialization lagged behind
+- string-literal user-defined literal calls now preserve
+  `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
+  name and argument list, instead of carrying only `mangled_name`
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
@@ -167,9 +176,10 @@ Remaining near-term scope:
 
 - the remaining compatibility surface is now concentrated in parser paths that
   still stamp only `mangled_name` or `qualified_name` without a typed
-  definition-lookup record, especially qualified-member materializers,
-  untyped fallback branches, some qualified member-template call materializers,
-  and the user-defined literal operator path
+  definition-lookup record, especially the truly untypable fallback branches
+  where both `get_expression_type(...)` and `appendFunctionCallArgType(...)`
+  still fail, plus any remaining niche qualified/member-template materializers
+  outside the now-covered shared helpers
 - the remaining sema/codegen boundary sync for direct calls should stay narrow;
   it now operates at whole-call granularity on the exact lowered AST, but the
   long-term target is still to remove even that hook once the remaining
@@ -194,8 +204,9 @@ Next direct-call target:
   still attach only compatibility metadata, then either preserve a typed
   `FunctionCallDefinitionLookupRecord` there or explicitly document why the
   call cannot yet carry one; after the current-member-context fast path, the
-  next typed branch to tighten is the remaining manual qualified-member
-  materializer coverage that still bypasses the shared helper
+  remaining highest-value cleanup is the final compatibility-only fallback
+  branches that still cannot produce stable typed arguments even after the
+  structured retry
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -230,16 +241,16 @@ When changing this area, always rerun:
 
 1. Finish the remaining parser-side direct-call metadata preservation in the
    still-uncovered resolved-call paths that only stamp `mangled_name` or
-   `qualified_name`, starting with the remaining typed qualified-member
-   materializers and then the untyped fallback branches.
-   Immediate follow-up: convert the remaining manual compatibility-only
-   qualified-member materializer branches in `Parser_Expr_PrimaryExpr.cpp`
-   that still bypass the shared helper to preserve
-   `FunctionCallDefinitionLookupRecord`, then move on to the untyped fallback
-   branches. Keep using focused regressions where hidden or later same-name
-   overloads could otherwise steal replayed call targets. After that, collapse
-   the new whole-call sema synchronization hook by proving those paths carry
-   their conversion annotations before lowering.
+   `qualified_name`, now focusing on the branches that still cannot assemble
+   stable typed arguments even after the new structured retry pass.
+   Immediate follow-up: audit the last compatibility-only fallback exits in
+   `Parser_Expr_PrimaryExpr.cpp` and either teach them to preserve
+   `FunctionCallDefinitionLookupRecord` or explicitly classify them as
+   unresolved/deferred instead of pretending to be fully resolved calls. Keep
+   using focused regressions where hidden or later same-name overloads could
+   otherwise steal replayed call targets. After that, collapse the new
+   whole-call sema synchronization hook by proving those paths carry their
+   conversion annotations before lowering.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -52,12 +52,15 @@ the areas that were previously blocking standards-visible behavior:
   `FunctionCallDefinitionLookupRecord` creation in that fast path just because
   parser-side `TypeSpecifierNode` materialization has not populated a concrete
   `type_index` yet
-- when a normalized direct call still reaches codegen without a scalar
-  argument-conversion slot, codegen now triggers the same sema single-argument
-  conversion annotator on that exact argument/parameter pair before asserting,
-  which closes the replay hole exposed by the restored
-  `int -> long` current-member static regression while keeping the conversion
-  decision sema-owned
+- the restored `int -> long` current-member static regression no longer relies
+  on a per-argument codegen repair; sema now has a whole-call synchronization
+  hook on the exact `CallExprNode` codegen lowers, and that hook is narrowly
+  limited to definition-bound / qualified / static-member direct calls where
+  the parser already preserves the selected target
+- current-struct explicit member-template materialization now routes its
+  qualified-name override through the shared direct-call metadata helper instead
+  of stamping the qualified name separately before attaching the rest of the
+  call metadata
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
@@ -163,9 +166,11 @@ Remaining near-term scope:
   definition-lookup record, especially qualified-member materializers,
   untyped fallback branches, some qualified member-template call materializers,
   and the user-defined literal operator path
-- the new late sema backfill in direct-call lowering should stay narrow and be
-  retired once the remaining replay/materialization paths reliably preserve or
-  reconstruct the needed argument-conversion annotations earlier
+- the remaining sema/codegen boundary sync for direct calls should stay narrow;
+  it now operates at whole-call granularity on the exact lowered AST, but the
+  long-term target is still to remove even that hook once the remaining
+  replay/materialization paths preserve enough structured call identity that
+  sema never has to resynchronize the lowered node
 
 ### 3. Current-instantiation / unknown-specialization precision
 
@@ -203,6 +208,7 @@ When changing this area, always rerun:
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
+- `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -220,12 +226,13 @@ When changing this area, always rerun:
    still-uncovered resolved-call paths that only stamp `mangled_name` or
    `qualified_name`, starting with the remaining typed qualified-member
    materializers and then the untyped fallback branches.
-   Immediate follow-up: convert the next qualified-member materializer in
-   `Parser_Expr_PrimaryExpr.cpp` to preserve
-   `FunctionCallDefinitionLookupRecord`, and keep using focused regressions
-   where hidden or later same-name overloads could otherwise steal replayed
-   call targets. After that, collapse the new codegen-triggered sema backfill
-   by proving those paths carry their conversion annotations before lowering.
+   Immediate follow-up: convert the next compatibility-only qualified-member
+   or untyped fallback materializer in `Parser_Expr_PrimaryExpr.cpp` to
+   preserve `FunctionCallDefinitionLookupRecord`, and keep using focused
+   regressions where hidden or later same-name overloads could otherwise steal
+   replayed call targets. After that, collapse the new whole-call sema
+   synchronization hook by proving those paths carry their conversion
+   annotations before lowering.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -61,6 +61,10 @@ the areas that were previously blocking standards-visible behavior:
   qualified-name override through the shared direct-call metadata helper instead
   of stamping the qualified name separately before attaching the rest of the
   call metadata
+- the shared qualified member-template call helper now also preserves
+  `FunctionCallDefinitionLookupRecord` when it has a concrete direct-call
+  target plus typed arguments, instead of carrying only
+  `qualified_name`/`mangled_name` compatibility metadata
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
@@ -190,7 +194,8 @@ Next direct-call target:
   still attach only compatibility metadata, then either preserve a typed
   `FunctionCallDefinitionLookupRecord` there or explicitly document why the
   call cannot yet carry one; after the current-member-context fast path, the
-  next typed branch to tighten is the remaining qualified-member materializer
+  next typed branch to tighten is the remaining manual qualified-member
+  materializer coverage that still bypasses the shared helper
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -209,6 +214,7 @@ When changing this area, always rerun:
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
+- `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -226,13 +232,14 @@ When changing this area, always rerun:
    still-uncovered resolved-call paths that only stamp `mangled_name` or
    `qualified_name`, starting with the remaining typed qualified-member
    materializers and then the untyped fallback branches.
-   Immediate follow-up: convert the next compatibility-only qualified-member
-   or untyped fallback materializer in `Parser_Expr_PrimaryExpr.cpp` to
-   preserve `FunctionCallDefinitionLookupRecord`, and keep using focused
-   regressions where hidden or later same-name overloads could otherwise steal
-   replayed call targets. After that, collapse the new whole-call sema
-   synchronization hook by proving those paths carry their conversion
-   annotations before lowering.
+   Immediate follow-up: convert the remaining manual compatibility-only
+   qualified-member materializer branches in `Parser_Expr_PrimaryExpr.cpp`
+   that still bypass the shared helper to preserve
+   `FunctionCallDefinitionLookupRecord`, then move on to the untyped fallback
+   branches. Keep using focused regressions where hidden or later same-name
+   overloads could otherwise steal replayed call targets. After that, collapse
+   the new whole-call sema synchronization hook by proving those paths carry
+   their conversion annotations before lowering.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -75,6 +75,9 @@ the areas that were previously blocking standards-visible behavior:
   collection fails, shrinking the cases that still lose
   `FunctionCallDefinitionLookupRecord` just because parser-side type
   materialization lagged behind
+- that structured retry is now shared with the current-member static fast
+  path as well, so those replay-preserving calls do not regress into a
+  separate weaker argument-typing path
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list, instead of carrying only `mangled_name`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -48,6 +48,16 @@ the areas that were previously blocking standards-visible behavior:
   `resolved_member_function_from_context` fast path, so later recovery does
   not have to rediscover those definition-bound member targets from
   `mangled_name`/`qualified_name` compatibility data alone
+- builtin-like literal/pointer argument types no longer block
+  `FunctionCallDefinitionLookupRecord` creation in that fast path just because
+  parser-side `TypeSpecifierNode` materialization has not populated a concrete
+  `type_index` yet
+- when a normalized direct call still reaches codegen without a scalar
+  argument-conversion slot, codegen now triggers the same sema single-argument
+  conversion annotator on that exact argument/parameter pair before asserting,
+  which closes the replay hole exposed by the restored
+  `int -> long` current-member static regression while keeping the conversion
+  decision sema-owned
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through preserved semantic metadata, typed lookup, or explicit
@@ -153,6 +163,9 @@ Remaining near-term scope:
   definition-lookup record, especially qualified-member materializers,
   untyped fallback branches, some qualified member-template call materializers,
   and the user-defined literal operator path
+- the new late sema backfill in direct-call lowering should stay narrow and be
+  retired once the remaining replay/materialization paths reliably preserve or
+  reconstruct the needed argument-conversion annotations earlier
 
 ### 3. Current-instantiation / unknown-specialization precision
 
@@ -211,7 +224,8 @@ When changing this area, always rerun:
    `Parser_Expr_PrimaryExpr.cpp` to preserve
    `FunctionCallDefinitionLookupRecord`, and keep using focused regressions
    where hidden or later same-name overloads could otherwise steal replayed
-   call targets.
+   call targets. After that, collapse the new codegen-triggered sema backfill
+   by proving those paths carry their conversion annotations before lowering.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -73,6 +73,14 @@ blocking areas:
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
   terminals instead of reusing the parser-selected target late
+- ordinary direct-call parsing now performs one last structured
+  `appendFunctionCallArgType(...)` collection pass before falling back to
+  compatibility-only metadata when primary `get_expression_type(...)` typing
+  fails, reducing the remaining surface where parser materialization lag alone
+  strips away definition-bound call identity
+- string-literal user-defined literal calls now preserve
+  `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
+  name and argument list instead of carrying only `mangled_name`
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
@@ -154,9 +162,10 @@ Remaining near-term scope:
 
 - the remaining compatibility boundary is now concentrated in parser
   materialization paths that still carry only `mangled_name` or
-  `qualified_name`, especially qualified-member materializers, untyped
-  fallbacks, some qualified member-template call materializers, and the
-  user-defined literal operator path
+  `qualified_name`, especially the fallback exits that still cannot assemble
+  stable typed arguments even after the new structured retry pass, plus any
+  remaining niche qualified/member-template materializers that do not yet
+  route through the shared helpers
 - the remaining whole-call sema synchronization hook for direct calls should
   remain temporary; the remaining parser/materialization work should make even
   that narrowed retry unnecessary by ensuring the structured call path already
@@ -178,9 +187,9 @@ Next direct-call target:
 - identify the remaining direct-call parser/materialization sites that still
   reach sema with compatibility-only metadata, then replace each typed case
   with preserved structured target metadata before touching the sema fallback;
-  after the current-member-context fast path, the next typed branch to tighten
-  is the remaining manual qualified-member materializer coverage that still
-  bypasses the shared helper
+  after the now-covered typed qualified-member and string-literal UDL paths,
+  the next target is the final fallback exits that still cannot produce stable
+  typed arguments even after the structured retry
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -224,15 +233,16 @@ For work in this area, rerun:
 ## Next steps
 
 1. Continue eliminating compatibility-only parser metadata in the remaining
-   resolved direct-call sites, starting with the remaining typed
-   qualified-member materializers and then the untyped fallback branches.
-   Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
-   remaining manual compatibility-only qualified-member materializer paths that
-   still bypass the shared helper, then move on to the untyped fallback
-   branches. Keep adding focused regressions for replayed member calls that
-   would otherwise be vulnerable to hidden or later same-name overloads. Once
-   those paths are covered, remove the new whole-call sema synchronization hook
-   by pushing that work back to earlier semantic ownership.
+   resolved direct-call sites, now focusing on the branches that still cannot
+   produce stable typed arguments even after the structured retry pass.
+   Immediate follow-up: audit the last compatibility-only fallback exits in
+   `Parser_Expr_PrimaryExpr.cpp` and either preserve
+   `FunctionCallDefinitionLookupRecord` there or reclassify those calls as
+   unresolved/deferred instead of pretending they are fully resolved. Keep
+   adding focused regressions for replayed calls that would otherwise be
+   vulnerable to hidden or later same-name overloads. Once those paths are
+   covered, remove the new whole-call sema synchronization hook by pushing that
+   work back to earlier semantic ownership.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -48,6 +48,11 @@ blocking areas:
   call materialization in the covered template paths now also preserve
   `FunctionCallDefinitionLookupRecord`, reducing the remaining standards risk
   that sema will reconstruct definition-bound targets from mangled names alone
+- current-member-context static direct-call replay now also preserves
+  `FunctionCallDefinitionLookupRecord` in the
+  `resolved_member_function_from_context` fast path, so sema no longer has to
+  recover those definition-bound member targets from compatibility metadata
+  alone in that route
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
@@ -133,7 +138,7 @@ Remaining near-term scope:
 
 - the remaining compatibility boundary is now concentrated in parser
   materialization paths that still carry only `mangled_name` or
-  `qualified_name`, especially current-member-context shortcuts, untyped
+  `qualified_name`, especially qualified-member materializers, untyped
   fallbacks, some qualified member-template call materializers, and the
   user-defined literal operator path
 
@@ -152,7 +157,9 @@ Next direct-call target:
 
 - identify the remaining direct-call parser/materialization sites that still
   reach sema with compatibility-only metadata, then replace each typed case
-  with preserved structured target metadata before touching the sema fallback
+  with preserved structured target metadata before touching the sema fallback;
+  after the current-member-context fast path, the next typed branch to tighten
+  is the remaining qualified-member materializer coverage
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -179,6 +186,7 @@ For work in this area, rerun:
 - `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
+- `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -193,12 +201,12 @@ For work in this area, rerun:
 ## Next steps
 
 1. Continue eliminating compatibility-only parser metadata in the remaining
-   resolved direct-call sites, starting with the typed current-member-context
-   and qualified-member materializers and then the untyped fallback branches.
+   resolved direct-call sites, starting with the remaining typed
+   qualified-member materializers and then the untyped fallback branches.
    Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
-   `resolved_member_function_from_context` path and add a focused regression
-   for replayed member calls that would otherwise be vulnerable to later
-   same-name overloads.
+   next qualified-member materializer path and keep adding focused regressions
+   for replayed member calls that would otherwise be vulnerable to hidden or
+   later same-name overloads.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -65,6 +65,10 @@ blocking areas:
 - current-struct explicit member-template materialization now routes its
   qualified-name override through the same shared direct-call metadata helper
   that attaches the rest of the structured call metadata
+- the shared qualified member-template call helper now also preserves
+  `FunctionCallDefinitionLookupRecord` when it has a concrete direct-call
+  target plus typed arguments, instead of falling back to
+  `qualified_name`/`mangled_name` compatibility metadata alone
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
@@ -175,7 +179,8 @@ Next direct-call target:
   reach sema with compatibility-only metadata, then replace each typed case
   with preserved structured target metadata before touching the sema fallback;
   after the current-member-context fast path, the next typed branch to tighten
-  is the remaining qualified-member materializer coverage
+  is the remaining manual qualified-member materializer coverage that still
+  bypasses the shared helper
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -204,6 +209,7 @@ For work in this area, rerun:
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
+- `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -221,8 +227,9 @@ For work in this area, rerun:
    resolved direct-call sites, starting with the remaining typed
    qualified-member materializers and then the untyped fallback branches.
    Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
-   next compatibility-only qualified-member or untyped fallback materializer
-   path and keep adding focused regressions for replayed member calls that
+   remaining manual compatibility-only qualified-member materializer paths that
+   still bypass the shared helper, then move on to the untyped fallback
+   branches. Keep adding focused regressions for replayed member calls that
    would otherwise be vulnerable to hidden or later same-name overloads. Once
    those paths are covered, remove the new whole-call sema synchronization hook
    by pushing that work back to earlier semantic ownership.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -57,10 +57,14 @@ blocking areas:
   from carrying `FunctionCallDefinitionLookupRecord` just because the parser
   has not yet materialized a concrete `type_index` for the temporary
   `TypeSpecifierNode`
-- normalized direct-call lowering now asks sema to annotate a missing scalar
-  argument conversion on the exact argument/parameter pair before asserting,
-  which restores the standards-facing `int -> long` current-member static case
-  while keeping conversion policy in sema instead of codegen heuristics
+- the restored `int -> long` current-member static case no longer relies on a
+  per-argument codegen patch; sema now synchronizes the exact lowered
+  `CallExprNode` at whole-call granularity, and that retry is narrowly bounded
+  to definition-bound / qualified / static-member direct calls whose selected
+  target is already preserved on the AST
+- current-struct explicit member-template materialization now routes its
+  qualified-name override through the same shared direct-call metadata helper
+  that attaches the rest of the structured call metadata
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
@@ -149,11 +153,10 @@ Remaining near-term scope:
   `qualified_name`, especially qualified-member materializers, untyped
   fallbacks, some qualified member-template call materializers, and the
   user-defined literal operator path
-- the direct-call lowering backfill added for the restored
-  `test_template_current_member_static_hides_base_overload_ret0.cpp` case
-  should remain temporary; the remaining parser/materialization work should
-  make that late retry unnecessary by ensuring the structured call path already
-  owns the needed argument-conversion annotation
+- the remaining whole-call sema synchronization hook for direct calls should
+  remain temporary; the remaining parser/materialization work should make even
+  that narrowed retry unnecessary by ensuring the structured call path already
+  owns the needed target and argument-conversion state
 
 ### 3. Current-instantiation / unknown-specialization coverage
 
@@ -200,6 +203,7 @@ For work in this area, rerun:
 - `template_lookup_non_dependent_no_rebind_ret0.cpp`
 - `test_template_explicit_function_id_definition_bound_ret0.cpp`
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
+- `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -217,11 +221,11 @@ For work in this area, rerun:
    resolved direct-call sites, starting with the remaining typed
    qualified-member materializers and then the untyped fallback branches.
    Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
-   next qualified-member materializer path and keep adding focused regressions
-   for replayed member calls that would otherwise be vulnerable to hidden or
-   later same-name overloads. Once those paths are covered, remove the new
-   late direct-call conversion-annotation retry by pushing that work back to
-   earlier semantic ownership.
+   next compatibility-only qualified-member or untyped fallback materializer
+   path and keep adding focused regressions for replayed member calls that
+   would otherwise be vulnerable to hidden or later same-name overloads. Once
+   those paths are covered, remove the new whole-call sema synchronization hook
+   by pushing that work back to earlier semantic ownership.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -78,6 +78,9 @@ blocking areas:
   compatibility-only metadata when primary `get_expression_type(...)` typing
   fails, reducing the remaining surface where parser materialization lag alone
   strips away definition-bound call identity
+- that structured retry is now reused by the current-member static fast path
+  too, so definition-bound replay coverage no longer depends on a separate
+  weaker argument-typing branch there
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list instead of carrying only `mangled_name`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -53,6 +53,14 @@ blocking areas:
   `resolved_member_function_from_context` fast path, so sema no longer has to
   recover those definition-bound member targets from compatibility metadata
   alone in that route
+- builtin-like literal/pointer argument types no longer prevent that fast path
+  from carrying `FunctionCallDefinitionLookupRecord` just because the parser
+  has not yet materialized a concrete `type_index` for the temporary
+  `TypeSpecifierNode`
+- normalized direct-call lowering now asks sema to annotate a missing scalar
+  argument conversion on the exact argument/parameter pair before asserting,
+  which restores the standards-facing `int -> long` current-member static case
+  while keeping conversion policy in sema instead of codegen heuristics
 - the final parser-selected non-receiver direct-call fallback in
   `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
   resolve through semantic metadata, typed lookup, or explicit unresolved
@@ -141,6 +149,11 @@ Remaining near-term scope:
   `qualified_name`, especially qualified-member materializers, untyped
   fallbacks, some qualified member-template call materializers, and the
   user-defined literal operator path
+- the direct-call lowering backfill added for the restored
+  `test_template_current_member_static_hides_base_overload_ret0.cpp` case
+  should remain temporary; the remaining parser/materialization work should
+  make that late retry unnecessary by ensuring the structured call path already
+  owns the needed argument-conversion annotation
 
 ### 3. Current-instantiation / unknown-specialization coverage
 
@@ -206,7 +219,9 @@ For work in this area, rerun:
    Immediate follow-up: preserve `FunctionCallDefinitionLookupRecord` in the
    next qualified-member materializer path and keep adding focused regressions
    for replayed member calls that would otherwise be vulnerable to hidden or
-   later same-name overloads.
+   later same-name overloads. Once those paths are covered, remove the new
+   late direct-call conversion-annotation retry by pushing that work back to
+   earlier semantic ownership.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -97,6 +97,11 @@ blocking areas:
   insertion time, and lazy nested-member registration is split from that
   structural insertion so nested constructor/member-template replay no longer
   depends on positional `StructTypeInfo` back-filling in the covered path
+- parser-side call-argument pack expansion now preserves unmatched complex
+  `expr...` nodes until substitution instead of treating "no function-parameter
+  pack matched" as a successful expansion; that closes the standards-visible
+  leak where `typeCode<Rest>()...` in `add3(..., tail)` lost pack semantics
+  before sema could scalarize the bound template pack
 
 ## Highest-value remaining standards gaps
 
@@ -169,6 +174,10 @@ Remaining near-term scope:
   stable typed arguments even after the new structured retry pass, plus any
   remaining niche qualified/member-template materializers that do not yet
   route through the shared helpers
+- the newly fixed explicit-template-argument pack-expansion leak confirms the
+  right layer for this class of problem: preserve the parser-only pack node
+  until substitution instead of teaching deeper sema/template-argument logic to
+  guess when a plain call expression was really meant to be expanded
 - the remaining whole-call sema synchronization hook for direct calls should
   remain temporary; the remaining parser/materialization work should make even
   that narrowed retry unnecessary by ensuring the structured call path already
@@ -246,6 +255,10 @@ For work in this area, rerun:
    vulnerable to hidden or later same-name overloads. Once those paths are
    covered, remove the new whole-call sema synchronization hook by pushing that
    work back to earlier semantic ownership.
+   In parallel with that audit, finish deleting the remaining legacy
+   parser-side `expr...` loops that still duplicate pack-expansion behavior
+   instead of routing through the shared helper and the new "preserve when not
+   truly expandable" rule.
 
 2. Use any concrete failures left after step 1 to drive the next
    current-instantiation / unknown-specialization expansion rather than

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,19 @@
 # Known Issues
 
+## Current-member static replay misses some sema conversion attachment
+While shaping the direct-call metadata refactor for
+`resolved_member_function_from_context`, a nearby gap showed up in a focused
+variant where the preserved current-member target required an `int -> long`
+conversion. The call stayed bound to the intended member, but IR conversion
+failed later with:
+
+`Phase 15: sema missed function call argument conversion (int -> long)`
+
+The committed regression for this slice was rewritten to isolate the metadata
+issue without depending on that separate conversion path. Follow-up should
+trace why replayed current-member static calls can still miss sema-owned
+implicit conversion attachment after the call target has already been fixed.
+
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner
 pointer in `InlineVector::size()` during `materializeMatchingConstructorTemplate`.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,19 +1,5 @@
 # Known Issues
 
-## Current-member static replay misses some sema conversion attachment
-While shaping the direct-call metadata refactor for
-`resolved_member_function_from_context`, a nearby gap showed up in a focused
-variant where the preserved current-member target required an `int -> long`
-conversion. The call stayed bound to the intended member, but IR conversion
-failed later with:
-
-`Phase 15: sema missed function call argument conversion (int -> long)`
-
-The committed regression for this slice was rewritten to isolate the metadata
-issue without depending on that separate conversion path. Follow-up should
-trace why replayed current-member static calls can still miss sema-owned
-implicit conversion attachment after the call target has already been fixed.
-
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner
 pointer in `InlineVector::size()` during `materializeMatchingConstructorTemplate`.

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -67,9 +67,7 @@ inline std::optional<FunctionCallDefinitionLookupRecord> tryBuildFunctionCallDef
 	}
 
 	FunctionCallDefinitionLookupRecord record;
-	if (definition_context != nullptr && definition_context->is_valid()) {
-		record.definition_context = *definition_context;
-	}
+	record.definition_context = *definition_context;
 	record.callee_name = callee_token.handle();
 	record.resolved_function = &func_decl;
 	if (func_decl.has_mangled_name()) {

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -26,6 +26,62 @@ inline const FunctionDeclarationNode* getParserStoredDirectCallTarget(const Call
 	return node.callee().function_declaration_or_null();
 }
 
+inline bool canBuildFunctionCallDefinitionLookupRecord(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args) {
+	if (definition_context == nullptr ||
+		!definition_context->is_valid() ||
+		has_deferred_template_call_args ||
+		callee_token.type() != Token::Type::Identifier) {
+		return false;
+	}
+	for (const TypeSpecifierNode& arg_type : arg_types) {
+		if (arg_type.category() == TypeCategory::Auto ||
+			arg_type.category() == TypeCategory::Template) {
+			return false;
+		}
+		if (!arg_type.type_index().is_valid() &&
+			!is_builtin_type(arg_type.category())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+inline std::optional<FunctionCallDefinitionLookupRecord> tryBuildFunctionCallDefinitionLookupRecord(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const FunctionDeclarationNode& func_decl,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included) {
+	if (!canBuildFunctionCallDefinitionLookupRecord(
+			definition_context,
+			callee_token,
+			arg_types,
+			has_deferred_template_call_args)) {
+		return std::nullopt;
+	}
+
+	FunctionCallDefinitionLookupRecord record;
+	if (definition_context != nullptr && definition_context->is_valid()) {
+		record.definition_context = *definition_context;
+	}
+	record.callee_name = callee_token.handle();
+	record.resolved_function = &func_decl;
+	if (func_decl.has_mangled_name()) {
+		record.resolved_mangled_name =
+			StringTable::getOrInternStringHandle(func_decl.mangled_name());
+	}
+	record.ordinary_lookup_included = ordinary_lookup_included;
+	record.argument_dependent_lookup_included =
+		argument_dependent_lookup_included;
+	return record;
+}
+
 struct CallInfo {
 	// Callee declaration (always present).
 	const DeclarationNode* declaration;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -633,6 +633,96 @@ void ExpressionSubstitutor::substituteCallArgumentPreservingPackExpansion(
 					out)) {
 				return;
 			}
+
+			InlineVector<StringHandle, 4> matched_pack_names;
+			AstTraversal::visitAST(pack_expansion_expr->pattern(), [&](const ASTNode& node) {
+				StringHandle candidate_name;
+				if (node.is<TemplateParameterReferenceNode>()) {
+					candidate_name = node.as<TemplateParameterReferenceNode>().param_name();
+				} else if (node.is<IdentifierNode>()) {
+					candidate_name = node.as<IdentifierNode>().getOrInternNameHandle();
+				} else if (node.is<TypeSpecifierNode>()) {
+					const TypeSpecifierNode& type_spec = node.as<TypeSpecifierNode>();
+					if (!type_spec.token().value().empty()) {
+						candidate_name = StringTable::getOrInternStringHandle(
+							type_spec.token().value());
+					} else if (type_spec.type_index().is_valid()) {
+						if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
+							candidate_name = type_info->name();
+						}
+					}
+				}
+				if (!candidate_name.isValid() ||
+					pack_map_.find(candidate_name) == pack_map_.end()) {
+					return;
+				}
+				for (StringHandle matched_name : matched_pack_names) {
+					if (matched_name == candidate_name) {
+						return;
+					}
+				}
+				matched_pack_names.push_back(candidate_name);
+			});
+
+			if (!matched_pack_names.empty()) {
+				size_t pack_size = pack_map_.find(matched_pack_names[0])->second.size();
+				for (size_t pack_index = 1; pack_index < matched_pack_names.size(); ++pack_index) {
+					size_t current_pack_size =
+						pack_map_.find(matched_pack_names[pack_index])->second.size();
+					if (current_pack_size != pack_size) {
+						throw InternalError(
+							"Mismatched pack sizes while preserving pack expansion during call substitution");
+					}
+				}
+				if (pack_size == 0) {
+					return;
+				}
+
+				InlineVector<std::string_view, 8> ordered_param_names;
+				if (!template_param_order_.empty()) {
+					for (std::string_view param_name : template_param_order_) {
+						ordered_param_names.push_back(param_name);
+					}
+				} else {
+					for (const TemplateBinding& binding : environment_.bindings) {
+						if (!binding.name.isValid()) {
+							continue;
+						}
+						ordered_param_names.push_back(
+							StringTable::getStringView(binding.name));
+					}
+				}
+
+				for (size_t expansion_index = 0; expansion_index < pack_size; ++expansion_index) {
+					std::unordered_map<std::string_view, TemplateTypeArg> scalar_bindings =
+						param_map_;
+					std::unordered_map<StringHandle, std::vector<TemplateTypeArg>, TransparentStringHash, std::equal_to<>> remaining_pack_bindings =
+						pack_map_;
+					for (StringHandle matched_pack_name : matched_pack_names) {
+						auto pack_it = remaining_pack_bindings.find(matched_pack_name);
+						if (pack_it == remaining_pack_bindings.end() ||
+							expansion_index >= pack_it->second.size()) {
+							throw InternalError(
+								"Missing pack element while preserving pack expansion during call substitution");
+						}
+						scalar_bindings[StringTable::getStringView(matched_pack_name)] =
+							pack_it->second[expansion_index];
+						remaining_pack_bindings.erase(pack_it);
+					}
+
+					ExpressionSubstitutor element_substitutor(
+						scalar_bindings,
+						remaining_pack_bindings,
+						parser_,
+						std::span<const std::string_view>(
+							ordered_param_names.data(),
+							ordered_param_names.size()));
+					element_substitutor.setCurrentOwnerTypeName(current_owner_type_name_);
+					out.push_back(element_substitutor.substitute(
+						pack_expansion_expr->pattern()));
+				}
+				return;
+			}
 		}
 	}
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -693,21 +693,24 @@ void ExpressionSubstitutor::substituteCallArgumentPreservingPackExpansion(
 					}
 				}
 
+				std::unordered_map<StringHandle, std::vector<TemplateTypeArg>, TransparentStringHash, std::equal_to<>> remaining_pack_bindings =
+					pack_map_;
+				for (StringHandle matched_pack_name : matched_pack_names) {
+					remaining_pack_bindings.erase(matched_pack_name);
+				}
+
 				for (size_t expansion_index = 0; expansion_index < pack_size; ++expansion_index) {
 					std::unordered_map<std::string_view, TemplateTypeArg> scalar_bindings =
 						param_map_;
-					std::unordered_map<StringHandle, std::vector<TemplateTypeArg>, TransparentStringHash, std::equal_to<>> remaining_pack_bindings =
-						pack_map_;
 					for (StringHandle matched_pack_name : matched_pack_names) {
-						auto pack_it = remaining_pack_bindings.find(matched_pack_name);
-						if (pack_it == remaining_pack_bindings.end() ||
+						auto pack_it = pack_map_.find(matched_pack_name);
+						if (pack_it == pack_map_.end() ||
 							expansion_index >= pack_it->second.size()) {
 							throw InternalError(
 								"Missing pack element while preserving pack expansion during call substitution");
 						}
 						scalar_bindings[StringTable::getStringView(matched_pack_name)] =
 							pack_it->second[expansion_index];
-						remaining_pack_bindings.erase(pack_it);
 					}
 
 					ExpressionSubstitutor element_substitutor(

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1257,6 +1257,10 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 	// Function returns (by value) produce temporaries with no persistent identity
 	setTempVarMetadata(ret_var, TempVarMetadata::makePRValue());
 
+	if (sema_normalized_current_function_) {
+		sema_.ensureCallArgConversionsAnnotated(callExprNode);
+	}
+
 	const std::vector<CachedParamInfo>* cached_param_list = nullptr;
 	{
 		StringHandle cache_key = callExprNode.has_mangled_name()
@@ -1441,28 +1445,6 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			}
 
 			// sema should annotate all resolved standard argument conversions.
-			if (!sema_applied_arg_conversion &&
-				param_ref_qualifier == CVReferenceQualifier::None &&
-				param_type->pointer_depth() == 0 &&
-				arg_type != param_base_type) {
-				TypeConversionResult standard_conversion = can_convert_type(arg_type, param_base_type);
-				if (standard_conversion.is_valid &&
-					standard_conversion.rank != ConversionRank::UserDefined) {
-					if (argument.is<ExpressionNode>()) {
-						const void* key = &argument.as<ExpressionNode>();
-						sema_.ensureSingleArgConversionAnnotated(
-							argument,
-							*param_type,
-							" in function call");
-						if (const auto retry_slot = sema_.getSlot(key);
-							retry_slot.has_value()) {
-							sema_applied_arg_conversion =
-								applySemaAnnotatedArgConversion(*retry_slot);
-						}
-					}
-				}
-			}
-
 			if (!sema_applied_arg_conversion &&
 				param_ref_qualifier == CVReferenceQualifier::None &&
 				param_type->pointer_depth() == 0 &&

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1361,64 +1361,108 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			TypeCategory param_base_type = param_type->type();
 
 			TypeIndex arg_type_index = argumentIrOperands.type_index;
+			auto applySemaAnnotatedArgConversion =
+				[&](const SemanticSlot& slot) -> bool {
+					if (!slot.has_cast()) {
+						return false;
+					}
+					const ImplicitCastInfo& cast_info =
+						sema_.castInfoTable()[slot.cast_info_index.value - 1];
+					TypeCategory from_type =
+						sema_.typeContext().get(cast_info.source_type_id).category();
+					const TypeCategory to_type =
+						sema_.typeContext().get(cast_info.target_type_id).category();
+					if (cast_info.cast_kind == StandardConversionKind::UserDefined &&
+						from_type == TypeCategory::Struct) {
+						TypeIndex source_type_idx =
+							sema_.typeContext().get(cast_info.source_type_id).type_index;
+						if (const TypeInfo* src_type_info = tryGetTypeInfo(source_type_idx)) {
+							const bool source_is_const =
+								((static_cast<uint8_t>(
+									 sema_.typeContext().get(cast_info.source_type_id).base_cv)) &
+								 (static_cast<uint8_t>(CVQualifier::Const))) != 0;
+							const StructMemberFunction* conv_op = findConversionOperator(
+								src_type_info->getStructInfo(),
+								param_type->type_index(),
+								source_is_const);
+							if (conv_op) {
+								FLASH_LOG(
+									Codegen,
+									Debug,
+									"Sema-annotated user-defined conversion in function arg from ",
+									StringTable::getStringView(src_type_info->name()),
+									" to parameter type");
+								const int param_size =
+									static_cast<int>(param_type->size_in_bits());
+								if (auto result = emitConversionOperatorCall(
+										argumentIrOperands,
+										*src_type_info,
+										*conv_op,
+										param_type->type_index(),
+										param_size,
+										callExprNode.called_from())) {
+									argumentIrOperands = *result;
+									arg_type = argumentIrOperands.typeEnum();
+									arg_type_index = argumentIrOperands.type_index;
+									return true;
+								}
+							}
+						}
+						return false;
+					}
+					if (!is_struct_type(from_type) &&
+						!is_struct_type(to_type) &&
+						cast_info.cast_kind != StandardConversionKind::ArrayToPointer) {
+						if (from_type == TypeCategory::Enum &&
+							from_type != argumentIrOperands.typeEnum()) {
+							from_type = argumentIrOperands.typeEnum();
+						}
+						argumentIrOperands = generateTypeConversion(
+							argumentIrOperands,
+							from_type,
+							to_type,
+							callExprNode.called_from());
+						arg_type = argumentIrOperands.typeEnum();
+						arg_type_index = argumentIrOperands.type_index;
+						return true;
+					}
+					return false;
+				};
 
 			// Check sema annotation first: if the semantic pass pre-computed a conversion, use it.
 			bool sema_applied_arg_conversion = false;
 			if (argument.is<ExpressionNode>()) {
 				const void* key = &argument.as<ExpressionNode>();
 				const auto slot = sema_.getSlot(key);
-				if (slot.has_value() && slot->has_cast()) {
-					const ImplicitCastInfo& cast_info =
-						sema_.castInfoTable()[slot->cast_info_index.value - 1];
-					TypeCategory from_type = sema_.typeContext().get(cast_info.source_type_id).category();
-					const TypeCategory to_type = sema_.typeContext().get(cast_info.target_type_id).category();
-					if (cast_info.cast_kind == StandardConversionKind::UserDefined &&
-						from_type == TypeCategory::Struct) {
-							// Sema annotated a user-defined conversion operator call
-						TypeIndex source_type_idx = sema_.typeContext().get(cast_info.source_type_id).type_index;
-						if (const TypeInfo* src_type_info = tryGetTypeInfo(source_type_idx)) {
-							const bool source_is_const = ((static_cast<uint8_t>(sema_.typeContext().get(cast_info.source_type_id).base_cv)) & (static_cast<uint8_t>(CVQualifier::Const))) != 0;
-							const StructMemberFunction* conv_op = findConversionOperator(
-								src_type_info->getStructInfo(), param_type->type_index(), source_is_const);
-							if (conv_op) {
-								FLASH_LOG(Codegen, Debug, "Sema-annotated user-defined conversion in function arg from ",
-										  StringTable::getStringView(src_type_info->name()), " to parameter type");
-								const int param_size = static_cast<int>(param_type->size_in_bits());
-								if (auto result = emitConversionOperatorCall(argumentIrOperands, *src_type_info, *conv_op,
-																			 param_type->type_index(), param_size,
-																			 callExprNode.called_from())) {
-									argumentIrOperands = *result;
-									arg_type = argumentIrOperands.typeEnum();
-									arg_type_index = argumentIrOperands.type_index;
-									sema_applied_arg_conversion = true;
-								}
-							}
-						}
-					} else if (!is_struct_type(from_type) && !is_struct_type(to_type) &&
-								   cast_info.cast_kind != StandardConversionKind::ArrayToPointer) {
-						// Sema may annotate as Type::Enum while codegen resolves enum
-						// constants to their underlying type; use actual runtime type.
-						// NOTE: ArrayToPointer is excluded from generateTypeConversion because that
-						//   function converts between scalar types (e.g. int->long), whereas
-						//   array-to-pointer decay requires emitting an AddressOf IR node to
-						//   materialise the base pointer from a stack-allocated array object.
-						//   Calling generateTypeConversion on an array operand would instead
-						//   integer-widen or reinterpret the value, producing garbage.
-						//   String-literal args already carry a 64-bit TempVar pointer from
-						//   generateStringLiteralIr, so decay is already complete.
-						//   Identifier-array args are handled in the needs_array_decay block
-						//   further below, which calls emitAddressOf to get the base pointer.
-						if (from_type == TypeCategory::Enum && from_type != argumentIrOperands.typeEnum())
-							from_type = argumentIrOperands.typeEnum();
-						argumentIrOperands = generateTypeConversion(argumentIrOperands, from_type, to_type, callExprNode.called_from());
-						arg_type = argumentIrOperands.typeEnum();
-						arg_type_index = argumentIrOperands.type_index;
-						sema_applied_arg_conversion = true;
-					}
+				if (slot.has_value()) {
+					sema_applied_arg_conversion =
+						applySemaAnnotatedArgConversion(*slot);
 				}
 			}
 
 			// sema should annotate all resolved standard argument conversions.
+			if (!sema_applied_arg_conversion &&
+				param_ref_qualifier == CVReferenceQualifier::None &&
+				param_type->pointer_depth() == 0 &&
+				arg_type != param_base_type) {
+				TypeConversionResult standard_conversion = can_convert_type(arg_type, param_base_type);
+				if (standard_conversion.is_valid &&
+					standard_conversion.rank != ConversionRank::UserDefined) {
+					if (argument.is<ExpressionNode>()) {
+						const void* key = &argument.as<ExpressionNode>();
+						sema_.ensureSingleArgConversionAnnotated(
+							argument,
+							*param_type,
+							" in function call");
+						if (const auto retry_slot = sema_.getSlot(key);
+							retry_slot.has_value()) {
+							sema_applied_arg_conversion =
+								applySemaAnnotatedArgConversion(*retry_slot);
+						}
+					}
+				}
+			}
+
 			if (!sema_applied_arg_conversion &&
 				param_ref_qualifier == CVReferenceQualifier::None &&
 				param_type->pointer_depth() == 0 &&

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3283,7 +3283,7 @@ private:	 // Resume private methods
 		return typed_template_parameters;
 	}
 
-	std::vector<ASTNode> expandPackExpressionArgument(const ASTNode& pattern);
+	InlineVector<ASTNode, 4> expandPackExpressionArgument(const ASTNode& pattern);
 
 	// Replace a pack parameter identifier in an expression pattern with its expanded name
 	// e.g., replace "args" with "args_0" in a pattern like identity(args)

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1924,6 +1924,9 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		std::span<const TypeSpecifierNode> arg_types,
 		std::span<const ASTNode> overload_candidates = {});
 	void appendFunctionCallArgType(const ASTNode& arg_node, std::vector<TypeSpecifierNode>* arg_types_out);
+	bool tryCollectOrdinaryDirectCallArgTypes(
+		const ChunkedVector<ASTNode>& args,
+		std::vector<TypeSpecifierNode>* arg_types_out);
 	// Shared helper: re-parse a template function body with concrete argument substitution.
 	// Called from both try_instantiate_template_explicit (preserve_ref_qualifier=true) and
 	// try_instantiate_single_template (preserve_ref_qualifier=false, default) after cycle

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5173,6 +5173,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (auto node = argResult.node()) {
 						// Check for pack expansion: arg...
 						if (current_token_.value() == "...") {
+							Token ellipsis_token = current_token_;
 							advance();  // consume '...'
 							// Mirror append_function_call_argument: use identifier-pack path for
 							// simple packs (correctly handles zero-size packs), expression-pack
@@ -5195,8 +5196,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								}
 							}
 							if (!added) {
-								for (ASTNode expanded_arg : expandPackExpressionArgument(*node)) {
-									args.push_back(std::move(expanded_arg));
+								InlineVector<ASTNode, 4> expanded_args =
+									expandPackExpressionArgument(*node);
+								if (!expanded_args.empty()) {
+									for (ASTNode expanded_arg : expanded_args) {
+										args.push_back(std::move(expanded_arg));
+									}
+								} else {
+									args.push_back(emplace_node<ExpressionNode>(
+										PackExpansionExprNode(*node, ellipsis_token)));
 								}
 							}
 						} else {
@@ -6177,48 +6185,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				return make_call_result(*resolution.selected_overload);
 			};
 
-			auto append_function_call_argument =
-				[&](const ParseResult& arg_result, ChunkedVector<ASTNode>& args_out, std::vector<TypeSpecifierNode>* arg_types_out) -> std::optional<ParseResult> {
-				auto append_single_arg = [&](const ASTNode& node) {
-					args_out.push_back(node);
-					appendFunctionCallArgType(node, arg_types_out);
-				};
-
-				if (peek() == "..."_tok) {
-					advance();
-
-					if (auto arg_node = arg_result.node()) {
-						if (arg_node->is<IdentifierNode>()) {
-							std::string_view pack_name = arg_node->as<IdentifierNode>().name();
-							if (auto identifier_pack_size = get_pack_size(pack_name); identifier_pack_size.has_value()) {
-								StringBuilder sb;
-								for (size_t i = 0; i < *identifier_pack_size; ++i) {
-									std::string_view element_name = sb
-																		.append(pack_name)
-																		.append("_")
-																		.append(i)
-																		.commit();
-
-									Token elem_token(Token::Type::Identifier, element_name, 0, 0, 0);
-									append_single_arg(emplace_node<ExpressionNode>(createBoundIdentifier(elem_token)));
-								}
-							} else {
-								append_single_arg(*arg_node);
-							}
-						} else {
-							std::vector<ASTNode> expanded_args = expandPackExpressionArgument(*arg_node);
-							for (ASTNode& expanded_arg : expanded_args) {
-								append_single_arg(expanded_arg);
-							}
-						}
-					}
-				} else if (auto node = arg_result.node()) {
-					append_single_arg(*node);
-				}
-
-				return std::nullopt;
-			};
-
 			// Check if this is a function call or constructor call (forward reference)
 			// Identifier already consumed at line 1621
 			// Skip this check for lambda variables - they should be handled by postfix operator parsing
@@ -6305,28 +6271,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (peek().is_eof())
 						return ParseResult::error(ParserError::NotImplemented, identifier_token);
 
-					ChunkedVector<ASTNode> args;
-					std::vector<TypeSpecifierNode> arg_types;
-
-					while (current_token_.type() != Token::Type::Punctuator || current_token_.value() != ")") {
-						ParseResult argResult = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-						if (argResult.is_error()) {
-							return argResult;
-						}
-
-						if (auto append_error = append_function_call_argument(argResult, args, &arg_types); append_error.has_value()) {
-							return *append_error;
-						}
-
-						if (current_token_.type() == Token::Type::Punctuator && current_token_.value() == ",") {
-							advance(); // Consume comma
-						} else if (current_token_.type() != Token::Type::Punctuator || current_token_.value() != ")") {
-							return ParseResult::error("Expected ',' or ')' after function argument", current_token_);
-						}
-
-						if (peek().is_eof())
-							return ParseResult::error(ParserError::NotImplemented, Token());
+					auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+						.handle_pack_expansion = true,
+						.collect_types = true,
+						.expand_simple_packs = false});
+					if (!args_result.success) {
+						return ParseResult::error(
+							args_result.error_message,
+							args_result.error_token.value_or(current_token_));
 					}
+					ChunkedVector<ASTNode> args = std::move(args_result.args);
+					std::vector<TypeSpecifierNode> arg_types =
+						apply_lvalue_reference_deduction(args, args_result.arg_types);
 
 					if (!consume(")"_tok)) {
 						return ParseResult::error("Expected ')' after function call arguments", current_token_);
@@ -6394,27 +6350,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (peek().is_eof())
 					return ParseResult::error(ParserError::NotImplemented, identifier_token);
 
-				ChunkedVector<ASTNode> args;
-				std::vector<TypeSpecifierNode> arg_types;
-				while (current_token_.type() != Token::Type::Punctuator || current_token_.value() != ")") {
-					ParseResult argResult = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-					if (argResult.is_error()) {
-						return argResult;
-					}
-
-					if (auto append_error = append_function_call_argument(argResult, args, &arg_types); append_error.has_value()) {
-						return *append_error;
-					}
-
-					if (current_token_.type() == Token::Type::Punctuator && current_token_.value() == ",") {
-						advance(); // Consume comma
-					} else if (current_token_.type() != Token::Type::Punctuator || current_token_.value() != ")") {
-						return ParseResult::error("Expected ',' or ')' after function argument", current_token_);
-					}
-
-					if (peek().is_eof())
-						return ParseResult::error(ParserError::NotImplemented, Token());
+				auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+					.handle_pack_expansion = true,
+					.collect_types = true,
+					.expand_simple_packs = false});
+				if (!args_result.success) {
+					return ParseResult::error(
+						args_result.error_message,
+						args_result.error_token.value_or(current_token_));
 				}
+				ChunkedVector<ASTNode> args = std::move(args_result.args);
+				std::vector<TypeSpecifierNode> arg_types =
+					apply_lvalue_reference_deduction(args, args_result.arg_types);
 
 				if (!consume(")"_tok)) {
 					return ParseResult::error("Expected ')' after function call arguments", current_token_);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -249,6 +249,19 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 	return record;
 }
 
+std::optional<std::string_view> makeQualifiedMemberCallNameOverride(
+	std::string_view owner_name,
+	std::string_view member_name) {
+	if (owner_name.empty()) {
+		return std::nullopt;
+	}
+	return StringBuilder()
+		.append(owner_name)
+		.append("::")
+		.append(member_name)
+		.commit();
+}
+
 void attachResolvedOrdinaryDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,
@@ -8610,14 +8623,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								qualified_owner = StringTable::getStringView(member_function_context_stack_.back().struct_name);
 							}
 							const std::optional<std::string_view> qualified_name_override =
-								qualified_owner.empty()
-									? std::nullopt
-									: std::optional<std::string_view>(
-										StringBuilder()
-											.append(qualified_owner)
-											.append("::")
-											.append(func_decl.decl_node().identifier_token().value())
-											.commit());
+								makeQualifiedMemberCallNameOverride(
+									qualified_owner,
+									func_decl.decl_node().identifier_token().value());
 							std::vector<TypeSpecifierNode> fast_path_arg_types;
 							for (size_t arg_index = 0; arg_index < current_member_call.arguments().size(); ++arg_index) {
 								const ASTNode& arg = current_member_call.arguments()[arg_index];
@@ -8892,17 +8900,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										if (!explicit_template_arg_nodes.empty()) {
 											setCallTemplateArguments(result->as<ExpressionNode>(), std::move(explicit_template_arg_nodes));
 										}
-										auto set_current_struct_qualified_name = [&](std::string_view struct_name) {
-											if (!struct_name.empty()) {
-												setCallQualifiedName(
-													result->as<ExpressionNode>(),
-													StringBuilder()
-														.append(struct_name)
-														.append("::")
-														.append(identifier_token.value())
-														.commit());
-											}
-										};
+										std::optional<std::string_view> qualified_name_override;
 										if (resolved_as_struct_member) {
 											std::string_view struct_name_for_qual;
 											if (!member_function_context_stack_.empty()) {
@@ -8912,7 +8910,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												struct_name_for_qual =
 													struct_parsing_context_stack_.back().struct_name;
 											}
-											set_current_struct_qualified_name(struct_name_for_qual);
+											qualified_name_override =
+												makeQualifiedMemberCallNameOverride(
+													struct_name_for_qual,
+													identifier_token.value());
 										}
 
 										if (instantiated_func->is<FunctionDeclarationNode>()) {
@@ -8925,7 +8926,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												false,
 												func_decl,
 												true,
-												true);
+												true,
+												qualified_name_override);
 										}
 										maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 											result->as<ExpressionNode>(),

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -8600,21 +8600,54 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								return *default_args_error;
 							}
 							result = emplace_node<ExpressionNode>(makeResolvedCallExpr(func_decl, std::move(args), identifier_token));
+							CallExprNode& current_member_call =
+								std::get<CallExprNode>(result->as<ExpressionNode>());
 							std::string_view qualified_owner = func_decl.parent_struct_name();
 							if (qualified_owner.empty() && !member_function_context_stack_.empty()) {
 								qualified_owner = StringTable::getStringView(member_function_context_stack_.back().struct_name);
 							}
-							if (func_decl.has_mangled_name()) {
+							const std::optional<std::string_view> qualified_name_override =
+								qualified_owner.empty()
+									? std::nullopt
+									: std::optional<std::string_view>(
+										StringBuilder()
+											.append(qualified_owner)
+											.append("::")
+											.append(func_decl.decl_node().identifier_token().value())
+											.commit());
+							std::vector<TypeSpecifierNode> fast_path_arg_types;
+							for (size_t arg_index = 0; arg_index < current_member_call.arguments().size(); ++arg_index) {
+								const ASTNode& arg = current_member_call.arguments()[arg_index];
+								const size_t arg_type_count_before = fast_path_arg_types.size();
+								appendFunctionCallArgType(arg, &fast_path_arg_types);
+								if (fast_path_arg_types.size() == arg_type_count_before + 1) {
+									applyIdentifierArgumentArrayBounds(arg, fast_path_arg_types.back());
+								}
+							}
+							const bool has_deferred_fast_path_call_args =
+								argsHaveDeferredTemplateDependency(
+									current_member_call.arguments(),
+									currentTemplateParamNames()) ||
+								argTypesAreDeferredTemplateDependent(
+									fast_path_arg_types,
+									currentTemplateParamNames());
+							if (fast_path_arg_types.size() == current_member_call.arguments().size()) {
+								attachResolvedOrdinaryDirectCallMetadata(
+									result->as<ExpressionNode>(),
+									current_template_definition_lookup_context_,
+									identifier_token,
+									fast_path_arg_types,
+									has_deferred_fast_path_call_args,
+									func_decl,
+									true,
+									false,
+									qualified_name_override);
+							} else if (func_decl.has_mangled_name()) {
 								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 							}
-							if (!qualified_owner.empty()) {
-								setCallQualifiedName(
-									result->as<ExpressionNode>(),
-									StringBuilder()
-										.append(qualified_owner)
-										.append("::")
-										.append(func_decl.decl_node().identifier_token().value())
-										.commit());
+							if (qualified_name_override.has_value() &&
+								!current_member_call.has_qualified_name()) {
+								setCallQualifiedName(result->as<ExpressionNode>(), *qualified_name_override);
 							}
 							return ParseResult::success(*result);
 						}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -183,8 +183,11 @@ bool isEligibleDefinitionLookupCall(
 	}
 	for (const TypeSpecifierNode& arg_type : arg_types) {
 		if (arg_type.category() == TypeCategory::Auto ||
-			arg_type.category() == TypeCategory::Template ||
-			!arg_type.type_index().is_valid()) {
+			arg_type.category() == TypeCategory::Template) {
+			return false;
+		}
+		if (!arg_type.type_index().is_valid() &&
+			!is_builtin_type(arg_type.category())) {
 			return false;
 		}
 	}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -3837,13 +3837,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							// Get the declaration node for the function
 							const DeclarationNode* decl_ptr = nullptr;
 							std::optional<ASTNode> instantiated_member_lookup;
+							std::vector<TypeSpecifierNode> deduced_arg_types =
+								apply_lvalue_reference_deduction(args, args_result.arg_types);
+							const bool has_dependent_call_arg =
+								argTypesAreDeferredTemplateDependent(
+									deduced_arg_types,
+									currentTemplateParamNames());
 							if (member_template_args.has_value()) {
-								std::vector<TypeSpecifierNode> deduced_arg_types =
-									apply_lvalue_reference_deduction(args, args_result.arg_types);
-								const bool has_dependent_call_arg =
-									argTypesAreDeferredTemplateDependent(
-										deduced_arg_types,
-										currentTemplateParamNames());
 								instantiated_member_lookup =
 									tryInstantiateMemberFunctionTemplateCall(
 										gNamespaceRegistry.getQualifiedName(full_ns_handle),
@@ -3930,13 +3930,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									result->as<ExpressionNode>(),
 									std::move(member_template_arg_nodes));
 							}
-
-						// Set mangled name if available
 							if (member_lookup.has_value() && member_lookup->is<FunctionDeclarationNode>()) {
 								const FunctionDeclarationNode& func_decl = member_lookup->as<FunctionDeclarationNode>();
-								if (func_decl.has_mangled_name()) {
-									setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-								}
+								attachResolvedOrdinaryDirectCallMetadata(
+									result->as<ExpressionNode>(),
+									current_template_definition_lookup_context_,
+									member_token,
+									deduced_arg_types,
+									has_dependent_call_arg,
+									func_decl,
+									true,
+									false,
+									buildQualifiedNameFromHandle(
+										full_ns_handle,
+										member_token.value()));
 							}
 
 							return ParseResult::success(*result);
@@ -8685,17 +8692,74 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 							// Extract argument types
 							std::vector<TypeSpecifierNode> arg_types;
+							auto applyLValueArgumentReference =
+								[&](const ASTNode& arg_node, TypeSpecifierNode& arg_type_node) {
+									if (!arg_node.is<ExpressionNode>()) {
+										return;
+									}
+									const ExpressionNode& arg_expr = arg_node.as<ExpressionNode>();
+									bool is_lvalue = std::visit([](const auto& inner) -> bool {
+										using T = std::decay_t<decltype(inner)>;
+										if constexpr (std::is_same_v<T, IdentifierNode>) {
+											return true;
+										} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
+											return true;
+										} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
+											return true;
+										} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
+											return inner.op() == "*" || inner.op() == "++" || inner.op() == "--";
+										} else if constexpr (std::is_same_v<T, StringLiteralNode>) {
+											return true;
+										} else {
+											return false;
+										}
+									},
+																	arg_expr);
+									if (is_lvalue) {
+										arg_type_node.set_reference_qualifier(
+											ReferenceQualifier::LValueReference);
+									}
+								};
+							bool needs_untyped_arg_fallback = false;
 							for (size_t i = 0; i < args.size(); ++i) {
 								auto arg_type = get_expression_type(args[i]);
 								if (!arg_type.has_value()) {
-									// If we can't determine the type, fall back to old behavior
+									needs_untyped_arg_fallback = true;
+									break;
+								}
+
+								TypeSpecifierNode arg_type_node = *arg_type;
+								applyIdentifierArgumentArrayBounds(args[i], arg_type_node);
+
+								FLASH_LOG(Parser, Debug, "  get_expression_type returned: type=", (int)arg_type_node.type(), ", is_ref=", arg_type_node.is_reference(), ", is_rvalue_ref=", arg_type_node.is_rvalue_reference());
+
+								applyLValueArgumentReference(args[i], arg_type_node);
+
+								arg_types.push_back(arg_type_node);
+							}
+							if (needs_untyped_arg_fallback) {
+								std::vector<TypeSpecifierNode> fallback_arg_types;
+								fallback_arg_types.reserve(args.size());
+								for (const ASTNode& arg : args) {
+									const size_t before = fallback_arg_types.size();
+									appendFunctionCallArgType(arg, &fallback_arg_types);
+									if (fallback_arg_types.size() != before + 1 ||
+										fallback_arg_types.back().category() == TypeCategory::Invalid) {
+										fallback_arg_types.clear();
+										break;
+									}
+									applyIdentifierArgumentArrayBounds(arg, fallback_arg_types.back());
+									applyLValueArgumentReference(arg, fallback_arg_types.back());
+								}
+								if (fallback_arg_types.size() == args.size()) {
+									arg_types = std::move(fallback_arg_types);
+								} else {
 									const DeclarationNode* decl_ptr = getDeclarationNode(*identifierType);
 									if (!decl_ptr) {
 										return ParseResult::error("Invalid function declaration", identifier_token);
 									}
-									result = emplace_node<ExpressionNode>(makeCallExprFromNode(*identifierType, std::move(args), identifier_token));
-
-									// Copy mangled name if available
+									result = emplace_node<ExpressionNode>(
+										makeCallExprFromNode(*identifierType, std::move(args), identifier_token));
 									if (identifierType->is<FunctionDeclarationNode>()) {
 										const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
 										if (func_decl.has_mangled_name()) {
@@ -8710,54 +8774,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										current_template_definition_lookup_context_,
 										true,
 										*identifierType);
-									// Return early - we've created the call expression with the args
-									if (result.has_value())
+									if (result.has_value()) {
 										return ParseResult::success(*result);
-									break;
-								}
-
-								TypeSpecifierNode arg_type_node = *arg_type;
-								applyIdentifierArgumentArrayBounds(args[i], arg_type_node);
-
-								FLASH_LOG(Parser, Debug, "  get_expression_type returned: type=", (int)arg_type_node.type(), ", is_ref=", arg_type_node.is_reference(), ", is_rvalue_ref=", arg_type_node.is_rvalue_reference());
-
-								// For perfect forwarding: check if argument is an lvalue
-								// Lvalues: named variables, array subscripts, member access, dereferences, string literals
-								// Rvalues: numeric/bool literals, temporaries, function calls returning non-reference
-								if (args[i].is<ExpressionNode>()) {
-									const ExpressionNode& arg_expr = args[i].as<ExpressionNode>();
-									bool is_lvalue = std::visit([](const auto& inner) -> bool {
-										using T = std::decay_t<decltype(inner)>;
-										if constexpr (std::is_same_v<T, IdentifierNode>) {
-											// Named variables are lvalues
-											return true;
-										} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
-											// Array subscript expressions are lvalues
-											return true;
-										} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
-											// Member access expressions are lvalues
-											return true;
-										} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
-											// Dereference (*ptr) is an lvalue
-											// Other unary operators like ++, --, etc. may also be lvalues
-											return inner.op() == "*" || inner.op() == "++" || inner.op() == "--";
-										} else if constexpr (std::is_same_v<T, StringLiteralNode>) {
-											// String literals are lvalues in C++
-											return true;
-										} else {
-											// All other expressions (literals, temporaries, etc.) are rvalues
-											return false;
-										}
-									},
-																arg_expr);
-
-									if (is_lvalue) {
-										// For forwarding reference deduction: Args&& deduces to T& for lvalues
-										arg_type_node.set_reference_qualifier(ReferenceQualifier::LValueReference);
 									}
 								}
-
-								arg_types.push_back(arg_type_node);
 							}
 
 							// If we successfully extracted all argument types, perform overload resolution
@@ -9327,10 +9347,27 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					result = emplace_node<ExpressionNode>(
 						makeResolvedCallExpr(func_decl, std::move(args), suffix_token));
 
-					// Set mangled name if available
-					if (func_decl.has_mangled_name()) {
-						setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
+					std::vector<TypeSpecifierNode> udl_arg_types;
+					udl_arg_types.reserve(2);
+					for (const ASTNode& arg :
+						 std::get<CallExprNode>(result->as<ExpressionNode>()).arguments()) {
+						appendFunctionCallArgType(arg, &udl_arg_types);
 					}
+					Token operator_name_token(
+						Token::Type::Identifier,
+						operator_name,
+						suffix_token.line(),
+						suffix_token.column(),
+						suffix_token.file_index());
+					attachResolvedOrdinaryDirectCallMetadata(
+						result->as<ExpressionNode>(),
+						current_template_definition_lookup_context_,
+						operator_name_token,
+						udl_arg_types,
+						false,
+						func_decl,
+						true,
+						false);
 				} else {
 					// Operator not found - restore position so suffix token is not lost
 					restore_token_position(pre_suffix_pos);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -21,6 +21,37 @@ void applyDeclarationArrayBoundsToTypeSpec(
 	Parser& parser);
 
 namespace {
+bool expressionYieldsOrdinaryCallLValue(const ExpressionNode& arg_expr) {
+	return std::visit([](const auto& inner) -> bool {
+		using T = std::decay_t<decltype(inner)>;
+		if constexpr (std::is_same_v<T, IdentifierNode>) {
+			return true;
+		} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
+			return true;
+		} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
+			return true;
+		} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
+			return inner.op() == "*" || inner.op() == "++" || inner.op() == "--";
+		} else if constexpr (std::is_same_v<T, StringLiteralNode>) {
+			return true;
+		} else {
+			return false;
+		}
+	},
+					  arg_expr);
+}
+
+void applyOrdinaryCallLValueReference(
+	const ASTNode& arg_node,
+	TypeSpecifierNode& arg_type_node) {
+	if (!arg_node.is<ExpressionNode>()) {
+		return;
+	}
+	if (expressionYieldsOrdinaryCallLValue(arg_node.as<ExpressionNode>())) {
+		arg_type_node.set_reference_qualifier(ReferenceQualifier::LValueReference);
+	}
+}
+
 bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<TemplateTypeArg, 4>& template_args) {
 	return std::any_of(template_args.begin(), template_args.end(), [](const TemplateTypeArg& arg) {
 		return arg.is_pack || templateArgIsStructurallyDependent(arg);
@@ -911,6 +942,48 @@ void Parser::applyIdentifierArgumentArrayBounds(const ASTNode& arg_node, TypeSpe
 	if (const DeclarationNode* decl = get_decl_from_symbol(*sym)) {
 		applyDeclarationArrayBoundsToTypeSpec(*decl, arg_type_node, *this);
 	}
+}
+
+bool Parser::tryCollectOrdinaryDirectCallArgTypes(
+	const ChunkedVector<ASTNode>& args,
+	std::vector<TypeSpecifierNode>* arg_types_out) {
+	if (arg_types_out == nullptr) {
+		return false;
+	}
+	arg_types_out->clear();
+	arg_types_out->reserve(args.size());
+
+	bool needs_structured_fallback = false;
+	for (const ASTNode& arg : args) {
+		std::optional<TypeSpecifierNode> arg_type = get_expression_type(arg);
+		if (!arg_type.has_value()) {
+			needs_structured_fallback = true;
+			break;
+		}
+
+		TypeSpecifierNode arg_type_node = *arg_type;
+		applyIdentifierArgumentArrayBounds(arg, arg_type_node);
+		applyOrdinaryCallLValueReference(arg, arg_type_node);
+		arg_types_out->push_back(arg_type_node);
+	}
+	if (!needs_structured_fallback) {
+		return arg_types_out->size() == args.size();
+	}
+
+	arg_types_out->clear();
+	arg_types_out->reserve(args.size());
+	for (const ASTNode& arg : args) {
+		const size_t before = arg_types_out->size();
+		appendFunctionCallArgType(arg, arg_types_out);
+		if (arg_types_out->size() != before + 1 ||
+			arg_types_out->back().category() == TypeCategory::Invalid) {
+			arg_types_out->clear();
+			return false;
+		}
+		applyIdentifierArgumentArrayBounds(arg, arg_types_out->back());
+		applyOrdinaryCallLValueReference(arg, arg_types_out->back());
+	}
+	return arg_types_out->size() == args.size();
 }
 
 namespace {
@@ -8634,14 +8707,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									qualified_owner,
 									func_decl.decl_node().identifier_token().value());
 							std::vector<TypeSpecifierNode> fast_path_arg_types;
-							for (size_t arg_index = 0; arg_index < current_member_call.arguments().size(); ++arg_index) {
-								const ASTNode& arg = current_member_call.arguments()[arg_index];
-								const size_t arg_type_count_before = fast_path_arg_types.size();
-								appendFunctionCallArgType(arg, &fast_path_arg_types);
-								if (fast_path_arg_types.size() == arg_type_count_before + 1) {
-									applyIdentifierArgumentArrayBounds(arg, fast_path_arg_types.back());
-								}
-							}
+							const bool has_fast_path_arg_types =
+								tryCollectOrdinaryDirectCallArgTypes(
+									current_member_call.arguments(),
+									&fast_path_arg_types);
 							const bool has_deferred_fast_path_call_args =
 								argsHaveDeferredTemplateDependency(
 									current_member_call.arguments(),
@@ -8649,7 +8718,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								argTypesAreDeferredTemplateDependent(
 									fast_path_arg_types,
 									currentTemplateParamNames());
-							if (fast_path_arg_types.size() == current_member_call.arguments().size()) {
+							if (has_fast_path_arg_types) {
 								attachResolvedOrdinaryDirectCallMetadata(
 									result->as<ExpressionNode>(),
 									current_template_definition_lookup_context_,
@@ -8692,68 +8761,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 							// Extract argument types
 							std::vector<TypeSpecifierNode> arg_types;
-							auto applyLValueArgumentReference =
-								[&](const ASTNode& arg_node, TypeSpecifierNode& arg_type_node) {
-									if (!arg_node.is<ExpressionNode>()) {
-										return;
-									}
-									const ExpressionNode& arg_expr = arg_node.as<ExpressionNode>();
-									bool is_lvalue = std::visit([](const auto& inner) -> bool {
-										using T = std::decay_t<decltype(inner)>;
-										if constexpr (std::is_same_v<T, IdentifierNode>) {
-											return true;
-										} else if constexpr (std::is_same_v<T, ArraySubscriptNode>) {
-											return true;
-										} else if constexpr (std::is_same_v<T, MemberAccessNode>) {
-											return true;
-										} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
-											return inner.op() == "*" || inner.op() == "++" || inner.op() == "--";
-										} else if constexpr (std::is_same_v<T, StringLiteralNode>) {
-											return true;
-										} else {
-											return false;
-										}
-									},
-																	arg_expr);
-									if (is_lvalue) {
-										arg_type_node.set_reference_qualifier(
-											ReferenceQualifier::LValueReference);
-									}
-								};
-							bool needs_untyped_arg_fallback = false;
-							for (size_t i = 0; i < args.size(); ++i) {
-								auto arg_type = get_expression_type(args[i]);
-								if (!arg_type.has_value()) {
-									needs_untyped_arg_fallback = true;
-									break;
-								}
-
-								TypeSpecifierNode arg_type_node = *arg_type;
-								applyIdentifierArgumentArrayBounds(args[i], arg_type_node);
-
-								FLASH_LOG(Parser, Debug, "  get_expression_type returned: type=", (int)arg_type_node.type(), ", is_ref=", arg_type_node.is_reference(), ", is_rvalue_ref=", arg_type_node.is_rvalue_reference());
-
-								applyLValueArgumentReference(args[i], arg_type_node);
-
-								arg_types.push_back(arg_type_node);
-							}
-							if (needs_untyped_arg_fallback) {
-								std::vector<TypeSpecifierNode> fallback_arg_types;
-								fallback_arg_types.reserve(args.size());
-								for (const ASTNode& arg : args) {
-									const size_t before = fallback_arg_types.size();
-									appendFunctionCallArgType(arg, &fallback_arg_types);
-									if (fallback_arg_types.size() != before + 1 ||
-										fallback_arg_types.back().category() == TypeCategory::Invalid) {
-										fallback_arg_types.clear();
-										break;
-									}
-									applyIdentifierArgumentArrayBounds(arg, fallback_arg_types.back());
-									applyLValueArgumentReference(arg, fallback_arg_types.back());
-								}
-								if (fallback_arg_types.size() == args.size()) {
-									arg_types = std::move(fallback_arg_types);
-								} else {
+							if (!tryCollectOrdinaryDirectCallArgTypes(args, &arg_types)) {
 									const DeclarationNode* decl_ptr = getDeclarationNode(*identifierType);
 									if (!decl_ptr) {
 										return ParseResult::error("Invalid function declaration", identifier_token);
@@ -8777,7 +8785,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									if (result.has_value()) {
 										return ParseResult::success(*result);
 									}
-								}
 							}
 
 							// If we successfully extracted all argument types, perform overload resolution

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -393,6 +393,20 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	if (func_decl_ptr && func_decl_ptr->has_mangled_name()) {
 		setCallMangledName(result.as<ExpressionNode>(), func_decl_ptr->mangled_name());
 	}
+	if (func_decl_ptr) {
+		if (std::optional<FunctionCallDefinitionLookupRecord> record =
+				tryBuildFunctionCallDefinitionLookupRecord(
+					current_template_definition_lookup_context_,
+					member_token,
+					deduced_arg_types,
+					has_dependent_call_arg,
+					*func_decl_ptr,
+					true,
+					false);
+			record.has_value()) {
+			setCallDefinitionLookupRecord(result.as<ExpressionNode>(), *record);
+		}
+	}
 
 	return ParseResult::success(result);
 }

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2835,6 +2835,12 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 		// For constructor calls like Widget(42), return the type being constructed
 		const auto& ctor_call = std::get<ConstructorCallNode>(expr);
 		return ctor_call.type_node();
+	} else if (std::holds_alternative<InitializerListConstructionNode>(expr)) {
+		const auto& init_list = std::get<InitializerListConstructionNode>(expr);
+		if (init_list.target_type().is<TypeSpecifierNode>()) {
+			return init_list.target_type().as<TypeSpecifierNode>();
+		}
+		return std::nullopt;
 	} else if (std::holds_alternative<StaticCastNode>(expr)) {
 		// For cast expressions like (Type)expr or static_cast<Type>(expr), return the target type
 		const auto& cast = std::get<StaticCastNode>(expr);

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -297,30 +297,9 @@ FlashCpp::ParsedFunctionArguments Parser::parse_function_arguments(const FlashCp
 						pack_name = std::get<IdentifierNode>(arg->as<ExpressionNode>()).name();
 					}
 					if (!pack_name.empty()) {
-
-					// Try to find expanded pack elements in the symbol table
-					// Pattern: pack_name_0, pack_name_1, etc.
-						size_t pack_size = 0;
-						StringBuilder sb;
-						for (size_t i = 0; i < MAX_PACK_ELEMENTS; ++i) {
-							std::string_view element_name = sb
-																.append(pack_name)
-																.append("_")
-																.append(i)
-																.preview();
-
-							if (gSymbolTable.lookup(element_name).has_value()) {
-								++pack_size;
-								sb.reset();
-							} else {
-								break;
-							}
-						}
-						sb.reset();
-
-						if (pack_size > 0) {
-						// Add each pack element as a separate argument
-							for (size_t i = 0; i < pack_size; ++i) {
+						if (std::optional<size_t> pack_size = get_pack_size(pack_name);
+							pack_size.has_value()) {
+							for (size_t i = 0; i < *pack_size; ++i) {
 								std::string_view element_name = StringBuilder()
 																	.append(pack_name)
 																	.append("_")
@@ -344,8 +323,72 @@ FlashCpp::ParsedFunctionArguments Parser::parse_function_arguments(const FlashCp
 								}
 							}
 							expanded = true;
+						} else {
+							// Fallback for older parser flows that still materialize pack
+							// elements in the symbol table without active pack metadata.
+							size_t symbol_pack_size = 0;
+							StringBuilder sb;
+							for (size_t i = 0; i < MAX_PACK_ELEMENTS; ++i) {
+								std::string_view element_name = sb
+																	.append(pack_name)
+																	.append("_")
+																	.append(i)
+																	.preview();
+
+								if (gSymbolTable.lookup(element_name).has_value()) {
+									++symbol_pack_size;
+									sb.reset();
+								} else {
+									break;
+								}
+							}
+							sb.reset();
+
+							if (symbol_pack_size > 0) {
+								for (size_t i = 0; i < symbol_pack_size; ++i) {
+									std::string_view element_name = StringBuilder()
+																		.append(pack_name)
+																		.append("_")
+																		.append(i)
+																		.commit();
+
+									Token elem_token(Token::Type::Identifier, element_name,
+													 ellipsis_token.line(), ellipsis_token.column(), ellipsis_token.file_index());
+									auto elem_node = emplace_node<ExpressionNode>(IdentifierNode(elem_token));
+									args.push_back(elem_node);
+
+									if (ctx.collect_types) {
+										std::optional<TypeSpecifierNode> elem_type = get_expression_type(elem_node);
+										if (elem_type.has_value()) {
+											arg_types.push_back(*elem_type);
+										} else {
+											arg_types.emplace_back(TypeCategory::Int, TypeQualifier::None, 32, ellipsis_token, CVQualifier::None);
+										}
+									}
+								}
+								expanded = true;
+							}
 						}
 					} // !pack_name.empty()
+
+					if (!expanded && !pack_param_info_.empty()) {
+						InlineVector<ASTNode, 4> expanded_args = expandPackExpressionArgument(*arg);
+						if (!expanded_args.empty()) {
+							for (const ASTNode& expanded_arg : expanded_args) {
+								args.push_back(expanded_arg);
+								if (ctx.collect_types) {
+									std::optional<TypeSpecifierNode> expanded_arg_type =
+										get_expression_type(expanded_arg);
+									if (expanded_arg_type.has_value()) {
+										arg_types.push_back(*expanded_arg_type);
+									} else {
+										arg_types.emplace_back(TypeCategory::Int, TypeQualifier::None, 32, ellipsis_token, CVQualifier::None);
+									}
+								}
+							}
+							expanded = true;
+						}
+					}
 				}
 
 				if (!expanded) {

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1384,6 +1384,7 @@ std::optional<ASTNode> Parser::parse_direct_initialization() {
 		if (auto arg_node = arg_result.node()) {
 			// Handle pack expansion: arg...
 			if (current_token_.value() == "...") {
+				Token ellipsis_token = current_token_;
 				advance();  // consume '...'
 				// Mirror append_function_call_argument: use identifier-pack path for simple
 				// packs (correctly handles zero-size packs), expression-pack path for complex.
@@ -1405,8 +1406,15 @@ std::optional<ASTNode> Parser::parse_direct_initialization() {
 					}
 				}
 				if (!added) {
-					for (ASTNode expanded : expandPackExpressionArgument(*arg_node)) {
-						init_list_ref.add_initializer(expanded);
+					InlineVector<ASTNode, 4> expanded_args =
+						expandPackExpressionArgument(*arg_node);
+					if (!expanded_args.empty()) {
+						for (ASTNode expanded : expanded_args) {
+							init_list_ref.add_initializer(expanded);
+						}
+					} else {
+						init_list_ref.add_initializer(emplace_node<ExpressionNode>(
+							PackExpansionExprNode(*arg_node, ellipsis_token)));
 					}
 				}
 			} else {

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -2510,8 +2510,8 @@ ASTNode Parser::replacePackIdentifierInExpr(const ASTNode& expr, std::string_vie
 }
 
 
-std::vector<ASTNode> Parser::expandPackExpressionArgument(const ASTNode& pattern) {
-	std::vector<const PackParamInfo*> packs_in_expr;
+InlineVector<ASTNode, 4> Parser::expandPackExpressionArgument(const ASTNode& pattern) {
+	InlineVector<const PackParamInfo*, 4> packs_in_expr;
 	for (const auto& pack_info : pack_param_info_) {
 		if (pack_info.pack_size > 0 && exprContainsIdentifier(pattern, pack_info.original_name)) {
 			packs_in_expr.push_back(&pack_info);
@@ -2519,7 +2519,7 @@ std::vector<ASTNode> Parser::expandPackExpressionArgument(const ASTNode& pattern
 	}
 
 	if (packs_in_expr.empty()) {
-		return {pattern};
+		return {};
 	}
 
 	size_t pack_size = packs_in_expr[0]->pack_size;
@@ -2530,7 +2530,7 @@ std::vector<ASTNode> Parser::expandPackExpressionArgument(const ASTNode& pattern
 		}
 	}
 
-	std::vector<ASTNode> expanded_args;
+	InlineVector<ASTNode, 4> expanded_args;
 	expanded_args.reserve(pack_size);
 	for (size_t i = 0; i < pack_size; ++i) {
 		ASTNode expanded_pattern = pattern;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4178,6 +4178,13 @@ CanonicalTypeId SemanticAnalysis::canonicalizeTypeForImplicitConversion(const Ty
 	return canonicalizeType(type);
 }
 
+void SemanticAnalysis::ensureSingleArgConversionAnnotated(
+	const ASTNode& arg,
+	const TypeSpecifierNode& param_type,
+	const char* context_description) {
+	tryAnnotateSingleArgConversion(arg, param_type, context_description);
+}
+
 std::optional<SemanticSlot> SemanticAnalysis::getSlot(const void* key) const {
 	auto it = semantic_slots_.find(key);
 	if (it != semantic_slots_.end())
@@ -8105,8 +8112,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 
 		return nullptr;
 	}
-	if (!normalized_call &&
-		!call_info.is_indirect &&
+	if (!call_info.is_indirect &&
 		!call_info.has_receiver &&
 		definition_lookup_record_target != nullptr) {
 		return definition_lookup_record_target;
@@ -8167,11 +8173,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 
-	if (!normalized_call) {
-		if (const FunctionDeclarationNode* mangled_candidate =
-				lookupFunctionByMangledName(call_info.mangled_name)) {
-			return mangled_candidate;
-		}
+	if (const FunctionDeclarationNode* mangled_candidate =
+			lookupFunctionByMangledName(call_info.mangled_name)) {
+		return mangled_candidate;
 	}
 
 	const DeclarationNode& decl = callee_decl;
@@ -8180,6 +8184,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 									  ? call_info.qualified_name.view()
 									  : decl.identifier_token().value();
 	std::vector<ASTNode> overloads;
+	bool used_qualified_owner_static_member_lookup = false;
 	if (call_info.qualified_name.isValid()) {
 		if (const std::optional<QualifiedLookupTarget> qualified_lookup =
 				resolveQualifiedLookupTarget(call_info.qualified_name.view());
@@ -8187,6 +8192,45 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			overloads = symbols_.lookup_qualified_all(
 				qualified_lookup->namespace_handle,
 				qualified_lookup->identifier);
+		}
+		if (overloads.empty()) {
+			const std::string_view qualified_name = call_info.qualified_name.view();
+			const size_t scope_sep = qualified_name.rfind("::");
+			if (scope_sep != std::string_view::npos) {
+				const std::string_view owner_name = qualified_name.substr(0, scope_sep);
+				if (const TypeInfo* owner_type = resolveQualifiedOwnerTypeForCall(owner_name);
+					owner_type != nullptr &&
+					owner_type->getStructInfo() != nullptr) {
+					const ConstAwareMemberCandidateSet member_candidates =
+						collectConstAwareVisibleMemberFunctionCandidates(
+							owner_type->getStructInfo(),
+							decl.identifier_token().handle(),
+							false,
+							true,
+							[](const StructMemberFunction&, const FunctionDeclarationNode& func_decl) {
+								return func_decl.is_static();
+							});
+					if (!member_candidates.compatible.empty()) {
+						for (const StructMemberFunction* member_candidate :
+							 member_candidates.preferred) {
+							if (member_candidate != nullptr) {
+								appendUniqueOverload(
+									overloads,
+									member_candidate->function_decl);
+							}
+						}
+						for (const StructMemberFunction* member_candidate :
+							 member_candidates.compatible) {
+							if (member_candidate != nullptr) {
+								appendUniqueOverload(
+									overloads,
+									member_candidate->function_decl);
+							}
+						}
+						used_qualified_owner_static_member_lookup = true;
+					}
+				}
+			}
 		}
 	}
 	if (overloads.empty()) {
@@ -8198,7 +8242,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			overloads = symbols_.lookup_all(unqualified_name);
 		}
 	}
-	if (overloads.empty() && call_info.qualified_name.isValid()) {
+	if (overloads.empty() &&
+		call_info.qualified_name.isValid() &&
+		!used_qualified_owner_static_member_lookup) {
 		const std::string_view qualified_name = call_info.qualified_name.view();
 		const size_t scope_sep = qualified_name.rfind("::");
 		if (scope_sep != std::string_view::npos) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4178,18 +4178,45 @@ CanonicalTypeId SemanticAnalysis::canonicalizeTypeForImplicitConversion(const Ty
 	return canonicalizeType(type);
 }
 
-void SemanticAnalysis::ensureSingleArgConversionAnnotated(
-	const ASTNode& arg,
-	const TypeSpecifierNode& param_type,
-	const char* context_description) {
-	tryAnnotateSingleArgConversion(arg, param_type, context_description);
-}
-
 std::optional<SemanticSlot> SemanticAnalysis::getSlot(const void* key) const {
 	auto it = semantic_slots_.find(key);
 	if (it != semantic_slots_.end())
 		return it->second;
 	return std::nullopt;
+}
+
+void SemanticAnalysis::ensureCallArgConversionsAnnotated(
+	const CallExprNode& call_node) {
+	tryAnnotateCallArgConversions(call_node);
+	const FunctionDeclarationNode* parser_target =
+		getParserStoredDirectCallTarget(call_node);
+	if (parser_target == nullptr ||
+		call_node.has_receiver() ||
+		call_node.callee().is_indirect()) {
+		return;
+	}
+	const bool has_definition_bound_metadata =
+		call_node.has_definition_lookup_record();
+	const bool has_qualified_name = call_node.has_qualified_name();
+	const bool is_static_member_direct_call =
+		!parser_target->parent_struct_name().empty() &&
+		parser_target->is_static();
+	if (!has_definition_bound_metadata &&
+		!has_qualified_name &&
+		!is_static_member_direct_call) {
+		return;
+	}
+	annotateResolvedCallResultType(ASTNode(&call_node), *parser_target);
+	annotateResolvedCallArgConversions(
+		&call_node,
+		call_node.arguments(),
+		*parser_target,
+		" in call argument");
+	ensureResolvedCallArgConversionsComplete(
+		&call_node,
+		call_node.arguments(),
+		*parser_target,
+		" in call argument");
 }
 
 namespace {
@@ -7727,7 +7754,18 @@ void SemanticAnalysis::tryAnnotateSingleArgConversion(const ASTNode& arg,
 	}
 
 	const CanonicalTypeId param_type_id = canonicalizeType(param_type);
-	const CanonicalTypeId arg_type_id = inferExpressionType(arg);
+	std::optional<TypeSpecifierNode> arg_binding_type;
+	CanonicalTypeId arg_type_id{};
+	if (std::optional<TypeSpecifierNode> resolved_arg_binding_type =
+			buildOverloadResolutionArgType(arg, &arg_type_id);
+		resolved_arg_binding_type.has_value()) {
+		arg_binding_type = *resolved_arg_binding_type;
+		TypeSpecifierNode arg_value_type = *arg_binding_type;
+		arg_value_type.set_reference_qualifier(ReferenceQualifier::None);
+		if (const CanonicalTypeId arg_value_type_id = canonicalizeType(arg_value_type)) {
+			arg_type_id = arg_value_type_id;
+		}
+	}
 	// Skip conversion annotation only when types truly match AND the source is not an array.
 	// An array source (e.g. char[5]) may need to decay to a pointer (const char*) even when
 	// canonical_types_match returns true due to the hybrid pointer+array descriptor produced
@@ -7739,8 +7777,32 @@ void SemanticAnalysis::tryAnnotateSingleArgConversion(const ASTNode& arg,
 
 	if (!tryAnnotateCopyInitConvertingConstructor(arg, param_type_id,
 												  context_description, arg_type_id)) {
-		tryAnnotateConversion(arg, param_type_id, arg_type_id);
+		const bool annotated_standard_conversion =
+			tryAnnotateConversion(arg, param_type_id, arg_type_id);
 		diagnoseScopedEnumConversion(arg, param_type_id, context_description, arg_type_id);
+		if (!annotated_standard_conversion &&
+			arg_binding_type.has_value() &&
+			param_type_id) {
+			TypeSpecifierNode arg_value_type = *arg_binding_type;
+			arg_value_type.set_reference_qualifier(ReferenceQualifier::None);
+			TypeSpecifierNode param_value_type = param_type;
+			param_value_type.set_reference_qualifier(ReferenceQualifier::None);
+			const ConversionPlan plan =
+				buildConversionPlan(arg_value_type, param_value_type);
+			if (plan.is_valid &&
+				plan.rank != ConversionRank::UserDefined &&
+				plan.kind != StandardConversionKind::None) {
+				SemanticSlot slot =
+					getSlot(getExpressionKey(arg)).value_or(SemanticSlot{});
+				slot.type_id = param_type_id;
+				slot.cast_info_index = allocateNonUserDefinedCastInfo(
+					arg_type_id,
+					param_type_id,
+					plan.kind);
+				slot.value_category = ValueCategory::PRValue;
+				setSlot(getExpressionKey(arg), slot);
+			}
+		}
 	}
 }
 
@@ -7822,6 +7884,98 @@ void SemanticAnalysis::annotateResolvedCallArgConversions(const void* call_key,
 
 		tryAnnotateSingleArgConversion(arg, param_type, context_description);
 		buildOverloadResolutionArgType(arg, nullptr);
+	}
+}
+
+void SemanticAnalysis::ensureResolvedCallArgConversionsComplete(
+	const void* call_key,
+	const ChunkedVector<ASTNode>& arguments,
+	const FunctionDeclarationNode& func_decl,
+	const char* context_description) {
+	const auto& param_nodes = func_decl.parameter_nodes();
+	if (arguments.size() < countMinRequiredArgs(func_decl))
+		return;
+	if (!func_decl.is_variadic() && arguments.size() > param_nodes.size())
+		return;
+
+	const size_t annotate_arg_count = std::min(arguments.size(), param_nodes.size());
+	auto& ref_bindings = call_ref_bindings_[call_key];
+	if (ref_bindings.size() < annotate_arg_count) {
+		ref_bindings.resize(annotate_arg_count);
+	}
+
+	const bool normalized_call =
+		call_key != nullptr &&
+		normalized_ast_nodes_.count(call_key) > 0;
+
+	for (size_t i = 0; i < annotate_arg_count; ++i) {
+		const ASTNode& arg = arguments[i];
+		if (!arg.is<ExpressionNode>())
+			continue;
+
+		const ASTNode& param_node = param_nodes[i];
+		if (!param_node.is<DeclarationNode>())
+			continue;
+		const ASTNode param_type_node = param_node.as<DeclarationNode>().type_node();
+		if (!param_type_node.has_value() || !param_type_node.is<TypeSpecifierNode>())
+			continue;
+		const TypeSpecifierNode& param_type = param_type_node.as<TypeSpecifierNode>();
+
+		if (param_type.is_reference() || param_type.is_rvalue_reference()) {
+			if (!ref_bindings[i].is_valid()) {
+				if (auto binding =
+						buildCallArgReferenceBinding(arg, param_type, context_description);
+					binding.has_value()) {
+					ref_bindings[i] = *binding;
+				}
+			}
+			continue;
+		}
+
+		tryAnnotateSingleArgConversion(arg, param_type, context_description);
+		if (!normalized_call) {
+			continue;
+		}
+
+		CanonicalTypeId arg_type_id{};
+		std::optional<TypeSpecifierNode> arg_binding_type =
+			buildOverloadResolutionArgType(arg, &arg_type_id);
+		if (!arg_binding_type.has_value()) {
+			continue;
+		}
+		TypeSpecifierNode arg_value_type = *arg_binding_type;
+		arg_value_type.set_reference_qualifier(ReferenceQualifier::None);
+		const CanonicalTypeId arg_value_type_id = canonicalizeType(arg_value_type);
+		const CanonicalTypeId param_type_id = canonicalizeType(param_type);
+		if (!arg_value_type_id || !param_type_id) {
+			continue;
+		}
+
+		const CanonicalTypeDesc& arg_desc = type_context_.get(arg_value_type_id);
+		if (canonical_types_match(arg_value_type_id, param_type_id) &&
+			arg_desc.array_dimensions.empty()) {
+			continue;
+		}
+
+		const SemanticSlot slot =
+			getSlot(static_cast<const void*>(&arg.as<ExpressionNode>()))
+				.value_or(SemanticSlot{});
+		if (slot.has_cast()) {
+			continue;
+		}
+
+		TypeSpecifierNode param_value_type = param_type;
+		param_value_type.set_reference_qualifier(ReferenceQualifier::None);
+		const ConversionPlan value_plan =
+			buildConversionPlan(arg_value_type, param_value_type);
+		const bool needs_standard_conversion =
+			!arg_desc.array_dimensions.empty() ||
+			(value_plan.is_valid && value_plan.kind != StandardConversionKind::None);
+		if (needs_standard_conversion) {
+			throw InternalError(
+				std::string("Phase 1: sema missed resolved function call argument conversion for parameter ") +
+				std::to_string(i));
+		}
 	}
 }
 
@@ -8019,6 +8173,24 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return call_info.function_declaration;
 	};
+	auto fallbackToParserSelectedStaticDirectTarget =
+		[&]() -> const FunctionDeclarationNode* {
+			if (call_info.is_indirect ||
+				call_info.has_receiver ||
+				call_info.function_declaration == nullptr ||
+				call_info.function_declaration->parent_struct_name().empty() ||
+				!call_info.function_declaration->is_static()) {
+				return nullptr;
+			}
+			if (call_info.definition_lookup_record != nullptr &&
+				call_info.definition_lookup_record->has_value()) {
+				return call_info.function_declaration;
+			}
+			if (call_info.qualified_name.isValid()) {
+				return call_info.function_declaration;
+			}
+			return nullptr;
+		};
 	// Resolution order:
 	// 1. receiver-member direct lookup
 	// 2. callable operator / local callable resolution
@@ -8116,6 +8288,11 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		!call_info.has_receiver &&
 		definition_lookup_record_target != nullptr) {
 		return definition_lookup_record_target;
+	}
+	if (const FunctionDeclarationNode* parser_selected_static_target =
+			fallbackToParserSelectedStaticDirectTarget();
+		parser_selected_static_target != nullptr) {
+		return parser_selected_static_target;
 	}
 
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
@@ -8746,6 +8923,11 @@ void SemanticAnalysis::tryAnnotateCallArgConversionsImpl(const ASTNode& call_exp
 
 	annotateResolvedCallResultType(call_expr_node, *func_decl);
 	annotateResolvedCallArgConversions(call_key, *call_info.arguments, *func_decl, context_description);
+	ensureResolvedCallArgConversionsComplete(
+		call_key,
+		*call_info.arguments,
+		*func_decl,
+		context_description);
 }
 
 

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -197,9 +197,7 @@ public:
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg);
 	void registerCodegenSynthesizedOverloadArgType(const ASTNode& arg, const TypeSpecifierNode& type);
 	void registerCodegenSynthesizedLocalType(StringHandle name, const TypeSpecifierNode& type);
-	void ensureSingleArgConversionAnnotated(const ASTNode& arg,
-											const TypeSpecifierNode& param_type,
-											const char* context_description);
+	void ensureCallArgConversionsAnnotated(const CallExprNode& call_node);
 
 	enum class StructuredBindingDecompositionKind : uint8_t {
 		Aggregate,
@@ -545,6 +543,10 @@ private:
 											const ChunkedVector<ASTNode>& arguments,
 											const FunctionDeclarationNode& func_decl,
 											const char* context_description);
+	void ensureResolvedCallArgConversionsComplete(const void* call_key,
+												  const ChunkedVector<ASTNode>& arguments,
+												  const FunctionDeclarationNode& func_decl,
+												  const char* context_description);
 	void tryAnnotateCallArgConversionsImpl(const ASTNode& call_expr_node,
 										   const CallInfo& call_info,
 										   const void* call_key,

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -197,6 +197,9 @@ public:
 	std::optional<TypeSpecifierNode> getOverloadResolutionArgType(const ASTNode& arg);
 	void registerCodegenSynthesizedOverloadArgType(const ASTNode& arg, const TypeSpecifierNode& type);
 	void registerCodegenSynthesizedLocalType(StringHandle name, const TypeSpecifierNode& type);
+	void ensureSingleArgConversionAnnotated(const ASTNode& arg,
+											const TypeSpecifierNode& param_type,
+											const char* context_description);
 
 	enum class StructuredBindingDecompositionKind : uint8_t {
 		Aggregate,

--- a/tests/test_template_current_member_static_hides_base_enum_conversion_ret0.cpp
+++ b/tests/test_template_current_member_static_hides_base_enum_conversion_ret0.cpp
@@ -1,0 +1,23 @@
+template <typename T>
+struct Base {
+	enum Small : unsigned char { value = 3 };
+
+	static int select(int) {
+		return 7;
+	}
+};
+
+template <typename T>
+struct Derived : Base<T> {
+	static int select(long value) {
+		return value == 3 ? static_cast<int>(sizeof(T)) + 40 : 1;
+	}
+
+	static int run() {
+		return select(Base<T>::value);
+	}
+};
+
+int main() {
+	return Derived<int>::run() == 44 ? 0 : 1;
+}

--- a/tests/test_template_current_member_static_hides_base_overload_ret0.cpp
+++ b/tests/test_template_current_member_static_hides_base_overload_ret0.cpp
@@ -1,0 +1,31 @@
+// Regression: a definition-bound current-member static call inside a class
+// template must preserve its selected member target through replay. The hidden
+// base overload must not re-enter the candidate set later and steal the call.
+
+template <typename T>
+struct Base {
+	static int select() {
+		return 7;
+	}
+};
+
+template <typename T>
+struct Derived : Base<T> {
+	static int select(int value = 0) {
+		return value + static_cast<int>(sizeof(T)) + 38;
+	}
+
+	static int run() {
+		return select();
+	}
+};
+
+int main() {
+	if (Derived<int>::run() != 42) {
+		return 1;
+	}
+	if (Derived<char>::run() != 39) {
+		return 2;
+	}
+	return 0;
+}

--- a/tests/test_template_current_member_static_hides_base_overload_ret0.cpp
+++ b/tests/test_template_current_member_static_hides_base_overload_ret0.cpp
@@ -4,19 +4,19 @@
 
 template <typename T>
 struct Base {
-	static int select() {
+	static int select(int) {
 		return 7;
 	}
 };
 
 template <typename T>
 struct Derived : Base<T> {
-	static int select(int value = 0) {
-		return value + static_cast<int>(sizeof(T)) + 38;
+	static int select(long) {
+		return static_cast<int>(sizeof(T)) + 38;
 	}
 
 	static int run() {
-		return select();
+		return select(0);
 	}
 };
 

--- a/tests/test_template_qualified_member_template_hides_base_overload_ret0.cpp
+++ b/tests/test_template_qualified_member_template_hides_base_overload_ret0.cpp
@@ -1,0 +1,25 @@
+namespace QualifiedMemberTemplateReplay {
+	template <typename T>
+	struct Base {
+		static int select(int) {
+			return 7;
+		}
+	};
+
+	template <typename T>
+	struct Holder : Base<T> {
+		template <typename U>
+		static int select(long) {
+			return static_cast<int>(sizeof(U)) + 40;
+		}
+	};
+}
+
+template <typename T>
+int runQualifiedMemberTemplateCall() {
+	return QualifiedMemberTemplateReplay::Holder<T>::template select<T>(0);
+}
+
+int main() {
+	return runQualifiedMemberTemplateCall<int>() == 44 ? 0 : 1;
+}

--- a/tests/test_template_udl_definition_bound_ret0.cpp
+++ b/tests/test_template_udl_definition_bound_ret0.cpp
@@ -1,0 +1,16 @@
+// Test: non-dependent user-defined literal calls inside template bodies stay
+// definition-bound through instantiation.
+
+inline constexpr int operator""_len(const char* str, unsigned long len) noexcept {
+	return static_cast<int>(len);
+}
+
+template <typename T>
+constexpr int literalLength() {
+	return "hello"_len;
+}
+
+int main() {
+	static_assert(literalLength<int>() == 5);
+	return literalLength<int>() - 5;
+}


### PR DESCRIPTION
## Summary
This branch continues the template direct-call metadata refactor and extends it into the remaining parser/substitution pack-expansion boundary.

- preserve `FunctionCallDefinitionLookupRecord` for current-member static direct calls and the covered qualified/member-template direct-call paths so replay stays bound to structured semantic metadata instead of `mangled_name`/`qualified_name` compatibility alone
- keep the earlier current-member static overload-hiding fix at the sema-owned whole-call synchronization layer instead of a per-argument codegen repair, and share the stronger structured argument-typing retry with the ordinary direct-call and current-member static fallback paths
- preserve structured lookup metadata for string-literal user-defined literal direct calls as well, reducing another remaining compatibility-only direct-call path
- fix parser/substitution handling of complex call-argument pack expansions so unmatched `expr...` patterns stay as `PackExpansionExprNode` until substitution instead of being flattened into a single ordinary argument too early
- add an `ExpressionSubstitutor` fallback that scalarizes active pack bindings element-by-element when a preserved pack-expansion argument reaches call substitution
- teach the shared parser pack-expansion helper to distinguish between “expanded a real function-parameter pack” and “no matching pack here”, and update the legacy constructor/initializer call sites to preserve the pack node in the latter case
- cover an expression-typing gap for `InitializerListConstructionNode` so initializer-list based calls keep the right semantic type during overload resolution and constexpr evaluation
- update the template-argument architecture and conformance docs with the pack-expansion boundary fix, why that was the correct layer, and the next cleanup targets

## Root cause
Two related parser-era assumptions were still leaking through the template infrastructure:

1. Several call-argument parsing paths treated “no active function-parameter pack matched this `expr...`” as a successful expansion and returned the original pattern, which silently stripped the pack-expansion wrapper from cases like `typeCode<Rest>()...`.
2. Once that wrapper was lost, the later substitution/direct-call metadata work only saw an ordinary `CallExprNode`, so sema could not recover the intended element-wise expansion and downstream direct-call replay failed in the instantiated body.

The correct fix was to keep pack-expansion ownership at the parser/substitution boundary and only expand when the compiler can prove there is an actual bound pack to scalarize.

## Impact
- restores standards-visible template pack-expansion behavior for explicit-template-argument call patterns with a deduced trailing parameter
- keeps the direct-call metadata refactor moving in the right direction by preventing parser-side flattening from forcing deeper sema/codegen compatibility repairs
- improves constexpr and overload-resolution behavior for initializer-list construction expressions

