### PR TITLE
[codex] Tighten member template owner lookup

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-12
+**Last updated:** 2026-06-13
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -81,6 +81,12 @@ the areas that were previously blocking standards-visible behavior:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list, instead of carrying only `mangled_name`
+- the newer ordinary direct-call fallback branches that still cannot assemble
+  stable typed arguments now route through a shared
+  compatibility-only metadata helper instead of silently upgrading those calls
+  to `FunctionCallDefinitionLookupRecord` in the absence of full typed
+  evidence; the current-member-context static fast path uses the same helper
+  on its remaining untyped exit
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
@@ -189,6 +195,15 @@ Remaining near-term scope:
   where both `get_expression_type(...)` and `appendFunctionCallArgType(...)`
   still fail, plus any remaining niche qualified/member-template materializers
   outside the now-covered shared helpers
+- the older unified ordinary identifier-call path in
+  `Parser_Expr_PrimaryExpr.cpp` still uses its pre-existing manual
+  `get_expression_type(...)` fallback instead of the shared structured retry;
+  a direct swap regressed
+  `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` because
+  parser-time constexpr/dependent-call consumers still rely on the resolved
+  callee's return type there, so that path now needs an explicit split between
+  "parse-time return-type preservation" and "authoritative semantic call
+  identity" instead of another broad helper transplant
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -216,10 +231,11 @@ Next direct-call target:
 - trace the remaining `Parser_Expr_PrimaryExpr.cpp` direct-call sites that
   still attach only compatibility metadata, then either preserve a typed
   `FunctionCallDefinitionLookupRecord` there or explicitly document why the
-  call cannot yet carry one; after the current-member-context fast path, the
-  remaining highest-value cleanup is the final compatibility-only fallback
-  branches that still cannot produce stable typed arguments even after the
-  structured retry
+  call cannot yet carry one; after the current-member-context fast path and
+  the newer compatibility-only fallback cleanup, the next highest-value target
+  is the older unified identifier-call fallback that still cannot adopt the
+  shared structured retry without first separating parser-time return-type
+  needs from semantic target identity
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -254,16 +270,17 @@ When changing this area, always rerun:
 
 1. Finish the remaining parser-side direct-call metadata preservation in the
    still-uncovered resolved-call paths that only stamp `mangled_name` or
-   `qualified_name`, now focusing on the branches that still cannot assemble
-   stable typed arguments even after the new structured retry pass.
-   Immediate follow-up: audit the last compatibility-only fallback exits in
-   `Parser_Expr_PrimaryExpr.cpp` and either teach them to preserve
-   `FunctionCallDefinitionLookupRecord` or explicitly classify them as
-   unresolved/deferred instead of pretending to be fully resolved calls. Keep
-   using focused regressions where hidden or later same-name overloads could
-   otherwise steal replayed call targets. After that, collapse the new
-   whole-call sema synchronization hook by proving those paths carry their
-   conversion annotations before lowering.
+   `qualified_name`, now focusing first on the legacy unified
+   identifier-call path in `Parser_Expr_PrimaryExpr.cpp`.
+   Immediate follow-up: split that path's "keep a callee return type visible to
+   parser-time constexpr/dependent consumers" concern from its "do not treat a
+   parser-selected callee as authoritative semantic identity" concern, then
+   move it onto the same explicit compatibility-only model already used by the
+   newer fallback exits. Use
+   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` as the
+   guardrail when doing that split, because it exposed the current coupling.
+   After that, collapse the new whole-call sema synchronization hook by
+   proving those paths carry their conversion annotations before lowering.
    Also clean up the remaining legacy parser sites that still hand-roll
    `expr...` handling (constructor/initializer parsing) so they share the same
    "expand only when a real function pack matched, otherwise preserve the pack

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -107,6 +107,15 @@ the areas that were previously blocking standards-visible behavior:
   `PackExpansionExprNode` until substitution, and call-site substitution can
   scalarize the active pack bindings element-by-element instead of silently
   flattening `expr...` into a single ordinary argument
+- deferred qualified/member-template direct calls now preserve explicit
+  template-argument AST, parser return-type hints, and dependent-qualified
+  lookup records separately instead of collapsing semantic ownership onto a
+  parser-selected callee
+- qualified direct-call target resolution now distinguishes type owners from
+  namespace qualifiers before consuming definition-bound compatibility data, so
+  sema resolves nested current-instantiation owners structurally and no longer
+  lets unrelated global templates steal calls like `Ops::read(value)` inside
+  `Runner<T>`
 
 ## Architectural invariants to preserve
 
@@ -198,6 +207,12 @@ Remaining near-term scope:
   materialization sites that still stamp only `mangled_name` or
   `qualified_name` without a typed semantic record, especially niche
   qualified/member-template paths outside the now-covered ordinary-call routes
+- the newly-covered qualified-owner split is intentionally sema-owned: the
+  deferred-template resolver is now bypassed for non-template qualified calls
+  whose left-hand side is a real type owner, but the parser helper still has a
+  compatibility-only ordinary-static-member branch that should eventually be
+  folded into the same structured owner/lookup model instead of remaining a
+  side path
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -269,9 +284,13 @@ When changing this area, always rerun:
    now used by untyped ordinary calls:
    parser-time return-type hints on the call node, structured deferred lookup
    state for semantic ownership, and no parser-selected callee as the source of
-   final meaning. After that, collapse the new whole-call sema synchronization
-   hook by proving those paths carry their conversion annotations before
-   lowering. Also clean up the remaining legacy parser sites that still
+   final meaning. First target: remove the remaining ordinary-static-member
+   compatibility branch inside `resolveDeferredQualifiedTemplateCall(...)` by
+   routing those cases through the same sema-owned type-owner vs
+   namespace-qualifier split now used in
+   `resolveCallArgAnnotationTarget(...)`. After that, collapse the new
+   whole-call sema synchronization hook by proving those paths carry their
+   conversion annotations before lowering. Also clean up the remaining legacy parser sites that still
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve
    the pack node" rule now enforced in ordinary call parsing.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -244,6 +244,16 @@ Next direct-call target:
   the untyped ordinary-call deferred-lookup split, the next highest-value
   targets are the remaining qualified/member-template materializers that still
   carry only `qualified_name`/`mangled_name` compatibility data
+- before expanding sema-side owner recovery further, fix the remaining
+  standards-visible nested-owner collision in explicit qualified member-template
+  calls where a nested owner name inside the current instantiation collides with
+  an unrelated global template owner
+  concrete uncovered case: inside `Runner<T>::run()`, `Ops::template read<int>(value)`
+  still binds to the unrelated global `Ops<T>::read` instead of the nested
+  `Runner<T>::Ops::read` when both exist
+  required implementation direction: preserve or reconstruct the exact nested
+  owner identity in the parser/member-template instantiation layer instead of
+  canonicalizing through a standalone owner spelling
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -294,6 +304,10 @@ When changing this area, always rerun:
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve
    the pack node" rule now enforced in ordinary call parsing.
+   First unresolved conformance regression to close in that slice:
+   add a focused test for the nested-owner collision described above only when
+   the parser/member-template owner identity is fixed at the source, not via a
+   new semantic or codegen compatibility branch.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -81,12 +81,12 @@ the areas that were previously blocking standards-visible behavior:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list, instead of carrying only `mangled_name`
-- the newer ordinary direct-call fallback branches that still cannot assemble
-  stable typed arguments now route through a shared
-  compatibility-only metadata helper instead of silently upgrading those calls
-  to `FunctionCallDefinitionLookupRecord` in the absence of full typed
-  evidence; the current-member-context static fast path uses the same helper
-  on its remaining untyped exit
+- the remaining untyped ordinary direct-call fallback exits no longer keep a
+  parser-selected callee as the call's semantic identity just to preserve
+  parse-time typing; they now carry an explicit parser return-type hint plus
+  either a deferred definition-bound lookup record or the existing deferred
+  dependent-unqualified lookup record, and sema can resolve those calls later
+  from structured lookup state instead of mangled-name recovery
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
@@ -189,21 +189,15 @@ Desired end state:
 
 Remaining near-term scope:
 
-- the remaining compatibility surface is now concentrated in parser paths that
-  still stamp only `mangled_name` or `qualified_name` without a typed
-  definition-lookup record, especially the truly untypable fallback branches
-  where both `get_expression_type(...)` and `appendFunctionCallArgType(...)`
-  still fail, plus any remaining niche qualified/member-template materializers
-  outside the now-covered shared helpers
-- the older unified ordinary identifier-call path in
-  `Parser_Expr_PrimaryExpr.cpp` still uses its pre-existing manual
-  `get_expression_type(...)` fallback instead of the shared structured retry;
-  a direct swap regressed
-  `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` because
-  parser-time constexpr/dependent-call consumers still rely on the resolved
-  callee's return type there, so that path now needs an explicit split between
-  "parse-time return-type preservation" and "authoritative semantic call
-  identity" instead of another broad helper transplant
+- the highest-impact legacy unified ordinary identifier-call fallback is now on
+  the proper split model: parse-time return-type visibility lives on an
+  explicit call-node hint, while deferred semantic ownership lives on a
+  definition-bound or dependent-unqualified lookup record rather than on a
+  parser-selected callee
+- the remaining debt is narrower and now concentrated in other parser
+  materialization sites that still stamp only `mangled_name` or
+  `qualified_name` without a typed semantic record, especially niche
+  qualified/member-template paths outside the now-covered ordinary-call routes
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -232,10 +226,9 @@ Next direct-call target:
   still attach only compatibility metadata, then either preserve a typed
   `FunctionCallDefinitionLookupRecord` there or explicitly document why the
   call cannot yet carry one; after the current-member-context fast path and
-  the newer compatibility-only fallback cleanup, the next highest-value target
-  is the older unified identifier-call fallback that still cannot adopt the
-  shared structured retry without first separating parser-time return-type
-  needs from semantic target identity
+  the untyped ordinary-call deferred-lookup split, the next highest-value
+  targets are the remaining qualified/member-template materializers that still
+  carry only `qualified_name`/`mangled_name` compatibility data
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -270,21 +263,18 @@ When changing this area, always rerun:
 
 1. Finish the remaining parser-side direct-call metadata preservation in the
    still-uncovered resolved-call paths that only stamp `mangled_name` or
-   `qualified_name`, now focusing first on the legacy unified
-   identifier-call path in `Parser_Expr_PrimaryExpr.cpp`.
-   Immediate follow-up: split that path's "keep a callee return type visible to
-   parser-time constexpr/dependent consumers" concern from its "do not treat a
-   parser-selected callee as authoritative semantic identity" concern, then
-   move it onto the same explicit compatibility-only model already used by the
-   newer fallback exits. Use
-   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` as the
-   guardrail when doing that split, because it exposed the current coupling.
-   After that, collapse the new whole-call sema synchronization hook by
-   proving those paths carry their conversion annotations before lowering.
-   Also clean up the remaining legacy parser sites that still hand-roll
-   `expr...` handling (constructor/initializer parsing) so they share the same
-   "expand only when a real function pack matched, otherwise preserve the pack
-   node" rule now enforced in ordinary call parsing.
+   `qualified_name`, now focusing on qualified/member-template materializers
+   outside the now-covered ordinary identifier-call routes.
+   Immediate follow-up: move those paths onto the same split ownership model
+   now used by untyped ordinary calls:
+   parser-time return-type hints on the call node, structured deferred lookup
+   state for semantic ownership, and no parser-selected callee as the source of
+   final meaning. After that, collapse the new whole-call sema synchronization
+   hook by proving those paths carry their conversion annotations before
+   lowering. Also clean up the remaining legacy parser sites that still
+   hand-roll `expr...` handling (constructor/initializer parsing) so they share
+   the same "expand only when a real function pack matched, otherwise preserve
+   the pack node" rule now enforced in ordinary call parsing.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-12
+**Last updated:** 2026-06-13
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -84,6 +84,11 @@ blocking areas:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list instead of carrying only `mangled_name`
+- the newer untyped ordinary direct-call fallback exits now use an explicit
+  compatibility-only metadata helper instead of silently manufacturing
+  definition-bound lookup records without complete typed evidence, and the
+  remaining untyped current-member-context static fast path now goes through
+  that same helper
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
@@ -174,6 +179,12 @@ Remaining near-term scope:
   stable typed arguments even after the new structured retry pass, plus any
   remaining niche qualified/member-template materializers that do not yet
   route through the shared helpers
+- the older unified ordinary identifier-call path still uses its legacy
+  manual `get_expression_type(...)` fallback because a direct conversion to the
+  shared retry/compatibility-only shape regressed
+  `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp`; that path
+  needs a dedicated split between parse-time return-type availability and final
+  semantic call-target authority before it can join the newer model safely
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -200,8 +211,9 @@ Next direct-call target:
   reach sema with compatibility-only metadata, then replace each typed case
   with preserved structured target metadata before touching the sema fallback;
   after the now-covered typed qualified-member and string-literal UDL paths,
-  the next target is the final fallback exits that still cannot produce stable
-  typed arguments even after the structured retry
+  the next target is the legacy unified identifier-call fallback that still
+  cannot adopt the shared retry path until parser-time return-type needs are
+  separated from semantic target identity
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -245,16 +257,15 @@ For work in this area, rerun:
 ## Next steps
 
 1. Continue eliminating compatibility-only parser metadata in the remaining
-   resolved direct-call sites, now focusing on the branches that still cannot
-   produce stable typed arguments even after the structured retry pass.
-   Immediate follow-up: audit the last compatibility-only fallback exits in
-   `Parser_Expr_PrimaryExpr.cpp` and either preserve
-   `FunctionCallDefinitionLookupRecord` there or reclassify those calls as
-   unresolved/deferred instead of pretending they are fully resolved. Keep
-   adding focused regressions for replayed calls that would otherwise be
-   vulnerable to hidden or later same-name overloads. Once those paths are
-   covered, remove the new whole-call sema synchronization hook by pushing that
-   work back to earlier semantic ownership.
+   resolved direct-call sites, now focusing first on the legacy unified
+   identifier-call fallback in `Parser_Expr_PrimaryExpr.cpp`.
+   Immediate follow-up: refactor that path so parser-time constexpr/dependent
+   consumers can still recover a callee return type without treating the
+   parser-selected callee as final semantic identity; use
+   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` as the
+   regression that guards this split. Once that path matches the newer
+   compatibility-only model, remove the new whole-call sema synchronization
+   hook by pushing that work back to earlier semantic ownership.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -225,6 +225,12 @@ Next direct-call target:
   after the now-covered typed qualified-member and string-literal UDL paths,
   the next targets are the remaining qualified/member-template paths that still
   have not adopted the deferred lookup + parser return-type hint split
+- explicitly cover the remaining nested-owner collision in qualified
+  member-template calls before widening current-instantiation heuristics:
+  `Ops::template read<int>(value)` inside `Runner<T>` must resolve to the
+  nested `Runner<T>::Ops::read`, not to an unrelated global `Ops<T>::read`
+  when both owners are visible and share the same simple nested name
+  this is a standards-visible lookup bug, not an acceptable compatibility case
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -282,6 +288,10 @@ For work in this area, rerun:
    calls in `resolveCallArgAnnotationTarget(...)`. Once those paths match the
    split model, remove the new whole-call sema synchronization hook by pushing
    that work back to earlier semantic ownership.
+   Immediate focused follow-up under that item:
+   fix nested-owner explicit member-template instantiation so concrete owner
+   normalization preserves the full nested owner pattern instead of collapsing
+   to a standalone owner spelling that can collide with unrelated templates.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -108,6 +108,15 @@ blocking areas:
   pack matched" as a successful expansion; that closes the standards-visible
   leak where `typeCode<Rest>()...` in `add3(..., tail)` lost pack semantics
   before sema could scalarize the bound template pack
+- deferred qualified/member-template calls now preserve explicit template
+  arguments, parser return-type hints, and dependent-qualified lookup records
+  as separate metadata so later semantic resolution can replay the correct
+  lookup instead of inheriting a parser-selected callee as final meaning
+- sema now distinguishes real type owners from namespace qualifiers before it
+  consumes definition-bound compatibility metadata for qualified direct calls,
+  which fixes current-instantiation nested-owner cases like
+  `Runner<T>::Ops::read(value)` being stolen by an unrelated global
+  `Ops<T>::read`
 
 ## Highest-value remaining standards gaps
 
@@ -182,6 +191,12 @@ Remaining near-term scope:
   materialization paths that still carry only `mangled_name` or
   `qualified_name`, especially niche qualified/member-template materializers
   that do not yet route through the same deferred-lookup model
+- the just-fixed qualified-owner collision confirms the right ownership split:
+  non-template qualified calls must first decide whether the left-hand side is
+  a type owner or a namespace qualifier, and only then may compatibility
+  records participate; the remaining parser helper that still does ordinary
+  static-member recovery inside `resolveDeferredQualifiedTemplateCall(...)`
+  should be moved onto that same model
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -260,9 +275,13 @@ For work in this area, rerun:
    untyped ordinary calls, and keep
    `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` in the
    guard set so parser-time constexpr users never again need a parser-selected
-   callee for return-type visibility. Once those paths match the split model,
-   remove the new whole-call sema synchronization hook by pushing that work
-   back to earlier semantic ownership.
+   callee for return-type visibility. First subtask: remove the remaining
+   ordinary-static-member compatibility branch from
+   `resolveDeferredQualifiedTemplateCall(...)` by reusing the same sema-owned
+   type-owner / namespace-qualifier split that now protects qualified direct
+   calls in `resolveCallArgAnnotationTarget(...)`. Once those paths match the
+   split model, remove the new whole-call sema synchronization hook by pushing
+   that work back to earlier semantic ownership.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -84,11 +84,12 @@ blocking areas:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list instead of carrying only `mangled_name`
-- the newer untyped ordinary direct-call fallback exits now use an explicit
-  compatibility-only metadata helper instead of silently manufacturing
-  definition-bound lookup records without complete typed evidence, and the
-  remaining untyped current-member-context static fast path now goes through
-  that same helper
+- untyped ordinary direct-call fallback exits no longer need a parser-selected
+  callee to keep parse-time typing alive: they now carry an explicit parser
+  return-type hint on the call node plus either a deferred
+  definition-context lookup record or a deferred dependent-unqualified lookup
+  record, so later semantic resolution can re-run the correct lookup instead of
+  leaning on mangled-name or parser-target compatibility
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
@@ -173,18 +174,14 @@ Why this matters:
 
 Remaining near-term scope:
 
-- the remaining compatibility boundary is now concentrated in parser
+- the biggest ordinary identifier-call coupling is now gone: parse-time
+  return-type availability and final semantic call-target authority are
+  separated on the call node / lookup-record boundary instead of being tied to
+  a parser-selected callee
+- the remaining compatibility boundary is now concentrated in other parser
   materialization paths that still carry only `mangled_name` or
-  `qualified_name`, especially the fallback exits that still cannot assemble
-  stable typed arguments even after the new structured retry pass, plus any
-  remaining niche qualified/member-template materializers that do not yet
-  route through the shared helpers
-- the older unified ordinary identifier-call path still uses its legacy
-  manual `get_expression_type(...)` fallback because a direct conversion to the
-  shared retry/compatibility-only shape regressed
-  `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp`; that path
-  needs a dedicated split between parse-time return-type availability and final
-  semantic call-target authority before it can join the newer model safely
+  `qualified_name`, especially niche qualified/member-template materializers
+  that do not yet route through the same deferred-lookup model
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -211,9 +208,8 @@ Next direct-call target:
   reach sema with compatibility-only metadata, then replace each typed case
   with preserved structured target metadata before touching the sema fallback;
   after the now-covered typed qualified-member and string-literal UDL paths,
-  the next target is the legacy unified identifier-call fallback that still
-  cannot adopt the shared retry path until parser-time return-type needs are
-  separated from semantic target identity
+  the next targets are the remaining qualified/member-template paths that still
+  have not adopted the deferred lookup + parser return-type hint split
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -257,15 +253,16 @@ For work in this area, rerun:
 ## Next steps
 
 1. Continue eliminating compatibility-only parser metadata in the remaining
-   resolved direct-call sites, now focusing first on the legacy unified
-   identifier-call fallback in `Parser_Expr_PrimaryExpr.cpp`.
-   Immediate follow-up: refactor that path so parser-time constexpr/dependent
-   consumers can still recover a callee return type without treating the
-   parser-selected callee as final semantic identity; use
-   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` as the
-   regression that guards this split. Once that path matches the newer
-   compatibility-only model, remove the new whole-call sema synchronization
-   hook by pushing that work back to earlier semantic ownership.
+   resolved direct-call sites, now focusing on the qualified/member-template
+   materializers that still have not adopted the deferred lookup + parser
+   return-type hint split.
+   Immediate follow-up: move those paths onto the same model now used by
+   untyped ordinary calls, and keep
+   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` in the
+   guard set so parser-time constexpr users never again need a parser-selected
+   callee for return-type visibility. Once those paths match the split model,
+   remove the new whole-call sema synchronization hook by pushing that work
+   back to earlier semantic ownership.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -3104,6 +3104,16 @@ public:
 	std::span<const ASTNode> template_arguments() const { return template_arguments_; }
 	bool has_template_arguments() const { return !template_arguments_.empty(); }
 
+	void set_parser_return_type_hint(const TypeSpecifierNode& type_hint) {
+		parser_return_type_hint_ = type_hint;
+	}
+	const std::optional<TypeSpecifierNode>& parser_return_type_hint() const {
+		return parser_return_type_hint_;
+	}
+	bool has_parser_return_type_hint() const {
+		return parser_return_type_hint_.has_value();
+	}
+
 	// --- Definition-context lookup record ---
 	void set_definition_lookup_record(const FunctionCallDefinitionLookupRecord& record) {
 		definition_lookup_record_ = record;
@@ -3142,6 +3152,7 @@ private:
 	StringHandle mangled_name_;          // Pre-computed mangled name
 	StringHandle qualified_name_;        // Source-level qualified name (e.g., "ns::func")
 	std::vector<ASTNode> template_arguments_;  // Explicit template arguments
+	std::optional<TypeSpecifierNode> parser_return_type_hint_;
 	std::optional<FunctionCallDefinitionLookupRecord> definition_lookup_record_;
 	std::optional<DependentUnqualifiedCallLookupRecord> dependent_unqualified_lookup_record_;
 	std::optional<TypeInfo::DependentQualifiedNameRecord> dependent_qualified_lookup_record_;

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -101,6 +101,7 @@ struct CallInfo {
 	StringHandle mangled_name;
 	StringHandle qualified_name;
 	std::span<const ASTNode> template_arguments;
+	const std::optional<TypeSpecifierNode>* parser_return_type_hint;
 	const std::optional<FunctionCallDefinitionLookupRecord>* definition_lookup_record;
 	const std::optional<DependentUnqualifiedCallLookupRecord>* dependent_unqualified_lookup_record;
 	const std::optional<TypeInfo::DependentQualifiedNameRecord>* dependent_qualified_lookup_record;
@@ -119,6 +120,7 @@ struct CallInfo {
 		info.mangled_name          = node.mangled_name_handle();
 		info.qualified_name        = node.qualified_name_handle();
 		info.template_arguments    = node.template_arguments();
+		info.parser_return_type_hint = &node.parser_return_type_hint();
 		info.definition_lookup_record = &node.definition_lookup_record();
 		info.dependent_unqualified_lookup_record =
 			&node.dependent_unqualified_lookup_record();
@@ -141,6 +143,7 @@ struct CallMetadataCopyOptions {
 	bool copy_mangled_name = true;
 	bool copy_qualified_name = true;
 	bool copy_template_arguments = true;
+	bool copy_parser_return_type_hint = true;
 	bool copy_definition_lookup_record = true;
 	bool copy_dependent_unqualified_lookup_record = true;
 	bool copy_dependent_qualified_lookup_record = true;
@@ -165,6 +168,12 @@ inline void copyCallMetadataFromInfo(
 			copied_template_args.push_back(template_arg);
 		}
 		target.set_template_arguments(std::move(copied_template_args));
+	}
+	if (options.copy_parser_return_type_hint &&
+		source.parser_return_type_hint != nullptr &&
+		source.parser_return_type_hint->has_value()) {
+		target.set_parser_return_type_hint(
+			source.parser_return_type_hint->value());
 	}
 	if (options.copy_definition_lookup_record &&
 		source.definition_lookup_record != nullptr &&
@@ -347,6 +356,20 @@ inline void setCallDependentQualifiedLookupRecord(
 
 inline void setCallTemplateArguments(CallExprNode& call_expr, std::vector<ASTNode>&& template_args) {
 	call_expr.set_template_arguments(std::move(template_args));
+}
+
+inline void setCallParserReturnTypeHint(
+	ExpressionNode& expr,
+	const TypeSpecifierNode& type_hint) {
+	if (auto* call_expr = std::get_if<CallExprNode>(&expr)) {
+		call_expr->set_parser_return_type_hint(type_hint);
+	}
+}
+
+inline void setCallParserReturnTypeHint(
+	CallExprNode& call_expr,
+	const TypeSpecifierNode& type_hint) {
+	call_expr.set_parser_return_type_hint(type_hint);
 }
 
 inline void setCallIndirect(ExpressionNode& expr) {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -4981,6 +4981,31 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 			return builtin_result;
 		}
 
+		if (call_expr.has_qualified_name() && context.parser) {
+			Parser& parser = *context.parser;
+			std::vector<TypeSpecifierNode> arg_types;
+			if (parser.tryCollectFunctionCallArgTypes(
+					call_expr.arguments(),
+					arg_types)) {
+				if (std::optional<ASTNode> resolved_template_call =
+						parser.resolveDeferredQualifiedTemplateCall(
+							call_expr.qualified_name(),
+							call_expr.template_arguments(),
+							call_expr.arguments(),
+							arg_types);
+					resolved_template_call.has_value()) {
+					context.normalizePendingSemanticRoots();
+					if (resolved_template_call->is<FunctionDeclarationNode>()) {
+						return evaluate_resolved_function_call(
+							resolved_template_call->as<FunctionDeclarationNode>(),
+							call_expr.arguments(),
+							context,
+							nullptr);
+					}
+				}
+			}
+		}
+
 		// Try variable template instantiation before giving up
 		// Variable templates like __is_ratio_v<T> might not be in the symbol table
 		// but can be instantiated from the template registry

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1935,7 +1935,6 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		Token called_from_token);
 	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(
 		const FunctionCallDefinitionLookupRecord& record,
-		const ChunkedVector<ASTNode>& arguments,
 		std::span<const TypeSpecifierNode> arg_types);
 	std::optional<ASTNode> resolveDeferredQualifiedTemplateCall(
 		std::string_view qualified_name,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3422,7 +3422,7 @@ private:	 // Resume private methods
 		std::string_view member_name,
 		const Token& member_token,
 		std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args,
-		const std::vector<ASTNode>* pre_parsed_member_template_arg_nodes);
+		std::vector<ASTNode> pre_parsed_member_template_arg_nodes);
 
 	// Utility functions
 	bool consume_punctuator(const std::string_view& value);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1910,6 +1910,8 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 	bool tryCollectFunctionCallArgTypes(
 		const ChunkedVector<ASTNode>& arguments,
 		std::vector<TypeSpecifierNode>& arg_types_out);
+	std::optional<InlineVector<TemplateTypeArg, 4>> materializeConcreteCallTemplateArguments(
+		std::span<const ASTNode> template_argument_nodes);
 	std::optional<ASTNode> resolveDependentUnqualifiedCallAtPointOfInstantiation(
 		const DependentUnqualifiedCallLookupRecord& record,
 		const ChunkedVector<ASTNode>& arguments,
@@ -1933,6 +1935,11 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		Token called_from_token);
 	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(
 		const FunctionCallDefinitionLookupRecord& record,
+		const ChunkedVector<ASTNode>& arguments,
+		std::span<const TypeSpecifierNode> arg_types);
+	std::optional<ASTNode> resolveDeferredQualifiedTemplateCall(
+		std::string_view qualified_name,
+		std::span<const ASTNode> template_argument_nodes,
 		const ChunkedVector<ASTNode>& arguments,
 		std::span<const TypeSpecifierNode> arg_types);
 	// Shared helper: re-parse a template function body with concrete argument substitution.
@@ -3414,7 +3421,8 @@ private:	 // Resume private methods
 		std::string_view instantiated_class_name,
 		std::string_view member_name,
 		const Token& member_token,
-		std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args);
+		std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args,
+		const std::vector<ASTNode>* pre_parsed_member_template_arg_nodes);
 
 	// Utility functions
 	bool consume_punctuator(const std::string_view& value);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1927,6 +1927,14 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 	bool tryCollectOrdinaryDirectCallArgTypes(
 		const ChunkedVector<ASTNode>& args,
 		std::vector<TypeSpecifierNode>* arg_types_out);
+	ExpressionNode makeDeferredOrdinaryDirectCallExpr(
+		const ASTNode& resolved_decl,
+		ChunkedVector<ASTNode>&& arguments,
+		Token called_from_token);
+	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(
+		const FunctionCallDefinitionLookupRecord& record,
+		const ChunkedVector<ASTNode>& arguments,
+		std::span<const TypeSpecifierNode> arg_types);
 	// Shared helper: re-parse a template function body with concrete argument substitution.
 	// Called from both try_instantiate_template_explicit (preserve_ref_qualifier=true) and
 	// try_instantiate_single_template (preserve_ref_qualifier=false, default) after cycle

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -433,6 +433,10 @@ void Parser::appendFunctionCallArgType(const ASTNode& arg_node, std::vector<Type
 					return;
 				}
 			}
+			if (inner.has_parser_return_type_hint()) {
+				arg_type = *inner.parser_return_type_hint();
+				return;
+			}
 			if (auto indirect_return_type =
 					FlashCpp::ParserFunctionTypeHelpers::tryGetReturnTypeFromFunctionType(
 						inner.callee().declaration().type_specifier_node(),

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -623,7 +623,6 @@ std::optional<ASTNode> Parser::resolveDependentUnqualifiedCallAtPointOfInstantia
 
 std::optional<ASTNode> Parser::resolveDefinitionBoundOrdinaryCall(
 	const FunctionCallDefinitionLookupRecord& record,
-	const ChunkedVector<ASTNode>& arguments,
 	std::span<const TypeSpecifierNode> arg_types) {
 	if (!record.callee_name.isValid()) {
 		return std::nullopt;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -280,6 +280,24 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 	return record;
 }
 
+std::optional<FunctionCallDefinitionLookupRecord> makeDeferredFunctionCallDefinitionLookupRecord(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included) {
+	if (definition_context == nullptr ||
+		!definition_context->is_valid() ||
+		callee_token.type() != Token::Type::Identifier) {
+		return std::nullopt;
+	}
+
+	FunctionCallDefinitionLookupRecord record;
+	initializeCallLookupRecordCommon(record, definition_context, callee_token);
+	record.ordinary_lookup_included = ordinary_lookup_included;
+	record.argument_dependent_lookup_included = argument_dependent_lookup_included;
+	return record;
+}
+
 std::optional<std::string_view> makeQualifiedMemberCallNameOverride(
 	std::string_view owner_name,
 	std::string_view member_name) {
@@ -333,14 +351,10 @@ void attachResolvedOrdinaryDirectCallMetadata(
 	}
 }
 
-void attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+void attachDeferredOrdinaryDirectCallHints(
 	ExpressionNode& call_expr,
 	const FunctionDeclarationNode& func_decl,
 	std::optional<std::string_view> qualified_name_override) {
-	if (func_decl.has_mangled_name()) {
-		setCallMangledName(call_expr, func_decl.mangled_name());
-	}
-
 	if (qualified_name_override.has_value() && !qualified_name_override->empty()) {
 		setCallQualifiedName(call_expr, *qualified_name_override);
 	} else if (!func_decl.parent_struct_name().empty()) {
@@ -352,6 +366,9 @@ void attachCompatibilityOnlyOrdinaryDirectCallMetadata(
 				.append(func_decl.decl_node().identifier_token().value())
 				.commit());
 	}
+	setCallParserReturnTypeHint(
+		call_expr,
+		func_decl.decl_node().type_specifier_node());
 }
 
 void attachResolvedOrdinaryDirectCallMetadata(
@@ -602,6 +619,42 @@ std::optional<ASTNode> Parser::resolveDependentUnqualifiedCallAtPointOfInstantia
 	}
 
 	return std::nullopt;
+}
+
+std::optional<ASTNode> Parser::resolveDefinitionBoundOrdinaryCall(
+	const FunctionCallDefinitionLookupRecord& record,
+	const ChunkedVector<ASTNode>& arguments,
+	std::span<const TypeSpecifierNode> arg_types) {
+	if (!record.callee_name.isValid()) {
+		return std::nullopt;
+	}
+
+	ScopedDefinitionLookupContext ctx_scope(
+		current_template_definition_lookup_context_,
+		record.definition_context.is_valid() ? &record.definition_context : nullptr);
+
+	std::vector<ASTNode> all_overloads =
+		gSymbolTable.lookup_all(StringTable::getStringView(record.callee_name));
+	filterPhase1OrdinaryFunctionOverloads(all_overloads);
+	if (record.argument_dependent_lookup_included && !arg_types.empty()) {
+		std::vector<ASTNode> adl_candidates =
+			gSymbolTable.lookup_adl_only(
+				StringTable::getStringView(record.callee_name),
+				arg_types);
+		appendUniqueOverloads(all_overloads, adl_candidates);
+	}
+
+	if (all_overloads.empty()) {
+		return std::nullopt;
+	}
+
+	OverloadResolutionResult resolution = resolve_overload(all_overloads, arg_types);
+	if (resolution.is_ambiguous ||
+		!resolution.has_match ||
+		resolution.selected_overload == nullptr) {
+		return std::nullopt;
+	}
+	return *resolution.selected_overload;
 }
 
 std::optional<ParseResult> Parser::tryQualifiedPhase1Lookup(
@@ -1006,6 +1059,61 @@ bool Parser::tryCollectOrdinaryDirectCallArgTypes(
 		applyOrdinaryCallLValueReference(arg, arg_types_out->back());
 	}
 	return arg_types_out->size() == args.size();
+}
+
+ExpressionNode Parser::makeDeferredOrdinaryDirectCallExpr(
+	const ASTNode& resolved_decl,
+	ChunkedVector<ASTNode>&& arguments,
+	Token called_from_token) {
+	if (resolved_decl.is<FunctionDeclarationNode>()) {
+		const FunctionDeclarationNode& func_decl =
+			resolved_decl.as<FunctionDeclarationNode>();
+		auto type_node = emplace_node<TypeSpecifierNode>(
+			TypeIndex{}.withCategory(TypeCategory::Auto),
+			0,
+			called_from_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		auto placeholder_decl =
+			emplace_node<DeclarationNode>(type_node, called_from_token);
+		ExpressionNode call_expr = makeDirectCallExpr(
+			placeholder_decl.as<DeclarationNode>(),
+			std::move(arguments),
+			called_from_token);
+		setCallParserReturnTypeHint(
+			call_expr,
+			func_decl.decl_node().type_specifier_node());
+		return call_expr;
+	}
+
+	if (resolved_decl.is<DeclarationNode>()) {
+		return makeDirectCallExpr(
+			resolved_decl.as<DeclarationNode>(),
+			std::move(arguments),
+			called_from_token);
+	}
+
+	if (resolved_decl.is<VariableDeclarationNode>()) {
+		return makeDirectCallExpr(
+			resolved_decl.as<VariableDeclarationNode>().declaration(),
+			std::move(arguments),
+			called_from_token);
+	}
+
+	if (resolved_decl.is<TemplateFunctionDeclarationNode>()) {
+		const ASTNode& function_decl =
+			resolved_decl.as<TemplateFunctionDeclarationNode>()
+				.function_declaration();
+		if (function_decl.is<FunctionDeclarationNode>()) {
+			return makeDeferredOrdinaryDirectCallExpr(
+				function_decl,
+				std::move(arguments),
+				called_from_token);
+		}
+	}
+
+	throw InternalError(
+		"Unsupported call target node type in makeDeferredOrdinaryDirectCallExpr");
 }
 
 namespace {
@@ -5992,21 +6100,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						return ParseResult::error("Invalid function declaration", identifier_token);
 					}
 					result = emplace_node<ExpressionNode>(
-						makeCallExprFromNode(
+						makeDeferredOrdinaryDirectCallExpr(
 							*identifierType,
 							std::move(args_ref),
 							identifier_token));
 					if (identifierType->is<FunctionDeclarationNode>()) {
 						const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
-						attachResolvedOrdinaryDirectCallMetadata(
+						attachDeferredOrdinaryDirectCallHints(
 							result->as<ExpressionNode>(),
-							current_template_definition_lookup_context_,
-							identifier_token,
-							arg_types,
-							has_deferred_template_call_args,
 							func_decl,
-							true,
-							argumentDependentLookupIncluded);
+							std::nullopt);
 					}
 					if (has_deferred_template_call_args) {
 						std::optional<DependentUnqualifiedCallLookupRecord> record =
@@ -6018,6 +6121,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (record.has_value()) {
 							setCallDependentUnqualifiedLookupRecord(result->as<ExpressionNode>(), *record);
 						}
+					} else if (std::optional<FunctionCallDefinitionLookupRecord> record =
+								   makeDeferredFunctionCallDefinitionLookupRecord(
+									   current_template_definition_lookup_context_,
+									   identifier_token,
+									   true,
+									   argumentDependentLookupIncluded);
+							   record.has_value()) {
+						setCallDefinitionLookupRecord(
+							result->as<ExpressionNode>(),
+							*record);
 					}
 					return ParseResult::success(*result);
 				}
@@ -8703,13 +8816,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									false,
 									qualified_name_override);
 							} else {
-								attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+								result = emplace_node<ExpressionNode>(
+									makeDeferredOrdinaryDirectCallExpr(
+										ASTNode(&func_decl),
+										copyCallArguments(current_member_call.arguments()),
+										identifier_token));
+								attachDeferredOrdinaryDirectCallHints(
 									result->as<ExpressionNode>(),
 									func_decl,
 									qualified_name_override);
 							}
 							if (qualified_name_override.has_value() &&
-								!current_member_call.has_qualified_name()) {
+								!std::get<CallExprNode>(result->as<ExpressionNode>()).has_qualified_name()) {
 								setCallQualifiedName(result->as<ExpressionNode>(), *qualified_name_override);
 							}
 							return ParseResult::success(*result);
@@ -8746,24 +8864,36 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										return ParseResult::error("Invalid function declaration", identifier_token);
 									}
 									result = emplace_node<ExpressionNode>(
-										makeCallExprFromNode(
+										makeDeferredOrdinaryDirectCallExpr(
 											*identifierType,
 											std::move(args),
 											identifier_token));
 									if (identifierType->is<FunctionDeclarationNode>()) {
 										const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
-										attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+										attachDeferredOrdinaryDirectCallHints(
 											result->as<ExpressionNode>(),
 											func_decl,
 											std::nullopt);
 									}
-									maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
-										result->as<ExpressionNode>(),
-										identifier_token,
-										has_deferred_ordinary_call_args,
-										current_template_definition_lookup_context_,
-										true,
-										*identifierType);
+									if (has_deferred_ordinary_call_args) {
+										maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
+											result->as<ExpressionNode>(),
+											identifier_token,
+											true,
+											current_template_definition_lookup_context_,
+											true,
+											*identifierType);
+									} else if (std::optional<FunctionCallDefinitionLookupRecord> record =
+												   makeDeferredFunctionCallDefinitionLookupRecord(
+													   current_template_definition_lookup_context_,
+													   identifier_token,
+													   true,
+													   true);
+											   record.has_value()) {
+										setCallDefinitionLookupRecord(
+											result->as<ExpressionNode>(),
+											*record);
+									}
 									if (result.has_value()) {
 										return ParseResult::success(*result);
 									}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -333,6 +333,27 @@ void attachResolvedOrdinaryDirectCallMetadata(
 	}
 }
 
+void attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+	ExpressionNode& call_expr,
+	const FunctionDeclarationNode& func_decl,
+	std::optional<std::string_view> qualified_name_override) {
+	if (func_decl.has_mangled_name()) {
+		setCallMangledName(call_expr, func_decl.mangled_name());
+	}
+
+	if (qualified_name_override.has_value() && !qualified_name_override->empty()) {
+		setCallQualifiedName(call_expr, *qualified_name_override);
+	} else if (!func_decl.parent_struct_name().empty()) {
+		setCallQualifiedName(
+			call_expr,
+			StringBuilder()
+				.append(func_decl.parent_struct_name())
+				.append("::")
+				.append(func_decl.decl_node().identifier_token().value())
+				.commit());
+	}
+}
+
 void attachResolvedOrdinaryDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,
@@ -970,6 +991,7 @@ bool Parser::tryCollectOrdinaryDirectCallArgTypes(
 		return arg_types_out->size() == args.size();
 	}
 
+	std::vector<TypeSpecifierNode> primary_arg_types = *arg_types_out;
 	arg_types_out->clear();
 	arg_types_out->reserve(args.size());
 	for (const ASTNode& arg : args) {
@@ -977,7 +999,7 @@ bool Parser::tryCollectOrdinaryDirectCallArgTypes(
 		appendFunctionCallArgType(arg, arg_types_out);
 		if (arg_types_out->size() != before + 1 ||
 			arg_types_out->back().category() == TypeCategory::Invalid) {
-			arg_types_out->clear();
+			*arg_types_out = std::move(primary_arg_types);
 			return false;
 		}
 		applyIdentifierArgumentArrayBounds(arg, arg_types_out->back());
@@ -5969,7 +5991,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (!decl_ptr) {
 						return ParseResult::error("Invalid function declaration", identifier_token);
 					}
-					result = emplace_node<ExpressionNode>(makeCallExprFromNode(*identifierType, std::move(args_ref), identifier_token));
+					result = emplace_node<ExpressionNode>(
+						makeCallExprFromNode(
+							*identifierType,
+							std::move(args_ref),
+							identifier_token));
 					if (identifierType->is<FunctionDeclarationNode>()) {
 						const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
 						attachResolvedOrdinaryDirectCallMetadata(
@@ -8676,8 +8702,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									true,
 									false,
 									qualified_name_override);
-							} else if (func_decl.has_mangled_name()) {
-								setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
+							} else {
+								attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+									result->as<ExpressionNode>(),
+									func_decl,
+									qualified_name_override);
 							}
 							if (qualified_name_override.has_value() &&
 								!current_member_call.has_qualified_name()) {
@@ -8709,23 +8738,29 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							// Extract argument types
 							std::vector<TypeSpecifierNode> arg_types;
 							if (!tryCollectOrdinaryDirectCallArgTypes(args, &arg_types)) {
+									const bool has_deferred_ordinary_call_args =
+										argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+										argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 									const DeclarationNode* decl_ptr = getDeclarationNode(*identifierType);
 									if (!decl_ptr) {
 										return ParseResult::error("Invalid function declaration", identifier_token);
 									}
 									result = emplace_node<ExpressionNode>(
-										makeCallExprFromNode(*identifierType, std::move(args), identifier_token));
+										makeCallExprFromNode(
+											*identifierType,
+											std::move(args),
+											identifier_token));
 									if (identifierType->is<FunctionDeclarationNode>()) {
 										const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
-										if (func_decl.has_mangled_name()) {
-											setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-										}
+										attachCompatibilityOnlyOrdinaryDirectCallMetadata(
+											result->as<ExpressionNode>(),
+											func_decl,
+											std::nullopt);
 									}
 									maybeAttachDependentUnqualifiedLookupRecordFromResolvedDecl(
 										result->as<ExpressionNode>(),
 										identifier_token,
-										argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-											argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames()),
+										has_deferred_ordinary_call_args,
 										current_template_definition_lookup_context_,
 										true,
 										*identifierType);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4175,7 +4175,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								member_token.value(),
 								member_token,
 								std::nullopt,
-								nullptr);
+								{});
 							if (member_call_result.has_value()) {
 								if (member_call_result->is_error()) {
 									return *member_call_result;
@@ -5317,7 +5317,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								qualified_node2.name(),
 								qualified_node2.identifier_token(),
 								std::nullopt,
-								nullptr);
+								{});
 							if (member_call_result.has_value()) {
 								if (member_call_result->is_error()) {
 									return *member_call_result;
@@ -7339,7 +7339,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								final_identifier.value(),
 								final_identifier,
 								member_template_args,
-								&member_template_arg_nodes);
+								std::move(member_template_arg_nodes));
 							if (func_call_result.has_value()) {
 								if (func_call_result->is_error()) {
 									return *func_call_result;
@@ -8470,7 +8470,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							qualified_node.name(),
 							qualified_node.identifier_token(),
 							std::nullopt,
-							nullptr);
+							{});
 						if (func_call_result.has_value()) {
 							if (func_call_result->is_error()) {
 								return *func_call_result;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -657,6 +657,247 @@ std::optional<ASTNode> Parser::resolveDefinitionBoundOrdinaryCall(
 	return *resolution.selected_overload;
 }
 
+std::optional<InlineVector<TemplateTypeArg, 4>> Parser::materializeConcreteCallTemplateArguments(
+	std::span<const ASTNode> template_argument_nodes) {
+	InlineVector<TemplateTypeArg, 4> concrete_args;
+	concrete_args.reserve(template_argument_nodes.size());
+
+	for (const ASTNode& template_arg_node : template_argument_nodes) {
+		if (template_arg_node.is<TypeSpecifierNode>()) {
+			TemplateTypeArg template_arg(template_arg_node.as<TypeSpecifierNode>());
+			if (template_arg.is_dependent) {
+				return std::nullopt;
+			}
+			concrete_args.push_back(std::move(template_arg));
+			continue;
+		}
+
+		if (!template_arg_node.is<ExpressionNode>()) {
+			return std::nullopt;
+		}
+
+		std::optional<ConstantValue> constant_value =
+			try_evaluate_constant_expression(template_arg_node);
+		if (!constant_value.has_value()) {
+			return std::nullopt;
+		}
+
+		TemplateTypeArg template_arg =
+			constant_value->type_index.is_valid()
+				? TemplateTypeArg::makeValue(
+					constant_value->value,
+					constant_value->type_index)
+				: TemplateTypeArg(
+					constant_value->value,
+					constant_value->type);
+		if (constant_value->identity.kind !=
+			FlashCpp::NonTypeValueIdentityKind::Integral) {
+			template_arg.setValueIdentity(constant_value->identity);
+		}
+		concrete_args.push_back(std::move(template_arg));
+	}
+
+	return concrete_args;
+}
+
+std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
+	std::string_view qualified_name,
+	std::span<const ASTNode> template_argument_nodes,
+	const ChunkedVector<ASTNode>& arguments,
+	std::span<const TypeSpecifierNode> arg_types) {
+	FLASH_LOG_FORMAT(
+		Templates,
+		Debug,
+		"resolveDeferredQualifiedTemplateCall: name='{}' template_args={} call_args={} typed_args={}",
+		qualified_name,
+		template_argument_nodes.size(),
+		arguments.size(),
+		arg_types.size());
+	if (qualified_name.empty()) {
+		return std::nullopt;
+	}
+
+	std::optional<InlineVector<TemplateTypeArg, 4>> explicit_template_args;
+	if (!template_argument_nodes.empty()) {
+		explicit_template_args =
+			materializeConcreteCallTemplateArguments(template_argument_nodes);
+		if (!explicit_template_args.has_value()) {
+			return std::nullopt;
+		}
+	}
+
+	const size_t scope_sep = qualified_name.rfind("::");
+	if (scope_sep != std::string_view::npos) {
+		std::string_view owner_name = qualified_name.substr(0, scope_sep);
+		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
+		if (AliasTemplateMaterializationResult canonical_owner =
+				resolveCanonicalInstantiatedOwnerForLookup(owner_name);
+			!canonical_owner.instantiated_name.empty()) {
+			owner_name = canonical_owner.instantiated_name;
+		}
+
+		StringHandle owner_name_handle =
+			StringTable::getOrInternStringHandle(owner_name);
+		instantiateLazyClassToPhase(
+			owner_name_handle,
+			ClassInstantiationPhase::Full);
+		const TypeInfo* owner_type_info =
+			findTypeByName(owner_name_handle);
+		FLASH_LOG_FORMAT(
+			Templates,
+			Debug,
+			"resolveDeferredQualifiedTemplateCall: owner='{}' found={} has_struct={}",
+			owner_name,
+			owner_type_info != nullptr,
+			owner_type_info != nullptr &&
+				owner_type_info->getStructInfo() != nullptr);
+		if (owner_type_info != nullptr &&
+			owner_type_info->getStructInfo() != nullptr) {
+			if (!explicit_template_args.has_value() &&
+				!gTemplateRegistry.lookupTemplate(qualified_name).has_value()) {
+				std::vector<ASTNode> ordinary_candidates;
+				const StringHandle member_name_handle =
+					StringTable::getOrInternStringHandle(member_name);
+				std::unordered_set<const StructTypeInfo*> visited_structs;
+				auto collect_visible_static_members =
+					[&](const StructTypeInfo* struct_info,
+						const auto& self) -> void {
+					if (struct_info == nullptr ||
+						!visited_structs.insert(struct_info).second) {
+						return;
+					}
+
+					bool found_local_match = false;
+					for (const auto& member_func : struct_info->member_functions) {
+						if (member_func.getName() != member_name_handle ||
+							!member_func.function_decl.is<FunctionDeclarationNode>()) {
+							continue;
+						}
+						const FunctionDeclarationNode& candidate =
+							member_func.function_decl.as<FunctionDeclarationNode>();
+						if (!candidate.is_static()) {
+							continue;
+						}
+						found_local_match = true;
+						const bool already_present =
+							std::any_of(
+								ordinary_candidates.begin(),
+								ordinary_candidates.end(),
+								[&](const ASTNode& existing_candidate) {
+									if (!existing_candidate.is<FunctionDeclarationNode>()) {
+										return false;
+									}
+									return &existing_candidate.as<FunctionDeclarationNode>() ==
+										   &candidate;
+								});
+						if (!already_present) {
+							ordinary_candidates.push_back(
+								member_func.function_decl);
+						}
+					}
+					if (found_local_match) {
+						return;
+					}
+
+					for (const auto& base_spec : struct_info->base_classes) {
+						if (const StructTypeInfo* base_struct =
+								tryGetStructTypeInfo(base_spec.type_index)) {
+							self(base_struct, self);
+						}
+					}
+				};
+				collect_visible_static_members(
+					owner_type_info->getStructInfo(),
+					collect_visible_static_members);
+				FLASH_LOG_FORMAT(
+					Templates,
+					Debug,
+					"resolveDeferredQualifiedTemplateCall: ordinary static candidates for '{}': {}",
+					qualified_name,
+					ordinary_candidates.size());
+
+				if (!ordinary_candidates.empty()) {
+					if (!arg_types.empty()) {
+						OverloadResolutionResult resolution =
+							resolve_overload(ordinary_candidates, arg_types);
+						if (resolution.has_match &&
+							!resolution.is_ambiguous &&
+							resolution.selected_overload != nullptr) {
+							return *resolution.selected_overload;
+						}
+					}
+					if (arguments.empty()) {
+						const FunctionDeclarationNode* zero_arg_candidate = nullptr;
+						bool ambiguous_zero_arg = false;
+						for (const ASTNode& candidate_node : ordinary_candidates) {
+							const FunctionDeclarationNode* candidate =
+								get_function_decl_node(candidate_node);
+							if (candidate == nullptr) {
+								continue;
+							}
+							const size_t min_required =
+								countMinRequiredArgs(*candidate);
+							if (min_required > 0) {
+								continue;
+							}
+							if (zero_arg_candidate != nullptr) {
+								ambiguous_zero_arg = true;
+								break;
+							}
+							zero_arg_candidate = candidate;
+						}
+						if (zero_arg_candidate != nullptr &&
+							!ambiguous_zero_arg) {
+							return ASTNode(zero_arg_candidate);
+						}
+					}
+					if (ordinary_candidates.size() == 1) {
+						return ordinary_candidates.front();
+					}
+				}
+			}
+
+			if (std::optional<ASTNode> resolved_member =
+					tryInstantiateMemberFunctionTemplateCall(
+						owner_name,
+						member_name,
+						explicit_template_args,
+						arg_types,
+						!arguments.empty(),
+						false);
+				resolved_member.has_value()) {
+				return resolved_member;
+			}
+		}
+	}
+
+	if (explicit_template_args.has_value()) {
+		if (arguments.empty()) {
+			return try_instantiate_template_explicit(
+				qualified_name,
+				*explicit_template_args,
+				arguments.size());
+		}
+		return try_instantiate_template_explicit(
+			qualified_name,
+			*explicit_template_args,
+			arg_types);
+	}
+
+	if (!arguments.empty()) {
+		const std::string_view simple_name =
+			scope_sep == std::string_view::npos
+				? qualified_name
+				: qualified_name.substr(scope_sep + 2);
+		return tryInstantiateTemplateFromCallArguments(
+			qualified_name,
+			simple_name,
+			arguments);
+	}
+
+	return std::nullopt;
+}
+
 std::optional<ParseResult> Parser::tryQualifiedPhase1Lookup(
 	const QualifiedIdentifierNode& qual_id,
 	std::string_view display_name,
@@ -3933,7 +4174,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								gNamespaceRegistry.getQualifiedName(full_ns_handle),
 								member_token.value(),
 								member_token,
-								std::nullopt);
+								std::nullopt,
+								nullptr);
 							if (member_call_result.has_value()) {
 								if (member_call_result->is_error()) {
 									return *member_call_result;
@@ -4397,6 +4639,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
 				setCallQualifiedName(result->as<ExpressionNode>(), qualified_name);
 				FLASH_LOG(Parser, Debug, "Set qualified name on call expression: ", qualified_name);
+				if (has_dependent_explicit_template_args &&
+					!identifierType->is<FunctionDeclarationNode>()) {
+					setCallParserReturnTypeHint(
+						result->as<ExpressionNode>(),
+						decl_ptr->type_specifier_node());
+				}
 
 				// If the function has a pre-computed mangled name, set it on the call expression
 				if (identifierType->is<FunctionDeclarationNode>()) {
@@ -5068,7 +5316,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								instantiated_name,
 								qualified_node2.name(),
 								qualified_node2.identifier_token(),
-								std::nullopt);
+								std::nullopt,
+								nullptr);
 							if (member_call_result.has_value()) {
 								if (member_call_result->is_error()) {
 									return *member_call_result;
@@ -7089,7 +7338,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								resolved_namespace_name,
 								final_identifier.value(),
 								final_identifier,
-								member_template_args);
+								member_template_args,
+								&member_template_arg_nodes);
 							if (func_call_result.has_value()) {
 								if (func_call_result->is_error()) {
 									return *func_call_result;
@@ -8219,7 +8469,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							instantiated_class_name,
 							qualified_node.name(),
 							qualified_node.identifier_token(),
-							std::nullopt);
+							std::nullopt,
+							nullptr);
 						if (func_call_result.has_value()) {
 							if (func_call_result->is_error()) {
 								return *func_call_result;
@@ -9101,6 +9352,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 										// Create the call expression with the placeholder
 										result = emplace_node<ExpressionNode>(makeDirectCallExpr(decl_ref, std::move(args), identifier_token));
+										setCallParserReturnTypeHint(
+											result->as<ExpressionNode>(),
+											placeholder_type);
 
 										// Store the template arguments in the call expression for later resolution
 										if (explicit_template_arg_nodes.empty() && effective_template_args.has_value()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -200,7 +200,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	std::string_view member_name,
 	const Token& member_token,
 	std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args,
-	const std::vector<ASTNode>* pre_parsed_member_template_arg_nodes) {
+	std::vector<ASTNode> pre_parsed_member_template_arg_nodes) {
 
 	FLASH_LOG(Templates, Debug, "try_parse_member_template_function_call called for: ", instantiated_class_name, "::", member_name);
 
@@ -208,9 +208,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	std::optional<InlineVector<TemplateTypeArg, 4>> member_template_args =
 		std::move(pre_parsed_member_template_args);
 	std::vector<ASTNode> member_template_arg_nodes =
-		pre_parsed_member_template_arg_nodes != nullptr
-			? *pre_parsed_member_template_arg_nodes
-			: std::vector<ASTNode>{};
+		std::move(pre_parsed_member_template_arg_nodes);
 	SaveHandle member_template_args_start = 0;
 	bool parsed_member_template_args = member_template_args.has_value();
 	bool tentatively_parsed_member_template_args = false;
@@ -329,12 +327,12 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 				member_name,
 				std::span<const TemplateTypeArg>{});
 	}
-	const std::string_view qualified_name =
+	const std::string qualified_name(
 		StringBuilder()
 			.append(instantiated_class_name)
 			.append("::")
 			.append(member_name)
-			.commit();
+			.commit());
 	const StringHandle owner_name_handle =
 		StringTable::getOrInternStringHandle(instantiated_class_name);
 	const StringHandle member_name_handle =

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -327,12 +327,12 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 				member_name,
 				std::span<const TemplateTypeArg>{});
 	}
-	const std::string qualified_name(
+	const std::string_view qualified_name =
 		StringBuilder()
 			.append(instantiated_class_name)
 			.append("::")
 			.append(member_name)
-			.commit());
+			.commit();
 	const StringHandle owner_name_handle =
 		StringTable::getOrInternStringHandle(instantiated_class_name);
 	const StringHandle member_name_handle =

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2719,6 +2719,9 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 		TypeSpecifierNode return_type;
 		if (call_info.function_declaration) {
 			return_type = call_info.function_declaration->decl_node().type_specifier_node();
+		} else if (call_info.parser_return_type_hint != nullptr &&
+				   call_info.parser_return_type_hint->has_value()) {
+			return_type = call_info.parser_return_type_hint->value();
 		} else if (auto indirect_return_type =
 					   FlashCpp::ParserFunctionTypeHelpers::tryGetReturnTypeFromFunctionType(
 						   callee_decl.type_specifier_node(),

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -199,13 +199,18 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	std::string_view instantiated_class_name,
 	std::string_view member_name,
 	const Token& member_token,
-	std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args) {
+	std::optional<InlineVector<TemplateTypeArg, 4>> pre_parsed_member_template_args,
+	const std::vector<ASTNode>* pre_parsed_member_template_arg_nodes) {
 
 	FLASH_LOG(Templates, Debug, "try_parse_member_template_function_call called for: ", instantiated_class_name, "::", member_name);
 
 	// Check for member template arguments: Template<T>::member<U>
 	std::optional<InlineVector<TemplateTypeArg, 4>> member_template_args =
 		std::move(pre_parsed_member_template_args);
+	std::vector<ASTNode> member_template_arg_nodes =
+		pre_parsed_member_template_arg_nodes != nullptr
+			? *pre_parsed_member_template_arg_nodes
+			: std::vector<ASTNode>{};
 	SaveHandle member_template_args_start = 0;
 	bool parsed_member_template_args = member_template_args.has_value();
 	bool tentatively_parsed_member_template_args = false;
@@ -214,7 +219,8 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		// Parse tentatively and only keep the parse if this is a call form.
 		member_template_args_start = save_token_position();
 		last_failed_template_arg_parse_handle_ = SIZE_MAX;
-		member_template_args = parse_explicit_template_arguments();
+		member_template_args =
+			parse_explicit_template_arguments(&member_template_arg_nodes);
 		if (member_template_args.has_value()) {
 			parsed_member_template_args = true;
 			tentatively_parsed_member_template_args = true;
@@ -295,6 +301,16 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		!canonical_owner.instantiated_name.empty()) {
 		instantiated_class_name = canonical_owner.instantiated_name;
 	}
+	const bool has_dependent_template_args =
+		member_template_args.has_value() &&
+		std::any_of(
+			member_template_args->begin(),
+			member_template_args->end(),
+			[](const TemplateTypeArg& arg) {
+				return arg.is_dependent;
+			});
+	const bool has_deferred_template_call_args =
+		has_dependent_call_arg || has_dependent_template_args;
 	std::optional<ASTNode> instantiated_func = tryInstantiateMemberFunctionTemplateCall(
 		instantiated_class_name,
 		member_name,
@@ -313,43 +329,27 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 				member_name,
 				std::span<const TemplateTypeArg>{});
 	}
-
-	// Build qualified function name including template args
-	StringBuilder func_name_builder;
-	func_name_builder.append(instantiated_class_name);
-	func_name_builder.append("::");
-	func_name_builder.append(member_name);
-
-	// If member has template args, append them using hash-based naming
-	if (member_template_args.has_value() && !member_template_args->empty()) {
-		// Generate hash suffix for template args
-		auto key = FlashCpp::makeInstantiationKey(StringTable::getOrInternStringHandle(member_name), *member_template_args);
-		func_name_builder.append("$");
-		auto hash_val = FlashCpp::TemplateInstantiationKeyHash{}(key);
-		char hex[17];
-		std::snprintf(hex, sizeof(hex), "%016llx", static_cast<unsigned long long>(hash_val));
-		func_name_builder.append(std::string_view(hex, 16));
-	}
-	std::string_view func_name = func_name_builder.commit();
-
-	// Create function call token
-	Token func_token(Token::Type::Identifier, func_name,
-					 member_token.line(),
-					 member_token.column(),
-					 member_token.file_index());
+	const std::string_view qualified_name =
+		StringBuilder()
+			.append(instantiated_class_name)
+			.append("::")
+			.append(member_name)
+			.commit();
+	const StringHandle owner_name_handle =
+		StringTable::getOrInternStringHandle(instantiated_class_name);
+	const StringHandle member_name_handle =
+		StringTable::getOrInternStringHandle(member_name);
 
 	// If we successfully instantiated the function, use its declaration
-	const DeclarationNode* decl_ptr = nullptr;
-	const FunctionDeclarationNode* func_decl_ptr = nullptr;
+	const FunctionDeclarationNode* resolved_function = nullptr;
+	const FunctionDeclarationNode* parser_hint_function = nullptr;
 	if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-		func_decl_ptr = &instantiated_func->as<FunctionDeclarationNode>();
-		decl_ptr = &func_decl_ptr->decl_node();
+		resolved_function = &instantiated_func->as<FunctionDeclarationNode>();
+		parser_hint_function = resolved_function;
 	} else {
 		// For non-template member functions (e.g. Template<T>::allocate()),
 		// resolve directly from the instantiated class before creating a fallback decl.
-		StringHandle class_name_handle = StringTable::getOrInternStringHandle(instantiated_class_name);
-		StringHandle member_name_handle = StringTable::getOrInternStringHandle(member_name);
-		auto type_it = getTypesByNameMap().find(class_name_handle);
+		auto type_it = getTypesByNameMap().find(owner_name_handle);
 		if (type_it != getTypesByNameMap().end() && type_it->second) {
 			const StructTypeInfo* struct_info = type_it->second->getStructInfo();
 			if (struct_info) {
@@ -362,50 +362,111 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 							first_name_match = &candidate;
 						}
 						if (candidate.parameter_nodes().size() == call_arg_count) {
-							func_decl_ptr = &candidate;
-							decl_ptr = &func_decl_ptr->decl_node();
+							resolved_function = &candidate;
 							break;
 						}
 					}
 				}
-				if (!decl_ptr && first_name_match) {
-					func_decl_ptr = first_name_match;
-					decl_ptr = &func_decl_ptr->decl_node();
+				if (resolved_function == nullptr && first_name_match != nullptr) {
+					parser_hint_function = first_name_match;
 				}
 			}
 		}
-
-		// Fall back to forward declaration only if we still couldn't resolve.
-		if (!decl_ptr) {
-			auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Int, TypeQualifier::None, 32, func_token, CVQualifier::None);
-			auto forward_decl = emplace_node<DeclarationNode>(type_node, func_token);
-			decl_ptr = &forward_decl.as<DeclarationNode>();
+		if (parser_hint_function == nullptr &&
+			member_template_args.has_value()) {
+			if (const std::vector<ASTNode>* template_overloads =
+					gTemplateRegistry.lookupAllTemplates(qualified_name);
+				template_overloads != nullptr) {
+				for (const ASTNode& template_overload : *template_overloads) {
+					if (const FunctionDeclarationNode* template_function =
+							get_function_decl_node(template_overload);
+						template_function != nullptr) {
+						parser_hint_function = template_function;
+						break;
+					}
+				}
+			}
 		}
 	}
 
-	auto result = emplace_node<ExpressionNode>(
-		func_decl_ptr
-			? makeResolvedCallExpr(*func_decl_ptr, std::move(args), func_token)
-			: makeDirectCallExpr(*decl_ptr, std::move(args), func_token));
-	setCallQualifiedName(result.as<ExpressionNode>(), func_name);
-
-	// Set the mangled name on the function call if we have the function declaration
-	if (func_decl_ptr && func_decl_ptr->has_mangled_name()) {
-		setCallMangledName(result.as<ExpressionNode>(), func_decl_ptr->mangled_name());
+	std::optional<ExpressionNode> call_expr;
+	if (resolved_function != nullptr) {
+		call_expr = makeResolvedCallExpr(
+			*resolved_function,
+			std::move(args),
+			member_token);
+	} else {
+		auto placeholder_type = emplace_node<TypeSpecifierNode>(
+			TypeCategory::Int,
+			TypeQualifier::None,
+			32,
+			member_token,
+			CVQualifier::None);
+		auto placeholder_decl = emplace_node<DeclarationNode>(
+			placeholder_type.as<TypeSpecifierNode>(),
+			member_token);
+		call_expr = makeDeferredOrdinaryDirectCallExpr(
+			placeholder_decl,
+			std::move(args),
+			member_token);
 	}
-	if (func_decl_ptr) {
+	auto result = emplace_node<ExpressionNode>(std::move(*call_expr));
+	setCallQualifiedName(result.as<ExpressionNode>(), qualified_name);
+	if (!member_template_arg_nodes.empty()) {
+		setCallTemplateArguments(
+			result.as<ExpressionNode>(),
+			std::move(member_template_arg_nodes));
+	}
+	if (resolved_function == nullptr) {
+		auto owner_type_it = getTypesByNameMap().find(owner_name_handle);
+		if (owner_type_it != getTypesByNameMap().end() &&
+			owner_type_it->second != nullptr &&
+			owner_type_it->second->isTemplateInstantiation() &&
+			owner_type_it->second->getStructInfo() == nullptr) {
+			TypeInfo::DependentQualifiedNameRecord dependent_record;
+			dependent_record.owner_kind =
+				TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
+			dependent_record.owner_name = owner_name_handle;
+			dependent_record.owner_type =
+				owner_type_it->second->registeredTypeIndex();
+			dependent_record.owner_template_arguments =
+				owner_type_it->second->templateArgs();
+			TypeInfo::DependentQualifiedNameRecord::Member member_record;
+			member_record.name = member_name_handle;
+			if (member_template_args.has_value()) {
+				member_record.template_arguments =
+					toTemplateArgInfoList(*member_template_args);
+				member_record.has_template_arguments = true;
+			}
+			dependent_record.member_chain.push_back(std::move(member_record));
+			setCallDependentQualifiedLookupRecord(
+				result.as<ExpressionNode>(),
+				dependent_record);
+		}
+	}
+
+	if (resolved_function != nullptr && resolved_function->has_mangled_name()) {
+		setCallMangledName(
+			result.as<ExpressionNode>(),
+			resolved_function->mangled_name());
+	}
+	if (resolved_function != nullptr) {
 		if (std::optional<FunctionCallDefinitionLookupRecord> record =
 				tryBuildFunctionCallDefinitionLookupRecord(
 					current_template_definition_lookup_context_,
 					member_token,
 					deduced_arg_types,
-					has_dependent_call_arg,
-					*func_decl_ptr,
+					has_deferred_template_call_args,
+					*resolved_function,
 					true,
 					false);
 			record.has_value()) {
 			setCallDefinitionLookupRecord(result.as<ExpressionNode>(), *record);
 		}
+	} else if (parser_hint_function != nullptr) {
+		setCallParserReturnTypeHint(
+			result.as<ExpressionNode>(),
+			parser_hint_function->decl_node().type_specifier_node());
 	}
 
 	return ParseResult::success(result);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -14,7 +14,15 @@ std::string_view unqualifiedTypeComponent(std::string_view type_name) {
 }
 
 std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_name) {
-	auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(struct_name));
+	const StringHandle struct_name_handle =
+		StringTable::getOrInternStringHandle(struct_name);
+	if (auto pattern_name =
+			gTemplateRegistry.get_instantiation_pattern(struct_name_handle);
+		pattern_name.has_value()) {
+		return *pattern_name;
+	}
+
+	auto type_it = getTypesByNameMap().find(struct_name_handle);
 	if (type_it == getTypesByNameMap().end()) {
 		return std::nullopt;
 	}
@@ -81,6 +89,31 @@ StringHandle getMemberTemplateOwnerName(StringHandle qualified_lookup_name, cons
 	}
 
 	return {};
+}
+
+void rebindConcreteMemberTemplateLookupResult(
+	TemplateNameLookupResult& lookup_result,
+	StringHandle concrete_owner_name,
+	StringHandle member_name) {
+	if (!concrete_owner_name.isValid() || !member_name.isValid()) {
+		return;
+	}
+
+	StringHandle concrete_lookup_name = StringTable::getOrInternStringHandle(
+		StringBuilder()
+			.append(StringTable::getStringView(concrete_owner_name))
+			.append("::")
+			.append(StringTable::getStringView(member_name))
+			.commit());
+	lookup_result.resolved_name = concrete_lookup_name;
+	for (auto& candidate : lookup_result.candidates) {
+		if (candidate.identity.kind != TemplateDeclarationKind::FunctionTemplate) {
+			continue;
+		}
+		candidate.identity.lookup_name = concrete_lookup_name;
+		candidate.lookup_owner_name = concrete_owner_name;
+		candidate.declaring_owner_name = concrete_owner_name;
+	}
 }
 
 void propagateSubstitutedFunctionSignature(
@@ -355,7 +388,15 @@ InlineVector<TemplateNameLookupCandidate, 4> Parser::lookupMemberFunctionTemplat
 					*lookup_owner,
 					member_name_handle,
 					false);
-				append_candidates(gTemplateRegistry.lookupTemplateName(base_request));
+				TemplateNameLookupResult base_lookup_result =
+					gTemplateRegistry.lookupTemplateName(base_request);
+				if (base_lookup_result.hasFunctionTemplate()) {
+					rebindConcreteMemberTemplateLookupResult(
+						base_lookup_result,
+						requested_owner,
+						member_name_handle);
+				}
+				append_candidates(base_lookup_result);
 				if (!candidates.empty()) {
 					FLASH_LOG(Templates, Debug, "Found base template class lookup: ", base_request.owner_name.view());
 				}
@@ -409,19 +450,10 @@ InlineVector<TemplateNameLookupCandidate, 4> Parser::lookupMemberFunctionTemplat
 							// Rewrite identity.lookup_name from "Base::get_n" to
 							// "Base<int>::get_n" so outer-binding and instantiation-key
 							// lookups use the concrete instantiation's qualified name.
-							StringBuilder inst_qname_sb;
-							inst_qname_sb.append(StringTable::getStringView(struct_name_handle))
-								.append("::")
-								.append(member_name);
-							StringHandle inst_qname =
-								StringTable::getOrInternStringHandle(inst_qname_sb);
-							for (auto& cand : base_tpl_result.candidates) {
-								if (cand.identity.kind ==
-									TemplateDeclarationKind::FunctionTemplate) {
-									cand.identity.lookup_name = inst_qname;
-									cand.declaring_owner_name = struct_name_handle;
-								}
-							}
+							rebindConcreteMemberTemplateLookupResult(
+								base_tpl_result,
+								struct_name_handle,
+								member_name_handle);
 							return {struct_name_handle, depth, std::move(base_tpl_result)};
 						}
 					}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8108,21 +8108,70 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			auto it = getTypesByNameMap().find(handle);
 			return it != getTypesByNameMap().end() ? it->second : nullptr;
 		};
+		auto resolve_nested_owner_from_base =
+			[&](StringHandle base_owner_handle,
+				StringHandle nested_owner_handle) -> const TypeInfo* {
+				if (!base_owner_handle.isValid() ||
+					!nested_owner_handle.isValid()) {
+					return nullptr;
+				}
+
+				auto resolve_from_owner = [&](StringHandle owner_handle) -> const TypeInfo* {
+					if (!owner_handle.isValid()) {
+						return nullptr;
+					}
+					if (LazyNestedTypeRegistry::getInstance().needsInstantiation(
+							owner_handle,
+							nested_owner_handle)) {
+						parser().instantiateLazyNestedType(
+							owner_handle,
+							nested_owner_handle);
+					}
+
+					QualifiedTypeMemberAccess nested_owner_access;
+					nested_owner_access.member_name = nested_owner_handle;
+					return parser().resolveBaseClassMemberTypeChain(
+						StringTable::getStringView(owner_handle),
+						std::span<const QualifiedTypeMemberAccess>(
+							&nested_owner_access,
+							1));
+				};
+
+				if (const TypeInfo* resolved_owner =
+						resolve_from_owner(base_owner_handle)) {
+					return resolved_owner;
+				}
+
+				if (std::optional<StringHandle> pattern_owner_handle =
+						gTemplateRegistry.get_instantiation_pattern(base_owner_handle);
+					pattern_owner_handle.has_value()) {
+					return resolve_from_owner(*pattern_owner_handle);
+				}
+
+				return nullptr;
+			};
 
 		const TypeInfo* type_info = nullptr;
 		if (const MemberContext* member_context = getCurrentMemberContext();
 			member_context &&
 			owner_name.find("::") == std::string_view::npos) {
 			if (const TypeInfo* current_type_info = tryGetTypeInfo(member_context->type_index)) {
-				const std::string_view current_type_name =
-					StringTable::getStringView(current_type_info->name());
-				type_info = resolve_type_info(
-					StringTable::getOrInternStringHandle(
-						StringBuilder()
-							.append(current_type_name)
-							.append("::")
-							.append(owner_name)
-							.commit()));
+				const StringHandle owner_name_handle =
+					StringTable::getOrInternStringHandle(owner_name);
+				type_info = resolve_nested_owner_from_base(
+					current_type_info->name(),
+					owner_name_handle);
+				if (!type_info) {
+					const std::string_view current_type_name =
+						StringTable::getStringView(current_type_info->name());
+					type_info = resolve_type_info(
+						StringTable::getOrInternStringHandle(
+							StringBuilder()
+								.append(current_type_name)
+								.append("::")
+								.append(owner_name)
+								.commit()));
+				}
 				if (!type_info) {
 					if (const TypeInfo::TemplateArgInfo* bound_arg =
 							current_type_info->findLegacyInstantiationArgByName(owner_name)) {
@@ -8136,6 +8185,22 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return tryResolveStructOwnerTypeInfo(type_info);
 	};
+	const bool qualified_name_has_type_owner = [&]() {
+		if (!call_info.qualified_name.isValid()) {
+			return false;
+		}
+		const std::string_view qualified_name = call_info.qualified_name.view();
+		const size_t scope_sep = qualified_name.rfind("::");
+		if (scope_sep == std::string_view::npos) {
+			return false;
+		}
+		const std::string_view owner_name = qualified_name.substr(0, scope_sep);
+		return resolveQualifiedOwnerTypeForCall(owner_name) != nullptr;
+	}();
+	const bool qualified_name_targets_namespace =
+		call_info.qualified_name.isValid() &&
+		!qualified_name_has_type_owner &&
+		resolveQualifiedLookupTarget(call_info.qualified_name.view()).has_value();
 	auto resolveLocalCallableStructInfo = [&]() -> const StructTypeInfo* {
 		if (call_info.has_receiver) {
 			return nullptr;
@@ -8182,11 +8247,14 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				!call_info.function_declaration->is_static()) {
 				return nullptr;
 			}
+			if (call_info.qualified_name.isValid()) {
+				// Qualified static calls need sema-owned owner resolution so nested
+				// current-instantiation owners cannot be stolen by broader parser-time
+				// matches such as unrelated global templates with the same name.
+				return nullptr;
+			}
 			if (call_info.definition_lookup_record != nullptr &&
 				call_info.definition_lookup_record->has_value()) {
-				return call_info.function_declaration;
-			}
-			if (call_info.qualified_name.isValid()) {
 				return call_info.function_declaration;
 			}
 			return nullptr;
@@ -8286,12 +8354,16 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 	if (!call_info.is_indirect &&
 		!call_info.has_receiver &&
+		(!call_info.qualified_name.isValid() ||
+		 qualified_name_targets_namespace) &&
 		definition_lookup_record_target != nullptr) {
 		return definition_lookup_record_target;
 	}
 	if (!normalized_call &&
 		!call_info.is_indirect &&
 		!call_info.has_receiver &&
+		(!call_info.qualified_name.isValid() ||
+		 qualified_name_targets_namespace) &&
 		definition_lookup_record_target == nullptr &&
 		call_info.definition_lookup_record != nullptr &&
 		call_info.definition_lookup_record->has_value()) {
@@ -8373,10 +8445,40 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return nullptr;
 	}
+	if (!call_info.has_receiver &&
+		call_info.function_declaration == nullptr &&
+		call_info.qualified_name.isValid()) {
+		const bool has_deferred_qualified_template_metadata =
+			!call_info.template_arguments.empty() ||
+			(call_info.dependent_qualified_lookup_record != nullptr &&
+			 call_info.dependent_qualified_lookup_record->has_value());
+		if (qualified_name_targets_namespace ||
+			has_deferred_qualified_template_metadata) {
+			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;
+			if (tryCollectOverloadResolutionArgTypes(arguments, qualified_template_arg_types)) {
+				if (std::optional<ASTNode> resolved_target =
+						parser().resolveDeferredQualifiedTemplateCall(
+							call_info.qualified_name.view(),
+							call_info.template_arguments,
+							arguments,
+							qualified_template_arg_types);
+					resolved_target.has_value()) {
+					if (const FunctionDeclarationNode* resolved_function =
+						get_function_decl_node(*resolved_target);
+					resolved_function != nullptr) {
+						return resolved_function;
+					}
+				}
+			}
+		}
+	}
 
-	if (const FunctionDeclarationNode* mangled_candidate =
-			lookupFunctionByMangledName(call_info.mangled_name)) {
-		return mangled_candidate;
+	if (!call_info.qualified_name.isValid() ||
+		qualified_name_targets_namespace) {
+		if (const FunctionDeclarationNode* mangled_candidate =
+				lookupFunctionByMangledName(call_info.mangled_name)) {
+			return mangled_candidate;
+		}
 	}
 
 	const DeclarationNode& decl = callee_decl;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8289,6 +8289,30 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		definition_lookup_record_target != nullptr) {
 		return definition_lookup_record_target;
 	}
+	if (!normalized_call &&
+		!call_info.is_indirect &&
+		!call_info.has_receiver &&
+		definition_lookup_record_target == nullptr &&
+		call_info.definition_lookup_record != nullptr &&
+		call_info.definition_lookup_record->has_value()) {
+		const FunctionCallDefinitionLookupRecord& deferred_record =
+			call_info.definition_lookup_record->value();
+		InlineVector<TypeSpecifierNode, 6> arg_types;
+		if (tryCollectOverloadResolutionArgTypes(arguments, arg_types)) {
+			if (std::optional<ASTNode> resolved_target =
+					parser().resolveDefinitionBoundOrdinaryCall(
+						deferred_record,
+						arguments,
+						arg_types);
+				resolved_target.has_value()) {
+				if (const FunctionDeclarationNode* resolved_function =
+						get_function_decl_node(*resolved_target);
+					resolved_function != nullptr) {
+					return resolved_function;
+				}
+			}
+		}
+	}
 	if (const FunctionDeclarationNode* parser_selected_static_target =
 			fallbackToParserSelectedStaticDirectTarget();
 		parser_selected_static_target != nullptr) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8458,7 +8458,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			 call_info.dependent_qualified_lookup_record->has_value());
 		if (qualified_name_targets_namespace ||
 			has_deferred_qualified_template_metadata) {
-			std::string qualified_name_for_resolution_storage;
 			std::string_view qualified_name_for_resolution =
 				call_info.qualified_name.view();
 			if (!qualified_name_targets_namespace &&
@@ -8473,14 +8472,12 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 					const std::string_view member_name =
 						qualified_name_for_resolution.substr(
 							owner_name.size() + 2);
-					qualified_name_for_resolution_storage =
+					qualified_name_for_resolution =
 						StringBuilder()
 							.append(resolved_owner_name)
 							.append("::")
 							.append(member_name)
 							.commit();
-					qualified_name_for_resolution =
-						qualified_name_for_resolution_storage;
 				}
 			}
 			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8185,18 +8185,23 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return tryResolveStructOwnerTypeInfo(type_info);
 	};
-	const bool qualified_name_has_type_owner = [&]() {
+	const std::optional<std::string_view> qualified_call_owner_name = [&]() -> std::optional<std::string_view> {
 		if (!call_info.qualified_name.isValid()) {
-			return false;
+			return std::nullopt;
 		}
 		const std::string_view qualified_name = call_info.qualified_name.view();
 		const size_t scope_sep = qualified_name.rfind("::");
 		if (scope_sep == std::string_view::npos) {
-			return false;
+			return std::nullopt;
 		}
-		const std::string_view owner_name = qualified_name.substr(0, scope_sep);
-		return resolveQualifiedOwnerTypeForCall(owner_name) != nullptr;
+		return qualified_name.substr(0, scope_sep);
 	}();
+	const TypeInfo* const qualified_type_owner =
+		qualified_call_owner_name.has_value()
+			? resolveQualifiedOwnerTypeForCall(*qualified_call_owner_name)
+			: nullptr;
+	const bool qualified_name_has_type_owner =
+		qualified_type_owner != nullptr;
 	const bool qualified_name_targets_namespace =
 		call_info.qualified_name.isValid() &&
 		!qualified_name_has_type_owner &&
@@ -8454,11 +8459,33 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			 call_info.dependent_qualified_lookup_record->has_value());
 		if (qualified_name_targets_namespace ||
 			has_deferred_qualified_template_metadata) {
+			std::string_view qualified_name_for_resolution =
+				call_info.qualified_name.view();
+			if (!qualified_name_targets_namespace &&
+				qualified_type_owner != nullptr &&
+				qualified_call_owner_name.has_value()) {
+				const std::string_view owner_name =
+					*qualified_call_owner_name;
+				const std::string_view resolved_owner_name =
+					StringTable::getStringView(qualified_type_owner->name());
+				if (!resolved_owner_name.empty() &&
+					resolved_owner_name != owner_name) {
+					const std::string_view member_name =
+						qualified_name_for_resolution.substr(
+							owner_name.size() + 2);
+					qualified_name_for_resolution =
+						StringBuilder()
+							.append(resolved_owner_name)
+							.append("::")
+							.append(member_name)
+							.commit();
+				}
+			}
 			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;
 			if (tryCollectOverloadResolutionArgTypes(arguments, qualified_template_arg_types)) {
 				if (std::optional<ASTNode> resolved_target =
 						parser().resolveDeferredQualifiedTemplateCall(
-							call_info.qualified_name.view(),
+							qualified_name_for_resolution,
 							call_info.template_arguments,
 							arguments,
 							qualified_template_arg_types);
@@ -8497,41 +8524,35 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				qualified_lookup->identifier);
 		}
 		if (overloads.empty()) {
-			const std::string_view qualified_name = call_info.qualified_name.view();
-			const size_t scope_sep = qualified_name.rfind("::");
-			if (scope_sep != std::string_view::npos) {
-				const std::string_view owner_name = qualified_name.substr(0, scope_sep);
-				if (const TypeInfo* owner_type = resolveQualifiedOwnerTypeForCall(owner_name);
-					owner_type != nullptr &&
-					owner_type->getStructInfo() != nullptr) {
-					const ConstAwareMemberCandidateSet member_candidates =
-						collectConstAwareVisibleMemberFunctionCandidates(
-							owner_type->getStructInfo(),
-							decl.identifier_token().handle(),
-							false,
-							true,
-							[](const StructMemberFunction&, const FunctionDeclarationNode& func_decl) {
-								return func_decl.is_static();
-							});
-					if (!member_candidates.compatible.empty()) {
-						for (const StructMemberFunction* member_candidate :
-							 member_candidates.preferred) {
-							if (member_candidate != nullptr) {
-								appendUniqueOverload(
-									overloads,
-									member_candidate->function_decl);
-							}
+			if (qualified_type_owner != nullptr &&
+				qualified_type_owner->getStructInfo() != nullptr) {
+				const ConstAwareMemberCandidateSet member_candidates =
+					collectConstAwareVisibleMemberFunctionCandidates(
+						qualified_type_owner->getStructInfo(),
+						decl.identifier_token().handle(),
+						false,
+						true,
+						[](const StructMemberFunction&, const FunctionDeclarationNode& func_decl) {
+							return func_decl.is_static();
+						});
+				if (!member_candidates.compatible.empty()) {
+					for (const StructMemberFunction* member_candidate :
+						 member_candidates.preferred) {
+						if (member_candidate != nullptr) {
+							appendUniqueOverload(
+								overloads,
+								member_candidate->function_decl);
 						}
-						for (const StructMemberFunction* member_candidate :
-							 member_candidates.compatible) {
-							if (member_candidate != nullptr) {
-								appendUniqueOverload(
-									overloads,
-									member_candidate->function_decl);
-							}
-						}
-						used_qualified_owner_static_member_lookup = true;
 					}
+					for (const StructMemberFunction* member_candidate :
+						 member_candidates.compatible) {
+						if (member_candidate != nullptr) {
+							appendUniqueOverload(
+								overloads,
+								member_candidate->function_decl);
+						}
+					}
+					used_qualified_owner_static_member_lookup = true;
 				}
 			}
 		}
@@ -8548,13 +8569,11 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (overloads.empty() &&
 		call_info.qualified_name.isValid() &&
 		!used_qualified_owner_static_member_lookup) {
-		const std::string_view qualified_name = call_info.qualified_name.view();
-		const size_t scope_sep = qualified_name.rfind("::");
-		if (scope_sep != std::string_view::npos) {
-			const std::string_view owner_name = qualified_name.substr(0, scope_sep);
-			if (const TypeInfo* owner_type = resolveQualifiedOwnerTypeForCall(owner_name)) {
-				appendOwnerMemberOverloads(owner_type, decl.identifier_token().value(), overloads);
-			}
+		if (qualified_type_owner != nullptr) {
+			appendOwnerMemberOverloads(
+				qualified_type_owner,
+				decl.identifier_token().value(),
+				overloads);
 		}
 	}
 	InlineVector<TypeSpecifierNode, 6> arg_types;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8459,6 +8459,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			 call_info.dependent_qualified_lookup_record->has_value());
 		if (qualified_name_targets_namespace ||
 			has_deferred_qualified_template_metadata) {
+			std::string qualified_name_for_resolution_storage;
 			std::string_view qualified_name_for_resolution =
 				call_info.qualified_name.view();
 			if (!qualified_name_targets_namespace &&
@@ -8473,12 +8474,14 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 					const std::string_view member_name =
 						qualified_name_for_resolution.substr(
 							owner_name.size() + 2);
-					qualified_name_for_resolution =
+					qualified_name_for_resolution_storage =
 						StringBuilder()
 							.append(resolved_owner_name)
 							.append("::")
 							.append(member_name)
 							.commit();
+					qualified_name_for_resolution =
+						qualified_name_for_resolution_storage;
 				}
 			}
 			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8379,7 +8379,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			if (std::optional<ASTNode> resolved_target =
 					parser().resolveDefinitionBoundOrdinaryCall(
 						deferred_record,
-						arguments,
 						arg_types);
 				resolved_target.has_value()) {
 				if (const FunctionDeclarationNode* resolved_function =

--- a/tests/test_qualified_static_member_template_decltype_ret0.cpp
+++ b/tests/test_qualified_static_member_template_decltype_ret0.cpp
@@ -1,0 +1,18 @@
+struct Host {
+	template <class T>
+	static T value() {
+		return static_cast<T>(42);
+	}
+};
+
+template <class T>
+using HostValue = decltype(Host::template value<T>());
+
+template <class T>
+HostValue<T> run() {
+	return Host::template value<T>();
+}
+
+int main() {
+	return run<int>() == 42 ? 0 : 1;
+}

--- a/tests/test_qualified_static_member_template_explicit_dependent_arg_ret0.cpp
+++ b/tests/test_qualified_static_member_template_explicit_dependent_arg_ret0.cpp
@@ -1,0 +1,27 @@
+template <class T>
+struct Source {
+	static T make() {
+		return T{};
+	}
+};
+
+struct Host {
+	template <class U>
+	static int pick(U) {
+		return 0;
+	}
+
+	template <class U>
+	static int pick(U*) {
+		return 1;
+	}
+};
+
+template <class T>
+int run() {
+	return Host::template pick<T*>(Source<T*>::make());
+}
+
+int main() {
+	return run<int>();
+}


### PR DESCRIPTION
## What changed

- continues the template direct-call metadata refactor so ordinary calls parsed in template contexts can carry structured recovery metadata instead of relying on parser-selected fallback targets
- adds parser/sema plumbing for deferred ordinary direct calls, including definition-bound lookup records, qualified/dependent lookup records, and semantic re-resolution from the actual call argument types
- tightens qualified and member-template owner rebinding so instantiated owners are resolved consistently at the parser lookup layer
- adds regression coverage for qualified static member template calls, including explicit dependent template arguments
- updates the template-argument architecture and conformance docs with the current status, what was fixed in this slice, and the next follow-up work

## Why

This branch is part of the ongoing effort to make template call handling match C++20 lookup and overload-resolution rules at the right architectural layer.

The main change in this slice is moving direct-call recovery away from compatibility-style parser fallbacks and toward structured metadata that sema can re-resolve using the real call shape and the original definition context. That gives us a more standard-aligned foundation for dependent ordinary calls, qualified template calls, and instantiated member-template ownership.

It also fixes the owner-identity issues that showed up around qualified/member-template calls, and records the remaining follow-up work in the docs rather than adding another non-architectural workaround.
