### PR TITLE
[codex] Preserve nested owner identity in qualified member-template calls

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-13
+**Last updated:** 2026-06-14
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -116,6 +116,16 @@ the areas that were previously blocking standards-visible behavior:
   sema resolves nested current-instantiation owners structurally and no longer
   lets unrelated global templates steal calls like `Ops::read(value)` inside
   `Runner<T>`
+- explicit qualified member-template direct calls now preserve nested current-
+  instantiation owner identity in the parser/materialization layer when the
+  owner spelling names a real nested owner (for example `Ops::template read<int>(value)`
+  inside `Runner<T>`), instead of normalizing through the standalone owner
+  spelling and letting an unrelated global template owner win
+- that parser-side owner rewrite is now intentionally narrow: it only rewrites
+  short owner spellings when the resolved owner is a true nested owner
+  extension (for example `Runner<int>::Ops`), so alias/self-owner qualified
+  calls remain on their existing paths instead of being eagerly collapsed onto
+  unrelated concrete owner names
 
 ## Architectural invariants to preserve
 
@@ -217,6 +227,12 @@ Remaining near-term scope:
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
   call-specific explicit-template-argument repairs deeper in sema/codegen
+- the standards-visible nested-owner collision in explicit qualified
+  member-template calls is now fixed in the parser/materialization layer by
+  preserving the full nested owner identity instead of recovering from the
+  short owner spelling later; remaining work in this bucket is the still-legacy
+  compatibility branch for ordinary static-member fallback inside
+  `resolveDeferredQualifiedTemplateCall(...)`, not more owner-collision repair
 - the remaining sema/codegen boundary sync for direct calls should stay narrow;
   it now operates at whole-call granularity on the exact lowered AST, but the
   long-term target is still to remove even that hook once the remaining
@@ -248,12 +264,9 @@ Next direct-call target:
   standards-visible nested-owner collision in explicit qualified member-template
   calls where a nested owner name inside the current instantiation collides with
   an unrelated global template owner
-  concrete uncovered case: inside `Runner<T>::run()`, `Ops::template read<int>(value)`
-  still binds to the unrelated global `Ops<T>::read` instead of the nested
-  `Runner<T>::Ops::read` when both exist
-  required implementation direction: preserve or reconstruct the exact nested
-  owner identity in the parser/member-template instantiation layer instead of
-  canonicalizing through a standalone owner spelling
+  status: covered by the new parser-side nested-owner identity preservation;
+  keep the focused regression for this case in the guard set and do not widen
+  the rewrite past true nested-owner extensions
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -273,6 +286,7 @@ When changing this area, always rerun:
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
+- `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -304,10 +318,15 @@ When changing this area, always rerun:
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve
    the pack node" rule now enforced in ordinary call parsing.
-   First unresolved conformance regression to close in that slice:
-   add a focused test for the nested-owner collision described above only when
-   the parser/member-template owner identity is fixed at the source, not via a
-   new semantic or codegen compatibility branch.
+   The nested-owner explicit member-template collision is now fixed at the
+   parser source and guarded by
+   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`.
+   The next concrete target in this slice is therefore the remaining
+   ordinary-static-member compatibility branch inside
+   `resolveDeferredQualifiedTemplateCall(...)`: move that branch onto the same
+   structured type-owner vs namespace-qualifier split, then remove any now-
+   redundant whole-call sema resynchronization that was only compensating for
+   that compatibility path.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -287,6 +287,7 @@ When changing this area, always rerun:
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
+- `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -320,7 +321,9 @@ When changing this area, always rerun:
    the pack node" rule now enforced in ordinary call parsing.
    The nested-owner explicit member-template collision is now fixed at the
    parser source and guarded by
-   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`.
+   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
+   plus the multi-segment owner-chain variant
+   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`.
    The next concrete target in this slice is therefore the remaining
    ordinary-static-member compatibility branch inside
    `resolveDeferredQualifiedTemplateCall(...)`: move that branch onto the same

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -121,6 +121,10 @@ the areas that were previously blocking standards-visible behavior:
   owner spelling names a real nested owner (for example `Ops::template read<int>(value)`
   inside `Runner<T>`), instead of normalizing through the standalone owner
   spelling and letting an unrelated global template owner win
+- that owner recovery now walks enclosing nested class/member-function contexts
+  from inner to outer, so the same explicit qualified member-template path also
+  resolves owners declared on an enclosing current instantiation from inside a
+  nested class body
 - that parser-side owner rewrite is now intentionally narrow: it only rewrites
   short owner spellings when the resolved owner is a true nested owner
   extension (for example `Runner<int>::Ops`), so alias/self-owner qualified
@@ -288,6 +292,7 @@ When changing this area, always rerun:
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
+- `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -323,7 +328,9 @@ When changing this area, always rerun:
    parser source and guarded by
    `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
    plus the multi-segment owner-chain variant
-   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`.
+   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
+   and the enclosing-scope nested-class variant
+   `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
    The next concrete target in this slice is therefore the remaining
    ordinary-static-member compatibility branch inside
    `resolveDeferredQualifiedTemplateCall(...)`: move that branch onto the same

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -329,7 +329,12 @@ When changing this area, always rerun:
    `resolveDeferredQualifiedTemplateCall(...)`: move that branch onto the same
    structured type-owner vs namespace-qualifier split, then remove any now-
    redundant whole-call sema resynchronization that was only compensating for
-   that compatibility path.
+   that compatibility path. Long-term direction: stop teaching individual
+   parser call sites to recover owner identity from short qualified spellings.
+   Instead, preserve a shared structured qualified-owner record on the AST and
+   route both parser materialization and sema fallback through one owner/type-
+   owner-vs-namespace resolver so this pattern does not repeat in more
+   qualified-call subpaths.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -121,6 +121,10 @@ blocking areas:
   identity in the parser/materialization layer when the owner spelling names a
   real nested owner, so `Ops::template read<int>(value)` inside `Runner<T>`
   no longer rebinds through an unrelated global `Ops<T>::read`
+- that owner recovery now also walks enclosing nested class/member-function
+  contexts from inner to outer, so a nested class body can still resolve an
+  owner declared on the enclosing current instantiation through the same
+  explicit qualified member-template path
 - that owner rewrite is now constrained to true nested-owner extensions only
   (for example `Runner<int>::Ops` from `Ops`), preventing alias/self-owner
   qualified calls from being eagerly collapsed onto unrelated concrete owner
@@ -277,6 +281,7 @@ For work in this area, rerun:
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
+- `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -310,7 +315,9 @@ For work in this area, rerun:
    guarded by
    `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
    plus the multi-segment owner-chain regression
-   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`.
+   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
+   and the enclosing-scope nested-class regression
+   `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
    The next concrete follow-up is narrower:
    remove the remaining ordinary static-member compatibility recovery inside
    `resolveDeferredQualifiedTemplateCall(...)` by routing those calls through

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -276,6 +276,7 @@ For work in this area, rerun:
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
+- `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -307,7 +308,9 @@ For work in this area, rerun:
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by
-   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`.
+   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
+   plus the multi-segment owner-chain regression
+   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`.
    The next concrete follow-up is narrower:
    remove the remaining ordinary static-member compatibility recovery inside
    `resolveDeferredQualifiedTemplateCall(...)` by routing those calls through

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-13
+**Last updated:** 2026-06-14
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -117,6 +117,14 @@ blocking areas:
   which fixes current-instantiation nested-owner cases like
   `Runner<T>::Ops::read(value)` being stolen by an unrelated global
   `Ops<T>::read`
+- explicit qualified member-template calls now preserve the full nested owner
+  identity in the parser/materialization layer when the owner spelling names a
+  real nested owner, so `Ops::template read<int>(value)` inside `Runner<T>`
+  no longer rebinds through an unrelated global `Ops<T>::read`
+- that owner rewrite is now constrained to true nested-owner extensions only
+  (for example `Runner<int>::Ops` from `Ops`), preventing alias/self-owner
+  qualified calls from being eagerly collapsed onto unrelated concrete owner
+  names while still closing the standards-visible collision above
 
 ## Highest-value remaining standards gaps
 
@@ -197,6 +205,11 @@ Remaining near-term scope:
   records participate; the remaining parser helper that still does ordinary
   static-member recovery inside `resolveDeferredQualifiedTemplateCall(...)`
   should be moved onto that same model
+- the explicit qualified member-template nested-owner collision is now closed
+  at the parser/materialization source rather than by adding a later semantic
+  compatibility branch; remaining work in this sub-area is the still-legacy
+  ordinary static-member recovery branch in
+  `resolveDeferredQualifiedTemplateCall(...)`, not more owner-collision repair
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -230,7 +243,9 @@ Next direct-call target:
   `Ops::template read<int>(value)` inside `Runner<T>` must resolve to the
   nested `Runner<T>::Ops::read`, not to an unrelated global `Ops<T>::read`
   when both owners are visible and share the same simple nested name
-  this is a standards-visible lookup bug, not an acceptable compatibility case
+  status: fixed in the parser/member-template materialization layer and now
+  guarded by a focused regression; keep that guard while the remaining
+  compatibility branch is removed
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -260,6 +275,7 @@ For work in this area, rerun:
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
+- `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -289,9 +305,15 @@ For work in this area, rerun:
    split model, remove the new whole-call sema synchronization hook by pushing
    that work back to earlier semantic ownership.
    Immediate focused follow-up under that item:
-   fix nested-owner explicit member-template instantiation so concrete owner
-   normalization preserves the full nested owner pattern instead of collapsing
-   to a standalone owner spelling that can collide with unrelated templates.
+   the nested-owner explicit member-template instantiation bug is now fixed and
+   guarded by
+   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`.
+   The next concrete follow-up is narrower:
+   remove the remaining ordinary static-member compatibility recovery inside
+   `resolveDeferredQualifiedTemplateCall(...)` by routing those calls through
+   the same structured type-owner vs namespace-qualifier split that now covers
+   both non-template qualified direct calls and explicit qualified member-
+   template nested-owner materialization.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -316,7 +316,11 @@ For work in this area, rerun:
    `resolveDeferredQualifiedTemplateCall(...)` by routing those calls through
    the same structured type-owner vs namespace-qualifier split that now covers
    both non-template qualified direct calls and explicit qualified member-
-   template nested-owner materialization.
+   template nested-owner materialization. Long-term direction: replace these
+   per-call-site parser repairs with one shared structured qualified-owner
+   representation plus a single resolver used by both parser materialization
+   and later sema fallback, so future qualified/member-template paths do not
+   regress by rebuilding owner meaning from short spellings.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2956,6 +2956,8 @@ private:
 		std::string_view primary_template_name,
 		std::string_view fallback_template_name,
 		std::span<const TemplateTypeArg> template_args);
+	std::optional<AliasTemplateMaterializationResult> tryResolveQualifiedTypeOwnerFromCurrentContext(
+		std::string_view owner_name);
 	ParseResult parseMaterializedTemplateFunctionalCast(
 		const AliasTemplateMaterializationResult& materialized_owner,
 		const Token& source_token);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -729,10 +729,28 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 	if (scope_sep != std::string_view::npos) {
 		std::string_view owner_name = qualified_name.substr(0, scope_sep);
 		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
-		if (AliasTemplateMaterializationResult canonical_owner =
-				resolveCanonicalInstantiatedOwnerForLookup(owner_name);
-			!canonical_owner.instantiated_name.empty()) {
+		const TypeInfo* resolved_owner_type_info = nullptr;
+		const auto is_nested_owner_match =
+			[owner_name](std::string_view resolved_owner_name) {
+				return resolved_owner_name.size() > owner_name.size() + 2 &&
+					resolved_owner_name.ends_with(owner_name) &&
+					resolved_owner_name.substr(
+						resolved_owner_name.size() - owner_name.size() - 2,
+						2) == "::";
+			};
+		if (std::optional<AliasTemplateMaterializationResult> current_owner =
+				tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
+			current_owner.has_value() &&
+			is_nested_owner_match(current_owner->instantiated_name)) {
+			if (!current_owner->instantiated_name.empty()) {
+				owner_name = current_owner->instantiated_name;
+			}
+			resolved_owner_type_info = current_owner->resolved_type_info;
+		} else if (AliasTemplateMaterializationResult canonical_owner =
+					   resolveCanonicalInstantiatedOwnerForLookup(owner_name);
+				   !canonical_owner.instantiated_name.empty()) {
 			owner_name = canonical_owner.instantiated_name;
+			resolved_owner_type_info = canonical_owner.resolved_type_info;
 		}
 
 		StringHandle owner_name_handle =
@@ -741,7 +759,9 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 			owner_name_handle,
 			ClassInstantiationPhase::Full);
 		const TypeInfo* owner_type_info =
-			findTypeByName(owner_name_handle);
+			resolved_owner_type_info != nullptr
+				? resolved_owner_type_info
+				: findTypeByName(owner_name_handle);
 		FLASH_LOG_FORMAT(
 			Templates,
 			Debug,
@@ -1148,6 +1168,138 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveCurr
 		result.instantiated_struct_node = ASTNode(current_struct_node);
 	}
 	return result;
+}
+
+std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveQualifiedTypeOwnerFromCurrentContext(
+	std::string_view owner_name) {
+	if (owner_name.empty()) {
+		return std::nullopt;
+	}
+
+	auto owner_matches_current_type =
+		[&](const TypeInfo& owner_type_info) {
+			if (owner_name == StringTable::getStringView(owner_type_info.name())) {
+				return true;
+			}
+			if (!owner_type_info.isTemplateInstantiation()) {
+				return false;
+			}
+
+			const std::string_view base_template_name =
+				StringTable::getStringView(owner_type_info.baseTemplateName());
+			if (owner_name == base_template_name) {
+				return true;
+			}
+
+			StringHandle qualified_base_handle =
+				gNamespaceRegistry.buildQualifiedIdentifier(
+					owner_type_info.sourceNamespace(),
+					owner_type_info.baseTemplateName());
+			const std::string_view qualified_base_name =
+				StringTable::getStringView(qualified_base_handle);
+			return !qualified_base_name.empty() &&
+				owner_name == qualified_base_name;
+		};
+
+	auto try_resolve_owner_chain =
+		[&](StringHandle base_owner_handle) -> const TypeInfo* {
+			if (!base_owner_handle.isValid()) {
+				return nullptr;
+			}
+
+			const std::vector<QualifiedTypeMemberAccess> owner_chain =
+				buildQualifiedTypeMemberChain(owner_name);
+			if (owner_chain.empty()) {
+				return nullptr;
+			}
+
+			if (owner_chain.size() == 1 &&
+				!owner_chain.front().has_template_arguments) {
+				instantiateLazyNestedType(
+					base_owner_handle,
+					owner_chain.front().member_name);
+			}
+
+			return resolveBaseClassMemberTypeChain(
+				StringTable::getStringView(base_owner_handle),
+				std::span<const QualifiedTypeMemberAccess>(
+					owner_chain.data(),
+					owner_chain.size()));
+		};
+
+	auto try_resolve_from_current_owner =
+		[&](const TypeInfo* current_type_info) -> std::optional<AliasTemplateMaterializationResult> {
+			if (current_type_info == nullptr) {
+				return std::nullopt;
+			}
+
+			if (owner_matches_current_type(*current_type_info)) {
+				return materializeCanonicalOwnerTypeForLookup(
+					*current_type_info,
+					std::span<const TemplateTypeArg>{});
+			}
+
+			if (const TypeInfo* nested_owner =
+					try_resolve_owner_chain(current_type_info->name());
+				nested_owner != nullptr &&
+				nested_owner->name().isValid()) {
+				return materializeCanonicalOwnerTypeForLookup(
+					*nested_owner,
+					std::span<const TemplateTypeArg>{});
+			}
+
+			if (std::optional<StringHandle> pattern_owner =
+					gTemplateRegistry.get_instantiation_pattern(
+						current_type_info->name());
+				pattern_owner.has_value()) {
+				if (const TypeInfo* nested_owner =
+						try_resolve_owner_chain(*pattern_owner);
+					nested_owner != nullptr &&
+					nested_owner->name().isValid()) {
+					return materializeCanonicalOwnerTypeForLookup(
+						*nested_owner,
+						std::span<const TemplateTypeArg>{});
+				}
+			}
+
+			return std::nullopt;
+		};
+
+	if (!member_function_context_stack_.empty()) {
+		const MemberFunctionContext& member_ctx =
+			member_function_context_stack_.back();
+		if (std::optional<AliasTemplateMaterializationResult> current_owner =
+				try_resolve_from_current_owner(
+					tryGetTypeInfo(member_ctx.struct_type_index));
+			current_owner.has_value()) {
+			return current_owner;
+		}
+	}
+
+	if (!struct_parsing_context_stack_.empty()) {
+		StringHandle active_struct_handle =
+			StringTable::getOrInternStringHandle(
+				struct_parsing_context_stack_.back().struct_name);
+		if (auto active_struct_it = getTypesByNameMap().find(active_struct_handle);
+			active_struct_it != getTypesByNameMap().end() &&
+			active_struct_it->second != nullptr) {
+			if (std::optional<AliasTemplateMaterializationResult> current_owner =
+					try_resolve_from_current_owner(active_struct_it->second);
+				current_owner.has_value()) {
+				return current_owner;
+			}
+		}
+	}
+
+	if (const TypeInfo* owner_type_info =
+			findTypeByName(StringTable::getOrInternStringHandle(owner_name));
+		owner_type_info != nullptr) {
+		return materializeCanonicalOwnerTypeForLookup(
+			*owner_type_info,
+			std::span<const TemplateTypeArg>{});
+	}
+
+	return std::nullopt;
 }
 
 // Helper to build an interned placeholder name for TTP instantiation.
@@ -4510,10 +4662,48 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					return ParseResult::error("Expected ')' after function call arguments", current_token_);
 				}
 
+				const std::string_view parsed_qualified_name =
+					buildQualifiedNameFromHandle(
+						qual_id.namespace_handle(),
+						qual_id.name());
+				std::string_view resolved_qualified_name =
+					parsed_qualified_name;
+				if (const size_t parsed_scope_sep =
+						parsed_qualified_name.rfind("::");
+					parsed_scope_sep != std::string_view::npos) {
+					const std::string_view owner_name =
+						parsed_qualified_name.substr(0, parsed_scope_sep);
+					const std::string_view member_name =
+						parsed_qualified_name.substr(parsed_scope_sep + 2);
+					const auto is_nested_owner_match =
+						[owner_name](std::string_view resolved_owner_name) {
+							return resolved_owner_name.size() > owner_name.size() + 2 &&
+								resolved_owner_name.ends_with(owner_name) &&
+								resolved_owner_name.substr(
+									resolved_owner_name.size() - owner_name.size() - 2,
+									2) == "::";
+						};
+					if (std::optional<AliasTemplateMaterializationResult> resolved_owner =
+							tryResolveQualifiedTypeOwnerFromCurrentContext(
+								owner_name);
+						resolved_owner.has_value() &&
+						!resolved_owner->instantiated_name.empty() &&
+						is_nested_owner_match(
+							resolved_owner->instantiated_name)) {
+						resolved_qualified_name =
+							StringBuilder()
+								.append(resolved_owner->instantiated_name)
+								.append("::")
+								.append(member_name)
+								.commit();
+					}
+				}
+
 				if (!template_args.has_value()) {
 					const auto& types_by_name = getTypesByNameMap();
-					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
-					StringHandle qualified_handle = StringTable::getOrInternStringHandle(qualified_name);
+					StringHandle qualified_handle =
+						StringTable::getOrInternStringHandle(
+							resolved_qualified_name);
 					auto type_it = types_by_name.find(qualified_handle);
 					const bool supports_constructor_call =
 						type_it != types_by_name.end() &&
@@ -4533,7 +4723,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 
 				if (auto err = tryQualifiedPhase1Lookup(qual_id,
-						buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name()),
+						resolved_qualified_name,
 						template_args, has_deferred_qualified_call_args, arg_types, identifierType)) {
 					return *err;
 				}
@@ -4546,7 +4736,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					current_linkage_ != Linkage::C &&
 					!has_deferred_qualified_call_args) {
 					// Build qualified template name
-					std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
+					std::string_view qualified_name = resolved_qualified_name;
 
 					// Phase 1 C++20: If we have explicit template arguments, use them instead of deducing
 					if (template_args.has_value() && !template_args->empty()) {
@@ -4635,7 +4825,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 
 				// Store the qualified source name for template lookup during constexpr evaluation
-				std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
+				std::string_view qualified_name = resolved_qualified_name;
 				setCallQualifiedName(result->as<ExpressionNode>(), qualified_name);
 				FLASH_LOG(Parser, Debug, "Set qualified name on call expression: ", qualified_name);
 				if (has_dependent_explicit_template_args &&

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -744,9 +744,7 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 				tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
 			current_owner.has_value() &&
 			isNestedOwnerExtension(owner_name, current_owner->instantiated_name)) {
-			if (!current_owner->instantiated_name.empty()) {
-				owner_name = current_owner->instantiated_name;
-			}
+			owner_name = current_owner->instantiated_name;
 			resolved_owner_type_info = current_owner->resolved_type_info;
 		} else if (AliasTemplateMaterializationResult canonical_owner =
 					   resolveCanonicalInstantiatedOwnerForLookup(owner_name);
@@ -1267,21 +1265,23 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveQual
 			return std::nullopt;
 		};
 
-	if (!member_function_context_stack_.empty()) {
-		const MemberFunctionContext& member_ctx =
-			member_function_context_stack_.back();
+	for (auto member_ctx_it = member_function_context_stack_.rbegin();
+		 member_ctx_it != member_function_context_stack_.rend();
+		 ++member_ctx_it) {
 		if (std::optional<AliasTemplateMaterializationResult> current_owner =
 				try_resolve_from_current_owner(
-					tryGetTypeInfo(member_ctx.struct_type_index));
+					tryGetTypeInfo(member_ctx_it->struct_type_index));
 			current_owner.has_value()) {
 			return current_owner;
 		}
 	}
 
-	if (!struct_parsing_context_stack_.empty()) {
+	for (auto struct_ctx_it = struct_parsing_context_stack_.rbegin();
+		 struct_ctx_it != struct_parsing_context_stack_.rend();
+		 ++struct_ctx_it) {
 		StringHandle active_struct_handle =
 			StringTable::getOrInternStringHandle(
-				struct_parsing_context_stack_.back().struct_name);
+				struct_ctx_it->struct_name);
 		if (auto active_struct_it = getTypesByNameMap().find(active_struct_handle);
 			active_struct_it != getTypesByNameMap().end() &&
 			active_struct_it->second != nullptr) {
@@ -4681,7 +4681,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							tryResolveQualifiedTypeOwnerFromCurrentContext(
 								owner_name);
 						resolved_owner.has_value() &&
-						!resolved_owner->instantiated_name.empty() &&
 						isNestedOwnerExtension(
 							owner_name,
 							resolved_owner->instantiated_name)) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -58,6 +58,16 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 	});
 }
 
+bool isNestedOwnerExtension(
+	std::string_view owner_name,
+	std::string_view resolved_owner_name) {
+	return resolved_owner_name.size() > owner_name.size() + 2 &&
+		resolved_owner_name.ends_with(owner_name) &&
+		resolved_owner_name.substr(
+			resolved_owner_name.size() - owner_name.size() - 2,
+			2) == "::";
+}
+
 struct ExpressionDependentMemberSegmentInfo {
 	StringHandle name;
 	bool has_template_keyword = false;
@@ -730,18 +740,10 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 		std::string_view owner_name = qualified_name.substr(0, scope_sep);
 		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
 		const TypeInfo* resolved_owner_type_info = nullptr;
-		const auto is_nested_owner_match =
-			[owner_name](std::string_view resolved_owner_name) {
-				return resolved_owner_name.size() > owner_name.size() + 2 &&
-					resolved_owner_name.ends_with(owner_name) &&
-					resolved_owner_name.substr(
-						resolved_owner_name.size() - owner_name.size() - 2,
-						2) == "::";
-			};
 		if (std::optional<AliasTemplateMaterializationResult> current_owner =
 				tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
 			current_owner.has_value() &&
-			is_nested_owner_match(current_owner->instantiated_name)) {
+			isNestedOwnerExtension(owner_name, current_owner->instantiated_name)) {
 			if (!current_owner->instantiated_name.empty()) {
 				owner_name = current_owner->instantiated_name;
 			}
@@ -4675,20 +4677,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						parsed_qualified_name.substr(0, parsed_scope_sep);
 					const std::string_view member_name =
 						parsed_qualified_name.substr(parsed_scope_sep + 2);
-					const auto is_nested_owner_match =
-						[owner_name](std::string_view resolved_owner_name) {
-							return resolved_owner_name.size() > owner_name.size() + 2 &&
-								resolved_owner_name.ends_with(owner_name) &&
-								resolved_owner_name.substr(
-									resolved_owner_name.size() - owner_name.size() - 2,
-									2) == "::";
-						};
 					if (std::optional<AliasTemplateMaterializationResult> resolved_owner =
 							tryResolveQualifiedTypeOwnerFromCurrentContext(
 								owner_name);
 						resolved_owner.has_value() &&
 						!resolved_owner->instantiated_name.empty() &&
-						is_nested_owner_match(
+						isNestedOwnerExtension(
+							owner_name,
 							resolved_owner->instantiated_name)) {
 						resolved_qualified_name =
 							StringBuilder()

--- a/tests/test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp
+++ b/tests/test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp
@@ -1,0 +1,45 @@
+// Regression: explicit qualified member-template calls inside a nested class
+// must still resolve owners declared on an enclosing current-instantiation
+// class, rather than falling through to an unrelated global template owner.
+
+template <typename T>
+struct Ops {
+	template <typename U>
+	static constexpr int read(int value) {
+		return value + 100 + static_cast<int>(sizeof(U));
+	}
+};
+
+template <typename T>
+struct Runner {
+	struct Ops {
+		template <typename U>
+		static constexpr int read(int value) {
+			return value + 37 + static_cast<int>(sizeof(U));
+		}
+	};
+
+	struct Bridge {
+		static int run() {
+			int value = 1;
+			return Ops::template read<int>(value);
+		}
+	};
+};
+
+int main() {
+	if (Runner<int>::Bridge::run() != 42) {
+		return 1;
+	}
+
+	if (Runner<char>::Bridge::run() != 42) {
+		return 2;
+	}
+
+	int global_value = 1;
+	if (Ops<int>::template read<char>(global_value) != 102) {
+		return 3;
+	}
+
+	return 0;
+}

--- a/tests/test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp
+++ b/tests/test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp
@@ -1,0 +1,54 @@
+// Regression: explicit qualified member-template calls must preserve
+// multi-segment nested owner identity inside the current instantiation.
+// A global template owner with the same spelled owner chain must not steal it.
+
+template <typename T>
+struct Bridge {
+	struct Ops {
+		template <typename U>
+		static int read(int& value) {
+			value += 100;
+			return value + static_cast<int>(sizeof(U));
+		}
+	};
+};
+
+template <typename T>
+struct Runner {
+	struct Bridge {
+		struct Ops {
+			template <typename U>
+			static int read(int value) {
+				return value + 37 + static_cast<int>(sizeof(U));
+			}
+		};
+	};
+
+	int run() {
+		int value = 1;
+		return Bridge::Ops::template read<int>(value);
+	}
+};
+
+int main() {
+	Runner<int> int_runner;
+	if (int_runner.run() != 42) {
+		return 1;
+	}
+
+	Runner<char> char_runner;
+	if (char_runner.run() != 42) {
+		return 2;
+	}
+
+	int global_value = 1;
+	if (Bridge<int>::Ops::template read<char>(global_value) != 102) {
+		return 3;
+	}
+
+	if (global_value != 101) {
+		return 4;
+	}
+
+	return 0;
+}

--- a/tests/test_template_qualified_member_template_nested_owner_collision_ret0.cpp
+++ b/tests/test_template_qualified_member_template_nested_owner_collision_ret0.cpp
@@ -1,0 +1,50 @@
+// Regression: explicit qualified member-template calls inside the current
+// instantiation must preserve the full nested owner identity. A global
+// template owner with the same simple nested name must not steal the call.
+
+template <typename T>
+struct Ops {
+	template <typename U>
+	static int read(int& value) {
+		value += 100;
+		return value + static_cast<int>(sizeof(U));
+	}
+};
+
+template <typename T>
+struct Runner {
+	struct Ops {
+		template <typename U>
+		static int read(int value) {
+			return value + 37 + static_cast<int>(sizeof(U));
+		}
+	};
+
+	int run() {
+		int value = 1;
+		return Ops::template read<int>(value);
+	}
+};
+
+int main() {
+	Runner<int> int_runner;
+	if (int_runner.run() != 42) {
+		return 1;
+	}
+
+	Runner<char> char_runner;
+	if (char_runner.run() != 42) {
+		return 2;
+	}
+
+	int global_value = 1;
+	if (Ops<int>::template read<char>(global_value) != 102) {
+		return 3;
+	}
+
+	if (global_value != 101) {
+		return 4;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## What changed

This PR continues the template-argument infrastructure refactor in the qualified/member-template call path.

It fixes the remaining standards-visible nested-owner collision where an explicit qualified member-template call inside the current instantiation could collapse onto an unrelated global template owner, for example `Ops::template read<int>(value)` inside `Runner<T>`.

The implementation preserves nested owner identity earlier in parser/materialization for these calls, narrows the rewrite to true nested-owner extensions only, and adds focused regressions for both single-segment and multi-segment owner chains.

It also updates the template architecture follow-up docs with the longer-term direction for removing this class of repair.

## Why it changed

The root cause was owner identity loss at the parser/materialization boundary for explicit qualified member-template calls. Once the short owner spelling had been canonicalized too early, later stages could only recover through compatibility behavior and could select the wrong owner.

This fix keeps the correct owner attached at the source of materialization instead of relying on later semantic recovery.

## Long-term follow-up

This is the correct fix for the current bug, but not the ideal endpoint.

The docs now call out the next architectural step explicitly: replace per-call-site parser owner repairs with a shared structured qualified-owner representation plus a single owner resolver used by both parser materialization and sema fallback. The next concrete cleanup target remains the ordinary static-member compatibility branch inside `resolveDeferredQualifiedTemplateCall(...)`.

