### PR TITLE
[codex] tighten qualified template/member call infrastructure

### DIFF
--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -500,7 +500,6 @@
     <ClInclude Include="src\TemplateRegistry_Types.h" />
     <ClInclude Include="src\TemplateEnvironment.h" />
     <ClInclude Include="src\TemplateExpressionEquivalence.h" />
-    <ClInclude Include="src\TemplateArgumentMaterialization.h" />
     <ClInclude Include="src\TemplateTypes.h" />
     <ClInclude Include="src\Token.h" />
     <ClInclude Include="src\TokenKind.h" />

--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -500,6 +500,7 @@
     <ClInclude Include="src\TemplateRegistry_Types.h" />
     <ClInclude Include="src\TemplateEnvironment.h" />
     <ClInclude Include="src\TemplateExpressionEquivalence.h" />
+    <ClInclude Include="src\TemplateArgumentMaterialization.h" />
     <ClInclude Include="src\TemplateTypes.h" />
     <ClInclude Include="src\Token.h" />
     <ClInclude Include="src\TokenKind.h" />

--- a/FlashCppMSVC.vcxproj.filters
+++ b/FlashCppMSVC.vcxproj.filters
@@ -443,9 +443,6 @@
     <ClInclude Include="src\TemplateExpressionEquivalence.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="src\TemplateArgumentMaterialization.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="src\TemplateTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/FlashCppMSVC.vcxproj.filters
+++ b/FlashCppMSVC.vcxproj.filters
@@ -443,6 +443,9 @@
     <ClInclude Include="src\TemplateExpressionEquivalence.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\TemplateArgumentMaterialization.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="src\TemplateTypes.h">
       <Filter>Header Files</Filter>
     </ClInclude>

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -552,7 +552,12 @@ When changing this area, always rerun:
    `test_alias_template_comprehensive_ret70.cpp`,
    `test_alias_two_pointers_ret30.cpp`, and
    `test_member_template_alias_ret250.cpp`. `pwsh ./tests/run_all_tests.ps1`
-   now passes again for the full regular suite. The next concrete target in
+   now passes again for the full regular suite. As cleanup on top of that
+   functional fix, the branch now routes definition-preferred qualified-owner
+   member lookup through `MemberFunctionLookupShared.h`, removes the remaining
+   bespoke qualified-id template-argument materializer in favor of
+   `TemplateArgumentMaterialization.h`, and keeps that helper header out of the
+   vcxproj lists. The next concrete target in
    this audit therefore moves back to standards-conformance expansion outside
    the passing core suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -405,14 +405,20 @@ Next direct-call target:
    `qualified_name` / `mangled_name` after owner resolution already succeeded,
    and move them onto the same deferred lookup + parser return-type-hint split
    now used by the covered ordinary-call paths.
-   Immediate next target: the remaining postfix explicit-qualified
-   member/operator owner-template-id exits in `Parser_Expr_PostfixCalls.cpp`,
-   where the qualifier itself carries template arguments (for example
-   `this->Base<T>::template pick<int>()`). The concrete explicit member/operator
-   template-id path without owner template arguments is now covered; the
-   remaining gap is that postfix member access currently drops owner template-id
-   structure before the `::template` continuation and therefore still cannot
-   preserve a structured qualified-owner record there.
+   The postfix explicit-qualified member/operator owner-template-id exits in
+   `Parser_Expr_PostfixCalls.cpp` are now covered too: `parse_member_postfix()`
+   consumes qualifiers like `this->Base<T>::template pick<int>()` and
+   `this->Base<T>::template operator()<int>()`, preserving dependent owner
+   template-id structure through the same structured deferred qualified-call
+   record used by the other qualified/member-template paths instead of dropping
+   the `Base<T>` template-id before the `::template` continuation.
+   Immediate next target: audit the remaining qualified/member-template
+   placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
+   `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
+   after owner resolution or deferred lookup shape is already known, and move
+   them onto preserved `FunctionCallDefinitionLookupRecord` or explicit
+   `DependentQualifiedNameRecord` state before removing the whole-call sema
+   synchronization hook.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -446,7 +452,8 @@ When changing this area, always rerun:
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_owner_template_member_template_call_fail.cpp`
+- `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -523,8 +530,11 @@ When changing this area, always rerun:
    `test_template_function_pointer_nttp_definition_bound_ret0.cpp`.
    The focused guards for the newly-covered explicit-qualified postfix
    member/operator builders are
-   `test_template_explicit_base_member_call_default_arg_ret0.cpp` and
-   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`.
+   `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
+   and
+   `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -166,6 +166,11 @@ the areas that were previously blocking standards-visible behavior:
   template-argument AST, parser return-type hints, and dependent-qualified
   lookup records separately instead of collapsing semantic ownership onto a
   parser-selected callee
+- deferred namespace-qualified explicit-template direct calls now also preserve
+  definition-bound replay metadata when the visible template candidate is
+  unique, but that exact parse-time binding is intentionally suppressed when
+  the template name already has registered exact specializations so later
+  instantiation can still select the specialization-first C++20 path
 - qualified direct-call target resolution now distinguishes type owners from
   namespace qualifiers before consuming definition-bound compatibility data, so
   sema resolves nested current-instantiation owners structurally and no longer
@@ -323,6 +328,14 @@ Remaining near-term scope:
   `pick<int>(...)`-style member-template calls inside a current instantiation
   must preserve structured owner/member identity and may not borrow parser-time
   return-type visibility from an unrelated `lookupAllTemplates(...)` result
+- the generic namespace-qualified explicit-template placeholder/materializers
+  in `Parser_Expr_PrimaryExpr.cpp` are now on that split model too, including a
+  specialization-aware guard that only preserves exact parse-time template
+  identity when no exact specialization is registered for the same qualified
+  template name; the remaining work in this sub-area is therefore the other
+  qualified/member-template parser exits, especially postfix explicit-qualified
+  member/operator placeholder paths that still do not preserve the same
+  deferred lookup structure end-to-end
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -385,6 +398,11 @@ Next direct-call target:
    `qualified_name` / `mangled_name` after owner resolution already succeeded,
    and move them onto the same deferred lookup + parser return-type-hint split
    now used by the covered ordinary-call paths.
+   Immediate next target: the remaining postfix explicit-qualified
+   member/operator placeholder/materializer exits in
+   `Parser_Expr_PostfixCalls.cpp` that still bypass
+   `FunctionCallDefinitionLookupRecord` or equivalent deferred lookup state
+   after owner resolution already succeeded.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -409,9 +427,13 @@ When changing this area, always rerun:
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
 - `test_template_current_member_explicit_template_decltype_ret0.cpp`
+- `test_template_disambiguation_pack_ret40.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
+- `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
+- `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
+- `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-15
+**Last updated:** 2026-06-18
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -136,6 +136,13 @@ the areas that were previously blocking standards-visible behavior:
   dependent-qualified owner record even when `StructTypeInfo` is already
   present instead of dropping back to `qualified_name` plus a parser return-type
   hint alone
+- that same qualified static-owner helper now also distinguishes "no owner
+  candidates exist" from "owner candidates exist but parser-time overload
+  ranking still cannot pick a final target": concrete owner calls like
+  `allocator_traits<allocator<int>>::allocate(a, 10)` now keep the canonical
+  owner type plus deferred qualified-call metadata when parser-time ranking is
+  still inconclusive, instead of reintroducing a parser-selected fallback or
+  hard-rejecting the call before later semantic resolution can finish it
 - the unqualified/current-owner explicit-member-template placeholder path in
   `Parser_Expr_PrimaryExpr.cpp` now preserves that same split for deferred
   class-scope member-template calls: it keeps a structured current-
@@ -418,12 +425,22 @@ Next direct-call target:
    after owner resolution or deferred lookup shape is already known, and move
    them onto preserved `FunctionCallDefinitionLookupRecord` or explicit
    `DependentQualifiedNameRecord` state before removing the whole-call sema
-   synchronization hook.
+   synchronization hook. Keep
+   `test_member_template_func_in_specialization_ret0.cpp` in the focused
+   guard set here: it exercises the new "candidate-bearing concrete owner
+   calls must defer instead of hard-failing" rule in
+   `try_parse_member_template_function_call(...)`.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
    `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. Leave replay/`StructTypeInfo` sync and broader
+3. Clean up the remaining parser diagnostic collapse around copy
+   initialization. This slice showed that inner qualified-call errors can
+   still surface as the generic "Failed to parse initializer expression" once
+   `parse_copy_initialization(...)` drops the nested `ParseResult`; that does
+   not block conformance, but it is the next diagnostics-quality follow-up in
+   this area.
+4. Leave replay/`StructTypeInfo` sync and broader
    current-instantiation/unknown-specialization expansion in opportunistic mode
    unless a concrete uncovered failure appears.
 
@@ -442,6 +459,7 @@ When changing this area, always rerun:
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
+- `test_member_template_func_in_specialization_ret0.cpp`
 - `test_template_current_member_explicit_template_decltype_ret0.cpp`
 - `test_template_disambiguation_pack_ret40.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -541,17 +541,23 @@ When changing this area, always rerun:
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
-   specializations. The next concrete target in this slice is therefore the
-   smaller alias/materialization cluster still visible in the full suite:
-   `test_alias_template_pointer_modifiers_ret0.cpp` still fails to preserve
-   concrete pointer/cv metadata through dependent member-alias paths, and the
-   related alias regressions (`test_alias_const_ptr_ret42.cpp`,
+   specializations. The alias/materialization cluster that had still been
+   visible in the full suite is now fixed as well: direct non-deferred alias
+   rebinding once again wins over the lossy alias-materialization path for
+   simple aliases, so pointer/cv/ref surface modifiers survive through
+   `identity_t<T>`, `T*`, and member-alias forms. Focused guards:
+   `test_alias_template_pointer_modifiers_ret0.cpp`,
+   `test_alias_const_ptr_ret42.cpp`,
    `test_alias_ptrptr_ret42.cpp`,
    `test_alias_template_comprehensive_ret70.cpp`,
    `test_alias_two_pointers_ret30.cpp`, and
-   `test_member_template_alias_ret250.cpp`) still crash at runtime. After that,
-   re-check the remaining canonical member-object-pointer type carrier gap if
-   another ABI-sensitive failure reaches it.
+   `test_member_template_alias_ret250.cpp`. `pwsh ./tests/run_all_tests.ps1`
+   now passes again for the full regular suite. The next concrete target in
+   this audit therefore moves back to standards-conformance expansion outside
+   the passing core suite: the remaining expected-failure coverage
+   (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
+   follow-on canonical member-object-pointer carrier gap if a new ABI-sensitive
+   regression reaches it.
    Long-term direction: stop teaching individual parser call sites to recover
    owner identity from short qualified spellings. Instead, preserve a shared
    structured qualified-owner record on the AST and route both parser

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -336,6 +336,13 @@ Remaining near-term scope:
   qualified/member-template parser exits, especially postfix explicit-qualified
   member/operator placeholder paths that still do not preserve the same
   deferred lookup structure end-to-end
+- postfix explicit-qualified member/operator call parsing in
+  `Parser_Expr_PostfixCalls.cpp` now also accepts explicit member-template ids
+  after a concrete owner qualifier such as `this->Base::template pick<int>()`
+  and `this->Base::template operator()<int>()`, routing the resolved owner
+  through the same member-template instantiation helper and preserving
+  `qualified_name + template_arguments` on unresolved placeholders so
+  substitution can recover the base-qualified owner later
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -399,10 +406,13 @@ Next direct-call target:
    and move them onto the same deferred lookup + parser return-type-hint split
    now used by the covered ordinary-call paths.
    Immediate next target: the remaining postfix explicit-qualified
-   member/operator placeholder/materializer exits in
-   `Parser_Expr_PostfixCalls.cpp` that still bypass
-   `FunctionCallDefinitionLookupRecord` or equivalent deferred lookup state
-   after owner resolution already succeeded.
+   member/operator owner-template-id exits in `Parser_Expr_PostfixCalls.cpp`,
+   where the qualifier itself carries template arguments (for example
+   `this->Base<T>::template pick<int>()`). The concrete explicit member/operator
+   template-id path without owner template arguments is now covered; the
+   remaining gap is that postfix member access currently drops owner template-id
+   structure before the `::template` continuation and therefore still cannot
+   preserve a structured qualified-owner record there.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -434,6 +444,9 @@ When changing this area, always rerun:
 - `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
 - `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
+- `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_owner_template_member_template_call_fail.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -535,14 +535,23 @@ When changing this area, always rerun:
    `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
    and
    `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
+   The focused guard for variable-template replay preserving the full nested
+   owner chain into the final direct-call target is
+   `test_var_template_replay_dependent_member_template_call_ret0.cpp`.
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
    specializations. The next concrete target in this slice is therefore the
-   smaller set of qualified/member-template materializers and placeholder
-   builders that still stop at compatibility metadata after owner resolution
-   already succeeded, plus the remaining canonical member-object-pointer type
-   carrier gap if another ABI-sensitive failure reaches it.
+   smaller alias/materialization cluster still visible in the full suite:
+   `test_alias_template_pointer_modifiers_ret0.cpp` still fails to preserve
+   concrete pointer/cv metadata through dependent member-alias paths, and the
+   related alias regressions (`test_alias_const_ptr_ret42.cpp`,
+   `test_alias_ptrptr_ret42.cpp`,
+   `test_alias_template_comprehensive_ret70.cpp`,
+   `test_alias_two_pointers_ret30.cpp`, and
+   `test_member_template_alias_ret250.cpp`) still crash at runtime. After that,
+   re-check the remaining canonical member-object-pointer type carrier gap if
+   another ABI-sensitive failure reaches it.
    Long-term direction: stop teaching individual parser call sites to recover
    owner identity from short qualified spellings. Instead, preserve a shared
    structured qualified-owner record on the AST and route both parser

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -128,6 +128,20 @@ the areas that were previously blocking standards-visible behavior:
   for forms such as `this->Base::touch()` and `this->Base::operator()()` when
   the receiver type and arguments are already concrete, instead of falling back
   to placeholder `auto` member-call nodes that later lose semantic identity
+- the shared qualified-owner member-call helper in
+  `Parser_Expr_QualLookup.cpp` now treats concrete `Type::member(...)` owner
+  calls more semantically too: non-template fallback selection is limited to
+  static members, uses real overload resolution once argument types are
+  concrete, and unresolved template-instantiation owners preserve a structured
+  dependent-qualified owner record even when `StructTypeInfo` is already
+  present instead of dropping back to `qualified_name` plus a parser return-type
+  hint alone
+- the unqualified/current-owner explicit-member-template placeholder path in
+  `Parser_Expr_PrimaryExpr.cpp` now preserves that same split for deferred
+  class-scope member-template calls: it keeps a structured current-
+  instantiation `DependentQualifiedNameRecord`, and parser return-type hints
+  now come from the matched current-owner member-template declaration instead
+  of whichever unrelated same-name global template was encountered first
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
@@ -288,7 +302,10 @@ Remaining near-term scope:
   qualified postfix placeholder member/operator builders are now covered too,
   and ordinary function-pointer member postfix placeholders plus the
   `.*` / `->*` member-function-pointer fast paths now preserve the real return
-  shape, so the remaining work is no longer that whole pointer-to-member
+  shape, and the shared qualified static-owner helper no longer relies on a
+  same-arity shape match for its non-template fallback or drops structured
+  owner metadata just because the owner `StructTypeInfo` is already present, so
+  the remaining work is no longer that whole pointer-to-member
   surface; it is the smaller set of still-uncovered placeholder/materializer
   exits plus the canonical `TypeCategory::MemberObjectPointer` carrier gap
   where the underlying member type is not yet preserved strongly enough for
@@ -301,6 +318,11 @@ Remaining near-term scope:
   classification itself, but the unresolved qualified/member-template
   materializers that still preserve only compatibility metadata after the owner
   split has already been decided
+- the now-covered unqualified/current-owner explicit-member-template path
+  confirms the same rule for short class-scope spellings: deferred
+  `pick<int>(...)`-style member-template calls inside a current instantiation
+  must preserve structured owner/member identity and may not borrow parser-time
+  return-type visibility from an unrelated `lookupAllTemplates(...)` result
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -347,7 +369,11 @@ Next direct-call target:
   explicit-qualified postfix member/operator preservation, the next
   highest-value targets are the remaining qualified/member-template
   compatibility-only materializers plus any smaller placeholder call builders
-  that still return immediately without a structured lookup record
+  that still return immediately without a structured lookup record. The shared
+  qualified static-owner helper is no longer one of those weak spots: its
+  non-template fallback now routes through real static-member overload
+  selection, and unresolved template-instantiation owners keep structured
+  owner metadata even when the owner `StructTypeInfo` is already available
 
 2. Only after step 1 is stable, expand
    current-instantiation/unknown-specialization modeling for the concrete cases
@@ -381,6 +407,8 @@ When changing this area, always rerun:
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
+- `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
+- `test_template_current_member_explicit_template_decltype_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
@@ -416,8 +444,18 @@ When changing this area, always rerun:
    `qualified_name`/`mangled_name`, preserve
    `FunctionCallDefinitionLookupRecord` (or an explicit deferred lookup record)
    there, and then collapse the whole-call sema synchronization hook that was
-   compensating for those compatibility-only paths. Also clean up the remaining
-   legacy parser sites that still
+   compensating for those compatibility-only paths. The just-finished
+   `Parser_Expr_QualLookup.cpp` pass removed the weak same-arity/static-member
+   fallback from `try_parse_member_template_function_call(...)` and widened
+   dependent-qualified owner preservation for unresolved template-instantiation
+   owners, and the current-owner explicit-member-template placeholder path in
+   `Parser_Expr_PrimaryExpr.cpp` now preserves the same structured deferred
+   owner metadata with member-template-derived parser return-type hints.
+   The next concrete parser target is therefore the remaining
+   qualified/member-template placeholder/materializer exits that still stamp
+   only compatibility metadata after owner resolution or deferred lookup shape
+   is already known. Also
+   clean up the remaining legacy parser sites that still
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve
    the pack node" rule now enforced in ordinary call parsing.
@@ -430,6 +468,9 @@ When changing this area, always rerun:
    `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
    The focused regression for the newly-covered class-scope constexpr path is
    `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`.
+   The focused regression for the newly-covered current-owner explicit-member-
+   template placeholder path is
+   `test_template_current_member_explicit_template_decltype_ret0.cpp`.
    The focused regression for the newly-covered substitution/materialization
    path is
    `test_template_qualified_explicit_function_id_definition_bound_ret0.cpp`.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -129,6 +129,14 @@ blocking areas:
   for forms such as `this->Base::touch()` and `this->Base::operator()()` when
   the receiver type and arguments are concrete, instead of materializing a
   placeholder `auto` member call that later loses semantic identity
+- the shared qualified-owner member-call helper in
+  `Parser_Expr_QualLookup.cpp` now treats concrete `Type::member(...)` owner
+  calls more semantically too: non-template fallback selection is limited to
+  static members, uses real overload resolution once argument types are
+  concrete, and unresolved template-instantiation owners preserve a structured
+  dependent-qualified owner record even when `StructTypeInfo` is already
+  present instead of dropping back to `qualified_name` plus a parser return-type
+  hint alone
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
@@ -151,6 +159,12 @@ blocking areas:
   arguments, parser return-type hints, and dependent-qualified lookup records
   as separate metadata so later semantic resolution can replay the correct
   lookup instead of inheriting a parser-selected callee as final meaning
+- the unqualified/current-owner explicit-member-template placeholder path in
+  `Parser_Expr_PrimaryExpr.cpp` now preserves the same split for deferred
+  class-scope member-template calls: it keeps a structured current-
+  instantiation `DependentQualifiedNameRecord`, and parser return-type hints
+  now come from the matched current-owner member-template declaration instead
+  of whichever unrelated same-name global template happened to be found first
 - sema now distinguishes real type owners from namespace qualifiers before it
   consumes definition-bound compatibility metadata for qualified direct calls,
   which fixes current-instantiation nested-owner cases like
@@ -266,8 +280,11 @@ Remaining near-term scope:
   materialization are covered as well, and the explicit-qualified postfix
   member/operator placeholder builders are now covered too, and ordinary
   function-pointer member postfix placeholders plus the `.*` / `->*`
-  member-function-pointer fast paths now preserve the real return shape, so
-  the remaining work is no longer that whole pointer-to-member surface; it is
+  member-function-pointer fast paths now preserve the real return shape, and
+  the shared qualified static-owner helper no longer relies on a same-arity
+  shape match for its non-template fallback or drops structured owner metadata
+  just because the owner `StructTypeInfo` is already present, so the remaining
+  work is no longer that whole pointer-to-member surface; it is
   the smaller set of still-uncovered placeholder/materializer exits plus the
   canonical `TypeCategory::MemberObjectPointer` carrier gap where the
   underlying member type is not yet preserved strongly enough for every
@@ -288,6 +305,12 @@ Remaining near-term scope:
   as well, so the remaining work in this sub-area is the narrower set of
   parser/materialization sites that still stop at compatibility metadata even
   after the owner resolution has succeeded
+- the newly-covered current-owner explicit-member-template path confirms that
+  short class-scope spellings must follow the same rule too: deferred
+  `pick<int>(...)`-style calls inside a current instantiation cannot source
+  parser-time return-type visibility from an unrelated
+  `lookupAllTemplates(...)` result once the matching member-template owner is
+  already known
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -320,7 +343,11 @@ Next direct-call target:
   explicit-qualified postfix member/operator preservation, the next targets
   are the remaining qualified/member-template compatibility-only materializers
   plus any smaller placeholder builders that still return immediately without
-  a structured lookup record
+  a structured lookup record. The shared qualified static-owner helper is no
+  longer one of those weak spots: its non-template fallback now routes through
+  real static-member overload selection, and unresolved
+  template-instantiation owners keep structured owner metadata even when the
+  owner `StructTypeInfo` is already available
 
 2. Expand current-instantiation and unknown-specialization handling only where
    it unblocks concrete replay or typed-lookup failures still remaining after
@@ -331,6 +358,14 @@ Next direct-call target:
 1. Continue eliminating compatibility-only parser metadata in the remaining
    qualified/member-template materializers that still stop at
    `qualified_name` / `mangled_name` after owner resolution already succeeded.
+   Immediate next target: audit the remaining qualified/member-template
+   placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
+   `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
+   even after owner resolution or deferred lookup shape is already known. The
+   unqualified/current-owner explicit-member-template placeholder path is now
+   covered; it preserves structured current-instantiation owner metadata and
+   member-template-derived parser return-type hints instead of deferring with
+   only `qualified_name`.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -364,6 +399,8 @@ For work in this area, rerun:
 - `test_template_current_member_static_hides_base_overload_ret0.cpp`
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
+- `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
+- `test_template_current_member_explicit_template_decltype_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
@@ -394,11 +431,20 @@ For work in this area, rerun:
    type-owner / namespace-qualifier split with explicit current-type fallback
    for class-scope evaluation. The substitution-time qualified/member-template
    materializer now also rebuilds `FunctionCallDefinitionLookupRecord` once the
-   substituted call is concrete. The next concrete step is therefore to finish
-   moving the remaining parser materializers onto preserved
+   substituted call is concrete, and the shared
+   `try_parse_member_template_function_call(...)` helper now uses real static-
+   member overload resolution plus structured deferred owner metadata instead of
+   a same-arity fallback. The current-owner explicit-member-template
+   placeholder path in `Parser_Expr_PrimaryExpr.cpp` is now on that model too:
+   it preserves a structured current-instantiation owner record and sources its
+   parser return-type hint from the matched member-template declaration instead
+   of an unrelated global template. The next concrete step is therefore to
+   finish moving the remaining parser materializers onto preserved
    `FunctionCallDefinitionLookupRecord` or explicit deferred lookup records,
-   and then remove the whole-call sema synchronization hook by pushing that
-   work back to earlier semantic ownership.
+   focusing on the other qualified/member-template placeholder/materializer
+   exits that still stop at compatibility metadata after owner resolution
+   already succeeded, and then remove the whole-call sema synchronization hook
+   by pushing that work back to earlier semantic ownership.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by
@@ -409,6 +455,9 @@ For work in this area, rerun:
    `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
    The new focused guard for class-scope constexpr nested-owner recovery is
    `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`.
+   The new focused guard for current-owner explicit-member-template deferred
+   target preservation is
+   `test_template_current_member_explicit_template_decltype_ret0.cpp`.
    The new focused guard for substitution-time qualified explicit-template
    target preservation is
    `test_template_qualified_explicit_function_id_definition_bound_ret0.cpp`.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -523,17 +523,22 @@ For work in this area, rerun:
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
-   specializations. The next concrete target in this slice is therefore the
-   remaining alias/materialization cluster still exposed by the full suite:
-   `test_alias_template_pointer_modifiers_ret0.cpp` still loses concrete
-   pointer/cv metadata through dependent member-alias substitution, and the
-   related alias regressions (`test_alias_const_ptr_ret42.cpp`,
+   specializations. The remaining alias/materialization cluster from this slice
+   is now fixed too: direct non-deferred alias rebinding is again preferred for
+   simple aliases, which preserves concrete pointer/cv/ref surface modifiers
+   through plain and member alias templates. Focused guards:
+   `test_alias_template_pointer_modifiers_ret0.cpp`,
+   `test_alias_const_ptr_ret42.cpp`,
    `test_alias_ptrptr_ret42.cpp`,
    `test_alias_template_comprehensive_ret70.cpp`,
    `test_alias_two_pointers_ret30.cpp`, and
-   `test_member_template_alias_ret250.cpp`) still crash at runtime. After that,
-   re-check the canonical member-object-pointer type carrier gap if another
-   ABI-sensitive failure reaches it.
+   `test_member_template_alias_ret250.cpp`. The full regular suite now passes
+   again via `pwsh ./tests/run_all_tests.ps1`. The next concrete target in this
+   investigation therefore shifts to standards-conformance growth outside the
+   green suite: the remaining expected-failure coverage
+   (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
+   future canonical member-object-pointer carrier gap if another ABI-sensitive
+   failure exposes it.
    Long-term direction: replace these per-call-site parser repairs with one
    shared structured qualified-owner representation plus a single resolver used
    by both parser materialization and later sema fallback, so future

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-15
+**Last updated:** 2026-06-18
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -137,6 +137,12 @@ blocking areas:
   dependent-qualified owner record even when `StructTypeInfo` is already
   present instead of dropping back to `qualified_name` plus a parser return-type
   hint alone
+- that qualified static-owner path now also stays conservative at the right
+  semantic boundary: if a concrete owner already has visible static-member
+  candidates but parser-time overload ranking still cannot prove the final
+  target, the call now defers with canonical owner identity plus structured
+  qualified-call metadata instead of either reviving a parser-selected fallback
+  or hard-rejecting a call that later semantic resolution can still complete
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of recovering it afterward
@@ -399,7 +405,13 @@ Next direct-call target:
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
    `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. Keep replay/identity and broader
+3. Improve parser diagnostics in the remaining copy-initialization path by
+   preserving nested expression or qualified-call failures instead of
+   collapsing them to the generic "Failed to parse initializer expression".
+   This is not the next conformance blocker, but the latest concrete-owner
+   qualified-call slice exposed it clearly enough that it should stay on the
+   list.
+4. Keep replay/identity and broader
    current-instantiation/unknown-specialization work in reserve for concrete
    failures; the remaining conformance pressure is now centered on the last
    parser compatibility boundaries rather than on broad replay drift.
@@ -429,6 +441,7 @@ For work in this area, rerun:
 - `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
+- `test_member_template_func_in_specialization_ret0.cpp`
 - `test_template_current_member_explicit_template_decltype_ret0.cpp`
 - `test_template_disambiguation_pack_ret40.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
@@ -517,6 +530,9 @@ For work in this area, rerun:
    `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
    and
    `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
+   The focused guard for the concrete-owner "candidate-bearing but not yet
+   parser-resolved" rule is
+   `test_member_template_func_in_specialization_ret0.cpp`.
    The new focused guard for variable-template replay preserving the full
    nested owner chain into the eventual direct-call target is
    `test_var_template_replay_dependent_member_template_call_ret0.cpp`.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -322,6 +322,12 @@ Remaining near-term scope:
   is registered for that qualified template name. Otherwise deferred
   instantiation must remain free to select the explicit specialization first,
   as in `ns::sum<Args...>()` with `template<> sum<int>()`
+- the postfix explicit-qualified member/operator path now follows the same rule
+  for concrete owner-qualified member-template ids: `this->Base::template pick<int>()`
+  and `this->Base::template operator()<int>()` now parse and instantiate through
+  the base-qualified owner instead of failing before overload selection, and
+  unresolved placeholders preserve `qualified_name + template_arguments` so
+  substitution can recover that owner later
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -379,8 +385,11 @@ Next direct-call target:
    only `qualified_name`. The generic namespace-qualified explicit-template
    placeholder path is now covered too, including the specialization-aware
    rule that suppresses exact primary-template binding when a registered exact
-   specialization must stay visible; the next uncovered parser target is the
-   remaining postfix explicit-qualified member/operator materializer surface.
+   specialization must stay visible; the concrete postfix explicit-qualified
+   member/operator template-id path without owner template arguments is now
+   covered too. The next uncovered parser target is the owner-template-id
+   variant, where `this->Base<T>::template pick<int>()` still drops the
+   `Base<T>` structure before the `::template` continuation.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -423,6 +432,9 @@ For work in this area, rerun:
 - `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
 - `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
+- `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_owner_template_member_template_call_fail.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -533,7 +533,12 @@ For work in this area, rerun:
    `test_alias_template_comprehensive_ret70.cpp`,
    `test_alias_two_pointers_ret30.cpp`, and
    `test_member_template_alias_ret250.cpp`. The full regular suite now passes
-   again via `pwsh ./tests/run_all_tests.ps1`. The next concrete target in this
+   again via `pwsh ./tests/run_all_tests.ps1`. As cleanup on top of that
+   functional fix, the branch now centralizes definition-preferred
+   qualified-owner member lookup in `MemberFunctionLookupShared.h`, reuses
+   `TemplateArgumentMaterialization.h` for the remaining qualified-id
+   template-argument materialization path, and removes the helper header from
+   the vcxproj lists. The next concrete target in this
    investigation therefore shifts to standards-conformance growth outside the
    green suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -387,9 +387,14 @@ Next direct-call target:
    rule that suppresses exact primary-template binding when a registered exact
    specialization must stay visible; the concrete postfix explicit-qualified
    member/operator template-id path without owner template arguments is now
-   covered too. The next uncovered parser target is the owner-template-id
-   variant, where `this->Base<T>::template pick<int>()` still drops the
-   `Base<T>` structure before the `::template` continuation.
+   covered too, and the postfix owner-template-id variant is covered as well:
+   `parse_member_postfix()` now preserves `Base<T>`-style owner template-ids
+   through the `::template` continuation for both member-template and
+   operator-template calls instead of dropping that structure before deferred
+   lookup. The next uncovered parser target is therefore narrower again:
+   the remaining qualified/member-template placeholder/materializer exits that
+   still stamp only compatibility metadata after owner resolution or deferred
+   lookup shape is already known.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -434,7 +439,8 @@ For work in this area, rerun:
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_owner_template_member_template_call_fail.cpp`
+- `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
@@ -506,8 +512,11 @@ For work in this area, rerun:
    `test_template_function_pointer_nttp_definition_bound_ret0.cpp`.
    The new focused guards for explicit-qualified postfix member/operator target
    preservation are
-   `test_template_explicit_base_member_call_default_arg_ret0.cpp` and
-   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`.
+   `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
+   and
+   `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -159,6 +159,11 @@ blocking areas:
   arguments, parser return-type hints, and dependent-qualified lookup records
   as separate metadata so later semantic resolution can replay the correct
   lookup instead of inheriting a parser-selected callee as final meaning
+- deferred namespace-qualified explicit-template calls now preserve exact
+  definition-bound replay metadata only when the visible function-template
+  candidate is unique and no exact specialization is registered for that same
+  qualified template name, so specialization-first lookup remains available
+  during later instantiation
 - the unqualified/current-owner explicit-member-template placeholder path in
   `Parser_Expr_PrimaryExpr.cpp` now preserves the same split for deferred
   class-scope member-template calls: it keeps a structured current-
@@ -311,6 +316,12 @@ Remaining near-term scope:
   parser-time return-type visibility from an unrelated
   `lookupAllTemplates(...)` result once the matching member-template owner is
   already known
+- the newly-covered generic namespace-qualified explicit-template path confirms
+  the same rule for specialization-aware lookup: preserving a unique parse-time
+  primary template declaration is only conforming when no exact specialization
+  is registered for that qualified template name. Otherwise deferred
+  instantiation must remain free to select the explicit specialization first,
+  as in `ns::sum<Args...>()` with `template<> sum<int>()`
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -365,7 +376,11 @@ Next direct-call target:
    unqualified/current-owner explicit-member-template placeholder path is now
    covered; it preserves structured current-instantiation owner metadata and
    member-template-derived parser return-type hints instead of deferring with
-   only `qualified_name`.
+   only `qualified_name`. The generic namespace-qualified explicit-template
+   placeholder path is now covered too, including the specialization-aware
+   rule that suppresses exact primary-template binding when a registered exact
+   specialization must stay visible; the next uncovered parser target is the
+   remaining postfix explicit-qualified member/operator materializer surface.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -401,9 +416,13 @@ For work in this area, rerun:
 - `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
 - `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
 - `test_template_current_member_explicit_template_decltype_ret0.cpp`
+- `test_template_disambiguation_pack_ret40.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
+- `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
+- `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
+- `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
 - `test_template_dependent_unqualified_member_replay_ret0.cpp`
 - `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -517,14 +517,23 @@ For work in this area, rerun:
    `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
    and
    `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
+   The new focused guard for variable-template replay preserving the full
+   nested owner chain into the eventual direct-call target is
+   `test_var_template_replay_dependent_member_template_call_ret0.cpp`.
    The member-function-pointer fast-path surface is now covered, including the
    `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
    qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
    specializations. The next concrete target in this slice is therefore the
-   smaller set of qualified/member-template materializers and placeholder
-   builders that still stop at compatibility metadata after owner resolution
-   already succeeded, plus the remaining canonical member-object-pointer type
-   carrier gap if another ABI-sensitive failure reaches it.
+   remaining alias/materialization cluster still exposed by the full suite:
+   `test_alias_template_pointer_modifiers_ret0.cpp` still loses concrete
+   pointer/cv metadata through dependent member-alias substitution, and the
+   related alias regressions (`test_alias_const_ptr_ret42.cpp`,
+   `test_alias_ptrptr_ret42.cpp`,
+   `test_alias_template_comprehensive_ret70.cpp`,
+   `test_alias_two_pointers_ret30.cpp`, and
+   `test_member_template_alias_ret250.cpp`) still crash at runtime. After that,
+   re-check the canonical member-object-pointer type carrier gap if another
+   ABI-sensitive failure reaches it.
    Long-term direction: replace these per-call-site parser repairs with one
    shared structured qualified-owner representation plus a single resolver used
    by both parser materialization and later sema fallback, so future

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -468,6 +468,7 @@ namespace {
 void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 	alias_type_info.placeholder_kind_ = DependentPlaceholderKind::None;
 	alias_type_info.dependent_qualified_name_.reset();
+	alias_type_info.clearDeferredDecltypeExpression();
 	alias_type_info.base_template_ = QualifiedIdentifier{};
 	alias_type_info.template_args_.clear();
 	alias_type_info.instantiation_context_.reset();
@@ -477,6 +478,12 @@ void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& semantic_source_type_info) {
 	alias_type_info.placeholder_kind_ = semantic_source_type_info.placeholder_kind_;
 	alias_type_info.dependent_qualified_name_ = semantic_source_type_info.dependent_qualified_name_;
+	if (const ASTNode* deferred_decltype_expr = semantic_source_type_info.deferredDecltypeExpression();
+		deferred_decltype_expr != nullptr) {
+		alias_type_info.setDeferredDecltypeExpression(*deferred_decltype_expr);
+	} else {
+		alias_type_info.clearDeferredDecltypeExpression();
+	}
 	alias_type_info.base_template_ = semantic_source_type_info.base_template_;
 	alias_type_info.template_args_ = semantic_source_type_info.template_args_;
 	alias_type_info.is_incomplete_instantiation_ = semantic_source_type_info.is_incomplete_instantiation_;

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2984,6 +2984,7 @@ struct CallLookupRecordShared {
 struct FunctionCallDefinitionLookupRecord : CallLookupRecordShared {
 	const FunctionDeclarationNode* resolved_function = nullptr;
 	StringHandle resolved_mangled_name{};
+	const void* definition_bound_template_declaration = nullptr;
 	bool ordinary_lookup_included = true;
 	bool argument_dependent_lookup_included = true;
 };

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1058,6 +1058,10 @@ struct TypeInfo {
 	// recover array/pointer/reference metadata by following the alias chain.
 	std::unique_ptr<TypeSpecifierNode> alias_type_spec_;
 
+	// Preserve dependent decltype operands so deferred alias/template
+	// materialization can re-evaluate them after substitution.
+	std::optional<ASTNode> deferred_decltype_expression_;
+
 	// For template instantiations: store metadata to avoid name parsing
 	// If base_template_ is valid, this type is a template instantiation
 	QualifiedIdentifier base_template_;	// e.g., {std, "vector"} for std::vector<int>
@@ -1288,6 +1292,9 @@ struct TypeInfo {
 	}
 	TypeIndex registeredTypeIndex() const { return registered_type_index_.is_valid() ? registered_type_index_ : type_index_; }
 	const TypeSpecifierNode* aliasTypeSpecifier() const { return alias_type_spec_.get(); }
+	const ASTNode* deferredDecltypeExpression() const {
+		return deferred_decltype_expression_.has_value() ? &*deferred_decltype_expression_ : nullptr;
+	}
 
 	void setTemplateInstantiationInfo(QualifiedIdentifier base_template, InlineVector<TemplateArgInfo, 4> args) {
 		base_template_ = base_template;
@@ -1296,6 +1303,8 @@ struct TypeInfo {
 
 	void clearAliasTypeSpecifier();
 	void setAliasTypeSpecifier(const TypeSpecifierNode& type_spec);
+	void clearDeferredDecltypeExpression();
+	void setDeferredDecltypeExpression(const ASTNode& expr);
 	void setDependentQualifiedName(DependentQualifiedNameRecord record) {
 		dependent_qualified_name_ = std::move(record);
 	}
@@ -1832,6 +1841,14 @@ inline void TypeInfo::clearAliasTypeSpecifier() {
 
 inline void TypeInfo::setAliasTypeSpecifier(const TypeSpecifierNode& type_spec) {
 	alias_type_spec_ = std::make_unique<TypeSpecifierNode>(type_spec);
+}
+
+inline void TypeInfo::clearDeferredDecltypeExpression() {
+	deferred_decltype_expression_.reset();
+}
+
+inline void TypeInfo::setDeferredDecltypeExpression(const ASTNode& expr) {
+	deferred_decltype_expression_ = expr;
 }
 
 struct ResolvedAliasTypeInfo {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -5060,43 +5060,11 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 	// Check if it's a FunctionDeclarationNode (regular function)
 	if (symbol_node.is<FunctionDeclarationNode>()) {
 		const FunctionDeclarationNode& func_decl = symbol_node.as<FunctionDeclarationNode>();
-
-		if (std::optional<EvalResult> builtin_result =
-				try_evaluate_builtin_function_call(func_name, call_expr.arguments(), context)) {
-			return *builtin_result;
-		}
-
-		// For static storage duration, also try non-constexpr functions with simple bodies
-		// (static initializers can call any function whose body is available)
-		if (!func_decl.is_constexpr() && !func_decl.is_consteval() && context.storage_duration != ConstExpr::StorageDuration::Static) {
-			return EvalResult::error(
-				"Function in constant expression must be constexpr: " + std::string(func_name),
-				EvalErrorType::NotConstantExpression);
-		}
-
-		// Get the function body
-		const auto& definition = func_decl.get_definition();
-		if (!definition.has_value()) {
-			return EvalResult::error("Constexpr function has no body: " + std::string(func_name));
-		}
-
-		// Evaluate arguments
-		const auto& arguments = call_expr.arguments();
-		const auto& parameters = func_decl.parameter_nodes();
-
-		const size_t parameter_count = parameters.size();
-		const size_t min_required = countMinRequiredArgs(func_decl);
-		if (arguments.size() < min_required || arguments.size() > parameter_count) {
-			return EvalResult::error("Function argument count mismatch in constant expression");
-		}
-
-		// Pass empty bindings for top-level function calls
-		std::unordered_map<std::string_view, EvalResult> empty_bindings;
-		return evaluate_function_call_with_template_context(
+		return evaluate_resolved_function_call(
 			func_decl,
-			arguments,
-			empty_bindings,
-			context);
+			call_expr.arguments(),
+			context,
+			nullptr);
 	}
 
 	// Check if it's a TemplateFunctionDeclarationNode (template function)

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2,6 +2,7 @@
 #include "CallNodeHelpers.h"
 #include "Parser.h"
 #include "TemplateInstantiationHelper.h"
+#include "TemplateArgumentMaterialization.h"
 #include "AstTraversal.h"
 #include "Log.h"
 #include <charconv>
@@ -92,26 +93,6 @@ bool decodeTTPPlaceholderArg(std::string_view encoded_arg, TemplateTypeArg& deco
 	return true;
 }
 
-int computeTypeSizeInBits(TypeIndex type_index) {
-	int size_in_bits = get_type_size_bits(type_index.category());
-	if (size_in_bits != 0) {
-		return size_in_bits;
-	}
-
-	const TypeInfo* type_info = tryGetTypeInfo(type_index);
-	if (!type_info) {
-		return 0;
-	}
-
-	size_in_bits = type_info->sizeInBits().value;
-	if (size_in_bits != 0 || !type_info->isStruct()) {
-		return size_in_bits;
-	}
-
-	const StructTypeInfo* struct_info = type_info->getStructInfo();
-	return struct_info ? struct_info->sizeInBits().value : 0;
-}
-
 std::vector<ASTNode> materializeTemplateArgumentNodesForQualifiedId(
 	std::span<const TemplateTypeArg> template_args,
 	const Token& source_token) {
@@ -120,50 +101,12 @@ std::vector<ASTNode> materializeTemplateArgumentNodesForQualifiedId(
 
 	for (const TemplateTypeArg& arg : template_args) {
 		if (arg.is_dependent || arg.dependent_name.isValid()) {
-			Token dep_token(
-				Token::Type::Identifier,
-				arg.dependent_name.view(),
-				source_token.line(),
-				source_token.column(),
-				source_token.file_index());
-			ExpressionNode& dep_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-				TemplateParameterReferenceNode(arg.dependent_name, dep_token));
-			result.push_back(ASTNode(&dep_expr));
+			result.push_back(materializeDependentTemplateArgumentNode(arg, source_token));
 			continue;
 		}
 
 		if (arg.is_value) {
-			if (arg.typeEnum() == TypeCategory::Bool) {
-				Token bool_token(
-					Token::Type::Keyword,
-					arg.value != 0 ? "true"sv : "false"sv,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& bool_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					BoolLiteralNode(bool_token, arg.value != 0));
-				result.push_back(ASTNode(&bool_expr));
-			} else {
-				StringBuilder text_builder;
-				std::string_view literal_text = text_builder.append(arg.value).commit();
-				TypeCategory literal_type = arg.typeEnum() == TypeCategory::Invalid
-					? TypeCategory::Int
-					: arg.typeEnum();
-				Token literal_token(
-					Token::Type::Literal,
-					literal_text,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& literal_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					NumericLiteralNode(
-						literal_token,
-						static_cast<unsigned long long>(arg.value),
-						literal_type,
-						TypeQualifier::None,
-						get_type_size_bits(literal_type)));
-				result.push_back(ASTNode(&literal_expr));
-			}
+			result.push_back(materializeValueTemplateArgumentNode(arg, source_token));
 			continue;
 		}
 
@@ -175,7 +118,7 @@ std::vector<ASTNode> materializeTemplateArgumentNodesForQualifiedId(
 			arg_type_index = TypeIndex{}.withCategory(arg.typeEnum());
 		}
 
-		int size_in_bits = computeTypeSizeInBits(arg_type_index);
+		int size_in_bits = computeTemplateArgumentTypeSizeBits(arg_type_index);
 		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
 			arg_type_index,
 			size_in_bits,
@@ -212,7 +155,7 @@ std::optional<std::string_view> tryResolveCanonicalTypeName(
 TypeSpecifierNode buildTerminalTypeFromResolvedAlias(const ResolvedAliasTypeInfo& resolved_alias, const Token& token) {
 	return TypeSpecifierNode(
 		resolved_alias.type_index,
-		computeTypeSizeInBits(resolved_alias.type_index),
+		computeTemplateArgumentTypeSizeBits(resolved_alias.type_index),
 		token,
 		CVQualifier::None,
 		ReferenceQualifier::None);
@@ -586,7 +529,7 @@ void ExpressionSubstitutor::substituteCallArgumentPreservingPackExpansion(
 						if (bound_arg.type_index.is_valid()) {
 							parameter_type = TypeSpecifierNode(
 								bound_arg.type_index,
-								computeTypeSizeInBits(bound_arg.type_index),
+								computeTemplateArgumentTypeSizeBits(bound_arg.type_index),
 								param_token,
 								CVQualifier::None,
 								ReferenceQualifier::None);

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1835,6 +1835,77 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	auto normalizePendingSemanticRoots = [&]() {
 		parser_.normalizePendingSemanticRoots();
 	};
+	auto resolveUniqueFunctionOverload = [&](
+		const std::vector<ASTNode>& candidates,
+		const std::vector<TypeSpecifierNode>& substituted_arg_types) -> const FunctionDeclarationNode* {
+		if (candidates.empty()) {
+			return nullptr;
+		}
+		OverloadResolutionResult resolution =
+			resolve_overload(candidates, substituted_arg_types);
+		if (resolution.has_match &&
+			!resolution.is_ambiguous &&
+			resolution.selected_overload != nullptr &&
+			resolution.selected_overload->is<FunctionDeclarationNode>()) {
+			return &resolution.selected_overload->as<FunctionDeclarationNode>();
+		}
+		return nullptr;
+	};
+	auto appendOwnerMemberCandidates = [&](
+		std::string_view owner_name,
+		std::string_view member_name,
+		std::vector<ASTNode>& candidates,
+		std::vector<ASTNode>& definition_candidates) {
+		if (owner_name.empty() || member_name.empty()) {
+			return;
+		}
+		StringHandle owner_handle =
+			StringTable::getOrInternStringHandle(owner_name);
+		StringHandle member_handle =
+			StringTable::getOrInternStringHandle(member_name);
+		parser_.instantiateLazyClassToPhase(
+			owner_handle,
+			ClassInstantiationPhase::Full);
+		auto appendCandidate = [&](const ASTNode& candidate_node) {
+			const FunctionDeclarationNode* candidate_func =
+				get_function_decl_node(candidate_node);
+			if (candidate_func == nullptr) {
+				return;
+			}
+			candidates.push_back(candidate_node);
+			if (candidate_func->get_definition().has_value()) {
+				definition_candidates.push_back(candidate_node);
+			}
+		};
+		if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
+			owner_type_info != nullptr) {
+			if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
+				for (const auto& member_func : struct_info->member_functions) {
+					if (member_func.getName() != member_handle ||
+						!member_func.function_decl.is<FunctionDeclarationNode>()) {
+						continue;
+					}
+					appendCandidate(member_func.function_decl);
+				}
+			}
+		}
+		if (!candidates.empty()) {
+			return;
+		}
+		for (const ASTNode& candidate_node : gSymbolTable.lookup_all(member_name)) {
+			const FunctionDeclarationNode* candidate_func =
+				get_function_decl_node(candidate_node);
+			if (candidate_func == nullptr) {
+				continue;
+			}
+			const std::string_view parent_name =
+				candidate_func->parent_struct_name();
+			if (parent_name == owner_name ||
+				(!parent_name.empty() && parent_name.ends_with(owner_name))) {
+				appendCandidate(candidate_node);
+			}
+		}
+	};
 	auto resolveQualifiedOwnerOverload = [&](
 		std::string_view owner_name,
 		std::string_view member_name,
@@ -1848,53 +1919,22 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		}
 
 		std::vector<ASTNode> candidates;
-		StringHandle owner_handle =
-			StringTable::getOrInternStringHandle(owner_name);
-		StringHandle member_handle =
-			StringTable::getOrInternStringHandle(member_name);
-		parser_.instantiateLazyClassToPhase(
-			owner_handle,
-			ClassInstantiationPhase::Full);
-		if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
-			owner_type_info != nullptr) {
-			if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
-				for (const auto& member_func : struct_info->member_functions) {
-					if (member_func.getName() != member_handle ||
-						!member_func.function_decl.is<FunctionDeclarationNode>()) {
-						continue;
-					}
-					candidates.push_back(member_func.function_decl);
-				}
-			}
+		std::vector<ASTNode> definition_candidates;
+		appendOwnerMemberCandidates(
+			owner_name,
+			member_name,
+			candidates,
+			definition_candidates);
+		if (const FunctionDeclarationNode* definition_target =
+				resolveUniqueFunctionOverload(
+					definition_candidates,
+					substituted_arg_types);
+			definition_target != nullptr) {
+			return definition_target;
 		}
-		if (candidates.empty()) {
-			for (const ASTNode& candidate_node : gSymbolTable.lookup_all(member_name)) {
-				const FunctionDeclarationNode* candidate_func =
-					get_function_decl_node(candidate_node);
-				if (candidate_func == nullptr) {
-					continue;
-				}
-				const std::string_view parent_name =
-					candidate_func->parent_struct_name();
-				if (parent_name == owner_name ||
-					(!parent_name.empty() && parent_name.ends_with(owner_name))) {
-					candidates.push_back(candidate_node);
-				}
-			}
-		}
-		if (candidates.empty()) {
-			return nullptr;
-		}
-
-		OverloadResolutionResult resolution =
-			resolve_overload(candidates, substituted_arg_types);
-		if (resolution.has_match &&
-			!resolution.is_ambiguous &&
-			resolution.selected_overload != nullptr &&
-			resolution.selected_overload->is<FunctionDeclarationNode>()) {
-			return &resolution.selected_overload->as<FunctionDeclarationNode>();
-		}
-		return nullptr;
+		return resolveUniqueFunctionOverload(
+			candidates,
+			substituted_arg_types);
 	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
 		CallExprNode substituted_call(
@@ -2609,6 +2649,17 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 								target_func = get_function_decl_node(*qualified_symbol);
 							}
 						}
+						if (const FunctionDeclarationNode* resolved_target =
+								resolveQualifiedOwnerOverload(
+									resolved_owner_name,
+									resolved_member_name,
+									substituted_args);
+							resolved_target != nullptr &&
+							(target_func == nullptr ||
+							 (!target_func->get_definition().has_value() &&
+							  resolved_target->get_definition().has_value()))) {
+							target_func = resolved_target;
+						}
 						if (target_func != nullptr) {
 							Token called_from_token(
 								Token::Type::Identifier,
@@ -2737,9 +2788,10 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 							}
 						}
 					}
-					if (target_func == nullptr &&
-						!materialized_record_owner_name.empty() &&
-						materialized_owner_name != materialized_record_owner_name) {
+					if (!materialized_record_owner_name.empty() &&
+						materialized_owner_name != materialized_record_owner_name &&
+						(target_func == nullptr ||
+						 !target_func->get_definition().has_value())) {
 						std::string_view qualified_owner_name =
 							StringBuilder()
 								.append(materialized_record_owner_name)
@@ -2748,17 +2800,44 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 								.commit();
 						std::string_view mutable_qualified_owner_name =
 							qualified_owner_name;
-						if (std::optional<ASTNode> qualified_instantiated_member =
+						if (const FunctionDeclarationNode* qualified_target =
+								resolveQualifiedOwnerOverload(
+									qualified_owner_name,
+									member_name,
+									substituted_args);
+							qualified_target != nullptr &&
+							(target_func == nullptr ||
+							 (!target_func->get_definition().has_value() &&
+							  qualified_target->get_definition().has_value()))) {
+							target_func = qualified_target;
+							materialized_owner_name = qualified_owner_name;
+						} else if (std::optional<ASTNode> qualified_instantiated_member =
 								parser_.instantiateLazyMemberForCanonicalOwner(
 									mutable_qualified_owner_name,
 									member_name,
 									std::span<const TemplateTypeArg>{});
 							qualified_instantiated_member.has_value() &&
 							qualified_instantiated_member->is<FunctionDeclarationNode>()) {
-							target_func =
-								&qualified_instantiated_member->as<FunctionDeclarationNode>();
-							materialized_owner_name = mutable_qualified_owner_name;
+							const FunctionDeclarationNode& instantiated_qualified_target =
+								qualified_instantiated_member->as<FunctionDeclarationNode>();
+							if (target_func == nullptr ||
+								(!target_func->get_definition().has_value() &&
+								 instantiated_qualified_target.get_definition().has_value())) {
+								target_func = &instantiated_qualified_target;
+								materialized_owner_name = mutable_qualified_owner_name;
+							}
 						}
+					}
+					if (const FunctionDeclarationNode* resolved_target =
+							resolveQualifiedOwnerOverload(
+								materialized_owner_name,
+								member_name,
+								substituted_args);
+						resolved_target != nullptr &&
+						(target_func == nullptr ||
+						 (!target_func->get_definition().has_value() &&
+						  resolved_target->get_definition().has_value()))) {
+						target_func = resolved_target;
 					}
 
 					if (target_func != nullptr) {
@@ -2852,6 +2931,17 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 							}
 						}
 					}
+				}
+				if (const FunctionDeclarationNode* resolved_target =
+						resolveQualifiedOwnerOverload(
+							instantiated_name,
+							member_name,
+							substituted_args);
+					resolved_target != nullptr &&
+					(target_func == nullptr ||
+					 (!target_func->get_definition().has_value() &&
+					  resolved_target->get_definition().has_value()))) {
+					target_func = resolved_target;
 				}
 
 				if (target_func == nullptr) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2143,6 +2143,33 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 					return std::nullopt;
 				}
 				if (have_complete_substituted_arg_types) {
+					if (call.has_definition_lookup_record() &&
+						call.definition_lookup_record()
+							->definition_bound_template_declaration != nullptr &&
+						call.has_qualified_name() &&
+						template_name == call.qualified_name()) {
+						std::vector<ASTNode> substituted_template_arg_nodes;
+						substituted_template_arg_nodes.reserve(
+							explicit_template_arg_nodes.size());
+						for (const auto& arg_node :
+							 explicit_template_arg_nodes) {
+							substituted_template_arg_nodes.push_back(
+								substitute(arg_node));
+						}
+						std::optional<ASTNode> instantiated =
+							parser_.resolveDefinitionBoundQualifiedTemplateCall(
+								*call.definition_lookup_record(),
+								template_name,
+								std::span<const ASTNode>(
+									substituted_template_arg_nodes.data(),
+									substituted_template_arg_nodes.size()),
+								substituted_args_nodes,
+								substituted_arg_types);
+						if (instantiated.has_value()) {
+							normalizePendingSemanticRoots();
+						}
+						return instantiated;
+					}
 					std::optional<ASTNode> instantiated = parser_.try_instantiate_template_explicit(
 						template_name,
 						substituted_template_args,

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1,5 +1,6 @@
 #include "ExpressionSubstitutor.h"
 #include "CallNodeHelpers.h"
+#include "MemberFunctionLookupShared.h"
 #include "Parser.h"
 #include "TemplateInstantiationHelper.h"
 #include "TemplateArgumentMaterialization.h"
@@ -91,44 +92,6 @@ bool decodeTTPPlaceholderArg(std::string_view encoded_arg, TemplateTypeArg& deco
 	decoded_arg.type_index = TypeIndex{static_cast<uint32_t>(raw_index), category};
 	decoded_arg.setCategory(category);
 	return true;
-}
-
-std::vector<ASTNode> materializeTemplateArgumentNodesForQualifiedId(
-	std::span<const TemplateTypeArg> template_args,
-	const Token& source_token) {
-	std::vector<ASTNode> result;
-	result.reserve(template_args.size());
-
-	for (const TemplateTypeArg& arg : template_args) {
-		if (arg.is_dependent || arg.dependent_name.isValid()) {
-			result.push_back(materializeDependentTemplateArgumentNode(arg, source_token));
-			continue;
-		}
-
-		if (arg.is_value) {
-			result.push_back(materializeValueTemplateArgumentNode(arg, source_token));
-			continue;
-		}
-
-		TypeIndex arg_type_index = arg.type_index;
-		if (!arg_type_index.is_valid()) {
-			if (arg.typeEnum() == TypeCategory::Invalid) {
-				continue;
-			}
-			arg_type_index = TypeIndex{}.withCategory(arg.typeEnum());
-		}
-
-		int size_in_bits = computeTemplateArgumentTypeSizeBits(arg_type_index);
-		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
-			arg_type_index,
-			size_in_bits,
-			source_token,
-			CVQualifier::None,
-			ReferenceQualifier::None);
-		result.push_back(ASTNode(&type_node));
-	}
-
-	return result;
 }
 
 std::optional<std::string_view> tryResolveCanonicalTypeName(
@@ -1836,8 +1799,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		parser_.normalizePendingSemanticRoots();
 	};
 	auto resolveUniqueFunctionOverload = [&](
-		const std::vector<ASTNode>& candidates,
-		const std::vector<TypeSpecifierNode>& substituted_arg_types) -> const FunctionDeclarationNode* {
+		std::span<const ASTNode> candidates,
+		std::span<const TypeSpecifierNode> substituted_arg_types) -> const FunctionDeclarationNode* {
 		if (candidates.empty()) {
 			return nullptr;
 		}
@@ -1854,8 +1817,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	auto appendOwnerMemberCandidates = [&](
 		std::string_view owner_name,
 		std::string_view member_name,
-		std::vector<ASTNode>& candidates,
-		std::vector<ASTNode>& definition_candidates) {
+		InlineVector<ASTNode, 8>& candidates,
+		InlineVector<ASTNode, 8>& definition_candidates) {
 		if (owner_name.empty() || member_name.empty()) {
 			return;
 		}
@@ -1866,27 +1829,22 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		parser_.instantiateLazyClassToPhase(
 			owner_handle,
 			ClassInstantiationPhase::Full);
-		auto appendCandidate = [&](const ASTNode& candidate_node) {
-			const FunctionDeclarationNode* candidate_func =
-				get_function_decl_node(candidate_node);
-			if (candidate_func == nullptr) {
-				return;
-			}
-			candidates.push_back(candidate_node);
-			if (candidate_func->get_definition().has_value()) {
-				definition_candidates.push_back(candidate_node);
-			}
-		};
 		if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
 			owner_type_info != nullptr) {
 			if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
-				for (const auto& member_func : struct_info->member_functions) {
-					if (member_func.getName() != member_handle ||
-						!member_func.function_decl.is<FunctionDeclarationNode>()) {
-						continue;
-					}
-					appendCandidate(member_func.function_decl);
-				}
+				DefinitionPreferredMemberOverloadSet owner_overloads =
+					collectVisibleMemberFunctionOverloadNodes(
+						struct_info,
+						member_handle,
+						true,
+						[](const StructMemberFunction& member_func,
+						   const FunctionDeclarationNode&) {
+							return !member_func.is_constructor &&
+								!member_func.is_destructor;
+						});
+				candidates = std::move(owner_overloads.all);
+				definition_candidates =
+					std::move(owner_overloads.definition_preferred);
 			}
 		}
 		if (!candidates.empty()) {
@@ -1902,7 +1860,12 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				candidate_func->parent_struct_name();
 			if (parent_name == owner_name ||
 				(!parent_name.empty() && parent_name.ends_with(owner_name))) {
-				appendCandidate(candidate_node);
+				appendUniqueOverloadNode(candidates, candidate_node);
+				if (candidate_func->get_definition().has_value()) {
+					appendUniqueOverloadNode(
+						definition_candidates,
+						candidate_node);
+				}
 			}
 		}
 	};
@@ -1918,8 +1881,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			return nullptr;
 		}
 
-		std::vector<ASTNode> candidates;
-		std::vector<ASTNode> definition_candidates;
+		InlineVector<ASTNode, 8> candidates;
+		InlineVector<ASTNode, 8> definition_candidates;
 		appendOwnerMemberCandidates(
 			owner_name,
 			member_name,
@@ -3386,7 +3349,7 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 					return ASTNode(&deferred_expr);
 				}
 				std::vector<ASTNode> explicit_template_arg_nodes =
-					materializeTemplateArgumentNodesForQualifiedId(
+					materializeTemplateArgumentNodes(
 						std::span<const TemplateTypeArg>(
 							final_member_args.data(),
 							final_member_args.size()),

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1835,6 +1835,67 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 	auto normalizePendingSemanticRoots = [&]() {
 		parser_.normalizePendingSemanticRoots();
 	};
+	auto resolveQualifiedOwnerOverload = [&](
+		std::string_view owner_name,
+		std::string_view member_name,
+		const ChunkedVector<ASTNode>& substituted_args) -> const FunctionDeclarationNode* {
+		if (owner_name.empty() || member_name.empty()) {
+			return nullptr;
+		}
+		std::vector<TypeSpecifierNode> substituted_arg_types;
+		if (!parser_.tryCollectFunctionCallArgTypes(substituted_args, substituted_arg_types)) {
+			return nullptr;
+		}
+
+		std::vector<ASTNode> candidates;
+		StringHandle owner_handle =
+			StringTable::getOrInternStringHandle(owner_name);
+		StringHandle member_handle =
+			StringTable::getOrInternStringHandle(member_name);
+		parser_.instantiateLazyClassToPhase(
+			owner_handle,
+			ClassInstantiationPhase::Full);
+		if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
+			owner_type_info != nullptr) {
+			if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
+				for (const auto& member_func : struct_info->member_functions) {
+					if (member_func.getName() != member_handle ||
+						!member_func.function_decl.is<FunctionDeclarationNode>()) {
+						continue;
+					}
+					candidates.push_back(member_func.function_decl);
+				}
+			}
+		}
+		if (candidates.empty()) {
+			for (const ASTNode& candidate_node : gSymbolTable.lookup_all(member_name)) {
+				const FunctionDeclarationNode* candidate_func =
+					get_function_decl_node(candidate_node);
+				if (candidate_func == nullptr) {
+					continue;
+				}
+				const std::string_view parent_name =
+					candidate_func->parent_struct_name();
+				if (parent_name == owner_name ||
+					(!parent_name.empty() && parent_name.ends_with(owner_name))) {
+					candidates.push_back(candidate_node);
+				}
+			}
+		}
+		if (candidates.empty()) {
+			return nullptr;
+		}
+
+		OverloadResolutionResult resolution =
+			resolve_overload(candidates, substituted_arg_types);
+		if (resolution.has_match &&
+			!resolution.is_ambiguous &&
+			resolution.selected_overload != nullptr &&
+			resolution.selected_overload->is<FunctionDeclarationNode>()) {
+			return &resolution.selected_overload->as<FunctionDeclarationNode>();
+		}
+		return nullptr;
+	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
 		CallExprNode substituted_call(
 			call.callee(),
@@ -2521,17 +2582,23 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 						ChunkedVector<ASTNode> substituted_args =
 							substituteCallArgumentsPreservingPackExpansion(call.arguments());
 
-						const FunctionDeclarationNode* target_func = nullptr;
+						const FunctionDeclarationNode* target_func =
+							resolveQualifiedOwnerOverload(
+								resolved_owner_name,
+								resolved_member_name,
+								substituted_args);
 						std::string_view mutable_resolved_owner_name =
 							resolved_owner_name;
-						if (std::optional<ASTNode> instantiated_member =
+						if (target_func == nullptr) {
+							std::optional<ASTNode> instantiated_member =
 								parser_.instantiateLazyMemberForCanonicalOwner(
 									mutable_resolved_owner_name,
 									resolved_member_name,
 									std::span<const TemplateTypeArg>{});
-							instantiated_member.has_value() &&
-							instantiated_member->is<FunctionDeclarationNode>()) {
-							target_func = &instantiated_member->as<FunctionDeclarationNode>();
+							if (instantiated_member.has_value() &&
+								instantiated_member->is<FunctionDeclarationNode>()) {
+								target_func = &instantiated_member->as<FunctionDeclarationNode>();
+							}
 						}
 						if (target_func == nullptr) {
 							auto qualified_symbol =
@@ -2607,17 +2674,23 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			if (!materialized_owner_name.empty()) {
 					ChunkedVector<ASTNode> substituted_args =
 						substituteCallArgumentsPreservingPackExpansion(call.arguments());
-					const FunctionDeclarationNode* target_func = nullptr;
-
-					std::optional<ASTNode> instantiated_member =
-						parser_.instantiateLazyMemberForCanonicalOwner(
+					const FunctionDeclarationNode* target_func =
+						resolveQualifiedOwnerOverload(
 							materialized_owner_name,
 							member_name,
-							std::span<const TemplateTypeArg>{});
-					if (instantiated_member.has_value() &&
-						instantiated_member->is<FunctionDeclarationNode>()) {
-						target_func =
-							&instantiated_member->as<FunctionDeclarationNode>();
+							substituted_args);
+
+					if (target_func == nullptr) {
+						std::optional<ASTNode> instantiated_member =
+							parser_.instantiateLazyMemberForCanonicalOwner(
+								materialized_owner_name,
+								member_name,
+								std::span<const TemplateTypeArg>{});
+						if (instantiated_member.has_value() &&
+							instantiated_member->is<FunctionDeclarationNode>()) {
+							target_func =
+								&instantiated_member->as<FunctionDeclarationNode>();
+						}
 					}
 					parser_.instantiateLazyClassToPhase(
 						StringTable::getOrInternStringHandle(materialized_owner_name),

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -11,6 +11,13 @@ struct ConstAwareMemberCandidateSet {
 	InlineVector<const StructMemberFunction*, 8> compatible;
 };
 
+struct DefinitionPreferredMemberOverloadSet {
+	InlineVector<ASTNode, 8> all;
+	InlineVector<ASTNode, 8> definition_preferred;
+	const FunctionDeclarationNode* first = nullptr;
+	const FunctionDeclarationNode* first_definition = nullptr;
+};
+
 inline void appendUniqueMemberFunctionCandidate(
 	InlineVector<const StructMemberFunction*, 8>& target,
 	const StructMemberFunction* candidate) {
@@ -19,6 +26,19 @@ inline void appendUniqueMemberFunctionCandidate(
 	}
 	if (std::ranges::none_of(target, [&](const StructMemberFunction* existing) {
 		return existing == candidate;
+	})) {
+		target.push_back(candidate);
+	}
+}
+
+inline void appendUniqueOverloadNode(
+	InlineVector<ASTNode, 8>& target,
+	const ASTNode& candidate) {
+	if (!candidate.raw_pointer()) {
+		return;
+	}
+	if (std::ranges::none_of(target, [&](const ASTNode& existing) {
+		return existing.raw_pointer() == candidate.raw_pointer();
 	})) {
 		target.push_back(candidate);
 	}
@@ -44,6 +64,71 @@ inline void appendUniqueMemberFunctionOverloadNodes(
 			target.push_back(function_decl);
 		}
 	}
+}
+
+template <typename AcceptFn>
+DefinitionPreferredMemberOverloadSet collectVisibleMemberFunctionOverloadNodes(
+	const StructTypeInfo* root_struct_info,
+	StringHandle member_name_handle,
+	bool stop_at_first_local_name_set,
+	AcceptFn&& accept_candidate) {
+	DefinitionPreferredMemberOverloadSet result;
+	if (root_struct_info == nullptr) {
+		return result;
+	}
+
+	InlineVector<const StructTypeInfo*, 8> visited;
+	auto recurse = [&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
+		if (current_struct_info == nullptr) {
+			return;
+		}
+		if (std::ranges::find(visited, current_struct_info) != visited.end()) {
+			return;
+		}
+		visited.push_back(current_struct_info);
+
+		bool found_local_overload = false;
+		for (const auto& member_func : current_struct_info->member_functions) {
+			if (member_func.getName() != member_name_handle ||
+				!member_func.function_decl.is<FunctionDeclarationNode>()) {
+				continue;
+			}
+
+			const auto& func_decl =
+				member_func.function_decl.as<FunctionDeclarationNode>();
+			if (!accept_candidate(member_func, func_decl)) {
+				continue;
+			}
+
+			found_local_overload = true;
+			if (result.first == nullptr) {
+				result.first = &func_decl;
+			}
+			appendUniqueOverloadNode(result.all, member_func.function_decl);
+			if (func_decl.get_definition().has_value()) {
+				if (result.first_definition == nullptr) {
+					result.first_definition = &func_decl;
+				}
+				appendUniqueOverloadNode(
+					result.definition_preferred,
+					member_func.function_decl);
+			}
+		}
+
+		if (found_local_overload && stop_at_first_local_name_set) {
+			return;
+		}
+
+		for (const auto& base_spec : current_struct_info->base_classes) {
+			if (const StructTypeInfo* base_struct =
+					tryGetStructTypeInfo(base_spec.type_index)) {
+				self(base_struct, self);
+			}
+		}
+	};
+
+	recurse(root_struct_info, recurse);
+	return result;
 }
 
 template <typename AcceptFn>

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3623,6 +3623,8 @@ private:	 // Resume private methods
 
 	// Lookup symbol with template parameter checking
 	std::optional<ASTNode> lookup_symbol_with_template_check(StringHandle identifier);
+	const FunctionDeclarationNode* trySelectUnambiguousParserReturnTypeHint(
+		std::span<const ASTNode> overloads) const;
 
 	void filterPhase1OrdinaryFunctionOverloads(std::vector<ASTNode>& overloads) {
 		const TemplateDefinitionLookupContext* definition_context =

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1129,6 +1129,7 @@ private:
 	size_t phase1_cutoff_file_idx_ = SIZE_MAX;
 	std::optional<Token> phase1_violation_token_;
 	const TemplateDefinitionLookupContext* current_template_definition_lookup_context_ = nullptr;
+	const void* preferred_definition_bound_template_declaration_ = nullptr;
 
 	// Add parsing depth counter to detect infinite loops
 	// This is incremented/decremented in critical parsing functions
@@ -1943,6 +1944,12 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		Token called_from_token);
 	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(
 		const FunctionCallDefinitionLookupRecord& record,
+		std::span<const TypeSpecifierNode> arg_types);
+	std::optional<ASTNode> resolveDefinitionBoundQualifiedTemplateCall(
+		const FunctionCallDefinitionLookupRecord& record,
+		std::string_view qualified_name,
+		std::span<const ASTNode> template_argument_nodes,
+		const ChunkedVector<ASTNode>& arguments,
 		std::span<const TypeSpecifierNode> arg_types);
 	std::optional<ASTNode> resolveDeferredQualifiedTemplateCall(
 		std::string_view qualified_name,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -2063,18 +2063,119 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 					}
 					return nullptr;
 				};
+				StringBuilder class_scope_builder;
+				for (size_t i = 0; i < namespaces.size(); ++i) {
+					if (i > 0) {
+						class_scope_builder.append("::");
+					}
+					class_scope_builder.append(std::string_view(namespaces[i]));
+				}
+				std::string_view class_scope = class_scope_builder.commit();
+				StringHandle class_name_handle =
+					StringTable::getOrInternStringHandle(class_scope);
+				auto resolveQualifiedStaticMemberFromOwner =
+					[&]() -> const FunctionDeclarationNode* {
+						auto class_type_it = getTypesByNameMap().find(class_name_handle);
+						if (class_type_it == getTypesByNameMap().end() ||
+							class_type_it->second == nullptr) {
+							return nullptr;
+						}
+						const StructTypeInfo* struct_info =
+							class_type_it->second->getStructInfo();
+						if (struct_info == nullptr) {
+							struct_info = tryGetStructTypeInfo(
+								class_type_it->second->registeredTypeIndex());
+						}
+						if (struct_info == nullptr) {
+							return nullptr;
+						}
+						std::vector<ASTNode> candidates;
+						std::vector<ASTNode> definition_candidates;
+						const FunctionDeclarationNode* first_candidate = nullptr;
+						const FunctionDeclarationNode* first_definition_candidate =
+							nullptr;
+						auto collect_candidates =
+							[&](const StructTypeInfo* current_struct,
+								const auto& self) -> void {
+								if (current_struct == nullptr) {
+									return;
+								}
+								for (const auto& member_func : current_struct->member_functions) {
+									if (member_func.getName() != final_identifier.handle() ||
+										!member_func.function_decl.is<FunctionDeclarationNode>()) {
+										continue;
+									}
+									const FunctionDeclarationNode& candidate =
+										member_func.function_decl.as<FunctionDeclarationNode>();
+									if (!candidate.is_static()) {
+										continue;
+									}
+									if (first_candidate == nullptr) {
+										first_candidate = &candidate;
+									}
+									const bool already_added =
+										std::any_of(
+											candidates.begin(),
+											candidates.end(),
+											[&](const ASTNode& existing_overload) {
+												const FunctionDeclarationNode* existing_function =
+													get_function_decl_node(existing_overload);
+												return existing_function == &candidate;
+											});
+									if (!already_added) {
+										candidates.push_back(member_func.function_decl);
+									}
+									if (candidate.get_definition().has_value()) {
+										if (first_definition_candidate == nullptr) {
+											first_definition_candidate = &candidate;
+										}
+										definition_candidates.push_back(
+											member_func.function_decl);
+									}
+								}
+								for (const auto& base_spec : current_struct->base_classes) {
+									if (const StructTypeInfo* base_struct =
+											tryGetStructTypeInfo(base_spec.type_index);
+										base_struct != nullptr) {
+										self(base_struct, self);
+									}
+								}
+							};
+						collect_candidates(struct_info, collect_candidates);
+						auto resolve_from_candidates =
+							[&](const std::vector<ASTNode>& overloads)
+								-> const FunctionDeclarationNode* {
+								if (overloads.empty()) {
+									return nullptr;
+								}
+								const OverloadResolutionResult overload_result =
+									resolve_overload(overloads, arg_types);
+								if (overload_result.has_match &&
+									!overload_result.is_ambiguous &&
+									overload_result.selected_overload != nullptr) {
+									return get_function_decl_node(
+										*overload_result.selected_overload);
+								}
+								return nullptr;
+							};
+						if (const FunctionDeclarationNode* definition_match =
+								resolve_from_candidates(definition_candidates);
+							definition_match != nullptr) {
+							return definition_match;
+						}
+						if (const FunctionDeclarationNode* resolved_match =
+								resolve_from_candidates(candidates);
+							resolved_match != nullptr) {
+							return resolved_match;
+						}
+						if (first_definition_candidate != nullptr) {
+							return first_definition_candidate;
+						}
+						return first_candidate;
+					};
 
 				const DeclarationNode* decl_ptr = qualified_symbol.has_value() ? getDeclarationNode(*qualified_symbol) : nullptr;
 				if (!decl_ptr) {
-					StringBuilder class_scope_builder;
-					for (size_t i = 0; i < namespaces.size(); ++i) {
-						if (i > 0) {
-							class_scope_builder.append("::");
-						}
-						class_scope_builder.append(std::string_view(namespaces[i]));
-					}
-					std::string_view class_scope = class_scope_builder.commit();
-					StringHandle class_name_handle = StringTable::getOrInternStringHandle(class_scope);
 					const TypeInfo* class_type_info = lookupTypeInCurrentContext(class_name_handle);
 					if (class_type_info == nullptr) {
 						auto class_type_it = getTypesByNameMap().find(class_name_handle);
@@ -2099,13 +2200,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							struct_info = tryGetStructTypeInfo(class_type_info->registeredTypeIndex());
 						}
 						if (struct_info != nullptr) {
-							auto member_function_result =
-								struct_info->findMemberFunctionRecursive(final_identifier.handle());
-							if (const StructMemberFunction* member_function = member_function_result.first) {
-								if (member_function->function_decl.is<FunctionDeclarationNode>()) {
-									qualified_symbol = member_function->function_decl;
-									decl_ptr = &qualified_symbol->as<FunctionDeclarationNode>().decl_node();
-								}
+							if (const FunctionDeclarationNode* resolved_member =
+									resolveQualifiedStaticMemberFromOwner();
+								resolved_member != nullptr) {
+								qualified_symbol = ASTNode(resolved_member);
+								decl_ptr = &resolved_member->decl_node();
 							}
 						}
 					}
@@ -2113,15 +2212,6 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				if (qualified_symbol.has_value() && qualified_symbol->is<FunctionDeclarationNode>()) {
 					const FunctionDeclarationNode& func_decl = qualified_symbol->as<FunctionDeclarationNode>();
 					if (!func_decl.is_materialized()) {
-						StringBuilder class_scope_builder;
-						for (size_t i = 0; i < namespaces.size(); ++i) {
-							if (i > 0) {
-								class_scope_builder.append("::");
-							}
-							class_scope_builder.append(std::string_view(namespaces[i]));
-						}
-						std::string_view class_scope = class_scope_builder.commit();
-						StringHandle class_name_handle = StringTable::getOrInternStringHandle(class_scope);
 						auto class_type_it = getTypesByNameMap().find(class_name_handle);
 						if (class_type_it != getTypesByNameMap().end() && class_type_it->second->isTemplateInstantiation()) {
 							if (!instantiating_lazy_member_) {
@@ -2140,6 +2230,14 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								}
 							}
 						}
+					}
+					if (const FunctionDeclarationNode* resolved_member =
+							resolveQualifiedStaticMemberFromOwner();
+						resolved_member != nullptr &&
+						(!func_decl.get_definition().has_value() ||
+						 resolved_member->get_definition().has_value())) {
+						qualified_symbol = ASTNode(resolved_member);
+						decl_ptr = &resolved_member->decl_node();
 					}
 				}
 

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -9,6 +9,11 @@
 #include <limits>
 
 namespace {
+struct PostfixDependentMemberSegmentInfo {
+	StringHandle name;
+	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>> template_args;
+};
+
 std::string_view buildQualifiedMemberCallName(
 	std::span<const StringHandle> owner_segments,
 	std::string_view member_name) {
@@ -26,6 +31,62 @@ std::string_view buildQualifiedMemberCallName(
 		builder.append(member_name);
 	}
 	return builder.commit();
+}
+
+bool postfixExplicitTemplateArgsRequireDeferredInstantiation(
+	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	return std::any_of(template_args.begin(), template_args.end(), [](const TemplateTypeArg& arg) {
+		return arg.is_pack || templateArgIsStructurallyDependent(arg);
+	});
+}
+
+TypeIndex lookupPostfixRecordedDependentOwnerType(StringHandle owner_handle) {
+	if (!owner_handle.isValid()) {
+		return {};
+	}
+	auto owner_it = getTypesByNameMap().find(owner_handle);
+	if (owner_it == getTypesByNameMap().end() || owner_it->second == nullptr) {
+		return {};
+	}
+	return owner_it->second->registeredTypeIndex();
+}
+
+TypeInfo::DependentQualifiedNameRecord makePostfixDependentQualifiedNameRecord(
+	StringHandle owner_name,
+	TypeIndex owner_type,
+	TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
+	InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments,
+	std::span<const PostfixDependentMemberSegmentInfo> member_segments) {
+	TypeInfo::DependentQualifiedNameRecord record;
+	record.owner_kind = owner_kind;
+	record.owner_name = owner_name;
+	record.owner_type = owner_type;
+	record.owner_template_arguments = std::move(owner_template_arguments);
+	record.names_current_instantiation =
+		owner_kind == TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation;
+	for (const PostfixDependentMemberSegmentInfo& segment_info : member_segments) {
+		TypeInfo::DependentQualifiedNameRecord::Member member;
+		member.name = segment_info.name;
+		member.has_template_keyword = segment_info.template_args.has_value();
+		if (segment_info.template_args.has_value()) {
+			member.template_arguments = *segment_info.template_args;
+			member.has_template_arguments = true;
+		}
+		record.member_chain.push_back(std::move(member));
+	}
+	return record;
+}
+
+std::string_view buildPostfixDependentQualifiedCallName(
+	std::string_view owner_name,
+	std::span<const PostfixDependentMemberSegmentInfo> member_segments) {
+	StringBuilder qualified_name_builder;
+	qualified_name_builder.append(owner_name);
+	for (const PostfixDependentMemberSegmentInfo& member_segment : member_segments) {
+		qualified_name_builder.append("::");
+		qualified_name_builder.append(StringTable::getStringView(member_segment.name));
+	}
+	return qualified_name_builder.commit();
 }
 
 void attachResolvedPostfixDirectCallMetadata(
@@ -731,6 +792,214 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 	advance(); // consume member name
 
 	TemplateTypeArgParsingResult explicit_template_args = parse_explicit_template_arguments_as_result(TokenDestroyPattern::Restore);
+	if (explicit_template_args && peek() == "::"_tok) {
+		explicit_template_args.destroy_pattern_ = TokenDestroyPattern::Discard;
+		std::optional<InlineVector<TemplateTypeArg, 4>> owner_template_args =
+			explicit_template_args.read_template_type_args();
+		if (!owner_template_args.has_value()) {
+			return ParseResult::error(
+				"Expected template arguments for qualified owner template-id",
+				member_name_token);
+		}
+
+		advance(); // consume '::'
+		bool saw_template_keyword = false;
+		if (peek() == "template"_tok) {
+			advance();
+			saw_template_keyword = true;
+		}
+
+		Token qualified_member_token;
+		if (peek() == "operator"_tok) {
+			Token operator_keyword_token = peek_info();
+			advance(); // consume 'operator'
+			std::string_view operator_name;
+			if (auto err = parse_operator_name(operator_keyword_token, operator_name)) {
+				return std::move(*err);
+			}
+			qualified_member_token = Token(
+				Token::Type::Identifier,
+				operator_name,
+				operator_keyword_token.line(),
+				operator_keyword_token.column(),
+				operator_keyword_token.file_index());
+		} else if (peek().is_identifier()) {
+			qualified_member_token = peek_info();
+			advance(); // consume member name
+		} else {
+			return ParseResult::error("Expected identifier after '::'", current_token_);
+		}
+
+		std::optional<InlineVector<TemplateTypeArg, 4>> member_template_args;
+		std::vector<ASTNode> member_template_arg_nodes;
+		if (peek() == "<"_tok || saw_template_keyword) {
+			last_failed_template_arg_parse_handle_ = SIZE_MAX;
+			member_template_args =
+				parse_explicit_template_arguments(&member_template_arg_nodes);
+			if (saw_template_keyword && !member_template_args.has_value()) {
+				return ParseResult::error(
+					"Expected explicit template arguments after 'template'",
+					qualified_member_token);
+			}
+		}
+
+		if (peek() != "("_tok) {
+			return ParseResult::error(
+				"Expected '(' after qualified member template-id",
+				current_token_);
+		}
+		advance(); // consume '('
+
+		auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+			.handle_pack_expansion = true,
+			.collect_types = true,
+			.expand_simple_packs = false});
+		if (!args_result.success) {
+			return ParseResult::error(
+				args_result.error_message,
+				args_result.error_token.value_or(current_token_));
+		}
+		ChunkedVector<ASTNode> args = std::move(args_result.args);
+		std::vector<TypeSpecifierNode> arg_types = std::move(args_result.arg_types);
+		if (!consume(")"_tok)) {
+			return ParseResult::error(
+				"Expected ')' after qualified member function call",
+				current_token_);
+		}
+
+		const bool owner_args_dependent =
+			postfixExplicitTemplateArgsRequireDeferredInstantiation(
+				*owner_template_args);
+		if (owner_args_dependent) {
+			std::vector<PostfixDependentMemberSegmentInfo> member_segments;
+			PostfixDependentMemberSegmentInfo member_segment;
+			member_segment.name = qualified_member_token.handle().isValid()
+				? qualified_member_token.handle()
+				: StringTable::getOrInternStringHandle(qualified_member_token.value());
+			if (member_template_args.has_value()) {
+				member_segment.template_args =
+					toTemplateArgInfoList(*member_template_args);
+			}
+			member_segments.push_back(std::move(member_segment));
+
+			auto type_spec = emplace_node<TypeSpecifierNode>(
+				TypeIndex{}.withCategory(TypeCategory::Auto),
+				0,
+				qualified_member_token,
+				CVQualifier::None,
+				ReferenceQualifier::None);
+			auto& member_decl =
+				emplace_node<DeclarationNode>(type_spec, qualified_member_token)
+					.as<DeclarationNode>();
+			std::string_view deferred_qualified_call_name =
+				buildPostfixDependentQualifiedCallName(
+					member_name_token.value(),
+					member_segments);
+			Token deferred_call_token(
+				Token::Type::Identifier,
+				deferred_qualified_call_name,
+				qualified_member_token.line(),
+				qualified_member_token.column(),
+				qualified_member_token.file_index());
+			result = emplace_node<ExpressionNode>(
+				makeDirectCallExpr(
+					member_decl,
+					std::move(args),
+					deferred_call_token));
+			setCallQualifiedName(
+				result->as<ExpressionNode>(),
+				deferred_qualified_call_name);
+			setCallDependentQualifiedLookupRecord(
+				result->as<ExpressionNode>(),
+				makePostfixDependentQualifiedNameRecord(
+					member_name_token.handle().isValid()
+						? member_name_token.handle()
+						: StringTable::getOrInternStringHandle(member_name_token.value()),
+					lookupPostfixRecordedDependentOwnerType(member_name_token.handle()),
+					TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization,
+					toTemplateArgInfoList(*owner_template_args),
+					member_segments));
+			if (!member_template_arg_nodes.empty()) {
+				setCallTemplateArguments(
+					result->as<ExpressionNode>(),
+					std::move(member_template_arg_nodes));
+			}
+			return ParseResult::success(*result);
+		}
+
+		AliasTemplateMaterializationResult materialized_owner =
+			resolveCanonicalInstantiatedOwnerForLookup(
+				member_name_token.value(),
+				std::span<const TemplateTypeArg>(
+					owner_template_args->data(),
+					owner_template_args->size()));
+		std::string_view qualified_owner_name =
+			materialized_owner.canonicalName();
+		std::optional<ASTNode> instantiated_func;
+		if (!qualified_owner_name.empty()) {
+			instantiated_func = tryInstantiateMemberFunctionTemplateCall(
+				qualified_owner_name,
+				qualified_member_token.value(),
+				member_template_args,
+				arg_types,
+				!args.empty(),
+				false);
+		}
+
+		if (instantiated_func.has_value() &&
+			instantiated_func->is<FunctionDeclarationNode>()) {
+			const auto& resolved_func =
+				instantiated_func->as<FunctionDeclarationNode>();
+			result = emplace_node<ExpressionNode>(
+				makeResolvedMemberCallExpr(
+					*result,
+					resolved_func,
+					std::move(args),
+					qualified_member_token));
+			attachResolvedMemberCallMetadata(
+				result->as<ExpressionNode>(),
+				current_template_definition_lookup_context_,
+				qualified_member_token,
+				arg_types,
+				false,
+				resolved_func);
+			return ParseResult::success(*result);
+		}
+
+		auto type_spec = emplace_node<TypeSpecifierNode>(
+			TypeIndex{}.withCategory(TypeCategory::Auto),
+			0,
+			qualified_member_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		auto& member_decl =
+			emplace_node<DeclarationNode>(type_spec, qualified_member_token)
+				.as<DeclarationNode>();
+		auto& func_decl_node =
+			emplace_node<FunctionDeclarationNode>(member_decl)
+				.as<FunctionDeclarationNode>();
+		result = emplace_node<ExpressionNode>(
+			makeResolvedMemberCallExpr(
+				*result,
+				func_decl_node,
+				std::move(args),
+				qualified_member_token));
+		if (!member_template_arg_nodes.empty()) {
+			setCallTemplateArguments(
+				result->as<ExpressionNode>(),
+				std::move(member_template_arg_nodes));
+		}
+		setCallQualifiedName(
+			result->as<ExpressionNode>(),
+			StringBuilder()
+				.append(qualified_owner_name.empty()
+					? member_name_token.value()
+					: qualified_owner_name)
+				.append("::")
+				.append(qualified_member_token.value())
+				.commit());
+		return ParseResult::success(*result);
+	}
 
 	if (peek() == "("_tok) {
 		explicit_template_args.destroy_pattern_ = TokenDestroyPattern::Discard;

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -4,127 +4,11 @@
 #include "NameMangling.h"
 #include "OverloadResolution.h"
 #include "Parser_FunctionTypeHelpers.h"
+#include "TemplateArgumentMaterialization.h"
 #include "TypeTraitEvaluator.h"
 #include <limits>
 
 namespace {
-std::string_view getPostfixTemplateArgTokenText(const TemplateTypeArg& arg) {
-	switch (arg.typeEnum()) {
-	case TypeCategory::Void: return "void";
-	case TypeCategory::Bool: return "bool";
-	case TypeCategory::Char: return "char";
-	case TypeCategory::UnsignedChar: return "unsigned char";
-	case TypeCategory::Short: return "short";
-	case TypeCategory::UnsignedShort: return "unsigned short";
-	case TypeCategory::Int: return "int";
-	case TypeCategory::UnsignedInt: return "unsigned int";
-	case TypeCategory::Long: return "long";
-	case TypeCategory::UnsignedLong: return "unsigned long";
-	case TypeCategory::LongLong: return "long long";
-	case TypeCategory::UnsignedLongLong: return "unsigned long long";
-	case TypeCategory::Float: return "float";
-	case TypeCategory::Double: return "double";
-	case TypeCategory::LongDouble: return "long double";
-	default: return {};
-	}
-}
-
-std::vector<ASTNode> materializePostfixTemplateArgumentNodes(
-	std::span<const TemplateTypeArg> template_args,
-	const Token& source_token) {
-	std::vector<ASTNode> result;
-	result.reserve(template_args.size());
-
-	for (const auto& arg : template_args) {
-		if (arg.is_dependent && arg.dependent_name.isValid()) {
-			Token dep_token(
-				Token::Type::Identifier,
-				arg.dependent_name.view(),
-				source_token.line(),
-				source_token.column(),
-				source_token.file_index());
-			ExpressionNode& dep_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-				TemplateParameterReferenceNode(arg.dependent_name, dep_token));
-			result.push_back(ASTNode(&dep_expr));
-			continue;
-		}
-
-		if (arg.is_value) {
-			if (arg.typeEnum() == TypeCategory::Bool) {
-				Token bool_token(
-					Token::Type::Keyword,
-					arg.value != 0 ? "true"sv : "false"sv,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& bool_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					BoolLiteralNode(bool_token, arg.value != 0));
-				result.push_back(ASTNode(&bool_expr));
-			} else {
-				StringBuilder text_builder;
-				std::string_view literal_text = text_builder.append(arg.value).commit();
-				TypeCategory literal_type = arg.typeEnum() == TypeCategory::Invalid
-					? TypeCategory::Int
-					: arg.typeEnum();
-				Token literal_token(
-					Token::Type::Literal,
-					literal_text,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& literal_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					NumericLiteralNode(
-						literal_token,
-						static_cast<unsigned long long>(arg.value),
-						literal_type,
-						TypeQualifier::None,
-						get_type_size_bits(literal_type)));
-				result.push_back(ASTNode(&literal_expr));
-			}
-			continue;
-		}
-
-		Token type_token = source_token;
-		TypeCategory type_category = arg.typeEnum();
-		if (const TypeInfo* type_info = tryGetTypeInfo(arg.type_index)) {
-			std::string_view type_name = StringTable::getStringView(type_info->name());
-			if (!type_name.empty()) {
-				type_token = Token(
-					Token::Type::Identifier,
-					type_name,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-			}
-		} else if (std::string_view builtin_name = getPostfixTemplateArgTokenText(arg);
-				   !builtin_name.empty()) {
-			type_token = Token(
-				Token::Type::Keyword,
-				builtin_name,
-				source_token.line(),
-				source_token.column(),
-				source_token.file_index());
-		}
-
-		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
-			arg.type_index.withCategory(type_category),
-			get_type_size_bits(type_category),
-			type_token,
-			arg.cv_qualifier,
-			arg.ref_qualifier);
-		type_node.set_pack_expansion(arg.is_pack);
-		for (size_t pointer_index = 0; pointer_index < arg.pointer_depth; ++pointer_index) {
-			CVQualifier pointer_cv = pointer_index < arg.pointer_cv_qualifiers.size()
-				? arg.pointer_cv_qualifiers[pointer_index]
-				: CVQualifier::None;
-			type_node.add_pointer_level(pointer_cv);
-		}
-		result.push_back(ASTNode(&type_node));
-	}
-
-	return result;
-}
-
 std::string_view buildQualifiedMemberCallName(
 	std::span<const StringHandle> owner_segments,
 	std::string_view member_name) {
@@ -1607,7 +1491,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								member_template_args =
 									explicit_template_args.read_template_type_args();
 								member_template_arg_nodes =
-									materializePostfixTemplateArgumentNodes(
+									materializeTemplateArgumentNodes(
 										*member_template_args,
 										qualified_member_token);
 							}
@@ -1711,7 +1595,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								member_template_args =
 									explicit_template_args.read_template_type_args();
 								member_template_arg_nodes =
-									materializePostfixTemplateArgumentNodes(
+									materializeTemplateArgumentNodes(
 										*member_template_args,
 										op_token);
 							}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -144,14 +144,6 @@ std::string_view buildQualifiedMemberCallName(
 	return builder.commit();
 }
 
-std::string_view buildQualifiedMemberCallName(
-	const StructTypeInfo& owner_struct,
-	std::string_view member_name) {
-	return buildQualifiedMemberCallName(
-		std::span<const StringHandle>(&owner_struct.name, 1),
-		member_name);
-}
-
 void attachResolvedPostfixDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1,6 +1,7 @@
 #include "Parser.h"
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
+#include "MemberFunctionLookupShared.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
 #include "Parser_FunctionTypeHelpers.h"
@@ -1542,22 +1543,20 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			return nullptr;
 		}
 
-		std::vector<ASTNode> candidates;
-		for (const auto& member_func : owner_struct->member_functions) {
-			if (member_func.is_constructor || member_func.is_destructor) {
-				continue;
-			}
-			if (member_func.getName() != member_name_handle ||
-				!member_func.function_decl.is<FunctionDeclarationNode>()) {
-				continue;
-			}
-			const FunctionDeclarationNode& candidate =
-				member_func.function_decl.as<FunctionDeclarationNode>();
-			if (candidate.failed_substitution()) {
-				continue;
-			}
-			candidates.push_back(member_func.function_decl);
-		}
+		DefinitionPreferredMemberOverloadSet candidate_set =
+			collectVisibleMemberFunctionOverloadNodes(
+				owner_struct,
+				member_name_handle,
+				true,
+				[](const StructMemberFunction& member_func,
+				   const FunctionDeclarationNode& candidate) {
+					return !member_func.is_constructor &&
+						!member_func.is_destructor &&
+						!candidate.failed_substitution();
+				});
+		std::span<const ASTNode> candidates(
+			candidate_set.all.data(),
+			candidate_set.all.size());
 		if (candidates.empty()) {
 			return nullptr;
 		}
@@ -2075,6 +2074,9 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 					StringTable::getOrInternStringHandle(class_scope);
 				auto resolveQualifiedStaticMemberFromOwner =
 					[&]() -> const FunctionDeclarationNode* {
+						instantiateLazyClassToPhase(
+							class_name_handle,
+							ClassInstantiationPhase::Full);
 						auto class_type_it = getTypesByNameMap().find(class_name_handle);
 						if (class_type_it == getTypesByNameMap().end() ||
 							class_type_it->second == nullptr) {
@@ -2089,61 +2091,19 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						if (struct_info == nullptr) {
 							return nullptr;
 						}
-						std::vector<ASTNode> candidates;
-						std::vector<ASTNode> definition_candidates;
-						const FunctionDeclarationNode* first_candidate = nullptr;
-						const FunctionDeclarationNode* first_definition_candidate =
-							nullptr;
-						auto collect_candidates =
-							[&](const StructTypeInfo* current_struct,
-								const auto& self) -> void {
-								if (current_struct == nullptr) {
-									return;
-								}
-								for (const auto& member_func : current_struct->member_functions) {
-									if (member_func.getName() != final_identifier.handle() ||
-										!member_func.function_decl.is<FunctionDeclarationNode>()) {
-										continue;
-									}
-									const FunctionDeclarationNode& candidate =
-										member_func.function_decl.as<FunctionDeclarationNode>();
-									if (!candidate.is_static()) {
-										continue;
-									}
-									if (first_candidate == nullptr) {
-										first_candidate = &candidate;
-									}
-									const bool already_added =
-										std::any_of(
-											candidates.begin(),
-											candidates.end(),
-											[&](const ASTNode& existing_overload) {
-												const FunctionDeclarationNode* existing_function =
-													get_function_decl_node(existing_overload);
-												return existing_function == &candidate;
-											});
-									if (!already_added) {
-										candidates.push_back(member_func.function_decl);
-									}
-									if (candidate.get_definition().has_value()) {
-										if (first_definition_candidate == nullptr) {
-											first_definition_candidate = &candidate;
-										}
-										definition_candidates.push_back(
-											member_func.function_decl);
-									}
-								}
-								for (const auto& base_spec : current_struct->base_classes) {
-									if (const StructTypeInfo* base_struct =
-											tryGetStructTypeInfo(base_spec.type_index);
-										base_struct != nullptr) {
-										self(base_struct, self);
-									}
-								}
-							};
-						collect_candidates(struct_info, collect_candidates);
+						DefinitionPreferredMemberOverloadSet candidate_set =
+							collectVisibleMemberFunctionOverloadNodes(
+								struct_info,
+								final_identifier.handle(),
+								true,
+								[](const StructMemberFunction& member_func,
+								   const FunctionDeclarationNode& candidate) {
+									return !member_func.is_constructor &&
+										!member_func.is_destructor &&
+										candidate.is_static();
+								});
 						auto resolve_from_candidates =
-							[&](const std::vector<ASTNode>& overloads)
+							[&](std::span<const ASTNode> overloads)
 								-> const FunctionDeclarationNode* {
 								if (overloads.empty()) {
 									return nullptr;
@@ -2159,19 +2119,25 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								return nullptr;
 							};
 						if (const FunctionDeclarationNode* definition_match =
-								resolve_from_candidates(definition_candidates);
+								resolve_from_candidates(
+									std::span<const ASTNode>(
+										candidate_set.definition_preferred.data(),
+										candidate_set.definition_preferred.size()));
 							definition_match != nullptr) {
 							return definition_match;
 						}
 						if (const FunctionDeclarationNode* resolved_match =
-								resolve_from_candidates(candidates);
+								resolve_from_candidates(
+									std::span<const ASTNode>(
+										candidate_set.all.data(),
+										candidate_set.all.size()));
 							resolved_match != nullptr) {
 							return resolved_match;
 						}
-						if (first_definition_candidate != nullptr) {
-							return first_definition_candidate;
+						if (candidate_set.first_definition != nullptr) {
+							return candidate_set.first_definition;
 						}
-						return first_candidate;
+						return candidate_set.first;
 					};
 
 				const DeclarationNode* decl_ptr = qualified_symbol.has_value() ? getDeclarationNode(*qualified_symbol) : nullptr;

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1759,6 +1759,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							template_inst = try_instantiate_template_explicit(final_identifier.value(), *template_args, arg_types);
 						}
 						if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
+							qualified_symbol = *template_inst;
 							decl_ptr = &template_inst->as<FunctionDeclarationNode>().decl_node();
 							FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template with explicit args: ", qualified_name);
 						}
@@ -1770,6 +1771,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
 							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
+								qualified_symbol = *template_inst;
 								decl_ptr = &template_inst->as<FunctionDeclarationNode>().decl_node();
 								FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template: ", qualified_name);
 							}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -2072,8 +2072,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				std::string_view class_scope = class_scope_builder.commit();
 				StringHandle class_name_handle =
 					StringTable::getOrInternStringHandle(class_scope);
+				const FunctionDeclarationNode* class_owner_return_hint = nullptr;
+				bool recognized_class_owner_qualification = false;
 				auto resolveQualifiedStaticMemberFromOwner =
 					[&]() -> const FunctionDeclarationNode* {
+						class_owner_return_hint = nullptr;
 						instantiateLazyClassToPhase(
 							class_name_handle,
 							ClassInstantiationPhase::Full);
@@ -2091,6 +2094,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						if (struct_info == nullptr) {
 							return nullptr;
 						}
+						recognized_class_owner_qualification = true;
 						DefinitionPreferredMemberOverloadSet candidate_set =
 							collectVisibleMemberFunctionOverloadNodes(
 								struct_info,
@@ -2134,10 +2138,19 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							resolved_match != nullptr) {
 							return resolved_match;
 						}
-						if (candidate_set.first_definition != nullptr) {
-							return candidate_set.first_definition;
+						class_owner_return_hint =
+							this->trySelectUnambiguousParserReturnTypeHint(
+								std::span<const ASTNode>(
+									candidate_set.definition_preferred.data(),
+									candidate_set.definition_preferred.size()));
+						if (class_owner_return_hint == nullptr) {
+							class_owner_return_hint =
+								this->trySelectUnambiguousParserReturnTypeHint(
+									std::span<const ASTNode>(
+										candidate_set.all.data(),
+										candidate_set.all.size()));
 						}
-						return candidate_set.first;
+						return nullptr;
 					};
 
 				const DeclarationNode* decl_ptr = qualified_symbol.has_value() ? getDeclarationNode(*qualified_symbol) : nullptr;
@@ -2239,6 +2252,41 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							}
 						}
 					}
+				}
+
+				if (!decl_ptr && recognized_class_owner_qualification) {
+					auto placeholder_type = emplace_node<TypeSpecifierNode>(
+						TypeCategory::Int,
+						TypeQualifier::None,
+						32,
+						final_identifier,
+						CVQualifier::None);
+					ASTNode placeholder_decl =
+						emplace_node<DeclarationNode>(placeholder_type, final_identifier);
+					ASTNode function_call_node = emplace_node<ExpressionNode>(
+						makeDeferredOrdinaryDirectCallExpr(
+							placeholder_decl,
+							std::move(args),
+							final_identifier));
+					setCallQualifiedName(
+						function_call_node.as<ExpressionNode>(),
+						buildQualifiedNameFromStrings(
+							namespaces,
+							final_identifier.value()));
+					if (class_owner_return_hint != nullptr) {
+						setCallParserReturnTypeHint(
+							function_call_node.as<ExpressionNode>(),
+							class_owner_return_hint->decl_node().type_specifier_node());
+					}
+					if (template_args.has_value()) {
+						setCallTemplateArguments(
+							function_call_node.as<ExpressionNode>(),
+							materializeTemplateArgumentNodes(
+								*template_args,
+								final_identifier));
+					}
+					result = function_call_node;
+					continue;
 				}
 
 				if (!decl_ptr) {

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -8,6 +8,150 @@
 #include <limits>
 
 namespace {
+std::string_view getPostfixTemplateArgTokenText(const TemplateTypeArg& arg) {
+	switch (arg.typeEnum()) {
+	case TypeCategory::Void: return "void";
+	case TypeCategory::Bool: return "bool";
+	case TypeCategory::Char: return "char";
+	case TypeCategory::UnsignedChar: return "unsigned char";
+	case TypeCategory::Short: return "short";
+	case TypeCategory::UnsignedShort: return "unsigned short";
+	case TypeCategory::Int: return "int";
+	case TypeCategory::UnsignedInt: return "unsigned int";
+	case TypeCategory::Long: return "long";
+	case TypeCategory::UnsignedLong: return "unsigned long";
+	case TypeCategory::LongLong: return "long long";
+	case TypeCategory::UnsignedLongLong: return "unsigned long long";
+	case TypeCategory::Float: return "float";
+	case TypeCategory::Double: return "double";
+	case TypeCategory::LongDouble: return "long double";
+	default: return {};
+	}
+}
+
+std::vector<ASTNode> materializePostfixTemplateArgumentNodes(
+	std::span<const TemplateTypeArg> template_args,
+	const Token& source_token) {
+	std::vector<ASTNode> result;
+	result.reserve(template_args.size());
+
+	for (const auto& arg : template_args) {
+		if (arg.is_dependent && arg.dependent_name.isValid()) {
+			Token dep_token(
+				Token::Type::Identifier,
+				arg.dependent_name.view(),
+				source_token.line(),
+				source_token.column(),
+				source_token.file_index());
+			ExpressionNode& dep_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+				TemplateParameterReferenceNode(arg.dependent_name, dep_token));
+			result.push_back(ASTNode(&dep_expr));
+			continue;
+		}
+
+		if (arg.is_value) {
+			if (arg.typeEnum() == TypeCategory::Bool) {
+				Token bool_token(
+					Token::Type::Keyword,
+					arg.value != 0 ? "true"sv : "false"sv,
+					source_token.line(),
+					source_token.column(),
+					source_token.file_index());
+				ExpressionNode& bool_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+					BoolLiteralNode(bool_token, arg.value != 0));
+				result.push_back(ASTNode(&bool_expr));
+			} else {
+				StringBuilder text_builder;
+				std::string_view literal_text = text_builder.append(arg.value).commit();
+				TypeCategory literal_type = arg.typeEnum() == TypeCategory::Invalid
+					? TypeCategory::Int
+					: arg.typeEnum();
+				Token literal_token(
+					Token::Type::Literal,
+					literal_text,
+					source_token.line(),
+					source_token.column(),
+					source_token.file_index());
+				ExpressionNode& literal_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+					NumericLiteralNode(
+						literal_token,
+						static_cast<unsigned long long>(arg.value),
+						literal_type,
+						TypeQualifier::None,
+						get_type_size_bits(literal_type)));
+				result.push_back(ASTNode(&literal_expr));
+			}
+			continue;
+		}
+
+		Token type_token = source_token;
+		TypeCategory type_category = arg.typeEnum();
+		if (const TypeInfo* type_info = tryGetTypeInfo(arg.type_index)) {
+			std::string_view type_name = StringTable::getStringView(type_info->name());
+			if (!type_name.empty()) {
+				type_token = Token(
+					Token::Type::Identifier,
+					type_name,
+					source_token.line(),
+					source_token.column(),
+					source_token.file_index());
+			}
+		} else if (std::string_view builtin_name = getPostfixTemplateArgTokenText(arg);
+				   !builtin_name.empty()) {
+			type_token = Token(
+				Token::Type::Keyword,
+				builtin_name,
+				source_token.line(),
+				source_token.column(),
+				source_token.file_index());
+		}
+
+		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
+			arg.type_index.withCategory(type_category),
+			get_type_size_bits(type_category),
+			type_token,
+			arg.cv_qualifier,
+			arg.ref_qualifier);
+		type_node.set_pack_expansion(arg.is_pack);
+		for (size_t pointer_index = 0; pointer_index < arg.pointer_depth; ++pointer_index) {
+			CVQualifier pointer_cv = pointer_index < arg.pointer_cv_qualifiers.size()
+				? arg.pointer_cv_qualifiers[pointer_index]
+				: CVQualifier::None;
+			type_node.add_pointer_level(pointer_cv);
+		}
+		result.push_back(ASTNode(&type_node));
+	}
+
+	return result;
+}
+
+std::string_view buildQualifiedMemberCallName(
+	std::span<const StringHandle> owner_segments,
+	std::string_view member_name) {
+	StringBuilder builder;
+	for (size_t i = 0; i < owner_segments.size(); ++i) {
+		if (i != 0) {
+			builder.append("::");
+		}
+		builder.append(StringTable::getStringView(owner_segments[i]));
+	}
+	if (!member_name.empty()) {
+		if (!owner_segments.empty()) {
+			builder.append("::");
+		}
+		builder.append(member_name);
+	}
+	return builder.commit();
+}
+
+std::string_view buildQualifiedMemberCallName(
+	const StructTypeInfo& owner_struct,
+	std::string_view member_name) {
+	return buildQualifiedMemberCallName(
+		std::span<const StringHandle>(&owner_struct.name, 1),
+		member_name);
+}
+
 void attachResolvedPostfixDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,
@@ -1302,6 +1446,27 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 
 		return matched_candidate;
 	};
+	auto tryInstantiateQualifiedMemberTemplateCall =
+		[&](const ASTNode& object_expr,
+			std::span<const StringHandle> owner_segments,
+			std::string_view member_name,
+			const std::optional<InlineVector<TemplateTypeArg, 4>>& explicit_template_args,
+			std::span<const TypeSpecifierNode> arg_types,
+			bool has_call_args,
+			bool has_dependent_call_args) -> std::optional<ASTNode> {
+			const StructTypeInfo* owner_struct =
+				tryResolveQualifiedOwnerStruct(object_expr, owner_segments);
+			if (!owner_struct) {
+				return std::nullopt;
+			}
+			return tryInstantiateMemberFunctionTemplateCall(
+				StringTable::getStringView(owner_struct->name),
+				member_name,
+				explicit_template_args,
+				arg_types,
+				has_call_args,
+				has_dependent_call_args);
+		};
 
 	// Handle postfix operators in a loop
 	constexpr int MAX_POSTFIX_ITERATIONS = 100;	// Safety limit to prevent infinite loops
@@ -1424,8 +1589,13 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						}
 
 						// This is the final member name
+						TemplateTypeArgParsingResult explicit_template_args =
+							parse_explicit_template_arguments_as_result(
+								TokenDestroyPattern::Restore);
 						// Check if it's a member function call
 						if (peek() == "("_tok) {
+							explicit_template_args.destroy_pattern_ =
+								TokenDestroyPattern::Discard;
 							advance(); // consume '('
 							auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
 								.handle_pack_expansion = true,
@@ -1438,16 +1608,43 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							if (!consume(")"_tok)) {
 								return ParseResult::error("Expected ')' after qualified member function call", current_token_);
 							}
-							const FunctionDeclarationNode* resolved_func =
-								tryResolveQualifiedMemberFunctionCall(
+							std::optional<InlineVector<TemplateTypeArg, 4>>
+								member_template_args;
+							std::vector<ASTNode> member_template_arg_nodes;
+							if (explicit_template_args) {
+								member_template_args =
+									explicit_template_args.read_template_type_args();
+								member_template_arg_nodes =
+									materializePostfixTemplateArgumentNodes(
+										*member_template_args,
+										qualified_member_token);
+							}
+							std::optional<ASTNode> instantiated_func =
+								tryInstantiateQualifiedMemberTemplateCall(
 									object,
 									qualified_owner_segments,
-									qualified_member_token.handle().isValid()
-										? qualified_member_token.handle()
-										: StringTable::getOrInternStringHandle(qualified_member_token.value()),
+									qualified_member_token.value(),
+									member_template_args,
 									args_result.arg_types,
-									args.size());
-							if (resolved_func) {
+									!args.empty(),
+									false);
+							const FunctionDeclarationNode* resolved_func = nullptr;
+							if (instantiated_func.has_value() &&
+								instantiated_func->is<FunctionDeclarationNode>()) {
+								resolved_func =
+									&instantiated_func->as<FunctionDeclarationNode>();
+							} else if (!member_template_args.has_value()) {
+								resolved_func =
+									tryResolveQualifiedMemberFunctionCall(
+										object,
+										qualified_owner_segments,
+										qualified_member_token.handle().isValid()
+											? qualified_member_token.handle()
+											: StringTable::getOrInternStringHandle(qualified_member_token.value()),
+										args_result.arg_types,
+										args.size());
+							}
+							if (resolved_func != nullptr) {
 								result = emplace_node<ExpressionNode>(
 									makeResolvedMemberCallExpr(object, *resolved_func, std::move(args), qualified_member_token));
 								attachResolvedMemberCallMetadata(
@@ -1463,6 +1660,18 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								auto& func_decl_node = emplace_node<FunctionDeclarationNode>(member_decl).as<FunctionDeclarationNode>();
 								result = emplace_node<ExpressionNode>(
 									makeResolvedMemberCallExpr(object, func_decl_node, std::move(args), qualified_member_token));
+								if (member_template_args.has_value()) {
+									if (!member_template_arg_nodes.empty()) {
+										setCallTemplateArguments(
+											result->as<ExpressionNode>(),
+											std::move(member_template_arg_nodes));
+									}
+									setCallQualifiedName(
+										result->as<ExpressionNode>(),
+										buildQualifiedMemberCallName(
+											qualified_owner_segments,
+											qualified_member_token.value()));
+								}
 							}
 						} else {
 							// Simple qualified member access
@@ -1484,7 +1693,12 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						}
 						Token op_token(Token::Type::Identifier, op_name,
 									   operator_keyword_token.line(), operator_keyword_token.column(), operator_keyword_token.file_index());
+						TemplateTypeArgParsingResult explicit_template_args =
+							parse_explicit_template_arguments_as_result(
+								TokenDestroyPattern::Restore);
 						if (peek() == "("_tok) {
+							explicit_template_args.destroy_pattern_ =
+								TokenDestroyPattern::Discard;
 							advance(); // consume '('
 							auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
 								.handle_pack_expansion = true,
@@ -1498,16 +1712,43 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								discard_saved_token(saved_pos);
 								return ParseResult::error("Expected ')' after qualified operator member call", current_token_);
 							}
-							const FunctionDeclarationNode* resolved_func =
-								tryResolveQualifiedMemberFunctionCall(
+							std::optional<InlineVector<TemplateTypeArg, 4>>
+								member_template_args;
+							std::vector<ASTNode> member_template_arg_nodes;
+							if (explicit_template_args) {
+								member_template_args =
+									explicit_template_args.read_template_type_args();
+								member_template_arg_nodes =
+									materializePostfixTemplateArgumentNodes(
+										*member_template_args,
+										op_token);
+							}
+							std::optional<ASTNode> instantiated_func =
+								tryInstantiateQualifiedMemberTemplateCall(
 									object,
 									qualified_owner_segments,
-									op_token.handle().isValid()
-										? op_token.handle()
-										: StringTable::getOrInternStringHandle(op_token.value()),
+									op_token.value(),
+									member_template_args,
 									args_result.arg_types,
-									args_result.args.size());
-							if (resolved_func) {
+									!args_result.args.empty(),
+									false);
+							const FunctionDeclarationNode* resolved_func = nullptr;
+							if (instantiated_func.has_value() &&
+								instantiated_func->is<FunctionDeclarationNode>()) {
+								resolved_func =
+									&instantiated_func->as<FunctionDeclarationNode>();
+							} else if (!member_template_args.has_value()) {
+								resolved_func =
+									tryResolveQualifiedMemberFunctionCall(
+										object,
+										qualified_owner_segments,
+										op_token.handle().isValid()
+											? op_token.handle()
+											: StringTable::getOrInternStringHandle(op_token.value()),
+										args_result.arg_types,
+										args_result.args.size());
+							}
+							if (resolved_func != nullptr) {
 								result = emplace_node<ExpressionNode>(
 									makeResolvedMemberCallExpr(object, *resolved_func, std::move(args_result.args), op_token));
 								attachResolvedMemberCallMetadata(
@@ -1523,6 +1764,18 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 								auto& func_decl_node = emplace_node<FunctionDeclarationNode>(member_decl).as<FunctionDeclarationNode>();
 								result = emplace_node<ExpressionNode>(
 									makeResolvedMemberCallExpr(object, func_decl_node, std::move(args_result.args), op_token));
+								if (member_template_args.has_value()) {
+									if (!member_template_arg_nodes.empty()) {
+										setCallTemplateArguments(
+											result->as<ExpressionNode>(),
+											std::move(member_template_arg_nodes));
+									}
+									setCallQualifiedName(
+										result->as<ExpressionNode>(),
+										buildQualifiedMemberCallName(
+											qualified_owner_segments,
+											op_token.value()));
+								}
 							}
 							handled = true;
 						}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -9414,50 +9414,141 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										}
 									}
 
+									struct CurrentStructMemberTemplateContext {
+										std::string_view struct_name;
+										TypeIndex struct_type_index;
+										const FunctionDeclarationNode* member_template_decl;
+									};
+
+									auto findMatchingMemberTemplateDecl =
+										[&](const StructDeclarationNode* struct_node,
+											const StructTypeInfo* local_struct_info,
+											StringHandle member_name) -> const FunctionDeclarationNode* {
+											auto matches_template_member = [&](const ASTNode& member_func_node) -> const FunctionDeclarationNode* {
+												if (!member_func_node.is<TemplateFunctionDeclarationNode>()) {
+													return nullptr;
+												}
+												const FunctionDeclarationNode& member_func_decl =
+													member_func_node
+														.as<TemplateFunctionDeclarationNode>()
+														.function_declaration()
+														.as<FunctionDeclarationNode>();
+												return member_func_decl.decl_node()
+															   .identifier_token()
+															   .handle() == member_name
+													? &member_func_decl
+													: nullptr;
+											};
+
+											if (struct_node != nullptr) {
+												for (const auto& member_func_decl :
+													 struct_node->member_functions()) {
+													if (const FunctionDeclarationNode* matching_decl =
+															matches_template_member(
+																member_func_decl.function_declaration);
+														matching_decl != nullptr) {
+														return matching_decl;
+													}
+												}
+											}
+											if (local_struct_info != nullptr) {
+												for (const auto& member_func :
+													 local_struct_info->member_functions) {
+													if (const FunctionDeclarationNode* matching_decl =
+															matches_template_member(
+																member_func.function_decl);
+														matching_decl != nullptr) {
+														return matching_decl;
+													}
+												}
+											}
+											return nullptr;
+										};
+
+									auto findCurrentStructMemberTemplateContext =
+										[&]() -> std::optional<CurrentStructMemberTemplateContext> {
+											if (!member_function_context_stack_.empty()) {
+												const auto& member_ctx = member_function_context_stack_.back();
+												const FunctionDeclarationNode* matching_decl =
+													findMatchingMemberTemplateDecl(
+														member_ctx.struct_node,
+														member_ctx.local_struct_info,
+														identifier_token.handle());
+												if (matching_decl != nullptr &&
+													!StringTable::getStringView(member_ctx.struct_name).empty()) {
+													return CurrentStructMemberTemplateContext{
+														StringTable::getStringView(member_ctx.struct_name),
+														member_ctx.struct_type_index,
+														matching_decl};
+												}
+											}
+
+											if (!struct_parsing_context_stack_.empty()) {
+												const auto& struct_ctx = struct_parsing_context_stack_.back();
+												const FunctionDeclarationNode* matching_decl =
+													findMatchingMemberTemplateDecl(
+														struct_ctx.struct_node,
+														struct_ctx.local_struct_info,
+														identifier_token.handle());
+												if (matching_decl != nullptr &&
+													!struct_ctx.struct_name.empty()) {
+													TypeIndex struct_type_index{};
+													if (auto scope_type_it = getTypesByNameMap().find(
+															StringTable::getOrInternStringHandle(struct_ctx.struct_name));
+														scope_type_it != getTypesByNameMap().end()) {
+														struct_type_index = scope_type_it->second->type_index_;
+													}
+													return CurrentStructMemberTemplateContext{
+														struct_ctx.struct_name,
+														struct_type_index,
+														matching_decl};
+												}
+											}
+
+											return std::nullopt;
+										};
+
+									const std::optional<CurrentStructMemberTemplateContext>
+										current_struct_member_template_context =
+											findCurrentStructMemberTemplateContext();
+									auto buildCurrentStructMemberTemplateDeferredRecord =
+										[&]() -> std::optional<
+											TypeInfo::DependentQualifiedNameRecord> {
+											if (!current_struct_member_template_context.has_value()) {
+												return std::nullopt;
+											}
+											ExpressionDependentMemberSegmentInfo member_segment;
+											member_segment.name = identifier_token.handle();
+											member_segment.template_args =
+												toTemplateArgInfoList(
+													*effective_template_args);
+											const std::array<
+												ExpressionDependentMemberSegmentInfo,
+												1> member_segments{
+												member_segment};
+											return makeExpressionDependentQualifiedNameRecord(
+												StringTable::getOrInternStringHandle(
+													current_struct_member_template_context
+														->struct_name),
+												current_struct_member_template_context
+													->struct_type_index,
+												TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation,
+												{},
+												std::span<
+													const ExpressionDependentMemberSegmentInfo>(
+													member_segments.data(),
+													member_segments.size()));
+										};
+									const std::optional<
+										TypeInfo::DependentQualifiedNameRecord>
+										current_struct_member_template_deferred_record =
+											buildCurrentStructMemberTemplateDeferredRecord();
+
 									// Skip template instantiation in extern "C" contexts - C has no templates
 									std::optional<ASTNode> instantiated_func;
 									bool resolved_as_struct_member = false;
 									bool defer_struct_member_template_instantiation = false;
 									if (current_linkage_ != Linkage::C && !has_dependent_template_args) {
-										auto structHasMatchingMemberTemplate =
-											[&](const StructDeclarationNode* struct_node,
-												const StructTypeInfo* local_struct_info,
-												StringHandle member_name) {
-												auto matches_template_member = [&](const ASTNode& member_func_node) {
-													if (!member_func_node.is<TemplateFunctionDeclarationNode>()) {
-														return false;
-													}
-													const FunctionDeclarationNode& member_func_decl =
-														member_func_node
-															.as<TemplateFunctionDeclarationNode>()
-															.function_declaration()
-															.as<FunctionDeclarationNode>();
-													return member_func_decl.decl_node()
-															   .identifier_token()
-															   .handle() == member_name;
-												};
-
-												if (struct_node != nullptr) {
-													for (const auto& member_func_decl :
-														 struct_node->member_functions()) {
-														if (matches_template_member(
-																member_func_decl.function_declaration)) {
-															return true;
-														}
-													}
-												}
-												if (local_struct_info != nullptr) {
-													for (const auto& member_func :
-														 local_struct_info->member_functions) {
-														if (matches_template_member(
-																member_func.function_decl)) {
-															return true;
-														}
-													}
-												}
-												return false;
-											};
-
 										auto should_defer_current_struct_member_template_instantiation =
 											[&](std::string_view struct_name, TypeIndex struct_type_index) -> bool {
 											if (struct_name.empty()) {
@@ -9473,66 +9564,23 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											return isTemplateBodyWithActiveParameters();
 										};
 
-										auto try_instantiate_current_struct_member_template = [&]() -> std::optional<ASTNode> {
-											if (!member_function_context_stack_.empty()) {
-												const auto& member_ctx = member_function_context_stack_.back();
-												std::string_view struct_name =
-													StringTable::getStringView(member_ctx.struct_name);
-												if (!struct_name.empty()) {
-													if (!structHasMatchingMemberTemplate(
-															member_ctx.struct_node,
-															member_ctx.local_struct_info,
-															identifier_token.handle())) {
-														return std::nullopt;
-													}
-													if (should_defer_current_struct_member_template_instantiation(
-															struct_name,
-															member_ctx.struct_type_index)) {
-														defer_struct_member_template_instantiation = true;
-														return std::nullopt;
-													}
-													if (auto member_inst = try_instantiate_member_function_template_explicit(
-															struct_name,
-															identifier_token.value(),
-															*effective_template_args)) {
-														return member_inst;
-													}
-												}
-											}
-
-											if (!struct_parsing_context_stack_.empty()) {
-												const auto& struct_ctx = struct_parsing_context_stack_.back();
-												if (!struct_ctx.struct_name.empty()) {
-													if (!structHasMatchingMemberTemplate(
-															struct_ctx.struct_node,
-															struct_ctx.local_struct_info,
-															identifier_token.handle())) {
-														return std::nullopt;
-													}
-													TypeIndex struct_type_index{};
-													if (auto scope_type_it = getTypesByNameMap().find(
-															StringTable::getOrInternStringHandle(struct_ctx.struct_name));
-														scope_type_it != getTypesByNameMap().end()) {
-														struct_type_index = scope_type_it->second->type_index_;
-													}
-													if (should_defer_current_struct_member_template_instantiation(
-															struct_ctx.struct_name,
-															struct_type_index)) {
-														defer_struct_member_template_instantiation = true;
-														return std::nullopt;
-													}
-													return try_instantiate_member_function_template_explicit(
-														struct_ctx.struct_name,
+										if (current_struct_member_template_context.has_value()) {
+											const CurrentStructMemberTemplateContext& member_template_context =
+												*current_struct_member_template_context;
+											if (should_defer_current_struct_member_template_instantiation(
+													member_template_context.struct_name,
+													member_template_context.struct_type_index)) {
+												defer_struct_member_template_instantiation = true;
+											} else {
+												instantiated_func =
+													try_instantiate_member_function_template_explicit(
+														member_template_context.struct_name,
 														identifier_token.value(),
 														*effective_template_args);
-												}
 											}
-
-											return std::nullopt;
-										};
-
-										instantiated_func = try_instantiate_current_struct_member_template();
-										resolved_as_struct_member = instantiated_func.has_value();
+										}
+										resolved_as_struct_member =
+											instantiated_func.has_value();
 										if (!resolved_as_struct_member && !defer_struct_member_template_instantiation) {
 											instantiated_func = try_instantiate_template_explicit(identifier_token.value(), *effective_template_args, arg_types);
 										}
@@ -9611,7 +9659,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 										// Create a placeholder declaration for the dependent function call
 										TypeSpecifierNode placeholder_type(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);
-										if (const std::vector<ASTNode>* template_overloads = gTemplateRegistry.lookupAllTemplates(identifier_token.value())) {
+										if (current_struct_member_template_context.has_value()) {
+											placeholder_type =
+												current_struct_member_template_context
+													->member_template_decl
+													->decl_node()
+													.type_specifier_node();
+										} else if (const std::vector<ASTNode>* template_overloads = gTemplateRegistry.lookupAllTemplates(identifier_token.value())) {
 											for (const ASTNode& template_overload : *template_overloads) {
 												const FunctionDeclarationNode* function_decl = get_function_decl_node(template_overload);
 												if (!function_decl) {
@@ -9640,24 +9694,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										if (!explicit_template_arg_nodes.empty()) {
 											setCallTemplateArguments(result->as<ExpressionNode>(), std::move(explicit_template_arg_nodes));
 										}
-										if (defer_struct_member_template_instantiation) {
-											std::string_view struct_name_for_qual;
-											if (!member_function_context_stack_.empty()) {
-												struct_name_for_qual =
-													StringTable::getStringView(member_function_context_stack_.back().struct_name);
-											} else if (!struct_parsing_context_stack_.empty()) {
-												struct_name_for_qual =
-													struct_parsing_context_stack_.back().struct_name;
-											}
-											if (!struct_name_for_qual.empty()) {
-												setCallQualifiedName(
-													result->as<ExpressionNode>(),
-													StringBuilder()
-														.append(struct_name_for_qual)
-														.append("::")
-														.append(identifier_token.value())
-														.commit());
-											}
+										if (current_struct_member_template_context.has_value()) {
+											setCallQualifiedName(
+												result->as<ExpressionNode>(),
+												StringBuilder()
+													.append(
+														current_struct_member_template_context
+															->struct_name)
+													.append("::")
+													.append(identifier_token.value())
+													.commit());
+										}
+										if (current_struct_member_template_deferred_record
+												.has_value()) {
+											setCallDependentQualifiedLookupRecord(
+												result->as<ExpressionNode>(),
+												*current_struct_member_template_deferred_record);
 										}
 									} else {
 										return ParseResult::error("No matching template for call to '" + std::string(identifier_token.value()) + "'", identifier_token);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -701,6 +701,26 @@ std::optional<ASTNode> Parser::resolveDefinitionBoundOrdinaryCall(
 	return *resolution.selected_overload;
 }
 
+std::optional<ASTNode> Parser::resolveDefinitionBoundQualifiedTemplateCall(
+	const FunctionCallDefinitionLookupRecord& record,
+	std::string_view qualified_name,
+	std::span<const ASTNode> template_argument_nodes,
+	const ChunkedVector<ASTNode>& arguments,
+	std::span<const TypeSpecifierNode> arg_types) {
+	ScopedDefinitionLookupContext ctx_scope(
+		current_template_definition_lookup_context_,
+		record.definition_context.is_valid() ? &record.definition_context : nullptr);
+	FlashCpp::ScopedState guard_preferred_definition_bound_template(
+		preferred_definition_bound_template_declaration_);
+	preferred_definition_bound_template_declaration_ =
+		record.definition_bound_template_declaration;
+	return resolveDeferredQualifiedTemplateCall(
+		qualified_name,
+		template_argument_nodes,
+		arguments,
+		arg_types);
+}
+
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::materializeConcreteCallTemplateArguments(
 	std::span<const ASTNode> template_argument_nodes) {
 	InlineVector<TemplateTypeArg, 4> concrete_args;
@@ -3698,13 +3718,21 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				return *err;
 			}
 
+			const bool has_explicit_template_args =
+				template_args.has_value() && !template_args->empty();
+			const bool has_dependent_explicit_template_args =
+				has_explicit_template_args &&
+				explicitTemplateArgsRequireDeferredInstantiation(*template_args);
+
 			// If not found (or explicit template arguments were provided) and we're not in extern "C",
 			// try template instantiation. The global-scope `::ns::func<T>(...)` path must support the
 			// same explicit-template parsing as the regular qualified-identifier path.
-			if (current_linkage_ != Linkage::C && !has_deferred_qualified_call_args) {
+			if (current_linkage_ != Linkage::C &&
+				!has_deferred_qualified_call_args &&
+				!has_dependent_explicit_template_args) {
 				std::string_view qualified_name = buildQualifiedNameFromStrings(namespaces, qual_id.name());
 
-				if (template_args.has_value() && !template_args->empty()) {
+				if (has_explicit_template_args) {
 					auto template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
 					if (!template_inst.has_value()) {
 						template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
@@ -3726,6 +3754,40 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 					}
 				}
+			}
+
+			bool keep_single_template_decl_for_dependent_call = false;
+			const void* definition_bound_template_declaration = nullptr;
+			if (has_dependent_explicit_template_args &&
+				identifierType.has_value() &&
+				identifierType->is<TemplateFunctionDeclarationNode>()) {
+				const std::vector<TemplateNameLookupCandidate> template_candidates =
+					lookupFunctionTemplateCandidatesForInstantiation(
+						buildQualifiedNameFromStrings(namespaces, qual_id.name()),
+						0);
+				keep_single_template_decl_for_dependent_call =
+					template_candidates.size() == 1 &&
+					!gTemplateRegistry.hasExactSpecializationsForName(
+						buildQualifiedNameFromStrings(namespaces, qual_id.name()));
+				if (keep_single_template_decl_for_dependent_call) {
+					definition_bound_template_declaration =
+						identifierType->raw_pointer();
+				}
+			}
+			if (has_dependent_explicit_template_args &&
+				(!identifierType.has_value() ||
+				 (identifierType->is<TemplateFunctionDeclarationNode>() &&
+				  !keep_single_template_decl_for_dependent_call))) {
+				auto placeholder_type = emplace_node<TypeSpecifierNode>(
+					TypeCategory::Auto,
+					TypeQualifier::None,
+					get_type_size_bits(TypeCategory::Auto),
+					qual_id.identifier_token(),
+					CVQualifier::None);
+				auto placeholder_decl = emplace_node<DeclarationNode>(
+					placeholder_type,
+					qual_id.identifier_token());
+				identifierType = placeholder_decl;
 			}
 
 			// If still not found, create a forward declaration
@@ -3750,7 +3812,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			// Create function call node with the qualified identifier
 			auto function_call_node = emplace_node<ExpressionNode>(
 				makeCallExprFromNode(*identifierType, std::move(args), qual_id.identifier_token()));
-			if (template_args.has_value() && !template_args->empty()) {
+			if (has_explicit_template_args) {
 				if (template_arg_nodes.empty()) {
 					template_arg_nodes = materializeTemplateArgumentNodes(*template_args, qual_id.identifier_token());
 				} else {
@@ -3780,6 +3842,45 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							false);
 					record.has_value()) {
 					setCallDefinitionLookupRecord(function_call_node.as<ExpressionNode>(), *record);
+				}
+			} else if (has_explicit_template_args) {
+				std::optional<TemplateDefinitionLookupContext>
+					deferred_definition_lookup_context;
+				if ((current_template_definition_lookup_context_ != nullptr &&
+					 current_template_definition_lookup_context_->is_valid()) ||
+					parsing_template_depth_ > 0 ||
+					hasActiveTemplateParameters()) {
+					StringHandle current_instantiation_name{};
+					if (!member_function_context_stack_.empty()) {
+						current_instantiation_name =
+							member_function_context_stack_.back().struct_name;
+					} else if (!struct_parsing_context_stack_.empty() &&
+							   !struct_parsing_context_stack_.back().struct_name.empty()) {
+						current_instantiation_name =
+							StringTable::getOrInternStringHandle(
+								struct_parsing_context_stack_.back().struct_name);
+					}
+					deferred_definition_lookup_context =
+						buildDefinitionLookupContextFromToken(
+							qual_id.identifier_token(),
+							current_instantiation_name);
+				}
+				const TemplateDefinitionLookupContext* definition_lookup_context =
+					deferred_definition_lookup_context.has_value()
+						? &*deferred_definition_lookup_context
+						: current_template_definition_lookup_context_;
+				if (std::optional<FunctionCallDefinitionLookupRecord> record =
+						makeDeferredFunctionCallDefinitionLookupRecord(
+							definition_lookup_context,
+							qual_id.identifier_token(),
+							true,
+							false);
+					record.has_value()) {
+					record->definition_bound_template_declaration =
+						definition_bound_template_declaration;
+					setCallDefinitionLookupRecord(
+						function_call_node.as<ExpressionNode>(),
+						*record);
 				}
 			}
 			result = function_call_node;
@@ -4699,16 +4800,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				// If not found OR if it's a template (not an instantiated function), try template instantiation
 				// Also try if explicit template arguments were provided (to handle overload resolution)
+				const bool has_any_explicit_template_args =
+					template_args.has_value() && !template_args->empty();
 				bool has_dependent_explicit_template_args = false;
 				if (((!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>()) ||
-					 (template_args.has_value() && !template_args->empty())) &&
+					 has_any_explicit_template_args) &&
 					current_linkage_ != Linkage::C &&
 					!has_deferred_qualified_call_args) {
 					// Build qualified template name
 					std::string_view qualified_name = resolved_qualified_name;
 
 					// Phase 1 C++20: If we have explicit template arguments, use them instead of deducing
-					if (template_args.has_value() && !template_args->empty()) {
+					if (has_any_explicit_template_args) {
 						FLASH_LOG_FORMAT(Parser, Debug, "Using explicit template arguments for function call to '{}'", qualified_name);
 
 						has_dependent_explicit_template_args =
@@ -4746,8 +4849,28 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// When explicit template arguments are dependent and instantiation failed,
 				// the call expression must use a dependent placeholder return type so that
 				// decltype(...) defers resolution to template instantiation time.
+				bool keep_single_template_decl_for_dependent_call = false;
+				const void* definition_bound_template_declaration = nullptr;
 				if (has_dependent_explicit_template_args &&
-					(!identifierType.has_value() || identifierType->is<TemplateFunctionDeclarationNode>())) {
+					identifierType.has_value() &&
+					identifierType->is<TemplateFunctionDeclarationNode>()) {
+					const std::vector<TemplateNameLookupCandidate> template_candidates =
+						lookupFunctionTemplateCandidatesForInstantiation(
+							resolved_qualified_name,
+							0);
+					keep_single_template_decl_for_dependent_call =
+						template_candidates.size() == 1 &&
+						!gTemplateRegistry.hasExactSpecializationsForName(
+							resolved_qualified_name);
+					if (keep_single_template_decl_for_dependent_call) {
+						definition_bound_template_declaration =
+							identifierType->raw_pointer();
+					}
+				}
+				if (has_dependent_explicit_template_args &&
+					(!identifierType.has_value() ||
+					 (identifierType->is<TemplateFunctionDeclarationNode>() &&
+					  !keep_single_template_decl_for_dependent_call))) {
 					// Use Auto category to signal that the return type is dependent
 					TypeSpecifierNode placeholder_type(TypeCategory::Auto, TypeQualifier::None,
 						get_type_size_bits(TypeCategory::Auto), final_identifier, CVQualifier::None);
@@ -4782,12 +4905,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				// If explicit template arguments were provided, store them in the call expression
 				// This is needed for deferred template-dependent expressions (e.g., decltype(base_trait<T>()))
-				if (template_args.has_value() && !template_args->empty() && template_arg_nodes.empty()) {
+				if (has_any_explicit_template_args && template_arg_nodes.empty()) {
 					template_arg_nodes = materializeTemplateArgumentNodes(*template_args, qual_id.identifier_token());
-				} else if (template_args.has_value() && !template_args->empty()) {
+				} else if (has_any_explicit_template_args) {
 					syncTemplateArgumentNodeMetadata(template_arg_nodes, *template_args);
 				}
-				bool has_explicit_template_args = template_args.has_value() && !template_args->empty() && !template_arg_nodes.empty();
+				bool has_explicit_template_args = has_any_explicit_template_args && !template_arg_nodes.empty();
 				if (has_explicit_template_args) {
 					setCallTemplateArguments(result->as<ExpressionNode>(), std::move(template_arg_nodes));
 					FLASH_LOG(Templates, Debug, "Stored ", template_arg_nodes.size(), " template argument nodes in call expression (path 1)");
@@ -4797,12 +4920,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				std::string_view qualified_name = resolved_qualified_name;
 				setCallQualifiedName(result->as<ExpressionNode>(), qualified_name);
 				FLASH_LOG(Parser, Debug, "Set qualified name on call expression: ", qualified_name);
-				if (has_dependent_explicit_template_args &&
-					!identifierType->is<FunctionDeclarationNode>()) {
-					setCallParserReturnTypeHint(
-						result->as<ExpressionNode>(),
-						decl_ptr->type_specifier_node());
-				}
 
 				// If the function has a pre-computed mangled name, set it on the call expression
 				if (identifierType->is<FunctionDeclarationNode>()) {
@@ -4821,6 +4938,45 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								false);
 						record.has_value()) {
 						setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
+				}
+			} else if (has_explicit_template_args) {
+					std::optional<TemplateDefinitionLookupContext>
+						deferred_definition_lookup_context;
+					if ((current_template_definition_lookup_context_ != nullptr &&
+						 current_template_definition_lookup_context_->is_valid()) ||
+						parsing_template_depth_ > 0 ||
+						hasActiveTemplateParameters()) {
+						StringHandle current_instantiation_name{};
+						if (!member_function_context_stack_.empty()) {
+							current_instantiation_name =
+								member_function_context_stack_.back().struct_name;
+						} else if (!struct_parsing_context_stack_.empty() &&
+								   !struct_parsing_context_stack_.back().struct_name.empty()) {
+							current_instantiation_name =
+								StringTable::getOrInternStringHandle(
+									struct_parsing_context_stack_.back().struct_name);
+						}
+						deferred_definition_lookup_context =
+							buildDefinitionLookupContextFromToken(
+								qual_id.identifier_token(),
+								current_instantiation_name);
+					}
+					const TemplateDefinitionLookupContext* definition_lookup_context =
+						deferred_definition_lookup_context.has_value()
+							? &*deferred_definition_lookup_context
+							: current_template_definition_lookup_context_;
+					if (std::optional<FunctionCallDefinitionLookupRecord> record =
+							makeDeferredFunctionCallDefinitionLookupRecord(
+								definition_lookup_context,
+								qual_id.identifier_token(),
+								true,
+								false);
+						record.has_value()) {
+						record->definition_bound_template_declaration =
+							definition_bound_template_declaration;
+						setCallDefinitionLookupRecord(
+							result->as<ExpressionNode>(),
+							*record);
 					}
 				}
 			} else {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1364,6 +1364,32 @@ void Parser::applyIdentifierArgumentArrayBounds(const ASTNode& arg_node, TypeSpe
 	}
 }
 
+const FunctionDeclarationNode* Parser::trySelectUnambiguousParserReturnTypeHint(
+	std::span<const ASTNode> overloads) const {
+	const FunctionDeclarationNode* hint_function = nullptr;
+	for (const ASTNode& overload : overloads) {
+		const FunctionDeclarationNode* candidate =
+			get_function_decl_node(overload);
+		if (candidate == nullptr) {
+			continue;
+		}
+		if (hint_function == nullptr) {
+			hint_function = candidate;
+			continue;
+		}
+		if (!types_equivalent(
+				hint_function->decl_node().type_specifier_node(),
+				candidate->decl_node().type_specifier_node())) {
+			return nullptr;
+		}
+		if (!hint_function->get_definition().has_value() &&
+			candidate->get_definition().has_value()) {
+			hint_function = candidate;
+		}
+	}
+	return hint_function;
+}
+
 bool Parser::tryCollectOrdinaryDirectCallArgTypes(
 	const ChunkedVector<ASTNode>& args,
 	std::vector<TypeSpecifierNode>* arg_types_out) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -3761,14 +3761,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			if (has_dependent_explicit_template_args &&
 				identifierType.has_value() &&
 				identifierType->is<TemplateFunctionDeclarationNode>()) {
+				const std::string_view lookup_name =
+					buildQualifiedNameFromStrings(namespaces, qual_id.name());
 				const std::vector<TemplateNameLookupCandidate> template_candidates =
 					lookupFunctionTemplateCandidatesForInstantiation(
-						buildQualifiedNameFromStrings(namespaces, qual_id.name()),
+						lookup_name,
 						0);
 				keep_single_template_decl_for_dependent_call =
 					template_candidates.size() == 1 &&
 					!gTemplateRegistry.hasExactSpecializationsForName(
-						buildQualifiedNameFromStrings(namespaces, qual_id.name()));
+						lookup_name);
 				if (keep_single_template_decl_for_dependent_call) {
 					definition_bound_template_declaration =
 						identifierType->raw_pointer();
@@ -4938,8 +4940,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								false);
 						record.has_value()) {
 						setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
+					}
 				}
-			} else if (has_explicit_template_args) {
+				if (!identifierType->is<FunctionDeclarationNode>() &&
+					has_explicit_template_args) {
 					std::optional<TemplateDefinitionLookupContext>
 						deferred_definition_lookup_context;
 					if ((current_template_definition_lookup_context_ != nullptr &&
@@ -9630,12 +9634,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 														member_ctx.struct_node,
 														member_ctx.local_struct_info,
 														identifier_token.handle());
-												if (matching_decl != nullptr &&
-													!StringTable::getStringView(member_ctx.struct_name).empty()) {
-													return CurrentStructMemberTemplateContext{
-														StringTable::getStringView(member_ctx.struct_name),
-														member_ctx.struct_type_index,
-														matching_decl};
+												if (matching_decl != nullptr) {
+													const std::string_view struct_name =
+														StringTable::getStringView(member_ctx.struct_name);
+													if (!struct_name.empty()) {
+														return CurrentStructMemberTemplateContext{
+															struct_name,
+															member_ctx.struct_type_index,
+															matching_decl};
+													}
 												}
 											}
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -7,6 +7,7 @@
 #include "Parser_FunctionTypeHelpers.h"
 #include "ParserTemplateClassShared.h"
 #include "StringLiteralTokenUtils.h"
+#include "TemplateArgumentMaterialization.h"
 #include "TypeTraitEvaluator.h"
 
 #include <algorithm>
@@ -1462,120 +1463,6 @@ ExpressionNode Parser::makeDeferredOrdinaryDirectCallExpr(
 }
 
 namespace {
-std::string_view getTemplateArgTokenText(const TemplateTypeArg& arg) {
-	switch (arg.typeEnum()) {
-	case TypeCategory::Void: return "void";
-	case TypeCategory::Bool: return "bool";
-	case TypeCategory::Char: return "char";
-	case TypeCategory::UnsignedChar: return "unsigned char";
-	case TypeCategory::Short: return "short";
-	case TypeCategory::UnsignedShort: return "unsigned short";
-	case TypeCategory::Int: return "int";
-	case TypeCategory::UnsignedInt: return "unsigned int";
-	case TypeCategory::Long: return "long";
-	case TypeCategory::UnsignedLong: return "unsigned long";
-	case TypeCategory::LongLong: return "long long";
-	case TypeCategory::UnsignedLongLong: return "unsigned long long";
-	case TypeCategory::Float: return "float";
-	case TypeCategory::Double: return "double";
-	case TypeCategory::LongDouble: return "long double";
-	default: return {};
-	}
-}
-
-std::vector<ASTNode> materializeTemplateArgumentNodes(
-	std::span<const TemplateTypeArg> template_args,
-	const Token& source_token) {
-	std::vector<ASTNode> result;
-	result.reserve(template_args.size());
-
-	for (const auto& arg : template_args) {
-		if (arg.is_dependent && arg.dependent_name.isValid()) {
-			Token dep_token(
-				Token::Type::Identifier,
-				arg.dependent_name.view(),
-				source_token.line(),
-				source_token.column(),
-				source_token.file_index());
-			ExpressionNode& dep_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-				TemplateParameterReferenceNode(arg.dependent_name, dep_token));
-			result.push_back(ASTNode(&dep_expr));
-			continue;
-		}
-
-		if (arg.is_value) {
-			if (arg.typeEnum() == TypeCategory::Bool) {
-				Token bool_token(
-					Token::Type::Keyword,
-					arg.value != 0 ? "true"sv : "false"sv,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& bool_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					BoolLiteralNode(bool_token, arg.value != 0));
-				result.push_back(ASTNode(&bool_expr));
-			} else {
-				StringBuilder text_builder;
-				std::string_view literal_text = text_builder.append(arg.value).commit();
-				TypeCategory literal_type = arg.typeEnum() == TypeCategory::Invalid ? TypeCategory::Int : arg.typeEnum();
-				Token literal_token(
-					Token::Type::Literal,
-					literal_text,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-				ExpressionNode& literal_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
-					NumericLiteralNode(
-						literal_token,
-						static_cast<unsigned long long>(arg.value),
-						literal_type,
-						TypeQualifier::None,
-						get_type_size_bits(literal_type)));
-				result.push_back(ASTNode(&literal_expr));
-			}
-			continue;
-		}
-
-		Token type_token = source_token;
-		TypeCategory type_category = arg.typeEnum();
-		if (const TypeInfo* type_info = tryGetTypeInfo(arg.type_index)) {
-			std::string_view type_name = StringTable::getStringView(type_info->name());
-			if (!type_name.empty()) {
-				type_token = Token(
-					Token::Type::Identifier,
-					type_name,
-					source_token.line(),
-					source_token.column(),
-					source_token.file_index());
-			}
-		} else if (std::string_view builtin_name = getTemplateArgTokenText(arg); !builtin_name.empty()) {
-			type_token = Token(
-				Token::Type::Keyword,
-				builtin_name,
-				source_token.line(),
-				source_token.column(),
-				source_token.file_index());
-		}
-
-		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
-			arg.type_index.withCategory(type_category),
-			get_type_size_bits(type_category),
-			type_token,
-			arg.cv_qualifier,
-			arg.ref_qualifier);
-		type_node.set_pack_expansion(arg.is_pack);
-		for (size_t pointer_index = 0; pointer_index < arg.pointer_depth; ++pointer_index) {
-			CVQualifier pointer_cv = pointer_index < arg.pointer_cv_qualifiers.size()
-				? arg.pointer_cv_qualifiers[pointer_index]
-				: CVQualifier::None;
-			type_node.add_pointer_level(pointer_cv);
-		}
-		result.push_back(ASTNode(&type_node));
-	}
-
-	return result;
-}
-
 bool astNodeHasDeferredTemplateDependency(
 	const ASTNode& node,
 	const InlineVector<StringHandle, 4>& current_template_param_names);

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -346,27 +346,78 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		parser_hint_function = resolved_function;
 	} else {
 		// For non-template member functions (e.g. Template<T>::allocate()),
-		// resolve directly from the instantiated class before creating a fallback decl.
+		// prefer real static-member overload selection on the instantiated owner.
 		auto type_it = getTypesByNameMap().find(owner_name_handle);
-		if (type_it != getTypesByNameMap().end() && type_it->second) {
+		const bool can_use_nontemplate_owner_lookup =
+			!parsed_member_template_args;
+		const bool have_complete_call_arg_types =
+			!has_dependent_call_arg &&
+			deduced_arg_types.size() == args.size();
+		if (can_use_nontemplate_owner_lookup &&
+			type_it != getTypesByNameMap().end() &&
+			type_it->second) {
 			const StructTypeInfo* struct_info = type_it->second->getStructInfo();
 			if (struct_info) {
-				const FunctionDeclarationNode* first_name_match = nullptr;
-				size_t call_arg_count = args.size();
-				for (const auto& member_func : struct_info->member_functions) {
-					if (member_func.getName() == member_name_handle && member_func.function_decl.is<FunctionDeclarationNode>()) {
-						const FunctionDeclarationNode& candidate = member_func.function_decl.as<FunctionDeclarationNode>();
-						if (!first_name_match) {
-							first_name_match = &candidate;
+				std::vector<ASTNode> static_member_overloads;
+				const FunctionDeclarationNode* first_static_name_match = nullptr;
+				auto collect_static_members =
+					[&](const StructTypeInfo* current_struct,
+						const auto& self) -> void {
+						if (current_struct == nullptr) {
+							return;
 						}
-						if (candidate.parameter_nodes().size() == call_arg_count) {
-							resolved_function = &candidate;
-							break;
+						for (const auto& member_func : current_struct->member_functions) {
+							if (member_func.getName() != member_name_handle ||
+								!member_func.function_decl.is<FunctionDeclarationNode>()) {
+								continue;
+							}
+							const FunctionDeclarationNode& candidate =
+								member_func.function_decl.as<FunctionDeclarationNode>();
+							if (!candidate.is_static()) {
+								continue;
+							}
+							if (first_static_name_match == nullptr) {
+								first_static_name_match = &candidate;
+							}
+							const bool already_added =
+								std::any_of(
+									static_member_overloads.begin(),
+									static_member_overloads.end(),
+									[&](const ASTNode& existing_overload) {
+										const FunctionDeclarationNode* existing_function =
+											get_function_decl_node(existing_overload);
+										return existing_function == &candidate;
+									});
+							if (!already_added) {
+								static_member_overloads.push_back(
+									member_func.function_decl);
+							}
 						}
+						for (const auto& base_spec : current_struct->base_classes) {
+							if (const StructTypeInfo* base_struct =
+									tryGetStructTypeInfo(base_spec.type_index);
+								base_struct != nullptr) {
+								self(base_struct, self);
+							}
+						}
+					};
+				collect_static_members(struct_info, collect_static_members);
+
+				if (have_complete_call_arg_types &&
+					!static_member_overloads.empty()) {
+					const OverloadResolutionResult overload_result =
+						resolve_overload(static_member_overloads, deduced_arg_types);
+					if (overload_result.has_match &&
+						!overload_result.is_ambiguous &&
+						overload_result.selected_overload != nullptr) {
+						resolved_function = get_function_decl_node(
+							*overload_result.selected_overload);
 					}
 				}
-				if (resolved_function == nullptr && first_name_match != nullptr) {
-					parser_hint_function = first_name_match;
+
+				if (resolved_function == nullptr &&
+					first_static_name_match != nullptr) {
+					parser_hint_function = first_static_name_match;
 				}
 			}
 		}
@@ -419,8 +470,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		auto owner_type_it = getTypesByNameMap().find(owner_name_handle);
 		if (owner_type_it != getTypesByNameMap().end() &&
 			owner_type_it->second != nullptr &&
-			owner_type_it->second->isTemplateInstantiation() &&
-			owner_type_it->second->getStructInfo() == nullptr) {
+			owner_type_it->second->isTemplateInstantiation()) {
 			TypeInfo::DependentQualifiedNameRecord dependent_record;
 			dependent_record.owner_kind =
 				TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -296,9 +296,9 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		}
 		deduced_arg_types.push_back(*type_opt);
 	}
-	if (AliasTemplateMaterializationResult canonical_owner =
-			resolveCanonicalInstantiatedOwnerForLookup(instantiated_class_name);
-		!canonical_owner.instantiated_name.empty()) {
+	AliasTemplateMaterializationResult canonical_owner =
+		resolveCanonicalInstantiatedOwnerForLookup(instantiated_class_name);
+	if (!canonical_owner.instantiated_name.empty()) {
 		instantiated_class_name = canonical_owner.instantiated_name;
 	}
 	const bool has_dependent_template_args =
@@ -345,19 +345,31 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		!has_dependent_call_arg &&
 		deduced_arg_types.size() == args.size();
 	DefinitionPreferredMemberOverloadSet static_member_overloads;
+	bool has_template_member_candidates = false;
 	auto collectOwnerStaticMemberOverloads = [&]() {
 		if (!can_use_nontemplate_owner_lookup) {
 			return;
 		}
-		instantiateLazyClassToPhase(
-			owner_name_handle,
-			ClassInstantiationPhase::Full);
-		auto type_it = getTypesByNameMap().find(owner_name_handle);
-		if (type_it == getTypesByNameMap().end() ||
-			type_it->second == nullptr) {
+		const TypeInfo* owner_lookup_type_info =
+			canonical_owner.resolved_type_info;
+		if (owner_lookup_type_info == nullptr) {
+			auto type_it = getTypesByNameMap().find(owner_name_handle);
+			if (type_it != getTypesByNameMap().end()) {
+				owner_lookup_type_info = type_it->second;
+			}
+		}
+		if (owner_lookup_type_info == nullptr) {
 			return;
 		}
-		const StructTypeInfo* struct_info = type_it->second->getStructInfo();
+		instantiateLazyClassToPhase(
+			owner_lookup_type_info->name(),
+			ClassInstantiationPhase::Full);
+		const StructTypeInfo* struct_info =
+			owner_lookup_type_info->getStructInfo();
+		if (struct_info == nullptr) {
+			struct_info = tryGetStructTypeInfo(
+				owner_lookup_type_info->registeredTypeIndex());
+		}
 		if (struct_info == nullptr) {
 			return;
 		}
@@ -415,25 +427,31 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		}
 
 		if (resolved_function == nullptr) {
-			if (static_member_overloads.first_definition != nullptr) {
-				parser_hint_function = static_member_overloads.first_definition;
-			} else if (static_member_overloads.first != nullptr) {
-				parser_hint_function = static_member_overloads.first;
+			parser_hint_function =
+				this->trySelectUnambiguousParserReturnTypeHint(
+					std::span<const ASTNode>(
+						static_member_overloads.definition_preferred.data(),
+						static_member_overloads.definition_preferred.size()));
+			if (parser_hint_function == nullptr) {
+				parser_hint_function =
+					this->trySelectUnambiguousParserReturnTypeHint(
+						std::span<const ASTNode>(
+							static_member_overloads.all.data(),
+							static_member_overloads.all.size()));
 			}
 		}
 		if (parser_hint_function == nullptr &&
 			member_template_args.has_value()) {
 			if (const std::vector<ASTNode>* template_overloads =
 					gTemplateRegistry.lookupAllTemplates(qualified_name);
-				template_overloads != nullptr) {
-				for (const ASTNode& template_overload : *template_overloads) {
-					if (const FunctionDeclarationNode* template_function =
-							get_function_decl_node(template_overload);
-						template_function != nullptr) {
-						parser_hint_function = template_function;
-						break;
-					}
-				}
+				template_overloads != nullptr &&
+				!template_overloads->empty()) {
+				has_template_member_candidates = true;
+				parser_hint_function =
+					this->trySelectUnambiguousParserReturnTypeHint(
+						std::span<const ASTNode>(
+							template_overloads->data(),
+							template_overloads->size()));
 			}
 		}
 	}
@@ -447,9 +465,70 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			definition_match != nullptr) {
 			resolved_function = definition_match;
 			parser_hint_function = resolved_function;
-		} else if (static_member_overloads.first_definition != nullptr) {
-			parser_hint_function = static_member_overloads.first_definition;
+		} else if (parser_hint_function == nullptr) {
+			parser_hint_function =
+				this->trySelectUnambiguousParserReturnTypeHint(
+					std::span<const ASTNode>(
+						static_member_overloads.definition_preferred.data(),
+						static_member_overloads.definition_preferred.size()));
 		}
+	}
+	const TypeInfo* owner_type_info = canonical_owner.resolved_type_info;
+	if (owner_type_info == nullptr) {
+		auto owner_type_it = getTypesByNameMap().find(owner_name_handle);
+		owner_type_info =
+			owner_type_it != getTypesByNameMap().end()
+			? owner_type_it->second
+			: nullptr;
+	}
+	const bool owner_is_dependent_instantiation =
+		owner_type_info != nullptr &&
+		owner_type_info->isTemplateInstantiation() &&
+		std::any_of(
+			owner_type_info->templateArgs().begin(),
+			owner_type_info->templateArgs().end(),
+			[](const TypeInfo::TemplateArgInfo& arg_info) {
+				return templateArgInfoContainsDependentPlaceholder(arg_info);
+			});
+	bool owner_is_current_instantiation_context = false;
+	if (!member_function_context_stack_.empty()) {
+		const auto& member_ctx = member_function_context_stack_.back();
+		if (owner_name_handle == member_ctx.struct_name) {
+			owner_is_current_instantiation_context = true;
+		} else if (const TypeInfo* current_type_info =
+					   tryGetTypeInfo(member_ctx.struct_type_index);
+				   current_type_info != nullptr) {
+			const StringHandle current_base_template_name =
+				current_type_info->baseTemplateName();
+			if (owner_name_handle == current_base_template_name) {
+				owner_is_current_instantiation_context = true;
+			} else {
+				const std::string_view qualified_base_template_name =
+					buildQualifiedNameFromHandle(
+						current_type_info->sourceNamespace(),
+						StringTable::getStringView(current_base_template_name));
+				if (!qualified_base_template_name.empty() &&
+					StringTable::getStringView(owner_name_handle) ==
+						qualified_base_template_name) {
+					owner_is_current_instantiation_context = true;
+				}
+			}
+		}
+	}
+	if (resolved_function == nullptr &&
+		static_member_overloads.all.empty() &&
+		!has_template_member_candidates &&
+		!has_deferred_template_call_args &&
+		!owner_is_dependent_instantiation &&
+		!owner_is_current_instantiation_context) {
+		return ParseResult::error(
+			std::string(
+				StringBuilder()
+					.append("No matching function for call to '")
+					.append(qualified_name)
+					.append("'")
+					.commit()),
+			member_token);
 	}
 
 	std::optional<ExpressionNode> call_expr;
@@ -481,18 +560,15 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			std::move(member_template_arg_nodes));
 	}
 	if (resolved_function == nullptr) {
-		auto owner_type_it = getTypesByNameMap().find(owner_name_handle);
-		if (owner_type_it != getTypesByNameMap().end() &&
-			owner_type_it->second != nullptr &&
-			owner_type_it->second->isTemplateInstantiation()) {
+		if (owner_is_dependent_instantiation) {
 			TypeInfo::DependentQualifiedNameRecord dependent_record;
 			dependent_record.owner_kind =
 				TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
 			dependent_record.owner_name = owner_name_handle;
 			dependent_record.owner_type =
-				owner_type_it->second->registeredTypeIndex();
+				owner_type_info->registeredTypeIndex();
 			dependent_record.owner_template_arguments =
-				owner_type_it->second->templateArgs();
+				owner_type_info->templateArgs();
 			TypeInfo::DependentQualifiedNameRecord::Member member_record;
 			member_record.name = member_name_handle;
 			if (member_template_args.has_value()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -490,31 +490,10 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			[](const TypeInfo::TemplateArgInfo& arg_info) {
 				return templateArgInfoContainsDependentPlaceholder(arg_info);
 			});
-	bool owner_is_current_instantiation_context = false;
-	if (!member_function_context_stack_.empty()) {
-		const auto& member_ctx = member_function_context_stack_.back();
-		if (owner_name_handle == member_ctx.struct_name) {
-			owner_is_current_instantiation_context = true;
-		} else if (const TypeInfo* current_type_info =
-					   tryGetTypeInfo(member_ctx.struct_type_index);
-				   current_type_info != nullptr) {
-			const StringHandle current_base_template_name =
-				current_type_info->baseTemplateName();
-			if (owner_name_handle == current_base_template_name) {
-				owner_is_current_instantiation_context = true;
-			} else {
-				const std::string_view qualified_base_template_name =
-					buildQualifiedNameFromHandle(
-						current_type_info->sourceNamespace(),
-						StringTable::getStringView(current_base_template_name));
-				if (!qualified_base_template_name.empty() &&
-					StringTable::getStringView(owner_name_handle) ==
-						qualified_base_template_name) {
-					owner_is_current_instantiation_context = true;
-				}
-			}
-		}
-	}
+	const bool owner_is_current_instantiation_context =
+		this->tryResolveQualifiedTypeOwnerFromCurrentContext(
+			instantiated_class_name)
+			.has_value();
 	if (resolved_function == nullptr &&
 		static_member_overloads.all.empty() &&
 		!has_template_member_candidates &&

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -338,6 +338,93 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		StringTable::getOrInternStringHandle(instantiated_class_name);
 	const StringHandle member_name_handle =
 		StringTable::getOrInternStringHandle(member_name);
+	const bool can_use_nontemplate_owner_lookup =
+		!parsed_member_template_args;
+	const bool have_complete_call_arg_types =
+		!has_dependent_call_arg &&
+		deduced_arg_types.size() == args.size();
+	std::vector<ASTNode> static_member_overloads;
+	std::vector<ASTNode> definition_static_member_overloads;
+	const FunctionDeclarationNode* first_static_name_match = nullptr;
+	const FunctionDeclarationNode* first_definition_static_name_match = nullptr;
+	auto collectOwnerStaticMemberOverloads = [&]() {
+		if (!can_use_nontemplate_owner_lookup) {
+			return;
+		}
+		auto type_it = getTypesByNameMap().find(owner_name_handle);
+		if (type_it == getTypesByNameMap().end() ||
+			type_it->second == nullptr) {
+			return;
+		}
+		const StructTypeInfo* struct_info = type_it->second->getStructInfo();
+		if (struct_info == nullptr) {
+			return;
+		}
+		auto collect_static_members =
+			[&](const StructTypeInfo* current_struct,
+				const auto& self) -> void {
+				if (current_struct == nullptr) {
+					return;
+				}
+				for (const auto& member_func : current_struct->member_functions) {
+					if (member_func.getName() != member_name_handle ||
+						!member_func.function_decl.is<FunctionDeclarationNode>()) {
+						continue;
+					}
+					const FunctionDeclarationNode& candidate =
+						member_func.function_decl.as<FunctionDeclarationNode>();
+					if (!candidate.is_static()) {
+						continue;
+					}
+					if (first_static_name_match == nullptr) {
+						first_static_name_match = &candidate;
+					}
+					const bool already_added =
+						std::any_of(
+							static_member_overloads.begin(),
+							static_member_overloads.end(),
+							[&](const ASTNode& existing_overload) {
+								const FunctionDeclarationNode* existing_function =
+									get_function_decl_node(existing_overload);
+								return existing_function == &candidate;
+							});
+					if (!already_added) {
+						static_member_overloads.push_back(
+							member_func.function_decl);
+					}
+					if (candidate.get_definition().has_value()) {
+						if (first_definition_static_name_match == nullptr) {
+							first_definition_static_name_match = &candidate;
+						}
+						definition_static_member_overloads.push_back(
+							member_func.function_decl);
+					}
+				}
+				for (const auto& base_spec : current_struct->base_classes) {
+					if (const StructTypeInfo* base_struct =
+							tryGetStructTypeInfo(base_spec.type_index);
+						base_struct != nullptr) {
+						self(base_struct, self);
+					}
+				}
+			};
+		collect_static_members(struct_info, collect_static_members);
+	};
+	auto resolveStaticOwnerMemberOverload =
+		[&](const std::vector<ASTNode>& overloads) -> const FunctionDeclarationNode* {
+		if (!have_complete_call_arg_types || overloads.empty()) {
+			return nullptr;
+		}
+		const OverloadResolutionResult overload_result =
+			resolve_overload(overloads, deduced_arg_types);
+		if (overload_result.has_match &&
+			!overload_result.is_ambiguous &&
+			overload_result.selected_overload != nullptr) {
+			return get_function_decl_node(*overload_result.selected_overload);
+		}
+		return nullptr;
+	};
+	collectOwnerStaticMemberOverloads();
 
 	// If we successfully instantiated the function, use its declaration
 	const FunctionDeclarationNode* resolved_function = nullptr;
@@ -348,78 +435,23 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	} else {
 		// For non-template member functions (e.g. Template<T>::allocate()),
 		// prefer real static-member overload selection on the instantiated owner.
-		auto type_it = getTypesByNameMap().find(owner_name_handle);
-		const bool can_use_nontemplate_owner_lookup =
-			!parsed_member_template_args;
-		const bool have_complete_call_arg_types =
-			!has_dependent_call_arg &&
-			deduced_arg_types.size() == args.size();
-		if (can_use_nontemplate_owner_lookup &&
-			type_it != getTypesByNameMap().end() &&
-			type_it->second) {
-			const StructTypeInfo* struct_info = type_it->second->getStructInfo();
-			if (struct_info) {
-				std::vector<ASTNode> static_member_overloads;
-				const FunctionDeclarationNode* first_static_name_match = nullptr;
-				auto collect_static_members =
-					[&](const StructTypeInfo* current_struct,
-						const auto& self) -> void {
-						if (current_struct == nullptr) {
-							return;
-						}
-						for (const auto& member_func : current_struct->member_functions) {
-							if (member_func.getName() != member_name_handle ||
-								!member_func.function_decl.is<FunctionDeclarationNode>()) {
-								continue;
-							}
-							const FunctionDeclarationNode& candidate =
-								member_func.function_decl.as<FunctionDeclarationNode>();
-							if (!candidate.is_static()) {
-								continue;
-							}
-							if (first_static_name_match == nullptr) {
-								first_static_name_match = &candidate;
-							}
-							const bool already_added =
-								std::any_of(
-									static_member_overloads.begin(),
-									static_member_overloads.end(),
-									[&](const ASTNode& existing_overload) {
-										const FunctionDeclarationNode* existing_function =
-											get_function_decl_node(existing_overload);
-										return existing_function == &candidate;
-									});
-							if (!already_added) {
-								static_member_overloads.push_back(
-									member_func.function_decl);
-							}
-						}
-						for (const auto& base_spec : current_struct->base_classes) {
-							if (const StructTypeInfo* base_struct =
-									tryGetStructTypeInfo(base_spec.type_index);
-								base_struct != nullptr) {
-								self(base_struct, self);
-							}
-						}
-					};
-				collect_static_members(struct_info, collect_static_members);
+		if (const FunctionDeclarationNode* definition_match =
+				resolveStaticOwnerMemberOverload(
+					definition_static_member_overloads);
+			definition_match != nullptr) {
+			resolved_function = definition_match;
+		} else if (const FunctionDeclarationNode* resolved_match =
+				resolveStaticOwnerMemberOverload(
+					static_member_overloads);
+			resolved_match != nullptr) {
+			resolved_function = resolved_match;
+		}
 
-				if (have_complete_call_arg_types &&
-					!static_member_overloads.empty()) {
-					const OverloadResolutionResult overload_result =
-						resolve_overload(static_member_overloads, deduced_arg_types);
-					if (overload_result.has_match &&
-						!overload_result.is_ambiguous &&
-						overload_result.selected_overload != nullptr) {
-						resolved_function = get_function_decl_node(
-							*overload_result.selected_overload);
-					}
-				}
-
-				if (resolved_function == nullptr &&
-					first_static_name_match != nullptr) {
-					parser_hint_function = first_static_name_match;
-				}
+		if (resolved_function == nullptr) {
+			if (first_definition_static_name_match != nullptr) {
+				parser_hint_function = first_definition_static_name_match;
+			} else if (first_static_name_match != nullptr) {
+				parser_hint_function = first_static_name_match;
 			}
 		}
 		if (parser_hint_function == nullptr &&
@@ -436,6 +468,18 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 					}
 				}
 			}
+		}
+	}
+	if (resolved_function != nullptr &&
+		!resolved_function->get_definition().has_value()) {
+		if (const FunctionDeclarationNode* definition_match =
+				resolveStaticOwnerMemberOverload(
+					definition_static_member_overloads);
+			definition_match != nullptr) {
+			resolved_function = definition_match;
+			parser_hint_function = resolved_function;
+		} else if (first_definition_static_name_match != nullptr) {
+			parser_hint_function = first_definition_static_name_match;
 		}
 	}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2,6 +2,7 @@
 #include "AstTraversal.h"
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
+#include "ExpressionSubstitutor.h"
 #include <span>
 #include <unordered_set>
 #include "NameMangling.h"
@@ -1940,6 +1941,43 @@ TypeIndex Parser::substitute_template_parameter(
 						 StringTable::getStringView(placeholder_info->name()), instantiated_name);
 		return true;
 	};
+	auto tryResolveDeferredDecltypePlaceholder = [&]() -> bool {
+		const TypeInfo* placeholder_info = tryGetTypeInfo(current_type_index);
+		if (placeholder_info == nullptr ||
+			placeholder_info->deferredDecltypeExpression() == nullptr) {
+			return false;
+		}
+
+		TemplateInstantiationContext substitution_context =
+			buildTemplateInstantiationContext(
+				template_params,
+				template_args,
+				nullptr,
+				currentTemplateSubstitutionFailurePolicy());
+		ExpressionSubstitutor substitutor(substitution_context, *this);
+		ASTNode substituted_expr =
+			substitutor.substitute(*placeholder_info->deferredDecltypeExpression());
+		auto resolved_type_spec = get_expression_type(substituted_expr);
+		if (!resolved_type_spec.has_value()) {
+			return false;
+		}
+
+		if (const TypeInfo* resolved_type_info =
+				tryGetTypeInfo(resolved_type_spec->type_index());
+			resolved_type_info != nullptr) {
+			assignResolvedType(*resolved_type_info);
+			return true;
+		}
+
+		TypeIndex native_index = nativeTypeIndex(resolved_type_spec->type());
+		if (native_index.is_valid()) {
+			current_type = resolved_type_spec->type();
+			current_type_index =
+				native_index.withCategory(resolved_type_spec->type());
+			return true;
+		}
+		return false;
+	};
 
 	if (const TypeInfo* indexed_type_info = tryGetTypeInfo(current_type_index)) {
 		type_name = StringTable::getStringView(indexed_type_info->name());
@@ -1954,6 +1992,10 @@ TypeIndex Parser::substitute_template_parameter(
 	}
 
 	if (type_name.empty()) {
+		return current_type_index.withCategory(current_type);
+	}
+
+	if (tryResolveDeferredDecltypePlaceholder()) {
 		return current_type_index.withCategory(current_type);
 	}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2895,6 +2895,16 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 		// For other unary operators (+, -, !, ~, ++, --), return the operand type
 		return operand_type;
 	} else if (auto call_info_opt = CallInfo::tryFrom(expr)) {
+		if (const auto* call_expr = std::get_if<CallExprNode>(&expr);
+			call_expr != nullptr &&
+			(call_expr->has_dependent_qualified_lookup_record() ||
+			 call_expr->has_dependent_unqualified_lookup_record())) {
+			// A dependent call's return type is not fixed until instantiation.
+			// Using a parser hint here can freeze the first same-name overload
+			// seen during template parsing, which is wrong for decltype(...)
+			// and other dependent unevaluated contexts.
+			return std::nullopt;
+		}
 		const CallInfo& call_info = *call_info_opt;
 		const DeclarationNode& callee_decl = *call_info.declaration;
 		auto normalize_alias_return_type = [&](TypeSpecifierNode& type) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -3,6 +3,7 @@
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
 #include "ExpressionSubstitutor.h"
+#include "MemberFunctionLookupShared.h"
 #include <span>
 #include <unordered_set>
 #include "NameMangling.h"
@@ -343,14 +344,14 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 	const bool have_complete_call_arg_types =
 		!has_dependent_call_arg &&
 		deduced_arg_types.size() == args.size();
-	std::vector<ASTNode> static_member_overloads;
-	std::vector<ASTNode> definition_static_member_overloads;
-	const FunctionDeclarationNode* first_static_name_match = nullptr;
-	const FunctionDeclarationNode* first_definition_static_name_match = nullptr;
+	DefinitionPreferredMemberOverloadSet static_member_overloads;
 	auto collectOwnerStaticMemberOverloads = [&]() {
 		if (!can_use_nontemplate_owner_lookup) {
 			return;
 		}
+		instantiateLazyClassToPhase(
+			owner_name_handle,
+			ClassInstantiationPhase::Full);
 		auto type_it = getTypesByNameMap().find(owner_name_handle);
 		if (type_it == getTypesByNameMap().end() ||
 			type_it->second == nullptr) {
@@ -360,58 +361,20 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		if (struct_info == nullptr) {
 			return;
 		}
-		auto collect_static_members =
-			[&](const StructTypeInfo* current_struct,
-				const auto& self) -> void {
-				if (current_struct == nullptr) {
-					return;
-				}
-				for (const auto& member_func : current_struct->member_functions) {
-					if (member_func.getName() != member_name_handle ||
-						!member_func.function_decl.is<FunctionDeclarationNode>()) {
-						continue;
-					}
-					const FunctionDeclarationNode& candidate =
-						member_func.function_decl.as<FunctionDeclarationNode>();
-					if (!candidate.is_static()) {
-						continue;
-					}
-					if (first_static_name_match == nullptr) {
-						first_static_name_match = &candidate;
-					}
-					const bool already_added =
-						std::any_of(
-							static_member_overloads.begin(),
-							static_member_overloads.end(),
-							[&](const ASTNode& existing_overload) {
-								const FunctionDeclarationNode* existing_function =
-									get_function_decl_node(existing_overload);
-								return existing_function == &candidate;
-							});
-					if (!already_added) {
-						static_member_overloads.push_back(
-							member_func.function_decl);
-					}
-					if (candidate.get_definition().has_value()) {
-						if (first_definition_static_name_match == nullptr) {
-							first_definition_static_name_match = &candidate;
-						}
-						definition_static_member_overloads.push_back(
-							member_func.function_decl);
-					}
-				}
-				for (const auto& base_spec : current_struct->base_classes) {
-					if (const StructTypeInfo* base_struct =
-							tryGetStructTypeInfo(base_spec.type_index);
-						base_struct != nullptr) {
-						self(base_struct, self);
-					}
-				}
-			};
-		collect_static_members(struct_info, collect_static_members);
+		static_member_overloads =
+			collectVisibleMemberFunctionOverloadNodes(
+				struct_info,
+				member_name_handle,
+				true,
+				[](const StructMemberFunction& member_func,
+				   const FunctionDeclarationNode& candidate) {
+					return !member_func.is_constructor &&
+						!member_func.is_destructor &&
+						candidate.is_static();
+				});
 	};
 	auto resolveStaticOwnerMemberOverload =
-		[&](const std::vector<ASTNode>& overloads) -> const FunctionDeclarationNode* {
+		[&](std::span<const ASTNode> overloads) -> const FunctionDeclarationNode* {
 		if (!have_complete_call_arg_types || overloads.empty()) {
 			return nullptr;
 		}
@@ -437,21 +400,25 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		// prefer real static-member overload selection on the instantiated owner.
 		if (const FunctionDeclarationNode* definition_match =
 				resolveStaticOwnerMemberOverload(
-					definition_static_member_overloads);
+					std::span<const ASTNode>(
+						static_member_overloads.definition_preferred.data(),
+						static_member_overloads.definition_preferred.size()));
 			definition_match != nullptr) {
 			resolved_function = definition_match;
 		} else if (const FunctionDeclarationNode* resolved_match =
 				resolveStaticOwnerMemberOverload(
-					static_member_overloads);
+					std::span<const ASTNode>(
+						static_member_overloads.all.data(),
+						static_member_overloads.all.size()));
 			resolved_match != nullptr) {
 			resolved_function = resolved_match;
 		}
 
 		if (resolved_function == nullptr) {
-			if (first_definition_static_name_match != nullptr) {
-				parser_hint_function = first_definition_static_name_match;
-			} else if (first_static_name_match != nullptr) {
-				parser_hint_function = first_static_name_match;
+			if (static_member_overloads.first_definition != nullptr) {
+				parser_hint_function = static_member_overloads.first_definition;
+			} else if (static_member_overloads.first != nullptr) {
+				parser_hint_function = static_member_overloads.first;
 			}
 		}
 		if (parser_hint_function == nullptr &&
@@ -474,12 +441,14 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		!resolved_function->get_definition().has_value()) {
 		if (const FunctionDeclarationNode* definition_match =
 				resolveStaticOwnerMemberOverload(
-					definition_static_member_overloads);
+					std::span<const ASTNode>(
+						static_member_overloads.definition_preferred.data(),
+						static_member_overloads.definition_preferred.size()));
 			definition_match != nullptr) {
 			resolved_function = definition_match;
 			parser_hint_function = resolved_function;
-		} else if (first_definition_static_name_match != nullptr) {
-			parser_hint_function = first_definition_static_name_match;
+		} else if (static_member_overloads.first_definition != nullptr) {
+			parser_hint_function = static_member_overloads.first_definition;
 		}
 	}
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3880,7 +3880,21 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 	};
 
 	std::optional<size_t> preferred_candidate_index;
-	if (use_shape_preselection) {
+	if (preferred_definition_bound_template_declaration_ != nullptr) {
+		for (size_t i = 0; i < viable_candidates.size(); ++i) {
+			if (viable_candidates[i].template_func == nullptr) {
+				continue;
+			}
+			if (static_cast<const void*>(viable_candidates[i].template_func) ==
+				preferred_definition_bound_template_declaration_) {
+				preferred_candidate_index = i;
+				break;
+			}
+		}
+		if (!preferred_candidate_index.has_value()) {
+			return std::nullopt;
+		}
+	} else if (use_shape_preselection) {
 		std::vector<ASTNode> shape_overloads;
 		std::vector<size_t> shape_candidate_indices;
 		shape_overloads.reserve(viable_candidates.size());

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1713,6 +1713,26 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		ASTNode substituted_expr = substitutor.substitute(*deferred_decltype_expr);
 		auto type_spec_opt = get_expression_type(substituted_expr);
 		if (!type_spec_opt.has_value()) {
+			if (substituted_expr.is<ExpressionNode>() &&
+				std::holds_alternative<CallExprNode>(
+					substituted_expr.as<ExpressionNode>())) {
+				const CallExprNode& substituted_call =
+					std::get<CallExprNode>(
+						substituted_expr.as<ExpressionNode>());
+				if (substituted_call.has_qualified_name() &&
+					!substituted_call.has_dependent_unqualified_lookup_record() &&
+					!substituted_call.has_dependent_qualified_lookup_record() &&
+					!substituted_call.has_definition_lookup_record() &&
+					!substituted_call.has_parser_return_type_hint()) {
+					throw CompileError(
+						std::string(
+							StringBuilder()
+								.append("No matching function for call to '")
+								.append(substituted_call.qualified_name())
+								.append("'")
+								.commit()));
+				}
+			}
 			return false;
 		}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1654,6 +1654,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 	std::string_view alias_template_name,
 	std::span<const TemplateTypeArg> template_args) {
 	AliasTemplateMaterializationResult result;
+	std::optional<TypeSpecifierNode> resolved_deferred_decltype_spec;
 	const TemplateAliasNode* alias_node = nullptr;
 	if (auto alias_entry = gTemplateRegistry.lookup_alias_template(alias_template_name);
 		alias_entry.has_value() && alias_entry->is<TemplateAliasNode>()) {
@@ -1682,6 +1683,61 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			   resolved_alias.function_signature.has_value() ||
 			   resolved_alias.member_class_name.has_value() ||
 			   !resolved_alias.array_dimensions.empty();
+	};
+	auto tryResolveDeferredDecltypeAliasTarget = [&]() -> bool {
+		if (alias_node == nullptr) {
+			return false;
+		}
+		const TypeInfo* target_type_info =
+			tryGetTypeInfo(alias_node->target_type_node().type_index());
+		if (target_type_info == nullptr) {
+			return false;
+		}
+		const ASTNode* deferred_decltype_expr =
+			target_type_info->deferredDecltypeExpression();
+		if (deferred_decltype_expr == nullptr) {
+			return false;
+		}
+
+		std::optional<TemplateEnvironment> outer_environment;
+		if (outer_binding != nullptr) {
+			outer_environment = buildTemplateEnvironment(*outer_binding);
+		}
+		TemplateInstantiationContext substitution_context =
+			buildTemplateInstantiationContext(
+				effective_template_params,
+				effective_template_args,
+				outer_environment.has_value() ? &*outer_environment : nullptr,
+				currentTemplateSubstitutionFailurePolicy());
+		ExpressionSubstitutor substitutor(substitution_context, *this);
+		ASTNode substituted_expr = substitutor.substitute(*deferred_decltype_expr);
+		auto type_spec_opt = get_expression_type(substituted_expr);
+		if (!type_spec_opt.has_value()) {
+			return false;
+		}
+
+		resolved_deferred_decltype_spec = *type_spec_opt;
+		const TypeSpecifierNode& resolved_type_spec =
+			*resolved_deferred_decltype_spec;
+		const TypeInfo* resolved_type_info =
+			tryGetTypeInfo(resolved_type_spec.type_index());
+		if (resolved_type_info == nullptr) {
+			TypeIndex native_index =
+				nativeTypeIndex(resolved_type_spec.type());
+			if (native_index.is_valid()) {
+				resolved_type_info =
+					tryGetTypeInfo(native_index.withCategory(
+						resolved_type_spec.type()));
+			}
+		}
+		if (resolved_type_info == nullptr) {
+			return false;
+		}
+
+		result.resolved_type_info = resolved_type_info;
+		result.instantiated_name =
+			StringTable::getStringView(resolved_type_info->name());
+		return true;
 	};
 	auto tryResolveDirectAliasTarget = [&]() -> bool {
 		if (alias_node == nullptr) {
@@ -1891,7 +1947,9 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 		// do not produce an instantiated helper type name; resolve them by
 		// rebinding the alias target parameter to the caller's concrete argument.
 		if (!tryResolveDirectAliasTarget()) {
-			(void)tryMaterializeTemplateAliasTarget();
+			if (!tryResolveDeferredDecltypeAliasTarget()) {
+				(void)tryMaterializeTemplateAliasTarget();
+			}
 		}
 		if (alias_node != nullptr &&
 			result.resolved_type_info == nullptr &&
@@ -1920,6 +1978,15 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 
 	result.resolved_type_info =
 		findTypeByName(StringTable::getOrInternStringHandle(result.instantiated_name));
+	if (result.resolved_type_info == nullptr &&
+		resolved_deferred_decltype_spec.has_value()) {
+		tryResolveDeferredDecltypeAliasTarget();
+	}
+	if (alias_node != nullptr &&
+		result.resolved_type_info != nullptr &&
+		!resolved_deferred_decltype_spec.has_value()) {
+		(void)tryResolveDeferredDecltypeAliasTarget();
+	}
 	if (alias_node != nullptr &&
 		!alias_node->is_deferred()) {
 		const TypeSpecifierNode& alias_target_type = alias_node->target_type_node();
@@ -2122,8 +2189,11 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 			alias_target_type_spec.pointer_depth() != 0 ||
 			alias_target_type_spec.has_function_signature() ||
 			alias_target_type_spec.is_array();
-		TypeSpecifierNode alias_registration_type_spec = alias_target_type_spec;
-		if (alias_target_preserves_surface) {
+		TypeSpecifierNode alias_registration_type_spec =
+			resolved_deferred_decltype_spec.value_or(alias_target_type_spec);
+		if (resolved_deferred_decltype_spec.has_value()) {
+			alias_registration_type_spec = *resolved_deferred_decltype_spec;
+		} else if (alias_target_preserves_surface) {
 			alias_registration_type_spec =
 				resolveTypeInfoToTypeSpec(
 					resolved_type_info,
@@ -3332,6 +3402,42 @@ std::string_view Parser::instantiate_and_register_base_template(
 			}
 
 			const TypeSpecifierNode& alias_target_type = alias_node.target_type_node();
+			if (const TypeInfo* alias_target_info =
+					tryGetTypeInfo(alias_target_type.type_index());
+				alias_target_info != nullptr &&
+				alias_target_info->deferredDecltypeExpression() != nullptr) {
+				const OuterTemplateBinding* outer =
+					gTemplateRegistry.getOuterTemplateBinding(base_class_name);
+				std::optional<TemplateEnvironment> outer_environment;
+				if (outer != nullptr) {
+					outer_environment = buildTemplateEnvironment(*outer);
+				}
+				TemplateInstantiationContext substitution_context =
+					buildTemplateInstantiationContext(
+						alias_node.template_parameters(),
+						template_args,
+						outer_environment.has_value() ? &*outer_environment : nullptr,
+						currentTemplateSubstitutionFailurePolicy());
+				ExpressionSubstitutor substitutor(substitution_context, *this);
+				ASTNode substituted_expr =
+					substitutor.substitute(*alias_target_info->deferredDecltypeExpression());
+				if (auto resolved_type = get_expression_type(substituted_expr);
+					resolved_type.has_value()) {
+					if (const TypeInfo* resolved_type_info =
+							tryGetTypeInfo(resolved_type->type_index());
+						resolved_type_info != nullptr) {
+						base_class_name =
+							StringTable::getStringView(resolved_type_info->name());
+						return base_class_name;
+					}
+					std::string_view builtin_name =
+						getTypeName(resolved_type->type());
+					if (!builtin_name.empty()) {
+						base_class_name = builtin_name;
+						return builtin_name;
+					}
+				}
+			}
 			if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target_type.type_index());
 				alias_target_info != nullptr && alias_target_info->isTemplateInstantiation()) {
 				std::vector<TemplateTypeArg> concrete_target_args =

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1810,10 +1810,24 @@ ParseResult Parser::parse_type_specifier() {
 							restore_token_position(scope_pos);
 						}
 
-						if (peek() == "::"_tok) {
-							FLASH_LOG(Parser, Debug, "DBG alias instantiated_type return before trailing member for ", type_name);
-						}
 						if (instantiated_type_info == nullptr) {
+							if (auto builtin_type = get_builtin_type_info(resolved_instantiated_type_name);
+								builtin_type.has_value()) {
+								if (const TypeInfo* native_type_info =
+										tryGetTypeInfo(nativeTypeIndex(builtin_type->first));
+									native_type_info != nullptr) {
+									return buildTypeFromInfo(*native_type_info, type_name_token, true);
+								}
+							}
+							if (TypeCategory terminal_category =
+									TemplateRegistry::stringToType(resolved_instantiated_type_name);
+								terminal_category != TypeCategory::Invalid) {
+								if (const TypeInfo* native_type_info =
+										tryGetTypeInfo(nativeTypeIndex(terminal_category));
+									native_type_info != nullptr) {
+									return buildTypeFromInfo(*native_type_info, type_name_token, true);
+								}
+							}
 							return std::nullopt;
 						}
 						return buildTypeFromInfo(*instantiated_type_info, type_name_token, false);
@@ -3752,7 +3766,7 @@ ParseResult Parser::parse_decltype_specifier() {
 	// Consume 'decltype' or '__typeof__' keyword
 	Token decltype_token = advance();
 	std::string_view keyword = decltype_token.value();
-	auto makeDependentDecltypeType = [&](const Token& source_token) -> ASTNode {
+	auto makeDependentDecltypeType = [&](const Token& source_token, const ASTNode* deferred_expr = nullptr) -> ASTNode {
 		StringHandle dependent_name = StringTable::getOrInternStringHandle(
 			StringBuilder()
 				.append("__dependent_decltype_")
@@ -3763,6 +3777,9 @@ ParseResult Parser::parse_decltype_specifier() {
 		type_info.name_ = dependent_name;
 		type_info.is_incomplete_instantiation_ = true;
 		type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
+		if (deferred_expr != nullptr) {
+			type_info.setDeferredDecltypeExpression(*deferred_expr);
+		}
 		getTypesByNameMap()[dependent_name] = &type_info;
 		return emplace_node<TypeSpecifierNode>(
 			type_info.type_index_.withCategory(TypeCategory::UserDefined),
@@ -3949,7 +3966,8 @@ ParseResult Parser::parse_decltype_specifier() {
 		// set parsing_template_depth_ > 0 but will have template parameter names.
 		if (decltype_source_mentions_active_template_param) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for decltype expression in template context");
-			return saved_position.success(makeDependentDecltypeType(decltype_token));
+			const ASTNode& deferred_decltype_expr = *expr_result.node();
+			return saved_position.success(makeDependentDecltypeType(decltype_token, &deferred_decltype_expr));
 		}
 		return ParseResult::error("Could not deduce type from decltype expression", decltype_token);
 	}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1846,11 +1846,17 @@ ParseResult Parser::parse_type_specifier() {
 					};
 					const bool has_dependent_alias_args =
 						aliasTemplateArgsStillDependent(*template_args);
+					const std::optional<TemplateTypeArg> direct_rebound_alias_arg =
+						!has_dependent_alias_args
+							? tryRebindAliasTargetTemplateArg(alias_node, *template_args)
+							: std::nullopt;
 
 					// OPTION 1: Alias materialization for concrete arguments (preferred over
 					// placeholder fallback and string parsing). Deferred aliases are still
 					// handled via the same materialization entrypoint when arguments are concrete.
-					if (!has_dependent_alias_args) {
+					if (!has_dependent_alias_args &&
+						(alias_node.is_deferred() ||
+						 !direct_rebound_alias_arg.has_value())) {
 						FLASH_LOG(Parser, Debug, "Using alias materialization for alias '", type_name, "' -> '", alias_node.target_template_name(), "'");
 
 						// Route directly through the alias-specific materialization path
@@ -1913,15 +1919,14 @@ ParseResult Parser::parse_type_specifier() {
 					// Handle non-deferred aliases (e.g., template<typename T> using Ptr = T*)
 					// Substitute template arguments into the target type
 					TypeSpecifierNode instantiated_type = alias_node.target_type_node();
-					if (std::optional<TemplateTypeArg> rebound_arg =
-							tryRebindAliasTargetTemplateArg(alias_node, *template_args);
-						rebound_arg.has_value()) {
-						if (rebound_arg->is_value) {
+					if (direct_rebound_alias_arg.has_value()) {
+						const TemplateTypeArg& rebound_arg = *direct_rebound_alias_arg;
+						if (rebound_arg.is_value) {
 							FLASH_LOG(Parser, Error, "Non-type template arguments not supported in alias templates yet");
 							return ParseResult::error("Non-type template arguments not supported in alias templates", type_name_token);
 						}
 						instantiated_type = makeTypeSpecifierFromTemplateTypeArg(
-							*rebound_arg,
+							rebound_arg,
 							Token());
 					} else if (!has_dependent_alias_args) {
 						if (const TypeInfo* concrete_member_info =

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -3950,6 +3950,29 @@ ParseResult Parser::parse_decltype_specifier() {
 	const bool decltype_source_mentions_active_template_param =
 		tokenRangeMentionsActiveTemplateParam(expr_start_pos);
 	discard_saved_token(expr_start_pos);
+	auto expressionRequiresDeferredDecltype =
+		[](const ASTNode& expr_node) -> bool {
+		if (!expr_node.is<ExpressionNode>()) {
+			return false;
+		}
+		const ExpressionNode& expr = expr_node.as<ExpressionNode>();
+		return std::visit(
+			[](const auto& inner) -> bool {
+				using T = std::decay_t<decltype(inner)>;
+				if constexpr (std::is_same_v<T, CallExprNode>) {
+					return inner.has_dependent_unqualified_lookup_record() ||
+						inner.has_dependent_qualified_lookup_record() ||
+						inner.has_parser_return_type_hint() ||
+						inner.has_template_arguments();
+				} else if constexpr (std::is_same_v<T, QualifiedIdentifierNode>) {
+					return inner.hasDependentQualifiedName() ||
+						inner.has_template_arguments();
+				} else {
+					return false;
+				}
+			},
+			expr);
+	};
 
 	// Expect ')'
 	if (!consume(")"_tok)) {
@@ -3964,7 +3987,8 @@ ParseResult Parser::parse_decltype_specifier() {
 		// Check both parsing_template_depth_ > 0 and current_template_param_names_ since
 		// some template contexts (like member function templates in structs) might not
 		// set parsing_template_depth_ > 0 but will have template parameter names.
-		if (decltype_source_mentions_active_template_param) {
+		if (decltype_source_mentions_active_template_param ||
+			expressionRequiresDeferredDecltype(*expr_result.node())) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for decltype expression in template context");
 			const ASTNode& deferred_decltype_expr = *expr_result.node();
 			return saved_position.success(makeDependentDecltypeType(decltype_token, &deferred_decltype_expr));

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -3984,8 +3984,13 @@ ParseResult Parser::parse_decltype_specifier() {
 		return ParseResult::error("Expected ')' after decltype expression", current_token_);
 	}
 
+	const std::optional<ASTNode> decltype_expr = expr_result.node();
+	if (!decltype_expr.has_value()) {
+		throw InternalError("decltype expression parse succeeded without an AST node");
+	}
+
 	// Deduce the type from the expression
-	auto type_spec_opt = get_expression_type(*expr_result.node());
+	auto type_spec_opt = get_expression_type(*decltype_expr);
 	if (!type_spec_opt.has_value()) {
 		// If we're in a template body/declaration and the expression is dependent,
 		// create a dependent type placeholder that will be resolved during instantiation.
@@ -3993,10 +3998,12 @@ ParseResult Parser::parse_decltype_specifier() {
 		// some template contexts (like member function templates in structs) might not
 		// set parsing_template_depth_ > 0 but will have template parameter names.
 		if (decltype_source_mentions_active_template_param ||
-			expressionRequiresDeferredDecltype(*expr_result.node())) {
+			expressionRequiresDeferredDecltype(*decltype_expr)) {
 			FLASH_LOG(Templates, Debug, "Creating dependent type for decltype expression in template context");
-			const ASTNode& deferred_decltype_expr = *expr_result.node();
-			return saved_position.success(makeDependentDecltypeType(decltype_token, &deferred_decltype_expr));
+			return saved_position.success(
+				makeDependentDecltypeType(
+					decltype_token,
+					&*decltype_expr));
 		}
 		return ParseResult::error("Could not deduce type from decltype expression", decltype_token);
 	}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8046,6 +8046,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	};
 	const FunctionDeclarationNode* definition_lookup_record_target =
 		resolveDefinitionLookupRecordTarget();
+	const bool has_deferred_qualified_template_metadata =
+		!call_info.template_arguments.empty() ||
+		(call_info.dependent_qualified_lookup_record != nullptr &&
+		 call_info.dependent_qualified_lookup_record->has_value());
 	struct QualifiedLookupTarget {
 		NamespaceHandle namespace_handle;
 		std::string_view identifier;
@@ -8403,6 +8407,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		!call_info.has_receiver &&
 		(!call_info.qualified_name.isValid() ||
 		 qualified_name_targets_namespace) &&
+		!has_deferred_qualified_template_metadata &&
 		definition_lookup_record_target == nullptr &&
 		call_info.definition_lookup_record != nullptr &&
 		call_info.definition_lookup_record->has_value()) {
@@ -8486,10 +8491,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (!call_info.has_receiver &&
 		call_info.function_declaration == nullptr &&
 		call_info.qualified_name.isValid()) {
-		const bool has_deferred_qualified_template_metadata =
-			!call_info.template_arguments.empty() ||
-			(call_info.dependent_qualified_lookup_record != nullptr &&
-			 call_info.dependent_qualified_lookup_record->has_value());
 		if (qualified_name_targets_namespace ||
 			has_deferred_qualified_template_metadata) {
 			std::string_view qualified_name_for_resolution =
@@ -8516,13 +8517,28 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			}
 			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;
 			if (tryCollectOverloadResolutionArgTypes(arguments, qualified_template_arg_types)) {
-				if (std::optional<ASTNode> resolved_target =
+				std::optional<ASTNode> resolved_target;
+				if (call_info.definition_lookup_record != nullptr &&
+					call_info.definition_lookup_record->has_value() &&
+					call_info.definition_lookup_record
+						->value()
+						.definition_bound_template_declaration != nullptr) {
+					resolved_target =
+						parser().resolveDefinitionBoundQualifiedTemplateCall(
+							call_info.definition_lookup_record->value(),
+							qualified_name_for_resolution,
+							call_info.template_arguments,
+							arguments,
+							qualified_template_arg_types);
+				} else {
+					resolved_target =
 						parser().resolveDeferredQualifiedTemplateCall(
 							qualified_name_for_resolution,
 							call_info.template_arguments,
 							arguments,
 							qualified_template_arg_types);
-					resolved_target.has_value()) {
+				}
+				if (resolved_target.has_value()) {
 					if (const FunctionDeclarationNode* resolved_function =
 						get_function_decl_node(*resolved_target);
 					resolved_function != nullptr) {

--- a/src/TemplateArgumentMaterialization.h
+++ b/src/TemplateArgumentMaterialization.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "Parser.h"
+
+inline std::string_view getTemplateArgumentBuiltinTokenText(const TemplateTypeArg& arg) {
+	switch (arg.typeEnum()) {
+	case TypeCategory::Void: return "void";
+	case TypeCategory::Bool: return "bool";
+	case TypeCategory::Char: return "char";
+	case TypeCategory::UnsignedChar: return "unsigned char";
+	case TypeCategory::Short: return "short";
+	case TypeCategory::UnsignedShort: return "unsigned short";
+	case TypeCategory::Int: return "int";
+	case TypeCategory::UnsignedInt: return "unsigned int";
+	case TypeCategory::Long: return "long";
+	case TypeCategory::UnsignedLong: return "unsigned long";
+	case TypeCategory::LongLong: return "long long";
+	case TypeCategory::UnsignedLongLong: return "unsigned long long";
+	case TypeCategory::Float: return "float";
+	case TypeCategory::Double: return "double";
+	case TypeCategory::LongDouble: return "long double";
+	default: return {};
+	}
+}
+
+inline ASTNode materializeDependentTemplateArgumentNode(
+	const TemplateTypeArg& arg,
+	const Token& source_token) {
+	Token dep_token(
+		Token::Type::Identifier,
+		arg.dependent_name.isValid() ? arg.dependent_name.view() : std::string_view{},
+		source_token.line(),
+		source_token.column(),
+		source_token.file_index());
+	ExpressionNode& dep_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+		TemplateParameterReferenceNode(arg.dependent_name, dep_token));
+	return ASTNode(&dep_expr);
+}
+
+inline ASTNode materializeValueTemplateArgumentNode(
+	const TemplateTypeArg& arg,
+	const Token& source_token) {
+	if (arg.typeEnum() == TypeCategory::Bool) {
+		Token bool_token(
+			Token::Type::Keyword,
+			arg.value != 0 ? "true"sv : "false"sv,
+			source_token.line(),
+			source_token.column(),
+			source_token.file_index());
+		ExpressionNode& bool_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+			BoolLiteralNode(bool_token, arg.value != 0));
+		return ASTNode(&bool_expr);
+	}
+
+	StringBuilder text_builder;
+	std::string_view literal_text = text_builder.append(arg.value).commit();
+	TypeCategory literal_type = arg.typeEnum() == TypeCategory::Invalid
+		? TypeCategory::Int
+		: arg.typeEnum();
+	Token literal_token(
+		Token::Type::Literal,
+		literal_text,
+		source_token.line(),
+		source_token.column(),
+		source_token.file_index());
+	ExpressionNode& literal_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+		NumericLiteralNode(
+			literal_token,
+			static_cast<unsigned long long>(arg.value),
+			literal_type,
+			TypeQualifier::None,
+			get_type_size_bits(literal_type)));
+	return ASTNode(&literal_expr);
+}
+
+inline Token makeTemplateArgumentTypeToken(
+	const TemplateTypeArg& arg,
+	const Token& source_token) {
+	if (const TypeInfo* type_info = tryGetTypeInfo(arg.type_index)) {
+		std::string_view type_name = StringTable::getStringView(type_info->name());
+		if (!type_name.empty()) {
+			return Token(
+				Token::Type::Identifier,
+				type_name,
+				source_token.line(),
+				source_token.column(),
+				source_token.file_index());
+		}
+	} else if (std::string_view builtin_name = getTemplateArgumentBuiltinTokenText(arg);
+			   !builtin_name.empty()) {
+		return Token(
+			Token::Type::Keyword,
+			builtin_name,
+			source_token.line(),
+			source_token.column(),
+			source_token.file_index());
+	}
+
+	return source_token;
+}
+
+inline int computeTemplateArgumentTypeSizeBits(TypeIndex type_index) {
+	int size_in_bits = get_type_size_bits(type_index.category());
+	if (size_in_bits != 0) {
+		return size_in_bits;
+	}
+
+	const TypeInfo* type_info = tryGetTypeInfo(type_index);
+	if (!type_info) {
+		return 0;
+	}
+
+	size_in_bits = type_info->sizeInBits().value;
+	if (size_in_bits != 0 || !type_info->isStruct()) {
+		return size_in_bits;
+	}
+
+	const StructTypeInfo* struct_info = type_info->getStructInfo();
+	return struct_info ? struct_info->sizeInBits().value : 0;
+}
+
+inline std::vector<ASTNode> materializeTemplateArgumentNodes(
+	std::span<const TemplateTypeArg> template_args,
+	const Token& source_token) {
+	std::vector<ASTNode> result;
+	result.reserve(template_args.size());
+
+	for (const TemplateTypeArg& arg : template_args) {
+		if (arg.is_dependent && arg.dependent_name.isValid()) {
+			result.push_back(materializeDependentTemplateArgumentNode(arg, source_token));
+			continue;
+		}
+
+		if (arg.is_value) {
+			result.push_back(materializeValueTemplateArgumentNode(arg, source_token));
+			continue;
+		}
+
+		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
+			arg.type_index.withCategory(arg.typeEnum()),
+			get_type_size_bits(arg.typeEnum()),
+			makeTemplateArgumentTypeToken(arg, source_token),
+			arg.cv_qualifier,
+			arg.ref_qualifier);
+		type_node.set_pack_expansion(arg.is_pack);
+		for (size_t pointer_index = 0; pointer_index < arg.pointer_depth; ++pointer_index) {
+			CVQualifier pointer_cv = pointer_index < arg.pointer_cv_qualifiers.size()
+				? arg.pointer_cv_qualifiers[pointer_index]
+				: CVQualifier::None;
+			type_node.add_pointer_level(pointer_cv);
+		}
+		result.push_back(ASTNode(&type_node));
+	}
+
+	return result;
+}

--- a/src/TemplateArgumentMaterialization.h
+++ b/src/TemplateArgumentMaterialization.h
@@ -136,9 +136,21 @@ inline std::vector<ASTNode> materializeTemplateArgumentNodes(
 			continue;
 		}
 
+		TypeIndex arg_type_index = arg.type_index;
+		if (!arg_type_index.is_valid()) {
+			if (arg.typeEnum() == TypeCategory::Invalid) {
+				continue;
+			}
+			arg_type_index = TypeIndex{}.withCategory(arg.typeEnum());
+		}
+		const TypeCategory arg_category =
+			arg.typeEnum() == TypeCategory::Invalid
+			? arg_type_index.category()
+			: arg.typeEnum();
+
 		TypeSpecifierNode& type_node = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
-			arg.type_index.withCategory(arg.typeEnum()),
-			get_type_size_bits(arg.typeEnum()),
+			arg_type_index.withCategory(arg_category),
+			computeTemplateArgumentTypeSizeBits(arg_type_index),
 			makeTemplateArgumentTypeToken(arg, source_token),
 			arg.cv_qualifier,
 			arg.ref_qualifier);

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -765,6 +765,15 @@ public:
 		return lookupSpecialization(StringTable::getStringView(qi.identifier_handle), template_args);
 	}
 
+	bool hasExactSpecializationsForName(std::string_view template_name) const {
+		for (const auto& entry : specializations_) {
+			if (entry.first.template_name == template_name) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	// Find a matching specialization pattern (StringHandle overload)
 	std::optional<ASTNode> matchSpecializationPattern(StringHandle template_name,
 													  std::span<const TemplateTypeArg> concrete_args) const {

--- a/tests/test_template_current_member_explicit_template_decltype_ret0.cpp
+++ b/tests/test_template_current_member_explicit_template_decltype_ret0.cpp
@@ -1,0 +1,22 @@
+template <typename U>
+char pick(U) {
+	return 0;
+}
+
+template <typename T>
+struct Holder {
+	template <typename U>
+	static long pick(U) {
+		return 2;
+	}
+
+	using PickType = decltype(pick<int>(0));
+
+	static int run() {
+		return sizeof(PickType) == sizeof(long) ? 0 : 1;
+	}
+};
+
+int main() {
+	return Holder<void>::run();
+}

--- a/tests/test_template_explicit_base_member_template_call_default_arg_ret0.cpp
+++ b/tests/test_template_explicit_base_member_template_call_default_arg_ret0.cpp
@@ -1,0 +1,22 @@
+struct Base {
+	template <class U>
+	int pick(U value = U{1}) {
+		return static_cast<int>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base {
+	template <class U>
+	int pick(U value) const {
+		return static_cast<int>(value) + 100;
+	}
+
+	int run() {
+		return this->Base::template pick<int>() - 1;
+	}
+};
+
+int main() {
+	return Holder<int>{}.run();
+}

--- a/tests/test_template_explicit_base_operator_template_call_default_arg_ret0.cpp
+++ b/tests/test_template_explicit_base_operator_template_call_default_arg_ret0.cpp
@@ -1,0 +1,22 @@
+struct Base {
+	template <class U>
+	int operator()(U value = U{1}) {
+		return static_cast<int>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base {
+	template <class U>
+	int operator()(U value) {
+		return static_cast<int>(value) + 100;
+	}
+
+	int run() {
+		return this->Base::template operator()<int>() - 1;
+	}
+};
+
+int main() {
+	return Holder<int>{}.run();
+}

--- a/tests/test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp
+++ b/tests/test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp
@@ -1,6 +1,3 @@
-// TODO(template-infra): currently fails while parsing `this->Base<T>::template ...`
-// because the postfix qualified-owner path drops owner template-ids before the
-// `::template` continuation is analyzed.
 template <class T>
 struct Base {
 	template <class U>

--- a/tests/test_template_explicit_base_owner_template_member_template_call_fail.cpp
+++ b/tests/test_template_explicit_base_owner_template_member_template_call_fail.cpp
@@ -1,0 +1,26 @@
+// TODO(template-infra): currently fails while parsing `this->Base<T>::template ...`
+// because the postfix qualified-owner path drops owner template-ids before the
+// `::template` continuation is analyzed.
+template <class T>
+struct Base {
+	template <class U>
+	int pick(U value = U{1}) {
+		return static_cast<int>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base<T> {
+	template <class U>
+	int pick(U value) {
+		return static_cast<int>(value) + 100;
+	}
+
+	int run() {
+		return this->Base<T>::template pick<int>() - 1;
+	}
+};
+
+int main() {
+	return Holder<long>{}.run();
+}

--- a/tests/test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp
+++ b/tests/test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp
@@ -1,0 +1,23 @@
+template <class T>
+struct Base {
+	template <class U>
+	int operator()(U value = U{1}) {
+		return static_cast<int>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base<T> {
+	template <class U>
+	int operator()(U value) {
+		return static_cast<int>(value) + 100;
+	}
+
+	int run() {
+		return this->Base<T>::template operator()<int>() - 1;
+	}
+};
+
+int main() {
+	return Holder<long>{}.run();
+}

--- a/tests/test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp
+++ b/tests/test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp
@@ -1,0 +1,26 @@
+namespace GlobalQualifiedNs {
+	template <typename U>
+	char pick(U) {
+		return 0;
+	}
+}
+
+template <typename T>
+struct Holder {
+	using PickType = decltype(::GlobalQualifiedNs::pick<T>(0));
+
+	static int run() {
+		return sizeof(PickType) == sizeof(char) ? 0 : 1;
+	}
+};
+
+namespace GlobalQualifiedNs {
+	template <typename U>
+	long pick(int) {
+		return 1;
+	}
+}
+
+int main() {
+	return Holder<int>::run();
+}

--- a/tests/test_template_qualified_namespace_explicit_definition_bound_ret0.cpp
+++ b/tests/test_template_qualified_namespace_explicit_definition_bound_ret0.cpp
@@ -1,0 +1,26 @@
+namespace QualifiedNs {
+	template <typename U>
+	char pick(U) {
+		return 0;
+	}
+}
+
+template <typename T>
+struct Holder {
+	using PickType = decltype(QualifiedNs::pick<T>(0));
+
+	static int run() {
+		return sizeof(PickType) == sizeof(char) ? 0 : 1;
+	}
+};
+
+namespace QualifiedNs {
+	template <typename U>
+	long pick(int) {
+		return 1;
+	}
+}
+
+int main() {
+	return Holder<int>::run();
+}

--- a/tests/test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp
+++ b/tests/test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp
@@ -1,0 +1,24 @@
+namespace QualifiedRuntimeNs {
+	template <typename U>
+	int pick(U) {
+		return 3;
+	}
+}
+
+template <typename T>
+struct Holder {
+	static int run() {
+		return QualifiedRuntimeNs::pick<T>(0) == 3 ? 0 : 1;
+	}
+};
+
+namespace QualifiedRuntimeNs {
+	template <typename U>
+	int pick(int) {
+		return 5;
+	}
+}
+
+int main() {
+	return Holder<int>::run();
+}

--- a/tests/test_template_qualified_static_member_same_arity_decltype_ret0.cpp
+++ b/tests/test_template_qualified_static_member_same_arity_decltype_ret0.cpp
@@ -1,0 +1,17 @@
+template <typename T>
+struct Holder {
+	static char pick(int) {
+		return 1;
+	}
+
+	static long pick(long) {
+		return 2;
+	}
+};
+
+template <typename T>
+using PickResult = decltype(Holder<T>::pick(0L));
+
+int main() {
+	return sizeof(PickResult<int>) == sizeof(long) ? 0 : 1;
+}


### PR DESCRIPTION
## What changed
- preserved structured deferred lookup metadata for qualified and member-template direct calls instead of collapsing unresolved cases onto parser-selected compatibility data
- kept specialization-first behavior for qualified explicit-template replay while still preserving definition-bound metadata when it is safe to do so
- covered postfix explicit-qualified member and operator template-id paths, including owner-template-id forms such as 	his->Base<T>::template pick<int>() and 	his->Base<T>::template operator()<int>()
- preserved nested owner chains and current-instantiation owner identity through parser materialization, replay, and substitution so qualified member-template calls do not rebind through unrelated global owners
- fixed dependent decltype alias and qualified static-member call replay/materialization so deferred type recovery stays on structured call metadata instead of compatibility guesses
- tightened concrete qualified static-member call handling: use real static-member overload resolution, keep candidate-bearing concrete owner calls deferred when parser-time ranking is still inconclusive, and only hard-error when no concrete owner candidates exist
- unified qualified-owner member lookup helpers and reused the shared current-owner resolver instead of carrying duplicate current-instantiation checks
- preserved direct non-deferred alias materialization surface modifiers by preferring direct rebinding over rebuilding from TypeInfo
- updated the template-infrastructure audit and conformance docs with the new baseline, current follow-ups, and focused guard tests
- added focused passing regressions for the newly covered qualified/member-template paths

## Why
Several qualified template/member call paths were still mixing structured semantic ownership with parser compatibility behavior. That caused two classes of standards-visible failures:
- later replay or substitution could lose the real owner chain and rebind through unrelated same-name entities
- parser-time call selection could either guess a target too early or reject a call too early even when later semantic resolution still had enough structured information to finish correctly

This branch moves more of that surface onto preserved owner metadata, deferred lookup records, and real overload resolution, which is closer to the C++20 model for current instantiation, dependent qualified names, and qualified static-member calls.

## Impact
This closes a broad qualified/member-template infrastructure slice rather than a single parser bug. The covered paths now preserve semantic identity more consistently across parsing, substitution, constexpr use, replay, and later semantic resolution.

The branch also removes a remaining non-standard behavior in the qualified static-member path: candidate-bearing concrete owner calls are no longer forced through parser-selected fallback behavior or rejected before later semantic resolution can finish them.

## Validation
- ./build_flashcpp.bat
- pwsh ./tests/run_all_tests.ps1 test_member_template_func_in_specialization_ret0.cpp
- pwsh ./tests/run_all_tests.ps1 test_template_current_instantiation_qualified_call_ret0.cpp
- pwsh ./tests/run_all_tests.ps1 test_template_qualified_static_member_same_arity_decltype_ret0.cpp
- pwsh ./tests/run_all_tests.ps1

Latest full-suite result on this branch: 2676 regular tests passed, 222 expected-failure tests failed as expected.

## Remaining follow-up
- improve parser diagnostics in parse_copy_initialization(...) so nested qualified-call failures do not collapse to the generic Failed to parse initializer expression
- continue removing the remaining compatibility-only qualified/member-template materializers that still stop at qualified_name or mangled_name after owner resolution already succeeded
- if another ABI-sensitive pointer-to-member issue appears, preserve the remaining canonical TypeCategory::MemberObjectPointer carrier instead of relying on declarator-shaped member_class + pointer_depth forms
- keep broader replay/current-instantiation expansion in reserve unless a concrete uncovered failure appears; the active follow-up is still the remaining qualified/member-template compatibility boundary cleanup