### PR TITLE
[codex] Fix deferred explicit-base member template metadata

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -347,9 +347,14 @@ Remaining near-term scope:
   `Parser_Expr_PostfixCalls.cpp` now also accepts explicit member-template ids
   after a concrete owner qualifier such as `this->Base::template pick<int>()`
   and `this->Base::template operator()<int>()`, routing the resolved owner
-  through the same member-template instantiation helper and preserving
-  `qualified_name + template_arguments` on unresolved placeholders so
-  substitution can recover the base-qualified owner later
+  through the same member-template instantiation helper
+- the explicit-base member-template placeholder half of that postfix path is
+  now on the structured side too: unresolved
+  `this->Base::template pick<T>()`-style calls preserve a recovered
+  base-owner `DependentQualifiedNameRecord`, carry the matched member-template
+  return type instead of a raw `auto` stub, and let substitution instantiate
+  the concrete base-qualified member template once `T` becomes concrete instead
+  of rebinding by bare member name
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -422,10 +427,11 @@ Next direct-call target:
    Immediate next target: audit the remaining qualified/member-template
    placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
    `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
-   after owner resolution or deferred lookup shape is already known, and move
-   them onto preserved `FunctionCallDefinitionLookupRecord` or explicit
-   `DependentQualifiedNameRecord` state before removing the whole-call sema
-   synchronization hook. Keep
+   after owner resolution or deferred lookup shape is already known. After
+   this slice, the most direct uncovered neighbor is the postfix explicit-
+   qualified operator-template placeholder path, which still needs the same
+   owner-preserving deferred lookup treatment that now covers
+   `this->Base::template pick<T>()`. Keep
    `test_member_template_func_in_specialization_ret0.cpp` in the focused
    guard set here: it exercises the new "candidate-bearing concrete owner
    calls must defer instead of hard-failing" rule in
@@ -510,11 +516,15 @@ When changing this area, always rerun:
    dependent-qualified owner preservation for unresolved template-instantiation
    owners, and the current-owner explicit-member-template placeholder path in
    `Parser_Expr_PrimaryExpr.cpp` now preserves the same structured deferred
-   owner metadata with member-template-derived parser return-type hints.
-   The next concrete parser target is therefore the remaining
+   owner metadata with member-template-derived parser return-type hints. This
+   slice now does the same for the explicit-base postfix member-template
+   placeholder in `parse_member_postfix()`, including late substitution-time
+   owner-qualified instantiation once `T` becomes concrete. The next concrete
+   parser target is therefore the remaining
    qualified/member-template placeholder/materializer exits that still stamp
    only compatibility metadata after owner resolution or deferred lookup shape
-   is already known. Also
+   is already known, with the postfix explicit-qualified operator-template
+   placeholder as the most direct follow-up. Also
    clean up the remaining legacy parser sites that still
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -331,9 +331,13 @@ Remaining near-term scope:
 - the postfix explicit-qualified member/operator path now follows the same rule
   for concrete owner-qualified member-template ids: `this->Base::template pick<int>()`
   and `this->Base::template operator()<int>()` now parse and instantiate through
-  the base-qualified owner instead of failing before overload selection, and
-  unresolved placeholders preserve `qualified_name + template_arguments` so
-  substitution can recover that owner later
+  the base-qualified owner instead of failing before overload selection
+- the unresolved explicit-base member-template placeholder in that postfix path
+  is now structural as well: `this->Base::template pick<T>()` preserves the
+  recovered base owner as deferred qualified metadata, keeps the matched
+  member-template return type on the placeholder instead of a raw `auto` stub,
+  and substitution instantiates the concrete base-qualified member template
+  once `T` becomes concrete instead of rebinding by unqualified member name
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -494,7 +498,11 @@ For work in this area, rerun:
    focusing on the other qualified/member-template placeholder/materializer
    exits that still stop at compatibility metadata after owner resolution
    already succeeded, and then remove the whole-call sema synchronization hook
-   by pushing that work back to earlier semantic ownership.
+   by pushing that work back to earlier semantic ownership. This slice closes
+   the explicit-base postfix member-template placeholder; the most direct next
+   follow-up is the sibling postfix explicit-qualified operator-template
+   placeholder, which still needs the same owner-preserving deferred lookup
+   treatment.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -101,6 +101,27 @@ tryBuildDeferredFunctionCallDefinitionLookupRecord(
 	return record;
 }
 
+inline std::optional<std::string_view> tryBuildQualifiedCallNameOverride(
+	std::string_view owner_name,
+	std::string_view member_name) {
+	if (owner_name.empty() || member_name.empty()) {
+		return std::nullopt;
+	}
+
+	return StringBuilder()
+		.append(owner_name)
+		.append("::")
+		.append(member_name)
+		.commit();
+}
+
+inline std::optional<std::string_view> tryBuildQualifiedCallNameOverride(
+	const FunctionDeclarationNode& func_decl) {
+	return tryBuildQualifiedCallNameOverride(
+		func_decl.parent_struct_name(),
+		func_decl.decl_node().identifier_token().value());
+}
+
 struct CallInfo {
 	// Callee declaration (always present).
 	const DeclarationNode* declaration;

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -80,6 +80,27 @@ inline std::optional<FunctionCallDefinitionLookupRecord> tryBuildFunctionCallDef
 	return record;
 }
 
+inline std::optional<FunctionCallDefinitionLookupRecord>
+tryBuildDeferredFunctionCallDefinitionLookupRecord(
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	bool ordinary_lookup_included,
+	bool argument_dependent_lookup_included) {
+	if (definition_context == nullptr ||
+		!definition_context->is_valid() ||
+		callee_token.type() != Token::Type::Identifier) {
+		return std::nullopt;
+	}
+
+	FunctionCallDefinitionLookupRecord record;
+	record.definition_context = *definition_context;
+	record.callee_name = callee_token.handle();
+	record.ordinary_lookup_included = ordinary_lookup_included;
+	record.argument_dependent_lookup_included =
+		argument_dependent_lookup_included;
+	return record;
+}
+
 struct CallInfo {
 	// Callee declaration (always present).
 	const DeclarationNode* declaration;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1814,61 +1814,6 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		}
 		return nullptr;
 	};
-	auto appendOwnerMemberCandidates = [&](
-		std::string_view owner_name,
-		std::string_view member_name,
-		InlineVector<ASTNode, 8>& candidates,
-		InlineVector<ASTNode, 8>& definition_candidates) {
-		if (owner_name.empty() || member_name.empty()) {
-			return;
-		}
-		StringHandle owner_handle =
-			StringTable::getOrInternStringHandle(owner_name);
-		StringHandle member_handle =
-			StringTable::getOrInternStringHandle(member_name);
-		parser_.instantiateLazyClassToPhase(
-			owner_handle,
-			ClassInstantiationPhase::Full);
-		if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
-			owner_type_info != nullptr) {
-			if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
-				DefinitionPreferredMemberOverloadSet owner_overloads =
-					collectVisibleMemberFunctionOverloadNodes(
-						struct_info,
-						member_handle,
-						true,
-						[](const StructMemberFunction& member_func,
-						   const FunctionDeclarationNode&) {
-							return !member_func.is_constructor &&
-								!member_func.is_destructor;
-						});
-				candidates = std::move(owner_overloads.all);
-				definition_candidates =
-					std::move(owner_overloads.definition_preferred);
-			}
-		}
-		if (!candidates.empty()) {
-			return;
-		}
-		for (const ASTNode& candidate_node : gSymbolTable.lookup_all(member_name)) {
-			const FunctionDeclarationNode* candidate_func =
-				get_function_decl_node(candidate_node);
-			if (candidate_func == nullptr) {
-				continue;
-			}
-			const std::string_view parent_name =
-				candidate_func->parent_struct_name();
-			if (parent_name == owner_name ||
-				(!parent_name.empty() && parent_name.ends_with(owner_name))) {
-				appendUniqueOverloadNode(candidates, candidate_node);
-				if (candidate_func->get_definition().has_value()) {
-					appendUniqueOverloadNode(
-						definition_candidates,
-						candidate_node);
-				}
-			}
-		}
-	};
 	auto resolveQualifiedOwnerOverload = [&](
 		std::string_view owner_name,
 		std::string_view member_name,
@@ -1881,22 +1826,29 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			return nullptr;
 		}
 
-		InlineVector<ASTNode, 8> candidates;
-		InlineVector<ASTNode, 8> definition_candidates;
-		appendOwnerMemberCandidates(
+		DefinitionPreferredMemberOverloadSet owner_overloads =
+			collectOwnerNamedMemberFunctionOverloads(
 			owner_name,
 			member_name,
-			candidates,
-			definition_candidates);
+			[this](StringHandle owner_handle) {
+				parser_.instantiateLazyClassToPhase(
+					owner_handle,
+					ClassInstantiationPhase::Full);
+			},
+			[](const StructMemberFunction& member_func,
+			   const FunctionDeclarationNode&) {
+				return !member_func.is_constructor &&
+					!member_func.is_destructor;
+			});
 		if (const FunctionDeclarationNode* definition_target =
 				resolveUniqueFunctionOverload(
-					definition_candidates,
+					owner_overloads.definition_preferred,
 					substituted_arg_types);
 			definition_target != nullptr) {
 			return definition_target;
 		}
 		return resolveUniqueFunctionOverload(
-			candidates,
+			owner_overloads.all,
 			substituted_arg_types);
 	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
@@ -2942,64 +2894,6 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 
 	if ((call.callee().is_member() || call.callee().is_static_member()) &&
 		call.called_from().kind().is_identifier()) {
-		auto appendOwnerMemberCandidates = [&](
-			std::string_view owner_name,
-			std::string_view member_name,
-			InlineVector<ASTNode, 8>& candidates,
-			InlineVector<ASTNode, 8>& definition_candidates) {
-			if (owner_name.empty() || member_name.empty()) {
-				return;
-			}
-			StringHandle owner_handle =
-				StringTable::getOrInternStringHandle(owner_name);
-			StringHandle member_handle =
-				StringTable::getOrInternStringHandle(member_name);
-			parser_.instantiateLazyClassToPhase(
-				owner_handle,
-				ClassInstantiationPhase::Full);
-			if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
-				owner_type_info != nullptr) {
-				if (const StructTypeInfo* struct_info =
-						owner_type_info->getStructInfo()) {
-					DefinitionPreferredMemberOverloadSet owner_overloads =
-						collectVisibleMemberFunctionOverloadNodes(
-							struct_info,
-							member_handle,
-							true,
-							[](const StructMemberFunction& member_func,
-							   const FunctionDeclarationNode&) {
-								return !member_func.is_constructor &&
-									!member_func.is_destructor;
-							});
-					candidates = std::move(owner_overloads.all);
-					definition_candidates =
-						std::move(owner_overloads.definition_preferred);
-				}
-			}
-			if (!candidates.empty()) {
-				return;
-			}
-			for (const ASTNode& candidate_node :
-				 gSymbolTable.lookup_all(member_name)) {
-				const FunctionDeclarationNode* candidate_func =
-					get_function_decl_node(candidate_node);
-				if (candidate_func == nullptr) {
-					continue;
-				}
-				const std::string_view parent_name =
-					candidate_func->parent_struct_name();
-				if (parent_name == owner_name ||
-					(!parent_name.empty() &&
-					 parent_name.ends_with(owner_name))) {
-					appendUniqueOverloadNode(candidates, candidate_node);
-					if (candidate_func->get_definition().has_value()) {
-						appendUniqueOverloadNode(
-							definition_candidates,
-							candidate_node);
-					}
-				}
-			}
-		};
 		auto resolveUniqueFunctionOverload = [&](
 			std::span<const ASTNode> candidates) -> const FunctionDeclarationNode* {
 			if (candidates.empty()) {
@@ -3098,26 +2992,33 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 						}
 					}
 				}
-				InlineVector<ASTNode, 8> candidates;
-				InlineVector<ASTNode, 8> definition_candidates;
-				appendOwnerMemberCandidates(
+				DefinitionPreferredMemberOverloadSet owner_overloads =
+					collectOwnerNamedMemberFunctionOverloads(
 					materialized_owner_name,
 					member_name,
-					candidates,
-					definition_candidates);
+					[this](StringHandle owner_handle) {
+						parser_.instantiateLazyClassToPhase(
+							owner_handle,
+							ClassInstantiationPhase::Full);
+					},
+					[](const StructMemberFunction& member_func,
+					   const FunctionDeclarationNode&) {
+						return !member_func.is_constructor &&
+							!member_func.is_destructor;
+					});
 				const FunctionDeclarationNode* target_func = nullptr;
 				if (const FunctionDeclarationNode* definition_target =
 						resolveUniqueFunctionOverload(
 							std::span<const ASTNode>(
-								definition_candidates.data(),
-								definition_candidates.size()));
+								owner_overloads.definition_preferred.data(),
+								owner_overloads.definition_preferred.size()));
 					definition_target != nullptr) {
 					target_func = definition_target;
 				} else {
 					target_func = resolveUniqueFunctionOverload(
 						std::span<const ASTNode>(
-							candidates.data(),
-							candidates.size()));
+							owner_overloads.all.data(),
+							owner_overloads.all.size()));
 				}
 				std::string_view mutable_owner_name =
 					materialized_owner_name;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2942,22 +2942,231 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 
 	if ((call.callee().is_member() || call.callee().is_static_member()) &&
 		call.called_from().kind().is_identifier()) {
-		if (const FunctionDeclarationNode* rebound_member =
-				parser_.tryResolveConcreteMemberFunction(substituted_receiver, call.called_from().value());
-			rebound_member != nullptr) {
-			if (auto receiver_type = parser_.get_expression_type(substituted_receiver);
-				receiver_type.has_value() && is_struct_type(receiver_type->category())) {
-				if (const TypeInfo* receiver_type_info = tryGetTypeInfo(receiver_type->type_index());
-					receiver_type_info != nullptr) {
-					std::string_view class_name =
-						StringTable::getStringView(receiver_type_info->name());
-					if (parser_.instantiateLazyMemberForCanonicalOwner(
-							class_name,
-							call.called_from().value(),
-							std::span<const TemplateTypeArg>{})
-							.has_value()) {
-						rebound_member =
-							parser_.tryResolveConcreteMemberFunction(substituted_receiver, call.called_from().value());
+		auto appendOwnerMemberCandidates = [&](
+			std::string_view owner_name,
+			std::string_view member_name,
+			InlineVector<ASTNode, 8>& candidates,
+			InlineVector<ASTNode, 8>& definition_candidates) {
+			if (owner_name.empty() || member_name.empty()) {
+				return;
+			}
+			StringHandle owner_handle =
+				StringTable::getOrInternStringHandle(owner_name);
+			StringHandle member_handle =
+				StringTable::getOrInternStringHandle(member_name);
+			parser_.instantiateLazyClassToPhase(
+				owner_handle,
+				ClassInstantiationPhase::Full);
+			if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
+				owner_type_info != nullptr) {
+				if (const StructTypeInfo* struct_info =
+						owner_type_info->getStructInfo()) {
+					DefinitionPreferredMemberOverloadSet owner_overloads =
+						collectVisibleMemberFunctionOverloadNodes(
+							struct_info,
+							member_handle,
+							true,
+							[](const StructMemberFunction& member_func,
+							   const FunctionDeclarationNode&) {
+								return !member_func.is_constructor &&
+									!member_func.is_destructor;
+							});
+					candidates = std::move(owner_overloads.all);
+					definition_candidates =
+						std::move(owner_overloads.definition_preferred);
+				}
+			}
+			if (!candidates.empty()) {
+				return;
+			}
+			for (const ASTNode& candidate_node :
+				 gSymbolTable.lookup_all(member_name)) {
+				const FunctionDeclarationNode* candidate_func =
+					get_function_decl_node(candidate_node);
+				if (candidate_func == nullptr) {
+					continue;
+				}
+				const std::string_view parent_name =
+					candidate_func->parent_struct_name();
+				if (parent_name == owner_name ||
+					(!parent_name.empty() &&
+					 parent_name.ends_with(owner_name))) {
+					appendUniqueOverloadNode(candidates, candidate_node);
+					if (candidate_func->get_definition().has_value()) {
+						appendUniqueOverloadNode(
+							definition_candidates,
+							candidate_node);
+					}
+				}
+			}
+		};
+		auto resolveUniqueFunctionOverload = [&](
+			std::span<const ASTNode> candidates) -> const FunctionDeclarationNode* {
+			if (candidates.empty()) {
+				return nullptr;
+			}
+			std::vector<TypeSpecifierNode> substituted_arg_types;
+			if (!parser_.tryCollectFunctionCallArgTypes(
+					substituted_args,
+					substituted_arg_types)) {
+				return nullptr;
+			}
+			OverloadResolutionResult resolution =
+				resolve_overload(candidates, substituted_arg_types);
+			if (resolution.has_match &&
+				!resolution.is_ambiguous &&
+				resolution.selected_overload != nullptr &&
+				resolution.selected_overload->is<FunctionDeclarationNode>()) {
+				return &resolution.selected_overload->as<FunctionDeclarationNode>();
+			}
+			return nullptr;
+		};
+		auto tryResolveQualifiedReceiverMember =
+			[&]() -> const FunctionDeclarationNode* {
+				if (!call.has_dependent_qualified_lookup_record()) {
+					return nullptr;
+				}
+				const TypeInfo::DependentQualifiedNameRecord& dependent_record =
+					*call.dependent_qualified_lookup_record();
+				if (dependent_record.member_chain.empty()) {
+					return nullptr;
+				}
+				Parser::AliasTemplateMaterializationResult materialized_owner =
+					materializeDependentQualifiedRecordOwner(
+						dependent_record,
+						kInitialDependentMemberTypeResolutionDepth,
+						true);
+				std::string_view materialized_owner_name =
+					materialized_owner.canonicalName();
+				if (materialized_owner_name.empty()) {
+					return nullptr;
+				}
+				if (dependent_record.member_chain.size() > 1) {
+					MaterializedQualifiedLookupOwner prefix_owner =
+						materializeDependentQualifiedMemberPrefixOwner(
+							materialized_owner.canonicalNameHandle(),
+							materialized_owner_name,
+							std::span<
+								const TypeInfo::DependentQualifiedNameRecord::
+									Member>(
+								dependent_record.member_chain.data(),
+								dependent_record.member_chain.size() - 1),
+							kInitialDependentMemberTypeResolutionDepth);
+					if (!prefix_owner.owner_name.isValid()) {
+						return nullptr;
+					}
+					materialized_owner_name =
+						StringTable::getStringView(prefix_owner.owner_name);
+				}
+				const std::string_view member_name =
+					StringTable::getStringView(
+						dependent_record.member_chain.back().name);
+				if (dependent_record.member_chain.back()
+						.has_template_arguments) {
+					InlineVector<TemplateTypeArg, 4>
+						explicit_member_template_args =
+							materializeDependentRecordTemplateArgs(
+								dependent_record.member_chain.back()
+									.template_arguments,
+								kInitialDependentMemberTypeResolutionDepth);
+					if (!templateArgsStillDependent(
+							std::span<const TemplateTypeArg>(
+								explicit_member_template_args.data(),
+								explicit_member_template_args.size()))) {
+						std::vector<TypeSpecifierNode>
+							substituted_arg_types;
+						if (parser_.tryCollectFunctionCallArgTypes(
+								substituted_args,
+								substituted_arg_types)) {
+							if (std::optional<ASTNode>
+									instantiated_member =
+										parser_
+											.tryInstantiateMemberFunctionTemplateCall(
+												materialized_owner_name,
+												member_name,
+												explicit_member_template_args,
+												substituted_arg_types,
+												!substituted_args.empty(),
+												false);
+								instantiated_member.has_value() &&
+								instantiated_member->is<
+									FunctionDeclarationNode>()) {
+								return &instantiated_member
+											->as<
+												FunctionDeclarationNode>();
+							}
+						}
+					}
+				}
+				InlineVector<ASTNode, 8> candidates;
+				InlineVector<ASTNode, 8> definition_candidates;
+				appendOwnerMemberCandidates(
+					materialized_owner_name,
+					member_name,
+					candidates,
+					definition_candidates);
+				const FunctionDeclarationNode* target_func = nullptr;
+				if (const FunctionDeclarationNode* definition_target =
+						resolveUniqueFunctionOverload(
+							std::span<const ASTNode>(
+								definition_candidates.data(),
+								definition_candidates.size()));
+					definition_target != nullptr) {
+					target_func = definition_target;
+				} else {
+					target_func = resolveUniqueFunctionOverload(
+						std::span<const ASTNode>(
+							candidates.data(),
+							candidates.size()));
+				}
+				std::string_view mutable_owner_name =
+					materialized_owner_name;
+				if (target_func == nullptr || !target_func->is_materialized()) {
+					if (std::optional<ASTNode> instantiated_member =
+							parser_.instantiateLazyMemberForCanonicalOwner(
+								mutable_owner_name,
+								member_name,
+								std::span<const TemplateTypeArg>{});
+						instantiated_member.has_value() &&
+						instantiated_member->is<FunctionDeclarationNode>()) {
+						return &instantiated_member
+									->as<FunctionDeclarationNode>();
+					}
+				}
+				return target_func;
+			};
+		const FunctionDeclarationNode* rebound_member =
+			tryResolveQualifiedReceiverMember();
+		const bool used_qualified_receiver_rebind =
+			rebound_member != nullptr;
+		if (rebound_member == nullptr) {
+			rebound_member =
+				parser_.tryResolveConcreteMemberFunction(
+					substituted_receiver,
+					call.called_from().value());
+		}
+		if (rebound_member != nullptr) {
+			if (!used_qualified_receiver_rebind) {
+				if (auto receiver_type =
+						parser_.get_expression_type(substituted_receiver);
+					receiver_type.has_value() &&
+					is_struct_type(receiver_type->category())) {
+					if (const TypeInfo* receiver_type_info =
+							tryGetTypeInfo(receiver_type->type_index());
+						receiver_type_info != nullptr) {
+						std::string_view class_name =
+							StringTable::getStringView(
+								receiver_type_info->name());
+						if (parser_.instantiateLazyMemberForCanonicalOwner(
+								class_name,
+								call.called_from().value(),
+								std::span<const TemplateTypeArg>{})
+								.has_value()) {
+							rebound_member =
+								parser_.tryResolveConcreteMemberFunction(
+									substituted_receiver,
+									call.called_from().value());
+						}
 					}
 				}
 			}
@@ -2968,13 +3177,15 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 					*rebound_member,
 					std::move(substituted_args),
 					call.called_from());
+				CallMetadataCopyOptions copy_options;
+				copy_options.copy_dependent_qualified_lookup_record = false;
 				copyCallMetadataWithTransformedTemplateArguments(
 					rebound_call,
 					call,
 					[this](const ASTNode& template_arg) {
 						return substitute(template_arg);
 					},
-					CallMetadataCopyOptions{});
+					copy_options);
 				if (rebound_member->has_mangled_name()) {
 					rebound_call.set_mangled_name(rebound_member->mangled_name());
 				}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1753,15 +1753,12 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		}
 		if (qualified_call_name.has_value() && !qualified_call_name->empty()) {
 			setCallQualifiedName(new_expr, *qualified_call_name);
-		} else if (infer_qualified_name_from_parent &&
-			!target_func.parent_struct_name().empty()) {
-			setCallQualifiedName(
-				new_expr,
-				StringBuilder()
-					.append(target_func.parent_struct_name())
-					.append("::")
-					.append(target_func.decl_node().identifier_token().value())
-					.commit());
+		} else if (infer_qualified_name_from_parent) {
+			if (std::optional<std::string_view> inferred_qualified_name =
+					tryBuildQualifiedCallNameOverride(target_func);
+				inferred_qualified_name.has_value()) {
+				setCallQualifiedName(new_expr, *inferred_qualified_name);
+			}
 		}
 		if (target_func.has_mangled_name()) {
 			setCallMangledName(new_expr, target_func.mangled_name());

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -131,6 +131,68 @@ DefinitionPreferredMemberOverloadSet collectVisibleMemberFunctionOverloadNodes(
 	return result;
 }
 
+template <typename InstantiateOwnerFn, typename AcceptFn>
+DefinitionPreferredMemberOverloadSet collectOwnerNamedMemberFunctionOverloads(
+	std::string_view owner_name,
+	std::string_view member_name,
+	InstantiateOwnerFn&& instantiate_owner,
+	AcceptFn&& accept_candidate) {
+	DefinitionPreferredMemberOverloadSet result;
+	if (owner_name.empty() || member_name.empty()) {
+		return result;
+	}
+
+	const StringHandle owner_handle =
+		StringTable::getOrInternStringHandle(owner_name);
+	const StringHandle member_handle =
+		StringTable::getOrInternStringHandle(member_name);
+	instantiate_owner(owner_handle);
+
+	if (const TypeInfo* owner_type_info = findTypeByName(owner_handle);
+		owner_type_info != nullptr) {
+		if (const StructTypeInfo* struct_info = owner_type_info->getStructInfo()) {
+			result = collectVisibleMemberFunctionOverloadNodes(
+				struct_info,
+				member_handle,
+				true,
+				std::forward<AcceptFn>(accept_candidate));
+		}
+	}
+	if (!result.all.empty()) {
+		return result;
+	}
+
+	for (const ASTNode& candidate_node : gSymbolTable.lookup_all(member_name)) {
+		const FunctionDeclarationNode* candidate_func =
+			get_function_decl_node(candidate_node);
+		if (candidate_func == nullptr) {
+			continue;
+		}
+
+		const std::string_view parent_name =
+			candidate_func->parent_struct_name();
+		if (parent_name != owner_name &&
+			(parent_name.empty() || !parent_name.ends_with(owner_name))) {
+			continue;
+		}
+
+		if (result.first == nullptr) {
+			result.first = candidate_func;
+		}
+		appendUniqueOverloadNode(result.all, candidate_node);
+		if (candidate_func->get_definition().has_value()) {
+			if (result.first_definition == nullptr) {
+				result.first_definition = candidate_func;
+			}
+			appendUniqueOverloadNode(
+				result.definition_preferred,
+				candidate_node);
+		}
+	}
+
+	return result;
+}
+
 template <typename AcceptFn>
 ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
 	const StructTypeInfo* root_struct_info,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1799,7 +1799,77 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									false,
 									*resolved_func);
 							} else {
-								auto type_spec = emplace_node<TypeSpecifierNode>(TypeIndex{}.withCategory(TypeCategory::Auto), 0, qualified_member_token, CVQualifier::None, ReferenceQualifier::None);
+								std::string_view qualified_member_call_name =
+									buildQualifiedMemberCallName(
+										qualified_owner_segments,
+										qualified_member_token.value());
+								const FunctionDeclarationNode*
+									qualified_member_template_return_hint =
+										nullptr;
+								std::optional<
+									AliasTemplateMaterializationResult>
+									resolved_current_owner;
+								if (member_template_args.has_value()) {
+									if (qualified_owner_segments.size() == 1) {
+										resolved_current_owner =
+											tryResolveQualifiedTypeOwnerFromCurrentContext(
+												StringTable::getStringView(
+													qualified_owner_segments.front()));
+										if (resolved_current_owner.has_value() &&
+											!resolved_current_owner
+												 ->canonicalName()
+												 .empty()) {
+											qualified_member_call_name =
+												StringBuilder()
+													.append(
+														resolved_current_owner
+															->canonicalName())
+													.append("::")
+													.append(
+														qualified_member_token
+															.value())
+													.commit();
+										}
+									}
+									const std::vector<TemplateNameLookupCandidate>
+										template_candidates =
+											lookupFunctionTemplateCandidatesForInstantiation(
+												qualified_member_call_name,
+												0);
+									std::vector<ASTNode> template_candidate_nodes;
+									template_candidate_nodes.reserve(
+										template_candidates.size());
+									for (const TemplateNameLookupCandidate&
+											 candidate : template_candidates) {
+										template_candidate_nodes.push_back(
+											candidate.declaration);
+									}
+									if (!template_candidate_nodes.empty()) {
+										qualified_member_template_return_hint =
+											this->trySelectUnambiguousParserReturnTypeHint(
+												std::span<const ASTNode>(
+													template_candidate_nodes
+														.data(),
+													template_candidate_nodes
+														.size()));
+									}
+								}
+								ASTNode type_spec;
+								if (qualified_member_template_return_hint !=
+									nullptr) {
+									type_spec = emplace_node<TypeSpecifierNode>(
+										qualified_member_template_return_hint
+											->decl_node()
+											.type_specifier_node());
+								} else {
+									type_spec = emplace_node<TypeSpecifierNode>(
+										TypeIndex{}.withCategory(
+											TypeCategory::Auto),
+										0,
+										qualified_member_token,
+										CVQualifier::None,
+										ReferenceQualifier::None);
+								}
 								auto& member_decl = emplace_node<DeclarationNode>(type_spec, qualified_member_token).as<DeclarationNode>();
 								auto& func_decl_node = emplace_node<FunctionDeclarationNode>(member_decl).as<FunctionDeclarationNode>();
 								result = emplace_node<ExpressionNode>(
@@ -1812,9 +1882,113 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									}
 									setCallQualifiedName(
 										result->as<ExpressionNode>(),
-										buildQualifiedMemberCallName(
-											qualified_owner_segments,
-											qualified_member_token.value()));
+										qualified_member_call_name);
+									if (qualified_member_template_return_hint !=
+										nullptr) {
+										setCallParserReturnTypeHint(
+											result->as<ExpressionNode>(),
+											qualified_member_template_return_hint
+												->decl_node()
+												.type_specifier_node());
+									}
+									StringHandle current_owner_handle{};
+									TypeIndex current_owner_type_index{};
+									bool current_owner_is_valid = false;
+									if (resolved_current_owner.has_value() &&
+										resolved_current_owner->canonicalNameHandle()
+											.isValid()) {
+										current_owner_handle =
+											resolved_current_owner
+												->canonicalNameHandle();
+										if (resolved_current_owner
+												->resolved_type_info != nullptr) {
+											current_owner_type_index =
+												resolved_current_owner
+													->resolved_type_info
+													->registeredTypeIndex();
+										}
+										current_owner_is_valid = true;
+									} else if (!member_function_context_stack_.empty()) {
+										current_owner_handle =
+											member_function_context_stack_.back()
+												.struct_name;
+										current_owner_is_valid =
+											current_owner_handle.isValid();
+									} else if (!struct_parsing_context_stack_.empty() &&
+											   !struct_parsing_context_stack_.back()
+													.struct_name.empty()) {
+										current_owner_handle =
+											StringTable::getOrInternStringHandle(
+												struct_parsing_context_stack_.back()
+													.struct_name);
+										current_owner_is_valid =
+											current_owner_handle.isValid();
+									}
+									if (current_owner_is_valid) {
+										std::vector<
+											PostfixDependentMemberSegmentInfo>
+											member_segments;
+										if (!resolved_current_owner.has_value()) {
+											member_segments.reserve(
+												qualified_owner_segments.size() +
+												1);
+											for (StringHandle owner_segment :
+												 qualified_owner_segments) {
+												PostfixDependentMemberSegmentInfo
+													member_segment;
+												member_segment.name =
+													owner_segment;
+												member_segments.push_back(
+													std::move(member_segment));
+											}
+										}
+										PostfixDependentMemberSegmentInfo
+											final_member_segment;
+										final_member_segment.name =
+											qualified_member_token.handle()
+												.isValid()
+												? qualified_member_token.handle()
+												: StringTable::
+														getOrInternStringHandle(
+															qualified_member_token
+																.value());
+										final_member_segment.template_args =
+											toTemplateArgInfoList(
+												*member_template_args);
+										member_segments.push_back(
+											std::move(final_member_segment));
+										TypeInfo::DependentQualifiedNameRecord::
+											OwnerKind owner_kind =
+												resolved_current_owner.has_value()
+													? TypeInfo::
+														  DependentQualifiedNameRecord::
+															  OwnerKind::
+																  DependentInstantiation
+													: TypeInfo::
+														  DependentQualifiedNameRecord::
+															  OwnerKind::
+																  CurrentInstantiation;
+										InlineVector<
+											TypeInfo::TemplateArgInfo,
+											4> owner_template_arguments;
+										if (resolved_current_owner.has_value() &&
+											resolved_current_owner
+												 ->resolved_type_info !=
+												nullptr) {
+											owner_template_arguments =
+												resolved_current_owner
+													->resolved_type_info
+													->templateArgs();
+										}
+										setCallDependentQualifiedLookupRecord(
+											result->as<ExpressionNode>(),
+											makePostfixDependentQualifiedNameRecord(
+												current_owner_handle,
+												current_owner_type_index,
+												owner_kind,
+												owner_template_arguments,
+												member_segments));
+									}
 								}
 							}
 						} else {

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -128,16 +128,6 @@ void attachResolvedMemberCallMetadata(
 	std::span<const TypeSpecifierNode> arg_types,
 	bool has_deferred_template_call_args,
 	const FunctionDeclarationNode& func_decl) {
-	std::optional<std::string_view> qualified_name_override;
-	if (func_decl.is_member_function() &&
-		!func_decl.parent_struct_name().empty()) {
-		StringBuilder qualified_name_builder;
-		qualified_name_builder
-			.append(func_decl.parent_struct_name())
-			.append("::")
-			.append(func_decl.decl_node().identifier_token().value());
-		qualified_name_override = qualified_name_builder.commit();
-	}
 	attachResolvedPostfixDirectCallMetadata(
 		call_expr,
 		definition_context,
@@ -147,7 +137,9 @@ void attachResolvedMemberCallMetadata(
 		func_decl,
 		true,
 		false,
-		qualified_name_override);
+		func_decl.is_member_function()
+			? tryBuildQualifiedCallNameOverride(func_decl)
+			: std::nullopt);
 }
 
 const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_spec, bool allow_pointers) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -291,24 +291,6 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 	return record;
 }
 
-std::optional<FunctionCallDefinitionLookupRecord> makeDeferredFunctionCallDefinitionLookupRecord(
-	const TemplateDefinitionLookupContext* definition_context,
-	const Token& callee_token,
-	bool ordinary_lookup_included,
-	bool argument_dependent_lookup_included) {
-	if (definition_context == nullptr ||
-		!definition_context->is_valid() ||
-		callee_token.type() != Token::Type::Identifier) {
-		return std::nullopt;
-	}
-
-	FunctionCallDefinitionLookupRecord record;
-	initializeCallLookupRecordCommon(record, definition_context, callee_token);
-	record.ordinary_lookup_included = ordinary_lookup_included;
-	record.argument_dependent_lookup_included = argument_dependent_lookup_included;
-	return record;
-}
-
 std::optional<std::string_view> makeQualifiedMemberCallNameOverride(
 	std::string_view owner_name,
 	std::string_view member_name) {
@@ -3785,7 +3767,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						? &*deferred_definition_lookup_context
 						: current_template_definition_lookup_context_;
 				if (std::optional<FunctionCallDefinitionLookupRecord> record =
-						makeDeferredFunctionCallDefinitionLookupRecord(
+						tryBuildDeferredFunctionCallDefinitionLookupRecord(
 							definition_lookup_context,
 							qual_id.identifier_token(),
 							true,
@@ -4883,7 +4865,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							? &*deferred_definition_lookup_context
 							: current_template_definition_lookup_context_;
 					if (std::optional<FunctionCallDefinitionLookupRecord> record =
-							makeDeferredFunctionCallDefinitionLookupRecord(
+							tryBuildDeferredFunctionCallDefinitionLookupRecord(
 								definition_lookup_context,
 								qual_id.identifier_token(),
 								true,
@@ -6622,7 +6604,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							setCallDependentUnqualifiedLookupRecord(result->as<ExpressionNode>(), *record);
 						}
 					} else if (std::optional<FunctionCallDefinitionLookupRecord> record =
-								   makeDeferredFunctionCallDefinitionLookupRecord(
+								   tryBuildDeferredFunctionCallDefinitionLookupRecord(
 									   current_template_definition_lookup_context_,
 									   identifier_token,
 									   true,
@@ -9432,7 +9414,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											true,
 											*identifierType);
 									} else if (std::optional<FunctionCallDefinitionLookupRecord> record =
-												   makeDeferredFunctionCallDefinitionLookupRecord(
+												   tryBuildDeferredFunctionCallDefinitionLookupRecord(
 													   current_template_definition_lookup_context_,
 													   identifier_token,
 													   true,

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -291,19 +291,6 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 	return record;
 }
 
-std::optional<std::string_view> makeQualifiedMemberCallNameOverride(
-	std::string_view owner_name,
-	std::string_view member_name) {
-	if (owner_name.empty()) {
-		return std::nullopt;
-	}
-	return StringBuilder()
-		.append(owner_name)
-		.append("::")
-		.append(member_name)
-		.commit();
-}
-
 void attachResolvedOrdinaryDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,
@@ -320,14 +307,12 @@ void attachResolvedOrdinaryDirectCallMetadata(
 
 	if (qualified_name_override.has_value() && !qualified_name_override->empty()) {
 		setCallQualifiedName(call_expr, *qualified_name_override);
-	} else if (!func_decl.parent_struct_name().empty()) {
+	} else if (std::optional<std::string_view> member_qualified_name =
+				   tryBuildQualifiedCallNameOverride(func_decl);
+			   member_qualified_name.has_value()) {
 		setCallQualifiedName(
 			call_expr,
-			StringBuilder()
-				.append(func_decl.parent_struct_name())
-				.append("::")
-				.append(func_decl.decl_node().identifier_token().value())
-				.commit());
+			*member_qualified_name);
 	}
 
 	if (std::optional<FunctionCallDefinitionLookupRecord> record =
@@ -359,14 +344,12 @@ void attachDeferredOrdinaryDirectCallHints(
 	std::optional<std::string_view> qualified_name_override) {
 	if (qualified_name_override.has_value() && !qualified_name_override->empty()) {
 		setCallQualifiedName(call_expr, *qualified_name_override);
-	} else if (!func_decl.parent_struct_name().empty()) {
+	} else if (std::optional<std::string_view> member_qualified_name =
+				   tryBuildQualifiedCallNameOverride(func_decl);
+			   member_qualified_name.has_value()) {
 		setCallQualifiedName(
 			call_expr,
-			StringBuilder()
-				.append(func_decl.parent_struct_name())
-				.append("::")
-				.append(func_decl.decl_node().identifier_token().value())
-				.commit());
+			*member_qualified_name);
 	}
 	setCallParserReturnTypeHint(
 		call_expr,
@@ -415,7 +398,7 @@ void attachResolvedReceiverDirectCallMetadata(
 		func_decl,
 		true,
 		false,
-		makeQualifiedMemberCallNameOverride(
+		tryBuildQualifiedCallNameOverride(
 			qualified_owner,
 			func_decl.decl_node().identifier_token().value()));
 }
@@ -9319,7 +9302,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								qualified_owner = StringTable::getStringView(member_function_context_stack_.back().struct_name);
 							}
 							const std::optional<std::string_view> qualified_name_override =
-								makeQualifiedMemberCallNameOverride(
+								tryBuildQualifiedCallNameOverride(
 									qualified_owner,
 									func_decl.decl_node().identifier_token().value());
 							std::vector<TypeSpecifierNode> fast_path_arg_types;
@@ -9682,7 +9665,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 													struct_parsing_context_stack_.back().struct_name;
 											}
 											qualified_name_override =
-												makeQualifiedMemberCallNameOverride(
+												tryBuildQualifiedCallNameOverride(
 													struct_name_for_qual,
 													identifier_token.value());
 										}

--- a/tests/test_template_explicit_base_member_template_dependent_arg_ret0.cpp
+++ b/tests/test_template_explicit_base_member_template_dependent_arg_ret0.cpp
@@ -1,0 +1,23 @@
+template <class T>
+struct Base {
+	template <class U>
+	int pick(U value = U{1}) {
+		return static_cast<int>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base<T> {
+	template <class U>
+	int pick(U value = U{1}) {
+		return static_cast<int>(value) + 100;
+	}
+
+	int run() {
+		return this->Base::template pick<T>() - 1;
+	}
+};
+
+int main() {
+	return Holder<int>{}.run();
+}


### PR DESCRIPTION
## Summary
- replace the explicit-base postfix member-template placeholder path with structured deferred definition metadata instead of compatibility-only qualified or mangled-name materialization
- reuse a shared helper for deferred call definition records across parser and substitution code
- add a focused regression for dependent explicit-base member-template calls and update the audit docs with covered and remaining paths

## Root cause
The parser still had one explicit-base member-template placeholder path that preserved only compatibility names after owner resolution had already succeeded. That dropped structured owner and template-call shape information during deferred replay.
