### PR TITLE
[codex] Preserve structured template direct-call metadata

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-18
+**Last updated:** 2026-06-19
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -81,6 +81,11 @@ the areas that were previously blocking standards-visible behavior:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list, instead of carrying only `mangled_name`
+- ordinary direct calls to concrete template-origin functions now also
+  preserve `FunctionCallDefinitionLookupRecord` even outside a valid template
+  definition context, so sema-normalized wrapper calls like
+  `callBase(holder)` stay on sema-owned resolved-call metadata instead of
+  reviving parser-selected call targets late
 - the remaining untyped ordinary direct-call fallback exits no longer keep a
   parser-selected callee as the call's semantic identity just to preserve
   parse-time typing; they now carry an explicit parser return-type hint plus
@@ -288,6 +293,10 @@ Latest progress:
   `FunctionCallDefinitionLookupRecord` instead of only stamping
   `mangled_name`, including unqualified overload-resolution paths in template
   bodies and namespace-qualified direct-call materialization
+- concrete template-origin ordinary direct calls in non-template bodies now
+  preserve that same structured lookup record too, rather than requiring a
+  sema-side parser-target compatibility escape hatch once the parser already
+  knows the concrete instantiated `FunctionDeclarationNode`
 
 Desired end state:
 
@@ -358,6 +367,14 @@ Remaining near-term scope:
 - the sibling postfix explicit-qualified operator-template placeholder is now
   on that same structured path as well: short-owner
   `holder.Base::template operator()<int>()` calls canonicalize the nested owner
+  metadata before substitution instantiates the concrete base-qualified
+  operator template
+- the next direct-call ownership cleanup should stay on this side of the
+  parser/sema boundary: consolidate the remaining ordinary template-
+  instantiation call builders so every concrete template-origin direct call
+  goes through the same `FunctionCallDefinitionLookupRecord` helper, then
+  tighten the normalized-body invariant so sema no longer needs bare parser
+  callee identity where a structured lookup record could have been preserved
   before template instantiation, preserve the deferred qualified-owner record
   when parsing must stay deferred, and keep the matched operator-template
   return type on the placeholder instead of falling back to global

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -355,6 +355,13 @@ Remaining near-term scope:
   return type instead of a raw `auto` stub, and let substitution instantiate
   the concrete base-qualified member template once `T` becomes concrete instead
   of rebinding by bare member name
+- the sibling postfix explicit-qualified operator-template placeholder is now
+  on that same structured path as well: short-owner
+  `holder.Base::template operator()<int>()` calls canonicalize the nested owner
+  before template instantiation, preserve the deferred qualified-owner record
+  when parsing must stay deferred, and keep the matched operator-template
+  return type on the placeholder instead of falling back to global
+  same-spelled owners
 - the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
   now fixed at the parser/substitution boundary; future work here should keep
   pack-expansion ownership at that boundary instead of reintroducing
@@ -424,14 +431,19 @@ Next direct-call target:
    template-id structure through the same structured deferred qualified-call
    record used by the other qualified/member-template paths instead of dropping
    the `Base<T>` template-id before the `::template` continuation.
+   The sibling postfix explicit-qualified operator-template placeholder without
+   owner template arguments is now covered too: short nested-owner
+   `Base::template operator()<int>()` spellings canonicalize the owner before
+   instantiation and preserve the same deferred qualified-owner metadata plus
+   parser return-type hints when parsing must stay deferred, which closes the
+   nested-owner collision that had still allowed a global same-spelled `Base`
+   to win during trailing `decltype(...)` parsing.
    Immediate next target: audit the remaining qualified/member-template
    placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
    `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
-   after owner resolution or deferred lookup shape is already known. After
-   this slice, the most direct uncovered neighbor is the postfix explicit-
-   qualified operator-template placeholder path, which still needs the same
-   owner-preserving deferred lookup treatment that now covers
-   `this->Base::template pick<T>()`. Keep
+   after owner resolution or deferred lookup shape is already known, then use
+   those preserved records to delete the remaining whole-call sema
+   synchronization hook. Keep
    `test_member_template_func_in_specialization_ret0.cpp` in the focused
    guard set here: it exercises the new "candidate-bearing concrete owner
    calls must defer instead of hard-failing" rule in
@@ -476,6 +488,8 @@ When changing this area, always rerun:
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_operator_template_decltype_ret0.cpp`
+- `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`
 - `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
@@ -519,12 +533,17 @@ When changing this area, always rerun:
    owner metadata with member-template-derived parser return-type hints. This
    slice now does the same for the explicit-base postfix member-template
    placeholder in `parse_member_postfix()`, including late substitution-time
-   owner-qualified instantiation once `T` becomes concrete. The next concrete
-   parser target is therefore the remaining
+   owner-qualified instantiation once `T` becomes concrete, and it now closes
+   the sibling postfix explicit-qualified operator-template placeholder too:
+   short nested-owner `Base::template operator()<int>()` calls no longer
+   instantiate against a global same-spelled owner during trailing
+   `decltype(...)` parsing, and deferred cases preserve the same structured
+   owner metadata plus parser return-type hints as the member-template branch.
+   The next concrete parser target is therefore the remaining
    qualified/member-template placeholder/materializer exits that still stamp
    only compatibility metadata after owner resolution or deferred lookup shape
-   is already known, with the postfix explicit-qualified operator-template
-   placeholder as the most direct follow-up. Also
+   is already known, plus the last whole-call sema synchronization hook that
+   still compensates for those compatibility boundaries. Also
    clean up the remaining legacy parser sites that still
    hand-roll `expr...` handling (constructor/initializer parsing) so they share
    the same "expand only when a real function pack matched, otherwise preserve
@@ -560,6 +579,8 @@ When changing this area, always rerun:
    member/operator builders are
    `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
    `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_operator_template_decltype_ret0.cpp`,
+   `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`,
    `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
    and
    `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -86,6 +86,11 @@ the areas that were previously blocking standards-visible behavior:
   definition context, so sema-normalized wrapper calls like
   `callBase(holder)` stay on sema-owned resolved-call metadata instead of
   reviving parser-selected call targets late
+- the remaining covered qualified/direct template-instantiation builders now
+  also normalize wrapper-vs-direct instantiation results through the same
+  concrete-function adoption rule, so structured call metadata no longer
+  depends on whether a parser branch received `FunctionDeclarationNode`
+  directly or inside a `TemplateFunctionDeclarationNode`
 - the remaining untyped ordinary direct-call fallback exits no longer keep a
   parser-selected callee as the call's semantic identity just to preserve
   parse-time typing; they now carry an explicit parser return-type hint plus
@@ -297,6 +302,10 @@ Latest progress:
   preserve that same structured lookup record too, rather than requiring a
   sema-side parser-target compatibility escape hatch once the parser already
   knows the concrete instantiated `FunctionDeclarationNode`
+- the covered qualified/direct template-instantiation branches now also reuse a
+  shared concrete-function adoption helper, shrinking the remaining branch-
+  specific drift where wrapper instantiations could silently drop back to
+  weaker call metadata
 
 Desired end state:
 
@@ -375,6 +384,10 @@ Remaining near-term scope:
   goes through the same `FunctionCallDefinitionLookupRecord` helper, then
   tighten the normalized-body invariant so sema no longer needs bare parser
   callee identity where a structured lookup record could have been preserved
+  earlier; after the newly-covered ordinary qualified/direct builders, the
+  next likely targets are the remaining member/callable-object
+  template-instantiation exits that still special-case bare
+  `FunctionDeclarationNode` results
   before template instantiation, preserve the deferred qualified-owner record
   when parsing must stay deferred, and keep the matched operator-template
   return type on the placeholder instead of falling back to global

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -338,6 +338,12 @@ Remaining near-term scope:
   member-template return type on the placeholder instead of a raw `auto` stub,
   and substitution instantiates the concrete base-qualified member template
   once `T` becomes concrete instead of rebinding by unqualified member name
+- the sibling postfix explicit-qualified operator-template placeholder is now
+  structural too: short-owner `holder.Base::template operator()<int>()`
+  spellings canonicalize the nested owner before instantiation, preserve the
+  deferred qualified-owner record when parsing must remain deferred, and keep
+  the matched operator-template return type instead of letting a global
+  same-spelled owner satisfy the parse
 - the newly fixed explicit-template-argument pack-expansion leak confirms the
   right layer for this class of problem: preserve the parser-only pack node
   until substitution instead of teaching deeper sema/template-argument logic to
@@ -401,10 +407,15 @@ Next direct-call target:
    `parse_member_postfix()` now preserves `Base<T>`-style owner template-ids
    through the `::template` continuation for both member-template and
    operator-template calls instead of dropping that structure before deferred
-   lookup. The next uncovered parser target is therefore narrower again:
-   the remaining qualified/member-template placeholder/materializer exits that
-   still stamp only compatibility metadata after owner resolution or deferred
-   lookup shape is already known.
+   lookup. The short-owner postfix explicit-qualified operator-template
+   placeholder is now covered too: nested `Base::template operator()<int>()`
+   spellings canonicalize the owner before instantiation and preserve the same
+   deferred qualified-owner metadata plus parser return-type hints when
+   parsing must stay deferred. The next uncovered parser target is therefore
+   narrower again: the remaining qualified/member-template
+   placeholder/materializer exits that still stamp only compatibility metadata
+   after owner resolution or deferred lookup shape is already known, followed
+   by the remaining whole-call sema synchronization hook.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -456,6 +467,8 @@ For work in this area, rerun:
 - `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
 - `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
+- `test_template_explicit_base_operator_template_decltype_ret0.cpp`
+- `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`
 - `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
 - `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
 - `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
@@ -499,10 +512,12 @@ For work in this area, rerun:
    exits that still stop at compatibility metadata after owner resolution
    already succeeded, and then remove the whole-call sema synchronization hook
    by pushing that work back to earlier semantic ownership. This slice closes
-   the explicit-base postfix member-template placeholder; the most direct next
-   follow-up is the sibling postfix explicit-qualified operator-template
-   placeholder, which still needs the same owner-preserving deferred lookup
-   treatment.
+   the explicit-base postfix member-template placeholder and the sibling
+   postfix explicit-qualified operator-template placeholder: short nested-owner
+   `Base::template operator()<int>()` spellings no longer instantiate against
+   a global same-spelled owner during trailing `decltype(...)` parsing, and
+   deferred cases preserve the same structured owner metadata plus parser
+   return-type hints as the member-template branch.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by
@@ -535,6 +550,8 @@ For work in this area, rerun:
    preservation are
    `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
    `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
+   `test_template_explicit_base_operator_template_decltype_ret0.cpp`,
+   `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`,
    `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
    and
    `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -89,6 +89,10 @@ blocking areas:
   a non-template body, so sema-normalized wrapper calls no longer need a
   parser-target compatibility path once the parser already knows the concrete
   instantiated function
+- the remaining covered qualified/direct template-instantiation builders now
+  also adopt concrete function results through the same wrapper-aware helper,
+  so preserving structured call metadata no longer depends on whether a parser
+  branch received a bare `FunctionDeclarationNode` or a wrapped template node
 - untyped ordinary direct-call fallback exits no longer need a parser-selected
   callee to keep parse-time typing alive: they now carry an explicit parser
   return-type hint on the call node plus either a deferred
@@ -276,6 +280,10 @@ Latest progress:
   preserve that same structured lookup record too, so sema can keep hard
   ownership of normalized direct-call target selection instead of accepting a
   parser-selected compatibility fallback for wrapper-style calls
+- the covered qualified/direct template-instantiation branches now also share
+  a common concrete-function adoption rule, shrinking the remaining
+  branch-specific drift where wrapper instantiations could still erase
+  sema-owned call metadata before normalization
 
 Why this matters:
 
@@ -351,7 +359,10 @@ Remaining near-term scope:
   remaining ordinary template-instantiation call builders through the same
   concrete-template direct-call record helper, then tighten the normalized
   sema invariant so direct-call ownership always comes from structured lookup
-  records when parser-time resolution already succeeded
+  records when parser-time resolution already succeeded; after the newly-
+  covered ordinary qualified/direct builders, the next likely targets are the
+  remaining member/callable-object template-instantiation exits that still
+  special-case bare `FunctionDeclarationNode` results
 - the sibling postfix explicit-qualified operator-template placeholder is now
   structural too: short-owner `holder.Base::template operator()<int>()`
   spellings canonicalize the nested owner before instantiation, preserve the

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-18
+**Last updated:** 2026-06-19
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -84,6 +84,11 @@ blocking areas:
 - string-literal user-defined literal calls now preserve
   `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
   name and argument list instead of carrying only `mangled_name`
+- ordinary direct calls to concrete template-origin functions now also
+  preserve `FunctionCallDefinitionLookupRecord` even when the call appears in
+  a non-template body, so sema-normalized wrapper calls no longer need a
+  parser-target compatibility path once the parser already knows the concrete
+  instantiated function
 - untyped ordinary direct-call fallback exits no longer need a parser-selected
   callee to keep parse-time typing alive: they now carry an explicit parser
   return-type hint on the call node plus either a deferred
@@ -267,6 +272,10 @@ Latest progress:
 - the highest-traffic non-dependent ordinary direct-call branches now preserve
   `FunctionCallDefinitionLookupRecord` directly, including unqualified
   overload-resolution in template bodies and namespace-qualified direct calls
+- concrete template-origin ordinary direct calls in non-template bodies now
+  preserve that same structured lookup record too, so sema can keep hard
+  ownership of normalized direct-call target selection instead of accepting a
+  parser-selected compatibility fallback for wrapper-style calls
 
 Why this matters:
 
@@ -338,6 +347,11 @@ Remaining near-term scope:
   member-template return type on the placeholder instead of a raw `auto` stub,
   and substitution instantiates the concrete base-qualified member template
   once `T` becomes concrete instead of rebinding by unqualified member name
+- the next standards-facing cleanup in this bucket should be to route the
+  remaining ordinary template-instantiation call builders through the same
+  concrete-template direct-call record helper, then tighten the normalized
+  sema invariant so direct-call ownership always comes from structured lookup
+  records when parser-time resolution already succeeded
 - the sibling postfix explicit-qualified operator-template placeholder is now
   structural too: short-owner `holder.Base::template operator()<int>()`
   spellings canonicalize the nested owner before instantiation, preserve the

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -147,6 +147,14 @@ inline const FunctionDeclarationNode* get_function_decl_node(const ASTNode& node
 	return nullptr;
 }
 
+inline const FunctionDeclarationNode* get_function_decl_node(
+	const std::optional<ASTNode>& node) {
+	if (!node.has_value()) {
+		return nullptr;
+	}
+	return get_function_decl_node(*node);
+}
+
 /// Non-const version of get_function_decl_node
 inline FunctionDeclarationNode* get_function_decl_node_mut(ASTNode& node) {
 	if (node.is<FunctionDeclarationNode>()) {

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -27,13 +27,10 @@ inline const FunctionDeclarationNode* getParserStoredDirectCallTarget(const Call
 }
 
 inline bool canBuildFunctionCallDefinitionLookupRecord(
-	const TemplateDefinitionLookupContext* definition_context,
 	const Token& callee_token,
 	std::span<const TypeSpecifierNode> arg_types,
 	bool has_deferred_template_call_args) {
-	if (definition_context == nullptr ||
-		!definition_context->is_valid() ||
-		has_deferred_template_call_args ||
+	if (has_deferred_template_call_args ||
 		callee_token.type() != Token::Type::Identifier) {
 		return false;
 	}
@@ -50,6 +47,13 @@ inline bool canBuildFunctionCallDefinitionLookupRecord(
 	return true;
 }
 
+inline bool isConcreteTemplateOriginDirectCallTarget(
+	const FunctionDeclarationNode& func_decl) {
+	return func_decl.has_template_declaration_position() &&
+		!func_decl.is_template_pattern() &&
+		func_decl.has_mangled_name();
+}
+
 inline std::optional<FunctionCallDefinitionLookupRecord> tryBuildFunctionCallDefinitionLookupRecord(
 	const TemplateDefinitionLookupContext* definition_context,
 	const Token& callee_token,
@@ -59,15 +63,23 @@ inline std::optional<FunctionCallDefinitionLookupRecord> tryBuildFunctionCallDef
 	bool ordinary_lookup_included,
 	bool argument_dependent_lookup_included) {
 	if (!canBuildFunctionCallDefinitionLookupRecord(
-			definition_context,
 			callee_token,
 			arg_types,
 			has_deferred_template_call_args)) {
 		return std::nullopt;
 	}
+	const bool has_definition_context =
+		definition_context != nullptr &&
+		definition_context->is_valid();
+	if (!has_definition_context &&
+		!isConcreteTemplateOriginDirectCallTarget(func_decl)) {
+		return std::nullopt;
+	}
 
 	FunctionCallDefinitionLookupRecord record;
-	record.definition_context = *definition_context;
+	if (has_definition_context) {
+		record.definition_context = *definition_context;
+	}
 	record.callee_name = callee_token.handle();
 	record.resolved_function = &func_decl;
 	if (func_decl.has_mangled_name()) {
@@ -318,7 +330,7 @@ inline ExpressionNode makeCallExprFromNode(const ASTNode& callee_node, ChunkedVe
 	if (callee_node.is<TemplateFunctionDeclarationNode>()) {
 		const ASTNode& function_decl = callee_node.as<TemplateFunctionDeclarationNode>().function_declaration();
 		if (function_decl.is<FunctionDeclarationNode>()) {
-			return makeDirectCallExpr(function_decl.as<FunctionDeclarationNode>().decl_node(), std::move(arguments), called_from_token);
+			return makeResolvedCallExpr(function_decl.as<FunctionDeclarationNode>(), std::move(arguments), called_from_token);
 		}
 		throw InternalError("TemplateFunctionDeclarationNode call target is missing FunctionDeclarationNode");
 	}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1256,11 +1256,13 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 			}
 		}
 
-		FunctionDeclarationNode* func_ref_ptr = nullptr;
-		if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-			func_ref_ptr = &instantiated_func->as<FunctionDeclarationNode>();
+		const FunctionDeclarationNode* instantiated_func_decl =
+			get_function_decl_node(instantiated_func);
+		const FunctionDeclarationNode* func_ref_ptr = nullptr;
+		if (instantiated_func_decl != nullptr) {
+			func_ref_ptr = instantiated_func_decl;
 		} else if (known_member_func) {
-			func_ref_ptr = const_cast<FunctionDeclarationNode*>(known_member_func);
+			func_ref_ptr = known_member_func;
 		} else {
 			ASTNode temp_type;
 			if (member_call_return_type_hint.has_value()) {
@@ -1289,8 +1291,7 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 				result->as<ExpressionNode>(),
 				*member_call_return_type_hint);
 		}
-		if ((instantiated_func.has_value() &&
-			 instantiated_func->is<FunctionDeclarationNode>()) ||
+		if (instantiated_func_decl != nullptr ||
 			known_member_func != nullptr) {
 			attachResolvedMemberCallMetadata(
 				result->as<ExpressionNode>(),
@@ -2411,9 +2412,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 										class_scope,
 										final_identifier.value(),
 										std::span<const TemplateTypeArg>{});
-								if (instantiated_func.has_value() && instantiated_func->is<FunctionDeclarationNode>()) {
-									qualified_symbol = instantiated_func;
-									decl_ptr = &instantiated_func->as<FunctionDeclarationNode>().decl_node();
+								if (const FunctionDeclarationNode* func_decl =
+										get_function_decl_node(instantiated_func);
+									func_decl != nullptr) {
+									qualified_symbol = ASTNode(func_decl);
+									decl_ptr = &func_decl->decl_node();
 								}
 							}
 						}
@@ -2441,9 +2444,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							// Also try without namespace prefix
 							template_inst = try_instantiate_template_explicit(final_identifier.value(), *template_args, arg_types);
 						}
-						if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-							qualified_symbol = *template_inst;
-							decl_ptr = &template_inst->as<FunctionDeclarationNode>().decl_node();
+						if (const FunctionDeclarationNode* func_decl =
+								get_function_decl_node(template_inst);
+							func_decl != nullptr) {
+							qualified_symbol = ASTNode(func_decl);
+							decl_ptr = &func_decl->decl_node();
 							FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template with explicit args: ", qualified_name);
 						}
 					}
@@ -2453,9 +2458,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						// Try to instantiate the qualified template function
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
-							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-								qualified_symbol = *template_inst;
-								decl_ptr = &template_inst->as<FunctionDeclarationNode>().decl_node();
+							if (const FunctionDeclarationNode* func_decl =
+									get_function_decl_node(template_inst);
+								func_decl != nullptr) {
+								qualified_symbol = ASTNode(func_decl);
+								decl_ptr = &func_decl->decl_node();
 								FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template: ", qualified_name);
 							}
 						}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -2412,11 +2412,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 										class_scope,
 										final_identifier.value(),
 										std::span<const TemplateTypeArg>{});
-								if (const FunctionDeclarationNode* func_decl =
+								if (const FunctionDeclarationNode* instantiated_func_decl =
 										get_function_decl_node(instantiated_func);
-									func_decl != nullptr) {
-									qualified_symbol = ASTNode(func_decl);
-									decl_ptr = &func_decl->decl_node();
+									instantiated_func_decl != nullptr) {
+									qualified_symbol = ASTNode(instantiated_func_decl);
+									decl_ptr = &instantiated_func_decl->decl_node();
 								}
 							}
 						}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1583,6 +1583,60 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 
 		return matched_candidate;
 	};
+	auto tryResolveCanonicalQualifiedOwnerName =
+		[&](const ASTNode& object_expr,
+			std::span<const StringHandle> owner_segments)
+			-> std::optional<std::string_view> {
+			if (owner_segments.empty()) {
+				return std::nullopt;
+			}
+
+			if (owner_segments.front().isValid()) {
+				const std::string_view root_owner_name =
+					StringTable::getStringView(owner_segments.front());
+				if (std::optional<AliasTemplateMaterializationResult>
+						resolved_current_owner =
+							tryResolveQualifiedTypeOwnerFromCurrentContext(
+								root_owner_name);
+					resolved_current_owner.has_value() &&
+					!resolved_current_owner->canonicalName().empty()) {
+					if (owner_segments.size() == 1) {
+						return resolved_current_owner->canonicalName();
+					}
+
+					std::vector<QualifiedTypeMemberAccess> owner_chain;
+					owner_chain.reserve(owner_segments.size() - 1);
+					for (size_t owner_index = 1;
+						 owner_index < owner_segments.size();
+						 ++owner_index) {
+						QualifiedTypeMemberAccess member_access;
+						member_access.member_name = owner_segments[owner_index];
+						owner_chain.push_back(std::move(member_access));
+					}
+
+					if (const TypeInfo* resolved_owner =
+							resolveBaseClassMemberTypeChain(
+								resolved_current_owner->canonicalName(),
+								std::span<const QualifiedTypeMemberAccess>(
+									owner_chain.data(),
+									owner_chain.size()));
+						resolved_owner != nullptr) {
+						return StringTable::getStringView(
+							resolved_owner->name());
+					}
+				}
+			}
+
+			if (const StructTypeInfo* owner_struct =
+					tryResolveQualifiedOwnerStruct(
+						object_expr,
+						owner_segments);
+				owner_struct != nullptr) {
+				return StringTable::getStringView(owner_struct->name);
+			}
+
+			return std::nullopt;
+		};
 	auto tryInstantiateQualifiedMemberTemplateCall =
 		[&](const ASTNode& object_expr,
 			std::span<const StringHandle> owner_segments,
@@ -1591,32 +1645,20 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			std::span<const TypeSpecifierNode> arg_types,
 			bool has_call_args,
 			bool has_dependent_call_args) -> std::optional<ASTNode> {
-			const StructTypeInfo* owner_struct =
-				tryResolveQualifiedOwnerStruct(object_expr, owner_segments);
-			if (!owner_struct) {
+			if (explicit_template_args.has_value() &&
+				postfixExplicitTemplateArgsRequireDeferredInstantiation(
+					*explicit_template_args)) {
 				return std::nullopt;
 			}
-			std::string_view owner_name_for_lookup =
-				StringTable::getStringView(owner_struct->name);
-			if (owner_segments.size() == 1 &&
-				owner_segments.front().isValid()) {
-				const std::string_view owner_segment_name =
-					StringTable::getStringView(owner_segments.front());
-				if (owner_name_for_lookup == owner_segment_name &&
-					!owner_segment_name.empty()) {
-					if (std::optional<AliasTemplateMaterializationResult>
-							resolved_current_owner =
-								tryResolveQualifiedTypeOwnerFromCurrentContext(
-									owner_segment_name);
-						resolved_current_owner.has_value() &&
-						!resolved_current_owner->canonicalName().empty()) {
-						owner_name_for_lookup =
-							resolved_current_owner->canonicalName();
-					}
-				}
+			std::optional<std::string_view> canonical_owner_name =
+				tryResolveCanonicalQualifiedOwnerName(
+					object_expr,
+					owner_segments);
+			if (!canonical_owner_name.has_value()) {
+				return std::nullopt;
 			}
 			return tryInstantiateMemberFunctionTemplateCall(
-				owner_name_for_lookup,
+				*canonical_owner_name,
 				member_name,
 				explicit_template_args,
 				arg_types,
@@ -1634,6 +1676,8 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				buildQualifiedMemberCallName(
 					owner_segments,
 					member_token.value());
+			std::string_view qualified_member_template_lookup_name =
+				qualified_member_call_name;
 			const FunctionDeclarationNode*
 				qualified_member_template_return_hint = nullptr;
 			std::optional<AliasTemplateMaterializationResult>
@@ -1650,12 +1694,30 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							.append("::")
 							.append(member_token.value())
 							.commit();
+					qualified_member_template_lookup_name =
+						StringBuilder()
+							.append(resolved_current_owner->canonicalName())
+							.append("::")
+							.append(member_token.value())
+							.commit();
 				}
+			}
+			if (std::optional<std::string_view> canonical_owner_name =
+					tryResolveCanonicalQualifiedOwnerName(
+						object_expr,
+						owner_segments);
+				canonical_owner_name.has_value()) {
+				qualified_member_template_lookup_name =
+					StringBuilder()
+						.append(*canonical_owner_name)
+						.append("::")
+						.append(member_token.value())
+						.commit();
 			}
 			const std::vector<TemplateNameLookupCandidate>
 				template_candidates =
 					lookupFunctionTemplateCandidatesForInstantiation(
-						qualified_member_call_name,
+						qualified_member_template_lookup_name,
 						0);
 			std::vector<ASTNode> template_candidate_nodes;
 			template_candidate_nodes.reserve(template_candidates.size());
@@ -1949,7 +2011,8 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							if (instantiated_func.has_value() &&
 								instantiated_func->is<FunctionDeclarationNode>()) {
 								resolved_func =
-									&instantiated_func->as<FunctionDeclarationNode>();
+									&instantiated_func
+										 ->as<FunctionDeclarationNode>();
 							} else if (!member_template_args.has_value()) {
 								resolved_func =
 									tryResolveQualifiedMemberFunctionCall(
@@ -2071,7 +2134,8 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 							if (instantiated_func.has_value() &&
 								instantiated_func->is<FunctionDeclarationNode>()) {
 								resolved_func =
-									&instantiated_func->as<FunctionDeclarationNode>();
+									&instantiated_func
+										 ->as<FunctionDeclarationNode>();
 							} else if (!member_template_args.has_value()) {
 								resolved_func =
 									tryResolveQualifiedMemberFunctionCall(

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1595,13 +1595,193 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			if (!owner_struct) {
 				return std::nullopt;
 			}
+			std::string_view owner_name_for_lookup =
+				StringTable::getStringView(owner_struct->name);
+			if (owner_segments.size() == 1 &&
+				owner_segments.front().isValid()) {
+				const std::string_view owner_segment_name =
+					StringTable::getStringView(owner_segments.front());
+				if (owner_name_for_lookup == owner_segment_name &&
+					!owner_segment_name.empty()) {
+					if (std::optional<AliasTemplateMaterializationResult>
+							resolved_current_owner =
+								tryResolveQualifiedTypeOwnerFromCurrentContext(
+									owner_segment_name);
+						resolved_current_owner.has_value() &&
+						!resolved_current_owner->canonicalName().empty()) {
+						owner_name_for_lookup =
+							resolved_current_owner->canonicalName();
+					}
+				}
+			}
 			return tryInstantiateMemberFunctionTemplateCall(
-				StringTable::getStringView(owner_struct->name),
+				owner_name_for_lookup,
 				member_name,
 				explicit_template_args,
 				arg_types,
 				has_call_args,
 				has_dependent_call_args);
+		};
+	auto buildDeferredQualifiedMemberTemplatePlaceholder =
+		[&](const ASTNode& object_expr,
+			std::span<const StringHandle> owner_segments,
+			const Token& member_token,
+			const InlineVector<TemplateTypeArg, 4>& member_template_args,
+			std::vector<ASTNode>&& member_template_arg_nodes,
+			ChunkedVector<ASTNode>&& args) -> ASTNode {
+			std::string_view qualified_member_call_name =
+				buildQualifiedMemberCallName(
+					owner_segments,
+					member_token.value());
+			const FunctionDeclarationNode*
+				qualified_member_template_return_hint = nullptr;
+			std::optional<AliasTemplateMaterializationResult>
+				resolved_current_owner;
+			if (owner_segments.size() == 1) {
+				resolved_current_owner =
+					tryResolveQualifiedTypeOwnerFromCurrentContext(
+						StringTable::getStringView(owner_segments.front()));
+				if (resolved_current_owner.has_value() &&
+					!resolved_current_owner->canonicalName().empty()) {
+					qualified_member_call_name =
+						StringBuilder()
+							.append(resolved_current_owner->canonicalName())
+							.append("::")
+							.append(member_token.value())
+							.commit();
+				}
+			}
+			const std::vector<TemplateNameLookupCandidate>
+				template_candidates =
+					lookupFunctionTemplateCandidatesForInstantiation(
+						qualified_member_call_name,
+						0);
+			std::vector<ASTNode> template_candidate_nodes;
+			template_candidate_nodes.reserve(template_candidates.size());
+			for (const TemplateNameLookupCandidate& candidate :
+				 template_candidates) {
+				template_candidate_nodes.push_back(candidate.declaration);
+			}
+			if (!template_candidate_nodes.empty()) {
+				qualified_member_template_return_hint =
+					this->trySelectUnambiguousParserReturnTypeHint(
+						std::span<const ASTNode>(
+							template_candidate_nodes.data(),
+							template_candidate_nodes.size()));
+			}
+
+			ASTNode type_spec;
+			if (qualified_member_template_return_hint != nullptr) {
+				type_spec = emplace_node<TypeSpecifierNode>(
+					qualified_member_template_return_hint
+						->decl_node()
+						.type_specifier_node());
+			} else {
+				type_spec = emplace_node<TypeSpecifierNode>(
+					TypeIndex{}.withCategory(TypeCategory::Auto),
+					0,
+					member_token,
+					CVQualifier::None,
+					ReferenceQualifier::None);
+			}
+			auto& member_decl =
+				emplace_node<DeclarationNode>(type_spec, member_token)
+					.as<DeclarationNode>();
+			auto& func_decl_node =
+				emplace_node<FunctionDeclarationNode>(member_decl)
+					.as<FunctionDeclarationNode>();
+			ASTNode deferred_call = emplace_node<ExpressionNode>(
+				makeResolvedMemberCallExpr(
+					object_expr,
+					func_decl_node,
+					std::move(args),
+					member_token));
+			if (!member_template_arg_nodes.empty()) {
+				setCallTemplateArguments(
+					deferred_call.as<ExpressionNode>(),
+					std::move(member_template_arg_nodes));
+			}
+			setCallQualifiedName(
+				deferred_call.as<ExpressionNode>(),
+				qualified_member_call_name);
+			if (qualified_member_template_return_hint != nullptr) {
+				setCallParserReturnTypeHint(
+					deferred_call.as<ExpressionNode>(),
+					qualified_member_template_return_hint
+						->decl_node()
+						.type_specifier_node());
+			}
+
+			StringHandle current_owner_handle{};
+			TypeIndex current_owner_type_index{};
+			bool current_owner_is_valid = false;
+			if (resolved_current_owner.has_value() &&
+				resolved_current_owner->canonicalNameHandle().isValid()) {
+				current_owner_handle =
+					resolved_current_owner->canonicalNameHandle();
+				if (resolved_current_owner->resolved_type_info != nullptr) {
+					current_owner_type_index =
+						resolved_current_owner->resolved_type_info
+							->registeredTypeIndex();
+				}
+				current_owner_is_valid = true;
+			} else if (!member_function_context_stack_.empty()) {
+				current_owner_handle =
+					member_function_context_stack_.back().struct_name;
+				current_owner_is_valid = current_owner_handle.isValid();
+			} else if (!struct_parsing_context_stack_.empty() &&
+					   !struct_parsing_context_stack_.back().struct_name.empty()) {
+				current_owner_handle =
+					StringTable::getOrInternStringHandle(
+						struct_parsing_context_stack_.back().struct_name);
+				current_owner_is_valid = current_owner_handle.isValid();
+			}
+
+			if (current_owner_is_valid) {
+				std::vector<PostfixDependentMemberSegmentInfo>
+					member_segments;
+				if (!resolved_current_owner.has_value()) {
+					member_segments.reserve(owner_segments.size() + 1);
+					for (StringHandle owner_segment : owner_segments) {
+						PostfixDependentMemberSegmentInfo member_segment;
+						member_segment.name = owner_segment;
+						member_segments.push_back(std::move(member_segment));
+					}
+				}
+				PostfixDependentMemberSegmentInfo final_member_segment;
+				final_member_segment.name =
+					member_token.handle().isValid()
+						? member_token.handle()
+						: StringTable::getOrInternStringHandle(
+								member_token.value());
+				final_member_segment.template_args =
+					toTemplateArgInfoList(member_template_args);
+				member_segments.push_back(std::move(final_member_segment));
+				TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind =
+					resolved_current_owner.has_value()
+						? TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+							  DependentInstantiation
+						: TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+							  CurrentInstantiation;
+				InlineVector<TypeInfo::TemplateArgInfo, 4>
+					owner_template_arguments;
+				if (resolved_current_owner.has_value() &&
+					resolved_current_owner->resolved_type_info != nullptr) {
+					owner_template_arguments =
+						resolved_current_owner->resolved_type_info
+							->templateArgs();
+				}
+				setCallDependentQualifiedLookupRecord(
+					deferred_call.as<ExpressionNode>(),
+					makePostfixDependentQualifiedNameRecord(
+						current_owner_handle,
+						current_owner_type_index,
+						owner_kind,
+						owner_template_arguments,
+						member_segments));
+			}
+
+			return deferred_call;
 		};
 
 	// Handle postfix operators in a loop
@@ -1791,196 +1971,40 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									false,
 									*resolved_func);
 							} else {
-								std::string_view qualified_member_call_name =
-									buildQualifiedMemberCallName(
-										qualified_owner_segments,
-										qualified_member_token.value());
-								const FunctionDeclarationNode*
-									qualified_member_template_return_hint =
-										nullptr;
-								std::optional<
-									AliasTemplateMaterializationResult>
-									resolved_current_owner;
 								if (member_template_args.has_value()) {
-									if (qualified_owner_segments.size() == 1) {
-										resolved_current_owner =
-											tryResolveQualifiedTypeOwnerFromCurrentContext(
-												StringTable::getStringView(
-													qualified_owner_segments.front()));
-										if (resolved_current_owner.has_value() &&
-											!resolved_current_owner
-												 ->canonicalName()
-												 .empty()) {
-											qualified_member_call_name =
-												StringBuilder()
-													.append(
-														resolved_current_owner
-															->canonicalName())
-													.append("::")
-													.append(
-														qualified_member_token
-															.value())
-													.commit();
-										}
-									}
-									const std::vector<TemplateNameLookupCandidate>
-										template_candidates =
-											lookupFunctionTemplateCandidatesForInstantiation(
-												qualified_member_call_name,
-												0);
-									std::vector<ASTNode> template_candidate_nodes;
-									template_candidate_nodes.reserve(
-										template_candidates.size());
-									for (const TemplateNameLookupCandidate&
-											 candidate : template_candidates) {
-										template_candidate_nodes.push_back(
-											candidate.declaration);
-									}
-									if (!template_candidate_nodes.empty()) {
-										qualified_member_template_return_hint =
-											this->trySelectUnambiguousParserReturnTypeHint(
-												std::span<const ASTNode>(
-													template_candidate_nodes
-														.data(),
-													template_candidate_nodes
-														.size()));
-									}
-								}
-								ASTNode type_spec;
-								if (qualified_member_template_return_hint !=
-									nullptr) {
-									type_spec = emplace_node<TypeSpecifierNode>(
-										qualified_member_template_return_hint
-											->decl_node()
-											.type_specifier_node());
+									result =
+										buildDeferredQualifiedMemberTemplatePlaceholder(
+											object,
+											qualified_owner_segments,
+											qualified_member_token,
+											*member_template_args,
+											std::move(
+												member_template_arg_nodes),
+											std::move(args));
 								} else {
-									type_spec = emplace_node<TypeSpecifierNode>(
-										TypeIndex{}.withCategory(
-											TypeCategory::Auto),
-										0,
-										qualified_member_token,
-										CVQualifier::None,
-										ReferenceQualifier::None);
-								}
-								auto& member_decl = emplace_node<DeclarationNode>(type_spec, qualified_member_token).as<DeclarationNode>();
-								auto& func_decl_node = emplace_node<FunctionDeclarationNode>(member_decl).as<FunctionDeclarationNode>();
-								result = emplace_node<ExpressionNode>(
-									makeResolvedMemberCallExpr(object, func_decl_node, std::move(args), qualified_member_token));
-								if (member_template_args.has_value()) {
-									if (!member_template_arg_nodes.empty()) {
-										setCallTemplateArguments(
-											result->as<ExpressionNode>(),
-											std::move(member_template_arg_nodes));
-									}
-									setCallQualifiedName(
-										result->as<ExpressionNode>(),
-										qualified_member_call_name);
-									if (qualified_member_template_return_hint !=
-										nullptr) {
-										setCallParserReturnTypeHint(
-											result->as<ExpressionNode>(),
-											qualified_member_template_return_hint
-												->decl_node()
-												.type_specifier_node());
-									}
-									StringHandle current_owner_handle{};
-									TypeIndex current_owner_type_index{};
-									bool current_owner_is_valid = false;
-									if (resolved_current_owner.has_value() &&
-										resolved_current_owner->canonicalNameHandle()
-											.isValid()) {
-										current_owner_handle =
-											resolved_current_owner
-												->canonicalNameHandle();
-										if (resolved_current_owner
-												->resolved_type_info != nullptr) {
-											current_owner_type_index =
-												resolved_current_owner
-													->resolved_type_info
-													->registeredTypeIndex();
-										}
-										current_owner_is_valid = true;
-									} else if (!member_function_context_stack_.empty()) {
-										current_owner_handle =
-											member_function_context_stack_.back()
-												.struct_name;
-										current_owner_is_valid =
-											current_owner_handle.isValid();
-									} else if (!struct_parsing_context_stack_.empty() &&
-											   !struct_parsing_context_stack_.back()
-													.struct_name.empty()) {
-										current_owner_handle =
-											StringTable::getOrInternStringHandle(
-												struct_parsing_context_stack_.back()
-													.struct_name);
-										current_owner_is_valid =
-											current_owner_handle.isValid();
-									}
-									if (current_owner_is_valid) {
-										std::vector<
-											PostfixDependentMemberSegmentInfo>
-											member_segments;
-										if (!resolved_current_owner.has_value()) {
-											member_segments.reserve(
-												qualified_owner_segments.size() +
-												1);
-											for (StringHandle owner_segment :
-												 qualified_owner_segments) {
-												PostfixDependentMemberSegmentInfo
-													member_segment;
-												member_segment.name =
-													owner_segment;
-												member_segments.push_back(
-													std::move(member_segment));
-											}
-										}
-										PostfixDependentMemberSegmentInfo
-											final_member_segment;
-										final_member_segment.name =
-											qualified_member_token.handle()
-												.isValid()
-												? qualified_member_token.handle()
-												: StringTable::
-														getOrInternStringHandle(
-															qualified_member_token
-																.value());
-										final_member_segment.template_args =
-											toTemplateArgInfoList(
-												*member_template_args);
-										member_segments.push_back(
-											std::move(final_member_segment));
-										TypeInfo::DependentQualifiedNameRecord::
-											OwnerKind owner_kind =
-												resolved_current_owner.has_value()
-													? TypeInfo::
-														  DependentQualifiedNameRecord::
-															  OwnerKind::
-																  DependentInstantiation
-													: TypeInfo::
-														  DependentQualifiedNameRecord::
-															  OwnerKind::
-																  CurrentInstantiation;
-										InlineVector<
-											TypeInfo::TemplateArgInfo,
-											4> owner_template_arguments;
-										if (resolved_current_owner.has_value() &&
-											resolved_current_owner
-												 ->resolved_type_info !=
-												nullptr) {
-											owner_template_arguments =
-												resolved_current_owner
-													->resolved_type_info
-													->templateArgs();
-										}
-										setCallDependentQualifiedLookupRecord(
-											result->as<ExpressionNode>(),
-											makePostfixDependentQualifiedNameRecord(
-												current_owner_handle,
-												current_owner_type_index,
-												owner_kind,
-												owner_template_arguments,
-												member_segments));
-									}
+									ASTNode type_spec =
+										emplace_node<TypeSpecifierNode>(
+											TypeIndex{}.withCategory(
+												TypeCategory::Auto),
+											0,
+											qualified_member_token,
+											CVQualifier::None,
+											ReferenceQualifier::None);
+									auto& member_decl =
+										emplace_node<DeclarationNode>(
+											type_spec,
+											qualified_member_token)
+											.as<DeclarationNode>();
+									auto& func_decl_node =
+										emplace_node<FunctionDeclarationNode>(
+											member_decl)
+											.as<FunctionDeclarationNode>();
+									result = emplace_node<ExpressionNode>(
+										makeResolvedMemberCallExpr(
+											object,
+											func_decl_node,
+											std::move(args),
+											qualified_member_token));
 								}
 							}
 						} else {
@@ -2069,22 +2093,40 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									false,
 									*resolved_func);
 							} else {
-								auto type_spec = emplace_node<TypeSpecifierNode>(TypeIndex{}.withCategory(TypeCategory::Auto), 0, op_token, CVQualifier::None, ReferenceQualifier::None);
-								auto& member_decl = emplace_node<DeclarationNode>(type_spec, op_token).as<DeclarationNode>();
-								auto& func_decl_node = emplace_node<FunctionDeclarationNode>(member_decl).as<FunctionDeclarationNode>();
-								result = emplace_node<ExpressionNode>(
-									makeResolvedMemberCallExpr(object, func_decl_node, std::move(args_result.args), op_token));
 								if (member_template_args.has_value()) {
-									if (!member_template_arg_nodes.empty()) {
-										setCallTemplateArguments(
-											result->as<ExpressionNode>(),
-											std::move(member_template_arg_nodes));
-									}
-									setCallQualifiedName(
-										result->as<ExpressionNode>(),
-										buildQualifiedMemberCallName(
+									result =
+										buildDeferredQualifiedMemberTemplatePlaceholder(
+											object,
 											qualified_owner_segments,
-											op_token.value()));
+											op_token,
+											*member_template_args,
+											std::move(
+												member_template_arg_nodes),
+											std::move(args_result.args));
+								} else {
+									auto type_spec =
+										emplace_node<TypeSpecifierNode>(
+											TypeIndex{}.withCategory(
+												TypeCategory::Auto),
+											0,
+											op_token,
+											CVQualifier::None,
+											ReferenceQualifier::None);
+									auto& member_decl =
+										emplace_node<DeclarationNode>(
+											type_spec,
+											op_token)
+											.as<DeclarationNode>();
+									auto& func_decl_node =
+										emplace_node<FunctionDeclarationNode>(
+											member_decl)
+											.as<FunctionDeclarationNode>();
+									result = emplace_node<ExpressionNode>(
+										makeResolvedMemberCallExpr(
+											object,
+											func_decl_node,
+											std::move(args_result.args),
+											op_token));
 								}
 							}
 							handled = true;

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -216,11 +216,18 @@ bool isEligibleDefinitionLookupCall(
 	std::span<const TypeSpecifierNode> arg_types,
 	bool has_deferred_template_call_args,
 	const ASTNode& resolved_decl) {
-	if (definition_context == nullptr ||
-		!definition_context->is_valid() ||
-		has_deferred_template_call_args ||
+	if (has_deferred_template_call_args ||
 		callee_token.type() != Token::Type::Identifier ||
 		!resolved_decl.is<FunctionDeclarationNode>()) {
+		return false;
+	}
+	const FunctionDeclarationNode& func_decl =
+		resolved_decl.as<FunctionDeclarationNode>();
+	const bool has_definition_context =
+		definition_context != nullptr &&
+		definition_context->is_valid();
+	if (!has_definition_context &&
+		!isConcreteTemplateOriginDirectCallTarget(func_decl)) {
 		return false;
 	}
 	for (const TypeSpecifierNode& arg_type : arg_types) {
@@ -278,7 +285,8 @@ std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLook
 		return std::nullopt;
 	}
 
-	const FunctionDeclarationNode& func_decl = resolved_decl.as<FunctionDeclarationNode>();
+	const FunctionDeclarationNode& func_decl =
+		resolved_decl.as<FunctionDeclarationNode>();
 	FunctionCallDefinitionLookupRecord record;
 	initializeCallLookupRecordCommon(record, definition_context, callee_token);
 	record.resolved_function = &func_decl;
@@ -5601,8 +5609,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					FLASH_LOG_FORMAT(Templates, Debug, "Trying function template instantiation for '{}' with {} args",
 									 qualified_template_name, template_args->size());
 					auto func_template_inst = try_instantiate_template_explicit(qualified_template_name, *template_args);
-					if (func_template_inst.has_value() && func_template_inst->is<FunctionDeclarationNode>()) {
-						identifierType = *func_template_inst;
+					if (func_template_inst.has_value()) {
+						if (const FunctionDeclarationNode* func_decl =
+								get_function_decl_node(*func_template_inst);
+							func_decl != nullptr) {
+							identifierType = ASTNode(func_decl);
+						}
 						FLASH_LOG(Templates, Debug, "Successfully instantiated function template with explicit arguments");
 					}
 				}
@@ -6092,17 +6104,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				template_func_inst = try_instantiate_template(identifier_token.value(), arg_types);
 			}
 
-			if (template_func_inst.has_value() && template_func_inst->is<FunctionDeclarationNode>()) {
-				const auto& func = template_func_inst->as<FunctionDeclarationNode>();
+			const FunctionDeclarationNode* template_func_decl =
+				template_func_inst.has_value()
+					? get_function_decl_node(*template_func_inst)
+					: nullptr;
+			if (template_func_decl != nullptr) {
 				auto function_call_node = emplace_node<ExpressionNode>(
-					makeResolvedCallExpr(func, std::move(args), identifier_token));
+					makeResolvedCallExpr(*template_func_decl, std::move(args), identifier_token));
 				attachResolvedOrdinaryDirectCallMetadata(
 					function_call_node.as<ExpressionNode>(),
 					current_template_definition_lookup_context_,
 					identifier_token,
 					arg_types,
 					false,
-					func,
+					*template_func_decl,
 					true,
 					true);
 
@@ -6613,20 +6628,55 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				}
 
 				auto make_call_result = [&](const ASTNode& resolved_decl) -> ParseResult {
-					const DeclarationNode* decl_ptr = getDeclarationNode(resolved_decl);
+					std::optional<ASTNode> materialized_resolved_decl;
+					const ASTNode* call_target = &resolved_decl;
+					if (resolved_decl.is<TemplateFunctionDeclarationNode>()) {
+						if (current_linkage_ != Linkage::C) {
+							materialized_resolved_decl =
+								try_instantiate_template(
+									identifier_token.value(),
+									arg_types);
+							if (!materialized_resolved_decl.has_value()) {
+								materialized_resolved_decl =
+									tryInstantiateAdlTemplateCandidates(
+										identifier_token.handle(),
+										true,
+										arg_types,
+										all_overloads);
+							}
+						}
+						if (!materialized_resolved_decl.has_value()) {
+							return ParseResult::error(
+								"No matching function for call to '" +
+									std::string(identifier_token.value()) + "\'",
+								identifier_token);
+						}
+						call_target = &*materialized_resolved_decl;
+						if (const FunctionDeclarationNode* func_decl =
+								get_function_decl_node(*call_target);
+							func_decl != nullptr) {
+							if (auto err = appendMissingDefaultArguments(*func_decl);
+								err.has_value()) {
+								return *err;
+							}
+						}
+					}
+
+					const DeclarationNode* decl_ptr = getDeclarationNode(*call_target);
 					if (!decl_ptr) {
 						return ParseResult::error("Invalid function declaration", identifier_token);
 					}
-					result = emplace_node<ExpressionNode>(makeCallExprFromNode(resolved_decl, std::move(args_ref), identifier_token));
-					if (resolved_decl.is<FunctionDeclarationNode>()) {
-						const FunctionDeclarationNode& func_decl = resolved_decl.as<FunctionDeclarationNode>();
+					result = emplace_node<ExpressionNode>(makeCallExprFromNode(*call_target, std::move(args_ref), identifier_token));
+					if (const FunctionDeclarationNode* func_decl =
+							get_function_decl_node(*call_target);
+						func_decl != nullptr) {
 						attachResolvedOrdinaryDirectCallMetadata(
 							result->as<ExpressionNode>(),
 							current_template_definition_lookup_context_,
 							identifier_token,
 							arg_types,
 							has_deferred_template_call_args,
-							func_decl,
+							*func_decl,
 							true,
 							argumentDependentLookupIncludedRuntime);
 					}
@@ -6636,7 +6686,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						has_deferred_template_call_args,
 						current_template_definition_lookup_context_,
 						argumentDependentLookupIncluded,
-						resolved_decl);
+						*call_target);
 					return ParseResult::success(*result);
 				};
 
@@ -6682,8 +6732,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							}
 							return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "\'", identifier_token);
 						}
-						if (instantiated_func->is<FunctionDeclarationNode>()) {
-							if (auto err = appendMissingDefaultArguments(instantiated_func->as<FunctionDeclarationNode>()); err.has_value()) {
+						if (const FunctionDeclarationNode* func_decl =
+								get_function_decl_node(*instantiated_func);
+							func_decl != nullptr) {
+							if (auto err = appendMissingDefaultArguments(*func_decl); err.has_value()) {
 								return *err;
 							}
 						}
@@ -6758,8 +6810,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							}
 							return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "\'", identifier_token);
 						}
-						if (instantiated_func->is<FunctionDeclarationNode>()) {
-							if (auto err = appendMissingDefaultArguments(instantiated_func->as<FunctionDeclarationNode>()); err.has_value()) {
+						if (const FunctionDeclarationNode* func_decl =
+								get_function_decl_node(*instantiated_func);
+							func_decl != nullptr) {
+							if (auto err = appendMissingDefaultArguments(*func_decl); err.has_value()) {
 								return *err;
 							}
 						}
@@ -6908,17 +6962,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						create_unresolved_call_decl_if_deferred();
 					}
 
-					if (template_func_inst.has_value() && template_func_inst->is<FunctionDeclarationNode>()) {
-						const auto& func = template_func_inst->as<FunctionDeclarationNode>();
+					const FunctionDeclarationNode* template_func_decl =
+						template_func_inst.has_value()
+							? get_function_decl_node(*template_func_inst)
+							: nullptr;
+					if (template_func_decl != nullptr) {
 						auto function_call_node = emplace_node<ExpressionNode>(
-							makeResolvedCallExpr(func, std::move(args), identifier_token));
+							makeResolvedCallExpr(*template_func_decl, std::move(args), identifier_token));
 						attachResolvedOrdinaryDirectCallMetadata(
 							function_call_node.as<ExpressionNode>(),
 							current_template_definition_lookup_context_,
 							identifier_token,
 							arg_types,
 							false,
-							func,
+							*template_func_decl,
 							true,
 							true);
 						result = function_call_node;
@@ -9635,8 +9692,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											}
 											return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "'", identifier_token);
 										}
-										if (instantiated_func->is<FunctionDeclarationNode>()) {
-											if (auto default_args_error = appendMissingDefaultArguments(instantiated_func->as<FunctionDeclarationNode>()); default_args_error.has_value()) {
+										if (const FunctionDeclarationNode* func_decl =
+												get_function_decl_node(*instantiated_func);
+											func_decl != nullptr) {
+											if (auto default_args_error = appendMissingDefaultArguments(*func_decl); default_args_error.has_value()) {
 												return *default_args_error;
 											}
 										}
@@ -9670,15 +9729,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 													identifier_token.value());
 										}
 
-										if (instantiated_func->is<FunctionDeclarationNode>()) {
-											const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
+										if (const FunctionDeclarationNode* func_decl =
+												get_function_decl_node(*instantiated_func);
+											func_decl != nullptr) {
 											attachResolvedOrdinaryDirectCallMetadata(
 												result->as<ExpressionNode>(),
 												current_template_definition_lookup_context_,
 												identifier_token,
 												arg_types,
 												false,
-												func_decl,
+												*func_decl,
 												true,
 												true,
 												qualified_name_override);
@@ -9803,8 +9863,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												}
 												return ParseResult::error("Call to deleted function '" + std::string(identifier_token.value()) + "'", identifier_token);
 											}
-											if (instantiated_func->is<FunctionDeclarationNode>()) {
-												if (auto default_args_error = appendMissingDefaultArguments(instantiated_func->as<FunctionDeclarationNode>()); default_args_error.has_value()) {
+											if (const FunctionDeclarationNode* func_decl =
+													get_function_decl_node(*instantiated_func);
+												func_decl != nullptr) {
+												if (auto default_args_error = appendMissingDefaultArguments(*func_decl); default_args_error.has_value()) {
 													return *default_args_error;
 												}
 											}
@@ -9815,15 +9877,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											}
 											result = emplace_node<ExpressionNode>(makeCallExprFromNode(*instantiated_func, std::move(args), identifier_token));
 
-											if (instantiated_func->is<FunctionDeclarationNode>()) {
-												const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
+											if (const FunctionDeclarationNode* func_decl =
+													get_function_decl_node(*instantiated_func);
+												func_decl != nullptr) {
 												attachResolvedOrdinaryDirectCallMetadata(
 													result->as<ExpressionNode>(),
 													current_template_definition_lookup_context_,
 													identifier_token,
 													arg_types,
 													false,
-													func_decl,
+													*func_decl,
 													true,
 													true);
 											}
@@ -9898,15 +9961,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												}
 												result = emplace_node<ExpressionNode>(makeCallExprFromNode(*instantiated_func, std::move(args), identifier_token));
 
-												if (instantiated_func->is<FunctionDeclarationNode>()) {
-													const FunctionDeclarationNode& func_decl = instantiated_func->as<FunctionDeclarationNode>();
+												if (const FunctionDeclarationNode* func_decl =
+														get_function_decl_node(*instantiated_func);
+													func_decl != nullptr) {
 													attachResolvedOrdinaryDirectCallMetadata(
 														result->as<ExpressionNode>(),
 														current_template_definition_lookup_context_,
 														identifier_token,
 														arg_types,
 														false,
-														func_decl,
+														*func_decl,
 														true,
 														true);
 												}
@@ -9937,32 +10001,66 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											}
 										} else {
 											// Get the selected overload
-											const DeclarationNode* decl_ptr = getDeclarationNode(*resolution_result.selected_overload);
+											std::optional<ASTNode> materialized_selected_overload;
+											const ASTNode* selected_overload =
+												resolution_result.selected_overload;
+											if (selected_overload->is<TemplateFunctionDeclarationNode>()) {
+												if (current_linkage_ != Linkage::C) {
+													materialized_selected_overload =
+														try_instantiate_template(
+															identifier_token.value(),
+															arg_types);
+													if (!materialized_selected_overload.has_value()) {
+														materialized_selected_overload =
+															tryInstantiateAdlTemplateCandidates(
+																identifier_token.handle(),
+																true,
+																arg_types,
+																all_overloads);
+													}
+												}
+												if (!materialized_selected_overload.has_value()) {
+													return ParseResult::error(
+														"No matching function for call to '" +
+															std::string(identifier_token.value()) + "'",
+														identifier_token);
+												}
+												selected_overload =
+													&*materialized_selected_overload;
+											}
+											const DeclarationNode* decl_ptr =
+												getDeclarationNode(*selected_overload);
 											if (!decl_ptr) {
 												return ParseResult::error("Invalid function declaration", identifier_token);
 											}
 
 											// Fill in default arguments for missing parameters
-											if (resolution_result.selected_overload->is<FunctionDeclarationNode>()) {
-												const auto& func_decl = resolution_result.selected_overload->as<FunctionDeclarationNode>();
-												if (auto err = appendMissingDefaultArguments(func_decl); err.has_value()) {
+											if (const FunctionDeclarationNode* func_decl =
+													get_function_decl_node(*selected_overload);
+												func_decl != nullptr) {
+												if (auto err = appendMissingDefaultArguments(*func_decl); err.has_value()) {
 													return *err;
 												}
 											}
 
-											result = emplace_node<ExpressionNode>(makeCallExprFromNode(*resolution_result.selected_overload, std::move(args), identifier_token));
+											result = emplace_node<ExpressionNode>(
+												makeCallExprFromNode(
+													*selected_overload,
+													std::move(args),
+													identifier_token));
 
 											// If the function has a pre-computed mangled name, set it on the call expression
 											// This is important for functions in namespaces accessed via using directives
-											if (resolution_result.selected_overload->is<FunctionDeclarationNode>()) {
-												const FunctionDeclarationNode& func_decl = resolution_result.selected_overload->as<FunctionDeclarationNode>();
+											if (const FunctionDeclarationNode* func_decl =
+													get_function_decl_node(*selected_overload);
+												func_decl != nullptr) {
 												attachResolvedOrdinaryDirectCallMetadata(
 													result->as<ExpressionNode>(),
 													current_template_definition_lookup_context_,
 													identifier_token,
 													arg_types,
 													has_deferred_call_args,
-													func_decl,
+													*func_decl,
 													true,
 													true);
 											}
@@ -9972,7 +10070,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												has_deferred_call_args,
 												current_template_definition_lookup_context_,
 												true,
-												*resolution_result.selected_overload);
+												*selected_overload);
 										}
 									}
 								}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -59,14 +59,6 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 	});
 }
 
-const FunctionDeclarationNode* tryGetConcreteInstantiatedFunction(
-	const std::optional<ASTNode>& instantiated_node) {
-	if (!instantiated_node.has_value()) {
-		return nullptr;
-	}
-	return get_function_decl_node(*instantiated_node);
-}
-
 bool isNestedOwnerExtension(
 	std::string_view owner_name,
 	std::string_view resolved_owner_name) {
@@ -218,39 +210,6 @@ std::string_view buildDependentQualifiedCallName(
 	return qualified_name_builder.commit();
 }
 
-bool isEligibleDefinitionLookupCall(
-	const TemplateDefinitionLookupContext* definition_context,
-	const Token& callee_token,
-	std::span<const TypeSpecifierNode> arg_types,
-	bool has_deferred_template_call_args,
-	const ASTNode& resolved_decl) {
-	if (has_deferred_template_call_args ||
-		callee_token.type() != Token::Type::Identifier ||
-		!resolved_decl.is<FunctionDeclarationNode>()) {
-		return false;
-	}
-	const FunctionDeclarationNode& func_decl =
-		resolved_decl.as<FunctionDeclarationNode>();
-	const bool has_definition_context =
-		definition_context != nullptr &&
-		definition_context->is_valid();
-	if (!has_definition_context &&
-		!isConcreteTemplateOriginDirectCallTarget(func_decl)) {
-		return false;
-	}
-	for (const TypeSpecifierNode& arg_type : arg_types) {
-		if (arg_type.category() == TypeCategory::Auto ||
-			arg_type.category() == TypeCategory::Template) {
-			return false;
-		}
-		if (!arg_type.type_index().is_valid() &&
-			!is_builtin_type(arg_type.category())) {
-			return false;
-		}
-	}
-	return true;
-}
-
 template <typename LookupRecordT>
 void initializeCallLookupRecordCommon(
 	LookupRecordT& record,
@@ -274,37 +233,6 @@ void setDefinitionBoundFunction(
 			StringTable::getOrInternStringHandle(
 				definition_bound_function->mangled_name());
 	}
-}
-
-std::optional<FunctionCallDefinitionLookupRecord> makeFunctionCallDefinitionLookupRecord(
-	const TemplateDefinitionLookupContext* definition_context,
-	const Token& callee_token,
-	std::span<const TypeSpecifierNode> arg_types,
-	bool has_deferred_template_call_args,
-	const ASTNode& resolved_decl,
-	bool ordinary_lookup_included,
-	bool argument_dependent_lookup_included) {
-	if (!isEligibleDefinitionLookupCall(
-			definition_context,
-			callee_token,
-			arg_types,
-			has_deferred_template_call_args,
-			resolved_decl)) {
-		return std::nullopt;
-	}
-
-	const FunctionDeclarationNode& func_decl =
-		resolved_decl.as<FunctionDeclarationNode>();
-	FunctionCallDefinitionLookupRecord record;
-	initializeCallLookupRecordCommon(record, definition_context, callee_token);
-	record.resolved_function = &func_decl;
-	if (func_decl.has_mangled_name()) {
-		record.resolved_mangled_name =
-			StringTable::getOrInternStringHandle(func_decl.mangled_name());
-	}
-	record.ordinary_lookup_included = ordinary_lookup_included;
-	record.argument_dependent_lookup_included = argument_dependent_lookup_included;
-	return record;
 }
 
 void attachResolvedOrdinaryDirectCallMetadata(
@@ -332,12 +260,12 @@ void attachResolvedOrdinaryDirectCallMetadata(
 	}
 
 	if (std::optional<FunctionCallDefinitionLookupRecord> record =
-			makeFunctionCallDefinitionLookupRecord(
+			tryBuildFunctionCallDefinitionLookupRecord(
 				definition_context,
 				callee_token,
 				arg_types,
 				has_deferred_template_call_args,
-				ASTNode(&func_decl),
+				func_decl,
 				ordinary_lookup_included,
 				argument_dependent_lookup_included);
 		record.has_value()) {
@@ -3632,7 +3560,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
 					}
 					if (const FunctionDeclarationNode* func_decl =
-							tryGetConcreteInstantiatedFunction(template_inst);
+							get_function_decl_node(template_inst);
 						func_decl != nullptr) {
 						identifierType = ASTNode(func_decl);
 						FLASH_LOG(Parser, Debug, "Successfully instantiated explicit qualified template: ", qualified_name);
@@ -3645,7 +3573,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (!arg_types.empty()) {
 						std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
 						if (const FunctionDeclarationNode* func_decl =
-								tryGetConcreteInstantiatedFunction(template_inst);
+								get_function_decl_node(template_inst);
 							func_decl != nullptr) {
 							identifierType = ASTNode(func_decl);
 							FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template: ", qualified_name);
@@ -3732,12 +3660,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					FLASH_LOG(Parser, Debug, "Set mangled name on qualified call expression: {}", func_decl.mangled_name());
 				}
 				if (std::optional<FunctionCallDefinitionLookupRecord> record =
-						makeFunctionCallDefinitionLookupRecord(
+						tryBuildFunctionCallDefinitionLookupRecord(
 							current_template_definition_lookup_context_,
 							qual_id.identifier_token(),
 							arg_types,
 							has_deferred_qualified_call_args,
-							*identifierType,
+							func_decl,
 							true,
 							false);
 					record.has_value()) {
@@ -4724,7 +4652,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							}
 
 							if (const FunctionDeclarationNode* func_decl =
-									tryGetConcreteInstantiatedFunction(template_inst);
+									get_function_decl_node(template_inst);
 								func_decl != nullptr) {
 								identifierType = ASTNode(func_decl);
 								FLASH_LOG_FORMAT(Parser, Debug, "Successfully instantiated function template '{}' with explicit arguments", qualified_name);
@@ -4742,7 +4670,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
 							if (const FunctionDeclarationNode* func_decl =
-									tryGetConcreteInstantiatedFunction(template_inst);
+									get_function_decl_node(template_inst);
 								func_decl != nullptr) {
 								identifierType = ASTNode(func_decl);
 							}
@@ -4832,12 +4760,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
 					}
 					if (std::optional<FunctionCallDefinitionLookupRecord> record =
-							makeFunctionCallDefinitionLookupRecord(
+							tryBuildFunctionCallDefinitionLookupRecord(
 								current_template_definition_lookup_context_,
 								qual_id.identifier_token(),
 								arg_types,
 								has_deferred_qualified_call_args,
-								*identifierType,
+								func_decl,
 								true,
 								false);
 						record.has_value()) {
@@ -5675,7 +5603,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										 qualified_name, template_args->size());
 						std::optional<ASTNode> template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
 						if (const FunctionDeclarationNode* func_decl =
-								tryGetConcreteInstantiatedFunction(template_inst);
+								get_function_decl_node(template_inst);
 							func_decl != nullptr) {
 							identifierType = ASTNode(func_decl);
 							FLASH_LOG(Templates, Debug, "Successfully instantiated function template with explicit arguments");
@@ -5685,7 +5613,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
 							if (const FunctionDeclarationNode* func_decl =
-									tryGetConcreteInstantiatedFunction(template_inst);
+									get_function_decl_node(template_inst);
 								func_decl != nullptr) {
 								identifierType = ASTNode(func_decl);
 							} else {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5553,12 +5553,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					FLASH_LOG_FORMAT(Templates, Debug, "Trying function template instantiation for '{}' with {} args",
 									 qualified_template_name, template_args->size());
 					auto func_template_inst = try_instantiate_template_explicit(qualified_template_name, *template_args);
-					if (func_template_inst.has_value()) {
-						if (const FunctionDeclarationNode* func_decl =
-								get_function_decl_node(*func_template_inst);
-							func_decl != nullptr) {
-							identifierType = ASTNode(func_decl);
-						}
+					if (const FunctionDeclarationNode* func_decl =
+							get_function_decl_node(func_template_inst);
+						func_decl != nullptr) {
+						identifierType = ASTNode(func_decl);
 						FLASH_LOG(Templates, Debug, "Successfully instantiated function template with explicit arguments");
 					}
 				}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -59,6 +59,14 @@ bool explicitTemplateArgsRequireDeferredInstantiation(const InlineVector<Templat
 	});
 }
 
+const FunctionDeclarationNode* tryGetConcreteInstantiatedFunction(
+	const std::optional<ASTNode>& instantiated_node) {
+	if (!instantiated_node.has_value()) {
+		return nullptr;
+	}
+	return get_function_decl_node(*instantiated_node);
+}
+
 bool isNestedOwnerExtension(
 	std::string_view owner_name,
 	std::string_view resolved_owner_name) {
@@ -3623,8 +3631,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (!template_inst.has_value()) {
 						template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
 					}
-					if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-						identifierType = *template_inst;
+					if (const FunctionDeclarationNode* func_decl =
+							tryGetConcreteInstantiatedFunction(template_inst);
+						func_decl != nullptr) {
+						identifierType = ASTNode(func_decl);
 						FLASH_LOG(Parser, Debug, "Successfully instantiated explicit qualified template: ", qualified_name);
 					}
 				}
@@ -3634,8 +3644,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					// Try to instantiate the qualified template function
 					if (!arg_types.empty()) {
 						std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
-						if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-							identifierType = *template_inst;
+						if (const FunctionDeclarationNode* func_decl =
+								tryGetConcreteInstantiatedFunction(template_inst);
+							func_decl != nullptr) {
+							identifierType = ASTNode(func_decl);
 							FLASH_LOG(Parser, Debug, "Successfully instantiated qualified template: ", qualified_name);
 						}
 					}
@@ -4711,8 +4723,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								template_inst = try_instantiate_template_explicit(qual_id.name(), *template_args, arg_types);
 							}
 
-							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-								identifierType = *template_inst;
+							if (const FunctionDeclarationNode* func_decl =
+									tryGetConcreteInstantiatedFunction(template_inst);
+								func_decl != nullptr) {
+								identifierType = ASTNode(func_decl);
 								FLASH_LOG_FORMAT(Parser, Debug, "Successfully instantiated function template '{}' with explicit arguments", qualified_name);
 							}
 						}
@@ -4727,8 +4741,10 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						// Try to instantiate the qualified template function
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
-							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-								identifierType = *template_inst;
+							if (const FunctionDeclarationNode* func_decl =
+									tryGetConcreteInstantiatedFunction(template_inst);
+								func_decl != nullptr) {
+								identifierType = ASTNode(func_decl);
 							}
 						}
 					}
@@ -5658,16 +5674,20 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						FLASH_LOG_FORMAT(Templates, Debug, "Instantiating function template '{}' with {} explicit template arguments",
 										 qualified_name, template_args->size());
 						std::optional<ASTNode> template_inst = try_instantiate_template_explicit(qualified_name, *template_args, arg_types);
-						if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-							identifierType = *template_inst;
+						if (const FunctionDeclarationNode* func_decl =
+								tryGetConcreteInstantiatedFunction(template_inst);
+							func_decl != nullptr) {
+							identifierType = ASTNode(func_decl);
 							FLASH_LOG(Templates, Debug, "Successfully instantiated function template with explicit arguments");
 						}
 					} else {
 						// Try to instantiate the qualified template function using argument deduction
 						if (!arg_types.empty()) {
 							std::optional<ASTNode> template_inst = try_instantiate_template(qualified_name, arg_types);
-							if (template_inst.has_value() && template_inst->is<FunctionDeclarationNode>()) {
-								identifierType = *template_inst;
+							if (const FunctionDeclarationNode* func_decl =
+									tryGetConcreteInstantiatedFunction(template_inst);
+								func_decl != nullptr) {
+								identifierType = ASTNode(func_decl);
 							} else {
 							}
 						} else {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8433,7 +8433,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		parser_selected_static_target != nullptr) {
 		return parser_selected_static_target;
 	}
-
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
 	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
 	if (!func_decl && op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {

--- a/tests/test_template_explicit_base_operator_template_decltype_ret0.cpp
+++ b/tests/test_template_explicit_base_operator_template_decltype_ret0.cpp
@@ -1,0 +1,30 @@
+struct Base {
+	template <class U>
+	long operator()(U value = U{1}) {
+		return static_cast<long>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base {
+	template <class U>
+	char operator()(U value) {
+		return static_cast<char>(value);
+	}
+};
+
+template <class T>
+auto callBase(Holder<T>& holder)
+	-> decltype(holder.Base::template operator()<int>()) {
+	return holder.Base::template operator()<int>();
+}
+
+int main() {
+	return sizeof(
+			   decltype(
+				   callBase(
+					   *static_cast<Holder<void>*>(nullptr))))
+			== sizeof(long)
+		? 0
+		: 1;
+}

--- a/tests/test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp
+++ b/tests/test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp
@@ -1,0 +1,31 @@
+struct Base {
+	template <class U>
+	char operator()(U value = U{1}) {
+		return static_cast<char>(value + 10);
+	}
+};
+
+template <class T>
+struct Outer {
+	struct Base {
+		template <class U>
+		long operator()(U value = U{2}) {
+			return static_cast<long>(value + 40);
+		}
+	};
+
+	struct Holder : Base {};
+
+	static auto call(Holder& holder)
+		-> decltype(holder.Base::template operator()<int>()) {
+		return holder.Base::template operator()<int>();
+	}
+};
+
+int main() {
+	Outer<void>::Holder holder;
+	return sizeof(decltype(Outer<void>::call(holder))) == sizeof(long) &&
+			Outer<void>::call(holder) == 42
+		? 0
+		: 1;
+}

--- a/tests/test_template_explicit_base_operator_template_runtime_wrapper_ret0.cpp
+++ b/tests/test_template_explicit_base_operator_template_runtime_wrapper_ret0.cpp
@@ -1,0 +1,25 @@
+struct Base {
+	template <class U>
+	long operator()(U value = U{1}) {
+		return static_cast<long>(value);
+	}
+};
+
+template <class T>
+struct Holder : Base {
+	template <class U>
+	char operator()(U value) {
+		return static_cast<char>(value);
+	}
+};
+
+template <class T>
+auto callBase(Holder<T>& holder)
+	-> decltype(holder.Base::template operator()<int>()) {
+	return holder.Base::template operator()<int>();
+}
+
+int main() {
+	Holder<void> holder;
+	return callBase(holder) == 1 ? 0 : 1;
+}

--- a/tests/test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp
+++ b/tests/test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp
@@ -1,0 +1,20 @@
+template <class T>
+struct Base {
+	template <class U>
+	static long pick() {
+		return static_cast<long>(sizeof(T) + sizeof(U));
+	}
+};
+
+template <class T>
+struct Holder : Base<T> {
+	using PickType = decltype(Base<T>::template pick<T>());
+
+	static int run() {
+		return sizeof(PickType) == sizeof(long) ? 0 : 1;
+	}
+};
+
+int main() {
+	return Holder<int>::run();
+}

--- a/tests/test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp
+++ b/tests/test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp
@@ -7,11 +7,21 @@ struct Base {
 };
 
 template <class T>
+struct IsExactLong {
+	static constexpr int value = 0;
+};
+
+template <>
+struct IsExactLong<long> {
+	static constexpr int value = 1;
+};
+
+template <class T>
 struct Holder : Base<T> {
 	using PickType = decltype(Base<T>::template pick<T>());
 
 	static int run() {
-		return sizeof(PickType) == sizeof(long) ? 0 : 1;
+		return IsExactLong<PickType>::value ? 0 : 1;
 	}
 };
 

--- a/tests/test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp
+++ b/tests/test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp
@@ -1,0 +1,28 @@
+template <class T>
+struct Base {
+	template <class U>
+	static char pick() {
+		return 0;
+	}
+};
+
+template <class T>
+struct Outer {
+	template <class U>
+	struct Base {
+		template <class V>
+		static long pick() {
+			return 0;
+		}
+	};
+
+	using PickType = decltype(Base<T>::template pick<T>());
+
+	static int run() {
+		return sizeof(PickType) == sizeof(long) ? 0 : 1;
+	}
+};
+
+int main() {
+	return Outer<int>::run();
+}

--- a/tests/test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp
+++ b/tests/test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp
@@ -7,6 +7,16 @@ struct Base {
 };
 
 template <class T>
+struct IsExactLong {
+	static constexpr int value = 0;
+};
+
+template <>
+struct IsExactLong<long> {
+	static constexpr int value = 1;
+};
+
+template <class T>
 struct Outer {
 	template <class U>
 	struct Base {
@@ -19,7 +29,7 @@ struct Outer {
 	using PickType = decltype(Base<T>::template pick<T>());
 
 	static int run() {
-		return sizeof(PickType) == sizeof(long) ? 0 : 1;
+		return IsExactLong<PickType>::value ? 0 : 1;
 	}
 };
 

--- a/tests/test_template_qualified_static_member_template_deferred_decltype_ret0.cpp
+++ b/tests/test_template_qualified_static_member_template_deferred_decltype_ret0.cpp
@@ -1,0 +1,14 @@
+template <class T>
+struct Host {
+	template <class U>
+	static long value() {
+		return static_cast<long>(sizeof(U) + sizeof(T));
+	}
+};
+
+template <class T>
+using HostValue = decltype(Host<T>::template value<T>());
+
+int main() {
+	return sizeof(HostValue<int>) == sizeof(long) ? 0 : 1;
+}

--- a/tests/test_template_qualified_static_member_template_deferred_decltype_ret0.cpp
+++ b/tests/test_template_qualified_static_member_template_deferred_decltype_ret0.cpp
@@ -7,8 +7,18 @@ struct Host {
 };
 
 template <class T>
+struct IsExactLong {
+	static constexpr int value = 0;
+};
+
+template <>
+struct IsExactLong<long> {
+	static constexpr int value = 1;
+};
+
+template <class T>
 using HostValue = decltype(Host<T>::template value<T>());
 
 int main() {
-	return sizeof(HostValue<int>) == sizeof(long) ? 0 : 1;
+	return IsExactLong<HostValue<int>>::value ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- preserve structured direct-call metadata for concrete template instantiations instead of relying on parser-selected fallback targets
- carry postfix/operator-template owner identity through qualified and wrapper-style call construction
- unify wrapper/direct `FunctionDeclarationNode` adoption and shared definition-lookup record construction across ordinary and postfix call paths
- document the architectural slice and remaining follow-up in the template-argument audit and investigation notes

## Root Cause
Several parser entry points treated instantiated template call targets inconsistently. Some paths kept template-wrapper shapes or rebuilt meaning from parser-selected names instead of preserving the concrete `FunctionDeclarationNode` plus lookup metadata that sema needs. That let standards-visible cases like qualified member-template calls, postfix operator-template calls, and `decltype(...)` wrapper paths drift into compatibility behavior instead of sema-owned resolution.

## What Changed
- `CallNodeHelpers.h` now centralizes the concrete-template-origin direct-call guard and shared call-target construction rules.
- Ordinary direct-call parsing now preserves sema-owned metadata for concrete template-origin wrappers and uses the shared lookup-record builder instead of duplicating eligibility logic locally.
- Postfix/member-call parsing now preserves concrete instantiated owners and routes wrapper/direct adoption through the same shared function-extraction helper.
- Shared AST helpers now expose `get_function_decl_node(std::optional<ASTNode>)` so parser paths no longer need local wrapper-unwrapping helpers.
- The planning docs were updated to reflect the completed slice and the remaining high-impact follow-up.

## User Impact
This closes a set of C++20 template-infrastructure gaps where explicit or qualified template calls could lose canonical callee identity before semantic analysis. The result is less parser-owned fallback behavior and more reliable sema resolution for direct calls, static member calls, postfix operator templates, and dependent `decltype(...)` paths.
