### PR TITLE
[codex] Finish structured qualified/member call materializers

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -469,13 +469,20 @@ Next direct-call target:
    parser return-type hints when parsing must stay deferred, which closes the
    nested-owner collision that had still allowed a global same-spelled `Base`
    to win during trailing `decltype(...)` parsing.
-   Immediate next target: audit the remaining legacy resolved-call builders in
-   `Parser_Expr_PrimaryExpr.cpp` / `Parser_Expr_PostfixCalls.cpp` that still do
-   not share the same sema-owned metadata attachment path, then revisit the
-   last unrelated static-member whole-call sema synchronization leg. Keep
-   `test_member_template_func_in_specialization_ret0.cpp` in the focused
-   guard set here: it exercises the new "candidate-bearing concrete owner
-   calls must defer instead of hard-failing" rule in
+   That follow-up is now closed for the remaining targeted qualified direct-call
+   builders in `Parser_Expr_PrimaryExpr.cpp`: the global-qualified and
+   namespace-qualified explicit-function-id exits no longer stop at
+   `qualified_name` / `mangled_name` compatibility metadata once the matched
+   declaration shape is already known, and they now preserve the same
+   definition-bound direct-call record plus parser return-type hints as the
+   shared ordinary-call helper path. The remaining next step in this area is
+   therefore narrower: keep `Parser_Expr_PostfixCalls.cpp` in audit mode for
+   any newly-exposed qualified/member-template builder drift, but the only
+   concrete targeted code still left is the unrelated static-member whole-call
+   sema synchronization leg. Keep
+   `test_member_template_func_in_specialization_ret0.cpp` in the focused guard
+   set here: it exercises the new "candidate-bearing concrete owner calls must
+   defer instead of hard-failing" rule in
    `try_parse_member_template_function_call(...)`.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -450,10 +450,11 @@ Next direct-call target:
 
 ## Next steps
 
-1. Finish the remaining parser/materialization sites that still preserve only
-   `qualified_name` / `mangled_name` after owner resolution already succeeded,
-   and move them onto the same deferred lookup + parser return-type-hint split
-   now used by the covered ordinary-call paths.
+1. Finish the remaining legacy resolved-call sites that still hand-roll
+   qualified/member metadata or parser return-type hints after owner resolution
+   already succeeded, now that the compatibility-only
+   placeholder/materializer exits in `Parser_Expr_PostfixCalls.cpp` are
+   covered.
    The postfix explicit-qualified member/operator owner-template-id exits in
    `Parser_Expr_PostfixCalls.cpp` are now covered too: `parse_member_postfix()`
    consumes qualifiers like `this->Base<T>::template pick<int>()` and
@@ -468,12 +469,10 @@ Next direct-call target:
    parser return-type hints when parsing must stay deferred, which closes the
    nested-owner collision that had still allowed a global same-spelled `Base`
    to win during trailing `decltype(...)` parsing.
-   Immediate next target: audit the remaining qualified/member-template
-   placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
-   `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
-   after owner resolution or deferred lookup shape is already known, then use
-   those preserved records to delete the remaining whole-call sema
-   synchronization hook. Keep
+   Immediate next target: audit the remaining legacy resolved-call builders in
+   `Parser_Expr_PrimaryExpr.cpp` / `Parser_Expr_PostfixCalls.cpp` that still do
+   not share the same sema-owned metadata attachment path, then revisit the
+   last unrelated static-member whole-call sema synchronization leg. Keep
    `test_member_template_func_in_specialization_ret0.cpp` in the focused
    guard set here: it exercises the new "candidate-bearing concrete owner
    calls must defer instead of hard-failing" rule in
@@ -569,15 +568,21 @@ When changing this area, always rerun:
    instantiate against a global same-spelled owner during trailing
    `decltype(...)` parsing, and deferred cases preserve the same structured
    owner metadata plus parser return-type hints as the member-template branch.
-   The next concrete parser target is therefore the remaining
-   qualified/member-template placeholder/materializer exits that still stamp
-   only compatibility metadata after owner resolution or deferred lookup shape
-   is already known, plus the last whole-call sema synchronization hook that
-   still compensates for those compatibility boundaries. Also
-   clean up the remaining legacy parser sites that still
-   hand-roll `expr...` handling (constructor/initializer parsing) so they share
-   the same "expand only when a real function pack matched, otherwise preserve
-   the pack node" rule now enforced in ordinary call parsing.
+   This follow-up closes the remaining targeted postfix/current
+   qualified/member-template compatibility-only exits in
+   `Parser_Expr_PostfixCalls.cpp`: the explicit owner-template-id
+   member-template placeholder now keeps a structured deferred qualified-owner
+   record even after owner canonicalization succeeds, and the recognized
+   qualified static-owner placeholder now preserves the same owner record plus
+   any unambiguous parser return-type hint instead of stopping at
+   `qualified_name`. `ExpressionSubstitutor.cpp` now consumes that preserved
+   owner record first when materializing explicit qualified member-template
+   calls, so late substitution no longer re-splits `qualified_name` text to
+   recover owner meaning. The whole-call sema synchronization hook could only
+   be narrowed part-way: the `has_qualified_name` compatibility branch is gone,
+   but the unrelated static-member direct-call branch still has to remain for
+   `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
+   and `test_template_current_member_static_hides_base_overload_ret0.cpp`.
    The nested-owner explicit member-template collision is now fixed at the
    parser source and guarded by
    `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -546,10 +546,17 @@ For work in this area, rerun:
    remaining compatibility-only explicit owner-qualified placeholder exits in
    `Parser_Expr_PostfixCalls.cpp`, and `ExpressionSubstitutor.cpp` now consumes
    those preserved owner records first instead of rebuilding meaning from
-   `qualified_name` text. The next concrete step is therefore the remaining
-   legacy resolved-call builders that still hand-roll qualified/member metadata
-   or parser return-type hints, plus the last unrelated static-member
-   whole-call sema synchronization leg.
+   `qualified_name` text. That direct-call follow-up is now closed for the
+   remaining targeted non-receiver qualified builders in
+   `Parser_Expr_PrimaryExpr.cpp`: the global-qualified and namespace-qualified
+   explicit-function-id paths now use the same helper-based
+   definition-record preservation and parser return-type hints as the ordinary
+   direct-call path instead of stopping at compatibility `qualified_name` /
+   `mangled_name` metadata. The next concrete step is now just the last
+   unrelated static-member whole-call sema synchronization leg, with
+   `Parser_Expr_PostfixCalls.cpp` and `ExpressionSubstitutor.cpp` remaining in
+   audit mode only for regressions that expose a still-unstructured
+   qualified/member-template materializer.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -436,11 +436,17 @@ Next direct-call target:
    placeholder is now covered too: nested `Base::template operator()<int>()`
    spellings canonicalize the owner before instantiation and preserve the same
    deferred qualified-owner metadata plus parser return-type hints when
-   parsing must stay deferred. The next uncovered parser target is therefore
-   narrower again: the remaining qualified/member-template
-   placeholder/materializer exits that still stamp only compatibility metadata
-   after owner resolution or deferred lookup shape is already known, followed
-   by the remaining whole-call sema synchronization hook.
+   parsing must stay deferred. This follow-up closes the remaining targeted
+   qualified/member-template compatibility-only placeholder/materializer exits
+   in `Parser_Expr_PostfixCalls.cpp`: the explicit owner-template-id
+   member-template placeholder and the recognized qualified static-owner
+   placeholder now both preserve structured deferred qualified-owner metadata,
+   and `ExpressionSubstitutor.cpp` now materializes explicit qualified
+   member-template calls from that record instead of re-splitting
+   `qualified_name` text. The whole-call sema synchronization hook could only
+   be narrowed part-way: the `has_qualified_name` compatibility branch is gone,
+   but the unrelated static-member direct-call branch still has to remain for
+   the current-member static hiding regressions.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -530,19 +536,20 @@ For work in this area, rerun:
    placeholder path in `Parser_Expr_PrimaryExpr.cpp` is now on that model too:
    it preserves a structured current-instantiation owner record and sources its
    parser return-type hint from the matched member-template declaration instead
-   of an unrelated global template. The next concrete step is therefore to
-   finish moving the remaining parser materializers onto preserved
-   `FunctionCallDefinitionLookupRecord` or explicit deferred lookup records,
-   focusing on the other qualified/member-template placeholder/materializer
-   exits that still stop at compatibility metadata after owner resolution
-   already succeeded, and then remove the whole-call sema synchronization hook
-   by pushing that work back to earlier semantic ownership. This slice closes
+   of an unrelated global template. This slice closes
    the explicit-base postfix member-template placeholder and the sibling
    postfix explicit-qualified operator-template placeholder: short nested-owner
    `Base::template operator()<int>()` spellings no longer instantiate against
    a global same-spelled owner during trailing `decltype(...)` parsing, and
    deferred cases preserve the same structured owner metadata plus parser
-   return-type hints as the member-template branch.
+   return-type hints as the member-template branch. It also closes the
+   remaining compatibility-only explicit owner-qualified placeholder exits in
+   `Parser_Expr_PostfixCalls.cpp`, and `ExpressionSubstitutor.cpp` now consumes
+   those preserved owner records first instead of rebuilding meaning from
+   `qualified_name` text. The next concrete step is therefore the remaining
+   legacy resolved-call builders that still hand-roll qualified/member metadata
+   or parser return-type hints, plus the last unrelated static-member
+   whole-call sema synchronization leg.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2196,9 +2196,89 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 				}
 				return false;
 			};
+			auto tryInstantiateExplicitQualifiedMemberTemplateFromRecord =
+				[&]() -> std::optional<ASTNode> {
+				if (!call.has_dependent_qualified_lookup_record()) {
+					return std::nullopt;
+				}
+				const TypeInfo::DependentQualifiedNameRecord& dependent_record =
+					*call.dependent_qualified_lookup_record();
+				if (dependent_record.member_chain.empty()) {
+					return std::nullopt;
+				}
+				const TypeInfo::DependentQualifiedNameRecord::Member&
+					final_member_record =
+						dependent_record.member_chain.back();
+				if (!final_member_record.has_template_arguments) {
+					return std::nullopt;
+				}
+				InlineVector<TemplateTypeArg, 4> member_template_args =
+					materializeDependentRecordTemplateArgs(
+						final_member_record.template_arguments,
+						kInitialDependentMemberTypeResolutionDepth);
+				if (templateArgsStillDependent(member_template_args)) {
+					return std::nullopt;
+				}
+				const bool prefer_current_owner_type_name =
+					dependent_record.owner_kind ==
+					TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+						CurrentInstantiation;
+				const std::string_view recorded_owner_name =
+					StringTable::getStringView(dependent_record.owner_name);
+				Parser::AliasTemplateMaterializationResult materialized_owner =
+					materializeDependentQualifiedRecordOwner(
+						dependent_record,
+						kInitialDependentMemberTypeResolutionDepth,
+						prefer_current_owner_type_name);
+				std::string_view materialized_owner_name =
+					materialized_owner.canonicalName();
+				if (!materialized_owner_name.empty() &&
+					dependent_record.member_chain.size() > 1) {
+					MaterializedQualifiedLookupOwner prefix_owner =
+						materializeDependentQualifiedMemberPrefixOwner(
+							StringTable::getOrInternStringHandle(
+								materialized_owner_name),
+							recorded_owner_name,
+							std::span<
+								const TypeInfo::DependentQualifiedNameRecord::Member>(
+								dependent_record.member_chain.data(),
+								dependent_record.member_chain.size() - 1),
+							kInitialDependentMemberTypeResolutionDepth);
+					materialized_owner_name =
+						prefix_owner.owner_name.isValid()
+							? StringTable::getStringView(
+								  prefix_owner.owner_name)
+							: std::string_view{};
+				}
+				if (materialized_owner_name.empty()) {
+					return std::nullopt;
+				}
+				const std::string_view member_name =
+					StringTable::getStringView(final_member_record.name);
+				if (member_name.empty()) {
+					return std::nullopt;
+				}
+				std::optional<ASTNode> instantiated =
+					parser_.try_instantiate_member_function_template_explicit(
+						materialized_owner_name,
+						member_name,
+						std::span<const TemplateTypeArg>(
+							member_template_args.data(),
+							member_template_args.size()));
+				if (instantiated.has_value()) {
+					normalizePendingSemanticRoots();
+				}
+				return instantiated;
+			};
 			// First try function template instantiation to obtain accurate return type
 			std::optional<ASTNode> instantiated_template = std::nullopt;
-			if (!qualified_name.empty()) {
+			if (call.has_dependent_qualified_lookup_record()) {
+				instantiated_template =
+					tryInstantiateExplicitQualifiedMemberTemplateFromRecord();
+			}
+			if (!instantiated_template.has_value() &&
+				!call.has_dependent_qualified_lookup_record() &&
+				!qualified_name.empty()) {
 				if (size_t scope_pos = qualified_name.rfind("::"); scope_pos != std::string_view::npos) {
 					std::string_view owner_name = qualified_name.substr(0, scope_pos);
 					std::string_view member_name = qualified_name.substr(scope_pos + 2);
@@ -2255,6 +2335,8 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 						}
 					}
 				}
+			}
+			if (!instantiated_template.has_value() && !qualified_name.empty()) {
 				if (!instantiated_template.has_value()) {
 					instantiated_template = tryInstantiateExplicitFunctionTemplate(qualified_name);
 				}

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -87,19 +87,17 @@ makeSingleSegmentPostfixDependentQualifiedNameRecord(
 	StringHandle member_name,
 	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>>
 		member_template_arguments) {
-	std::vector<PostfixDependentMemberSegmentInfo> member_segments;
 	PostfixDependentMemberSegmentInfo member_segment;
 	member_segment.name = member_name;
 	member_segment.template_args = std::move(member_template_arguments);
-	member_segments.push_back(std::move(member_segment));
 	return makePostfixDependentQualifiedNameRecord(
 		owner_name,
 		owner_type,
 		owner_kind,
 		std::move(owner_template_arguments),
 		std::span<const PostfixDependentMemberSegmentInfo>(
-			member_segments.data(),
-			member_segments.size()));
+			&member_segment,
+			1));
 }
 
 std::string_view buildPostfixDependentQualifiedCallName(

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -78,6 +78,30 @@ TypeInfo::DependentQualifiedNameRecord makePostfixDependentQualifiedNameRecord(
 	return record;
 }
 
+TypeInfo::DependentQualifiedNameRecord
+makeSingleSegmentPostfixDependentQualifiedNameRecord(
+	StringHandle owner_name,
+	TypeIndex owner_type,
+	TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind,
+	InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments,
+	StringHandle member_name,
+	std::optional<InlineVector<TypeInfo::TemplateArgInfo, 4>>
+		member_template_arguments) {
+	std::vector<PostfixDependentMemberSegmentInfo> member_segments;
+	PostfixDependentMemberSegmentInfo member_segment;
+	member_segment.name = member_name;
+	member_segment.template_args = std::move(member_template_arguments);
+	member_segments.push_back(std::move(member_segment));
+	return makePostfixDependentQualifiedNameRecord(
+		owner_name,
+		owner_type,
+		owner_kind,
+		std::move(owner_template_arguments),
+		std::span<const PostfixDependentMemberSegmentInfo>(
+			member_segments.data(),
+			member_segments.size()));
+}
+
 std::string_view buildPostfixDependentQualifiedCallName(
 	std::string_view owner_name,
 	std::span<const PostfixDependentMemberSegmentInfo> member_segments) {
@@ -118,6 +142,14 @@ void attachResolvedPostfixDirectCallMetadata(
 				argument_dependent_lookup_included);
 		record.has_value()) {
 		setCallDefinitionLookupRecord(call_expr, *record);
+	}
+	if (std::optional<TypeSpecifierNode> concrete_return_type =
+			FlashCpp::ParserFunctionTypeHelpers::
+				tryGetConcreteReturnTypeFromFunctionDeclaration(
+					func_decl,
+					callee_token);
+		concrete_return_type.has_value()) {
+		setCallParserReturnTypeHint(call_expr, *concrete_return_type);
 	}
 }
 
@@ -982,15 +1014,50 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 				result->as<ExpressionNode>(),
 				std::move(member_template_arg_nodes));
 		}
-		setCallQualifiedName(
-			result->as<ExpressionNode>(),
+		const StringHandle qualified_owner_handle =
+			materialized_owner.canonicalNameHandle();
+		const std::string_view deferred_qualified_call_name =
 			StringBuilder()
 				.append(qualified_owner_name.empty()
 					? member_name_token.value()
 					: qualified_owner_name)
 				.append("::")
 				.append(qualified_member_token.value())
-				.commit());
+				.commit();
+		setCallQualifiedName(
+			result->as<ExpressionNode>(),
+			deferred_qualified_call_name);
+		if (qualified_owner_handle.isValid()) {
+			TypeIndex owner_type =
+				lookupPostfixRecordedDependentOwnerType(
+					qualified_owner_handle);
+			InlineVector<TypeInfo::TemplateArgInfo, 4>
+				owner_template_arguments;
+			if (materialized_owner.resolved_type_info != nullptr) {
+				owner_type =
+					materialized_owner.resolved_type_info
+						->registeredTypeIndex();
+				owner_template_arguments =
+					materialized_owner.resolved_type_info
+						->templateArgs();
+			}
+			setCallDependentQualifiedLookupRecord(
+				result->as<ExpressionNode>(),
+				makeSingleSegmentPostfixDependentQualifiedNameRecord(
+					qualified_owner_handle,
+					owner_type,
+					TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+						DependentInstantiation,
+					std::move(owner_template_arguments),
+					qualified_member_token.handle().isValid()
+						? qualified_member_token.handle()
+						: StringTable::getOrInternStringHandle(
+								qualified_member_token.value()),
+					member_template_args.has_value()
+						? std::make_optional(
+							  toTemplateArgInfoList(*member_template_args))
+						: std::nullopt));
+		}
 		return ParseResult::success(*result);
 	}
 
@@ -2552,6 +2619,20 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 						buildQualifiedNameFromStrings(
 							namespaces,
 							final_identifier.value()));
+					setCallDependentQualifiedLookupRecord(
+						function_call_node.as<ExpressionNode>(),
+						makeSingleSegmentPostfixDependentQualifiedNameRecord(
+							class_name_handle,
+							lookupPostfixRecordedDependentOwnerType(
+								class_name_handle),
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+								UnknownSpecialization,
+							{},
+							final_identifier.handle(),
+							template_args.has_value()
+								? std::make_optional(
+									  toTemplateArgInfoList(*template_args))
+								: std::nullopt));
 					if (class_owner_return_hint != nullptr) {
 						setCallParserReturnTypeHint(
 							function_call_node.as<ExpressionNode>(),

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -321,6 +321,46 @@ void attachResolvedOrdinaryDirectCallMetadata(
 		std::nullopt);
 }
 
+void attachResolvedQualifiedDirectCallMetadata(
+	ExpressionNode& call_expr,
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::span<const TypeSpecifierNode> arg_types,
+	bool has_deferred_template_call_args,
+	const FunctionDeclarationNode& func_decl,
+	std::string_view qualified_name) {
+	attachResolvedOrdinaryDirectCallMetadata(
+		call_expr,
+		definition_context,
+		callee_token,
+		arg_types,
+		has_deferred_template_call_args,
+		func_decl,
+		true,
+		false,
+		qualified_name);
+}
+
+void attachDeferredQualifiedDirectCallMetadata(
+	ExpressionNode& call_expr,
+	const TemplateDefinitionLookupContext* definition_context,
+	const Token& callee_token,
+	std::string_view qualified_name,
+	const void* definition_bound_template_declaration) {
+	setCallQualifiedName(call_expr, qualified_name);
+	if (std::optional<FunctionCallDefinitionLookupRecord> record =
+			tryBuildDeferredFunctionCallDefinitionLookupRecord(
+				definition_context,
+				callee_token,
+				true,
+				false);
+		record.has_value()) {
+		record->definition_bound_template_declaration =
+			definition_bound_template_declaration;
+		setCallDefinitionLookupRecord(call_expr, *record);
+	}
+}
+
 void attachResolvedReceiverDirectCallMetadata(
 	ExpressionNode& call_expr,
 	const TemplateDefinitionLookupContext* definition_context,
@@ -3650,26 +3690,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					setCallTemplateArguments(function_call_node.as<ExpressionNode>(), std::move(template_arg_nodes));
 				}
 			}
-			setCallQualifiedName(function_call_node.as<ExpressionNode>(), buildQualifiedNameFromStrings(namespaces, qual_id.name()));
+			const std::string_view qualified_name =
+				buildQualifiedNameFromStrings(namespaces, qual_id.name());
 			// If the function has a pre-computed mangled name, set it on the call expression
 			if (identifierType->is<FunctionDeclarationNode>()) {
 				const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
 				FLASH_LOG(Parser, Debug, "Qualified function has mangled name: {}, name: {}", func_decl.has_mangled_name(), func_decl.mangled_name());
+				attachResolvedQualifiedDirectCallMetadata(
+					function_call_node.as<ExpressionNode>(),
+					current_template_definition_lookup_context_,
+					qual_id.identifier_token(),
+					arg_types,
+					has_deferred_qualified_call_args,
+					func_decl,
+					qualified_name);
 				if (func_decl.has_mangled_name()) {
-					setCallMangledName(function_call_node.as<ExpressionNode>(), func_decl.mangled_name());
 					FLASH_LOG(Parser, Debug, "Set mangled name on qualified call expression: {}", func_decl.mangled_name());
-				}
-				if (std::optional<FunctionCallDefinitionLookupRecord> record =
-						tryBuildFunctionCallDefinitionLookupRecord(
-							current_template_definition_lookup_context_,
-							qual_id.identifier_token(),
-							arg_types,
-							has_deferred_qualified_call_args,
-							func_decl,
-							true,
-							false);
-					record.has_value()) {
-					setCallDefinitionLookupRecord(function_call_node.as<ExpressionNode>(), *record);
 				}
 			} else if (has_explicit_template_args) {
 				std::optional<TemplateDefinitionLookupContext>
@@ -3697,19 +3733,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					deferred_definition_lookup_context.has_value()
 						? &*deferred_definition_lookup_context
 						: current_template_definition_lookup_context_;
-				if (std::optional<FunctionCallDefinitionLookupRecord> record =
-						tryBuildDeferredFunctionCallDefinitionLookupRecord(
-							definition_lookup_context,
-							qual_id.identifier_token(),
-							true,
-							false);
-					record.has_value()) {
-					record->definition_bound_template_declaration =
-						definition_bound_template_declaration;
-					setCallDefinitionLookupRecord(
-						function_call_node.as<ExpressionNode>(),
-						*record);
-				}
+				attachDeferredQualifiedDirectCallMetadata(
+					function_call_node.as<ExpressionNode>(),
+					definition_lookup_context,
+					qual_id.identifier_token(),
+					qualified_name,
+					definition_bound_template_declaration);
+			} else {
+				setCallQualifiedName(
+					function_call_node.as<ExpressionNode>(),
+					qualified_name);
 			}
 			result = function_call_node;
 		} else {
@@ -4750,27 +4783,18 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				// Store the qualified source name for template lookup during constexpr evaluation
 				std::string_view qualified_name = resolved_qualified_name;
-				setCallQualifiedName(result->as<ExpressionNode>(), qualified_name);
-				FLASH_LOG(Parser, Debug, "Set qualified name on call expression: ", qualified_name);
-
-				// If the function has a pre-computed mangled name, set it on the call expression
 				if (identifierType->is<FunctionDeclarationNode>()) {
 					const FunctionDeclarationNode& func_decl = identifierType->as<FunctionDeclarationNode>();
-					if (func_decl.has_mangled_name()) {
-						setCallMangledName(result->as<ExpressionNode>(), func_decl.mangled_name());
-					}
-					if (std::optional<FunctionCallDefinitionLookupRecord> record =
-							tryBuildFunctionCallDefinitionLookupRecord(
-								current_template_definition_lookup_context_,
-								qual_id.identifier_token(),
-								arg_types,
-								has_deferred_qualified_call_args,
-								func_decl,
-								true,
-								false);
-						record.has_value()) {
-						setCallDefinitionLookupRecord(result->as<ExpressionNode>(), *record);
-					}
+					attachResolvedQualifiedDirectCallMetadata(
+						result->as<ExpressionNode>(),
+						current_template_definition_lookup_context_,
+						qual_id.identifier_token(),
+						arg_types,
+						has_deferred_qualified_call_args,
+						func_decl,
+						qualified_name);
+				} else {
+					setCallQualifiedName(result->as<ExpressionNode>(), qualified_name);
 				}
 				if (!identifierType->is<FunctionDeclarationNode>() &&
 					has_explicit_template_args) {
@@ -4799,19 +4823,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						deferred_definition_lookup_context.has_value()
 							? &*deferred_definition_lookup_context
 							: current_template_definition_lookup_context_;
-					if (std::optional<FunctionCallDefinitionLookupRecord> record =
-							tryBuildDeferredFunctionCallDefinitionLookupRecord(
-								definition_lookup_context,
-								qual_id.identifier_token(),
-								true,
-								false);
-						record.has_value()) {
-						record->definition_bound_template_declaration =
-							definition_bound_template_declaration;
-						setCallDefinitionLookupRecord(
-							result->as<ExpressionNode>(),
-							*record);
-					}
+					attachDeferredQualifiedDirectCallMetadata(
+						result->as<ExpressionNode>(),
+						definition_lookup_context,
+						qual_id.identifier_token(),
+						qualified_name,
+						definition_bound_template_declaration);
 				}
 			} else {
 				// Just a qualified identifier reference

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4197,12 +4197,10 @@ void SemanticAnalysis::ensureCallArgConversionsAnnotated(
 	}
 	const bool has_definition_bound_metadata =
 		call_node.has_definition_lookup_record();
-	const bool has_qualified_name = call_node.has_qualified_name();
 	const bool is_static_member_direct_call =
 		!parser_target->parent_struct_name().empty() &&
 		parser_target->is_static();
 	if (!has_definition_bound_metadata &&
-		!has_qualified_name &&
 		!is_static_member_direct_call) {
 		return;
 	}


### PR DESCRIPTION
## What changed
This PR now finishes the narrow post-1769 qualified/member-template materializer slice.

- `Parser_Expr_PostfixCalls.cpp` preserves structured deferred qualified-owner records for the covered explicit qualified member/operator template placeholders instead of stopping at compatibility `qualified_name` metadata.
- `ExpressionSubstitutor.cpp` consumes those preserved owner records first for the covered explicit qualified member-template materialization paths.
- `Parser_Expr_PrimaryExpr.cpp` now routes the remaining global-qualified and namespace-qualified explicit-function-id direct-call builders through shared resolved/deferred qualified-call metadata helpers, so they preserve `FunctionCallDefinitionLookupRecord` plus parser return-type hints instead of only `qualified_name` / `mangled_name`.
- The docs now record that these remaining targeted `PrimaryExpr` direct-call builders are closed and that the last concrete follow-up is the unrelated static-member whole-call sema synchronization leg.

## Why
The remaining weak spots were still preserving call meaning as compatibility text after owner resolution or deferred lookup shape was already known. That forced later stages to reconstruct intent from strings instead of consuming preserved semantic records.

## Impact
Covered qualified/member-template parser materializers now preserve structured semantic metadata through parse, substitution, and semantic analysis. The only concrete targeted work left from this slice is the unrelated static-member whole-call sema synchronization leg; `Parser_Expr_PostfixCalls.cpp` and `ExpressionSubstitutor.cpp` stay in audit mode unless a new regression exposes another unstructured qualified/member-template path.
