### PR TITLE
[codex] Remove last direct-call sema fallback and preserve init errors

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -475,11 +475,15 @@ Next direct-call target:
    `qualified_name` / `mangled_name` compatibility metadata once the matched
    declaration shape is already known, and they now preserve the same
    definition-bound direct-call record plus parser return-type hints as the
-   shared ordinary-call helper path. The remaining next step in this area is
-   therefore narrower: keep `Parser_Expr_PostfixCalls.cpp` in audit mode for
-   any newly-exposed qualified/member-template builder drift, but the only
-   concrete targeted code still left is the unrelated static-member whole-call
-   sema synchronization leg. Keep
+   shared ordinary-call helper path. The last unrelated static-member
+   whole-call sema synchronization leg is now closed too:
+   `resolveCallArgAnnotationTarget(...)` no longer needs the
+   parser-selected static direct-call fallback, and the current-member static
+   hiding regressions still pass through the preserved definition-bound call
+   metadata alone. Keep `Parser_Expr_PostfixCalls.cpp`,
+   `ExpressionSubstitutor.cpp`, and this sema area in audit mode for any
+   newly-exposed qualified/member-template builder drift, but there is no
+   remaining targeted work left inside this slice. Keep
    `test_member_template_func_in_specialization_ret0.cpp` in the focused guard
    set here: it exercises the new "candidate-bearing concrete owner calls must
    defer instead of hard-failing" rule in

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -492,12 +492,13 @@ Next direct-call target:
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
    `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. Clean up the remaining parser diagnostic collapse around copy
-   initialization. This slice showed that inner qualified-call errors can
-   still surface as the generic "Failed to parse initializer expression" once
-   `parse_copy_initialization(...)` drops the nested `ParseResult`; that does
-   not block conformance, but it is the next diagnostics-quality follow-up in
-   this area.
+3. The initializer-diagnostics follow-up that this slice exposed is now
+   covered too: both `parse_copy_initialization(...)` and
+   `parse_direct_initialization(...)` preserve nested parse failures instead of
+   collapsing them to generic wrapper errors, and the dedicated `_fail`
+   anchors `test_copy_init_nested_qualified_call_error_fail.cpp` and
+   `test_direct_init_nested_qualified_call_error_fail.cpp` now keep that
+   behavior pinned.
 4. Leave replay/`StructTypeInfo` sync and broader
    current-instantiation/unknown-specialization expansion in opportunistic mode
    unless a concrete uncovered failure appears.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -443,10 +443,12 @@ Next direct-call target:
    placeholder now both preserve structured deferred qualified-owner metadata,
    and `ExpressionSubstitutor.cpp` now materializes explicit qualified
    member-template calls from that record instead of re-splitting
-   `qualified_name` text. The whole-call sema synchronization hook could only
-   be narrowed part-way: the `has_qualified_name` compatibility branch is gone,
-   but the unrelated static-member direct-call branch still has to remain for
-   the current-member static hiding regressions.
+   `qualified_name` text. The whole-call sema synchronization hook is now
+   closed fully for this slice: the qualified compatibility branch is gone,
+   and the unrelated static-member direct-call fallback in
+   `resolveCallArgAnnotationTarget(...)` is removed as well because the
+   current-member static hiding regressions still resolve correctly through the
+   preserved definition-bound call metadata.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
@@ -552,11 +554,12 @@ For work in this area, rerun:
    explicit-function-id paths now use the same helper-based
    definition-record preservation and parser return-type hints as the ordinary
    direct-call path instead of stopping at compatibility `qualified_name` /
-   `mangled_name` metadata. The next concrete step is now just the last
-   unrelated static-member whole-call sema synchronization leg, with
-   `Parser_Expr_PostfixCalls.cpp` and `ExpressionSubstitutor.cpp` remaining in
-   audit mode only for regressions that expose a still-unstructured
-   qualified/member-template materializer.
+   `mangled_name` metadata. That last unrelated static-member whole-call sema
+   synchronization leg is now closed too, so the remaining work in this area
+   is no longer another in-slice compatibility cleanup. Keep
+   `Parser_Expr_PostfixCalls.cpp`, `ExpressionSubstitutor.cpp`, and the
+   direct-call sema path in audit mode only for regressions that expose a
+   still-unstructured qualified/member-template materializer.
    Immediate focused follow-up under that item:
    the nested-owner explicit member-template instantiation bug is now fixed and
    guarded by

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -453,12 +453,13 @@ Next direct-call target:
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped
    `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. Improve parser diagnostics in the remaining copy-initialization path by
-   preserving nested expression or qualified-call failures instead of
-   collapsing them to the generic "Failed to parse initializer expression".
-   This is not the next conformance blocker, but the latest concrete-owner
-   qualified-call slice exposed it clearly enough that it should stay on the
-   list.
+3. The parser-diagnostics follow-up exposed by this area is now covered too:
+   `parse_copy_initialization(...)` and `parse_direct_initialization(...)`
+   both preserve nested expression / qualified-call failures instead of
+   collapsing them to generic wrapper errors, and the dedicated `_fail`
+   anchors `test_copy_init_nested_qualified_call_error_fail.cpp` and
+   `test_direct_init_nested_qualified_call_error_fail.cpp` now keep that
+   behavior pinned.
 4. Keep replay/identity and broader
    current-instantiation/unknown-specialization work in reserve for concrete
    failures; the remaining conformance pressure is now centered on the last

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3136,7 +3136,7 @@ private:	 // Resume private methods
 	bool looks_like_elaborated_type_variable_declaration();  // Disambiguate 'struct Foo f = ...' from 'struct Foo { ... }'
 
 	std::optional<ASTNode> parse_direct_initialization();  // Parse Type var(args) - returns initializer node
-	std::optional<ASTNode> parse_copy_initialization(DeclarationNode& decl_node, TypeSpecifierNode& type_specifier);	 // Parse Type var = expr or Type var = {args}
+	ParseResult parse_copy_initialization(DeclarationNode& decl_node, TypeSpecifierNode& type_specifier);	 // Parse Type var = expr or Type var = {args}
 	void prepareArrayTypeForBraceInitializer(const DeclarationNode& decl_node, TypeSpecifierNode& type_specifier);
 	void inferUnsizedArraySizeFromInitializer(const DeclarationNode& decl_node,
 											 TypeSpecifierNode& type_specifier,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3135,7 +3135,7 @@ private:	 // Resume private methods
 	bool looks_like_function_parameters();  // Detect if '(' starts function params vs direct init
 	bool looks_like_elaborated_type_variable_declaration();  // Disambiguate 'struct Foo f = ...' from 'struct Foo { ... }'
 
-	std::optional<ASTNode> parse_direct_initialization();  // Parse Type var(args) - returns initializer node
+	ParseResult parse_direct_initialization();  // Parse Type var(args) - returns initializer node
 	ParseResult parse_copy_initialization(DeclarationNode& decl_node, TypeSpecifierNode& type_specifier);	 // Parse Type var = expr or Type var = {args}
 	void prepareArrayTypeForBraceInitializer(const DeclarationNode& decl_node, TypeSpecifierNode& type_specifier);
 	void inferUnsizedArraySizeFromInitializer(const DeclarationNode& decl_node,

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -415,7 +415,10 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 			push_static_member_parse_context();
 			auto init_result = parse_copy_initialization(decl_node, type_spec);
 			pop_static_member_parse_context();
-			if (!init_result.has_value()) {
+			if (init_result.is_error()) {
+				return init_result;
+			}
+			if (!init_result.node().has_value()) {
 				FLASH_LOG(Parser, Error, "Failed to parse initializer for static member variable '",
 						  class_name.view(), "::", function_name_token.value(), "'");
 				return ParseResult::error(ParserError::UnexpectedToken, function_name_token);
@@ -427,7 +430,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				return ParseResult::error(ParserError::UnexpectedToken, peek_info());
 			}
 
-			return finalize_static_member_init(static_member, *init_result, decl_node, function_name_token, saved_position);
+			return finalize_static_member_init(static_member, init_result.node(), decl_node, function_name_token, saved_position);
 		}
 
 		// Create a new declaration node with the function name
@@ -965,8 +968,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		// Phase 3 Consolidation: Use shared copy initialization helper for = and = {} forms
 		if (peek() == "="_tok) {
 			auto init_result = parse_copy_initialization(registered_decl, type_specifier);
-			if (init_result.has_value()) {
-				initializer = init_result;
+			if (init_result.is_error()) {
+				return init_result;
+			}
+			if (init_result.node().has_value()) {
+				initializer = init_result.node();
 			} else {
 				return ParseResult::error("Failed to parse initializer expression", current_token_);
 			}
@@ -1147,8 +1153,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				std::optional<ASTNode> next_initializer;
 				if (peek() == "="_tok) {
 					auto init_result = parse_copy_initialization(next_decl, next_type_spec);
-					if (init_result.has_value()) {
-						next_initializer = init_result;
+					if (init_result.is_error()) {
+						return init_result;
+					}
+					if (init_result.node().has_value()) {
+						next_initializer = init_result.node();
 					} else {
 						return ParseResult::error("Failed to parse initializer expression", current_token_);
 					}

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -1019,8 +1019,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 					ConstructorCallNode(type_node_copy, std::move(arguments), paren_token));
 			} else {
 				auto init_result = parse_direct_initialization();
-				if (init_result.has_value()) {
-					initializer = init_result;
+				if (init_result.is_error()) {
+					return init_result;
+				}
+				if (init_result.node().has_value()) {
+					initializer = init_result.node();
 				} else {
 					return ParseResult::error("Expected ')' after direct initialization arguments", current_token_);
 				}
@@ -1164,8 +1167,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 				} else if (peek() == "("_tok) {
 					// Direct initialization for comma-separated declaration: Type var1, var2(args)
 					auto init_result = parse_direct_initialization();
-					if (init_result.has_value()) {
-						next_initializer = init_result;
+					if (init_result.is_error()) {
+						return init_result;
+					}
+					if (init_result.node().has_value()) {
+						next_initializer = init_result.node();
 					} else {
 						return ParseResult::error("Expected ')' after direct initialization arguments", current_token_);
 					}

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1775,10 +1775,13 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				// Pop context after parsing
 				member_function_context_stack_.pop_back();
 
-				if (!init_result.has_value()) {
+				if (init_result.is_error()) {
+					return init_result;
+				}
+				if (!init_result.node().has_value()) {
 					return ParseResult::error("Failed to parse initializer expression", current_token_);
 				}
-				init_expr_opt = *init_result;
+				init_expr_opt = *init_result.node();
 			} else if (peek() == "{"_tok) {
 				// Brace initialization: static constexpr int x{42};
 				// Save position for lazy re-parse as well.

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1879,10 +1879,13 @@ ParseResult Parser::parse_static_member_block(
 		// Pop context after parsing
 		member_function_context_stack_.pop_back();
 
-		if (!init_result.has_value()) {
+		if (init_result.is_error()) {
+			return init_result;
+		}
+		if (!init_result.node().has_value()) {
 			return ParseResult::error("Failed to parse initializer expression", current_token_);
 		}
-		init_expr_opt = *init_result;
+		init_expr_opt = *init_result.node();
 	} else if (peek() == "{"_tok) {
 		// Brace initialization: static constexpr int x{42};
 		initializer_position = save_token_position();

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1604,7 +1604,7 @@ ParseResult Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSp
 
 		inferUnsizedArraySizeFromInitializer(decl_node, type_specifier, initializer);
 
-		return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
+		return init_list_result;
 	} else {
 		// Regular expression initializer
 		ParseResult init_expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
@@ -1668,7 +1668,7 @@ ParseResult Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSp
 					type_specifier.set_cv_qualifier(original_cv_qual);
 				}
 				FLASH_LOG(Parser, Debug, "Deduced auto lambda+ type: FunctionPointer size=64");
-				return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
+				return init_expr_result;
 			}
 
 			// Get the full type specifier from the initializer expression
@@ -1682,7 +1682,7 @@ ParseResult Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSp
 				ExpressionTypeDeductionResult deduction_result = deduce_type_from_expression(*initializer);
 				if (deduction_result.status == ExpressionTypeDeductionStatus::StillDependent) {
 					FLASH_LOG(Parser, Debug, "Deferred auto variable type deduction for dependent initializer");
-					return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
+					return init_expr_result;
 				}
 				if (deduction_result.status != ExpressionTypeDeductionStatus::Deduced) {
 					throw CompileError(std::string(StringBuilder()
@@ -1722,7 +1722,7 @@ ParseResult Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSp
 		}
 
 		inferUnsizedArraySizeFromInitializer(decl_node, type_specifier, initializer);
-		return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
+		return init_expr_result;
 	}
 }
 

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1204,8 +1204,11 @@ ParseResult Parser::parse_variable_declaration() {
 	// Check for direct initialization with parentheses: Type var(args)
 	if (peek() == "("_tok) {
 		auto init_result = parse_direct_initialization();
-		if (init_result.has_value()) {
-			first_init_expr = init_result;
+		if (init_result.is_error()) {
+			return init_result;
+		}
+		if (init_result.node().has_value()) {
+			first_init_expr = init_result.node();
 			// After closing ), skip any trailing specifiers (this might be a function forward declaration)
 			// e.g., void func() noexcept; or void func() const;
 			FlashCpp::MemberQualifiers member_quals;
@@ -1317,8 +1320,11 @@ ParseResult Parser::parse_variable_declaration() {
 			} else if (peek() == "("_tok) {
 				// Constructor-style initialization for comma-separated declaration: Type var1, var2(args)
 				auto init_result = parse_direct_initialization();
-				if (init_result.has_value()) {
-					init_expr = init_result;
+				if (init_result.is_error()) {
+					return init_result;
+				}
+				if (init_result.node().has_value()) {
+					init_expr = init_result.node();
 				} else {
 					return ParseResult::error("Failed to parse direct initialization", current_token_);
 				}
@@ -1356,12 +1362,12 @@ ParseResult Parser::parse_variable_declaration() {
 }
 
 // Phase 3 Consolidation: Parse direct initialization with parentheses: Type var(args)
-// Returns the initializer node (InitializerListNode) or std::nullopt if not at '('
+// Returns the initializer node (InitializerListNode) or an error if nested parsing fails.
 // Assumes we're positioned at '(' when called
-std::optional<ASTNode> Parser::parse_direct_initialization() {
+ParseResult Parser::parse_direct_initialization() {
 	// Must be at '('
 	if (peek() != "("_tok) {
-		return std::nullopt;
+		return ParseResult{};
 	}
 
 	advance(); // consume '('
@@ -1380,8 +1386,7 @@ std::optional<ASTNode> Parser::parse_direct_initialization() {
 
 		ParseResult arg_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 		if (arg_result.is_error()) {
-			// Return nullopt on error - caller should handle
-			return std::nullopt;
+			return arg_result;
 		}
 
 		if (auto arg_node = arg_result.node()) {
@@ -1433,11 +1438,10 @@ std::optional<ASTNode> Parser::parse_direct_initialization() {
 	}
 
 	if (!consume(")"_tok)) {
-		// Return nullopt on error - caller should handle
-		return std::nullopt;
+		return ParseResult::error("Expected ')' after direct initialization arguments", current_token_);
 	}
 
-	return init_list_node;
+	return ParseResult::success(init_list_node);
 }
 
 void Parser::prepareArrayTypeForBraceInitializer(const DeclarationNode& decl_node, TypeSpecifierNode& type_specifier) {

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1217,8 +1217,11 @@ ParseResult Parser::parse_variable_declaration() {
 	// Check for copy initialization: TypeCategory var = expr or TypeCategory var = {args}
 	else if (peek() == "="_tok) {
 		auto init_result = parse_copy_initialization(first_decl, type_specifier);
-		if (init_result.has_value()) {
-			first_init_expr = init_result;
+		if (init_result.is_error()) {
+			return init_result;
+		}
+		if (init_result.node().has_value()) {
+			first_init_expr = init_result.node();
 		} else {
 			return ParseResult::error("Failed to parse initializer expression", current_token_);
 		}
@@ -1575,10 +1578,10 @@ void Parser::inferUnsizedArraySizeFromInitializer(const DeclarationNode& decl_no
 // Phase 3 Consolidation: Parse copy initialization: TypeCategory var = expr or TypeCategory var = {args}
 // Returns the initializer expression/list node or std::nullopt if not at '='
 // Also handles auto type deduction and array size inference
-std::optional<ASTNode> Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSpecifierNode& type_specifier) {
+ParseResult Parser::parse_copy_initialization(DeclarationNode& decl_node, TypeSpecifierNode& type_specifier) {
 	// Must be at '='
 	if (peek() != "="_tok) {
-		return std::nullopt;
+		return ParseResult{};
 	}
 
 	advance(); // consume '='
@@ -1590,19 +1593,19 @@ std::optional<ASTNode> Parser::parse_copy_initialization(DeclarationNode& decl_n
 		// Parse brace initializer list
 		ParseResult init_list_result = parse_brace_initializer(type_specifier);
 		if (init_list_result.is_error()) {
-			return std::nullopt;
+			return init_list_result;
 		}
 
 		auto initializer = init_list_result.node();
 
 		inferUnsizedArraySizeFromInitializer(decl_node, type_specifier, initializer);
 
-		return initializer;
+		return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
 	} else {
 		// Regular expression initializer
 		ParseResult init_expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
 		if (init_expr_result.is_error()) {
-			return std::nullopt;
+			return init_expr_result;
 		}
 		auto initializer = init_expr_result.node();
 
@@ -1661,7 +1664,7 @@ std::optional<ASTNode> Parser::parse_copy_initialization(DeclarationNode& decl_n
 					type_specifier.set_cv_qualifier(original_cv_qual);
 				}
 				FLASH_LOG(Parser, Debug, "Deduced auto lambda+ type: FunctionPointer size=64");
-				return initializer;
+				return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
 			}
 
 			// Get the full type specifier from the initializer expression
@@ -1675,7 +1678,7 @@ std::optional<ASTNode> Parser::parse_copy_initialization(DeclarationNode& decl_n
 				ExpressionTypeDeductionResult deduction_result = deduce_type_from_expression(*initializer);
 				if (deduction_result.status == ExpressionTypeDeductionStatus::StillDependent) {
 					FLASH_LOG(Parser, Debug, "Deferred auto variable type deduction for dependent initializer");
-					return initializer;
+					return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
 				}
 				if (deduction_result.status != ExpressionTypeDeductionStatus::Deduced) {
 					throw CompileError(std::string(StringBuilder()
@@ -1715,7 +1718,7 @@ std::optional<ASTNode> Parser::parse_copy_initialization(DeclarationNode& decl_n
 		}
 
 		inferUnsizedArraySizeFromInitializer(decl_node, type_specifier, initializer);
-		return initializer;
+		return initializer.has_value() ? ParseResult(*initializer) : ParseResult{};
 	}
 }
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3062,9 +3062,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 							std::optional<ASTNode> reparsed_initializer;
 							if (peek() == "="_tok) {
-								reparsed_initializer = parse_copy_initialization(
+								ParseResult init_result = parse_copy_initialization(
 									declaration_copy,
 									type_spec);
+								if (!init_result.is_error()) {
+									reparsed_initializer = init_result.node();
+								}
 							} else if (peek() == "{"_tok) {
 								ParseResult init_result = parse_brace_initializer(type_spec);
 								if (!init_result.is_error() &&
@@ -7402,9 +7405,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		std::optional<ASTNode> reparsed_initializer;
 		if (peek() == "="_tok) {
-			reparsed_initializer = parse_copy_initialization(
+			ParseResult init_result = parse_copy_initialization(
 				declaration_copy_ref,
 				type_spec);
+			if (!init_result.is_error()) {
+				reparsed_initializer = init_result.node();
+			}
 		} else if (peek() == "{"_tok) {
 			ParseResult init_result = parse_brace_initializer(type_spec);
 			if (!init_result.is_error() && init_result.node().has_value()) {
@@ -11867,9 +11873,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 				std::optional<ASTNode> reparsed_initializer;
 				if (peek() == "="_tok) {
-					reparsed_initializer = parse_copy_initialization(
+					ParseResult init_result = parse_copy_initialization(
 						declaration_copy_ref,
 						type_spec);
+					if (!init_result.is_error()) {
+						reparsed_initializer = init_result.node();
+					}
 				} else if (peek() == "{"_tok) {
 					ParseResult init_parse_result = parse_brace_initializer(type_spec);
 					if (!init_parse_result.is_error() && init_parse_result.node().has_value()) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3067,12 +3067,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									type_spec);
 								if (!init_result.is_error()) {
 									reparsed_initializer = init_result.node();
+								} else {
+									FLASH_LOG(Templates, Debug,
+										"Replay parse failed for static member initializer ",
+										declaration_copy.identifier_token().value(), ": ",
+										init_result.error_message(),
+										" - falling back to AST substitution");
 								}
 							} else if (peek() == "{"_tok) {
 								ParseResult init_result = parse_brace_initializer(type_spec);
 								if (!init_result.is_error() &&
 									init_result.node().has_value()) {
 									reparsed_initializer = *init_result.node();
+								} else if (init_result.is_error()) {
+									FLASH_LOG(Templates, Debug,
+										"Replay brace-init parse failed for static member initializer ",
+										declaration_copy.identifier_token().value(), ": ",
+										init_result.error_message(),
+										" - falling back to AST substitution");
 								}
 							}
 
@@ -7410,11 +7422,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				type_spec);
 			if (!init_result.is_error()) {
 				reparsed_initializer = init_result.node();
+			} else {
+				FLASH_LOG(Templates, Debug,
+					"Replay parse failed for class static initializer ",
+					declaration_copy_ref.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to AST substitution");
 			}
 		} else if (peek() == "{"_tok) {
 			ParseResult init_result = parse_brace_initializer(type_spec);
 			if (!init_result.is_error() && init_result.node().has_value()) {
 				reparsed_initializer = *init_result.node();
+			} else if (init_result.is_error()) {
+				FLASH_LOG(Templates, Debug,
+					"Replay brace-init parse failed for class static initializer ",
+					declaration_copy_ref.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to AST substitution");
 			}
 		} else {
 			return std::nullopt;
@@ -11878,11 +11902,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						type_spec);
 					if (!init_result.is_error()) {
 						reparsed_initializer = init_result.node();
+					} else {
+						FLASH_LOG(Templates, Debug,
+							"Replay parse failed for out-of-line static member initializer ",
+							declaration_copy_ref.identifier_token().value(), ": ",
+							init_result.error_message(),
+							" - falling back to AST substitution");
 					}
 				} else if (peek() == "{"_tok) {
 					ParseResult init_parse_result = parse_brace_initializer(type_spec);
 					if (!init_parse_result.is_error() && init_parse_result.node().has_value()) {
 						reparsed_initializer = *init_parse_result.node();
+					} else if (init_parse_result.is_error()) {
+						FLASH_LOG(Templates, Debug,
+							"Replay brace-init parse failed for out-of-line static member initializer ",
+							declaration_copy_ref.identifier_token().value(), ": ",
+							init_parse_result.error_message(),
+							" - falling back to AST substitution");
 					}
 				}
 

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -4429,9 +4429,12 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(
 
 		std::optional<ASTNode> reparsed_initializer;
 		if (peek() == "="_tok) {
-			reparsed_initializer = parse_copy_initialization(
+			ParseResult init_result = parse_copy_initialization(
 				declaration_for_reparse,
 				type_spec);
+			if (!init_result.is_error()) {
+				reparsed_initializer = init_result.node();
+			}
 		} else if (peek() == "{"_tok) {
 			ParseResult init_result = parse_brace_initializer(type_spec);
 			if (!init_result.is_error() &&

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -4434,12 +4434,24 @@ std::optional<ASTNode> Parser::try_instantiate_variable_template(
 				type_spec);
 			if (!init_result.is_error()) {
 				reparsed_initializer = init_result.node();
+			} else {
+				FLASH_LOG(Templates, Debug,
+					"Replay parse failed for variable template initializer ",
+					declaration_for_reparse.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to AST substitution");
 			}
 		} else if (peek() == "{"_tok) {
 			ParseResult init_result = parse_brace_initializer(type_spec);
 			if (!init_result.is_error() &&
 				init_result.node().has_value()) {
 				reparsed_initializer = *init_result.node();
+			} else if (init_result.is_error()) {
+				FLASH_LOG(Templates, Debug,
+					"Replay brace-init parse failed for variable template initializer ",
+					declaration_for_reparse.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to AST substitution");
 			}
 		}
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1082,6 +1082,11 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			if (!init_result.is_error()) {
 				substituted_initializer = init_result.node();
 			} else {
+				FLASH_LOG(Templates, Debug,
+					"try_reparse_lazy_static_initializer: parse_copy_initialization failed for ",
+					decl.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to stored initializer AST");
 				substituted_initializer.reset();
 			}
 			FLASH_LOG(Templates, Debug, "try_reparse_lazy_static_initializer: parse_copy_initialization result has_value=",
@@ -1091,6 +1096,11 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			if (!init_result.is_error()) {
 				substituted_initializer = init_result.node();
 			} else {
+				FLASH_LOG(Templates, Debug,
+					"try_reparse_lazy_static_initializer: brace initializer parse failed for ",
+					decl.identifier_token().value(), ": ",
+					init_result.error_message(),
+					" - falling back to stored initializer AST");
 				substituted_initializer.reset();
 			}
 		} else {

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1078,7 +1078,12 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 
 		if (peek() == "="_tok) {
 			FLASH_LOG(Templates, Debug, "try_reparse_lazy_static_initializer: reparsing from '=' position");
-			substituted_initializer = parse_copy_initialization(decl, type_spec);
+			ParseResult init_result = parse_copy_initialization(decl, type_spec);
+			if (!init_result.is_error()) {
+				substituted_initializer = init_result.node();
+			} else {
+				substituted_initializer.reset();
+			}
 			FLASH_LOG(Templates, Debug, "try_reparse_lazy_static_initializer: parse_copy_initialization result has_value=",
 					  substituted_initializer.has_value());
 		} else if (peek() == "{"_tok) {

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -584,10 +584,18 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 		ParseResult init_result = parse_copy_initialization(
 			declaration_ref,
 			declaration_ref.type_specifier_node());
-		std::optional<ASTNode> initializer =
-			!init_result.is_error() ? init_result.node() : std::nullopt;
+		if (init_result.is_error()) {
+			FLASH_LOG(Parser, Error,
+				"Failed to parse initializer for static member variable ",
+				qualified_class_name, "::", function_name_token.value(), ": ",
+				init_result.error_message());
+			return std::nullopt;
+		}
+		std::optional<ASTNode> initializer = init_result.node();
 		if (!initializer.has_value()) {
-			FLASH_LOG(Parser, Error, "Failed to parse initializer for static member variable");
+			FLASH_LOG(Parser, Error,
+				"Failed to materialize initializer AST for static member variable ",
+				qualified_class_name, "::", function_name_token.value());
 			return std::nullopt;
 		}
 

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -581,9 +581,11 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 			definition_lookup_context.is_valid()
 				? &definition_lookup_context
 				: current_template_definition_lookup_context_);
-		std::optional<ASTNode> initializer = parse_copy_initialization(
+		ParseResult init_result = parse_copy_initialization(
 			declaration_ref,
 			declaration_ref.type_specifier_node());
+		std::optional<ASTNode> initializer =
+			!init_result.is_error() ? init_result.node() : std::nullopt;
 		if (!initializer.has_value()) {
 			FLASH_LOG(Parser, Error, "Failed to parse initializer for static member variable");
 			return std::nullopt;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8279,32 +8279,14 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return call_info.function_declaration;
 	};
-	auto fallbackToParserSelectedStaticDirectTarget =
-		[&]() -> const FunctionDeclarationNode* {
-			if (call_info.is_indirect ||
-				call_info.has_receiver ||
-				call_info.function_declaration == nullptr ||
-				call_info.function_declaration->parent_struct_name().empty() ||
-				!call_info.function_declaration->is_static()) {
-				return nullptr;
-			}
-			if (call_info.qualified_name.isValid()) {
-				// Qualified static calls need sema-owned owner resolution so nested
-				// current-instantiation owners cannot be stolen by broader parser-time
-				// matches such as unrelated global templates with the same name.
-				return nullptr;
-			}
-			if (call_info.definition_lookup_record != nullptr &&
-				call_info.definition_lookup_record->has_value()) {
-				return call_info.function_declaration;
-			}
-			return nullptr;
-		};
 	// Resolution order:
-	// 1. receiver-member direct lookup
-	// 2. callable operator / local callable resolution
-	// 3. non-receiver compatibility metadata (mangled / definition-bound / POI)
-	// 4. fresh overload lookup + ranking
+	// 1. receiver-member direct lookup, including receiver-side parser-selected fallback
+	// 2. non-receiver definition-bound direct-call recovery
+	// 3. callable operator / local callable resolution
+	// 4. dependent-unqualified POI / definition-bound recovery
+	// 5. qualified deferred template resolution
+	// 6. mangled-name compatibility fallback
+	// 7. fresh overload lookup + ranking
 	if (call_info.is_indirect) {
 		return nullptr;
 	}
@@ -8425,11 +8407,6 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 				}
 			}
 		}
-	}
-	if (const FunctionDeclarationNode* parser_selected_static_target =
-			fallbackToParserSelectedStaticDirectTarget();
-		parser_selected_static_target != nullptr) {
-		return parser_selected_static_target;
 	}
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
 	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;

--- a/tests/test_copy_init_nested_qualified_call_error_fail.cpp
+++ b/tests/test_copy_init_nested_qualified_call_error_fail.cpp
@@ -1,0 +1,8 @@
+// Regression anchor for copy-initialization diagnostics:
+// this remains a hard parse failure, and the direct compiler repro for this
+// file should surface the nested qualified-call error instead of collapsing it
+// to "Failed to parse initializer expression".
+int main() {
+	int value = Missing::f();
+	return value;
+}

--- a/tests/test_direct_init_nested_qualified_call_error_fail.cpp
+++ b/tests/test_direct_init_nested_qualified_call_error_fail.cpp
@@ -1,0 +1,8 @@
+// Regression anchor for direct-initialization diagnostics:
+// this remains a hard parse failure, and the direct compiler repro for this
+// file should surface the nested qualified-call error instead of collapsing it
+// to a generic direct-initialization wrapper.
+int main() {
+	int value(Missing::f());
+	return value;
+}


### PR DESCRIPTION
## What changed
This PR extends the post-`#1770` cleanup branch with two narrow follow-ups:

- removes the last static-member whole-call sema fallback in `resolveCallArgAnnotationTarget(...)`
- preserves nested parser failures through both `parse_copy_initialization(...)` and `parse_direct_initialization(...)` instead of collapsing them to generic wrapper errors
- adds dedicated `_fail` regressions for nested qualified-call failures in copy-init and direct-init
- updates the planning docs to record that the last whole-call sema sync leg is closed and that the initializer-diagnostics follow-up is covered

## Why
The remaining static-member branch in sema was the last direct-call synchronization hook left over from earlier compatibility-only parser metadata paths. Once the structured call metadata work landed, that branch was supposed to become unnecessary.

The initializer helpers had a separate but adjacent problem: they dropped nested `ParseResult` errors and replaced them with generic messages such as `Failed to parse initializer expression` or `Expected ')' after direct initialization arguments`. That obscured the real nested qualified-call failure that triggered the parse stop.

## Impact
Direct-call target recovery is now more strictly sema-owned: current-member static hiding still resolves correctly without the parser-selected static fallback.

Parser diagnostics are also more faithful for initializer expressions. Nested failures now surface their real cause for both `=` and `(...)` initialization forms, and the new `_fail` tests pin those diagnostics paths.

## Root cause
Two separate leftovers remained after the qualified/member-template metadata refactor:

- one sema compatibility fallback that still trusted an early parser-selected static target
- initializer helper APIs that returned only `std::optional<ASTNode>` and therefore had no way to propagate nested parse errors back to top-level declaration parsing

## Validation
Focused checks:
- `test_copy_init_nested_qualified_call_error_fail.cpp`
- `test_direct_init_nested_qualified_call_error_fail.cpp`

Manual diagnostic spot checks:
- `FlashCppMSVC.exe tests/test_copy_init_nested_qualified_call_error_fail.cpp`
- `FlashCppMSVC.exe tests/test_direct_init_nested_qualified_call_error_fail.cpp`
  Both now report `Use of undeclared identifier 'Missing::f'` instead of a generic initializer wrapper.

