### PR TITLE
[codex] refine deferred qualified member-template calls

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-20
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -159,6 +159,12 @@ the areas that were previously blocking standards-visible behavior:
   instantiation `DependentQualifiedNameRecord`, and parser return-type hints
   now come from the matched current-owner member-template declaration instead
   of whichever unrelated same-name global template was encountered first
+- the remaining dependent owner-template/member-template placeholder builders
+  in `Parser_Expr_PrimaryExpr.cpp` now route through one shared deferred
+  qualified-call helper as well, preserving the structured dependent-qualified
+  record, exact template-argument AST, and any unambiguous exact qualified
+  member-template return-type hint instead of hand-rolling four separate
+  compatibility-only exits
 - primary-template out-of-line constructor replay now synchronizes the
   `StructTypeInfo` constructor copy through preserved source-member identity
   when that identity is already known, instead of always rescanning
@@ -450,11 +456,9 @@ Next direct-call target:
 
 ## Next steps
 
-1. Finish the remaining legacy resolved-call sites that still hand-roll
-   qualified/member metadata or parser return-type hints after owner resolution
-   already succeeded, now that the compatibility-only
-   placeholder/materializer exits in `Parser_Expr_PostfixCalls.cpp` are
-   covered.
+1. Keep the parser/materializer side narrow and shift the next audit to the
+   remaining consumer paths now that the lingering dependent qualified-call
+   placeholder builders in `Parser_Expr_PrimaryExpr.cpp` are covered too.
    The postfix explicit-qualified member/operator owner-template-id exits in
    `Parser_Expr_PostfixCalls.cpp` are now covered too: `parse_member_postfix()`
    consumes qualifiers like `this->Base<T>::template pick<int>()` and
@@ -480,14 +484,19 @@ Next direct-call target:
    `resolveCallArgAnnotationTarget(...)` no longer needs the
    parser-selected static direct-call fallback, and the current-member static
    hiding regressions still pass through the preserved definition-bound call
-   metadata alone. Keep `Parser_Expr_PostfixCalls.cpp`,
-   `ExpressionSubstitutor.cpp`, and this sema area in audit mode for any
-   newly-exposed qualified/member-template builder drift, but there is no
-   remaining targeted work left inside this slice. Keep
-   `test_member_template_func_in_specialization_ret0.cpp` in the focused guard
-   set here: it exercises the new "candidate-bearing concrete owner calls must
-   defer instead of hard-failing" rule in
-   `try_parse_member_template_function_call(...)`.
+   metadata alone. `Parser_Expr_PrimaryExpr.cpp` now also shares one helper for
+   its remaining deferred owner-template/member-template call builders, so
+   those placeholder exits no longer diverge on whether they preserve the
+   structured deferred qualified record, template-argument AST, or exact
+   qualified member-template return-type hint. The next concrete audit target
+   is therefore the consumer side: verify `ExpressionSubstitutor.cpp`,
+   constexpr, and the remaining sema-qualified-call consumers do not still
+   re-split `qualified_name` text or assume missing parser return-type hints in
+   the covered owner-template/member-template flows. Keep
+   `test_member_template_func_in_specialization_ret0.cpp`,
+   `test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp`,
+   and `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
+   in the focused guard set here.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-19
+**Last updated:** 2026-06-20
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -185,6 +185,12 @@ blocking areas:
   instantiation `DependentQualifiedNameRecord`, and parser return-type hints
   now come from the matched current-owner member-template declaration instead
   of whichever unrelated same-name global template happened to be found first
+- the remaining dependent owner-template/member-template placeholder builders
+  in `Parser_Expr_PrimaryExpr.cpp` now also share one deferred qualified-call
+  materializer, so they preserve the structured dependent-qualified record,
+  exact template-argument AST, and any unambiguous exact qualified
+  member-template return-type hint instead of diverging across four separate
+  compatibility-only exits
 - sema now distinguishes real type owners from namespace qualifiers before it
   consumes definition-bound compatibility metadata for qualified direct calls,
   which fixes current-instantiation nested-owner cases like
@@ -413,42 +419,40 @@ Next direct-call target:
 
 ## Next steps
 
-1. Continue eliminating compatibility-only parser metadata in the remaining
-   qualified/member-template materializers that still stop at
-   `qualified_name` / `mangled_name` after owner resolution already succeeded.
-   Immediate next target: audit the remaining qualified/member-template
-   placeholder/materializer exits in `Parser_Expr_PrimaryExpr.cpp` and
-   `Parser_Expr_PostfixCalls.cpp` that still stop at compatibility metadata
-   even after owner resolution or deferred lookup shape is already known. The
-   unqualified/current-owner explicit-member-template placeholder path is now
-   covered; it preserves structured current-instantiation owner metadata and
-   member-template-derived parser return-type hints instead of deferring with
-   only `qualified_name`. The generic namespace-qualified explicit-template
-   placeholder path is now covered too, including the specialization-aware
-   rule that suppresses exact primary-template binding when a registered exact
-   specialization must stay visible; the concrete postfix explicit-qualified
-   member/operator template-id path without owner template arguments is now
-   covered too, and the postfix owner-template-id variant is covered as well:
-   `parse_member_postfix()` now preserves `Base<T>`-style owner template-ids
-   through the `::template` continuation for both member-template and
-   operator-template calls instead of dropping that structure before deferred
-   lookup. The short-owner postfix explicit-qualified operator-template
-   placeholder is now covered too: nested `Base::template operator()<int>()`
-   spellings canonicalize the owner before instantiation and preserve the same
-   deferred qualified-owner metadata plus parser return-type hints when
-   parsing must stay deferred. This follow-up closes the remaining targeted
-   qualified/member-template compatibility-only placeholder/materializer exits
-   in `Parser_Expr_PostfixCalls.cpp`: the explicit owner-template-id
-   member-template placeholder and the recognized qualified static-owner
-   placeholder now both preserve structured deferred qualified-owner metadata,
-   and `ExpressionSubstitutor.cpp` now materializes explicit qualified
-   member-template calls from that record instead of re-splitting
-   `qualified_name` text. The whole-call sema synchronization hook is now
-   closed fully for this slice: the qualified compatibility branch is gone,
-   and the unrelated static-member direct-call fallback in
-   `resolveCallArgAnnotationTarget(...)` is removed as well because the
-   current-member static hiding regressions still resolve correctly through the
-   preserved definition-bound call metadata.
+1. Keep the parser/materialization side narrowed and move the next audit to
+   the consumer paths now that the remaining targeted
+   owner-template/member-template placeholder builders in
+   `Parser_Expr_PrimaryExpr.cpp` are covered too. The unqualified/current-owner
+   explicit-member-template placeholder path is now covered; it preserves
+   structured current-instantiation owner metadata and member-template-derived
+   parser return-type hints instead of deferring with only `qualified_name`.
+   The generic namespace-qualified explicit-template placeholder path is now
+   covered too, including the specialization-aware rule that suppresses exact
+   primary-template binding when a registered exact specialization must stay
+   visible; the concrete postfix explicit-qualified member/operator template-id
+   path without owner template arguments is now covered too, and the postfix
+   owner-template-id variant is covered as well: `parse_member_postfix()` now
+   preserves `Base<T>`-style owner template-ids through the `::template`
+   continuation for both member-template and operator-template calls instead
+   of dropping that structure before deferred lookup. The short-owner postfix
+   explicit-qualified operator-template placeholder is now covered too: nested
+   `Base::template operator()<int>()` spellings canonicalize the owner before
+   instantiation and preserve the same deferred qualified-owner metadata plus
+   parser return-type hints when parsing must stay deferred. The remaining
+   targeted deferred owner-template/member-template call builders in
+   `Parser_Expr_PrimaryExpr.cpp` now share the same structured deferred-call
+   helper too, so they no longer diverge on whether they preserve the
+   dependent-qualified record, template-argument AST, or exact qualified
+   member-template return-type hint. The next concrete audit target is
+   therefore `ExpressionSubstitutor.cpp`, constexpr, and the remaining
+   sema-qualified-call consumers: verify those paths consume the structured
+   deferred qualified metadata directly instead of re-splitting
+   `qualified_name` text or assuming the old missing-hint behavior. The
+   whole-call sema synchronization hook is now closed fully for this slice:
+   the qualified compatibility branch is gone, and the unrelated static-member
+   direct-call fallback in `resolveCallArgAnnotationTarget(...)` is removed as
+   well because the current-member static hiding regressions still resolve
+   correctly through the preserved definition-bound call metadata.
 2. If another pointer-to-member issue appears, close the remaining canonical
    `TypeCategory::MemberObjectPointer` carrier gap by preserving the
    underlying member type explicitly instead of relying on declarator-shaped

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1946,7 +1946,7 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		std::string_view qualified_call_name,
 		const Token& called_from_token,
 		ChunkedVector<ASTNode>&& arguments,
-		const TypeInfo::DependentQualifiedNameRecord& dependent_record,
+		const TypeInfo::DependentQualifiedNameRecord* dependent_record,
 		std::vector<ASTNode>&& template_argument_nodes,
 		const TypeSpecifierNode* parser_return_type_hint);
 	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1942,6 +1942,13 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		const ASTNode& resolved_decl,
 		ChunkedVector<ASTNode>&& arguments,
 		Token called_from_token);
+	ExpressionNode makeDeferredDependentQualifiedCallExpr(
+		std::string_view qualified_call_name,
+		const Token& called_from_token,
+		ChunkedVector<ASTNode>&& arguments,
+		const TypeInfo::DependentQualifiedNameRecord& dependent_record,
+		std::vector<ASTNode>&& template_argument_nodes,
+		const TypeSpecifierNode* parser_return_type_hint);
 	std::optional<ASTNode> resolveDefinitionBoundOrdinaryCall(
 		const FunctionCallDefinitionLookupRecord& record,
 		std::span<const TypeSpecifierNode> arg_types);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -210,6 +210,29 @@ std::string_view buildDependentQualifiedCallName(
 	return qualified_name_builder.commit();
 }
 
+std::string_view buildDependentQualifiedLookupName(
+	std::string_view owner_name,
+	std::span<const ExpressionDependentMemberSegmentInfo> member_segments) {
+	StringBuilder qualified_name_builder;
+	qualified_name_builder.append(owner_name);
+	for (const ExpressionDependentMemberSegmentInfo& member_segment : member_segments) {
+		qualified_name_builder.append("::");
+		qualified_name_builder.append(StringTable::getStringView(member_segment.name));
+	}
+	return qualified_name_builder.commit();
+}
+
+const std::vector<ASTNode>* lookupDeferredQualifiedMemberTemplateOverloads(
+	std::string_view owner_name,
+	std::span<const ExpressionDependentMemberSegmentInfo> member_segments) {
+	if (owner_name.empty() || member_segments.empty()) {
+		return nullptr;
+	}
+	const std::string_view qualified_lookup_name =
+		buildDependentQualifiedLookupName(owner_name, member_segments);
+	return gTemplateRegistry.lookupAllTemplates(qualified_lookup_name);
+}
+
 template <typename LookupRecordT>
 void initializeCallLookupRecordCommon(
 	LookupRecordT& record,
@@ -1435,6 +1458,42 @@ ExpressionNode Parser::makeDeferredOrdinaryDirectCallExpr(
 
 	throw InternalError(
 		"Unsupported call target node type in makeDeferredOrdinaryDirectCallExpr");
+}
+
+ExpressionNode Parser::makeDeferredDependentQualifiedCallExpr(
+	std::string_view qualified_call_name,
+	const Token& called_from_token,
+	ChunkedVector<ASTNode>&& arguments,
+	const TypeInfo::DependentQualifiedNameRecord& dependent_record,
+	std::vector<ASTNode>&& template_argument_nodes,
+	const TypeSpecifierNode* parser_return_type_hint) {
+	auto type_node = emplace_node<TypeSpecifierNode>(
+		TypeIndex{}.withCategory(TypeCategory::Auto),
+		0,
+		called_from_token,
+		CVQualifier::None,
+		ReferenceQualifier::None);
+	auto placeholder_decl =
+		emplace_node<DeclarationNode>(type_node, called_from_token);
+	Token deferred_call_token(
+		Token::Type::Identifier,
+		qualified_call_name,
+		called_from_token.line(),
+		called_from_token.column(),
+		called_from_token.file_index());
+	ExpressionNode call_expr = makeDirectCallExpr(
+		placeholder_decl.as<DeclarationNode>(),
+		std::move(arguments),
+		deferred_call_token);
+	setCallQualifiedName(call_expr, qualified_call_name);
+	setCallDependentQualifiedLookupRecord(call_expr, dependent_record);
+	if (!template_argument_nodes.empty()) {
+		setCallTemplateArguments(call_expr, std::move(template_argument_nodes));
+	}
+	if (parser_return_type_hint != nullptr) {
+		setCallParserReturnTypeHint(call_expr, *parser_return_type_hint);
+	}
+	return call_expr;
 }
 
 namespace {
@@ -7266,44 +7325,38 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											toTemplateArgInfoList(*explicit_template_args),
 											dependent_member_segments));
 									if (has_deferred_member_call) {
-										auto type_node = emplace_node<TypeSpecifierNode>(
-											TypeIndex{}.withCategory(TypeCategory::Auto),
-											0,
-											deferred_member_call_token,
-											CVQualifier::None,
-											ReferenceQualifier::None);
-										auto placeholder_decl =
-											emplace_node<DeclarationNode>(
-												type_node,
-												deferred_member_call_token);
 										std::string_view deferred_qualified_call_name =
 											buildDependentQualifiedCallName(
 												StringTable::getStringView(dependent_owner_handle),
 												dependent_member_segments);
-										Token deferred_call_token(
-											Token::Type::Identifier,
-											deferred_qualified_call_name,
-											deferred_member_call_token.line(),
-											deferred_member_call_token.column(),
-											deferred_member_call_token.file_index());
-										result = emplace_node<ExpressionNode>(
-											makeDirectCallExpr(
-												placeholder_decl.as<DeclarationNode>(),
-												std::move(deferred_member_call_args),
-												deferred_call_token));
-										setCallQualifiedName(
-											result->as<ExpressionNode>(),
-											deferred_qualified_call_name);
+										const std::vector<ASTNode>* deferred_template_overloads =
+											lookupDeferredQualifiedMemberTemplateOverloads(
+												StringTable::getStringView(
+													dependent_owner_handle),
+												dependent_member_segments);
+										const FunctionDeclarationNode* parser_return_hint_decl =
+											(deferred_template_overloads != nullptr &&
+											 !deferred_template_overloads->empty())
+												? this->trySelectUnambiguousParserReturnTypeHint(
+													std::span<const ASTNode>(
+														deferred_template_overloads->data(),
+														deferred_template_overloads->size()))
+												: nullptr;
 										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 												dependent_qual_id.dependentQualifiedName()) {
-											setCallDependentQualifiedLookupRecord(
-												result->as<ExpressionNode>(),
-												*dependent_record);
-										}
-										if (!deferred_member_call_template_arg_nodes.empty()) {
-											setCallTemplateArguments(
-												result->as<ExpressionNode>(),
-												std::move(deferred_member_call_template_arg_nodes));
+											result = emplace_node<ExpressionNode>(
+												makeDeferredDependentQualifiedCallExpr(
+													deferred_qualified_call_name,
+													deferred_member_call_token,
+													std::move(deferred_member_call_args),
+													*dependent_record,
+													std::move(
+														deferred_member_call_template_arg_nodes),
+													parser_return_hint_decl != nullptr
+														? &parser_return_hint_decl
+															 ->decl_node()
+															 .type_specifier_node()
+														: nullptr));
 										}
 									} else {
 										if (!terminal_member_template_arg_nodes.empty()) {
@@ -7424,44 +7477,37 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 											toTemplateArgInfoList(*explicit_template_args),
 											deferred_member_segments));
 									if (has_deferred_member_call) {
-										auto type_node = emplace_node<TypeSpecifierNode>(
-											TypeIndex{}.withCategory(TypeCategory::Auto),
-											0,
-											deferred_member_call_token,
-											CVQualifier::None,
-											ReferenceQualifier::None);
-										auto placeholder_decl =
-											emplace_node<DeclarationNode>(
-												type_node,
-												deferred_member_call_token);
 										std::string_view deferred_qualified_call_name =
 											buildDependentQualifiedCallName(
 												instantiated_name,
 												deferred_member_segments);
-										Token deferred_call_token(
-											Token::Type::Identifier,
-											deferred_qualified_call_name,
-											deferred_member_call_token.line(),
-											deferred_member_call_token.column(),
-											deferred_member_call_token.file_index());
-										result = emplace_node<ExpressionNode>(
-											makeDirectCallExpr(
-												placeholder_decl.as<DeclarationNode>(),
-												std::move(deferred_member_call_args),
-												deferred_call_token));
-										setCallQualifiedName(
-											result->as<ExpressionNode>(),
-											deferred_qualified_call_name);
+										const std::vector<ASTNode>* deferred_template_overloads =
+											lookupDeferredQualifiedMemberTemplateOverloads(
+												instantiated_name,
+												deferred_member_segments);
+										const FunctionDeclarationNode* parser_return_hint_decl =
+											(deferred_template_overloads != nullptr &&
+											 !deferred_template_overloads->empty())
+												? this->trySelectUnambiguousParserReturnTypeHint(
+													std::span<const ASTNode>(
+														deferred_template_overloads->data(),
+														deferred_template_overloads->size()))
+												: nullptr;
 										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 												dependent_qual_id.dependentQualifiedName()) {
-											setCallDependentQualifiedLookupRecord(
-												result->as<ExpressionNode>(),
-												*dependent_record);
-										}
-										if (!deferred_member_call_template_arg_nodes.empty()) {
-											setCallTemplateArguments(
-												result->as<ExpressionNode>(),
-												std::move(deferred_member_call_template_arg_nodes));
+											result = emplace_node<ExpressionNode>(
+												makeDeferredDependentQualifiedCallExpr(
+													deferred_qualified_call_name,
+													deferred_member_call_token,
+													std::move(deferred_member_call_args),
+													*dependent_record,
+													std::move(
+														deferred_member_call_template_arg_nodes),
+													parser_return_hint_decl != nullptr
+														? &parser_return_hint_decl
+															 ->decl_node()
+															 .type_specifier_node()
+														: nullptr));
 										}
 									} else {
 										if (!terminal_member_template_arg_nodes.empty()) {
@@ -8498,44 +8544,38 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									toTemplateArgInfoList(*explicit_template_args),
 									dependent_member_segments));
 							if (has_deferred_member_call) {
-								auto type_node = emplace_node<TypeSpecifierNode>(
-									TypeIndex{}.withCategory(TypeCategory::Auto),
-									0,
-									deferred_member_call_token,
-									CVQualifier::None,
-									ReferenceQualifier::None);
-								auto placeholder_decl =
-									emplace_node<DeclarationNode>(
-										type_node,
-										deferred_member_call_token);
 								std::string_view deferred_qualified_call_name =
 									buildDependentQualifiedCallName(
 										StringTable::getStringView(dependent_owner_handle),
 										dependent_member_segments);
-								Token deferred_call_token(
-									Token::Type::Identifier,
-									deferred_qualified_call_name,
-									deferred_member_call_token.line(),
-									deferred_member_call_token.column(),
-									deferred_member_call_token.file_index());
-								result = emplace_node<ExpressionNode>(
-									makeDirectCallExpr(
-										placeholder_decl.as<DeclarationNode>(),
-										std::move(deferred_member_call_args),
-										deferred_call_token));
-								setCallQualifiedName(
-									result->as<ExpressionNode>(),
-									deferred_qualified_call_name);
+								const std::vector<ASTNode>* deferred_template_overloads =
+									lookupDeferredQualifiedMemberTemplateOverloads(
+										StringTable::getStringView(
+											dependent_owner_handle),
+										dependent_member_segments);
+								const FunctionDeclarationNode* parser_return_hint_decl =
+									(deferred_template_overloads != nullptr &&
+									 !deferred_template_overloads->empty())
+										? this->trySelectUnambiguousParserReturnTypeHint(
+											std::span<const ASTNode>(
+												deferred_template_overloads->data(),
+												deferred_template_overloads->size()))
+										: nullptr;
 								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 										dependent_qual_id.dependentQualifiedName()) {
-									setCallDependentQualifiedLookupRecord(
-										result->as<ExpressionNode>(),
-										*dependent_record);
-								}
-								if (!deferred_member_call_template_arg_nodes.empty()) {
-									setCallTemplateArguments(
-										result->as<ExpressionNode>(),
-										std::move(deferred_member_call_template_arg_nodes));
+									result = emplace_node<ExpressionNode>(
+										makeDeferredDependentQualifiedCallExpr(
+											deferred_qualified_call_name,
+											deferred_member_call_token,
+											std::move(deferred_member_call_args),
+											*dependent_record,
+											std::move(
+												deferred_member_call_template_arg_nodes),
+											parser_return_hint_decl != nullptr
+												? &parser_return_hint_decl
+													 ->decl_node()
+													 .type_specifier_node()
+												: nullptr));
 								}
 							} else {
 								if (!terminal_member_template_arg_nodes.empty()) {
@@ -8654,44 +8694,37 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 									toTemplateArgInfoList(*explicit_template_args),
 									deferred_member_segments));
 							if (has_deferred_member_call) {
-								auto type_node = emplace_node<TypeSpecifierNode>(
-									TypeIndex{}.withCategory(TypeCategory::Auto),
-									0,
-									deferred_member_call_token,
-									CVQualifier::None,
-									ReferenceQualifier::None);
-								auto placeholder_decl =
-									emplace_node<DeclarationNode>(
-										type_node,
-										deferred_member_call_token);
 								std::string_view deferred_qualified_call_name =
 									buildDependentQualifiedCallName(
 										instantiated_class_name,
 										deferred_member_segments);
-								Token deferred_call_token(
-									Token::Type::Identifier,
-									deferred_qualified_call_name,
-									deferred_member_call_token.line(),
-									deferred_member_call_token.column(),
-									deferred_member_call_token.file_index());
-								result = emplace_node<ExpressionNode>(
-									makeDirectCallExpr(
-										placeholder_decl.as<DeclarationNode>(),
-										std::move(deferred_member_call_args),
-										deferred_call_token));
-								setCallQualifiedName(
-									result->as<ExpressionNode>(),
-									deferred_qualified_call_name);
+								const std::vector<ASTNode>* deferred_template_overloads =
+									lookupDeferredQualifiedMemberTemplateOverloads(
+										instantiated_class_name,
+										deferred_member_segments);
+								const FunctionDeclarationNode* parser_return_hint_decl =
+									(deferred_template_overloads != nullptr &&
+									 !deferred_template_overloads->empty())
+										? this->trySelectUnambiguousParserReturnTypeHint(
+											std::span<const ASTNode>(
+												deferred_template_overloads->data(),
+												deferred_template_overloads->size()))
+										: nullptr;
 								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
 										dependent_qual_id.dependentQualifiedName()) {
-									setCallDependentQualifiedLookupRecord(
-										result->as<ExpressionNode>(),
-										*dependent_record);
-								}
-								if (!deferred_member_call_template_arg_nodes.empty()) {
-									setCallTemplateArguments(
-										result->as<ExpressionNode>(),
-										std::move(deferred_member_call_template_arg_nodes));
+									result = emplace_node<ExpressionNode>(
+										makeDeferredDependentQualifiedCallExpr(
+											deferred_qualified_call_name,
+											deferred_member_call_token,
+											std::move(deferred_member_call_args),
+											*dependent_record,
+											std::move(
+												deferred_member_call_template_arg_nodes),
+											parser_return_hint_decl != nullptr
+												? &parser_return_hint_decl
+													 ->decl_node()
+													 .type_specifier_node()
+												: nullptr));
 								}
 							} else {
 								if (!terminal_member_template_arg_nodes.empty()) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1464,7 +1464,7 @@ ExpressionNode Parser::makeDeferredDependentQualifiedCallExpr(
 	std::string_view qualified_call_name,
 	const Token& called_from_token,
 	ChunkedVector<ASTNode>&& arguments,
-	const TypeInfo::DependentQualifiedNameRecord& dependent_record,
+	const TypeInfo::DependentQualifiedNameRecord* dependent_record,
 	std::vector<ASTNode>&& template_argument_nodes,
 	const TypeSpecifierNode* parser_return_type_hint) {
 	auto type_node = emplace_node<TypeSpecifierNode>(
@@ -1486,7 +1486,9 @@ ExpressionNode Parser::makeDeferredDependentQualifiedCallExpr(
 		std::move(arguments),
 		deferred_call_token);
 	setCallQualifiedName(call_expr, qualified_call_name);
-	setCallDependentQualifiedLookupRecord(call_expr, dependent_record);
+	if (dependent_record != nullptr) {
+		setCallDependentQualifiedLookupRecord(call_expr, *dependent_record);
+	}
 	if (!template_argument_nodes.empty()) {
 		setCallTemplateArguments(call_expr, std::move(template_argument_nodes));
 	}
@@ -7342,22 +7344,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 														deferred_template_overloads->data(),
 														deferred_template_overloads->size()))
 												: nullptr;
-										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-												dependent_qual_id.dependentQualifiedName()) {
-											result = emplace_node<ExpressionNode>(
-												makeDeferredDependentQualifiedCallExpr(
-													deferred_qualified_call_name,
-													deferred_member_call_token,
-													std::move(deferred_member_call_args),
-													*dependent_record,
-													std::move(
-														deferred_member_call_template_arg_nodes),
-													parser_return_hint_decl != nullptr
-														? &parser_return_hint_decl
-															 ->decl_node()
-															 .type_specifier_node()
-														: nullptr));
-										}
+										result = emplace_node<ExpressionNode>(
+											makeDeferredDependentQualifiedCallExpr(
+												deferred_qualified_call_name,
+												deferred_member_call_token,
+												std::move(deferred_member_call_args),
+												dependent_qual_id.dependentQualifiedName(),
+												std::move(
+													deferred_member_call_template_arg_nodes),
+												parser_return_hint_decl != nullptr
+													? &parser_return_hint_decl
+														 ->decl_node()
+														 .type_specifier_node()
+													: nullptr));
 									} else {
 										if (!terminal_member_template_arg_nodes.empty()) {
 											dependent_qual_id.set_template_arguments(
@@ -7493,22 +7492,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 														deferred_template_overloads->data(),
 														deferred_template_overloads->size()))
 												: nullptr;
-										if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-												dependent_qual_id.dependentQualifiedName()) {
-											result = emplace_node<ExpressionNode>(
-												makeDeferredDependentQualifiedCallExpr(
-													deferred_qualified_call_name,
-													deferred_member_call_token,
-													std::move(deferred_member_call_args),
-													*dependent_record,
-													std::move(
-														deferred_member_call_template_arg_nodes),
-													parser_return_hint_decl != nullptr
-														? &parser_return_hint_decl
-															 ->decl_node()
-															 .type_specifier_node()
-														: nullptr));
-										}
+										result = emplace_node<ExpressionNode>(
+											makeDeferredDependentQualifiedCallExpr(
+												deferred_qualified_call_name,
+												deferred_member_call_token,
+												std::move(deferred_member_call_args),
+												dependent_qual_id.dependentQualifiedName(),
+												std::move(
+													deferred_member_call_template_arg_nodes),
+												parser_return_hint_decl != nullptr
+													? &parser_return_hint_decl
+														 ->decl_node()
+														 .type_specifier_node()
+													: nullptr));
 									} else {
 										if (!terminal_member_template_arg_nodes.empty()) {
 											dependent_qual_id.set_template_arguments(
@@ -8561,22 +8557,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												deferred_template_overloads->data(),
 												deferred_template_overloads->size()))
 										: nullptr;
-								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-										dependent_qual_id.dependentQualifiedName()) {
-									result = emplace_node<ExpressionNode>(
-										makeDeferredDependentQualifiedCallExpr(
-											deferred_qualified_call_name,
-											deferred_member_call_token,
-											std::move(deferred_member_call_args),
-											*dependent_record,
-											std::move(
-												deferred_member_call_template_arg_nodes),
-											parser_return_hint_decl != nullptr
-												? &parser_return_hint_decl
-													 ->decl_node()
-													 .type_specifier_node()
-												: nullptr));
-								}
+								result = emplace_node<ExpressionNode>(
+									makeDeferredDependentQualifiedCallExpr(
+										deferred_qualified_call_name,
+										deferred_member_call_token,
+										std::move(deferred_member_call_args),
+										dependent_qual_id.dependentQualifiedName(),
+										std::move(
+											deferred_member_call_template_arg_nodes),
+										parser_return_hint_decl != nullptr
+											? &parser_return_hint_decl
+												 ->decl_node()
+												 .type_specifier_node()
+											: nullptr));
 							} else {
 								if (!terminal_member_template_arg_nodes.empty()) {
 									dependent_qual_id.set_template_arguments(
@@ -8710,22 +8703,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 												deferred_template_overloads->data(),
 												deferred_template_overloads->size()))
 										: nullptr;
-								if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
-										dependent_qual_id.dependentQualifiedName()) {
-									result = emplace_node<ExpressionNode>(
-										makeDeferredDependentQualifiedCallExpr(
-											deferred_qualified_call_name,
-											deferred_member_call_token,
-											std::move(deferred_member_call_args),
-											*dependent_record,
-											std::move(
-												deferred_member_call_template_arg_nodes),
-											parser_return_hint_decl != nullptr
-												? &parser_return_hint_decl
-													 ->decl_node()
-													 .type_specifier_node()
-												: nullptr));
-								}
+								result = emplace_node<ExpressionNode>(
+									makeDeferredDependentQualifiedCallExpr(
+										deferred_qualified_call_name,
+										deferred_member_call_token,
+										std::move(deferred_member_call_args),
+										dependent_qual_id.dependentQualifiedName(),
+										std::move(
+											deferred_member_call_template_arg_nodes),
+										parser_return_hint_decl != nullptr
+											? &parser_return_hint_decl
+												 ->decl_node()
+												 .type_specifier_node()
+											: nullptr));
 							} else {
 								if (!terminal_member_template_arg_nodes.empty()) {
 									dependent_qual_id.set_template_arguments(

--- a/tests/test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp
+++ b/tests/test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp
@@ -1,0 +1,34 @@
+template <class T>
+struct Box {
+	T value;
+
+	T operator()() const;
+
+	template <class U>
+	U read() const;
+};
+
+template <class T>
+struct Base {
+	template <class U>
+	static Box<U> make();
+};
+
+template <class T>
+struct Holder {
+	using ValueType = decltype(Base<T>::template make<T>().value);
+	using CallType = decltype(Base<T>::template make<T>()());
+	using ReadType = decltype(Base<T>::template make<T>().template read<T>());
+
+	static int run() {
+		return sizeof(ValueType) == sizeof(T) &&
+				sizeof(CallType) == sizeof(T) &&
+				sizeof(ReadType) == sizeof(T)
+			? 0
+			: 1;
+	}
+};
+
+int main() {
+	return Holder<int>::run();
+}


### PR DESCRIPTION
## What changed
- consolidated the remaining deferred owner-template/member-template placeholder builders in `Parser_Expr_PrimaryExpr.cpp` onto one shared `makeDeferredDependentQualifiedCallExpr(...)` path
- preserved structured dependent-qualified lookup metadata, template-argument AST, and unambiguous parser return-type hints for those deferred qualified calls
- added `tests/test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
- updated the template-argument audit docs to mark the parser/materializer slice closed and move the next step to the consumer-side audit

## Why
The remaining parser exits in this area still hand-rolled deferred qualified call placeholders. That left the owner-template/member-template paths needlessly divergent on whether they preserved exact structured metadata and return-type hints after owner resolution had already succeeded.

## Root cause
The deferred qualified member-template builders were duplicated across several `PrimaryExpr` branches. Each branch rebuilt the same placeholder shape separately, which made it easy for one path to preserve structured owner metadata while another omitted return-type hints or template-argument state.

## Impact
- deferred qualified owner-template/member-template calls now materialize through one consistent parser path
- downstream substitution / sema / constexpr consumers receive the same structured qualified-call payload more reliably
- the new regression covers postfix `decltype` continuation off a qualified member-template result
