### PR TITLE
[codex] Fix contextual bool pointer normalization

### DIFF
--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -1045,6 +1045,12 @@ typename IrToObjConverter<TWriterClass>::ArithmeticOperationContext IrToObjConve
 		ctx.operand_type = TypeCategory::UnsignedLongLong;
 		ctx.operand_size_in_bits = 64;
 	}
+	// Operand loads below must follow the coerced runtime representation, not
+	// the original semantic base type. This matters for pointer-like values
+	// whose semantic category may be Float/Double but whose IR representation is
+	// still a 64-bit address.
+	operand_type = ctx.operand_type;
+	operand_size = ctx.operand_size_in_bits;
 	if (!isIrIntegerType(ctx.result_value.effectiveIrType()) && !isIrFloatingPointType(ctx.result_value.effectiveIrType())) {
 		auto type_name = getTypeName(ctx.result_value.typeEnum());
 		std::string type_desc = type_name.empty() ? std::string("type_id=") + std::to_string(static_cast<int>(ctx.result_value.typeEnum())) : std::string(type_name);

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -2563,18 +2563,48 @@ TypeCategory AstToIr::getSemaAnnotatedTargetType(const ASTNode& node) const {
 }
 
 ExprResult AstToIr::applyConditionBoolConversion(ExprResult condition, const ASTNode& cond_node, const Token& source_token) {
-	// C++20 [conv.bool]: convert condition to bool for control-flow statements.
+	// C++20 [conv.bool]: contextual conversion to bool yields an actual bool
+	// prvalue, not a full-width integer/pointer value that only happens to work
+	// in branch instructions.
 	//
-	// Integer types: the backend's TEST instruction already implements the
-	// correct "nonzero → true, zero → false" semantics.  No conversion needed.
+	// Integer/pointer/enum-like values: emit != 0 so all consumers see a
+	// normalized bool8 result.
 	//
-	// Floating-point types: we emit a FloatNotEqual comparison against 0.0.
+	// Floating-point types: emit FloatNotEqual against 0.0.
 	// This correctly handles:
 	//   - -0.0: UCOMISD/UCOMISS treats -0.0 == +0.0, so SETNE → 0 (false). ✓
 	//   - Fractional values (e.g. 0.5): 0.5 != 0.0 → SETNE → 1 (true). ✓
 	//   - NaN: unordered comparison → PF=1, SETNE → 1 (truthy per C++20). ✓
 	// The previous FloatToInt (cvttsd2si) truncation was wrong because it
 	// mapped fractional values like 0.5 to integer 0 (false).
+	if (condition.pointer_depth.value == 0 && condition.typeEnum() == TypeCategory::Bool) {
+		return condition;
+	}
+
+	auto emitNonZeroBoolTest = [&](ExprResult cond) -> ExprResult {
+		const bool use_integer_pointer_rep =
+			cond.pointer_depth.is_pointer() ||
+			cond.effectiveIrType() == IrType::FunctionPointer ||
+			cond.effectiveIrType() == IrType::MemberFunctionPointer ||
+			cond.effectiveIrType() == IrType::MemberObjectPointer ||
+			cond.effectiveIrType() == IrType::Nullptr;
+
+		TypedValue lhs = use_integer_pointer_rep
+			? makeTypedValue(TypeCategory::UnsignedLongLong, cond.size_in_bits, toIrValue(cond.value))
+			: toTypedValue(cond);
+		TypedValue rhs = use_integer_pointer_rep
+			? makeTypedValue(TypeCategory::UnsignedLongLong, cond.size_in_bits, 0ULL)
+			: makeTypedValue(cond.typeEnum(), cond.size_in_bits, 0ULL);
+
+		TempVar result_var = var_counter.next();
+		BinaryOp bin_op{
+			.lhs = lhs,
+			.rhs = rhs,
+			.result = result_var,
+		};
+		ir_.addInstruction(IrInstruction(IrOpcode::NotEqual, std::move(bin_op), source_token));
+		return makeExprResult(nativeTypeIndex(TypeCategory::Bool), SizeInBits{8}, IrOperand{result_var}, PointerDepth{}, ValueStorage::ContainsData);
+	};
 
 	auto emitFloatNonZeroTest = [&](ExprResult cond) -> ExprResult {
 		// Materialize a 0.0 constant with the same float type as the condition.
@@ -2606,12 +2636,12 @@ ExprResult AstToIr::applyConditionBoolConversion(ExprResult condition, const AST
 			if (from_desc.pointer_levels.empty() && is_floating_point_type(from_desc.category())) {
 				return emitFloatNonZeroTest(condition);
 			}
-			// Enum/pointer → bool (Phase 9): backend TEST already implements
-			// correct zero/null → false, non-zero/non-null → true semantics.
-			// Consume the annotation without emitting extra code.
+			// Enum/integer/pointer/void* → bool: normalize to an actual bool8 value
+			// so logical operators and other consumers do not reinterpret a
+			// full-width scalar as an already-materialized bool.
 			if (cast_info.cast_kind == StandardConversionKind::BooleanConversion ||
 				cast_info.cast_kind == StandardConversionKind::PointerConversion) {
-				return condition;
+				return emitNonZeroBoolTest(condition);
 			}
 				// Phase 23: Struct → bool via user-defined operator bool().
 				// Sema annotates as UserDefined; call emitConversionOperatorCall.
@@ -2637,12 +2667,16 @@ ExprResult AstToIr::applyConditionBoolConversion(ExprResult condition, const AST
 		}
 	}
 	// 2. Fallback: floating-point conditions need explicit conversion because
-	//    the backend's TEST instruction operates on integer bit patterns and
-	//    would mishandle -0.0, which has nonzero bits but is semantically false.
+	//    bool conversion is based on numeric comparison with 0.0, not raw bits.
 	//    Guard: pointer types (even float*/double*) are integer-width addresses
-	//    and must use TEST, not FloatNotEqual.
+	//    and must use != 0, not FloatNotEqual.
 	if (condition.pointer_depth.value == 0 && is_floating_point_type(condition.typeEnum())) {
 		return emitFloatNonZeroTest(condition);
+	}
+	// Integer, enum, pointer-like, and other scalar truthiness cases normalize
+	// through != 0 so every contextual-bool consumer receives bool8.
+	if (condition.category() != TypeCategory::Struct) {
+		return emitNonZeroBoolTest(condition);
 	}
 	// Note 2026-04-29: the codegen-side struct → bool conversion-operator fallback
 	// previously located here was probed across the full 2243-test corpus with a

--- a/tests/test_contextual_bool_float_pointer_ret0.cpp
+++ b/tests/test_contextual_bool_float_pointer_ret0.cpp
@@ -11,34 +11,73 @@
 int main() {
 	float f = 0.0f;
 	float* fp = &f;		// non-null pointer to a zero float
-	float* fn = nullptr;	 // null pointer
+	float* fn = nullptr; // null pointer
 
 	double d = 0.0;
-	double* dp = &d;		 // non-null pointer to a zero double
+	double* dp = &d;	 // non-null pointer to a zero double
 	double* dn = nullptr; // null pointer
 
-	int result = 0;
-
- // Non-null float pointer: truthy (even though *fp == 0.0f).
-	if (fp) {
-		result += 1;
+	// Non-null float pointer: truthy (even though *fp == 0.0f).
+	if (!fp) {
+		return 1;
 	}
 
- // Null float pointer: falsy.
+	// Null float pointer: falsy.
 	if (fn) {
-		result += 100;  // should NOT execute
+		return 2;
 	}
 
- // Non-null double pointer: truthy (even though *dp == 0.0).
-	if (dp) {
-		result += 10;
+	// Non-null double pointer: truthy (even though *dp == 0.0).
+	if (!dp) {
+		return 3;
 	}
 
- // Null double pointer: falsy.
+	// Null double pointer: falsy.
 	if (dn) {
-		result += 100;  // should NOT execute
+		return 4;
 	}
 
- // Expected: result == 11 (1 + 10)
-	return result - 11;
+	// Logical operators and ternary must observe the normalized bool result of
+	// contextual conversion, not reinterpret the raw pointer bits as bool8.
+	if (!(fp && dp)) {
+		return 5;
+	}
+
+	if (fp && fn) {
+		return 6;
+	}
+
+	if (!(fp || fn)) {
+		return 7;
+	}
+
+	if (fn || dn) {
+		return 8;
+	}
+
+	if (!!fn) {
+		return 9;
+	}
+
+	if (!fp) {
+		return 10;
+	}
+
+	if ((fp ? 1 : 0) != 1) {
+		return 11;
+	}
+
+	if ((fn ? 1 : 0) != 0) {
+		return 12;
+	}
+
+	if ((dn ? 1 : 0) != 0) {
+		return 13;
+	}
+
+	if ((dp ? 1 : 0) != 1) {
+		return 14;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
## Summary
Fix contextual-bool lowering so pointer and scalar conditions materialize a real `bool` result instead of relying on branch-only truthiness.

## Root cause
`applyConditionBoolConversion(...)` left integer, enum, and pointer conditions as their original full-width values. That happened to work for `if` and loop branches because the backend tests the full register directly, but it was not a valid `bool` result for other contextual-bool consumers such as `&&`, `||`, `!`, and `?:`.

A second issue in binary-op lowering kept using the original semantic base type when loading operands even after pointer-like values had been coerced to integer runtime representation, so cases like `double* != 0` could still be loaded through floating-point paths.

## What changed
- normalize contextual-bool scalar and pointer cases through `!= 0`
- keep contextual conversion of existing `bool` values as an identity conversion
- make binary-op operand loads follow the coerced runtime representation for pointer-like values
- extend the existing float/double pointer contextual-bool regression to cover `if`, `&&`, `||`, `!`, and ternary usage
