### PR TITLE
Improve parser and semantic handling for static operators, type spellings, and nullptr conversions

### DIFF
--- a/src/ConstExprEvaluator_Bindings.cpp
+++ b/src/ConstExprEvaluator_Bindings.cpp
@@ -82,7 +82,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::resolveConstexprMemberCall
 			}
 
 			const OverloadResolutionResult overload_result =
-				resolve_overload(overloads, arg_types);
+				resolve_overload_with_argument_nodes(overloads, arg_types, std::span<const ASTNode>{});
 			if (overload_result.is_ambiguous) {
 				if (ambiguous_out != nullptr) {
 					*ambiguous_out = true;

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1936,7 +1936,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			return nullptr;
 		}
 		OverloadResolutionResult resolution =
-			resolve_overload(candidates, substituted_arg_types);
+			resolve_overload_with_argument_nodes(candidates, substituted_arg_types, std::span<const ASTNode>{});
 		if (resolution.has_match &&
 			!resolution.is_ambiguous &&
 			resolution.selected_overload != nullptr &&
@@ -3130,7 +3130,7 @@ ASTNode ExpressionSubstitutor::substituteCallExpr(const CallExprNode& call) {
 				return nullptr;
 			}
 			OverloadResolutionResult resolution =
-				resolve_overload(candidates, substituted_arg_types);
+				resolve_overload_with_argument_nodes(candidates, substituted_arg_types, std::span<const ASTNode>{});
 			if (resolution.has_match &&
 				!resolution.is_ambiguous &&
 				resolution.selected_overload != nullptr &&

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1033,6 +1033,10 @@ inline TypeConversionResult can_convert_type(const TypeSpecifierNode& from, cons
 
 inline bool isIntegerLiteralZeroNullPointerConstant(const ASTNode& arg_node);
 inline bool parameterSupportsNullPointerConstantOverloadConversion(const TypeSpecifierNode& parameter_type);
+inline bool isNullptrTypeParameterForNullPointerConstantOverloadConversion(const TypeSpecifierNode& parameter_type);
+inline bool isIntegerLiteralZeroNullptrTypeOverloadConversion(
+	const ASTNode* argument_node,
+	const TypeSpecifierNode& parameter_type);
 inline TypeSpecifierNode normalizeArgumentTypeForNullPointerConstantConversion(
 	const TypeSpecifierNode& argument_type,
 	const TypeSpecifierNode& parameter_type,
@@ -1047,6 +1051,9 @@ inline ArgumentConversionInfo buildArgumentConversionInfo(
 			argument_type,
 			parameter_type,
 			argument_node);
+	if (isIntegerLiteralZeroNullptrTypeOverloadConversion(argument_node, parameter_type)) {
+		return {ConversionRank::Conversion, &parameter_type, true};
+	}
 
 	const ConversionPlan conversion = buildConversionPlan(effective_argument_type, parameter_type);
 	return {conversion.rank, &parameter_type, conversion.is_valid};
@@ -1141,7 +1148,21 @@ inline bool parameterSupportsNullPointerConstantOverloadConversion(const TypeSpe
 	return parameter_type.is_pointer() ||
 		   parameter_type.is_function_pointer() ||
 		   parameter_type.is_member_function_pointer() ||
-		   parameter_type.is_member_object_pointer();
+		   parameter_type.is_member_object_pointer() ||
+		   isNullptrTypeParameterForNullPointerConstantOverloadConversion(parameter_type);
+}
+
+inline bool isNullptrTypeParameterForNullPointerConstantOverloadConversion(const TypeSpecifierNode& parameter_type) {
+	return parameter_type.category() == TypeCategory::Nullptr ||
+		   resolve_type_alias(parameter_type.type_index()) == TypeCategory::Nullptr;
+}
+
+inline bool isIntegerLiteralZeroNullptrTypeOverloadConversion(
+	const ASTNode* argument_node,
+	const TypeSpecifierNode& parameter_type) {
+	return argument_node != nullptr &&
+		   isIntegerLiteralZeroNullPointerConstant(*argument_node) &&
+		   isNullptrTypeParameterForNullPointerConstantOverloadConversion(parameter_type);
 }
 
 inline TypeSpecifierNode normalizeArgumentTypeForNullPointerConstantConversion(

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1031,10 +1031,24 @@ inline TypeConversionResult can_convert_type(const TypeSpecifierNode& from, cons
 	return buildConversionPlan(from, to).toResult();
 }
 
+inline bool isIntegerLiteralZeroNullPointerConstant(const ASTNode& arg_node);
+inline bool parameterSupportsNullPointerConstantOverloadConversion(const TypeSpecifierNode& parameter_type);
+inline TypeSpecifierNode normalizeArgumentTypeForNullPointerConstantConversion(
+	const TypeSpecifierNode& argument_type,
+	const TypeSpecifierNode& parameter_type,
+	const ASTNode* argument_node = nullptr);
+
 inline ArgumentConversionInfo buildArgumentConversionInfo(
 	const TypeSpecifierNode& argument_type,
-	const TypeSpecifierNode& parameter_type) {
-	const ConversionPlan conversion = buildConversionPlan(argument_type, parameter_type);
+	const TypeSpecifierNode& parameter_type,
+	const ASTNode* argument_node = nullptr) {
+	const TypeSpecifierNode effective_argument_type =
+		normalizeArgumentTypeForNullPointerConstantConversion(
+			argument_type,
+			parameter_type,
+			argument_node);
+
+	const ConversionPlan conversion = buildConversionPlan(effective_argument_type, parameter_type);
 	return {conversion.rank, &parameter_type, conversion.is_valid};
 }
 
@@ -1102,6 +1116,47 @@ inline bool is_lvalue_expression_for_overload_resolution(const ASTNode& arg_node
 		}
 	},
 					  arg_expr);
+}
+
+inline bool isIntegerLiteralZeroNullPointerConstant(const ASTNode& arg_node) {
+	if (!arg_node.is<ExpressionNode>()) {
+		return false;
+	}
+
+	const ExpressionNode& arg_expr = arg_node.as<ExpressionNode>();
+	const auto* numeric_literal = std::get_if<NumericLiteralNode>(&arg_expr);
+	if (numeric_literal == nullptr || !isIntegralType(numeric_literal->type())) {
+		return false;
+	}
+
+	const NumericLiteralValue literal_value = numeric_literal->value();
+	if (const auto* integer_value = std::get_if<unsigned long long>(&literal_value)) {
+		return *integer_value == 0;
+	}
+
+	return false;
+}
+
+inline bool parameterSupportsNullPointerConstantOverloadConversion(const TypeSpecifierNode& parameter_type) {
+	return parameter_type.is_pointer() ||
+		   parameter_type.is_function_pointer() ||
+		   parameter_type.is_member_function_pointer() ||
+		   parameter_type.is_member_object_pointer();
+}
+
+inline TypeSpecifierNode normalizeArgumentTypeForNullPointerConstantConversion(
+	const TypeSpecifierNode& argument_type,
+	const TypeSpecifierNode& parameter_type,
+	const ASTNode* argument_node) {
+	TypeSpecifierNode effective_argument_type = argument_type;
+	if (argument_node != nullptr &&
+		parameterSupportsNullPointerConstantOverloadConversion(parameter_type) &&
+		isIntegerLiteralZeroNullPointerConstant(*argument_node)) {
+		effective_argument_type.set_type_index(nativeTypeIndex(TypeCategory::Nullptr));
+		effective_argument_type.set_size_in_bits(get_type_size_bits(TypeCategory::Nullptr));
+		effective_argument_type.set_reference_qualifier(ReferenceQualifier::None);
+	}
+	return effective_argument_type;
 }
 
 inline void adjust_argument_type_for_overload_resolution(const ASTNode& arg_node, TypeSpecifierNode& arg_type) {
@@ -1415,11 +1470,22 @@ inline ConstructorOverloadResolutionResult resolve_constructor_overload_arity(
 
 // countMinRequiredArgs is defined in SymbolTable.h (included above)
 
+inline const ASTNode* getOverloadArgumentNodeOrNull(std::span<const ASTNode> argument_nodes, size_t index) {
+	return index < argument_nodes.size() ? &argument_nodes[index] : nullptr;
+}
+
+template <typename ArgumentNodeContainer>
+inline const ASTNode* getOverloadArgumentNodeOrNull(const ArgumentNodeContainer& argument_nodes, size_t index) {
+	return index < argument_nodes.size() ? &argument_nodes[index] : nullptr;
+}
+
 // Perform overload resolution for a function call
 // Returns the best matching overload, or nullptr if no match or ambiguous
-inline OverloadResolutionResult resolve_overload(
+template <typename ArgumentNodeContainer>
+inline OverloadResolutionResult resolve_overload_with_argument_nodes(
 	std::span<const ASTNode> overloads,
-	std::span<const TypeSpecifierNode> argument_types) {
+	std::span<const TypeSpecifierNode> argument_types,
+	const ArgumentNodeContainer& argument_nodes) {
 	if (overloads.empty()) {
 		return OverloadResolutionResult::no_match();
 	}
@@ -1469,8 +1535,10 @@ inline OverloadResolutionResult resolve_overload(
 		for (size_t i = 0; i < params_to_check; ++i) {
 			const auto& param_type = parameters[i].as<DeclarationNode>().type_specifier_node();
 			const auto& arg_type = argument_types[i];
+			const ASTNode* arg_node = getOverloadArgumentNodeOrNull(argument_nodes, i);
 
-			const ArgumentConversionInfo conversion = buildArgumentConversionInfo(arg_type, param_type);
+			const ArgumentConversionInfo conversion =
+				buildArgumentConversionInfo(arg_type, param_type, arg_node);
 			if (!conversion.is_valid) {
 				all_convertible = false;
 				break;
@@ -1528,7 +1596,9 @@ inline OverloadResolutionResult resolve_overload(
 					bool prev_valid = true;
 					for (size_t k = 0; k < prev_params_to_check; ++k) {
 						const auto& pt = prev_params[k].as<DeclarationNode>().type_specifier_node();
-						const ArgumentConversionInfo conv = buildArgumentConversionInfo(argument_types[k], pt);
+						const ASTNode* arg_node = getOverloadArgumentNodeOrNull(argument_nodes, k);
+						const ArgumentConversionInfo conv =
+							buildArgumentConversionInfo(argument_types[k], pt, arg_node);
 						if (!conv.is_valid) {
 							prev_valid = false;
 							break;
@@ -2403,7 +2473,10 @@ inline OverloadResolutionResult resolve_overload_cached(
 	}
 
 	// Cache miss - perform full overload resolution
-	auto result = resolve_overload(overloads, argument_types);
+	auto result = resolve_overload_with_argument_nodes(
+		overloads,
+		argument_types,
+		std::span<const ASTNode>{});
 
 	// Cache the result
 	cache[key] = result;

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1052,7 +1052,10 @@ inline ArgumentConversionInfo buildArgumentConversionInfo(
 			parameter_type,
 			argument_node);
 	if (isIntegerLiteralZeroNullptrTypeOverloadConversion(argument_node, parameter_type)) {
-		return {ConversionRank::Conversion, &parameter_type, true};
+		const ConversionPlan conversion = buildConversionPlan(effective_argument_type, parameter_type);
+		return {conversion.is_valid ? ConversionRank::Conversion : ConversionRank::NoMatch,
+				&parameter_type,
+				conversion.is_valid};
 	}
 
 	const ConversionPlan conversion = buildConversionPlan(effective_argument_type, parameter_type);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3474,6 +3474,7 @@ private:	 // Resume private methods
 	bool parse_constructor_exception_specifier(); // Parse noexcept or throw() and return true if noexcept
 	void consume_conversion_operator_target_modifiers(TypeSpecifierNode& target_type);  // Consume *, &, && after conversion operator target type
 	void consume_pointer_ref_modifiers(TypeSpecifierNode& type_spec);  // Consume trailing *, &, && and apply to type specifier
+	void consume_cast_type_id_postfix_modifiers(TypeSpecifierNode& type_spec); // Consume postfix cv-qualifiers and trailing ptr/ref modifiers in a cast type-id
 	// Parse trailing return type (-> type) with the given parameters visible for decltype expressions.
 	// Expects the '->' token to be the next token. Consumes it, registers params in a temporary scope,
 	// calls parse_type_specifier + consume_pointer_ref_modifiers, then pops the scope.

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1579,6 +1579,7 @@ private:
 	ParseResult parse_declaration_or_function_definition();
 	ParseResult parse_out_of_line_constructor_or_destructor(std::string_view class_name, bool is_destructor, const FlashCpp::DeclarationSpecifiers& specs);	// NEW: Parse out-of-line constructor/destructor
 	ParseResult parse_function_declaration(DeclarationNode& declaration_node, CallingConvention calling_convention = CallingConvention::Default, bool is_member = false);
+	ParseResult parse_function_declaration_with_storage_specs(DeclarationNode& declaration_node, CallingConvention calling_convention, bool is_member, const FlashCpp::StorageSpecifiers& storage_specs);
 	ParseResult parse_parameter_list(FlashCpp::ParsedParameterList& out_params, CallingConvention calling_convention = CallingConvention::Default);	// Phase 1: Unified parameter list parsing
 	FlashCpp::ParsedFunctionArguments parse_function_arguments(const FlashCpp::FunctionArgumentContext& ctx = {});  // Unified function call argument parsing
 	std::vector<TypeSpecifierNode> apply_lvalue_reference_deduction(const ChunkedVector<ASTNode>& args, std::span<const TypeSpecifierNode> arg_types);  // For template deduction: marks lvalue args with lvalue_reference for T&& forwarding

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -199,7 +199,12 @@ ParseResult Parser::parse_member_function_declarator_result(ParseResult& member_
 ParseResult Parser::validateOperatorSignature(const FunctionDeclarationNode& func_decl, bool is_member) const {
 	const OverloadableOperator operator_kind =
 		overloadableOperatorFromFunctionName(func_decl.decl_node().identifier_token().value());
-	if (!is_member && mustBeMemberOperator(operator_kind)) {
+	const bool treat_static_operator_as_member =
+		func_decl.is_static() &&
+		(operator_kind == OverloadableOperator::Call ||
+		 operator_kind == OverloadableOperator::Subscript);
+	const bool effective_is_member = is_member || treat_static_operator_as_member;
+	if (!effective_is_member && mustBeMemberOperator(operator_kind)) {
 		return ParseResult::error(std::string(StringBuilder()
 			.append(func_decl.decl_node().identifier_token().value())
 			.append(" must be a non-static member function")
@@ -259,11 +264,11 @@ ParseResult Parser::validateOperatorSignature(const FunctionDeclarationNode& fun
 	const bool valid = [&]() {
 		switch (arity_kind) {
 			case OrdinaryOperatorArityKind::UnaryOnly:
-				return is_member ? param_count == 0 : param_count == 1;
+				return effective_is_member ? param_count == 0 : param_count == 1;
 			case OrdinaryOperatorArityKind::BinaryOnly:
-				return is_member ? param_count == 1 : param_count == 2;
+				return effective_is_member ? param_count == 1 : param_count == 2;
 			case OrdinaryOperatorArityKind::UnaryOrBinary:
-				return is_member ? (param_count == 0 || param_count == 1)
+				return effective_is_member ? (param_count == 0 || param_count == 1)
 								 : (param_count == 1 || param_count == 2);
 			case OrdinaryOperatorArityKind::Skip:
 				return true;
@@ -272,7 +277,7 @@ ParseResult Parser::validateOperatorSignature(const FunctionDeclarationNode& fun
 	}();
 	if (!valid) {
 		const std::string message = std::string(StringBuilder()
-			.append(is_member ? "member " : "non-member ")
+			.append(effective_is_member ? "member " : "non-member ")
 			.append(func_decl.decl_node().identifier_token().value())
 			.append(" has invalid parameter count for its operator form")
 			.commit());

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -199,6 +199,17 @@ ParseResult Parser::parse_member_function_declarator_result(ParseResult& member_
 ParseResult Parser::validateOperatorSignature(const FunctionDeclarationNode& func_decl, bool is_member) const {
 	const OverloadableOperator operator_kind =
 		overloadableOperatorFromFunctionName(func_decl.decl_node().identifier_token().value());
+	if (is_member &&
+		func_decl.is_static() &&
+		operator_kind != OverloadableOperator::None &&
+		operator_kind != OverloadableOperator::Call &&
+		operator_kind != OverloadableOperator::Subscript) {
+		return ParseResult::error(std::string(StringBuilder()
+			.append(func_decl.decl_node().identifier_token().value())
+			.append(" must be a non-static member function")
+			.commit()),
+			func_decl.decl_node().identifier_token());
+	}
 	const bool treat_static_operator_as_member =
 		func_decl.is_static() &&
 		(operator_kind == OverloadableOperator::Call ||

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -458,6 +458,7 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 			// Parse inline struct: typedef struct { ... } Alias; or typedef struct Name { ... } Alias;
 			bool is_class = peek() == "class"_tok;
 			advance(); // consume 'struct' or 'class'
+			parse_declspec_attributes();
 
 			// Check if there's a struct name or if it's anonymous
 			std::string_view struct_name_view;
@@ -1113,6 +1114,7 @@ ParseResult Parser::parse_typedef_declaration() {
 		is_inline_union = (peek() == "union"_tok);
 		SaveHandle next_pos = save_token_position();
 		advance(); // consume 'struct', 'class', or 'union'
+		parse_declspec_attributes();
 
 		// Check if next token is '{' (anonymous struct/union) or identifier followed by '{'
 		if (peek() == "{"_tok) {

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1638,7 +1638,13 @@ bool Parser::parse_static_member_function(
 	DeclarationNode& decl_node = type_and_name_result.node()->as<DeclarationNode>();
 
 	// Parse function declaration with parameters
-	auto func_result = parse_function_declaration(decl_node);
+	FlashCpp::StorageSpecifiers storage_specs;
+	storage_specs.storage_class = StorageClass::Static;
+	auto func_result = parse_function_declaration_with_storage_specs(
+		decl_node,
+		CallingConvention::Default,
+		true,
+		storage_specs);
 	if (func_result.is_error()) {
 		type_and_name_result = func_result;
 		return true;

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1561,6 +1561,12 @@ void Parser::consume_pointer_ref_modifiers(TypeSpecifierNode& type_spec) {
 	}
 }
 
+void Parser::consume_cast_type_id_postfix_modifiers(TypeSpecifierNode& type_spec) {
+	type_spec.add_cv_qualifier(parse_cv_qualifiers());
+	skip_noop_gnu_qualifiers();
+	consume_pointer_ref_modifiers(type_spec);
+}
+
 // Consume pointer/reference modifiers after conversion operator target type
 // Handles: operator _Tp&(), operator _Tp*(), operator _Tp&&()
 void Parser::consume_conversion_operator_target_modifiers(TypeSpecifierNode& target_type) {

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -364,7 +364,8 @@ Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 	}
 
 	if (all_arg_types_known) {
-		const OverloadResolutionResult op_result = resolve_overload(call_candidates, arg_types);
+		const OverloadResolutionResult op_result =
+			resolve_overload_with_argument_nodes(call_candidates, arg_types, std::span<const ASTNode>{});
 		if (op_result.has_match && !op_result.is_ambiguous && op_result.selected_overload != nullptr) {
 			return {
 				ConcreteCallOperatorResolution::State::Resolved,
@@ -1620,7 +1621,8 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 		}
 
 		if (arg_types.size() == argument_count) {
-			auto overload_result = resolve_overload(candidates, arg_types);
+			auto overload_result =
+				resolve_overload_with_argument_nodes(candidates, arg_types, std::span<const ASTNode>{});
 			if (overload_result.has_match &&
 				!overload_result.is_ambiguous &&
 				overload_result.selected_overload != nullptr &&
@@ -2451,7 +2453,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 									return nullptr;
 								}
 								const OverloadResolutionResult overload_result =
-									resolve_overload(overloads, arg_types);
+									resolve_overload_with_argument_nodes(overloads, arg_types, std::span<const ASTNode>{});
 								if (overload_result.has_match &&
 									!overload_result.is_ambiguous &&
 									overload_result.selected_overload != nullptr) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -607,7 +607,7 @@ std::optional<ASTNode> Parser::resolveDependentUnqualifiedCallAtPointOfInstantia
 	}
 
 	if (!all_overloads.empty()) {
-		OverloadResolutionResult resolution = resolve_overload(all_overloads, arg_types);
+		OverloadResolutionResult resolution = resolve_overload_with_argument_nodes(all_overloads, arg_types, arguments);
 		if (resolution.is_ambiguous) {
 			return std::nullopt;
 		}
@@ -665,7 +665,8 @@ std::optional<ASTNode> Parser::resolveDefinitionBoundOrdinaryCall(
 		return std::nullopt;
 	}
 
-	OverloadResolutionResult resolution = resolve_overload(all_overloads, arg_types);
+	OverloadResolutionResult resolution =
+		resolve_overload_with_argument_nodes(all_overloads, arg_types, std::span<const ASTNode>{});
 	if (resolution.is_ambiguous ||
 		!resolution.has_match ||
 		resolution.selected_overload == nullptr) {
@@ -856,7 +857,7 @@ std::optional<ParseResult> Parser::tryQualifiedPhase1Lookup(
 		filterPhase1OrdinaryFunctionOverloads(qualified_overloads);
 		if (!qualified_overloads.empty()) {
 			OverloadResolutionResult resolution =
-				resolve_overload(qualified_overloads, arg_types);
+				resolve_overload_with_argument_nodes(qualified_overloads, arg_types, std::span<const ASTNode>{});
 			if (resolution.is_ambiguous) {
 				return ParseResult::error(
 					"Ambiguous call to qualified function '" +
@@ -882,7 +883,7 @@ std::optional<ParseResult> Parser::tryQualifiedPhase1Lookup(
 				const std::vector<ASTNode> all_qualified_overloads =
 					gSymbolTable.lookup_qualified_all(qual_id.namespace_handle(), qual_id.nameHandle());
 				OverloadResolutionResult resolution =
-					resolve_overload(all_qualified_overloads, arg_types);
+					resolve_overload_with_argument_nodes(all_qualified_overloads, arg_types, std::span<const ASTNode>{});
 				if (!resolution.is_ambiguous && resolution.has_match &&
 					resolution.selected_overload != nullptr) {
 					identifierType = *resolution.selected_overload;
@@ -6310,7 +6311,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							return overload.is<TemplateFunctionDeclarationNode>();
 						}),
 					all_overloads.end());
-				auto resolution = resolve_overload(all_overloads, arg_types);
+				auto resolution = resolve_overload_with_argument_nodes(all_overloads, arg_types, args);
 				if (resolution.has_match && !resolution.is_ambiguous) {
 					result = emplace_node<ExpressionNode>(
 						makeCallExprFromNode(*resolution.selected_overload, std::move(args), identifier_token));
@@ -6936,7 +6937,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					return make_call_result(*identifierType);
 				}
 
-				auto resolution = resolve_overload(all_overloads, arg_types);
+				auto resolution = resolve_overload_with_argument_nodes(all_overloads, arg_types, args_ref);
 				FLASH_LOG(Parser, Debug, "Overload resolution result: has_match=", resolution.has_match, ", is_ambiguous=", resolution.is_ambiguous);
 
 				if (resolution.is_ambiguous) {
@@ -9355,7 +9356,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 					if (!op_candidates.empty()) {
 						// Try type-based overload resolution first.
 						if (all_op_types_known) {
-							auto op_result = resolve_overload(op_candidates, op_arg_types);
+							auto op_result = resolve_overload_with_argument_nodes(op_candidates, op_arg_types, args);
 							if (op_result.has_match && !op_result.is_ambiguous) {
 								operator_call_func = &op_result.selected_overload->as<FunctionDeclarationNode>();
 							}
@@ -10067,7 +10068,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										}
 									} else {
 										// Have overloads - do overload resolution
-										auto resolution_result = resolve_overload(all_overloads, arg_types);
+										auto resolution_result = resolve_overload_with_argument_nodes(all_overloads, arg_types, args);
 
 										FLASH_LOG(Parser, Debug, "Overload resolution result: has_match=", resolution_result.has_match, ", is_ambiguous=", resolution_result.is_ambiguous);
 

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -130,6 +130,8 @@ ParseResult Parser::parse_cpp_cast_expression(CppCastKind kind, std::string_view
 
 	// Parse pointer/reference declarators: *, **, &, && (ptr-operator in C++20 grammar)
 	TypeSpecifierNode& type_spec = type_result.node()->as<TypeSpecifierNode>();
+	type_spec.add_cv_qualifier(parse_cv_qualifiers());
+	skip_noop_gnu_qualifiers();
 	consume_pointer_ref_modifiers(type_spec);
 
 	// Handle member object pointer type: T ClassName::*
@@ -359,6 +361,9 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 
 		if (!type_result.is_error() && type_result.node().has_value()) {
 			TypeSpecifierNode& type_spec = type_result.node()->as<TypeSpecifierNode>();
+
+			type_spec.add_cv_qualifier(parse_cv_qualifiers());
+			skip_noop_gnu_qualifiers();
 
 			// Parse pointer/reference declarators (ptr-operator in C++20 grammar)
 			consume_pointer_ref_modifiers(type_spec);

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -130,9 +130,7 @@ ParseResult Parser::parse_cpp_cast_expression(CppCastKind kind, std::string_view
 
 	// Parse pointer/reference declarators: *, **, &, && (ptr-operator in C++20 grammar)
 	TypeSpecifierNode& type_spec = type_result.node()->as<TypeSpecifierNode>();
-	type_spec.add_cv_qualifier(parse_cv_qualifiers());
-	skip_noop_gnu_qualifiers();
-	consume_pointer_ref_modifiers(type_spec);
+	consume_cast_type_id_postfix_modifiers(type_spec);
 
 	// Handle member object pointer type: T ClassName::*
 	// e.g., static_cast<int S::*>(nullptr)
@@ -362,11 +360,7 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 		if (!type_result.is_error() && type_result.node().has_value()) {
 			TypeSpecifierNode& type_spec = type_result.node()->as<TypeSpecifierNode>();
 
-			type_spec.add_cv_qualifier(parse_cv_qualifiers());
-			skip_noop_gnu_qualifiers();
-
-			// Parse pointer/reference declarators (ptr-operator in C++20 grammar)
-			consume_pointer_ref_modifiers(type_spec);
+			consume_cast_type_id_postfix_modifiers(type_spec);
 
 			// Check if followed by ')'
 			if (consume(")"_tok)) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -391,7 +391,7 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			return nullptr;
 		}
 		const OverloadResolutionResult overload_result =
-			resolve_overload(overloads, deduced_arg_types);
+			resolve_overload_with_argument_nodes(overloads, deduced_arg_types, std::span<const ASTNode>{});
 		if (overload_result.has_match &&
 			!overload_result.is_ambiguous &&
 			overload_result.selected_overload != nullptr) {

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -690,6 +690,19 @@ void Parser::compute_and_set_mangled_name(FunctionDeclarationNode& func_node, bo
 }
 
 ParseResult Parser::parse_function_declaration(DeclarationNode& declaration_node, CallingConvention calling_convention, bool is_member) {
+	const FlashCpp::StorageSpecifiers storage_specs{};
+	return parse_function_declaration_with_storage_specs(
+		declaration_node,
+		calling_convention,
+		is_member,
+		storage_specs);
+}
+
+ParseResult Parser::parse_function_declaration_with_storage_specs(
+	DeclarationNode& declaration_node,
+	CallingConvention calling_convention,
+	bool is_member,
+	const FlashCpp::StorageSpecifiers& storage_specs) {
 	// Create the function declaration first
 	auto [func_node, func_ref] =
 		create_node_ref<FunctionDeclarationNode>(declaration_node);
@@ -717,6 +730,9 @@ ParseResult Parser::parse_function_declaration(DeclarationNode& declaration_node
 		func_ref.add_parameter_node(param);
 	}
 	func_ref.set_is_variadic(params.is_variadic);
+	if (storage_specs.is_static()) {
+		func_ref.set_is_static(true);
+	}
 	if (auto signature_result = validateOperatorSignature(func_ref, is_member);
 		signature_result.is_error()) {
 		return signature_result;

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -89,7 +89,13 @@ ParseResult Parser::parse_template_function_declaration_body(
 
 		// Parse function declaration with parameters
 		const bool is_member = !struct_parsing_context_stack_.empty();
-		auto func_result = parse_function_declaration(decl_node, CallingConvention::Default, is_member);
+		FlashCpp::StorageSpecifiers storage_specs;
+		storage_specs.storage_class = specs.storage_class;
+		auto func_result = parse_function_declaration_with_storage_specs(
+			decl_node,
+			CallingConvention::Default,
+			is_member,
+			storage_specs);
 		if (func_result.is_error()) {
 			return func_result;
 		}

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3961,7 +3961,10 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 		if (shape_overloads.size() == 1) {
 			preferred_candidate_index = shape_candidate_indices[0];
 		} else if (shape_overloads.size() > 1) {
-			auto resolution = resolve_overload(shape_overloads, *current_explicit_call_arg_types_);
+			auto resolution = resolve_overload_with_argument_nodes(
+				shape_overloads,
+				*current_explicit_call_arg_types_,
+				std::span<const ASTNode>{});
 			if (resolution.has_match &&
 				!resolution.is_ambiguous &&
 				resolution.selected_overload != nullptr) {
@@ -4162,7 +4165,10 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 		}
 
 		if (shape_overloads.size() > 1) {
-			auto resolution = resolve_overload(shape_overloads, arg_types);
+			auto resolution = resolve_overload_with_argument_nodes(
+				shape_overloads,
+				arg_types,
+				std::span<const ASTNode>{});
 			if (resolution.has_match &&
 				!resolution.is_ambiguous &&
 				resolution.selected_overload != nullptr) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -990,7 +990,10 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 			}
 		}
 		if (shape_overloads.size() > 1) {
-			auto resolution = resolve_overload(shape_overloads, arg_types);
+			auto resolution = resolve_overload_with_argument_nodes(
+				shape_overloads,
+				arg_types,
+				std::span<const ASTNode>{});
 			if (resolution.has_match &&
 				!resolution.is_ambiguous &&
 				resolution.selected_overload != nullptr) {

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -411,12 +411,14 @@ ParseResult Parser::parse_type_specifier() {
 		return parse_decltype_specifier();
 	}
 
-	// Check for __underlying_type(T) which returns the underlying type of an enum
-	// This is a type-returning intrinsic used in <type_traits>:
-	//   using type = __underlying_type(_Tp);
-	// Note: __underlying_type is an identifier, not a keyword — string compare is required
-	if (!peek().is_eof() && peek_info().type() == Token::Type::Identifier &&
-		peek_info().value() == "__underlying_type") {
+	auto applyLeadingCvToParsedType = [](ParseResult result, CVQualifier leading_cv) -> ParseResult {
+		if (!result.is_error() && result.node().has_value() && leading_cv != CVQualifier::None) {
+			result.node()->as<TypeSpecifierNode>().add_cv_qualifier(leading_cv);
+		}
+		return result;
+	};
+
+	auto parseUnderlyingTypeSpecifier = [&]() -> ParseResult {
 		Token underlying_token = peek_info();
 		advance(); // consume '__underlying_type'
 
@@ -509,6 +511,15 @@ ParseResult Parser::parse_type_specifier() {
 		}
 
 		return ParseResult::error("__underlying_type requires an enumeration type", underlying_token);
+	};
+
+	// Check for __underlying_type(T) which returns the underlying type of an enum
+	// This is a type-returning intrinsic used in <type_traits>:
+	//   using type = __underlying_type(_Tp);
+	// Note: __underlying_type is an identifier, not a keyword — string compare is required
+	if (!peek().is_eof() && peek_info().type() == Token::Type::Identifier &&
+		peek_info().value() == "__underlying_type") {
+		return parseUnderlyingTypeSpecifier();
 	}
 
 	// Check for typename keyword (used in template-dependent contexts)
@@ -580,6 +591,17 @@ ParseResult Parser::parse_type_specifier() {
 		} else {
 			parsing_qualifiers = false;
 		}
+	}
+
+	// Leading cv-qualifiers also apply to intrinsic type specifiers such as
+	// `const decltype(expr)` and `const __underlying_type(E)`.
+	if (peek() == "decltype"_tok ||
+		(!peek().is_eof() && (peek_info().value() == "__typeof__" || peek_info().value() == "__typeof"))) {
+		return applyLeadingCvToParsedType(parse_decltype_specifier(), cv_qualifier);
+	}
+	if (!peek().is_eof() && peek_info().type() == Token::Type::Identifier &&
+		peek_info().value() == "__underlying_type") {
+		return applyLeadingCvToParsedType(parseUnderlyingTypeSpecifier(), cv_qualifier);
 	}
 
 	// Check for typename keyword AFTER cv-qualifiers

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -111,7 +111,8 @@ const FunctionDeclarationNode* tryResolveUniqueOverloadByArgTypes(
 		return nullptr;
 	}
 
-	const OverloadResolutionResult result = resolve_overload(overload_set, arg_types);
+	const OverloadResolutionResult result =
+		resolve_overload_with_argument_nodes(overload_set, arg_types, std::span<const ASTNode>{});
 	if (result.is_ambiguous) {
 		if (is_ambiguous_out != nullptr) {
 			*is_ambiguous_out = true;
@@ -2210,8 +2211,10 @@ ASTNode SemanticAnalysis::normalizeRangedForLoopDecl(const RangedForStatementNod
 		auto adl_begin = symbols_.lookup_adl("begin", adl_arg_types);
 		auto adl_end = symbols_.lookup_adl("end", adl_arg_types);
 		if (!adl_begin.empty() && !adl_end.empty()) {
-			auto begin_res = resolve_overload(adl_begin, adl_arg_types);
-			auto end_res = resolve_overload(adl_end, adl_arg_types);
+			auto begin_res =
+				resolve_overload_with_argument_nodes(adl_begin, adl_arg_types, std::span<const ASTNode>{});
+			auto end_res =
+				resolve_overload_with_argument_nodes(adl_end, adl_arg_types, std::span<const ASTNode>{});
 			if (begin_res.has_match && !begin_res.is_ambiguous &&
 				end_res.has_match && !end_res.is_ambiguous &&
 				begin_res.selected_overload->is<FunctionDeclarationNode>() &&
@@ -7689,7 +7692,11 @@ std::optional<CallArgReferenceBindingInfo> SemanticAnalysis::buildCallArgReferen
 	if (!arg_binding_type_opt.has_value())
 		return std::nullopt;
 
-	const TypeSpecifierNode& arg_binding_type = *arg_binding_type_opt;
+	const TypeSpecifierNode arg_binding_type =
+		normalizeArgumentTypeForNullPointerConstantConversion(
+			*arg_binding_type_opt,
+			param_type,
+			&arg);
 	TypeSpecifierNode param_value_type = param_type;
 	param_value_type.set_reference_qualifier(ReferenceQualifier::None);
 	TypeSpecifierNode arg_value_type = arg_binding_type;
@@ -7770,7 +7777,11 @@ void SemanticAnalysis::tryAnnotateSingleArgConversion(const ASTNode& arg,
 	if (std::optional<TypeSpecifierNode> resolved_arg_binding_type =
 			buildOverloadResolutionArgType(arg, &arg_type_id);
 		resolved_arg_binding_type.has_value()) {
-		arg_binding_type = *resolved_arg_binding_type;
+		arg_binding_type =
+			normalizeArgumentTypeForNullPointerConstantConversion(
+				*resolved_arg_binding_type,
+				param_type,
+				&arg);
 		TypeSpecifierNode arg_value_type = *arg_binding_type;
 		arg_value_type.set_reference_qualifier(ReferenceQualifier::None);
 		if (const CanonicalTypeId arg_value_type_id = canonicalizeType(arg_value_type)) {
@@ -7954,7 +7965,11 @@ void SemanticAnalysis::ensureResolvedCallArgConversionsComplete(
 		if (!arg_binding_type.has_value()) {
 			continue;
 		}
-		TypeSpecifierNode arg_value_type = *arg_binding_type;
+		TypeSpecifierNode arg_value_type =
+			normalizeArgumentTypeForNullPointerConstantConversion(
+				*arg_binding_type,
+				param_type,
+				&arg);
 		arg_value_type.set_reference_qualifier(ReferenceQualifier::None);
 		const CanonicalTypeId arg_value_type_id = canonicalizeType(arg_value_type);
 		const CanonicalTypeId param_type_id = canonicalizeType(param_type);
@@ -8616,7 +8631,8 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 
 	if (arg_types_collected) {
-		const OverloadResolutionResult result = resolve_overload(overloads, arg_types);
+		const OverloadResolutionResult result =
+			resolve_overload_with_argument_nodes(overloads, arg_types, arguments);
 		if (result.has_match && !result.is_ambiguous && result.selected_overload != nullptr) {
 			if (const FunctionDeclarationNode* resolved_candidate =
 					getCallTargetFunctionCandidate(*result.selected_overload)) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7697,6 +7697,8 @@ std::optional<CallArgReferenceBindingInfo> SemanticAnalysis::buildCallArgReferen
 			*arg_binding_type_opt,
 			param_type,
 			&arg);
+	const bool null_pointer_constant_to_nullptr =
+		isIntegerLiteralZeroNullptrTypeOverloadConversion(&arg, param_type);
 	TypeSpecifierNode param_value_type = param_type;
 	param_value_type.set_reference_qualifier(ReferenceQualifier::None);
 	TypeSpecifierNode arg_value_type = arg_binding_type;
@@ -7746,7 +7748,14 @@ std::optional<CallArgReferenceBindingInfo> SemanticAnalysis::buildCallArgReferen
 	}
 
 	info.flags = ConversionPlanFlags::IsValid | ConversionPlanFlags::MaterializesTemporary;
-	if (value_plan.kind != StandardConversionKind::None) {
+	if (null_pointer_constant_to_nullptr &&
+		inferred_arg_type_id &&
+		inferred_arg_type_id != param_value_type_id) {
+		info.pre_bind_cast_info_index = allocateNonUserDefinedCastInfo(
+			inferred_arg_type_id,
+			param_value_type_id,
+			StandardConversionKind::PointerConversion);
+	} else if (value_plan.kind != StandardConversionKind::None) {
 		info.pre_bind_cast_info_index = allocateNonUserDefinedCastInfo(
 			arg_value_type_id,
 			param_value_type_id,

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -7774,9 +7774,13 @@ void SemanticAnalysis::tryAnnotateSingleArgConversion(const ASTNode& arg,
 	const CanonicalTypeId param_type_id = canonicalizeType(param_type);
 	std::optional<TypeSpecifierNode> arg_binding_type;
 	CanonicalTypeId arg_type_id{};
+	CanonicalTypeId original_arg_type_id{};
+	const bool null_pointer_constant_to_nullptr =
+		isIntegerLiteralZeroNullptrTypeOverloadConversion(&arg, param_type);
 	if (std::optional<TypeSpecifierNode> resolved_arg_binding_type =
 			buildOverloadResolutionArgType(arg, &arg_type_id);
 		resolved_arg_binding_type.has_value()) {
+		original_arg_type_id = arg_type_id;
 		arg_binding_type =
 			normalizeArgumentTypeForNullPointerConstantConversion(
 				*resolved_arg_binding_type,
@@ -7794,6 +7798,19 @@ void SemanticAnalysis::tryAnnotateSingleArgConversion(const ASTNode& arg,
 	// by inferResolvedSymbolType for identifier-based arrays.
 	const bool arg_is_array = arg_type_id && !type_context_.get(arg_type_id).array_dimensions.empty();
 	if (arg_type_id && !arg_is_array && canonical_types_match(arg_type_id, param_type_id)) {
+		if (null_pointer_constant_to_nullptr &&
+			original_arg_type_id &&
+			original_arg_type_id != param_type_id) {
+			SemanticSlot slot =
+				getSlot(getExpressionKey(arg)).value_or(SemanticSlot{});
+			slot.type_id = param_type_id;
+			slot.cast_info_index = allocateNonUserDefinedCastInfo(
+				original_arg_type_id,
+				param_type_id,
+				StandardConversionKind::PointerConversion);
+			slot.value_category = ValueCategory::PRValue;
+			setSlot(getExpressionKey(arg), slot);
+		}
 		return;
 	}
 

--- a/tests/test_cv_qualified_intrinsic_type_specifiers_ret0.cpp
+++ b/tests/test_cv_qualified_intrinsic_type_specifiers_ret0.cpp
@@ -1,0 +1,25 @@
+enum class Small : unsigned short {
+	Value = 9
+};
+
+int bindNullConstRef(const decltype(nullptr)& value) {
+	return value == nullptr ? 11 : 0;
+}
+
+int bindNullConstRRef(const decltype(nullptr) const&& value) {
+	return value == nullptr ? 13 : 0;
+}
+
+int main() {
+	const decltype(1) one = 1;
+	const decltype(one + 41) answer = one + 41;
+	if (answer != 42) return 1;
+
+	const __underlying_type(Small) raw = 9;
+	if (raw != 9) return 2;
+
+	if (bindNullConstRef(0) != 11) return 3;
+	if (bindNullConstRRef(nullptr) != 13) return 4;
+
+	return 0;
+}

--- a/tests/test_nullptr_literal_nonconst_lref_fail.cpp
+++ b/tests/test_nullptr_literal_nonconst_lref_fail.cpp
@@ -1,0 +1,9 @@
+using Null = decltype(nullptr);
+
+int bindNullLRef(Null& value) {
+	return value == nullptr ? 1 : 0;
+}
+
+int main() {
+	return bindNullLRef(0);
+}

--- a/tests/test_static_call_operator_ret0.cpp
+++ b/tests/test_static_call_operator_ret0.cpp
@@ -1,0 +1,18 @@
+struct NonTemplateCallable {
+	static int operator()(int x) {
+		return x + 1;
+	}
+};
+
+template <typename T>
+struct TemplateCallable {
+	static int operator()(T x) {
+		return static_cast<int>(x) + 2;
+	}
+};
+
+int main() {
+	int object_non_template = NonTemplateCallable{}(1);
+	int object_template = TemplateCallable<int>{}(2);
+	return object_non_template + object_template - 6;
+}

--- a/tests/test_static_member_operator_plus_fail.cpp
+++ b/tests/test_static_member_operator_plus_fail.cpp
@@ -1,0 +1,9 @@
+struct InvalidStaticOperator {
+	static int operator+(int rhs) {
+		return rhs;
+	}
+};
+
+int main() {
+	return 0;
+}

--- a/tests/test_typedef_postfix_const_cast_ret0.cpp
+++ b/tests/test_typedef_postfix_const_cast_ret0.cpp
@@ -1,0 +1,11 @@
+// Regression: cast type-ids must accept postfix cv-qualifiers on typedef names
+// before pointer declarators.
+
+typedef int Scalar;
+
+int main() {
+	int value = 7;
+	Scalar const* c_style = (Scalar const*)&value;
+	Scalar const* cpp_style = static_cast<Scalar const*>(&value);
+	return (*c_style == 7 && *cpp_style == 7) ? 0 : 1;
+}

--- a/tests/test_typedef_struct_declspec_align_ret0.cpp
+++ b/tests/test_typedef_struct_declspec_align_ret0.cpp
@@ -1,0 +1,14 @@
+// Regression: MSVC headers use typedef'd struct definitions with __declspec
+// between the struct keyword and the tag name.
+
+typedef struct __declspec(align(16)) _AlignedTag
+{
+	unsigned __int64 parts[2];
+} AlignedTag;
+
+int main() {
+	AlignedTag value{};
+	value.parts[0] = 7;
+	(void)value;
+	return 0;
+}

--- a/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
+++ b/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
@@ -41,9 +41,24 @@ int pick(_locale_t) {
 	return 2;
 }
 
+int pickNullptr(int) {
+	return 3;
+}
+
+int pickNullptr(decltype(nullptr)) {
+	return 4;
+}
+
+int onlyNullptr(decltype(nullptr)) {
+	return 5;
+}
+
 int main() {
 	va_list args = 0;
 	if (vfwprintf(0, 0, args) != 0) return 1;
 	if (pick(0) != 1) return 2;
+	if (pickNullptr(0) != 3) return 3;
+	if (pickNullptr(nullptr) != 4) return 4;
+	if (onlyNullptr(0) != 5) return 5;
 	return 0;
 }

--- a/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
+++ b/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
@@ -1,0 +1,49 @@
+// Regression: overload resolution must treat the integer literal 0 as a null
+// pointer constant for pointer-like parameters without stealing exact integer
+// matches from non-pointer overloads.
+
+using va_list = char*;
+
+struct FILE;
+struct __crt_locale_pointers;
+
+using _locale_t = __crt_locale_pointers*;
+
+int __stdio_common_vfwprintf(
+	unsigned long long options,
+	FILE* stream,
+	wchar_t const* format,
+	_locale_t locale,
+	va_list args) {
+	return (options == 0 && stream == 0 && format == 0 && locale == 0 && args == 0) ? 0 : 7;
+}
+
+int _vfwprintf_l(
+	FILE* const stream,
+	wchar_t const* const format,
+	_locale_t const locale,
+	va_list args) {
+	return __stdio_common_vfwprintf(0, stream, format, locale, args);
+}
+
+int vfwprintf(
+	FILE* const stream,
+	wchar_t const* const format,
+	va_list args) {
+	return _vfwprintf_l(stream, format, 0, args);
+}
+
+int pick(int) {
+	return 1;
+}
+
+int pick(_locale_t) {
+	return 2;
+}
+
+int main() {
+	va_list args = 0;
+	if (vfwprintf(0, 0, args) != 0) return 1;
+	if (pick(0) != 1) return 2;
+	return 0;
+}

--- a/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
+++ b/tests/test_ucrt_vfwprintf_zero_literal_nullptr_arg_ret0.cpp
@@ -8,6 +8,7 @@ struct FILE;
 struct __crt_locale_pointers;
 
 using _locale_t = __crt_locale_pointers*;
+using Null = decltype(nullptr);
 
 int __stdio_common_vfwprintf(
 	unsigned long long options,
@@ -53,6 +54,14 @@ int onlyNullptr(decltype(nullptr)) {
 	return 5;
 }
 
+int bindNullConstRef(const Null& value) {
+	return value == nullptr ? 6 : 0;
+}
+
+int bindNullRRef(Null&& value) {
+	return value == nullptr ? 7 : 0;
+}
+
 int main() {
 	va_list args = 0;
 	if (vfwprintf(0, 0, args) != 0) return 1;
@@ -60,5 +69,7 @@ int main() {
 	if (pickNullptr(0) != 3) return 3;
 	if (pickNullptr(nullptr) != 4) return 4;
 	if (onlyNullptr(0) != 5) return 5;
+	if (bindNullConstRef(0) != 6) return 6;
+	if (bindNullRRef(0) != 7) return 7;
 	return 0;
 }


### PR DESCRIPTION
## Summary
This branch improves several C++20-facing parser and semantic paths that were blocking standard-library patterns and exposing incorrect callable behavior.

### What changed
- Parse `static` call operators and reject invalid static member operator forms with a focused diagnostic path.
- Accept additional typedef and type-id spellings used in real code, including postfix cv-qualified typedef targets, declspec/alignment forms, and leading cv-qualified intrinsic type specifiers such as `const decltype(...)` and `const __underlying_type(...)`.
- Align integer-literal-zero to `nullptr_t` handling across overload resolution and related semantic/template call paths so null pointer constant calls use the correct viability and ranking rules, including proper reference-binding behavior.

### Why
These fixes move more real-world library code through parsing and semantic analysis without broadening the PR into unrelated later-stage issues. The changes stay concentrated in parser and overload/sema layers rather than codegen workarounds.

## Newly added tests
- `tests/test_static_call_operator_ret0.cpp`
- `tests/test_static_member_operator_plus_fail.cpp`
- `tests/test_typedef_postfix_const_cast_ret0.cpp`
- `tests/test_typedef_struct_declspec_align_ret0.cpp`
- `tests/test_cv_qualified_intrinsic_type_specifiers_ret0.cpp`
- `tests/test_nullptr_literal_nonconst_lref_fail.cpp`