### PR TITLE
Tighten requires parameter declarators and callable-object parsing for std headers

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1135,6 +1135,7 @@ private:
 	// This is incremented/decremented in critical parsing functions
 	size_t parsing_depth_ = 0;
 	bool parsing_alias_type_id_ = false;
+	bool parsing_parameter_declaration_type_id_ = false;
 	static constexpr size_t MAX_PARSING_DEPTH = 500;	 // Reasonable limit for nested parsing
 	std::vector<std::string_view> template_param_names_;	 // Template parameter names in current scope
 
@@ -3395,6 +3396,9 @@ private:	 // Resume private methods
 		const FunctionDeclarationNode* function = nullptr;
 	};
 	const FunctionDeclarationNode* tryResolveConcreteMemberFunction(const std::optional<ASTNode>& object_expr, std::string_view member_name);
+	bool concreteOwnerHasMemberFunctionTemplate(
+		const TypeInfo& type_info,
+		StringHandle member_name_handle);
 	ConcreteCallOperatorResolution tryResolveConcreteCallOperator(
 		const std::optional<ASTNode>& object_expr,
 		std::span<const TypeSpecifierNode> arg_types,

--- a/src/Parser_Decl_DeclaratorCore.cpp
+++ b/src/Parser_Decl_DeclaratorCore.cpp
@@ -175,9 +175,9 @@ ParseResult Parser::parse_type_and_name() {
 			restore_token_position(saved_pos);
 			;
 		} else if (!peek().is_eof() && (peek() == "&"_tok || peek() == "&&"_tok)) {
-			// This is a reference to array pattern: T (&arr)[N] or T (&&arr)[N]
-			// Also handles unnamed variant: T (&)[N] (used in function parameters)
-			// Pattern: type (&identifier)[array_size] or type (&&identifier)[array_size]
+			// This is a reference-to-array or reference-to-function pattern:
+			// T (&arr)[N], T (&&arr)[N], T (&fn)(Args...), or T (&&fn)(Args...)
+			// Also handles unnamed variants used in parameter declarations.
 			bool is_rvalue_ref = (peek() == "&&"_tok);
 			advance(); // consume '&' or '&&'
 
@@ -197,11 +197,8 @@ ParseResult Parser::parse_type_and_name() {
 			} else {
 				advance(); // consume ')'
 
-				// Expect array size: '[' size ']'
-				if (peek() != "["_tok) {
-					// Not a reference-to-array pattern, restore and continue
-					restore_token_position(saved_pos);
-				} else {
+				// Reference-to-array: T (&name)[N]
+				if (peek() == "["_tok) {
 					advance(); // consume '['
 
 					// Parse array size expression
@@ -245,6 +242,68 @@ ParseResult Parser::parse_type_and_name() {
 							return ParseResult::success(decl_node);
 						}
 					}
+				}
+				// Reference-to-function: T (&name)(Args...)
+				else if (peek() == "("_tok) {
+					advance(); // consume '('
+
+					std::vector<TypeIndex> param_types;
+					bool is_variadic = false;
+					auto param_result =
+						parse_function_pointer_parameter_types(param_types, is_variadic);
+					if (param_result.is_error()) {
+						restore_token_position(saved_pos);
+					} else if (!consume(")"_tok)) {
+						restore_token_position(saved_pos);
+					} else {
+						bool is_noexcept = false;
+						if (peek() == "noexcept"_tok) {
+							advance(); // consume 'noexcept'
+							is_noexcept = parse_noexcept_value();
+						}
+
+						FunctionSignature signature;
+						signature.return_type_index = type_spec.type_index();
+						signature.return_pointer_depth =
+							static_cast<int>(type_spec.pointer_depth());
+						signature.return_reference_qualifier =
+							type_spec.reference_qualifier();
+						signature.parameter_type_indices = std::move(param_types);
+						signature.linkage = Linkage::None;
+						signature.calling_convention = last_calling_convention_;
+						signature.is_variadic = is_variadic;
+						signature.is_noexcept = is_noexcept;
+
+						type_spec.set_function_signature(signature);
+						type_spec.set_reference_qualifier(
+							is_rvalue_ref
+								? ReferenceQualifier::RValueReference
+								: ReferenceQualifier::LValueReference);
+
+						if (!has_name) {
+							ref_identifier = Token(
+								Token::Type::Identifier,
+								""sv,
+								type_spec.token().line(),
+								type_spec.token().column(),
+								type_spec.token().file_index());
+						}
+
+						auto decl_node = emplace_node<DeclarationNode>(
+							emplace_node<TypeSpecifierNode>(type_spec),
+							ref_identifier);
+
+						if (custom_alignment.has_value()) {
+							decl_node.as<DeclarationNode>().set_custom_alignment(
+								custom_alignment.value());
+						}
+
+						discard_saved_token(saved_pos);
+						return ParseResult::success(decl_node);
+					}
+				} else {
+					// Not a valid reference declarator pattern, restore and continue
+					restore_token_position(saved_pos);
 				}
 			}
 		} else if (peek().is_identifier()) {

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -474,6 +474,7 @@ ParseResult Parser::parse_namespace() {
 	if (!consume("namespace"_tok)) {
 		return ParseResult::error("Expected 'namespace' keyword", peek_info());
 	}
+	skip_cpp_attributes();
 
 	// Check if this is an anonymous namespace (namespace { ... })
 	std::string_view namespace_name = "";

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -201,6 +201,49 @@ const TypeInfo* tryResolveConcreteStructOwnerType(const TypeSpecifierNode& type_
 }
 } // namespace
 
+bool Parser::concreteOwnerHasMemberFunctionTemplate(
+	const TypeInfo& type_info,
+	StringHandle member_name_handle) {
+	const StructTypeInfo* struct_info = type_info.getStructInfo();
+	if (struct_info == nullptr) {
+		return false;
+	}
+
+	std::unordered_set<const StructTypeInfo*> visited;
+	auto has_visible_member_template = [&](const StructTypeInfo* current_struct, const auto& self) -> bool {
+		if (current_struct == nullptr ||
+			!visited.insert(current_struct).second) {
+			return false;
+		}
+
+		bool has_local_member_with_name = false;
+		bool has_local_member_template = false;
+		for (const auto& member_func : current_struct->member_functions) {
+			if (member_func.getName() != member_name_handle) {
+				continue;
+			}
+			has_local_member_with_name = true;
+			if (member_func.function_decl.is<TemplateFunctionDeclarationNode>()) {
+				has_local_member_template = true;
+			}
+		}
+		if (has_local_member_with_name) {
+			return has_local_member_template;
+		}
+
+		for (const auto& base_spec : current_struct->base_classes) {
+			if (const StructTypeInfo* base_struct = tryGetStructTypeInfo(base_spec.type_index);
+				base_struct != nullptr &&
+				self(base_struct, self)) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	return has_visible_member_template(struct_info, has_visible_member_template);
+}
+
 // Helper: resolve object type from expression and try to instantiate member function template.
 // Uses get_expression_type() to handle any expression (identifiers, function calls, member access, etc.).
 // Returns the instantiated function node if successful, nullopt otherwise.
@@ -224,6 +267,10 @@ std::optional<ASTNode> Parser::tryResolveMemberFunctionTemplate(
 		}
 	}
 	auto struct_name = StringTable::getStringView(type_info->name());
+	if (const StructTypeInfo* struct_info = type_info->getStructInfo();
+		struct_info != nullptr) {
+		struct_name = StringTable::getStringView(struct_info->name);
+	}
 	instantiateLazyClassToPhase(type_info->name(), ClassInstantiationPhase::Full);
 	if (explicit_template_args.has_value()) {
 		// Propagate call argument types so overload resolution can reject mismatched
@@ -326,6 +373,10 @@ Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 	const StructTypeInfo* struct_info = type_info->getStructInfo();
 	if (!struct_info)
 		return {};
+	const bool has_call_operator_template =
+		concreteOwnerHasMemberFunctionTemplate(
+			*type_info,
+			StringTable::getOrInternStringHandle("operator()"sv));
 
 	std::vector<ASTNode> call_candidates;
 	std::unordered_set<const StructTypeInfo*> visited;
@@ -358,8 +409,24 @@ Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 		}
 	};
 	collect_visible_call_operators(struct_info, collect_visible_call_operators);
-
 	if (call_candidates.empty()) {
+		if (all_arg_types_known && has_call_operator_template) {
+			if (std::optional<ASTNode> instantiated_operator = tryResolveMemberFunctionTemplate(
+					object_expr,
+					"operator()"sv,
+					std::nullopt,
+					arg_types);
+				instantiated_operator.has_value() &&
+				instantiated_operator->is<FunctionDeclarationNode>()) {
+				return {
+					ConcreteCallOperatorResolution::State::Resolved,
+					&instantiated_operator->as<FunctionDeclarationNode>()
+				};
+			}
+		}
+		if (has_call_operator_template) {
+			return {};
+		}
 		return {ConcreteCallOperatorResolution::State::NoViableMatch, nullptr};
 	}
 
@@ -1190,32 +1257,13 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 		if (object_struct_name.has_value() &&
 			isHardUseLikeInstantiationMode() &&
 			!known_member_func && !instantiated_func.has_value()) {
-			auto checkHasMemberTemplate = [&]() {
-				auto hasFunctionTemplateForOwner = [&](StringHandle owner_name_handle) {
-					TemplateNameLookupResult lookup_result = gTemplateRegistry.lookupTemplateName(
-						buildMemberFunctionTemplateLookupRequest(
-							owner_name_handle,
-							member_name_token.handle(),
-							false));
-					return lookup_result.hasFunctionTemplate();
-				};
-
-				const StringHandle owner_name_handle =
-					StringTable::getOrInternStringHandle(*object_struct_name);
-				if (hasFunctionTemplateForOwner(owner_name_handle)) {
-					return true;
-				}
-
-				std::string_view base_name = extractBaseTemplateName(*object_struct_name);
-				if (base_name.empty()) {
-					return false;
-				}
-
-				return hasFunctionTemplateForOwner(
-					StringTable::getOrInternStringHandle(base_name));
-			};
-
-			if (checkHasMemberTemplate()) {
+			if (const TypeInfo* object_type_info =
+					findTypeByName(
+						StringTable::getOrInternStringHandle(*object_struct_name));
+				object_type_info != nullptr &&
+				concreteOwnerHasMemberFunctionTemplate(
+					*object_type_info,
+					member_name_token.handle())) {
 				return ParseResult::error(
 					"No matching member function for call to '" + std::string(member_name_token.value()) + "'",
 					member_name_token);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4775,6 +4775,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 			// Check if followed by '(' for function call
 			if (current_token_.value() == "(") {
+				Token open_paren_token = current_token_;
 				advance(); // consume '('
 
 				// Parse function arguments using unified helper (expand simple packs for qualified calls)
@@ -4846,6 +4847,22 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						result = emplace_node<ExpressionNode>(ConstructorCallNode(type_spec_node, std::move(args), final_identifier));
 						return ParseResult::success(*result);
 					}
+				}
+
+				if (!template_args.has_value() &&
+					identifierType.has_value() &&
+					!identifierType->is<FunctionDeclarationNode>() &&
+					!identifierType->is<TemplateFunctionDeclarationNode>()) {
+					result = emplace_node<ExpressionNode>(
+						QualifiedIdentifierNode(
+							qual_id.namespace_handle(),
+							qual_id.identifier_token()));
+					finalizePostfixCallExpression(
+						result,
+						open_paren_token,
+						std::move(args),
+						std::move(arg_types));
+					return ParseResult::success(*result);
 				}
 
 				if (auto err = tryQualifiedPhase1Lookup(qual_id,
@@ -9315,98 +9332,55 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				if (has_operator_call) {
 					// Create a member function call: object.operator()(args)
 					auto object_expr = emplace_node<ExpressionNode>(createBoundIdentifier(identifier_token));
-
-					// Find the operator() function declaration in the struct
-					const DeclarationNode* decl = get_decl_from_symbol(*identifierType);
-					if (!decl) {
-						return ParseResult::error("Invalid declaration for operator() call", identifier_token);
-					}
-					const auto& type_node = decl->type_specifier_node();
-					TypeIndex type_index = type_node.type_index();
-					const TypeInfo& type_info = getTypeInfo(type_index);
-					if (!type_info.struct_info_) {
-						return ParseResult::error("operator() not found in struct", identifier_token);
-					}
-
-					// Find the best operator() overload using type-based overload resolution.
-					// Falls back to arity-only selection when argument types cannot be determined.
-					const FunctionDeclarationNode* operator_call_func = nullptr;
-					bool op_explicitly_ambiguous = false;
 					std::vector<TypeSpecifierNode> op_arg_types;
-					bool all_op_types_known = true;
 					for (const auto& arg : args) {
 						auto arg_type = get_expression_type(arg);
 						if (arg_type.has_value()) {
 							op_arg_types.push_back(*arg_type);
-						} else {
-							all_op_types_known = false;
-							break;
 						}
 					}
-
-					// Build candidate list for resolve_overload.
-					std::vector<ASTNode> op_candidates;
-					for (const auto& member_func : type_info.struct_info_->member_functions) {
-						if (member_func.operator_kind == OverloadableOperator::Call &&
-							member_func.function_decl.is<FunctionDeclarationNode>()) {
-							op_candidates.push_back(member_func.function_decl);
-						}
+					const bool all_op_types_known = op_arg_types.size() == args.size();
+					const ConcreteCallOperatorResolution call_operator_resolution =
+						tryResolveConcreteCallOperator(
+							object_expr,
+							op_arg_types,
+							args.size(),
+							all_op_types_known);
+					const FunctionDeclarationNode* operator_call_func =
+						call_operator_resolution.function;
+					if (call_operator_resolution.state ==
+						ConcreteCallOperatorResolution::State::Ambiguous) {
+						return ParseResult::error(
+							"call to overloaded operator() is ambiguous",
+							identifier_token);
 					}
-
-					if (!op_candidates.empty()) {
-						// Try type-based overload resolution first.
-						if (all_op_types_known) {
-							auto op_result = resolve_overload_with_argument_nodes(op_candidates, op_arg_types, args);
-							if (op_result.has_match && !op_result.is_ambiguous) {
-								operator_call_func = &op_result.selected_overload->as<FunctionDeclarationNode>();
-							}
-							if (op_result.is_ambiguous) {
-								op_explicitly_ambiguous = true;
-							}
-						}
-
-						if (!operator_call_func && !op_explicitly_ambiguous) {
-							// Fall back to arity-only heuristic when type inference fails
-							// or when resolve_overload found no match (e.g. template/generic
-							// lambda operator()). When resolve_overload explicitly reported
-							// ambiguity, the call is ill-formed.
-							const FunctionDeclarationNode* sole_op_candidate = nullptr;
-							size_t op_candidate_count = 0;
-							for (const auto& candidate_node : op_candidates) {
-								const auto& candidate = candidate_node.as<FunctionDeclarationNode>();
-								++op_candidate_count;
-								if (!sole_op_candidate)
-									sole_op_candidate = &candidate;
-								if (candidate.parameter_nodes().size() == args.size()) {
-									operator_call_func = &candidate;
-									break;
-								}
-							}
-							if (!operator_call_func && op_candidate_count == 1)
-								operator_call_func = sole_op_candidate;
-						}
+					if (call_operator_resolution.state ==
+						ConcreteCallOperatorResolution::State::NoViableMatch) {
+						return ParseResult::error(
+							"operator() not found in struct",
+							identifier_token);
 					}
-
-					if (!operator_call_func && !op_explicitly_ambiguous && all_op_types_known) {
-						if (auto instantiated_operator = try_instantiate_member_function_template(
-								StringTable::getStringView(type_info.struct_info_->name),
-								"operator()"sv,
-								op_arg_types);
-							instantiated_operator.has_value() && instantiated_operator->is<FunctionDeclarationNode>()) {
-							operator_call_func = &instantiated_operator->as<FunctionDeclarationNode>();
-						}
-					}
-
-					if (!operator_call_func) {
-						const char* err_msg = op_explicitly_ambiguous
-												  ? "call to overloaded operator() is ambiguous"
-												  : "operator() not found in struct";
-						return ParseResult::error(err_msg, identifier_token);
+					if (operator_call_func == nullptr) {
+						auto temp_type = emplace_node<TypeSpecifierNode>(
+							TypeCategory::Int,
+							TypeQualifier::None,
+							32,
+							identifier_token,
+							CVQualifier::None);
+						auto temp_decl = emplace_node<DeclarationNode>(
+							temp_type,
+							identifier_token);
+						operator_call_func =
+							&emplace_node<FunctionDeclarationNode>(
+								 temp_decl.as<DeclarationNode>())
+								 .as<FunctionDeclarationNode>();
 					}
 
 					Token operator_token(Token::Type::Identifier, "operator()"sv, identifier_token.line(), identifier_token.column(), identifier_token.file_index());
 					result = emplace_node<ExpressionNode>(makeResolvedMemberCallExpr(object_expr, *operator_call_func, std::move(args), operator_token));
-					if (all_op_types_known) {
+					if (call_operator_resolution.state ==
+							ConcreteCallOperatorResolution::State::Resolved &&
+						all_op_types_known) {
 						attachResolvedReceiverDirectCallMetadata(
 							result->as<ExpressionNode>(),
 							current_template_definition_lookup_context_,
@@ -9414,7 +9388,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							op_arg_types,
 							false,
 							*operator_call_func,
-							StringTable::getStringView(type_info.struct_info_->name));
+							{});
 					}
 				}
 				// For template parameter constructor calls, create ConstructorCallNode

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -60,6 +60,9 @@ ParseResult Parser::parse_parameter_list(FlashCpp::ParsedParameterList& out_para
 		}
 
 		// Parse parameter type and name
+		FlashCpp::ScopedState parameter_type_id_guard(
+			parsing_parameter_declaration_type_id_);
+		parsing_parameter_declaration_type_id_ = true;
 		ParseResult type_and_name_result = parse_type_and_name();
 		if (type_and_name_result.is_error()) {
 			return type_and_name_result;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2869,6 +2869,9 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				}
 			}
 
+			// Skip C++11 attributes between struct/class and name (e.g., [[deprecated]])
+			skip_cpp_attributes();
+
 			// Parse class name
 			if (!peek().is_identifier()) {
 				return ParseResult::error("Expected class name", current_token_);

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -81,150 +81,33 @@ ParseResult Parser::parse_requires_expression() {
 	// or no parameters: requires { ... }
 	std::vector<ASTNode> parameters;
 	if (peek() == "("_tok) {
-		advance(); // consume '('
-
-		// Parse parameter list (similar to function parameters)
-		// For now, we'll accept a simple parameter list
-		// Full implementation would parse: Type name, Type name, ...
-		while (peek() != ")"_tok) {
-			// Parse type
-			auto type_result = parse_type_specifier();
-			if (type_result.is_error()) {
-				return type_result;
-			}
-
-			// Parse pointer/reference modifiers after the type
-			TypeSpecifierNode& type_spec = type_result.node()->as<TypeSpecifierNode>();
-
-			// Check for parenthesized declarator: type(&name)(params) or type(*name)(params)
-			// This is used for function pointer/reference parameters
-			if (peek() == "("_tok) {
-				advance(); // consume '('
-
-				// Expect & or * for function reference/pointer
-				if (peek() == "&"_tok) {
-					advance(); // consume '&'
-					type_spec.set_reference_qualifier(ReferenceQualifier::LValueReference);	// lvalue reference
-				} else if (peek() == "*"_tok) {
-					advance(); // consume '*'
-					type_spec.add_pointer_level(CVQualifier::None);
-				} else {
-					return ParseResult::error("Expected '&' or '*' in function declarator", current_token_);
-				}
-
-				// Parse parameter name
-				if (!peek().is_identifier()) {
-					return ParseResult::error("Expected identifier in function declarator", current_token_);
-				}
-				Token param_name = peek_info();
-				advance();
-
-				// Expect closing ')'
-				if (!consume(")"_tok)) {
-					return ParseResult::error("Expected ')' after function declarator name", current_token_);
-				}
-
-				// Parse function parameter list: (params)
-				if (!consume("("_tok)) {
-					return ParseResult::error("Expected '(' for function parameter list", current_token_);
-				}
-
-				// Skip function parameters (we don't need them for requires expressions)
-				int paren_depth = 1;
-				while (paren_depth > 0 && !peek().is_eof()) {
-					if (peek() == "("_tok) {
-						paren_depth++;
-					} else if (peek() == ")"_tok) {
-						paren_depth--;
-					}
-					if (paren_depth > 0)
-						advance();
-				}
-
-				if (!consume(")"_tok)) {
-					return ParseResult::error("Expected ')' after function parameter list", current_token_);
-				}
-
-				// Create a declaration node for the parameter
-				auto decl_node = emplace_node<DeclarationNode>(*type_result.node(), param_name);
-				parameters.push_back(decl_node);
-
-				// Add parameter to the scope so it can be used in the requires body
-				gSymbolTable.insert(param_name.value(), decl_node);
-
-				// Check for comma (more parameters) or end
-				if (peek() == ","_tok) {
-					advance(); // consume ','
-				}
-
-				continue; // Skip the rest of the loop for this parameter
-			}
-
-			// Parse cv-qualifiers (const, volatile)
-			CVQualifier cv = parse_cv_qualifiers();
-			type_spec.add_cv_qualifier(cv);
-
-			// Parse pointer/reference declarators (ptr-operator in C++20 grammar)
-			consume_pointer_ref_modifiers(type_spec);
-
-			// Check for ellipsis (parameter pack): type... name
-			bool is_parameter_pack = false;
-			if (peek() == "..."_tok) {
-				advance(); // consume '...'
-				is_parameter_pack = true;
-				// Next must be parameter name
-				if (!peek().is_identifier()) {
-					return ParseResult::error("Expected parameter name after '...' in requires expression", current_token_);
-				}
-			}
-
-			// Parse parameter name
-			if (!peek().is_identifier()) {
-				return ParseResult::error("Expected parameter name in requires expression", current_token_);
-			}
-			Token param_name = peek_info();
-			advance();
-
-			// Check if this is a function reference/pointer: type(&name)(params) or type(*name)(params)
-			// After the parameter name, if we see '(', it's a function declarator
-			if (peek() == "("_tok) {
-				// Pattern: void(&f)(T) means f is a reference to function taking T
-				advance(); // consume '('
-
-				// Parse the function parameter list (simplified - just skip to ')')
-				// We don't need the full parameter info for requires expressions
-				int paren_depth = 1;
-				while (paren_depth > 0 && !peek().is_eof()) {
-					if (peek() == "("_tok) {
-						paren_depth++;
-					} else if (peek() == ")"_tok) {
-						paren_depth--;
-					}
-					if (paren_depth > 0)
-						advance();
-				}
-
-				if (!consume(")"_tok)) {
-					return ParseResult::error("Expected ')' after function declarator parameter list", current_token_);
-				}
-			}
-
-			// Create a declaration node for the parameter
-			auto decl_node = emplace_node<DeclarationNode>(*type_result.node(), param_name);
-			decl_node.as<DeclarationNode>().set_parameter_pack(is_parameter_pack);
-			parameters.push_back(decl_node);
-
-			// Add parameter to the scope so it can be used in the requires body
-			gSymbolTable.insert(param_name.value(), decl_node);
-
-			// Check for comma (more parameters) or end
-			if (peek() == ","_tok) {
-				advance(); // consume ','
-			}
+		FlashCpp::ParsedParameterList parsed_params;
+		ParseResult params_result = parse_parameter_list(parsed_params, CallingConvention::Default);
+		if (params_result.is_error()) {
+			return params_result;
 		}
 
-		if (!consume(")"_tok)) {
-			return ParseResult::error("Expected ')' after requires expression parameters", current_token_);
+		if (parsed_params.is_variadic) {
+			return ParseResult::error("Requires expression parameters cannot be variadic", requires_token);
+		}
+
+		for (const auto& param : parsed_params.parameters) {
+			if (!param.is<DeclarationNode>()) {
+				return ParseResult::error("Expected declaration in requires expression parameter list", requires_token);
+			}
+
+			const auto& decl = param.as<DeclarationNode>();
+			if (decl.has_default_value()) {
+				Token diagnostic_token = !decl.identifier_token().value().empty()
+					? decl.identifier_token()
+					: requires_token;
+				return ParseResult::error("Requires expression parameters cannot have default arguments", diagnostic_token);
+			}
+
+			parameters.push_back(param);
+			if (!decl.identifier_token().value().empty()) {
+				gSymbolTable.insert(decl.identifier_token().value(), param);
+			}
 		}
 	}
 

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -624,6 +624,7 @@ ParseResult Parser::parse_type_specifier() {
 		}
 		if (saw_typename_keyword ||
 			parsing_alias_type_id_ ||
+			parsing_parameter_declaration_type_id_ ||
 			allow_member_template_type_id ||
 			!dependentQualifiedOwnerNeedsTypename(owner_kind)) {
 			return std::nullopt;

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -48,7 +48,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeinfo>` | `test_std_typeinfo_ret0.cpp` | ✅ Compiled | ~46ms (retested 2026-04-30, Linux/libstdc++-14). Sema now models pointer arithmetic (`T* + integral`, `T* - integral`, `T* - T*`) so the ternary in `type_info::name()` (`__name[0] == '*' ? __name + 1 : __name`) gets a sema-owned exact result type and codegen no longer throws. Regression: `tests/test_ternary_pointer_arithmetic_branches_ret0.cpp`. |
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ✅ Compiled | ~7529ms (retested 2026-05-25, Linux/libstdc++-14). **NOW WORKS**: ternary common-type fix resolved `numeric_limits` member constexpr folding. Builtin `__builtin_huge_val`/`__builtin_nan` families now handled in constexpr evaluator. |
-| `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~2481ms (retested 2026-04-11). Call to deleted function 'swap'. |
+| `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~13.49s (`TOTAL`) / ~16.5s wall (retested 2026-06-21, Windows/MSVC STL 14.44). Progressed past the old `swap`-adjacent parser stops; current first hard error is `Could not evaluate non-type template default for parameter 2 of 'subrange'`. |
 | `<variant>` | `test_std_variant.cpp` | ✅ Compiled | ~736ms (retested 2026-04-24, Linux/libstdc++). **NEW: Now compiles successfully on Linux!** The `_Variadic_union` arithmetic non-type template argument (`_Np-1`) inside a member initializer is now resolved. |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |

--- a/tests/test_constrained_member_template_call_operator_decltype_ret0.cpp
+++ b/tests/test_constrained_member_template_call_operator_decltype_ret0.cpp
@@ -1,0 +1,28 @@
+// Regression: postfix callable resolution must defer/resolve constrained
+// member-template operator() calls used inside decltype.
+
+namespace constrained_call_operator_decltype {
+	template<class T>
+	T&& declval() noexcept;
+
+	struct Synth {
+		template <class T, class U>
+		auto operator()(const T& left, const U& right) const
+			requires requires {
+				left < right;
+				right < left;
+			}
+		{
+			return 0;
+		}
+	};
+
+	template<class T, class U = T>
+	using result = decltype(Synth{}(declval<T&>(), declval<U&>()));
+
+	result<int> make_result();
+}
+
+int main() {
+	return 0;
+}

--- a/tests/test_namespace_attributes_ret0.cpp
+++ b/tests/test_namespace_attributes_ret0.cpp
@@ -1,0 +1,14 @@
+// Regression: namespace attributes are permitted between the namespace keyword
+// and the namespace name.
+
+#define ATTR_NAMESPACE [[deprecated("namespace attribute regression")]]
+
+namespace ATTR_NAMESPACE attr_ns {
+	int value() {
+		return 42;
+	}
+}
+
+int main() {
+	return attr_ns::value() == 42 ? 0 : 1;
+}

--- a/tests/test_noexcept_nested_callable_object_member_template_ret0.cpp
+++ b/tests/test_noexcept_nested_callable_object_member_template_ret0.cpp
@@ -1,0 +1,55 @@
+// Regression: class-scope noexcept(...) probes must accept identifier calls to
+// callable objects whose visible operator() is only a constrained member template.
+
+namespace std_like {
+template <class T>
+T&& declval() noexcept;
+}
+
+struct RangeAccessCpo {
+private:
+	enum class State { None, Ok };
+
+	struct Choice {
+		State _Strategy;
+		bool _No_throw;
+	};
+
+	template <class T>
+	static consteval Choice choose() noexcept {
+		return {State::Ok, true};
+	}
+
+	template <class T>
+	static constexpr Choice choice = choose<T>();
+
+public:
+	template <class T>
+		requires (choice<T&>._Strategy != State::None)
+	constexpr auto operator()(T&&) const noexcept(choice<T&>._No_throw) {
+		return 0;
+	}
+};
+
+inline constexpr RangeAccessCpo begin_like{};
+inline constexpr RangeAccessCpo end_like{};
+
+struct DistanceLike {
+private:
+	template <class It, class Se>
+	static constexpr int distance_unchecked(It, Se) noexcept {
+		return 0;
+	}
+
+public:
+	template <class R>
+	static constexpr bool nothrow_size = noexcept(
+		distance_unchecked(
+			begin_like(::std_like::declval<R&>()),
+			end_like(::std_like::declval<R&>())));
+};
+
+int main() {
+	(void) DistanceLike::nothrow_size<int>;
+	return 0;
+}

--- a/tests/test_partial_specialization_attributes_ret0.cpp
+++ b/tests/test_partial_specialization_attributes_ret0.cpp
@@ -1,0 +1,15 @@
+// Regression: class-template partial specializations accept attributes between
+// the class-keyword and the specialization name.
+
+template<class T>
+struct AttributePartialSpecialization;
+
+template<class T>
+struct [[deprecated("partial specialization attribute regression")]]
+AttributePartialSpecialization<T*> {
+	static constexpr int value = 42;
+};
+
+int main() {
+	return AttributePartialSpecialization<int*>::value == 42 ? 0 : 1;
+}

--- a/tests/test_requires_parameter_implicit_typename_ret0.cpp
+++ b/tests/test_requires_parameter_implicit_typename_ret0.cpp
@@ -1,0 +1,16 @@
+// Regression: C++20 permits omitted `typename` for dependent qualified types
+// in requires-expression parameter declarations.
+
+template<class T>
+struct identity_traits {
+	using type = T;
+};
+
+template<class T>
+concept has_self_parameter = requires(identity_traits<T>::type value) {
+	value;
+};
+
+int main() {
+	return has_self_parameter<int> ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- route requires-expression parameter declarations through the shared parser without regressing function-reference declarators like `requires(void (&f)(T))`
- reuse the shared concrete `operator()` resolver for identifier calls so constrained callable objects work in class-scope `noexcept(...)` probes and similar std-header paths
- accept standard attributes on namespace heads and class-template partial-specialization heads used by the MSVC STL
- add focused regressions and refresh the std-header notes with the new `<iterator>` frontier

## Details
This branch now covers the full parser-facing slice that moved the MSVC STL `<iterator>` path forward.

Implemented changes:
- `requires(...)` parameters now use the shared parameter-list parser.
- dependent qualified parameter types in that context no longer spuriously require `typename`.
- parenthesized function-reference declarators in shared declaration parsing now handle forms like `T (&f)(Args...)` and unnamed parameter variants, which fixed the follow-up regressions in `test_requires_funcref_ret0.cpp` and `test_stdlib_features_ret0.cpp`.
- identifier-call handling now reuses the shared concrete call-operator resolver instead of a stale duplicated overload scan.
- qualified callable objects can flow through postfix-call finalization correctly.
- namespace heads and class-template partial-specialization heads now skip C++ attributes in the STL forms this branch hit.

Focused regressions added:
- `tests/test_requires_parameter_implicit_typename_ret0.cpp`
- `tests/test_requires_funcref_ret0.cpp` and existing `tests/test_stdlib_features_ret0.cpp` now pass again through the shared declarator path
- `tests/test_constrained_member_template_call_operator_decltype_ret0.cpp`
- `tests/test_noexcept_nested_callable_object_member_template_ret0.cpp`
- `tests/test_namespace_attributes_ret0.cpp`
- `tests/test_partial_specialization_attributes_ret0.cpp`


## Current std-header status
- `tests/std/test_std_iterator.cpp` now gets past the old missing-`typename` and callable-object `noexcept(...)` parser stops.
- current first hard error is later: `Could not evaluate non-type template default for parameter 2 of 'subrange'`.
- `tests/std/README_STANDARD_HEADERS.md` is updated with the current Windows/MSVC STL timing and frontier.