### PR TITLE
Improve C++20 requires and dependent template-call semantics

### DIFF
--- a/src/AstNodeTypes_Expr.h
+++ b/src/AstNodeTypes_Expr.h
@@ -947,15 +947,19 @@ private:
 class RequiresExpressionNode {
 public:
 	explicit RequiresExpressionNode(
+		std::vector<ASTNode> parameters,
 		std::vector<ASTNode> requirements,
 		Token requires_token = Token())
-		: requirements_(std::move(requirements)),
+		: parameters_(std::move(parameters)),
+		  requirements_(std::move(requirements)),
 		  requires_token_(requires_token) {}
 
+	std::span<const ASTNode> parameter_nodes() const { return parameters_; }
 	std::span<const ASTNode> requirements() const { return requirements_; }
 	const Token& requires_token() const { return requires_token_; }
 
 private:
+	std::vector<ASTNode> parameters_;
 	std::vector<ASTNode> requirements_;	// List of requirement expressions
 	Token requires_token_;			   // For error reporting
 };

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1827,6 +1827,149 @@ const TypeInfo* ExpressionSubstitutor::resolveDependentMemberTypeForSubstitution
 	return resolveDependentMemberType(type_info, kInitialDependentMemberTypeResolutionDepth);
 }
 
+std::optional<ASTNode> ExpressionSubstitutor::tryEvaluateConcreteConceptCall(const CallExprNode& call) const {
+	const std::string_view concept_name = call.has_qualified_name()
+		? call.qualified_name()
+		: call.called_from().value();
+	auto concept_opt = gConceptRegistry.lookupConcept(concept_name);
+	if (!concept_opt.has_value() && call.has_qualified_name()) {
+		concept_opt = gConceptRegistry.lookupConcept(call.called_from().value());
+	}
+	if (!concept_opt.has_value() || !call.has_template_arguments()) {
+		return std::nullopt;
+	}
+
+	const auto try_materialize_bound_template_arg = [&](const ASTNode& template_arg)
+		-> std::optional<std::vector<ASTNode>> {
+		if (template_arg.is<TypeSpecifierNode>()) {
+			return std::vector<ASTNode>{template_arg};
+		}
+		if (!template_arg.is<ExpressionNode>()) {
+			return std::nullopt;
+		}
+
+		const ExpressionNode& expr = template_arg.as<ExpressionNode>();
+		std::string_view param_name;
+		Token source_token = call.called_from();
+		auto try_materialize_concrete_type = [&](std::string_view type_name, const Token& type_token)
+			-> std::optional<std::vector<ASTNode>> {
+			if (!type_name.empty()) {
+				if (const TypeInfo* type_info =
+						findTypeByName(StringTable::getOrInternStringHandle(type_name));
+					type_info != nullptr) {
+					TypeSpecifierNode type_spec = makeTypeSpecifierFromTemplateTypeArg(
+						TemplateTypeArg::makeType(
+							type_info->registeredTypeIndex().withCategory(
+								type_info->typeEnum())),
+						type_token);
+					return std::vector<ASTNode>{
+						ASTNode::emplace_node<TypeSpecifierNode>(std::move(type_spec))};
+				}
+
+				if (auto builtin_type = parser_.get_builtin_type_info(type_name)) {
+					TypeSpecifierNode type_spec = makeTypeSpecifierFromTemplateTypeArg(
+						TemplateTypeArg::makeType(nativeTypeIndex(builtin_type->first)),
+						type_token);
+					return std::vector<ASTNode>{
+						ASTNode::emplace_node<TypeSpecifierNode>(std::move(type_spec))};
+				}
+			}
+			return std::nullopt;
+		};
+		if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
+			param_name = identifier->name();
+			source_token = identifier->identifier_token();
+			if (std::optional<std::vector<ASTNode>> concrete_type =
+					try_materialize_concrete_type(param_name, source_token);
+				concrete_type.has_value()) {
+				return concrete_type;
+			}
+		} else if (const auto* qualified = std::get_if<QualifiedIdentifierNode>(&expr)) {
+			source_token = qualified->identifier_token();
+			if (std::optional<std::vector<ASTNode>> concrete_type =
+					try_materialize_concrete_type(
+						qualified->full_name(),
+						source_token);
+				concrete_type.has_value()) {
+				return concrete_type;
+			}
+			if (std::optional<std::vector<ASTNode>> concrete_type =
+					try_materialize_concrete_type(
+						qualified->name(),
+						source_token);
+				concrete_type.has_value()) {
+				return concrete_type;
+			}
+			return std::nullopt;
+		} else if (const auto* tparam_ref = std::get_if<TemplateParameterReferenceNode>(&expr)) {
+			param_name = tparam_ref->param_name().view();
+			source_token = tparam_ref->token();
+		} else {
+			return std::nullopt;
+		}
+
+		auto scalar_it = param_map_.find(param_name);
+		if (scalar_it != param_map_.end()) {
+			const TemplateTypeArg bound_arg = scalar_it->second;
+			return materializeTemplateArgumentNodes(
+				std::span<const TemplateTypeArg>(&bound_arg, 1),
+				source_token);
+		}
+
+		auto pack_it = pack_map_.find(StringTable::getOrInternStringHandle(param_name));
+		if (pack_it != pack_map_.end()) {
+			return materializeTemplateArgumentNodes(
+				std::span<const TemplateTypeArg>(pack_it->second.data(), pack_it->second.size()),
+				source_token);
+		}
+
+		return std::nullopt;
+	};
+
+	std::optional<InlineVector<TemplateTypeArg, 4>> concrete_args =
+		parser_.materializeConcreteCallTemplateArguments(call.template_arguments());
+	if (!concrete_args.has_value()) {
+		std::vector<ASTNode> rebound_template_args;
+		rebound_template_args.reserve(call.template_arguments().size());
+		bool rebound_any_template_arg = false;
+
+		for (const ASTNode& template_arg : call.template_arguments()) {
+			if (std::optional<std::vector<ASTNode>> rebound_nodes =
+					try_materialize_bound_template_arg(template_arg);
+				rebound_nodes.has_value()) {
+				rebound_any_template_arg = true;
+				rebound_template_args.insert(
+					rebound_template_args.end(),
+					rebound_nodes->begin(),
+					rebound_nodes->end());
+				continue;
+			}
+
+			rebound_template_args.push_back(template_arg);
+		}
+
+		if (!rebound_any_template_arg) {
+			return std::nullopt;
+		}
+
+		concrete_args = parser_.materializeConcreteCallTemplateArguments(rebound_template_args);
+		if (!concrete_args.has_value()) {
+			return std::nullopt;
+		}
+	}
+
+	const ConstraintEvaluationResult constraint_result =
+		evaluateConstraint(concept_opt->as<ConceptDeclarationNode>(), *concrete_args);
+	const Token bool_token(
+		Token::Type::Keyword,
+		constraint_result.satisfied ? "true"sv : "false"sv,
+		call.called_from().line(),
+		call.called_from().column(),
+		call.called_from().file_index());
+	return ASTNode::emplace_node<ExpressionNode>(
+		BoolLiteralNode(bool_token, constraint_result.satisfied));
+}
+
 ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& call) {
 	FLASH_LOG(Templates, Debug, "ExpressionSubstitutor: Processing function call");
 	FLASH_LOG(Templates, Debug, "  has_mangled_name: ", call.has_mangled_name());
@@ -1999,6 +2142,25 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		return ASTNode(&new_expr);
 	};
 	std::vector<ASTNode> explicit_template_arg_nodes;
+
+	if (call.has_template_arguments()) {
+		CallExprNode substituted_concept_call(
+			call.callee(),
+			ChunkedVector<ASTNode>{},
+			call.called_from());
+		copyCallMetadataWithTransformedTemplateArguments(
+			substituted_concept_call,
+			call,
+			[this](const ASTNode& template_arg) {
+				return substitute(template_arg);
+			},
+			CallMetadataCopyOptions{});
+		if (std::optional<ASTNode> concept_result =
+				tryEvaluateConcreteConceptCall(substituted_concept_call);
+			concept_result.has_value()) {
+			return *concept_result;
+		}
+	}
 
 	// Check if this function call has explicit template arguments (e.g., base_trait<T>())
 	if (call.has_template_arguments()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1959,7 +1959,7 @@ std::optional<ASTNode> ExpressionSubstitutor::tryEvaluateConcreteConceptCall(con
 	}
 
 	const ConstraintEvaluationResult constraint_result =
-		evaluateConstraint(concept_opt->as<ConceptDeclarationNode>(), *concrete_args);
+		evaluateConstraint(concept_opt->as<ConceptDeclarationNode>(), *concrete_args, &parser_);
 	const Token bool_token(
 		Token::Type::Keyword,
 		constraint_result.satisfied ? "true"sv : "false"sv,

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1835,7 +1835,7 @@ std::optional<ASTNode> ExpressionSubstitutor::tryEvaluateConcreteConceptCall(con
 	if (!concept_opt.has_value() && call.has_qualified_name()) {
 		concept_opt = gConceptRegistry.lookupConcept(call.called_from().value());
 	}
-	if (!concept_opt.has_value() || !call.has_template_arguments()) {
+	if (!concept_opt.has_value() || !concept_opt->is<ConceptDeclarationNode>() || !call.has_template_arguments()) {
 		return std::nullopt;
 	}
 

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -184,6 +184,7 @@ private:
 	const TypeInfo* resolveCurrentOwnerQualifiedNamespaceMember(
 		StringHandle member_name_handle);
 	const TypeInfo* resolveDependentMemberType(const TypeInfo& type_info, int depth);
+	std::optional<ASTNode> tryEvaluateConcreteConceptCall(const CallExprNode& call) const;
 	void rebuildEnvironmentFromCurrentBindings();
 
 // Substitution context

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1409,7 +1409,11 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 
 							// Evaluate the constraint with the template arguments
 							auto constraint_result = evaluateConstraint(
-								requires_clause.constraint_expr(), type_args, eval_param_names);
+								requires_clause.constraint_expr(),
+								type_args,
+								eval_param_names,
+								&parser_,
+								template_func.template_parameters());
 
 							if (!constraint_result.satisfied) {
 								// Constraint not satisfied - report detailed error

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -519,6 +519,40 @@ inline bool hasConvertingConstructorFrom(TypeIndex target_idx, TypeIndex source_
 	return false;
 }
 
+inline bool isDirectCtorTemplateParameterMatch(
+	const StructMemberFunction& mf,
+	const TypeSpecifierNode& param_spec) {
+	if (!mf.function_decl.is<ConstructorDeclarationNode>()) {
+		return false;
+	}
+
+	const auto& ctor_decl = mf.function_decl.as<ConstructorDeclarationNode>();
+	if (!ctor_decl.has_template_parameters()) {
+		return false;
+	}
+
+	const TypeCategory param_category = param_spec.category();
+	if (param_category != TypeCategory::Template &&
+		param_category != TypeCategory::TypeAlias &&
+		param_category != TypeCategory::UserDefined &&
+		!isPlaceholderAutoType(param_category)) {
+		return false;
+	}
+
+	const StringHandle param_name = param_spec.token().handle();
+	if (!param_name.isValid()) {
+		return false;
+	}
+
+	for (const auto& template_param : ctor_decl.template_parameters()) {
+		if (template_param.nameHandle() == param_name) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 inline bool hasImplicitConvertingConstructorForArgument(TypeIndex target_idx, const TypeSpecifierNode& source_type) {
 	if (!target_idx.is_valid()) {
 		return false;
@@ -554,6 +588,14 @@ inline bool hasImplicitConvertingConstructorForArgument(TypeIndex target_idx, co
 				return true;
 			}
 			continue;
+		}
+		if (isDirectCtorTemplateParameterMatch(mf, param_spec)) {
+			// Constructor templates like `template<class T> _Literal_zero(T)` do
+			// not have a concrete first-parameter type to resolve here. Matching
+			// the ctor's own template parameter name keeps the viability check
+			// narrow while still allowing the later template-deduction path to
+			// instantiate the concrete conversion when needed.
+			return true;
 		}
 		if (param_spec.category() == TypeCategory::Struct) {
 			if (!source_type.type_index().is_valid() || !param_spec.type_index().is_valid()) {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -489,6 +489,12 @@ class Parser {
 	friend class SemanticAnalysis;
 	friend class FlashCpp::FunctionParsingScopeGuard;  // Access current_function_, setup_member_function_context, etc.
 	friend struct DeferredBaseReplayContextScope;
+	friend ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
+		const RequiresExpressionNode& requires_expr,
+		const InlineVector<TemplateTypeArg, 4>& template_args,
+		const InlineVector<std::string_view, 4>& template_param_names,
+		Parser* parser,
+		std::span<const TemplateParameterNode> template_params);
 	template <typename ParserLike, typename ParamContainer, typename ArgContainer>
 	friend TypeIndex resolveDependentMemberTemplateSubstitutionArtifacts(
 		ParserLike& parser,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1346,6 +1346,30 @@ private:
 	// Track last failed template argument parse handle to prevent infinite loops
 	SaveHandle last_failed_template_arg_parse_handle_ = SIZE_MAX;
 
+	std::span<const TemplateParameterNode> current_explicit_template_arg_target_params_{};
+
+	class ScopedExplicitTemplateArgumentTargetParams {
+	public:
+		ScopedExplicitTemplateArgumentTargetParams(
+			Parser& parser,
+			std::span<const TemplateParameterNode> target_params)
+			: parser_(parser),
+			  previous_target_params_(parser.current_explicit_template_arg_target_params_) {
+			parser_.current_explicit_template_arg_target_params_ = target_params;
+		}
+
+		~ScopedExplicitTemplateArgumentTargetParams() {
+			parser_.current_explicit_template_arg_target_params_ = previous_target_params_;
+		}
+
+		ScopedExplicitTemplateArgumentTargetParams(const ScopedExplicitTemplateArgumentTargetParams&) = delete;
+		ScopedExplicitTemplateArgumentTargetParams& operator=(const ScopedExplicitTemplateArgumentTargetParams&) = delete;
+
+	private:
+		Parser& parser_;
+		std::span<const TemplateParameterNode> previous_target_params_;
+	};
+
 	// Track functions currently undergoing auto return type deduction to prevent infinite recursion
 	std::unordered_set<const FunctionDeclarationNode*> functions_being_deduced_;
 
@@ -3742,6 +3766,20 @@ private:	 // Resume private methods
 
 	std::optional<TemplateParameterKind> currentTemplateParamKind(StringHandle param_name) const {
 		return current_template_params_.kindOf(param_name);
+	}
+
+	const TemplateParameterNode* currentExplicitTemplateArgumentTargetParam(size_t arg_index) const {
+		if (current_explicit_template_arg_target_params_.empty()) {
+			return nullptr;
+		}
+		if (arg_index < current_explicit_template_arg_target_params_.size()) {
+			return &current_explicit_template_arg_target_params_[arg_index];
+		}
+		const TemplateParameterNode& last_param = current_explicit_template_arg_target_params_.back();
+		if (last_param.is_variadic()) {
+			return &last_param;
+		}
+		return nullptr;
 	}
 
 	std::optional<TypeCategory> currentTemplateParamNonTypeCategory(StringHandle param_name) const {

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -498,8 +498,11 @@ ParseResult Parser::parse_expression(int precedence, ExpressionContext context) 
 					// If it's a variable, don't try template argument parsing
 					if (symbol_type && (symbol_type->is<VariableDeclarationNode>() ||
 										symbol_type->is<DeclarationNode>())) {
-						// This is a regular variable, treat < as comparison
-						could_be_template_name = false;
+						could_be_template_name =
+							gTemplateRegistry.lookupTemplate(ident_name).has_value() ||
+							gTemplateRegistry.lookup_alias_template(ident_name).has_value() ||
+							gTemplateRegistry.lookupVariableTemplate(ident_name).has_value() ||
+							gConceptRegistry.hasConcept(ident_name);
 					} else {
 						// Not a known variable, could be a template
 						could_be_template_name = true;
@@ -689,6 +692,81 @@ ParseResult Parser::parse_expression(int precedence, ExpressionContext context) 
 						return makeBinaryLoopStallError();
 					}
 					continue;
+				}
+
+				if (peek() == "("_tok && result.node()->is<ExpressionNode>()) {
+					const ExpressionNode& callee_expr = result.node()->as<ExpressionNode>();
+					if (const auto* identifier_ptr = std::get_if<IdentifierNode>(&callee_expr)) {
+						Token callee_token = identifier_ptr->identifier_token();
+						advance(); // consume '('
+
+						auto args_result = parse_function_arguments(FlashCpp::FunctionArgumentContext{
+							.handle_pack_expansion = true,
+							.collect_types = true,
+							.expand_simple_packs = true,
+							.callee_name = callee_token.value()});
+						if (!args_result.success) {
+							return ParseResult::error(
+								args_result.error_message,
+								args_result.error_token.value_or(current_token_));
+						}
+						if (!consume(")"_tok)) {
+							return ParseResult::error(
+								"Expected ')' after function call arguments",
+								current_token_);
+						}
+
+						const InlineVector<TemplateTypeArg, 4>& explicit_args =
+							template_args.read_template_type_args();
+						std::optional<ASTNode> instantiated_func =
+							try_instantiate_template_explicit(
+								callee_token.value(),
+								explicit_args,
+								args_result.arg_types);
+						if (!instantiated_func.has_value()) {
+							NamespaceHandle current_namespace =
+								gSymbolTable.get_current_namespace_handle();
+							if (!current_namespace.isGlobal()) {
+								StringHandle qualified_handle =
+									gNamespaceRegistry.buildQualifiedIdentifier(
+										current_namespace,
+										callee_token.handle());
+								instantiated_func =
+									try_instantiate_template_explicit(
+										StringTable::getStringView(qualified_handle),
+										explicit_args,
+										args_result.arg_types);
+							}
+						}
+
+						if (instantiated_func.has_value()) {
+							result = ParseResult::success(
+								emplace_node<ExpressionNode>(
+									makeCallExprFromNode(
+										*instantiated_func,
+										std::move(args_result.args),
+										callee_token)));
+						} else {
+							auto type_node = emplace_node<TypeSpecifierNode>(
+								TypeCategory::Auto,
+								TypeQualifier::None,
+								get_type_size_bits(TypeCategory::Auto),
+								callee_token,
+								CVQualifier::None);
+							auto placeholder_decl =
+								emplace_node<DeclarationNode>(type_node, callee_token);
+							result = ParseResult::success(
+								emplace_node<ExpressionNode>(
+									makeDirectCallExpr(
+										placeholder_decl.as<DeclarationNode>(),
+										std::move(args_result.args),
+										callee_token)));
+						}
+						if (isParserAtSameToken(loop_start_token, peek_info())) {
+							return makeBinaryLoopStallError();
+						}
+						continue;
+					}
 				}
 
 				// Template arguments were parsed but followed by '(' instead of '::'.

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4261,7 +4261,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						auto constraint_result = evaluateConstraint(
 							concept_node.constraint_expr(),
 							*template_args,
-							concept_param_names
+							concept_param_names,
+							this,
+							concept_node.template_params()
 						);
 
 						// Create a BoolLiteralNode with the result
@@ -7290,6 +7292,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						explicit_template_args = parse_explicit_template_arguments(
 							variable_template_opt->as<TemplateVariableDeclarationNode>().template_parameters(),
 							&explicit_template_arg_nodes);
+					} else if (auto concept_opt = gConceptRegistry.lookupConcept(identifier_token.value());
+							   concept_opt.has_value() &&
+							   concept_opt->is<ConceptDeclarationNode>()) {
+						explicit_template_args = parse_explicit_template_arguments(
+							concept_opt->as<ConceptDeclarationNode>().template_params(),
+							&explicit_template_arg_nodes);
 					} else {
 						explicit_template_args = parse_explicit_template_arguments();
 					}
@@ -8130,7 +8138,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								auto constraint_result = evaluateConstraint(
 									concept_node.constraint_expr(),
 									*explicit_template_args,
-									concept_param_names
+									concept_param_names,
+									this,
+									concept_node.template_params()
 								);
 
 								// Create a BoolLiteralNode with the result
@@ -8536,6 +8546,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						variable_template_opt->is<TemplateVariableDeclarationNode>()) {
 						return parse_explicit_template_arguments(
 							variable_template_opt->as<TemplateVariableDeclarationNode>().template_parameters(),
+							&explicit_template_arg_nodes);
+					}
+					if (auto concept_opt = gConceptRegistry.lookupConcept(identifier_token.value());
+						concept_opt.has_value() &&
+						concept_opt->is<ConceptDeclarationNode>()) {
+						return parse_explicit_template_arguments(
+							concept_opt->as<ConceptDeclarationNode>().template_params(),
 							&explicit_template_arg_nodes);
 					}
 					return parse_explicit_template_arguments(&explicit_template_arg_nodes);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5074,98 +5074,168 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						 !peek().is_eof() ? peek_info().value() : "N/A",
 						 member_function_context_stack_.size());
 
-		// BUGFIX: Check if we're in a member function context and this identifier is a member function
-		// This handles the case where register_member_functions_in_scope already added the function to the symbol table
-		// so identifierType is set, but we still need to detect it as a member function call with implicit 'this'
-		// Declare this flag here so it's visible throughout the rest of the function
-		bool found_member_function_in_context = false;
-		bool resolved_member_function_from_context = false;
-		if (!member_function_context_stack_.empty() && identifierType.has_value() &&
-			identifierType->is<FunctionDeclarationNode>() && peek() == "("_tok) {
-			const auto& mf_ctx = member_function_context_stack_.back();
-			const StructDeclarationNode* struct_node = mf_ctx.struct_node;
-			if (struct_node) {
-				// Check if this function is a member function of the current struct
-				for (const auto& member_func : struct_node->member_functions()) {
-					if (member_func.function_declaration.is<FunctionDeclarationNode>()) {
-						const auto& func_decl = member_func.function_declaration.as<FunctionDeclarationNode>();
-						if (func_decl.decl_node().identifier_token().value() == identifier_token.value()) {
-							gSymbolTable.insert(identifier_token.value(), member_func.function_declaration);
-							identifierType = member_func.function_declaration;
-							found_member_function_in_context = !func_decl.is_static();
-							resolved_member_function_from_context = true;
-							FLASH_LOG_FORMAT(Parser, Debug,
-											 "EARLY CHECK: Detected {} member function call '{}' in current context",
-											 func_decl.is_static() ? "static" : "non-static",
-											 identifier_token.value());
+		struct CurrentStructFunctionLookupResult {
+			bool found_any = false;
+			bool found_non_static = false;
+		};
+
+		auto registerCurrentStructFunctionOverloadsForContext =
+			[&](const StructDeclarationNode* struct_node,
+				const StructTypeInfo* struct_info,
+				std::string_view log_context) -> CurrentStructFunctionLookupResult {
+			CurrentStructFunctionLookupResult lookup_result;
+
+			auto registerFunctionDecl = [&](const ASTNode& function_decl) {
+				if (!function_decl.is<FunctionDeclarationNode>()) {
+					return false;
+				}
+				const auto& func_decl = function_decl.as<FunctionDeclarationNode>();
+				if (func_decl.decl_node().identifier_token().handle() != identifier_token.handle()) {
+					return false;
+				}
+				gSymbolTable.insert(identifier_token.value(), function_decl);
+				identifierType = function_decl;
+				lookup_result.found_any = true;
+				lookup_result.found_non_static |= !func_decl.is_static();
+				FLASH_LOG_FORMAT(Parser, Debug,
+								 "Resolved {} member function '{}' from {}",
+								 func_decl.is_static() ? "static" : "non-static",
+								 identifier_token.value(),
+								 log_context);
+				return true;
+			};
+
+			auto registerCurrentStructDecls = [&](const StructDeclarationNode* current_struct_node) {
+				bool found_in_current_struct = false;
+				if (current_struct_node == nullptr) {
+					return false;
+				}
+				for (const auto& member_func : current_struct_node->member_functions()) {
+					found_in_current_struct |= registerFunctionDecl(member_func.function_declaration);
+				}
+				return found_in_current_struct;
+			};
+
+			auto registerCurrentStructInfoDecls = [&](const StructTypeInfo* current_struct_info) {
+				bool found_in_current_struct = false;
+				if (current_struct_info == nullptr) {
+					return false;
+				}
+				for (const auto& member_func : current_struct_info->member_functions) {
+					found_in_current_struct |= registerFunctionDecl(member_func.function_decl);
+				}
+				return found_in_current_struct;
+			};
+
+			bool found_in_current_struct = registerCurrentStructDecls(struct_node);
+			if (!found_in_current_struct) {
+				found_in_current_struct = registerCurrentStructInfoDecls(struct_info);
+			}
+			if (found_in_current_struct || struct_info == nullptr) {
+				return lookup_result;
+			}
+
+			std::vector<TypeIndex> base_classes_to_search;
+			base_classes_to_search.reserve(struct_info->base_classes.size());
+			for (const auto& base : struct_info->base_classes) {
+				base_classes_to_search.push_back(base.type_index);
+			}
+
+			for (size_t i = 0; i < base_classes_to_search.size(); ++i) {
+				TypeIndex base_idx = base_classes_to_search[i];
+				const TypeInfo* base_type_info = tryGetTypeInfo(base_idx);
+				if (!base_type_info) {
+					continue;
+				}
+
+				const StructTypeInfo* base_struct_info = base_type_info->getStructInfo();
+				if (!base_struct_info) {
+					continue;
+				}
+
+				for (const auto& member_func : base_struct_info->member_functions) {
+					registerFunctionDecl(member_func.function_decl);
+				}
+
+				for (const auto& nested_base : base_struct_info->base_classes) {
+					bool already_in_list = false;
+					for (TypeIndex existing : base_classes_to_search) {
+						if (existing == nested_base.type_index) {
+							already_in_list = true;
 							break;
 						}
 					}
-				}
-
-				// If not found in current struct, search in base classes
-				if (!found_member_function_in_context) {
-					// Get the struct's base classes and search recursively
-					TypeIndex struct_type_index = mf_ctx.struct_type_index;
-					if (const TypeInfo* type_info = tryGetTypeInfo(struct_type_index)) {
-						const StructTypeInfo* struct_info = type_info->getStructInfo();
-						if (struct_info) {
-							// Collect base classes to search (breadth-first to handle multiple inheritance)
-							std::vector<TypeIndex> base_classes_to_search;
-							for (const auto& base : struct_info->base_classes) {
-								base_classes_to_search.push_back(base.type_index);
-							}
-
-							// Search through base classes
-							for (size_t i = 0; i < base_classes_to_search.size() && !found_member_function_in_context; ++i) {
-								TypeIndex base_idx = base_classes_to_search[i];
-								const TypeInfo* base_type_info = tryGetTypeInfo(base_idx);
-								if (!base_type_info)
-									continue;
-
-								const StructTypeInfo* base_struct_info = base_type_info->getStructInfo();
-								if (!base_struct_info)
-									continue;
-
-								// Check member functions in this base class
-								// StructMemberFunction has function_decl which is an ASTNode
-								for (const auto& member_func : base_struct_info->member_functions) {
-									if (member_func.getName() == identifier_token.handle()) {
-										// Found matching member function in base class
-										if (member_func.function_decl.is<FunctionDeclarationNode>()) {
-											const auto& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-											// Update identifierType to point to the base class function
-											gSymbolTable.insert(identifier_token.value(), member_func.function_decl);
-											identifierType = member_func.function_decl;
-											found_member_function_in_context = !func_decl.is_static();
-											resolved_member_function_from_context = true;
-											FLASH_LOG_FORMAT(Parser, Debug,
-															 "EARLY CHECK: Detected {} base class member function call '{}'",
-															 func_decl.is_static() ? "static" : "non-static",
-															 identifier_token.value());
-											break;
-										}
-									}
-								}
-
-								// Add this base's base classes to search list (for multi-level inheritance)
-								for (const auto& nested_base : base_struct_info->base_classes) {
-									// Avoid duplicates (relevant for diamond inheritance)
-									bool already_in_list = false;
-									for (TypeIndex existing : base_classes_to_search) {
-										if (existing == nested_base.type_index) {
-											already_in_list = true;
-											break;
-										}
-									}
-									if (!already_in_list) {
-										base_classes_to_search.push_back(nested_base.type_index);
-									}
-								}
-							}
-						}
+					if (!already_in_list) {
+						base_classes_to_search.push_back(nested_base.type_index);
 					}
 				}
+			}
+
+			return lookup_result;
+		};
+
+		auto registerCurrentStructFunctionOverloads = [&]() -> CurrentStructFunctionLookupResult {
+			if (!member_function_context_stack_.empty()) {
+				const auto& member_ctx = member_function_context_stack_.back();
+				const StructTypeInfo* struct_info = member_ctx.local_struct_info;
+				if (struct_info == nullptr) {
+					if (const TypeInfo* type_info = tryGetTypeInfo(member_ctx.struct_type_index)) {
+						struct_info = type_info->getStructInfo();
+					}
+				}
+
+				CurrentStructFunctionLookupResult lookup_result =
+					registerCurrentStructFunctionOverloadsForContext(
+						member_ctx.struct_node,
+						struct_info,
+						"member function context");
+				if (lookup_result.found_any) {
+					return lookup_result;
+				}
+			}
+
+			if (!struct_parsing_context_stack_.empty()) {
+				const auto& struct_ctx = struct_parsing_context_stack_.back();
+				const StructTypeInfo* struct_info = struct_ctx.local_struct_info;
+				if (struct_info == nullptr && !struct_ctx.struct_name.empty()) {
+					auto struct_it = getTypesByNameMap().find(
+						StringTable::getOrInternStringHandle(struct_ctx.struct_name));
+					if (struct_it != getTypesByNameMap().end()) {
+						struct_info = struct_it->second->getStructInfo();
+					}
+				}
+				return registerCurrentStructFunctionOverloadsForContext(
+					struct_ctx.struct_node,
+					struct_info,
+					"struct parsing context");
+			}
+
+			return {};
+		};
+
+		// BUGFIX: Check if we're in member-function or class-body parsing context and this identifier is a member function.
+		// This handles both member bodies and expressions inside the class body such as using-alias decltype(...) probes.
+		// Declare these flags here so they're visible throughout the rest of the function.
+		bool found_member_function_in_context = false;
+		bool resolved_member_function_from_context = false;
+		if (peek() == "("_tok &&
+			(!identifierType.has_value() || identifierType->is<FunctionDeclarationNode>())) {
+			CurrentStructFunctionLookupResult current_struct_lookup =
+				registerCurrentStructFunctionOverloads();
+			const bool class_scope_decltype_without_implicit_object =
+				member_function_context_stack_.empty() &&
+				context == ExpressionContext::Decltype;
+			found_member_function_in_context =
+				current_struct_lookup.found_non_static &&
+				!class_scope_decltype_without_implicit_object;
+			resolved_member_function_from_context = current_struct_lookup.found_any;
+			if (class_scope_decltype_without_implicit_object &&
+				identifierType.has_value() &&
+				identifierType->is<FunctionDeclarationNode>() &&
+				!identifierType->as<FunctionDeclarationNode>().is_static()) {
+				return ParseResult::error(
+					"Call of non-static member function requires an object",
+					identifier_token);
 			}
 		}
 
@@ -5235,7 +5305,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							member_arg_types,
 							currentTemplateParamNames()),
 					func_decl,
-					StringTable::getStringView(member_function_context_stack_.back().struct_name));
+					!member_function_context_stack_.empty()
+						? StringTable::getStringView(member_function_context_stack_.back().struct_name)
+						: (!struct_parsing_context_stack_.empty()
+							? std::string_view(struct_parsing_context_stack_.back().struct_name)
+							: std::string_view{}));
 			}
 
 			FLASH_LOG_FORMAT(Parser, Debug, "Created CallExprNode for implicit this-call '{}'", identifier_token.value());

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -6349,9 +6349,15 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				return ParseResult::error("Expected ')' after function call arguments", current_token_);
 			}
 
-			// Try to instantiate the template function (skip in extern "C" contexts - C has no templates)
+			const bool has_dependent_call_args =
+				argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+				argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
+
+			// Try to instantiate the template function (skip in extern "C" contexts - C has no templates).
+			// Dependent calls are resolved at the point of instantiation; attempting overload
+			// resolution here can emit false diagnostics for overloads that are not viable yet.
 			std::optional<ASTNode> template_func_inst;
-			if (current_linkage_ != Linkage::C) {
+			if (current_linkage_ != Linkage::C && !has_dependent_call_args) {
 				template_func_inst = try_instantiate_template(identifier_token.value(), arg_types);
 			}
 
@@ -6375,9 +6381,6 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				result = function_call_node;
 				return ParseResult::success(*result);
 			} else {
-				const bool has_dependent_call_args =
-					argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
-					argTypesAreDeferredTemplateDependent(arg_types, currentTemplateParamNames());
 				if (has_dependent_call_args) {
 					FLASH_LOG(Templates, Debug, "Creating dependent call expression for implicit call to '", identifier_token.value(), "'");
 					auto type_node = emplace_node<TypeSpecifierNode>(TypeCategory::Auto, TypeQualifier::None, get_type_size_bits(TypeCategory::Auto), identifier_token, CVQualifier::None);

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5230,6 +5230,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				!class_scope_decltype_without_implicit_object;
 			resolved_member_function_from_context = current_struct_lookup.found_any;
 			if (class_scope_decltype_without_implicit_object &&
+				current_struct_lookup.found_non_static &&
 				identifierType.has_value() &&
 				identifierType->is<FunctionDeclarationNode>() &&
 				!identifierType->as<FunctionDeclarationNode>().is_static()) {
@@ -8581,7 +8582,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 
 				if (is_regular_var) {
 					// It's definitely a variable, don't try template args
-					should_try_template_args = false;
+					should_try_template_args =
+						gTemplateRegistry.lookupTemplate(identifier_token.value()).has_value() ||
+						gTemplateRegistry.lookup_alias_template(identifier_token.value()).has_value() ||
+						gTemplateRegistry.lookupVariableTemplate(identifier_token.value()).has_value() ||
+						gConceptRegistry.hasConcept(identifier_token.value());
 				}
 				// For all other cases (templates, functions, unknown), try template args
 			}

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -342,15 +342,23 @@ ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
 			if (expr_node.is<ExpressionNode>()) {
 				const ExpressionNode& expr = expr_node.as<ExpressionNode>();
 				if (const auto* call_expr = std::get_if<CallExprNode>(&expr)) {
-					if (call_expr->has_dependent_qualified_lookup_record() ||
-						call_expr->has_dependent_unqualified_lookup_record()) {
+					if (call_expr->has_dependent_qualified_lookup_record()) {
+						return false;
+					}
+					if (call_expr->has_dependent_unqualified_lookup_record() &&
+						call_expr->dependent_unqualified_lookup_record()
+							->point_of_instantiation_function == nullptr) {
 						return false;
 					}
 					if (call_expr->call_kind() != CalleeKind::IndirectCall) {
-						const ResolvedFunctionQueryResult direct_call_query =
-							parser->semanticAnalysis().getResolvedDirectCallQuery(call_expr);
-						if (direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
-							return false;
+						if (call_expr->callee().has_function_declaration()) {
+							return true;
+						} else {
+							const ResolvedFunctionQueryResult direct_call_query =
+								parser->semanticAnalysis().getResolvedDirectCallQuery(call_expr);
+							if (direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
+								return false;
+							}
 						}
 					}
 				}

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -317,10 +317,173 @@ ParseResult Parser::parse_requires_expression() {
 
 	// Create RequiresExpressionNode
 	auto requires_expr_node = emplace_node<RequiresExpressionNode>(
+		std::move(parameters),
 		std::move(requirements),
 		requires_token);
 
 	return saved_position.success(requires_expr_node);
+}
+
+ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
+	const RequiresExpressionNode& requires_expr,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	const InlineVector<std::string_view, 4>& template_param_names,
+	Parser* parser,
+	std::span<const TemplateParameterNode> template_params) {
+	auto isValidRequirementExpression = [&](const ASTNode& expr_node) {
+		if (parser == nullptr) {
+			return false;
+		}
+
+		try {
+			TypeSpecifierQueryResult type_query =
+				parser->semanticAnalysis().analyzeExpressionTypeQuery(expr_node);
+
+			if (expr_node.is<ExpressionNode>()) {
+				const ExpressionNode& expr = expr_node.as<ExpressionNode>();
+				if (const auto* call_expr = std::get_if<CallExprNode>(&expr)) {
+					if (call_expr->has_dependent_qualified_lookup_record() ||
+						call_expr->has_dependent_unqualified_lookup_record()) {
+						return false;
+					}
+					if (call_expr->call_kind() != CalleeKind::IndirectCall) {
+						const ResolvedFunctionQueryResult direct_call_query =
+							parser->semanticAnalysis().getResolvedDirectCallQuery(call_expr);
+						if (direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
+							return false;
+						}
+					}
+				}
+			}
+
+			return type_query.hasValue();
+		} catch (const CompileError&) {
+			return false;
+		}
+	};
+
+	gSymbolTable.enter_scope(ScopeType::Block);
+	ScopeGuard requires_scope_guard([&]() { gSymbolTable.exit_scope(); });
+
+	if (parser != nullptr) {
+		for (const ASTNode& param_node : requires_expr.parameter_nodes()) {
+			ASTNode substituted_param = template_params.empty()
+				? param_node
+				: parser->substituteTemplateParameters(param_node, template_params, template_args);
+			if (!substituted_param.is<DeclarationNode>()) {
+				return ConstraintEvaluationResult::failure(
+					"constraint not satisfied: requires parameter could not be materialized",
+					"requires parameter",
+					"preserve the requires parameter declaration through substitution");
+			}
+			const auto& decl = substituted_param.as<DeclarationNode>();
+			if (!decl.identifier_token().value().empty()) {
+				gSymbolTable.insert(decl.identifier_token().value(), substituted_param);
+			}
+		}
+	} else if (!requires_expr.parameter_nodes().empty()) {
+		return ConstraintEvaluationResult::failure(
+			"constraint not satisfied: requires expression parameters need parser context",
+			"requires parameter",
+			"evaluate this concept from parser/template-instantiation context");
+	}
+
+	for (const ASTNode& requirement : requires_expr.requirements()) {
+		ASTNode substituted_requirement = requirement;
+		if (parser != nullptr && !template_params.empty()) {
+			substituted_requirement =
+				parser->substituteTemplateParameters(requirement, template_params, template_args);
+		}
+
+		if (substituted_requirement.is<CompoundRequirementNode>()) {
+			continue;
+		}
+		if (substituted_requirement.is<BoolLiteralNode>()) {
+			if (!substituted_requirement.as<BoolLiteralNode>().value()) {
+				return ConstraintEvaluationResult::failure(
+					"requirement not satisfied: expression is ill-formed",
+					"false",
+					"the expression is not valid for the substituted types");
+			}
+			continue;
+		}
+		if (substituted_requirement.is<RequiresClauseNode>()) {
+			const auto& nested_req = substituted_requirement.as<RequiresClauseNode>();
+			auto nested_result = evaluateConstraint(
+				nested_req.constraint_expr(),
+				template_args,
+				template_param_names,
+				parser,
+				template_params);
+			if (!nested_result.satisfied) {
+				return nested_result;
+			}
+			continue;
+		}
+		if (substituted_requirement.is<ExpressionNode>()) {
+			const ExpressionNode& expr = substituted_requirement.as<ExpressionNode>();
+			if (std::holds_alternative<BoolLiteralNode>(expr)) {
+				const BoolLiteralNode& bool_lit = std::get<BoolLiteralNode>(expr);
+				if (!bool_lit.value()) {
+					return ConstraintEvaluationResult::failure(
+						"requirement not satisfied: expression is not valid for the given types",
+						"false",
+						"the expression is ill-formed for the substituted types");
+				}
+				continue;
+			}
+			if (!isValidRequirementExpression(substituted_requirement)) {
+				return ConstraintEvaluationResult::failure(
+					"requirement not satisfied: expression is not valid for the given types",
+					"simple requirement",
+					"the expression is ill-formed for the substituted types");
+			}
+			if (std::holds_alternative<CallExprNode>(expr)) {
+				const CallExprNode& call = std::get<CallExprNode>(expr);
+				std::string_view called_name = call.called_from().value();
+				const std::vector<ASTNode>* all_templates = gTemplateRegistry.lookupAllTemplates(called_name);
+				if (all_templates != nullptr) {
+					for (const ASTNode& tmpl : *all_templates) {
+						if (!tmpl.is<TemplateFunctionDeclarationNode>()) {
+							continue;
+						}
+						const auto& tfdn = tmpl.as<TemplateFunctionDeclarationNode>();
+						if (!tfdn.has_requires_clause()) {
+							continue;
+						}
+						InlineVector<std::string_view, 4> callee_param_names;
+						for (const auto& param_node : tfdn.template_parameters()) {
+							callee_param_names.push_back(param_node.name());
+						}
+						auto req_result = evaluateConstraint(
+							tfdn.requires_clause()->as<RequiresClauseNode>().constraint_expr(),
+							template_args,
+							callee_param_names,
+							parser,
+							tfdn.template_parameters());
+						if (!req_result.satisfied) {
+							return ConstraintEvaluationResult::failure(
+								"requirement not satisfied: constrained function call failed",
+								std::string(called_name),
+								"check the constraint on the called function");
+						}
+					}
+				}
+			}
+			continue;
+		}
+		if (substituted_requirement.is<BinaryOperatorNode>()) {
+			if (!isValidRequirementExpression(substituted_requirement)) {
+				return ConstraintEvaluationResult::failure(
+					"requirement not satisfied: binary expression is not valid for the given types",
+					"binary requirement",
+					"the operation is ill-formed for the substituted types");
+			}
+			continue;
+		}
+	}
+
+	return ConstraintEvaluationResult::success();
 }
 
 // Parse template parameter list: typename T, int N, ...

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -330,6 +330,11 @@ ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
 	const InlineVector<std::string_view, 4>& template_param_names,
 	Parser* parser,
 	std::span<const TemplateParameterNode> template_params) {
+	std::optional<Parser::ScopedParserInstantiationContext> requires_probe;
+	if (parser != nullptr) {
+		requires_probe.emplace(*parser, Parser::TemplateInstantiationMode::SoftProbe, StringHandle{});
+	}
+
 	auto isValidRequirementExpression = [&](const ASTNode& expr_node) {
 		if (parser == nullptr) {
 			return false;
@@ -458,38 +463,6 @@ ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
 					"requirement not satisfied: expression is not valid for the given types",
 					"simple requirement",
 					"the expression is ill-formed for the substituted types");
-			}
-			if (std::holds_alternative<CallExprNode>(expr)) {
-				const CallExprNode& call = std::get<CallExprNode>(expr);
-				std::string_view called_name = call.called_from().value();
-				const std::vector<ASTNode>* all_templates = gTemplateRegistry.lookupAllTemplates(called_name);
-				if (all_templates != nullptr) {
-					for (const ASTNode& tmpl : *all_templates) {
-						if (!tmpl.is<TemplateFunctionDeclarationNode>()) {
-							continue;
-						}
-						const auto& tfdn = tmpl.as<TemplateFunctionDeclarationNode>();
-						if (!tfdn.has_requires_clause()) {
-							continue;
-						}
-						InlineVector<std::string_view, 4> callee_param_names;
-						for (const auto& param_node : tfdn.template_parameters()) {
-							callee_param_names.push_back(param_node.name());
-						}
-						auto req_result = evaluateConstraint(
-							tfdn.requires_clause()->as<RequiresClauseNode>().constraint_expr(),
-							template_args,
-							callee_param_names,
-							parser,
-							tfdn.template_parameters());
-						if (!req_result.satisfied) {
-							return ConstraintEvaluationResult::failure(
-								"requirement not satisfied: constrained function call failed",
-								std::string(called_name),
-								"check the constraint on the called function");
-						}
-					}
-				}
 			}
 			continue;
 		}

--- a/src/Parser_Templates_Concepts.cpp
+++ b/src/Parser_Templates_Concepts.cpp
@@ -351,14 +351,27 @@ ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
 						return false;
 					}
 					if (call_expr->call_kind() != CalleeKind::IndirectCall) {
-						if (call_expr->callee().has_function_declaration()) {
-							return true;
-						} else {
+						if (call_expr->has_receiver()) {
 							const ResolvedFunctionQueryResult direct_call_query =
 								parser->semanticAnalysis().getResolvedDirectCallQuery(call_expr);
-							if (direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
+							if (direct_call_query.hasValue()) {
+								return true;
+							}
+							const ResolvedFunctionQueryResult op_call_query =
+								parser->semanticAnalysis().getResolvedOpCallQuery(call_expr);
+							if (op_call_query.hasValue()) {
+								return true;
+							}
+							if (direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent ||
+								op_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
 								return false;
 							}
+						} else if (call_expr->callee().has_function_declaration()) {
+							return true;
+						} else if (const ResolvedFunctionQueryResult direct_call_query =
+									   parser->semanticAnalysis().getResolvedDirectCallQuery(call_expr);
+								   direct_call_query.state == ResolvedFunctionQueryResult::State::AnalyzedAbsent) {
+							return false;
 						}
 					}
 				}

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3637,7 +3637,11 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 
 			// Evaluate the constraint with the template arguments
 			auto constraint_result = evaluateConstraint(
-				requires_clause.constraint_expr(), constraint_eval_args, eval_param_names);
+				requires_clause.constraint_expr(),
+				constraint_eval_args,
+				eval_param_names,
+				this,
+				template_params);
 
 			FLASH_LOG(Templates, Debug, "  Constraint evaluation result: satisfied=", constraint_result.satisfied);
 
@@ -3685,7 +3689,9 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 					InlineVector<TemplateTypeArg, 4> concept_args;
 					concept_args.push_back(concept_arg);
 					auto constraint_result = evaluateConstraint(
-						concept_node, concept_args);
+						concept_node,
+						concept_args,
+						this);
 					if (!constraint_result.satisfied) {
 						FLASH_LOG(Parser, Error, "concept constraint '", concept_name, "' not satisfied for parameter '", param.name(), "' of '", template_name, "'");
 						FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
@@ -4202,7 +4208,12 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 							InlineVector<std::string_view, 4> param_names;
 							for (const auto& tp : winner_template_params)
 								param_names.push_back(tp.name());
-							auto cr = evaluateConstraint(rc.constraint_expr(), winner.template_args, param_names);
+							auto cr = evaluateConstraint(
+								rc.constraint_expr(),
+								winner.template_args,
+								param_names,
+								this,
+								winner_template_params);
 							if (!cr.satisfied) {
 								failTemplateInstantiation(
 									StringBuilder()
@@ -4231,7 +4242,7 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 									concept_arg.ref_qualifier = ReferenceQualifier::None;
 									InlineVector<TemplateTypeArg, 4> concept_args;
 									concept_args.push_back(concept_arg);
-									auto cr = evaluateConstraint(concept_node, concept_args);
+									auto cr = evaluateConstraint(concept_node, concept_args, this);
 									if (!cr.satisfied) {
 										concept_failed = true;
 									}
@@ -4832,7 +4843,11 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 
 		// Evaluate the constraint with the template arguments
 		auto constraint_result = evaluateConstraint(
-			requires_clause.constraint_expr(), template_args, eval_param_names);
+			requires_clause.constraint_expr(),
+			template_args,
+			eval_param_names,
+			this,
+			template_params);
 
 		FLASH_LOG(Templates, Debug, "  Constraint evaluation result: satisfied=", constraint_result.satisfied);
 
@@ -4892,7 +4907,9 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 				InlineVector<TemplateTypeArg, 4> concept_args;
 				concept_args.push_back(concept_arg);
 				auto constraint_result = evaluateConstraint(
-					concept_node, concept_args);
+					concept_node,
+					concept_args,
+					this);
 				if (!constraint_result.satisfied) {
 					FLASH_LOG(Parser, Error, "concept constraint '", concept_name, "' not satisfied for parameter '", param.name(), "' of '", template_name, "'");
 					FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -10,6 +10,35 @@
 
 #include <numeric>
 
+static void logTemplateRequiresClauseFailure(
+	bool emit_parser_error,
+	std::string_view template_name,
+	const ConstraintEvaluationResult& constraint_result,
+	std::string_view args_str) {
+	if (emit_parser_error) {
+		FLASH_LOG(Parser, Error, "constraint not satisfied for template function '", template_name, "'");
+		FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
+		if (!constraint_result.failed_requirement.empty()) {
+			FLASH_LOG(Parser, Error, "  failed requirement: ", constraint_result.failed_requirement);
+		}
+		if (!constraint_result.suggestion.empty()) {
+			FLASH_LOG(Parser, Error, "  suggestion: ", constraint_result.suggestion);
+		}
+		FLASH_LOG(Parser, Error, "  template arguments: ", args_str);
+		return;
+	}
+
+	FLASH_LOG(Templates, Debug, "constraint not satisfied for template function '", template_name, "'");
+	FLASH_LOG(Templates, Debug, "  ", constraint_result.error_message);
+	if (!constraint_result.failed_requirement.empty()) {
+		FLASH_LOG(Templates, Debug, "  failed requirement: ", constraint_result.failed_requirement);
+	}
+	if (!constraint_result.suggestion.empty()) {
+		FLASH_LOG(Templates, Debug, "  suggestion: ", constraint_result.suggestion);
+	}
+	FLASH_LOG(Templates, Debug, "  template arguments: ", args_str);
+}
+
 template <typename ParamContainer>
 static bool defaultExpressionReferencesTemplateParams(
 	const ASTNode& expr,
@@ -3654,15 +3683,11 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 					args_str += constraint_eval_args[j].toString();
 				}
 
-				FLASH_LOG(Parser, Error, "constraint not satisfied for template function '", template_name, "'");
-				FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
-				if (!constraint_result.failed_requirement.empty()) {
-					FLASH_LOG(Parser, Error, "  failed requirement: ", constraint_result.failed_requirement);
-				}
-				if (!constraint_result.suggestion.empty()) {
-					FLASH_LOG(Parser, Error, "  suggestion: ", constraint_result.suggestion);
-				}
-				FLASH_LOG(Parser, Error, "  template arguments: ", args_str);
+				logTemplateRequiresClauseFailure(
+					!isTemplateInstantiationFailureProbeMode(),
+					template_name,
+					constraint_result,
+					args_str);
 
 				// Don't create instantiation - constraint failed, try next overload
 				continue;
@@ -4861,15 +4886,11 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 				args_str += template_args[i].toString();
 			}
 
-			FLASH_LOG(Parser, Error, "constraint not satisfied for template function '", template_name, "'");
-			FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
-			if (!constraint_result.failed_requirement.empty()) {
-				FLASH_LOG(Parser, Error, "  failed requirement: ", constraint_result.failed_requirement);
-			}
-			if (!constraint_result.suggestion.empty()) {
-				FLASH_LOG(Parser, Error, "  suggestion: ", constraint_result.suggestion);
-			}
-			FLASH_LOG(Parser, Error, "  template arguments: ", args_str);
+			logTemplateRequiresClauseFailure(
+				!isTemplateInstantiationFailureProbeMode(),
+				template_name,
+				constraint_result,
+				args_str);
 
 			// Don't create instantiation - constraint failed.
 			// Memoize under a per-overload key so repeat SFINAE probes for the
@@ -4911,8 +4932,13 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 					concept_args,
 					this);
 				if (!constraint_result.satisfied) {
-					FLASH_LOG(Parser, Error, "concept constraint '", concept_name, "' not satisfied for parameter '", param.name(), "' of '", template_name, "'");
-					FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
+					if (isTemplateInstantiationFailureProbeMode()) {
+						FLASH_LOG(Templates, Debug, "concept constraint '", concept_name, "' not satisfied for parameter '", param.name(), "' of '", template_name, "'");
+						FLASH_LOG(Templates, Debug, "  ", constraint_result.error_message);
+					} else {
+						FLASH_LOG(Parser, Error, "concept constraint '", concept_name, "' not satisfied for parameter '", param.name(), "' of '", template_name, "'");
+						FLASH_LOG(Parser, Error, "  ", constraint_result.error_message);
+					}
 					concept_failed = true;
 				}
 			});

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -302,7 +302,38 @@ ParseResult Parser::parse_template_parameter() {
 
 			// Expect identifier (parameter name)
 			if (!peek().is_identifier()) {
-				return ParseResult::error("Expected identifier after concept constraint", current_token_);
+				auto param_node = emplace_node<TemplateParameterNode>(StringHandle(), concept_token);
+				param_node.as<TemplateParameterNode>().set_concept_constraint(potential_concept);
+				if (!concept_template_args.empty()) {
+					param_node.as<TemplateParameterNode>().set_concept_args(
+						std::move(concept_template_args));
+				}
+				if (is_variadic) {
+					param_node.as<TemplateParameterNode>().set_variadic(true);
+				}
+				if (!is_variadic && peek() == "="_tok) {
+					advance(); // consume '='
+
+					SaveHandle default_pos = save_token_position();
+					ScopedParserInstantiationContext guard_instantiation_mode(
+						*this,
+						TemplateInstantiationMode::ShapeOnly,
+						StringHandle{});
+					auto default_type_result = parse_type_specifier();
+					if (default_type_result.is_error()) {
+						discard_saved_token(default_pos);
+						return default_type_result;
+					}
+					discard_saved_token(default_pos);
+					if (!default_type_result.node().has_value()) {
+						return ParseResult::error(
+							"Expected default argument after '=' in template parameter",
+							current_token_);
+					}
+					param_node.as<TemplateParameterNode>().set_default_value(
+						*default_type_result.node());
+				}
+				return saved_position.success(param_node);
 			}
 
 			Token param_name_token = peek_info();

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -314,17 +314,14 @@ ParseResult Parser::parse_template_parameter() {
 				if (!is_variadic && peek() == "="_tok) {
 					advance(); // consume '='
 
-					SaveHandle default_pos = save_token_position();
 					ScopedParserInstantiationContext guard_instantiation_mode(
 						*this,
 						TemplateInstantiationMode::ShapeOnly,
 						StringHandle{});
 					auto default_type_result = parse_type_specifier();
 					if (default_type_result.is_error()) {
-						discard_saved_token(default_pos);
 						return default_type_result;
 					}
-					discard_saved_token(default_pos);
 					if (!default_type_result.node().has_value()) {
 						return ParseResult::error(
 							"Expected default argument after '=' in template parameter",

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1271,6 +1271,16 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		return TypeCategory::Int;
 	};
 
+	auto currentTargetTemplateParam = [&]() -> const TemplateParameterNode* {
+		return currentExplicitTemplateArgumentTargetParam(template_args.size());
+	};
+
+	auto currentArgRejectsValueLikeParsing = [&]() {
+		const TemplateParameterNode* target_param = currentTargetTemplateParam();
+		return target_param != nullptr &&
+			   target_param->kind() != TemplateParameterKind::NonType;
+	};
+
 	auto hasConcreteSubstitutionForName = [&](StringHandle name) {
 		if (!name.isValid()) {
 			return false;
@@ -1595,7 +1605,8 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				}
 
 				auto [simple_identifier_kind, prebuilt_arg] = classifySimpleTemplateArgName(identifier_handle);
-				if (simple_identifier_kind == SimpleTemplateArgKind::ValueLike) {
+				if (simple_identifier_kind == SimpleTemplateArgKind::ValueLike &&
+					!currentArgRejectsValueLikeParsing()) {
 					// Use the concrete arg returned by the classify call (avoids a second loop over
 					// template_param_substitutions_). Fall back to a dependent-value placeholder when
 					// no concrete substitution was found yet (deferred template-body parse context).
@@ -1635,8 +1646,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		// like T::value || my_or<Rest...>::value
 		// Precedence 2 allows all binary operators except comma (precedence 1)
 		// The TemplateTypeArg context ensures we stop at '>' and ',' delimiters
-		auto expr_result = parse_expression(2, ExpressionContext::TemplateTypeArg);
-		if (!expr_result.is_error() && expr_result.node().has_value()) {
+		if (!currentArgRejectsValueLikeParsing()) {
+			auto expr_result = parse_expression(2, ExpressionContext::TemplateTypeArg);
+			if (!expr_result.is_error() && expr_result.node().has_value()) {
 			// Successfully parsed an expression - check if it's a boolean or numeric literal
 			const ExpressionNode& expr = expr_result.node()->as<ExpressionNode>();
 
@@ -1912,7 +1924,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 						}
 					}
 
-					if (!is_concrete_qualified_type && (peek() == ">"_tok || peek() == ","_tok || peek() == "..."_tok)) {
+					if (!is_concrete_qualified_type &&
+						!currentArgRejectsValueLikeParsing() &&
+						(peek() == ">"_tok || peek() == ","_tok || peek() == "..."_tok)) {
 						FLASH_LOG(Templates, Debug, "Accepting dependent compile-time expression as template argument");
 						// Create a dependent template argument
 						auto makeDependentCompileTimeArg = [&](StringHandle dependent_name, std::optional<ASTNode> dep_expr) {
@@ -2277,7 +2291,8 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								std::holds_alternative<CallExprNode>(expr) ||
 								std::holds_alternative<ConstructorCallNode>(expr) ||
 								simple_identifier_kind == SimpleTemplateArgKind::ValueLike;
-							if (is_value_like_dependent_expr) {
+							if (is_value_like_dependent_expr &&
+								!currentArgRejectsValueLikeParsing()) {
 								// Store the original AST expression for dependent NTTP expressions
 								// so it can be re-evaluated during template instantiation
 								std::optional<ASTNode> stored_expr = std::nullopt;
@@ -2306,9 +2321,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 									dependentExpressionValueCategory(expr),
 									0,
 									std::move(stored_expr));
-							} else {
+							} else if (!is_value_like_dependent_expr) {
 								dependent_arg.type_index = nativeTypeIndex(TypeCategory::UserDefined);  // Template parameter is a user-defined type placeholder; will try to look up
 								dependent_arg.is_value = false;	// This is a TYPE parameter, not a value
+							} else {
+								goto try_type_template_argument_parse;
 							}
 							dependent_arg.is_dependent = true;
 
@@ -2405,10 +2422,12 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				}  // End of else block for !is_array_subscript
 			}
 
-			// Expression is not a numeric literal or evaluable constant - fall through to type parsing
+				// Expression is not a numeric literal or evaluable constant - fall through to type parsing
+			}
 		}
 
 		// Expression parsing failed or wasn't a numeric literal - try parsing a type
+try_type_template_argument_parse:
 		restore_token_position(arg_saved_pos);
 		auto type_result = parse_type_specifier();
 		if (type_result.is_error() || !type_result.node().has_value()) {
@@ -3702,6 +3721,7 @@ StringHandle Parser::extractDependentMemberProbeFromCurrentTemplateArg() {
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_arguments(
 	std::span<const TemplateParameterNode> target_template_params,
 	std::vector<ASTNode>* out_type_nodes) {
+	ScopedExplicitTemplateArgumentTargetParams target_param_guard(*this, target_template_params);
 	auto parsed_args = parse_explicit_template_arguments(out_type_nodes);
 	if (parsed_args.has_value()) {
 		classifyExplicitTemplateArgumentsAgainstParameters(
@@ -3715,6 +3735,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_arguments(
 	std::span<const TemplateParameterNode> target_template_params,
 	InlineVector<ASTNode, 4>* out_type_nodes) {
+	ScopedExplicitTemplateArgumentTargetParams target_param_guard(*this, target_template_params);
 	if (out_type_nodes == nullptr) {
 		auto parsed_args = parse_explicit_template_arguments();
 		if (parsed_args.has_value()) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4419,6 +4419,12 @@ TypeSpecifierQueryResult SemanticAnalysis::getExpressionTypeQuery(const ASTNode&
 	return {TypeSpecifierQueryResult::State::Available, type};
 }
 
+TypeSpecifierQueryResult SemanticAnalysis::analyzeExpressionTypeQuery(const ASTNode& node) {
+	SemanticContext ctx;
+	normalizeExpression(node, ctx);
+	return getExpressionTypeQuery(node);
+}
+
 std::optional<TypeSpecifierNode> SemanticAnalysis::getTernaryResultType(const TernaryOperatorNode& ternary_node) const {
 	auto it = ternary_result_types_.find(&ternary_node);
 	if (it == ternary_result_types_.end()) {

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -185,6 +185,7 @@ public:
 	// Key is the raw pointer to the ExpressionNode (stable, from gChunkedAnyStorage).
 	std::optional<SemanticSlot> getSlot(const void* key) const;
 	TypeSpecifierQueryResult getExpressionTypeQuery(const ASTNode& node) const;
+	TypeSpecifierQueryResult analyzeExpressionTypeQuery(const ASTNode& node);
 	std::optional<TypeSpecifierNode> getExpressionType(const ASTNode& node) const;
 	std::optional<TypeSpecifierNode> getTernaryResultType(const TernaryOperatorNode& ternary_node) const;
 	// Public bridge for codegen/helper paths that need the same canonical type

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cstdint>
 
+class Parser;
+
 // Strip namespace prefix from a class name handle (e.g., "ns::Foo$hash" -> "Foo$hash").
 // Used by lazy registries so lookups match regardless of qualification.
 static StringHandle normalizeClassName(StringHandle handle) {
@@ -1359,6 +1361,13 @@ struct ConstraintEvaluationResult {
 	}
 };
 
+ConstraintEvaluationResult evaluateRequiresExpressionConstraint(
+	const RequiresExpressionNode& requires_expr,
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	const InlineVector<std::string_view, 4>& template_param_names,
+	Parser* parser,
+	std::span<const TemplateParameterNode> template_params);
+
 // isIntegralType and isFloatingPointType moved to AstNodeTypes_TypeSystem.h
 
 // Helper function to evaluate type traits like std::is_integral_v<T>
@@ -1994,12 +2003,15 @@ inline std::optional<long long> evaluateConstraintExpression(
 // Evaluates constraints and provides detailed error messages when they fail
 inline ConstraintEvaluationResult evaluateConstraint(
 	const ConceptDeclarationNode& concept_node,
-	const InlineVector<TemplateTypeArg, 4>& template_args);
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	Parser* parser = nullptr);
 
 inline ConstraintEvaluationResult evaluateConstraint(
 	const ASTNode& constraint_expr,
 	const InlineVector<TemplateTypeArg, 4>& template_args,
-	const InlineVector<std::string_view, 4>& template_param_names = {}) {
+	const InlineVector<std::string_view, 4>& template_param_names = {},
+	Parser* parser = nullptr,
+	std::span<const TemplateParameterNode> template_params = {}) {
 
 	FLASH_LOG(Templates, Debug, "evaluateConstraint: constraint type=", constraint_expr.type_name(), ", template_args.size()=", template_args.size());
 	for (size_t i = 0; i < template_param_names.size(); ++i) {
@@ -2017,7 +2029,7 @@ inline ConstraintEvaluationResult evaluateConstraint(
 		return std::visit([&](const auto& inner) -> ConstraintEvaluationResult {
 			// Create an ASTNode wrapper around the inner node
 			ASTNode inner_ast_node(&inner);
-			return evaluateConstraint(inner_ast_node, template_args, template_param_names);
+			return evaluateConstraint(inner_ast_node, template_args, template_param_names, parser, template_params);
 		},
 						  expr_variant);
 	}
@@ -2097,7 +2109,12 @@ inline ConstraintEvaluationResult evaluateConstraint(
 
 		// Concept found - evaluate its constraint expression with the template arguments
 		const auto& concept_node = concept_opt->as<ConceptDeclarationNode>();
-		return evaluateConstraint(concept_node.constraint_expr(), template_args, template_param_names);
+		return evaluateConstraint(
+			concept_node.constraint_expr(),
+			template_args,
+			template_param_names,
+			parser,
+			concept_node.template_params());
 	}
 
 	// For member access nodes (e.g., std::is_integral_v<T>)
@@ -2204,7 +2221,7 @@ inline ConstraintEvaluationResult evaluateConstraint(
 		}
 
 		// Evaluate the concept's constraint with the resolved arguments
-		return evaluateConstraint(concept_node, concept_args);
+		return evaluateConstraint(concept_node, concept_args, parser);
 	}
 
 	// For binary operators (&&, ||)
@@ -2214,12 +2231,12 @@ inline ConstraintEvaluationResult evaluateConstraint(
 
 		if (op == "&&") {
 			// Conjunction - both must be satisfied
-			auto left_result = evaluateConstraint(binop.get_lhs(), template_args, template_param_names);
+			auto left_result = evaluateConstraint(binop.get_lhs(), template_args, template_param_names, parser, template_params);
 			if (!left_result.satisfied) {
 				return left_result;	// Return first failure
 			}
 
-			auto right_result = evaluateConstraint(binop.get_rhs(), template_args, template_param_names);
+			auto right_result = evaluateConstraint(binop.get_rhs(), template_args, template_param_names, parser, template_params);
 			if (!right_result.satisfied) {
 				return right_result;
 			}
@@ -2227,12 +2244,12 @@ inline ConstraintEvaluationResult evaluateConstraint(
 			return ConstraintEvaluationResult::success();
 		} else if (op == "||") {
 			// Disjunction - at least one must be satisfied
-			auto left_result = evaluateConstraint(binop.get_lhs(), template_args, template_param_names);
+			auto left_result = evaluateConstraint(binop.get_lhs(), template_args, template_param_names, parser, template_params);
 			if (left_result.satisfied) {
 				return ConstraintEvaluationResult::success();
 			}
 
-			auto right_result = evaluateConstraint(binop.get_rhs(), template_args, template_param_names);
+			auto right_result = evaluateConstraint(binop.get_rhs(), template_args, template_param_names, parser, template_params);
 			if (right_result.satisfied) {
 				return ConstraintEvaluationResult::success();
 			}
@@ -2297,7 +2314,7 @@ inline ConstraintEvaluationResult evaluateConstraint(
 	if (constraint_expr.is<UnaryOperatorNode>()) {
 		const auto& unop = constraint_expr.as<UnaryOperatorNode>();
 		if (unop.op() == "!") {
-			auto operand_result = evaluateConstraint(unop.get_operand(), template_args, template_param_names);
+			auto operand_result = evaluateConstraint(unop.get_operand(), template_args, template_param_names, parser, template_params);
 			if (operand_result.satisfied) {
 				return ConstraintEvaluationResult::failure(
 					"constraint not satisfied: negated constraint is true",
@@ -2310,98 +2327,12 @@ inline ConstraintEvaluationResult evaluateConstraint(
 
 	// For requires expressions: requires { expr; ... } or requires(params) { expr; ... }
 	if (constraint_expr.is<RequiresExpressionNode>()) {
-		const auto& requires_expr = constraint_expr.as<RequiresExpressionNode>();
-		// Evaluate each requirement in the requires expression
-		// For now, we check if each requirement is a valid expression
-		// This is a simplified check - full implementation would need to verify
-		// that the expressions are well-formed with the substituted template arguments
-		for (const auto& requirement : requires_expr.requirements()) {
-			// Check different types of requirements
-			if (requirement.is<CompoundRequirementNode>()) {
-				// Compound requirement: { expression } -> Type
-				// For now, assume satisfied - full implementation would check
-				// that the expression is valid and the return type matches
-				continue;
-			}
-			// Check for false literal (from SFINAE recovery when expression parsing failed)
-			if (requirement.is<BoolLiteralNode>()) {
-				if (!requirement.as<BoolLiteralNode>().value()) {
-					return ConstraintEvaluationResult::failure(
-						"requirement not satisfied: expression is ill-formed",
-						"false",
-						"the expression is not valid for the substituted types");
-				}
-				continue;
-			}
-			if (requirement.is<RequiresClauseNode>()) {
-				// Nested requirement: requires constraint
-				const auto& nested_req = requirement.as<RequiresClauseNode>();
-				auto nested_result = evaluateConstraint(nested_req.constraint_expr(), template_args, template_param_names);
-				if (!nested_result.satisfied) {
-					return nested_result;
-				}
-				continue;
-			}
-			// Simple requirement: expression must be valid
-			// For binary operator expressions like a + b, we need to check if the operation is valid for the type
-			if (requirement.is<ExpressionNode>()) {
-				const ExpressionNode& expr = requirement.as<ExpressionNode>();
-				// Check if this is a false literal (SFINAE recovery created this when wrapped in ExpressionNode)
-				if (std::holds_alternative<BoolLiteralNode>(expr)) {
-					const BoolLiteralNode& bool_lit = std::get<BoolLiteralNode>(expr);
-					if (!bool_lit.value()) {
-						return ConstraintEvaluationResult::failure(
-							"requirement not satisfied: expression is not valid for the given types",
-							"false",
-							"the expression is ill-formed for the substituted types");
-					}
-					continue;
-				}
-				// Check if this is a function call to a constrained template function
-				if (std::holds_alternative<CallExprNode>(expr)) {
-					const CallExprNode& call = std::get<CallExprNode>(expr);
-					std::string_view called_name = call.called_from().value();
-					// Look up if this function is a template with a requires clause
-					const std::vector<ASTNode>* all_templates = gTemplateRegistry.lookupAllTemplates(called_name);
-					if (all_templates) {
-						for (const auto& tmpl : *all_templates) {
-							if (tmpl.is<TemplateFunctionDeclarationNode>()) {
-								const auto& tfdn = tmpl.as<TemplateFunctionDeclarationNode>();
-								if (tfdn.has_requires_clause()) {
-									// Build the called function's own template parameter names
-									// and map outer template args to them via positional matching
-									InlineVector<std::string_view, 4> callee_param_names;
-									for (const auto& param_node : tfdn.template_parameters()) {
-										callee_param_names.push_back(param_node.name());
-									}
-									// Evaluate using the callee's param names with the outer args
-									// (positional: concept's T maps to callee's T by position)
-									auto req_result = evaluateConstraint(
-										tfdn.requires_clause()->as<RequiresClauseNode>().constraint_expr(),
-										template_args, callee_param_names);
-									if (!req_result.satisfied) {
-										return ConstraintEvaluationResult::failure(
-											"requirement not satisfied: constrained function call failed",
-											std::string(called_name),
-											"check the constraint on the called function");
-									}
-								}
-							}
-						}
-					}
-				}
-				// The expression parsing succeeded, so it's syntactically valid
-				continue;
-			}
-			if (requirement.is<BinaryOperatorNode>()) {
-				// Binary operation like a + b
-				// For now, assume satisfied - full implementation would check
-				// if the types support the operation
-				continue;
-			}
-		}
-		// All requirements satisfied
-		return ConstraintEvaluationResult::success();
+		return evaluateRequiresExpressionConstraint(
+			constraint_expr.as<RequiresExpressionNode>(),
+			template_args,
+			template_param_names,
+			parser,
+			template_params);
 	}
 
 	// For TypeTraitExprNode (e.g., __is_same(T, int), __is_integral(T))
@@ -2509,7 +2440,8 @@ inline ConstraintEvaluationResult evaluateConstraint(
 
 inline ConstraintEvaluationResult evaluateConstraint(
 	const ConceptDeclarationNode& concept_node,
-	const InlineVector<TemplateTypeArg, 4>& template_args) {
+	const InlineVector<TemplateTypeArg, 4>& template_args,
+	Parser* parser) {
 	InlineVector<std::string_view, 4> derived_param_names;
 	derived_param_names.reserve(concept_node.template_params().size());
 	for (const TemplateParameterNode& concept_param : concept_node.template_params()) {
@@ -2518,5 +2450,7 @@ inline ConstraintEvaluationResult evaluateConstraint(
 	return evaluateConstraint(
 		concept_node.constraint_expr(),
 		template_args,
-		derived_param_names);
+		derived_param_names,
+		parser,
+		concept_node.template_params());
 }

--- a/tests/test_class_scope_decltype_inherited_member_ret1.cpp
+++ b/tests/test_class_scope_decltype_inherited_member_ret1.cpp
@@ -1,0 +1,19 @@
+struct ClassScopeDecltypeBase {
+	static int inherited() {
+		return 1;
+	}
+};
+
+template <class T>
+struct ClassScopeDecltypeDerived : ClassScopeDecltypeBase {
+	using inherited_result = decltype(inherited());
+
+	inherited_result call() {
+		return inherited();
+	}
+};
+
+int main() {
+	ClassScopeDecltypeDerived<int> value;
+	return value.call();
+}

--- a/tests/test_class_scope_decltype_nonstatic_inherited_member_fail.cpp
+++ b/tests/test_class_scope_decltype_nonstatic_inherited_member_fail.cpp
@@ -1,0 +1,14 @@
+struct ClassScopeDecltypeNonstaticBase {
+	int inherited() {
+		return 1;
+	}
+};
+
+template <class T>
+struct ClassScopeDecltypeNonstaticDerived : ClassScopeDecltypeNonstaticBase {
+	using inherited_result = decltype(inherited());
+};
+
+int main() {
+	return 0;
+}

--- a/tests/test_concept_default_nttp_enum_ternary_ret0.cpp
+++ b/tests/test_concept_default_nttp_enum_ternary_ret0.cpp
@@ -1,0 +1,27 @@
+// Regression: a deferred concept-id used inside a default NTTP expression
+// must collapse to a concrete bool after template substitution.
+// Reduced from MSVC STL ranges::subrange's enum-typed default:
+//   sized_sentinel_for<_Se, _It> ? subrange_kind::sized : subrange_kind::unsized
+
+template<typename Se, typename It>
+concept sized_sentinel_like = __is_same(Se, It);
+
+enum class subrange_kind : bool {
+	unsized,
+	sized
+};
+
+template<typename It, typename Se = It,
+	subrange_kind Kind =
+		sized_sentinel_like<Se, It> ? subrange_kind::sized : subrange_kind::unsized>
+struct subrange_like {
+	static constexpr subrange_kind kind = Kind;
+};
+
+struct sentinel {};
+
+int main() {
+	static_assert(subrange_like<int*>::kind == subrange_kind::sized);
+	static_assert(subrange_like<int*, sentinel>::kind == subrange_kind::unsized);
+	return 0;
+}

--- a/tests/test_hidden_friend_literal_zero_ctor_template_ret0.cpp
+++ b/tests/test_hidden_friend_literal_zero_ctor_template_ret0.cpp
@@ -1,0 +1,80 @@
+// Regression: hidden-friend comparison operators must remain viable when one
+// operand reaches the overload via an implicit conversion through a constructor
+// template such as std::_Literal_zero(T). This pattern appears in MSVC
+// <compare>, where reverse-order operators forward to sibling hidden friends.
+namespace std {
+	enum class _Compare_ord : signed char {
+		less = -1,
+		equivalent = 0,
+		greater = 1
+	};
+
+	using _Compare_t = signed char;
+
+	struct _Literal_zero {
+		template<class T>
+		constexpr _Literal_zero(T) noexcept {}
+	};
+
+	class partial_ordering {
+		_Compare_t _Value;
+
+	public:
+		static const partial_ordering less;
+		static const partial_ordering equivalent;
+		static const partial_ordering greater;
+
+		constexpr partial_ordering(_Compare_t value) noexcept : _Value(value) {}
+
+		friend constexpr bool operator==(const partial_ordering value, _Literal_zero) noexcept {
+			return value._Value == 0;
+		}
+
+		friend constexpr bool operator>(const partial_ordering value, _Literal_zero) noexcept {
+			return value._Value > 0;
+		}
+
+		friend constexpr bool operator<(const partial_ordering value, _Literal_zero) noexcept {
+			return value._Value < 0;
+		}
+
+		friend constexpr bool operator<(_Literal_zero, const partial_ordering value) noexcept {
+			return value > 0;
+		}
+
+		friend constexpr bool operator>(_Literal_zero, const partial_ordering value) noexcept {
+			return value < 0;
+		}
+
+		friend constexpr bool operator<=(_Literal_zero, const partial_ordering value) noexcept {
+			return !(value > 0);
+		}
+
+		friend constexpr bool operator>=(_Literal_zero, const partial_ordering value) noexcept {
+			return !(value < 0);
+		}
+	};
+
+	inline constexpr partial_ordering partial_ordering::less{static_cast<_Compare_t>(_Compare_ord::less)};
+	inline constexpr partial_ordering partial_ordering::equivalent{static_cast<_Compare_t>(_Compare_ord::equivalent)};
+	inline constexpr partial_ordering partial_ordering::greater{static_cast<_Compare_t>(_Compare_ord::greater)};
+}
+
+int main() {
+	if (!(0 < std::partial_ordering::greater)) {
+		return 1;
+	}
+	if (!(0 > std::partial_ordering::less)) {
+		return 2;
+	}
+	if (!(0 <= std::partial_ordering::equivalent)) {
+		return 3;
+	}
+	if (!(0 >= std::partial_ordering::equivalent)) {
+		return 4;
+	}
+	if (!(std::partial_ordering::equivalent == 0)) {
+		return 5;
+	}
+	return 0;
+}

--- a/tests/test_requires_overload_constraints_viable_ret0.cpp
+++ b/tests/test_requires_overload_constraints_viable_ret0.cpp
@@ -1,0 +1,22 @@
+template <class T>
+int select(T)
+	requires(__is_same(T, int))
+{
+	return 1;
+}
+
+template <class T>
+int select(T)
+	requires(__is_same(T, char))
+{
+	return 2;
+}
+
+template <class T>
+concept CanSelect = requires(T value) {
+	select(value);
+};
+
+int main() {
+	return CanSelect<int> && CanSelect<char> && !CanSelect<long> ? 0 : 1;
+}

--- a/tests/test_template_arg_contextual_concept_ret1.cpp
+++ b/tests/test_template_arg_contextual_concept_ret1.cpp
@@ -1,0 +1,27 @@
+template <class T>
+concept HasMemberArrow = requires(T value) {
+	value.operator->();
+};
+
+struct WithArrow {
+	int operator->() const {
+		return 1;
+	}
+};
+
+struct WithoutArrow {};
+
+template <class T>
+int classifyArrowSupport() {
+	if constexpr (HasMemberArrow<const T&>) {
+		return 2;
+	}
+	return 1;
+}
+
+int main() {
+	return (classifyArrowSupport<WithArrow>() == 2 &&
+			classifyArrowSupport<WithoutArrow>() == 1)
+		? 1
+		: 0;
+}

--- a/tests/test_template_arg_known_type_slot_ret1.cpp
+++ b/tests/test_template_arg_known_type_slot_ret1.cpp
@@ -1,0 +1,21 @@
+template <class T>
+using AddRef = T&;
+
+template <class T>
+struct Box {
+	static constexpr int value = 0;
+};
+
+template <class T>
+struct Box<T&> {
+	static constexpr int value = 1;
+};
+
+template <class T>
+int testKnownTypeSlot() {
+	return Box<AddRef<T>>::value;
+}
+
+int main() {
+	return testKnownTypeSlot<int>() == 1 ? 1 : 0;
+}

--- a/tests/test_template_dependent_unqualified_begin_ret1.cpp
+++ b/tests/test_template_dependent_unqualified_begin_ret1.cpp
@@ -1,0 +1,24 @@
+template <class T>
+auto begin(T& value) -> decltype(value.not_begin()) {
+	return value.not_begin();
+}
+
+template <class T>
+auto dependentBeginProbe(T& value) -> decltype(begin(value)) {
+	return begin(value);
+}
+
+namespace DependentBeginAdl {
+	struct Range {
+		int not_begin() {
+			return data;
+		}
+
+		int data;
+	};
+}
+
+int main() {
+	DependentBeginAdl::Range range{1};
+	return dependentBeginProbe(range);
+}

--- a/tests/test_unnamed_constrained_template_param_default_ret0.cpp
+++ b/tests/test_unnamed_constrained_template_param_default_ret0.cpp
@@ -1,11 +1,12 @@
-#include <concepts>
+template <class T>
+concept LocalIntegral = __is_integral(T);
 
-template <std::integral = int>
+template <LocalIntegral = int>
 struct box {
 	static constexpr int value = 7;
 };
 
-template <std::integral>
+template <LocalIntegral>
 struct tag {
 	static constexpr int value = 4;
 };

--- a/tests/test_unnamed_constrained_template_param_default_ret0.cpp
+++ b/tests/test_unnamed_constrained_template_param_default_ret0.cpp
@@ -1,0 +1,15 @@
+#include <concepts>
+
+template <std::integral = int>
+struct box {
+	static constexpr int value = 7;
+};
+
+template <std::integral>
+struct tag {
+	static constexpr int value = 4;
+};
+
+int main() {
+	return box<>::value - tag<long long>::value - 3;
+}


### PR DESCRIPTION
## Summary
- improve C++20 template/concept parsing and substitution paths used by MSVC STL headers
- preserve dependent/template argument metadata through contextual concept checks, lazy substitution, and hidden-friend conversions
- defer dependent unqualified template calls and support class-scope inherited static member lookup in decltype
- add focused regressions for each fixed parser/sema path

## Notes
- `tests/std/test_std_iterator.cpp` advances past the prior dependent `begin` overload frontier; the current next frontier is `xutility:3576` inside `noexcept(_Distance_unchecked(...))`.