### PR TITLE
Centralize builtin template-argument canonicalization for type-traits folds

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -692,6 +692,17 @@ When changing this area, always rerun:
    structured qualified-owner record on the AST and route both parser
    materialization and sema fallback through one owner/type-owner-vs-namespace
    resolver so this pattern does not repeat in more qualified-call subpaths.
+   Follow-up for the standard-header frontier: builtin type template arguments
+   are now canonicalized through `TemplateArgumentMaterialization.h` instead of
+   ad hoc `get_type_name` / empty-token reconstruction. Expression-form
+   template arguments in constexpr variable-template calls, raw
+   `TypeSpecifierNode` substitution, and parser-side type-parameter expression
+   replacement all use the shared token/type-argument helpers. This fixes the
+   MSVC `<type_traits>` `is_integral_v` shape where `wchar_t`, `char8_t`,
+   `char16_t`, and `char32_t` were previously reconstructed as an `unknown`
+   identifier inside an `is_same_v<T, U>` fold. Guard:
+   `test_variable_template_fold_remove_cv_builtin_list_ret0.cpp`; focused
+   validation also covers `std/test_std_type_traits.cpp`.
 
 2. Only then spend complexity on current-instantiation /
    unknown-specialization expansion, and only for concrete typed-lookup or

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -654,6 +654,16 @@ For work in this area, rerun:
    by both parser materialization and later sema fallback, so future
    qualified/member-template paths do not regress by rebuilding owner meaning
    from short spellings.
+   Standard-header follow-up: the builtin type template-argument surface is now
+   canonicalized in `TemplateArgumentMaterialization.h`. Parser substitution,
+   expression substitution, and constexpr variable-template evaluation all
+   share the same builtin spelling/category conversion instead of rebuilding
+   concrete type arguments from local strings or empty tokens. This is required
+   by the C++20 distinct fundamental character types and unblocks the
+   `is_any_of_v<remove_cv_t<T>, ...>` boolean fold used by MSVC
+   `<type_traits>` for `is_integral_v`. New guard:
+   `test_variable_template_fold_remove_cv_builtin_list_ret0.cpp`; focused std
+   validation: `std/test_std_type_traits.cpp`.
    In parallel with that audit, finish deleting the remaining legacy
    parser-side `expr...` loops that still duplicate pack-expansion behavior
    instead of routing through the shared helper and the new "preserve when not

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -7,6 +7,7 @@
 #include "CallNodeHelpers.h"
 #include "SemanticAnalysis.h"
 #include "StringLiteralTokenUtils.h"
+#include "TemplateArgumentMaterialization.h"
 #include "TypeTraitEvaluator.h"
 
 namespace ConstExpr {
@@ -4600,6 +4601,12 @@ EvalResult Evaluator::tryEvaluateAsVariableTemplate(std::string_view func_name, 
 			}
 			template_args.push_back(std::move(template_arg));
 		} else if (arg_node.is<ExpressionNode>()) {
+			const ExpressionNode& arg_expr = arg_node.as<ExpressionNode>();
+			if (std::optional<TemplateTypeArg> type_arg =
+					materializeTemplateTypeArgumentFromExpression(arg_expr)) {
+				template_args.push_back(*type_arg);
+				continue;
+			}
 			EvalResult arg_val = evaluate(arg_node, context);
 			if (!arg_val.success()) {
 				return EvalResult::error("Failed to evaluate non-type template argument: " + arg_val.error_message);

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1866,9 +1866,11 @@ std::optional<ASTNode> ExpressionSubstitutor::tryEvaluateConcreteConceptCall(con
 						ASTNode::emplace_node<TypeSpecifierNode>(std::move(type_spec))};
 				}
 
-				if (auto builtin_type = parser_.get_builtin_type_info(type_name)) {
+				if (TypeCategory builtin_category =
+						getTemplateArgumentBuiltinCategoryFromTokenText(type_name);
+					builtin_category != TypeCategory::Invalid) {
 					TypeSpecifierNode type_spec = makeTypeSpecifierFromTemplateTypeArg(
-						TemplateTypeArg::makeType(nativeTypeIndex(builtin_type->first)),
+						TemplateTypeArg::makeType(nativeTypeIndex(builtin_category)),
 						type_token);
 					return std::vector<ASTNode>{
 						ASTNode::emplace_node<TypeSpecifierNode>(std::move(type_spec))};
@@ -2326,9 +2328,11 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 								substituted_template_args.push_back(TemplateTypeArg::makeType(type_info->type_index_));
 								continue;
 							}
-							if (auto builtin_type = parser_.get_builtin_type_info(identifier->name())) {
+							if (TypeCategory builtin_category =
+									getTemplateArgumentBuiltinCategoryFromTokenText(identifier->name());
+								builtin_category != TypeCategory::Invalid) {
 								substituted_template_args.push_back(
-									TemplateTypeArg::makeType(nativeTypeIndex(builtin_type->first)));
+									TemplateTypeArg::makeType(nativeTypeIndex(builtin_category)));
 								continue;
 							}
 							FLASH_LOG(Templates, Debug, "    Substituted identifier template argument is not a known type: ", identifier->name());
@@ -4531,9 +4535,11 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 	if (!token_type_name.empty()) {
 		FLASH_LOG(Templates, Debug, "  Type candidate for template substitution: ", token_type_name);
 
-		if (auto builtin_type = parser_.get_builtin_type_info(token_type_name); builtin_type.has_value()) {
+		if (TypeCategory builtin_category =
+				getTemplateArgumentBuiltinCategoryFromTokenText(token_type_name);
+			builtin_category != TypeCategory::Invalid) {
 			TypeSpecifierNode builtin_spec(
-				nativeTypeIndex(builtin_type->first),
+				nativeTypeIndex(builtin_category),
 				type.size_in_bits(),
 				type.token(),
 				type.cv_qualifier(),
@@ -4937,9 +4943,11 @@ std::vector<TemplateTypeArg> ExpressionSubstitutor::expandPacksInArguments(
 						expanded_args.push_back(TemplateTypeArg::makeType(type_info->type_index_));
 						continue;
 					}
-					if (auto builtin_type = parser_.get_builtin_type_info(identifier->name())) {
+					if (TypeCategory builtin_category =
+							getTemplateArgumentBuiltinCategoryFromTokenText(identifier->name());
+						builtin_category != TypeCategory::Invalid) {
 						expanded_args.push_back(
-							TemplateTypeArg::makeType(nativeTypeIndex(builtin_type->first)));
+							TemplateTypeArg::makeType(nativeTypeIndex(builtin_category)));
 						continue;
 					}
 				}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -409,6 +409,13 @@ ASTNode ExpressionSubstitutor::substitute(const ASTNode& expr) {
 		return substituteIdentifier(expr.as<IdentifierNode>());
 	} else if (expr.is<QualifiedIdentifierNode>()) {
 		return substituteQualifiedIdentifier(expr.as<QualifiedIdentifierNode>());
+	} else if (expr.is<TypeSpecifierNode>()) {
+		TypeSpecifierNode substituted_type =
+			substituteInType(expr.as<TypeSpecifierNode>());
+		TypeSpecifierNode& stored_type =
+			gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
+				std::move(substituted_type));
+		return ASTNode(&stored_type);
 	} else if (expr.is<MemberAccessNode>()) {
 		return substituteMemberAccess(expr.as<MemberAccessNode>());
 	} else if (expr.is<SizeofExprNode>()) {
@@ -3623,23 +3630,14 @@ ASTNode ExpressionSubstitutor::substituteIdentifier(const IdentifierNode& id) {
 		}
 
 		// Handle type template parameters
-		// Create a TypeSpecifierNode from the template argument
-		TypeSpecifierNode& new_type = gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(
-			arg.type_index.withCategory(arg.typeEnum()),
-			64,	// Default size, will be adjusted by type system
-			Token{},
-			arg.cv_qualifier,
-			ReferenceQualifier::None);
-
-		// Add pointer levels if needed
-		for (size_t i = 0; i < arg.pointer_depth; ++i) {
-			new_type.add_pointer_level();
-		}
-
-		// Set reference qualifiers
-		new_type.set_reference_qualifier(arg.ref_qualifier);
-
-		return ASTNode(&new_type);
+		Token substituted_token = makeTemplateArgumentTypeToken(
+			arg,
+			id.identifier_token());
+		TypeSpecifierNode new_type =
+			makeTypeSpecifierFromTemplateTypeArg(arg, substituted_token);
+		TypeSpecifierNode& stored_type =
+			gChunkedAnyStorage.emplace_back<TypeSpecifierNode>(std::move(new_type));
+		return ASTNode(&stored_type);
 	}
 
 	// Not a template parameter, return as-is (wrapped in ExpressionNode so the
@@ -4522,6 +4520,11 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 				return substituted_alias;
 			}
 		}
+	}
+
+	if (std::optional<TypeSpecifierNode> canonical_builtin =
+			makeCanonicalBuiltinTypeSpecifier(type)) {
+		return *canonical_builtin;
 	}
 
 	// First, check whether this type spelling names a template parameter that needs substitution.

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -6501,6 +6501,39 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							val_arg.is_pack = arg_info.is_pack;
 							return val_arg;
 						};
+						struct DeferredBaseConstantValue {
+							int64_t value = 0;
+							TypeCategory type = TypeCategory::Int;
+							TypeIndex type_index{};
+						};
+						auto tryEvaluateDeferredBaseConstant =
+							[&](const ASTNode& node) -> std::optional<DeferredBaseConstantValue> {
+							if (auto value = try_evaluate_constant_expression(node)) {
+								return DeferredBaseConstantValue{
+									value->value,
+									value->type,
+									value->type_index};
+							}
+							ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
+							auto eval_result = ConstExpr::Evaluator::evaluate(node, eval_ctx);
+							if (!eval_result.success()) {
+								return std::nullopt;
+							}
+							TypeCategory result_type = TypeCategory::Int;
+							TypeIndex result_type_index{};
+							if (eval_result.exact_type.has_value()) {
+								result_type = eval_result.exact_type->category();
+								result_type_index = eval_result.exact_type->type_index();
+							} else if (std::holds_alternative<bool>(eval_result.value)) {
+								result_type = TypeCategory::Bool;
+							} else if (eval_result.is_uint()) {
+								result_type = TypeCategory::UnsignedLongLong;
+							}
+							return DeferredBaseConstantValue{
+								eval_result.as_int(),
+								result_type,
+								result_type_index};
+						};
 
 						// Special handling for TypeTraitExprNode - need to substitute template parameters
 						if (std::holds_alternative<TypeTraitExprNode>(expr)) {
@@ -6719,7 +6752,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								if (var_template_node.has_value() && var_template_node->is<VariableDeclarationNode>()) {
 									const VariableDeclarationNode& var_decl = var_template_node->as<VariableDeclarationNode>();
 									if (var_decl.initializer().has_value()) {
-										if (auto value = try_evaluate_constant_expression(*var_decl.initializer())) {
+										if (auto value = tryEvaluateDeferredBaseConstant(*var_decl.initializer())) {
 											FLASH_LOG_FORMAT(Templates, Debug, "Evaluated variable template '{}' to value {}",
 															 func_name, value->value);
 											resolved_args.push_back(makeEvaluatedDeferredBaseValueArg(*value));
@@ -6731,7 +6764,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 							ExpressionSubstitutor substitutor(subst_map, *this, template_param_order);
 							ASTNode substituted_node = substitutor.substitute(arg_info.node);
-							if (auto value = try_evaluate_constant_expression(substituted_node)) {
+							if (auto value = tryEvaluateDeferredBaseConstant(substituted_node)) {
 								FLASH_LOG_FORMAT(Templates, Debug, "Evaluated substituted deferred base call to value {}", value->value);
 								resolved_args.push_back(makeEvaluatedDeferredBaseValueArg(*value));
 								continue;

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -5,6 +5,7 @@
 #include "ExpressionSubstitutor.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
+#include "TemplateArgumentMaterialization.h"
 #include "TypeTraitEvaluator.h"
 
 namespace {
@@ -539,9 +540,9 @@ ASTNode Parser::substituteTemplateParameters(
 						return;
 
 					if (arg.isTypeArgument()) {
-						Token type_token(Token::Type::Identifier, get_type_name(arg.typeEnum()),
-										 tparam_ref.token().line(), tparam_ref.token().column(),
-										 tparam_ref.token().file_index());
+						Token type_token = makeTemplateArgumentTypeToken(
+							arg,
+							tparam_ref.token());
 						substituted_node = emplace_node<ExpressionNode>(IdentifierNode(type_token));
 						substituted_template_param_ref = true;
 					} else if (arg.is_value) {
@@ -636,7 +637,9 @@ ASTNode Parser::substituteTemplateParameters(
 					if (tparam.kind() == TemplateParameterKind::NonType && !arg.is_value)
 						return;
 					if (arg.isTypeArgument()) {
-						Token type_token(Token::Type::Identifier, get_type_name(arg.typeEnum()), 0, 0, 0);
+						Token type_token = makeTemplateArgumentTypeToken(
+							arg,
+							id_node.identifier_token());
 						substituted_node = emplace_node<ExpressionNode>(IdentifierNode(type_token));
 						substituted_identifier = true;
 					} else if (arg.is_value) {
@@ -1082,6 +1085,52 @@ ASTNode Parser::substituteTemplateParameters(
 			if (pack_values.empty()) {
 				FLASH_LOG(Templates, Warning, "Fold expression pack is empty");
 				return node;
+			}
+
+			auto tryReduceConstexprLogicalFold = [&]() -> std::optional<ASTNode> {
+				std::string_view op = fold.op();
+				if (op != "&&" && op != "||") {
+					return std::nullopt;
+				}
+
+				bool folded_value = (op == "&&");
+				ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
+				auto appendConstantOperand = [&](const ASTNode& operand) -> bool {
+					auto eval_result = ConstExpr::Evaluator::evaluate(operand, eval_ctx);
+					if (!eval_result.success()) {
+						return false;
+					}
+					bool operand_value = eval_result.as_bool();
+					folded_value = op == "&&"
+						? (folded_value && operand_value)
+						: (folded_value || operand_value);
+					return true;
+				};
+
+				if (fold.type() == FoldExpressionNode::Type::Binary && fold.init_expr().has_value()) {
+					ASTNode init = substituteTemplateParameters(*fold.init_expr(), template_params, template_args);
+					if (!appendConstantOperand(init)) {
+						return std::nullopt;
+					}
+				}
+
+				for (const ASTNode& pack_value : pack_values) {
+					if (!appendConstantOperand(pack_value)) {
+						return std::nullopt;
+					}
+				}
+
+				Token bool_token(
+					Token::Type::Keyword,
+					folded_value ? "true"sv : "false"sv,
+					fold.get_token().line(),
+					fold.get_token().column(),
+					fold.get_token().file_index());
+				return emplace_node<ExpressionNode>(BoolLiteralNode(bool_token, folded_value));
+			};
+
+			if (std::optional<ASTNode> folded_logical = tryReduceConstexprLogicalFold()) {
+				return *folded_logical;
 			}
 
 			// Expand the fold expression based on type and direction

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1115,6 +1115,10 @@ ASTNode Parser::substituteTemplateParameters(
 				}
 
 				for (const ASTNode& pack_value : pack_values) {
+					if ((op == "&&" && !folded_value) ||
+						(op == "||" && folded_value)) {
+						break;
+					}
 					if (!appendConstantOperand(pack_value)) {
 						return std::nullopt;
 					}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2076,6 +2076,23 @@ ParseResult Parser::parse_type_specifier() {
 					}
 				}
 
+				auto lookup_variable_template_for_type_name = [&]() -> std::optional<ASTNode> {
+					auto var_template_check = gTemplateRegistry.lookupVariableTemplate(type_name);
+					if (!var_template_check.has_value()) {
+						NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
+						if (!current_namespace.isGlobal()) {
+							StringHandle type_handle = StringTable::getOrInternStringHandle(type_name);
+							StringHandle qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(current_namespace, type_handle);
+							var_template_check = gTemplateRegistry.lookupVariableTemplate(StringTable::getStringView(qualified_handle));
+						}
+					}
+					return var_template_check;
+				};
+				if (lookup_variable_template_for_type_name().has_value()) {
+					FLASH_LOG_FORMAT(Templates, Debug, "Rejecting variable template '{}' as a type-specifier", type_name);
+					return ParseResult::error("Variable template is not a type", type_name_token);
+				}
+
 				// Check if this is a template parameter being used with template arguments (e.g., Container<T>)
 				// When parsing a template body, if the type name is a template parameter (type or template template param),
 				// we should NOT try to instantiate it - it's a dependent type that will be resolved during instantiation
@@ -2261,37 +2278,13 @@ ParseResult Parser::parse_type_specifier() {
 					}
 				}
 
-				// Check if this is a variable template (like is_reference_v<T>) - if so, don't try to
-				// instantiate as a class template. Variable templates are expressions, not types.
-				// First try unqualified, then try namespace-qualified lookup
-				auto var_template_check = gTemplateRegistry.lookupVariableTemplate(type_name);
-				if (!var_template_check.has_value()) {
-					NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
-					if (!current_namespace.isGlobal()) {
-						StringHandle type_handle = StringTable::getOrInternStringHandle(type_name);
-						StringHandle qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(current_namespace, type_handle);
-						var_template_check = gTemplateRegistry.lookupVariableTemplate(StringTable::getStringView(qualified_handle));
-					}
-				}
-				if (var_template_check.has_value()) {
-					// This is a variable template, not a class template
-					// In a type context, this is an error - return a failure so caller can handle
-					FLASH_LOG_FORMAT(Templates, Debug, "Skipping class template instantiation for variable template '{}'", type_name);
-					// Don't call try_instantiate_class_template - just continue to look up the type
-					// The variable template instantiation should happen in expression context, not type context
-				}
-
-				const bool is_class_template = !var_template_check.has_value();
 				std::optional<ASTNode> instantiated_class;
-				if (is_class_template) {
-					// Only try class template instantiation if this is NOT a variable template
 #if WITH_PARSER_RUNTIME_STATS
-					if (runtime_stats_enabled_) {
-						++runtime_stats_.type_specifier_triggered_template_instantiations;
-					}
-#endif
-					instantiated_class = try_instantiate_class_template(type_name, *template_args);
+				if (runtime_stats_enabled_) {
+					++runtime_stats_.type_specifier_triggered_template_instantiations;
 				}
+#endif
+				instantiated_class = try_instantiate_class_template(type_name, *template_args);
 
 				// If instantiation returned a struct node, add it to the AST so it gets visited during codegen
 				if (instantiated_class.has_value() && instantiated_class->is<StructDeclarationNode>()) {
@@ -2347,7 +2340,7 @@ ParseResult Parser::parse_type_specifier() {
 				// If filling defaults changed the template-id, instantiate that completed spelling too
 				// so nested aliases like enable_if<true>::type can be looked up via the normalized
 				// specialization (enable_if<true, void>).
-				if (is_class_template && filled_template_args.size() != template_args->size()) {
+				if (filled_template_args.size() != template_args->size()) {
 #if WITH_PARSER_RUNTIME_STATS
 					if (runtime_stats_enabled_) {
 						++runtime_stats_.type_specifier_triggered_template_instantiations;

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1132,6 +1132,9 @@ ParseResult Parser::parse_type_specifier() {
 		// Handle user-defined type (struct, class, or other user-defined types)
 		// Build qualified name using StringBuilder for efficiency
 		SaveHandle type_name_start_pos = save_token_position();
+		ScopeGuard type_name_start_guard([&]() {
+			discard_saved_token(type_name_start_pos);
+		});
 		StringBuilder type_name_builder;
 		type_name_builder.append(peek_info().value());
 		Token type_name_token = peek_info(); // Save the token before consuming it

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1131,6 +1131,7 @@ ParseResult Parser::parse_type_specifier() {
 	} else if (peek().is_identifier()) {
 		// Handle user-defined type (struct, class, or other user-defined types)
 		// Build qualified name using StringBuilder for efficiency
+		SaveHandle type_name_start_pos = save_token_position();
 		StringBuilder type_name_builder;
 		type_name_builder.append(peek_info().value());
 		Token type_name_token = peek_info(); // Save the token before consuming it
@@ -2090,7 +2091,8 @@ ParseResult Parser::parse_type_specifier() {
 				};
 				if (lookup_variable_template_for_type_name().has_value()) {
 					FLASH_LOG_FORMAT(Templates, Debug, "Rejecting variable template '{}' as a type-specifier", type_name);
-					return ParseResult::error("Variable template is not a type", type_name_token);
+					restore_token_position(type_name_start_pos);
+					return ParseResult::null();
 				}
 
 				// Check if this is a template parameter being used with template arguments (e.g., Container<T>)

--- a/src/TemplateArgumentMaterialization.h
+++ b/src/TemplateArgumentMaterialization.h
@@ -2,12 +2,16 @@
 
 #include "Parser.h"
 
-inline std::string_view getTemplateArgumentBuiltinTokenText(const TemplateTypeArg& arg) {
-	switch (arg.typeEnum()) {
+inline std::string_view getTemplateArgumentBuiltinTokenText(TypeCategory category) {
+	switch (category) {
 	case TypeCategory::Void: return "void";
 	case TypeCategory::Bool: return "bool";
 	case TypeCategory::Char: return "char";
 	case TypeCategory::UnsignedChar: return "unsigned char";
+	case TypeCategory::WChar: return "wchar_t";
+	case TypeCategory::Char8: return "char8_t";
+	case TypeCategory::Char16: return "char16_t";
+	case TypeCategory::Char32: return "char32_t";
 	case TypeCategory::Short: return "short";
 	case TypeCategory::UnsignedShort: return "unsigned short";
 	case TypeCategory::Int: return "int";
@@ -21,6 +25,10 @@ inline std::string_view getTemplateArgumentBuiltinTokenText(const TemplateTypeAr
 	case TypeCategory::LongDouble: return "long double";
 	default: return {};
 	}
+}
+
+inline std::string_view getTemplateArgumentBuiltinTokenText(const TemplateTypeArg& arg) {
+	return getTemplateArgumentBuiltinTokenText(arg.typeEnum());
 }
 
 inline TypeCategory getTemplateArgumentBuiltinCategoryFromTokenText(std::string_view type_name) {
@@ -60,6 +68,85 @@ inline TypeCategory getTemplateArgumentBuiltinCategoryFromTokenText(std::string_
 	if (type_name == "double") return TypeCategory::Double;
 	if (type_name == "long double") return TypeCategory::LongDouble;
 	return TypeCategory::Invalid;
+}
+
+inline std::optional<TemplateTypeArg> materializeTemplateTypeArgumentFromName(
+	std::string_view type_name) {
+	if (type_name.empty()) {
+		return std::nullopt;
+	}
+
+	if (TypeCategory builtin_category =
+			getTemplateArgumentBuiltinCategoryFromTokenText(type_name);
+		builtin_category != TypeCategory::Invalid) {
+		return TemplateTypeArg::makeType(nativeTypeIndex(builtin_category));
+	}
+
+	StringHandle type_name_handle = StringTable::getOrInternStringHandle(type_name);
+	if (const TypeInfo* type_info = findTypeByName(type_name_handle)) {
+		return TemplateTypeArg::makeType(
+			type_info->registeredTypeIndex().withCategory(
+				type_info->typeEnum()));
+	}
+
+	return std::nullopt;
+}
+
+inline std::optional<TemplateTypeArg> materializeTemplateTypeArgumentFromExpression(
+	const ExpressionNode& expr) {
+	if (const auto* identifier = std::get_if<IdentifierNode>(&expr)) {
+		return materializeTemplateTypeArgumentFromName(identifier->name());
+	}
+	if (const auto* qualified_identifier =
+			std::get_if<QualifiedIdentifierNode>(&expr)) {
+		if (std::optional<TemplateTypeArg> qualified_arg =
+				materializeTemplateTypeArgumentFromName(
+					qualified_identifier->full_name())) {
+			return qualified_arg;
+		}
+		return materializeTemplateTypeArgumentFromName(
+			qualified_identifier->name());
+	}
+	return std::nullopt;
+}
+
+inline std::optional<TypeSpecifierNode> makeCanonicalBuiltinTypeSpecifier(
+	const TypeSpecifierNode& type) {
+	TypeCategory category = type.type_index().is_valid()
+		? type.type_index().category()
+		: type.category();
+	std::string_view builtin_name = getTemplateArgumentBuiltinTokenText(category);
+	if (builtin_name.empty()) {
+		return std::nullopt;
+	}
+
+	Token canonical_token(
+		Token::Type::Keyword,
+		builtin_name,
+		type.token().line(),
+		type.token().column(),
+		type.token().file_index());
+	TypeSpecifierNode builtin_spec(
+		nativeTypeIndex(category),
+		type.size_in_bits() != 0 ? type.size_in_bits() : get_type_size_bits(category),
+		canonical_token,
+		type.cv_qualifier(),
+		type.reference_qualifier());
+	for (const PointerLevel& pointer_level : type.pointer_levels()) {
+		builtin_spec.add_pointer_level(pointer_level.cv_qualifier);
+	}
+	if (type.is_pack_expansion()) {
+		builtin_spec.set_pack_expansion(true);
+	}
+	if (type.is_array()) {
+		for (size_t dim : type.array_dimensions()) {
+			builtin_spec.add_array_dimension(dim);
+		}
+	}
+	if (type.has_function_signature()) {
+		builtin_spec.set_function_signature(type.function_signature());
+	}
+	return builtin_spec;
 }
 
 inline ASTNode materializeDependentTemplateArgumentNode(
@@ -115,6 +202,16 @@ inline ASTNode materializeValueTemplateArgumentNode(
 inline Token makeTemplateArgumentTypeToken(
 	const TemplateTypeArg& arg,
 	const Token& source_token) {
+	if (std::string_view builtin_name = getTemplateArgumentBuiltinTokenText(arg);
+		!builtin_name.empty()) {
+		return Token(
+			Token::Type::Keyword,
+			builtin_name,
+			source_token.line(),
+			source_token.column(),
+			source_token.file_index());
+	}
+
 	if (const TypeInfo* type_info = tryGetTypeInfo(arg.type_index)) {
 		std::string_view type_name = StringTable::getStringView(type_info->name());
 		if (!type_name.empty()) {
@@ -125,14 +222,6 @@ inline Token makeTemplateArgumentTypeToken(
 				source_token.column(),
 				source_token.file_index());
 		}
-	} else if (std::string_view builtin_name = getTemplateArgumentBuiltinTokenText(arg);
-			   !builtin_name.empty()) {
-		return Token(
-			Token::Type::Keyword,
-			builtin_name,
-			source_token.line(),
-			source_token.column(),
-			source_token.file_index());
 	}
 
 	return source_token;

--- a/src/TemplateArgumentMaterialization.h
+++ b/src/TemplateArgumentMaterialization.h
@@ -23,6 +23,45 @@ inline std::string_view getTemplateArgumentBuiltinTokenText(const TemplateTypeAr
 	}
 }
 
+inline TypeCategory getTemplateArgumentBuiltinCategoryFromTokenText(std::string_view type_name) {
+	if (type_name == "void") return TypeCategory::Void;
+	if (type_name == "bool") return TypeCategory::Bool;
+	if (type_name == "char") return TypeCategory::Char;
+	if (type_name == "signed char") return TypeCategory::Char;
+	if (type_name == "unsigned char") return TypeCategory::UnsignedChar;
+	if (type_name == "wchar_t") return TypeCategory::WChar;
+	if (type_name == "char8_t") return TypeCategory::Char8;
+	if (type_name == "char16_t") return TypeCategory::Char16;
+	if (type_name == "char32_t") return TypeCategory::Char32;
+	if (type_name == "short") return TypeCategory::Short;
+	if (type_name == "short int") return TypeCategory::Short;
+	if (type_name == "signed short") return TypeCategory::Short;
+	if (type_name == "signed short int") return TypeCategory::Short;
+	if (type_name == "unsigned short") return TypeCategory::UnsignedShort;
+	if (type_name == "unsigned short int") return TypeCategory::UnsignedShort;
+	if (type_name == "int") return TypeCategory::Int;
+	if (type_name == "signed") return TypeCategory::Int;
+	if (type_name == "signed int") return TypeCategory::Int;
+	if (type_name == "unsigned") return TypeCategory::UnsignedInt;
+	if (type_name == "unsigned int") return TypeCategory::UnsignedInt;
+	if (type_name == "long") return TypeCategory::Long;
+	if (type_name == "long int") return TypeCategory::Long;
+	if (type_name == "signed long") return TypeCategory::Long;
+	if (type_name == "signed long int") return TypeCategory::Long;
+	if (type_name == "unsigned long") return TypeCategory::UnsignedLong;
+	if (type_name == "unsigned long int") return TypeCategory::UnsignedLong;
+	if (type_name == "long long") return TypeCategory::LongLong;
+	if (type_name == "long long int") return TypeCategory::LongLong;
+	if (type_name == "signed long long") return TypeCategory::LongLong;
+	if (type_name == "signed long long int") return TypeCategory::LongLong;
+	if (type_name == "unsigned long long") return TypeCategory::UnsignedLongLong;
+	if (type_name == "unsigned long long int") return TypeCategory::UnsignedLongLong;
+	if (type_name == "float") return TypeCategory::Float;
+	if (type_name == "double") return TypeCategory::Double;
+	if (type_name == "long double") return TypeCategory::LongDouble;
+	return TypeCategory::Invalid;
+}
+
 inline ASTNode materializeDependentTemplateArgumentNode(
 	const TemplateTypeArg& arg,
 	const Token& source_token) {

--- a/tests/test_variable_template_fold_false_nttp_base_ret0.cpp
+++ b/tests/test_variable_template_fold_false_nttp_base_ret0.cpp
@@ -1,0 +1,30 @@
+// Regression: a variable template fold that evaluates to false must still
+// materialize the dependent base class for bool_constant<false>.
+
+namespace traits {
+template <class, class>
+constexpr bool is_same_v = false;
+
+template <class T>
+constexpr bool is_same_v<T, T> = true;
+
+template <class Ty, class... Types>
+constexpr bool is_any_of_v = (is_same_v<Ty, Types> || ...);
+
+template <class Ty>
+constexpr bool is_integral_v = is_any_of_v<Ty, bool, char, short, unsigned short>;
+
+template <bool Value>
+struct bool_constant {
+	static constexpr bool value = Value;
+};
+
+template <class Ty>
+struct is_integral : bool_constant<is_integral_v<Ty>> {};
+}
+
+static_assert(!traits::is_integral<float>::value);
+
+int main() {
+	return !traits::is_integral<float>::value ? 0 : 1;
+}

--- a/tests/test_variable_template_fold_remove_cv_builtin_list_ret0.cpp
+++ b/tests/test_variable_template_fold_remove_cv_builtin_list_ret0.cpp
@@ -1,0 +1,42 @@
+// Regression: a full type-traits-style boolean fold over a type pack must
+// reduce after remove_cv_t<T> substitution and builtin type canonicalization.
+
+namespace traits {
+template <class T>
+struct remove_cv {
+	using type = T;
+};
+
+template <class T>
+using remove_cv_t = typename remove_cv<T>::type;
+
+template <class, class>
+constexpr bool is_same_v = false;
+
+template <class T>
+constexpr bool is_same_v<T, T> = true;
+
+template <class Ty, class... Types>
+constexpr bool is_any_of_v = (is_same_v<Ty, Types> || ...);
+
+template <class Ty>
+constexpr bool is_integral_v =
+	is_any_of_v<remove_cv_t<Ty>, bool, char, signed char, unsigned char,
+		wchar_t, char8_t, char16_t, char32_t, short, unsigned short,
+		int, unsigned int, long, unsigned long, long long, unsigned long long>;
+
+template <bool Value>
+struct bool_constant {
+	static constexpr bool value = Value;
+};
+
+template <class Ty>
+struct is_integral : bool_constant<is_integral_v<Ty>> {};
+}
+
+static_assert(traits::is_integral<int>::value);
+static_assert(!traits::is_integral<float>::value);
+
+int main() {
+	return traits::is_integral<int>::value && !traits::is_integral<float>::value ? 0 : 1;
+}

--- a/tests/test_variable_template_fold_true_nttp_base_ret0.cpp
+++ b/tests/test_variable_template_fold_true_nttp_base_ret0.cpp
@@ -1,0 +1,30 @@
+// Regression: a variable template whose initializer is a fold over another
+// variable template can feed a true value into a dependent base NTTP.
+
+namespace traits {
+template <class, class>
+constexpr bool is_same_v = false;
+
+template <class T>
+constexpr bool is_same_v<T, T> = true;
+
+template <class Ty, class... Types>
+constexpr bool is_any_of_v = (is_same_v<Ty, Types> || ...);
+
+template <class Ty>
+constexpr bool is_integral_v = is_any_of_v<Ty, bool, char, short, unsigned short>;
+
+template <bool Value>
+struct bool_constant {
+	static constexpr bool value = Value;
+};
+
+template <class Ty>
+struct is_integral : bool_constant<is_integral_v<Ty>> {};
+}
+
+static_assert(traits::is_integral<char>::value);
+
+int main() {
+	return traits::is_integral<char>::value ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR improves C++20 std-header template handling around variable-template folds and builtin type template arguments.

- Materializes variable-template boolean folds in dependent base NTTPs so `bool_constant<is_integral_v<T>>`-style bases can be instantiated for both true and false results.
- Canonicalizes builtin type spellings used as template arguments, including multi-token spellings such as `unsigned short`, `long long`, and `unsigned long long`.
- Centralizes builtin type template-argument spelling/category conversion in `TemplateArgumentMaterialization.h` and routes parser substitution, expression substitution, and constexpr variable-template evaluation through shared helpers instead of local string fallbacks.
- Adds focused regressions for true/false fold variable-template bases and the MSVC `<type_traits>`-style `remove_cv_t<T>` plus full builtin integral list.
- Updates the template-argument architecture and standards-conformance audit docs with the new canonicalization finding.

## Root Cause

Several template-substitution paths reconstructed concrete type template arguments from local token strings or empty/stale tokens. For C++20 builtin character-width types and multi-token builtin spellings, this could produce non-standard identifiers like `unknown` or fail to recover the intended builtin category. That left `is_same_v<T, U>` calls unresolved inside boolean folds, which then prevented dependent base class NTTPs from materializing.