### PR TITLE
[codex] Introduce shared qualified owner resolver

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -235,9 +235,10 @@ the areas that were previously blocking standards-visible behavior:
   member-pointer owner as opaque text
 - qualified-owner parser lookup now has the first shared
   `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
-  qualified-call resolver and the qualified member-template parser path now
-  consume that carrier for current-instantiation classification and nested-
-  owner canonicalization instead of open-coding the owner split separately.
+  qualified-call resolver, qualified member-template parser path, and postfix
+  explicit-qualified member-template placeholder path now consume that carrier
+  for current-instantiation classification and nested-owner canonicalization
+  instead of open-coding the owner split separately.
 
 ## Architectural invariants to preserve
 
@@ -681,8 +682,9 @@ When changing this area, always rerun:
    rather than creating more per-call-site owner repairs. The first parser
    resolver now separates the requested spelling, lookup spelling, resolved
    `TypeInfo`, current-context classification, and nested-owner-extension
-   rewrite decision for deferred qualified-call lookup. Next, extend that
-   carrier to consume preserved `DependentQualifiedNameRecord` owner-template
+   rewrite decision for deferred qualified-call and postfix explicit-qualified
+   member-template lookup. Next, extend that carrier to consume preserved
+   `DependentQualifiedNameRecord` owner-template
    arguments and member-prefix chains, then route `ExpressionSubstitutor.cpp`,
    constexpr qualified member access, and the remaining sema qualified-call
    fallback through the same resolved-owner result. After those consumers stop

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-20
+**Last updated:** 2026-06-30
 
 This document is a planning aid for the remaining template-infrastructure work.
 It should describe the current architectural baseline, the highest-value
@@ -233,6 +233,11 @@ the areas that were previously blocking standards-visible behavior:
   pointer-to-member declarator forms, and the `_Is_memfunptr`-style partial-
   specialization matcher now deduces the owner class instead of treating the
   member-pointer owner as opaque text
+- qualified-owner parser lookup now has the first shared
+  `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
+  qualified-call resolver and the qualified member-template parser path now
+  consume that carrier for current-instantiation classification and nested-
+  owner canonicalization instead of open-coding the owner split separately.
 
 ## Architectural invariants to preserve
 
@@ -672,18 +677,18 @@ When changing this area, always rerun:
    bespoke qualified-id template-argument materializer in favor of
    `TemplateArgumentMaterialization.h`, and keeps that helper header out of the
    vcxproj lists. The next concrete target in
-   this audit is now a larger architectural extraction before more
-   standards-conformance expansion: introduce one shared structured
-   `ResolvedQualifiedOwner`-style layer plus a single qualified-owner resolver
-   that separates owner resolution, owner materialization, and alias
-   normalization instead of letting parser helpers, substitution, and sema each
-   canonicalize owner meaning independently. That resolver should consume the
-   preserved `DependentQualifiedNameRecord`, carry current-instantiation vs
-   nested-owner context explicitly, and hand the same resolved owner object to
-   ordinary member lookup and explicit member-template lookup so we stop
-   rebuilding owner identity from placeholder or base-template spellings. After
-   that extraction lands, the next standards-conformance target moves back
-   outside the passing core suite: the remaining expected-failure coverage
+   this audit is to continue adopting the new `ResolvedQualifiedOwner` layer
+   rather than creating more per-call-site owner repairs. The first parser
+   resolver now separates the requested spelling, lookup spelling, resolved
+   `TypeInfo`, current-context classification, and nested-owner-extension
+   rewrite decision for deferred qualified-call lookup. Next, extend that
+   carrier to consume preserved `DependentQualifiedNameRecord` owner-template
+   arguments and member-prefix chains, then route `ExpressionSubstitutor.cpp`,
+   constexpr qualified member access, and the remaining sema qualified-call
+   fallback through the same resolved-owner result. After those consumers stop
+   independently canonicalizing owner meaning from placeholder or base-template
+   spellings, the next standards-conformance target moves back outside the
+   passing core suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
    follow-on canonical member-object-pointer carrier gap if a new ABI-sensitive
    regression reaches it.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -229,10 +229,10 @@ blocking areas:
   text
 - qualified-owner parser lookup now has the first shared
   `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
-  qualified-call resolver and qualified member-template parser path consume it
-  for current-instantiation classification and nested-owner canonicalization,
-  keeping that standards-sensitive owner split out of per-call-site string
-  reconstruction.
+  qualified-call resolver, qualified member-template parser path, and postfix
+  explicit-qualified member-template placeholder path consume it for current-
+  instantiation classification and nested-owner canonicalization, keeping that
+  standards-sensitive owner split out of per-call-site string reconstruction.
 
 ## Highest-value remaining standards gaps
 
@@ -646,7 +646,8 @@ For work in this area, rerun:
    `ResolvedQualifiedOwner` entrypoint keeps requested spelling, lookup
    spelling, current-instantiation classification, nested-owner-extension
    rewriting, and resolved `TypeInfo` together for the parser deferred-call
-   path. Extend that result to consume `DependentQualifiedNameRecord`
+   and postfix explicit-qualified member-template paths. Extend that result to
+   consume `DependentQualifiedNameRecord`
    owner-template arguments and member-prefix chains, then make the explicit
    member-template path, ordinary qualified-member path, constexpr member
    access, and later sema fallback consume the same resolved-owner object

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-20
+**Last updated:** 2026-06-30
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. It should describe the intended semantic model, the
@@ -227,6 +227,12 @@ blocking areas:
   pointer-to-member declarator forms, and `_Is_memfunptr`-style partial
   specializations now deduce the owner class instead of treating it as opaque
   text
+- qualified-owner parser lookup now has the first shared
+  `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
+  qualified-call resolver and qualified member-template parser path consume it
+  for current-instantiation classification and nested-owner canonicalization,
+  keeping that standards-sensitive owner split out of per-call-site string
+  reconstruction.
 
 ## Highest-value remaining standards gaps
 
@@ -635,17 +641,19 @@ For work in this area, rerun:
    `TemplateArgumentMaterialization.h` for the remaining qualified-id
    template-argument materialization path, and removes the helper header from
    the vcxproj lists. The next concrete target in this
-   investigation is now an architectural cleanup before more
-   standards-conformance growth: extract a shared structured qualified-owner
-   resolver (`ResolvedQualifiedOwner`-style carrier plus one resolver
-   entrypoint) that keeps current-instantiation, nested-owner,
-   dependent-instantiation, owner template arguments, and alias-normalization
-   decisions in one place. The explicit member-template path, ordinary
-   qualified-member path, and later sema fallback should all consume that same
-   resolved-owner result instead of re-canonicalizing owner meaning from
-   `baseTemplateName()`, instantiation patterns, or placeholder spellings. Once
-   that layer exists, the next standards-conformance target shifts back outside
-   the green suite: the remaining expected-failure coverage
+   investigation is now adoption of the new shared structured qualified-owner
+   resolver before more standards-conformance growth. The first
+   `ResolvedQualifiedOwner` entrypoint keeps requested spelling, lookup
+   spelling, current-instantiation classification, nested-owner-extension
+   rewriting, and resolved `TypeInfo` together for the parser deferred-call
+   path. Extend that result to consume `DependentQualifiedNameRecord`
+   owner-template arguments and member-prefix chains, then make the explicit
+   member-template path, ordinary qualified-member path, constexpr member
+   access, and later sema fallback consume the same resolved-owner object
+   instead of re-canonicalizing owner meaning from `baseTemplateName()`,
+   instantiation patterns, or placeholder spellings. Once those consumers are
+   on the shared layer, the next standards-conformance target shifts back
+   outside the green suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
    future canonical member-object-pointer carrier gap if another ABI-sensitive
    failure exposes it.

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2980,6 +2980,24 @@ private:
 				: std::string_view{};
 		}
 	};
+	struct ResolvedQualifiedOwner {
+		std::string_view requested_name{};
+		std::string_view lookup_name{};
+		const TypeInfo* type_info = nullptr;
+		bool resolved_from_current_context = false;
+		bool resolved_as_nested_owner_extension = false;
+
+		StringHandle lookupNameHandle() const {
+			if (type_info != nullptr &&
+				type_info->name().isValid()) {
+				return type_info->name();
+			}
+			if (!lookup_name.empty()) {
+				return StringTable::getOrInternStringHandle(lookup_name);
+			}
+			return StringHandle{};
+		}
+	};
 	std::string_view get_instantiated_class_name(std::string_view template_name, std::span<const TemplateTypeArg> template_args);	 // NEW: Get mangled name for instantiated class
 	std::string_view instantiate_and_register_base_template(std::string_view& base_class_name, std::span<const TemplateTypeArg> template_args);  // Helper: Instantiate base class template and add to AST
 	AliasTemplateMaterializationResult materializeTemplateInstantiationForLookup(
@@ -3012,6 +3030,8 @@ private:
 		std::string_view fallback_template_name,
 		std::span<const TemplateTypeArg> template_args);
 	std::optional<AliasTemplateMaterializationResult> tryResolveQualifiedTypeOwnerFromCurrentContext(
+		std::string_view owner_name);
+	ResolvedQualifiedOwner resolveQualifiedOwnerForLookup(
 		std::string_view owner_name);
 	ParseResult parseMaterializedTemplateFunctionalCast(
 		const AliasTemplateMaterializationResult& materialized_owner,

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1711,7 +1711,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 					StringTable::getStringView(owner_segments.front());
 				ResolvedQualifiedOwner resolved_root_owner =
 					resolveQualifiedOwnerForLookup(root_owner_name);
-				if (!resolved_root_owner.lookup_name.empty()) {
+				if (resolved_root_owner.resolved_from_current_context) {
 					if (owner_segments.size() == 1) {
 						return resolved_root_owner.lookup_name;
 					}
@@ -1797,7 +1797,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				resolved_root_owner =
 					resolveQualifiedOwnerForLookup(
 						StringTable::getStringView(owner_segments.front()));
-				if (!resolved_root_owner.lookup_name.empty()) {
+				if (resolved_root_owner.resolved_from_current_context) {
 					qualified_member_call_name =
 						StringBuilder()
 							.append(resolved_root_owner.lookup_name)

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1709,14 +1709,11 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			if (owner_segments.front().isValid()) {
 				const std::string_view root_owner_name =
 					StringTable::getStringView(owner_segments.front());
-				if (std::optional<AliasTemplateMaterializationResult>
-						resolved_current_owner =
-							tryResolveQualifiedTypeOwnerFromCurrentContext(
-								root_owner_name);
-					resolved_current_owner.has_value() &&
-					!resolved_current_owner->canonicalName().empty()) {
+				ResolvedQualifiedOwner resolved_root_owner =
+					resolveQualifiedOwnerForLookup(root_owner_name);
+				if (!resolved_root_owner.lookup_name.empty()) {
 					if (owner_segments.size() == 1) {
-						return resolved_current_owner->canonicalName();
+						return resolved_root_owner.lookup_name;
 					}
 
 					std::vector<QualifiedTypeMemberAccess> owner_chain;
@@ -1731,7 +1728,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 
 					if (const TypeInfo* resolved_owner =
 							resolveBaseClassMemberTypeChain(
-								resolved_current_owner->canonicalName(),
+								resolved_root_owner.lookup_name,
 								std::span<const QualifiedTypeMemberAccess>(
 									owner_chain.data(),
 									owner_chain.size()));
@@ -1795,23 +1792,21 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				qualified_member_call_name;
 			const FunctionDeclarationNode*
 				qualified_member_template_return_hint = nullptr;
-			std::optional<AliasTemplateMaterializationResult>
-				resolved_current_owner;
+			ResolvedQualifiedOwner resolved_root_owner;
 			if (owner_segments.size() == 1) {
-				resolved_current_owner =
-					tryResolveQualifiedTypeOwnerFromCurrentContext(
+				resolved_root_owner =
+					resolveQualifiedOwnerForLookup(
 						StringTable::getStringView(owner_segments.front()));
-				if (resolved_current_owner.has_value() &&
-					!resolved_current_owner->canonicalName().empty()) {
+				if (!resolved_root_owner.lookup_name.empty()) {
 					qualified_member_call_name =
 						StringBuilder()
-							.append(resolved_current_owner->canonicalName())
+							.append(resolved_root_owner.lookup_name)
 							.append("::")
 							.append(member_token.value())
 							.commit();
 					qualified_member_template_lookup_name =
 						StringBuilder()
-							.append(resolved_current_owner->canonicalName())
+							.append(resolved_root_owner.lookup_name)
 							.append("::")
 							.append(member_token.value())
 							.commit();
@@ -1893,14 +1888,12 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			StringHandle current_owner_handle{};
 			TypeIndex current_owner_type_index{};
 			bool current_owner_is_valid = false;
-			if (resolved_current_owner.has_value() &&
-				resolved_current_owner->canonicalNameHandle().isValid()) {
-				current_owner_handle =
-					resolved_current_owner->canonicalNameHandle();
-				if (resolved_current_owner->resolved_type_info != nullptr) {
+			if (resolved_root_owner.resolved_from_current_context &&
+				resolved_root_owner.lookupNameHandle().isValid()) {
+				current_owner_handle = resolved_root_owner.lookupNameHandle();
+				if (resolved_root_owner.type_info != nullptr) {
 					current_owner_type_index =
-						resolved_current_owner->resolved_type_info
-							->registeredTypeIndex();
+						resolved_root_owner.type_info->registeredTypeIndex();
 				}
 				current_owner_is_valid = true;
 			} else if (!member_function_context_stack_.empty()) {
@@ -1918,7 +1911,7 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			if (current_owner_is_valid) {
 				std::vector<PostfixDependentMemberSegmentInfo>
 					member_segments;
-				if (!resolved_current_owner.has_value()) {
+				if (!resolved_root_owner.resolved_from_current_context) {
 					member_segments.reserve(owner_segments.size() + 1);
 					for (StringHandle owner_segment : owner_segments) {
 						PostfixDependentMemberSegmentInfo member_segment;
@@ -1936,18 +1929,17 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 					toTemplateArgInfoList(member_template_args);
 				member_segments.push_back(std::move(final_member_segment));
 				TypeInfo::DependentQualifiedNameRecord::OwnerKind owner_kind =
-					resolved_current_owner.has_value()
+					resolved_root_owner.resolved_from_current_context
 						? TypeInfo::DependentQualifiedNameRecord::OwnerKind::
 							  DependentInstantiation
 						: TypeInfo::DependentQualifiedNameRecord::OwnerKind::
 							  CurrentInstantiation;
 				InlineVector<TypeInfo::TemplateArgInfo, 4>
 					owner_template_arguments;
-				if (resolved_current_owner.has_value() &&
-					resolved_current_owner->resolved_type_info != nullptr) {
+				if (resolved_root_owner.resolved_from_current_context &&
+					resolved_root_owner.type_info != nullptr) {
 					owner_template_arguments =
-						resolved_current_owner->resolved_type_info
-							->templateArgs();
+						resolved_root_owner.type_info->templateArgs();
 				}
 				setCallDependentQualifiedLookupRecord(
 					deferred_call.as<ExpressionNode>(),

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -770,9 +770,13 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
 		ResolvedQualifiedOwner resolved_owner =
 			resolveQualifiedOwnerForLookup(owner_name);
-		owner_name = resolved_owner.lookup_name;
+		if (!resolved_owner.resolved_from_current_context ||
+			resolved_owner.resolved_as_nested_owner_extension) {
+			owner_name = resolved_owner.lookup_name;
+		}
 
-		StringHandle owner_name_handle = resolved_owner.lookupNameHandle();
+		StringHandle owner_name_handle =
+			StringTable::getOrInternStringHandle(owner_name);
 		instantiateLazyClassToPhase(
 			owner_name_handle,
 			ClassInstantiationPhase::Full);
@@ -1231,14 +1235,18 @@ Parser::ResolvedQualifiedOwner Parser::resolveQualifiedOwnerForLookup(
 			tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
 		current_owner.has_value()) {
 		result.resolved_from_current_context = true;
+		if (std::string_view current_owner_name =
+				current_owner->canonicalName();
+			!current_owner_name.empty()) {
+			result.lookup_name = current_owner_name;
+		}
+		result.type_info = current_owner->resolved_type_info;
 		const bool nested_owner_extension =
 			isNestedOwnerExtension(owner_name, current_owner->instantiated_name);
 		if (nested_owner_extension) {
-			result.lookup_name = current_owner->instantiated_name;
-			result.type_info = current_owner->resolved_type_info;
 			result.resolved_as_nested_owner_extension = true;
-			return result;
 		}
+		return result;
 	}
 
 	AliasTemplateMaterializationResult canonical_owner =

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -768,28 +768,17 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 	if (scope_sep != std::string_view::npos) {
 		std::string_view owner_name = qualified_name.substr(0, scope_sep);
 		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
-		const TypeInfo* resolved_owner_type_info = nullptr;
-		if (std::optional<AliasTemplateMaterializationResult> current_owner =
-				tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
-			current_owner.has_value() &&
-			isNestedOwnerExtension(owner_name, current_owner->instantiated_name)) {
-			owner_name = current_owner->instantiated_name;
-			resolved_owner_type_info = current_owner->resolved_type_info;
-		} else if (AliasTemplateMaterializationResult canonical_owner =
-					   resolveCanonicalInstantiatedOwnerForLookup(owner_name);
-				   !canonical_owner.instantiated_name.empty()) {
-			owner_name = canonical_owner.instantiated_name;
-			resolved_owner_type_info = canonical_owner.resolved_type_info;
-		}
+		ResolvedQualifiedOwner resolved_owner =
+			resolveQualifiedOwnerForLookup(owner_name);
+		owner_name = resolved_owner.lookup_name;
 
-		StringHandle owner_name_handle =
-			StringTable::getOrInternStringHandle(owner_name);
+		StringHandle owner_name_handle = resolved_owner.lookupNameHandle();
 		instantiateLazyClassToPhase(
 			owner_name_handle,
 			ClassInstantiationPhase::Full);
 		const TypeInfo* owner_type_info =
-			resolved_owner_type_info != nullptr
-				? resolved_owner_type_info
+			resolved_owner.type_info != nullptr
+				? resolved_owner.type_info
 				: findTypeByName(owner_name_handle);
 		FLASH_LOG_FORMAT(
 			Templates,
@@ -1227,6 +1216,45 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveQual
 	}
 
 	return std::nullopt;
+}
+
+Parser::ResolvedQualifiedOwner Parser::resolveQualifiedOwnerForLookup(
+	std::string_view owner_name) {
+	ResolvedQualifiedOwner result;
+	result.requested_name = owner_name;
+	result.lookup_name = owner_name;
+	if (owner_name.empty()) {
+		return result;
+	}
+
+	if (std::optional<AliasTemplateMaterializationResult> current_owner =
+			tryResolveQualifiedTypeOwnerFromCurrentContext(owner_name);
+		current_owner.has_value()) {
+		result.resolved_from_current_context = true;
+		const bool nested_owner_extension =
+			isNestedOwnerExtension(owner_name, current_owner->instantiated_name);
+		if (nested_owner_extension) {
+			result.lookup_name = current_owner->instantiated_name;
+			result.type_info = current_owner->resolved_type_info;
+			result.resolved_as_nested_owner_extension = true;
+			return result;
+		}
+	}
+
+	AliasTemplateMaterializationResult canonical_owner =
+		resolveCanonicalInstantiatedOwnerForLookup(owner_name);
+	if (!canonical_owner.instantiated_name.empty()) {
+		result.lookup_name = canonical_owner.instantiated_name;
+		result.type_info = canonical_owner.resolved_type_info;
+		return result;
+	}
+
+	if (const TypeInfo* owner_type_info =
+			findTypeByName(StringTable::getOrInternStringHandle(owner_name));
+		owner_type_info != nullptr) {
+		result.type_info = owner_type_info;
+	}
+	return result;
 }
 
 // Helper to build an interned placeholder name for TTP instantiation.

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -491,9 +491,8 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 				return templateArgInfoContainsDependentPlaceholder(arg_info);
 			});
 	const bool owner_is_current_instantiation_context =
-		this->tryResolveQualifiedTypeOwnerFromCurrentContext(
-			instantiated_class_name)
-			.has_value();
+		this->resolveQualifiedOwnerForLookup(instantiated_class_name)
+			.resolved_from_current_context;
 	if (resolved_function == nullptr &&
 		static_member_overloads.all.empty() &&
 		!has_template_member_candidates &&


### PR DESCRIPTION
## Summary
- introduce a shared parser-side `ResolvedQualifiedOwner` carrier and resolver for qualified owner lookup
- route deferred qualified-template calls, qualified member-template parsing, and postfix explicit-qualified member-template placeholders through the shared owner result
- update the template-argument audit docs with the new baseline and next consumer-side adoption target

## Validation
- `./build_flashcpp.bat`
- focused postfix/member-template qualified-owner guard set
- `pwsh ./tests/run_all_tests.ps1` (2707 regular tests passed, 229 expected-fail tests failed as expected)

## Next slice
The remaining use cases are larger consumer-side migrations in `ExpressionSubstitutor.cpp`, `ConstExprEvaluator_MemberAccess.cpp`, and `SemanticAnalysis.cpp`. Those need `ResolvedQualifiedOwner` to consume `DependentQualifiedNameRecord` owner-template arguments and member-prefix chains before migrating each consumer.