### PR TITLE
[codex] Adopt qualified owner resolver in consumers

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -4,723 +4,137 @@
 **Last updated:** 2026-06-30
 
 This document is a planning aid for the remaining template-infrastructure work.
-It should describe the current architectural baseline, the highest-value
-remaining gaps, and the next tasks to execute. It is intentionally not a
-chronological work log.
+It is intentionally forward-looking: keep it focused on the current baseline,
+the architectural invariants, and the next tasks. Avoid turning it into a
+history of completed branches.
 
 ## Current architectural baseline
 
-The template system is now substantially more sema-owned than parser-owned in
-the areas that were previously blocking standards-visible behavior:
+The template implementation has moved substantially toward sema-owned,
+identity-preserving behavior:
 
-- covered non-dependent template-body lookup preserves definition-context
-  binding
-- dependent alias resolution is semantic-only; the old textual
-  `base::member` reconstruction path is gone
-- replay/materialization paths are increasingly source-identity-driven instead
-  of shape-driven
-- normalized template/member direct-call resolution uses sema-owned
-  overload-resolution argument typing rather than parser-owned argument typing
-- semantic receiver-sensitive lookup for ordinary member calls, `operator[]`,
-  and callable `operator()` now shares the same const-aware candidate
-  partitioning model
-- parser-selected direct/member-call targets are no longer trusted early once
-  sema has enough typed evidence to decide or reject the call
-- direct-call viability now requires real conversion paths instead of accepting
-  parser-only optimistic struct-to-scalar matches
-- function-pointer/function-reference call typing preserves the callee return
-  type during overload ranking
-- replay attachment in the covered out-of-line member and constructor paths now
-  expects positive identity/signature evidence rather than silently accepting
-  unresolved shape-based matches
-- resolved direct-call materialization now preserves
-  `DependentUnqualifiedCallLookupRecord` both when the instantiated target
-  stays definition-bound and when dependent-unqualified POI completion selects
-  a different final function, so sema/constexpr can reuse structured call
-  metadata instead of re-running parser lookup or relying on mangled-name
-  recovery in those paths
-- non-dependent ordinary overload-resolution and namespace-qualified direct
-  call materialization in the covered template/replay paths now preserve
-  `FunctionCallDefinitionLookupRecord`, so sema no longer has to recover those
-  definition-bound targets from `call_info.mangled_name`
-- current-member-context static direct-call replay now preserves
-  `FunctionCallDefinitionLookupRecord` in the
-  `resolved_member_function_from_context` fast path, so later recovery does
-  not have to rediscover those definition-bound member targets from
-  `mangled_name`/`qualified_name` compatibility data alone
-- builtin-like literal/pointer argument types no longer block
-  `FunctionCallDefinitionLookupRecord` creation in that fast path just because
-  parser-side `TypeSpecifierNode` materialization has not populated a concrete
-  `type_index` yet
-- the restored `int -> long` current-member static regression no longer relies
-  on a per-argument codegen repair; sema now has a whole-call synchronization
-  hook on the exact `CallExprNode` codegen lowers, and that hook is narrowly
-  limited to definition-bound / qualified / static-member direct calls where
-  the parser already preserves the selected target
-- current-struct explicit member-template materialization now routes its
-  qualified-name override through the shared direct-call metadata helper instead
-  of stamping the qualified name separately before attaching the rest of the
-  call metadata
-- the shared qualified member-template call helper now also preserves
-  `FunctionCallDefinitionLookupRecord` when it has a concrete direct-call
-  target plus typed arguments, instead of carrying only
-  `qualified_name`/`mangled_name` compatibility metadata
-- the final parser-selected non-receiver direct-call fallback in
-  `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
-  resolve through preserved semantic metadata, typed lookup, or explicit
-  unresolved terminals instead of reusing the parser-selected target late
-- ordinary direct-call parsing now makes one last structured
-  `appendFunctionCallArgType(...)` pass before dropping to the
-  compatibility-only fallback when primary `get_expression_type(...)`
-  collection fails, shrinking the cases that still lose
-  `FunctionCallDefinitionLookupRecord` just because parser-side type
-  materialization lagged behind
-- that structured retry is now shared with the current-member static fast
-  path as well, so those replay-preserving calls do not regress into a
-  separate weaker argument-typing path
-- string-literal user-defined literal calls now preserve
-  `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
-  name and argument list, instead of carrying only `mangled_name`
-- ordinary direct calls to concrete template-origin functions now also
-  preserve `FunctionCallDefinitionLookupRecord` even outside a valid template
-  definition context, so sema-normalized wrapper calls like
-  `callBase(holder)` stay on sema-owned resolved-call metadata instead of
-  reviving parser-selected call targets late
-- the remaining covered qualified/direct template-instantiation builders now
-  also normalize wrapper-vs-direct instantiation results through the same
-  concrete-function adoption rule, so structured call metadata no longer
-  depends on whether a parser branch received `FunctionDeclarationNode`
-  directly or inside a `TemplateFunctionDeclarationNode`
-- the remaining untyped ordinary direct-call fallback exits no longer keep a
-  parser-selected callee as the call's semantic identity just to preserve
-  parse-time typing; they now carry an explicit parser return-type hint plus
-  either a deferred definition-bound lookup record or the existing deferred
-  dependent-unqualified lookup record, and sema can resolve those calls later
-  from structured lookup state instead of mangled-name recovery
-- `resolveDeferredQualifiedTemplateCall(...)` no longer performs ordinary
-  static-member overload recovery for qualified type owners; those non-template
-  direct calls now stay on sema-owned owner/overload resolution instead of
-  reusing the parser's compatibility path
-- constexpr evaluation now reuses sema-owned qualified direct-call resolution
-  before falling back to parser-owned deferred template instantiation, and that
-  shared resolver accepts an explicit current-type fallback so class-scope
-  `static constexpr` initializers in the current instantiation keep the same
-  nested-owner/type-owner-vs-namespace split that member-function sema already
-  used
-- instantiation-time resolved-call materialization in `ExpressionSubstitutor`
-  now opportunistically rebuilds `FunctionCallDefinitionLookupRecord` for
-  qualified/member-template direct calls once substitution has concrete
-  arguments plus a concrete `FunctionDeclarationNode`, instead of preserving
-  only copied `qualified_name`/`mangled_name` compatibility metadata in those
-  paths
-- postfix qualified direct-call and concrete member-postfix fast paths in
-  `Parser_Expr_PostfixCalls.cpp` now attach structured call metadata when they
-  already hold a concrete `FunctionDeclarationNode`, instead of stopping at
-  copied `qualified_name`/`mangled_name` compatibility data in those parser
-  materializers
-- direct operator function-id calls in `Parser_Expr_PrimaryExpr.cpp`, including
-  the namespace-qualified `N::operator...(args)` helper plus the global-
-  qualified `::operator...(args)` entry path, and the postfix declaration-
-  address fast path in `Parser_Expr_PostfixCalls.cpp` now preserve structured
-  non-receiver call metadata as well, so late sema no longer has to rediscover
-  their definition-bound target from a parser-selected callee alone
-- the remaining concrete receiver-call builders now preserve the same shared
-  metadata too: postfix `operator()` finalization plus the implicit-`this`,
-  member-operator, and callable-object `operator()` builders in
-  `Parser_Expr_PrimaryExpr.cpp` all attach structured receiver-call metadata
-  once they already hold the exact `FunctionDeclarationNode`
-- template-parameter function-pointer direct-call materialization in
-  `Parser_Expr_PrimaryExpr.cpp` now preserves
-  `FunctionCallDefinitionLookupRecord` when definition-context lookup already
-  resolves the bound function, so later sema does not have to rediscover that
-  target from name compatibility after additional same-name overloads appear
-- explicit-qualified postfix member/operator call builders in
-  `Parser_Expr_PostfixCalls.cpp` now resolve concrete owner-qualified targets
-  for forms such as `this->Base::touch()` and `this->Base::operator()()` when
-  the receiver type and arguments are already concrete, instead of falling back
-  to placeholder `auto` member-call nodes that later lose semantic identity
-- the shared qualified-owner member-call helper in
-  `Parser_Expr_QualLookup.cpp` now treats concrete `Type::member(...)` owner
-  calls more semantically too: non-template fallback selection is limited to
-  static members, uses real overload resolution once argument types are
-  concrete, and unresolved template-instantiation owners preserve a structured
-  dependent-qualified owner record even when `StructTypeInfo` is already
-  present instead of dropping back to `qualified_name` plus a parser return-type
-  hint alone
-- that same qualified static-owner helper now also distinguishes "no owner
-  candidates exist" from "owner candidates exist but parser-time overload
-  ranking still cannot pick a final target": concrete owner calls like
-  `allocator_traits<allocator<int>>::allocate(a, 10)` now keep the canonical
-  owner type plus deferred qualified-call metadata when parser-time ranking is
-  still inconclusive, instead of reintroducing a parser-selected fallback or
-  hard-rejecting the call before later semantic resolution can finish it
-- the unqualified/current-owner explicit-member-template placeholder path in
-  `Parser_Expr_PrimaryExpr.cpp` now preserves that same split for deferred
-  class-scope member-template calls: it keeps a structured current-
-  instantiation `DependentQualifiedNameRecord`, and parser return-type hints
-  now come from the matched current-owner member-template declaration instead
-  of whichever unrelated same-name global template was encountered first
-- the remaining dependent owner-template/member-template placeholder builders
-  in `Parser_Expr_PrimaryExpr.cpp` now route through one shared deferred
-  qualified-call helper as well, preserving the structured dependent-qualified
-  record, exact template-argument AST, and any unambiguous exact qualified
-  member-template return-type hint instead of hand-rolling four separate
-  compatibility-only exits
-- primary-template out-of-line constructor replay now synchronizes the
-  `StructTypeInfo` constructor copy through preserved source-member identity
-  when that identity is already known, instead of always rescanning
-  `StructTypeInfo` constructors afterward
-- copied member-function-template stubs now register source-member identity
-  into `StructTypeInfo` immediately in the primary-template and covered
-  specialization paths, including operator overloads, so later out-of-line
-  replay sync no longer has to recover those copies through replay-source-key
-  scans once the matched source declaration is already known
-- nested class-template member-function population now happens before
-  nested out-of-line replay, with `StructTypeInfo` identity recorded at
-  insertion time and lazy-registration split from structural insertion, so the
-  nested constructor/member-template replay helpers no longer depend on
-  positional back-fill of `StructTypeInfo` indices in that path
-- parser-side pack-expansion handling for ordinary identifier-call and shared
-  argument-list parsing no longer treats "no matching function-parameter pack
-  found" as a successful expansion; unmatched complex expansions now stay as
-  `PackExpansionExprNode` until substitution, and call-site substitution can
-  scalarize the active pack bindings element-by-element instead of silently
-  flattening `expr...` into a single ordinary argument
-- deferred qualified/member-template direct calls now preserve explicit
-  template-argument AST, parser return-type hints, and dependent-qualified
-  lookup records separately instead of collapsing semantic ownership onto a
-  parser-selected callee
-- deferred namespace-qualified explicit-template direct calls now also preserve
-  definition-bound replay metadata when the visible template candidate is
-  unique, but that exact parse-time binding is intentionally suppressed when
-  the template name already has registered exact specializations so later
-  instantiation can still select the specialization-first C++20 path
-- qualified direct-call target resolution now distinguishes type owners from
-  namespace qualifiers before consuming definition-bound compatibility data, so
-  sema resolves nested current-instantiation owners structurally and no longer
-  lets unrelated global templates steal calls like `Ops::read(value)` inside
-  `Runner<T>`
-- explicit qualified member-template direct calls now preserve nested current-
-  instantiation owner identity in the parser/materialization layer when the
-  owner spelling names a real nested owner (for example `Ops::template read<int>(value)`
-  inside `Runner<T>`), instead of normalizing through the standalone owner
-  spelling and letting an unrelated global template owner win
-- that owner recovery now walks enclosing nested class/member-function contexts
-  from inner to outer, so the same explicit qualified member-template path also
-  resolves owners declared on an enclosing current instantiation from inside a
-  nested class body
-- that parser-side owner rewrite is now intentionally narrow: it only rewrites
-  short owner spellings when the resolved owner is a true nested owner
-  extension (for example `Runner<int>::Ops`), so alias/self-owner qualified
-  calls remain on their existing paths instead of being eagerly collapsed onto
-  unrelated concrete owner names
-- instantiated template class members now preserve function-pointer member
-  signatures through alias/template-argument recovery plus source
-  `StructTypeInfo` fallback, so indirect calls through concrete
-  function-pointer data members no longer lose the signature required for
-  IR-lowering return typing
-- postfix member-call placeholders for function-pointer data members now carry
-  the synthesized return type from the member signature instead of a fake
-  scalar stub, so overload resolution and chained postfix analysis no longer
-  misclassify calls like `pick(this->callback())` inside template bodies
-- `.*` / `->*` member-function-pointer postfix calls now preserve the pointed-
-  to return shape and parser return-type hint through template-body
-  materialization, so overload ranking and chained postfix analysis no longer
-  collapse those calls onto fake scalar placeholders
-- member-function-pointer template arguments now preserve declaring-class
-  identity through substitution/materialization, MSVC mangling now covers
-  member-function-pointer cv/ref/noexcept qualifiers plus ordinary
-  pointer-to-member declarator forms, and the `_Is_memfunptr`-style partial-
-  specialization matcher now deduces the owner class instead of treating the
-  member-pointer owner as opaque text
-- qualified-owner parser lookup now has the first shared
-  `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
-  qualified-call resolver, qualified member-template parser path, and postfix
-  explicit-qualified member-template placeholder path now consume that carrier
-  for current-instantiation classification and nested-owner canonicalization
-  instead of open-coding the owner split separately.
-- `ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(...)` now
-  also uses the shared `ResolvedQualifiedOwner` current-context classification
-  before materializing a dependent qualified owner, instead of calling the
-  older current-context owner helper and redoing the same canonicalization
-  branch locally.
-- constexpr qualified member access and sema qualified-call target recovery
-  now also consult the shared resolved-owner result before falling back to
-  their consumer-specific dependent-record prefix-chain and overload recovery
-  logic, so the parser, substitution, constexpr, and sema entry points all
-  share the same current-instantiation owner classification.
+- non-dependent template-body lookup remains definition-bound through covered
+  replay/materialization paths
+- dependent aliases and qualified owners preserve structured metadata instead
+  of relying on textual reconstruction where covered
+- direct-call resolution is increasingly represented by
+  `FunctionCallDefinitionLookupRecord`,
+  `DependentUnqualifiedCallLookupRecord`, or
+  `DependentQualifiedNameRecord`, not by parser-selected callee fallbacks
+- sema owns final overload selection for normalized direct/member calls,
+  including const-aware receiver lookup, `operator[]`, callable `operator()`,
+  and qualified direct calls in the covered paths
+- replay and `StructTypeInfo` synchronization now prefer source-member
+  identity plus canonical substituted-signature evidence over name/arity repair
+- pack expansion in call arguments now preserves unmatched complex `expr...`
+  nodes until substitution instead of flattening them early
+- qualified/member-template parser paths now preserve explicit template
+  arguments, parser return-type hints, dependent-qualified owner records, and
+  definition-bound call metadata where concrete targets are known
+- `ResolvedQualifiedOwner` is the shared owner-classification entry point for
+  the parser, `ExpressionSubstitutor`, constexpr qualified member access, and
+  sema qualified-call target recovery
+- builtin type template arguments are canonicalized through
+  `TemplateArgumentMaterialization.h`, covering the MSVC `<type_traits>`
+  `is_integral_v` fundamental-character-type fold shape
 
-## Architectural invariants to preserve
+## Architectural invariants
 
-Follow-up work in this area should preserve these rules:
+Follow-up work should preserve these rules:
 
-- preserve semantic identity end-to-end; do not rebuild meaning from text if a
-  structured record can be carried instead
-- prefer replay-first attachment using source identity plus canonical
-  substituted-signature evidence
-- treat parser-selected compatibility paths as temporary debt, not as a normal
-  resolution mechanism
-- when sema has enough typed evidence to decide, reject broad parser/codegen
-  fallback instead of letting it continue
-- if a path still lacks enough metadata, narrow the compatibility surface and
-  document the gap explicitly
+- preserve semantic identity end to end; do not rebuild meaning from strings
+  when a structured record exists
+- keep parser-selected compatibility paths explicit, narrow, and temporary
+- when sema has enough typed evidence, reject stale parser choices rather than
+  silently recovering through compatibility metadata
+- keep substitution, deduction, overload ranking, replay/materialization, and
+  constexpr evaluation as separate responsibilities
+- prefer identity-first replay attachment over `StructTypeInfo` repair scans
+- add abstractions only when they remove real repeated owner/replay logic or
+  prevent standards-visible fallback behavior from reappearing
 
-## Highest-value remaining architectural gaps
+## Remaining architectural gaps
 
-### 1. Residual replay/`StructTypeInfo` sync gaps
+### 1. Standard-header frontier
 
-The broad signature-equivalent sync fallback is gone from the currently-covered
-paths, but future failures in replay-heavy areas will likely still come from
-metadata loss between source declarations and instantiated `StructTypeInfo`
-copies.
+The green core suite is no longer blocked by the qualified-owner/direct-call
+metadata work. The next high-value target is the remaining standard-header
+expected-failure frontier:
 
-Desired end state:
+- `tests/std/test_cstddef.cpp`
+- `tests/std/test_cstdio_puts.cpp`
+- `tests/std/test_cstdlib.cpp`
 
-- every replay/sync path preserves source-member identity directly
-- `StructTypeInfo` repair scans are not used to rediscover targets by name or
-  arity when identity could have been preserved
+Start by running each focused test and identifying the first compiler failure.
+Use the actual failure to decide whether the next slice belongs in
+preprocessing, namespace/header modeling, template argument materialization,
+constexpr evaluation, or semantic lookup. Do not assume the next failure is in
+qualified-owner infrastructure.
 
-Near-term remaining scope:
+### 2. Dependent-qualified owner prefix-chain extraction
 
-- in-loop member-function / constructor registration inside
-  `Parser::try_instantiate_class_template()` is now unified locally, so the
-  next cleanup target in this area is the remaining out-of-line replay/sync
-  helper duplication rather than more registration drift
-- top-level replay-driven `StructTypeInfo` sync now uses shared
-  identity-first helpers for plain members and constructors; the remaining
-  duplication is in nested/member-template-specific attachment paths that do
-  not all route through those helpers yet
-- partial-specialization constructor copies now use the same
-  source-member-to-`StructTypeInfo` index map as the primary-template path,
-  and the nested/member-template replay sites that already preserve a matched
-  source declaration now route through the shared identity-first helpers too
-- partial-specialization nested member-template replay now also syncs the
-  `StructTypeInfo` copy through the shared identity-first helper once the
-  matched source declaration is preserved
-- the previously highest-impact nested replay/sync gap is now covered in the
-  primary nested-class path as well; remaining replay debt in this bucket is no
-  longer the obvious first task and should be handled opportunistically only if
-  a concrete uncovered attachment/sync failure appears
+Do not do this speculatively. The direct consumer migration to
+`ResolvedQualifiedOwner` is complete for the currently identified parser,
+substitution, constexpr, and sema entry points.
 
-### 2. Remaining direct-call metadata loss outside dependent-unqualified completion
+Extract deeper shared helpers only if a concrete failure proves that duplicate
+handling of one of these is now the blocker:
 
-Dependent-unqualified direct-call completion now preserves both the
-definition-bound ordinary lookup and the final point-of-instantiation target
-through resolved-call materialization, and the final parser-selected
-non-receiver fallback is gone. The remaining direct-call metadata risk is
-therefore narrower: other instantiated ordinary direct-call paths may still
-reach sema with only mangled compatibility evidence instead of preserved
-structured lookup metadata.
+- `DependentQualifiedNameRecord` owner-template argument rebinding
+- member-prefix chain materialization
+- current-instantiation vs unknown-specialization owner binding across
+  substitution, constexpr, and sema
 
-Latest progress:
+If extracted, the helper should consume the preserved dependent-qualified
+record and return a resolved owner/prefix result that consumers can use without
+re-splitting `qualified_name` or rebuilding owner identity from
+`baseTemplateName()`.
 
-- sema now prefers the structured `FunctionDeclarationNode*` already stored in
-  definition-lookup and dependent-unqualified records, and only falls back to
-  mangled-name canonicalization when that structured target is absent
-- the highest-traffic non-dependent ordinary direct-call branches now preserve
-  `FunctionCallDefinitionLookupRecord` instead of only stamping
-  `mangled_name`, including unqualified overload-resolution paths in template
-  bodies and namespace-qualified direct-call materialization
-- concrete template-origin ordinary direct calls in non-template bodies now
-  preserve that same structured lookup record too, rather than requiring a
-  sema-side parser-target compatibility escape hatch once the parser already
-  knows the concrete instantiated `FunctionDeclarationNode`
-- the covered qualified/direct template-instantiation branches now also reuse a
-  shared concrete-function adoption helper, shrinking the remaining branch-
-  specific drift where wrapper instantiations could silently drop back to
-  weaker call metadata
+### 3. Replay / `StructTypeInfo` sync debt
 
-Desired end state:
+Most high-value replay identity gaps are closed in the covered template member
+and nested constructor paths. Keep this bucket opportunistic unless a concrete
+failure shows a remaining path syncing by weak name/arity evidence. When it
+does, prefer routing the replay site through existing identity-first helpers
+before adding new repair scans.
 
-- every instantiated ordinary direct call preserves enough structured semantic
-  evidence to recover its final target directly
-- sema does not need mangled-name recovery to reuse a completed
-  replay/materialization result
+### 4. Member-object-pointer carrier
 
-Remaining near-term scope:
+If a future ABI-sensitive pointer-to-member regression appears, close the
+remaining canonical `TypeCategory::MemberObjectPointer` carrier gap by
+preserving the underlying member type explicitly instead of relying on
+declarator-shaped `member_class + pointer_depth` forms.
 
-- the highest-impact legacy unified ordinary identifier-call fallback is now on
-  the proper split model: parse-time return-type visibility lives on an
-  explicit call-node hint, while deferred semantic ownership lives on a
-  definition-bound or dependent-unqualified lookup record rather than on a
-  parser-selected callee
-- the remaining debt is narrower and now concentrated in other parser
-  materialization sites that still stamp only `mangled_name` or
-  `qualified_name` without a typed semantic record, especially niche
-  qualified/member-template paths outside the now-covered ordinary-call routes;
-  the highest-impact postfix qualified/member fast paths plus the direct
-  operator/declaration-address non-receiver paths are now covered too, and the
-  main concrete receiver-call builders plus template-parameter
-  function-pointer call materialization are covered as well, and the explicit-
-  qualified postfix placeholder member/operator builders are now covered too,
-  and ordinary function-pointer member postfix placeholders plus the
-  `.*` / `->*` member-function-pointer fast paths now preserve the real return
-  shape, and the shared qualified static-owner helper no longer relies on a
-  same-arity shape match for its non-template fallback or drops structured
-  owner metadata just because the owner `StructTypeInfo` is already present, so
-  the remaining work is no longer that whole pointer-to-member
-  surface; it is the smaller set of still-uncovered placeholder/materializer
-  exits plus the canonical `TypeCategory::MemberObjectPointer` carrier gap
-  where the underlying member type is not yet preserved strongly enough for
-  every ABI-sensitive consumer
-- the newly-covered qualified-owner split is intentionally sema-owned: the
-  deferred-template resolver is now bypassed for non-template qualified calls
-  whose left-hand side is a real type owner, and the old parser-side ordinary
-  static-member recovery in `resolveDeferredQualifiedTemplateCall(...)` is now
-  gone; the remaining debt in this sub-area is no longer owner-kind
-  classification itself, but the unresolved qualified/member-template
-  materializers that still preserve only compatibility metadata after the owner
-  split has already been decided
-- the now-covered unqualified/current-owner explicit-member-template path
-  confirms the same rule for short class-scope spellings: deferred
-  `pick<int>(...)`-style member-template calls inside a current instantiation
-  must preserve structured owner/member identity and may not borrow parser-time
-  return-type visibility from an unrelated `lookupAllTemplates(...)` result
-- the generic namespace-qualified explicit-template placeholder/materializers
-  in `Parser_Expr_PrimaryExpr.cpp` are now on that split model too, including a
-  specialization-aware guard that only preserves exact parse-time template
-  identity when no exact specialization is registered for the same qualified
-  template name; the remaining work in this sub-area is therefore the other
-  qualified/member-template parser exits, especially postfix explicit-qualified
-  member/operator placeholder paths that still do not preserve the same
-  deferred lookup structure end-to-end
-- postfix explicit-qualified member/operator call parsing in
-  `Parser_Expr_PostfixCalls.cpp` now also accepts explicit member-template ids
-  after a concrete owner qualifier such as `this->Base::template pick<int>()`
-  and `this->Base::template operator()<int>()`, routing the resolved owner
-  through the same member-template instantiation helper
-- the explicit-base member-template placeholder half of that postfix path is
-  now on the structured side too: unresolved
-  `this->Base::template pick<T>()`-style calls preserve a recovered
-  base-owner `DependentQualifiedNameRecord`, carry the matched member-template
-  return type instead of a raw `auto` stub, and let substitution instantiate
-  the concrete base-qualified member template once `T` becomes concrete instead
-  of rebinding by bare member name
-- the sibling postfix explicit-qualified operator-template placeholder is now
-  on that same structured path as well: short-owner
-  `holder.Base::template operator()<int>()` calls canonicalize the nested owner
-  metadata before substitution instantiates the concrete base-qualified
-  operator template
-- the next direct-call ownership cleanup should stay on this side of the
-  parser/sema boundary: consolidate the remaining ordinary template-
-  instantiation call builders so every concrete template-origin direct call
-  goes through the same `FunctionCallDefinitionLookupRecord` helper, then
-  tighten the normalized-body invariant so sema no longer needs bare parser
-  callee identity where a structured lookup record could have been preserved
-  earlier; after the newly-covered ordinary qualified/direct builders, the
-  next likely targets are the remaining member/callable-object
-  template-instantiation exits that still special-case bare
-  `FunctionDeclarationNode` results
-  before template instantiation, preserve the deferred qualified-owner record
-  when parsing must stay deferred, and keep the matched operator-template
-  return type on the placeholder instead of falling back to global
-  same-spelled owners
-- the previously uncovered `typeCode<Rest>()...`-style call-argument leak is
-  now fixed at the parser/substitution boundary; future work here should keep
-  pack-expansion ownership at that boundary instead of reintroducing
-  call-specific explicit-template-argument repairs deeper in sema/codegen
-- the standards-visible nested-owner collision in explicit qualified
-  member-template calls is now fixed in the parser/materialization layer by
-  preserving the full nested owner identity instead of recovering from the
-  short owner spelling later; the old ordinary static-member compatibility
-  branch in `resolveDeferredQualifiedTemplateCall(...)` is now gone too, and
-  the main postfix qualified/member parser path now preserves structured call
-  metadata as well, so the remaining work in this bucket is the smaller set of
-  substitution/parser materializers that still stop at compatibility data
-  after the owner split has already succeeded
-- the remaining sema/codegen boundary sync for direct calls should stay narrow;
-  it now operates at whole-call granularity on the exact lowered AST, but the
-  long-term target is still to remove even that hook once the remaining
-  replay/materialization paths preserve enough structured call identity that
-  sema never has to resynchronize the lowered node
+## Recommended next task
 
-### 3. Current-instantiation / unknown-specialization precision
-
-This is no longer the first task, but it remains the next structural lever once
-the replay-identity gaps above are smaller. Expand it only where it unblocks
-real replay or typed-lookup failures.
-
-## Recommended task order
-
-1. Tighten the next remaining mangled-name compatibility path by preserving
-   structured direct-call metadata in the owning replay/materialization path
-   instead of relying on mangled recovery.
-
-Next direct-call target:
-
-- trace the remaining concrete resolved-call builders outside the now-covered
-  postfix qualified/member helpers, then either preserve a typed
-  `FunctionCallDefinitionLookupRecord` there or explicitly document why the
-  call cannot yet carry one; after the current-member-context fast path, the
-  untyped ordinary-call deferred-lookup split, the postfix qualified/member
-  metadata preservation pass, the direct operator/declaration-address
-  metadata preservation pass, the removal of the parser-owned
-  ordinary-static-member qualified fallback, and the substitution-time
-  qualified-call record rebuild, template-parameter function-pointer call
-  preservation, the `.*` / `->*` member-function-pointer pass, and
-  explicit-qualified postfix member/operator preservation, the next
-  highest-value targets are the remaining qualified/member-template
-  compatibility-only materializers plus any smaller placeholder call builders
-  that still return immediately without a structured lookup record. The shared
-  qualified static-owner helper is no longer one of those weak spots: its
-  non-template fallback now routes through real static-member overload
-  selection, and unresolved template-instantiation owners keep structured
-  owner metadata even when the owner `StructTypeInfo` is already available
-
-2. Only after step 1 is stable, expand
-   current-instantiation/unknown-specialization modeling for the concrete cases
-   that still block standards-conforming typed lookup.
-
-## Next steps
-
-1. Keep the parser/materializer side narrow and shift the next audit to the
-   remaining consumer paths now that the lingering dependent qualified-call
-   placeholder builders in `Parser_Expr_PrimaryExpr.cpp` are covered too.
-   The postfix explicit-qualified member/operator owner-template-id exits in
-   `Parser_Expr_PostfixCalls.cpp` are now covered too: `parse_member_postfix()`
-   consumes qualifiers like `this->Base<T>::template pick<int>()` and
-   `this->Base<T>::template operator()<int>()`, preserving dependent owner
-   template-id structure through the same structured deferred qualified-call
-   record used by the other qualified/member-template paths instead of dropping
-   the `Base<T>` template-id before the `::template` continuation.
-   The sibling postfix explicit-qualified operator-template placeholder without
-   owner template arguments is now covered too: short nested-owner
-   `Base::template operator()<int>()` spellings canonicalize the owner before
-   instantiation and preserve the same deferred qualified-owner metadata plus
-   parser return-type hints when parsing must stay deferred, which closes the
-   nested-owner collision that had still allowed a global same-spelled `Base`
-   to win during trailing `decltype(...)` parsing.
-   That follow-up is now closed for the remaining targeted qualified direct-call
-   builders in `Parser_Expr_PrimaryExpr.cpp`: the global-qualified and
-   namespace-qualified explicit-function-id exits no longer stop at
-   `qualified_name` / `mangled_name` compatibility metadata once the matched
-   declaration shape is already known, and they now preserve the same
-   definition-bound direct-call record plus parser return-type hints as the
-   shared ordinary-call helper path. The namespace-qualified operator
-   function-id helper and the leading global-qualified `::operator...` parser
-   entry now follow that same resolved/deferred qualified-call metadata model
-   too, with
-   `test_template_namespace_qualified_operator_definition_bound_ret0.cpp`
-   and
-   `test_template_global_qualified_operator_definition_bound_ret0.cpp`
-   keeping the direct definition-bound paths pinned. The last unrelated
-   static-member
-   whole-call sema synchronization leg is now closed too:
-   `resolveCallArgAnnotationTarget(...)` no longer needs the
-   parser-selected static direct-call fallback, and the current-member static
-   hiding regressions still pass through the preserved definition-bound call
-   metadata alone. `Parser_Expr_PrimaryExpr.cpp` now also shares one helper for
-   its remaining deferred owner-template/member-template call builders, so
-   those placeholder exits no longer diverge on whether they preserve the
-   structured deferred qualified record, template-argument AST, or exact
-   qualified member-template return-type hint. The next concrete audit target
-   is therefore the consumer side: verify `ExpressionSubstitutor.cpp`,
-   constexpr, and the remaining sema-qualified-call consumers do not still
-   re-split `qualified_name` text or assume missing parser return-type hints in
-   the covered owner-template/member-template flows. Keep
-   `test_member_template_func_in_specialization_ret0.cpp`,
-   `test_template_explicit_base_owner_template_member_template_decltype_ret0.cpp`,
-   and `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
-   in the focused guard set here.
-2. If another pointer-to-member issue appears, close the remaining canonical
-   `TypeCategory::MemberObjectPointer` carrier gap by preserving the
-   underlying member type explicitly instead of relying on declarator-shaped
-   `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. The initializer-diagnostics follow-up that this slice exposed is now
-   covered too: both `parse_copy_initialization(...)` and
-   `parse_direct_initialization(...)` preserve nested parse failures instead of
-   collapsing them to generic wrapper errors, and the dedicated `_fail`
-   anchors `test_copy_init_nested_qualified_call_error_fail.cpp` and
-   `test_direct_init_nested_qualified_call_error_fail.cpp` now keep that
-   behavior pinned.
-4. Leave replay/`StructTypeInfo` sync and broader
-   current-instantiation/unknown-specialization expansion in opportunistic mode
-   unless a concrete uncovered failure appears.
+1. Start with the standard-header frontier:
+   `test_cstddef.cpp`, `test_cstdio_puts.cpp`, then `test_cstdlib.cpp`.
+2. For the first concrete failure, trace the real layer responsible before
+   editing.
+3. Add a focused regression that captures the standards-visible behavior outside
+   the std-header test when practical.
+4. Keep docs updates last and update this section with the next concrete
+   frontier after validation.
 
 ## Validation guidance
 
-When changing this area, always rerun:
+For template-infrastructure changes, run the motivating focused test plus the
+small guard set relevant to the touched layer. Common guards:
 
-- the focused regression that motivated the slice
-- `test_template_ool_member_template_operator_identity_ret0.cpp`
-- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
-- `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
-- `template_lookup_non_dependent_no_rebind_ret0.cpp`
-- `test_template_explicit_function_id_definition_bound_ret0.cpp`
-- `test_template_current_member_static_hides_base_overload_ret0.cpp`
-- `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
-- `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
-- `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
 - `test_member_template_func_in_specialization_ret0.cpp`
-- `test_template_current_member_explicit_template_decltype_ret0.cpp`
-- `test_template_disambiguation_pack_ret40.cpp`
+- `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
+- `test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp`
+- `test_sema_resolved_qualified_owner_template_nested_collision_ret0.cpp`
+- `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`
+- `test_var_template_replay_dependent_member_template_call_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
 - `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
 - `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
-- `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
-- `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
-- `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
-- `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_operator_template_decltype_ret0.cpp`
-- `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`
-- `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
-- `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
-- `test_template_dependent_unqualified_member_replay_ret0.cpp`
-- `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
-- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_subscript_const_ambiguity_fail.cpp`
-- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
-- `test_subscript_pointer_conversion_template_ret42.cpp`
-- full `pwsh tests/run_all_tests.ps1` before closing the slice
+- `test_template_disambiguation_pack_ret40.cpp`
+- `std/test_std_type_traits.cpp`
 
-## Next steps
+Before closing a slice, run:
 
-1. Finish the remaining parser-side direct-call metadata preservation in the
-   still-uncovered resolved-call paths that only stamp `mangled_name` or
-   `qualified_name`, now focusing on qualified/member-template materializers
-   outside the now-covered ordinary identifier-call routes.
-   Immediate follow-up: move those paths onto the same split ownership model
-   now used by untyped ordinary calls:
-   parser-time return-type hints on the call node, structured deferred lookup
-   state for semantic ownership, and no parser-selected callee as the source of
-   final meaning. The old ordinary-static-member compatibility branch inside
-   `resolveDeferredQualifiedTemplateCall(...)` is now removed, constexpr
-   reuse goes through the same sema-owned type-owner vs namespace-qualifier
-   split with explicit current-type fallback for class-scope evaluation, and
-   the substitution-time qualified/member-template materializer now rebuilds
-   `FunctionCallDefinitionLookupRecord` once the substituted call is concrete.
-   The next concrete target in this slice is therefore narrower:
-   audit the remaining parser materializers that still stamp only
-   `qualified_name`/`mangled_name`, preserve
-   `FunctionCallDefinitionLookupRecord` (or an explicit deferred lookup record)
-   there, and then collapse the whole-call sema synchronization hook that was
-   compensating for those compatibility-only paths. The just-finished
-   `Parser_Expr_QualLookup.cpp` pass removed the weak same-arity/static-member
-   fallback from `try_parse_member_template_function_call(...)` and widened
-   dependent-qualified owner preservation for unresolved template-instantiation
-   owners, and the current-owner explicit-member-template placeholder path in
-   `Parser_Expr_PrimaryExpr.cpp` now preserves the same structured deferred
-   owner metadata with member-template-derived parser return-type hints. This
-   slice now does the same for the explicit-base postfix member-template
-   placeholder in `parse_member_postfix()`, including late substitution-time
-   owner-qualified instantiation once `T` becomes concrete, and it now closes
-   the sibling postfix explicit-qualified operator-template placeholder too:
-   short nested-owner `Base::template operator()<int>()` calls no longer
-   instantiate against a global same-spelled owner during trailing
-   `decltype(...)` parsing, and deferred cases preserve the same structured
-   owner metadata plus parser return-type hints as the member-template branch.
-   This follow-up closes the remaining targeted postfix/current
-   qualified/member-template compatibility-only exits in
-   `Parser_Expr_PostfixCalls.cpp`: the explicit owner-template-id
-   member-template placeholder now keeps a structured deferred qualified-owner
-   record even after owner canonicalization succeeds, and the recognized
-   qualified static-owner placeholder now preserves the same owner record plus
-   any unambiguous parser return-type hint instead of stopping at
-   `qualified_name`. `ExpressionSubstitutor.cpp` now consumes that preserved
-   owner record first when materializing explicit qualified member-template
-   calls, so late substitution no longer re-splits `qualified_name` text to
-   recover owner meaning. The whole-call sema synchronization hook could only
-   be narrowed part-way: the `has_qualified_name` compatibility branch is gone,
-   but the unrelated static-member direct-call branch still has to remain for
-   `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
-   and `test_template_current_member_static_hides_base_overload_ret0.cpp`.
-   The nested-owner explicit member-template collision is now fixed at the
-   parser source and guarded by
-   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
-   plus the multi-segment owner-chain variant
-   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
-   and the enclosing-scope nested-class variant
-   `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
-   The focused regression for the newly-covered class-scope constexpr path is
-   `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`.
-   The focused regression for the newly-covered current-owner explicit-member-
-   template placeholder path is
-   `test_template_current_member_explicit_template_decltype_ret0.cpp`.
-   The focused regression for the newly-covered substitution/materialization
-   path is
-   `test_template_qualified_explicit_function_id_definition_bound_ret0.cpp`.
-   The focused regression for the newly-covered postfix qualified direct-call
-   path is
-   `test_template_namespace_qualified_explicit_function_id_definition_bound_ret0.cpp`.
-   The focused regressions for the newly-covered non-receiver concrete-call
-   builders are `test_template_direct_operator_definition_bound_ret0.cpp` and
-   `test_template_postfix_address_call_definition_bound_ret0.cpp`.
-   The focused guards for the newly-covered concrete receiver-call builders are
-   `test_template_postfix_call_operator_default_arg_ret0.cpp` and
-   `test_template_implicit_this_member_call_default_arg_ret0.cpp`.
-   The focused guard for the newly-covered template-parameter function-pointer
-   materialization path is
-   `test_template_function_pointer_nttp_definition_bound_ret0.cpp`.
-   The focused guards for the newly-covered explicit-qualified postfix
-   member/operator builders are
-   `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
-   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
-   `test_template_explicit_base_operator_template_decltype_ret0.cpp`,
-   `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`,
-   `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
-   and
-   `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
-   The focused guard for variable-template replay preserving the full nested
-   owner chain into the final direct-call target is
-   `test_var_template_replay_dependent_member_template_call_ret0.cpp`.
-   The member-function-pointer fast-path surface is now covered, including the
-   `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
-   qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
-   specializations. The alias/materialization cluster that had still been
-   visible in the full suite is now fixed as well: direct non-deferred alias
-   rebinding once again wins over the lossy alias-materialization path for
-   simple aliases, so pointer/cv/ref surface modifiers survive through
-   `identity_t<T>`, `T*`, and member-alias forms. Focused guards:
-   `test_alias_template_pointer_modifiers_ret0.cpp`,
-   `test_alias_const_ptr_ret42.cpp`,
-   `test_alias_ptrptr_ret42.cpp`,
-   `test_alias_template_comprehensive_ret70.cpp`,
-   `test_alias_two_pointers_ret30.cpp`, and
-   `test_member_template_alias_ret250.cpp`. `pwsh ./tests/run_all_tests.ps1`
-   now passes again for the full regular suite. As cleanup on top of that
-   functional fix, the branch now routes definition-preferred qualified-owner
-   member lookup through `MemberFunctionLookupShared.h`, removes the remaining
-   bespoke qualified-id template-argument materializer in favor of
-   `TemplateArgumentMaterialization.h`, and keeps that helper header out of the
-   vcxproj lists. The next concrete target in
-   this audit is to continue adopting the new `ResolvedQualifiedOwner` layer
-   rather than creating more per-call-site owner repairs. The first parser
-   resolver now separates the requested spelling, lookup spelling, resolved
-   `TypeInfo`, current-context classification, and nested-owner-extension
-   rewrite decision for deferred qualified-call and postfix explicit-qualified
-   member-template lookup, and the substitutor, constexpr, and sema consumer
-   entry points now consume that current-instantiation owner classification as
-   well. The remaining owner work is no longer another direct consumer
-   migration; it is a deeper extraction only if future failures require moving
-   `DependentQualifiedNameRecord` owner-template argument rebinding and
-   member-prefix chain materialization into a shared helper. Until such a
-   concrete failure appears, the next standards-conformance target moves back
-   outside the passing core suite: the remaining expected-failure coverage
-   (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
-   follow-on canonical member-object-pointer carrier gap if a new ABI-sensitive
-   regression reaches it.
-   Long-term direction: stop teaching individual parser call sites to recover
-   owner identity from short qualified spellings. Instead, preserve a shared
-   structured qualified-owner record on the AST and route both parser
-   materialization and sema fallback through one owner/type-owner-vs-namespace
-   resolver so this pattern does not repeat in more qualified-call subpaths.
-   Follow-up for the standard-header frontier: builtin type template arguments
-   are now canonicalized through `TemplateArgumentMaterialization.h` instead of
-   ad hoc `get_type_name` / empty-token reconstruction. Expression-form
-   template arguments in constexpr variable-template calls, raw
-   `TypeSpecifierNode` substitution, and parser-side type-parameter expression
-   replacement all use the shared token/type-argument helpers. This fixes the
-   MSVC `<type_traits>` `is_integral_v` shape where `wchar_t`, `char8_t`,
-   `char16_t`, and `char32_t` were previously reconstructed as an `unknown`
-   identifier inside an `is_same_v<T, U>` fold. Guard:
-   `test_variable_template_fold_remove_cv_builtin_list_ret0.cpp`; focused
-   validation also covers `std/test_std_type_traits.cpp`.
-
-2. Only then spend complexity on current-instantiation /
-   unknown-specialization expansion, and only for concrete typed-lookup or
-   replay failures that remain after step 1.
+- `.\build_flashcpp.bat`
+- focused regressions for the changed behavior
+- `pwsh ./tests/run_all_tests.ps1`

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -239,6 +239,16 @@ the areas that were previously blocking standards-visible behavior:
   explicit-qualified member-template placeholder path now consume that carrier
   for current-instantiation classification and nested-owner canonicalization
   instead of open-coding the owner split separately.
+- `ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(...)` now
+  also uses the shared `ResolvedQualifiedOwner` current-context classification
+  before materializing a dependent qualified owner, instead of calling the
+  older current-context owner helper and redoing the same canonicalization
+  branch locally.
+- constexpr qualified member access and sema qualified-call target recovery
+  now also consult the shared resolved-owner result before falling back to
+  their consumer-specific dependent-record prefix-chain and overload recovery
+  logic, so the parser, substitution, constexpr, and sema entry points all
+  share the same current-instantiation owner classification.
 
 ## Architectural invariants to preserve
 
@@ -683,14 +693,14 @@ When changing this area, always rerun:
    resolver now separates the requested spelling, lookup spelling, resolved
    `TypeInfo`, current-context classification, and nested-owner-extension
    rewrite decision for deferred qualified-call and postfix explicit-qualified
-   member-template lookup. Next, extend that carrier to consume preserved
-   `DependentQualifiedNameRecord` owner-template
-   arguments and member-prefix chains, then route `ExpressionSubstitutor.cpp`,
-   constexpr qualified member access, and the remaining sema qualified-call
-   fallback through the same resolved-owner result. After those consumers stop
-   independently canonicalizing owner meaning from placeholder or base-template
-   spellings, the next standards-conformance target moves back outside the
-   passing core suite: the remaining expected-failure coverage
+   member-template lookup, and the substitutor, constexpr, and sema consumer
+   entry points now consume that current-instantiation owner classification as
+   well. The remaining owner work is no longer another direct consumer
+   migration; it is a deeper extraction only if future failures require moving
+   `DependentQualifiedNameRecord` owner-template argument rebinding and
+   member-prefix chain materialization into a shared helper. Until such a
+   concrete failure appears, the next standards-conformance target moves back
+   outside the passing core suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
    follow-on canonical member-object-pointer carrier gap if a new ABI-sensitive
    regression reaches it.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -4,688 +4,128 @@
 **Last updated:** 2026-06-30
 
 This document tracks the standards-facing target for the remaining template
-infrastructure work. It should describe the intended semantic model, the
-highest-value remaining conformance gaps, and the next tasks required to close
-them. It is intentionally not a branch diary.
+infrastructure work. Keep it focused on the intended semantic model, active
+conformance gaps, and the next concrete tasks. Do not use it as a branch log.
 
 ## Target model
 
-Move FlashCpp toward a template implementation where:
+FlashCpp should move toward a C++20 template implementation where:
 
 - dependency classification is explicit
 - non-dependent lookup remains definition-bound through instantiation
-- dependent names preserve semantic identity end-to-end
-- substitution, deduction, ranking, and replay/materialization stay separate
-- semantic analysis, not parser leftovers, owns final call-target selection in
-  normalized flows
-- replay succeeds because invariant evidence matches, not because a repair scan
-  guessed correctly
+- dependent names preserve semantic identity end to end
+- substitution, deduction, overload ranking, replay/materialization, and
+  constexpr evaluation stay separate
+- semantic analysis owns final call-target selection in normalized flows
+- replay succeeds because invariant evidence matches, not because repair scans
+  guessed a compatible declaration
 
 ## Current conformance baseline
 
-The compiler now has a workable standards-facing baseline in several previously
-blocking areas:
+The core suite now covers several formerly blocking standards-visible areas:
 
-- covered non-dependent template-body lookup remains definition-bound
-- dependent alias resolution no longer relies on textual reconstruction
-- normalized direct-call resolution for template/member calls uses sema-owned
-  overload-resolution argument typing
-- semantic const-aware lookup for ordinary member calls, `operator[]`, and
-  callable `operator()` now rejects stale non-const parser-selected targets
-  once sema has typed evidence
-- direct-call viability now requires real conversion paths
-- indirect call typing preserves the returned object type during overload
-  ranking
-- replay attachment in the covered routes now expects positive
-  identity/signature evidence rather than accepting unresolved
-  shape-based matches
-- resolved direct-call materialization now preserves
-  `DependentUnqualifiedCallLookupRecord` both when the instantiated target
-  stays definition-bound and when dependent-unqualified POI completion selects
-  a different final function, reducing replay-heavy dependence on parser
-  reruns and mangled-name recovery in those paths
-- non-dependent ordinary overload-resolution and namespace-qualified direct
-  call materialization in the covered template paths now also preserve
-  `FunctionCallDefinitionLookupRecord`, reducing the remaining standards risk
-  that sema will reconstruct definition-bound targets from mangled names alone
-- current-member-context static direct-call replay now also preserves
-  `FunctionCallDefinitionLookupRecord` in the
-  `resolved_member_function_from_context` fast path, so sema no longer has to
-  recover those definition-bound member targets from compatibility metadata
-  alone in that route
-- builtin-like literal/pointer argument types no longer prevent that fast path
-  from carrying `FunctionCallDefinitionLookupRecord` just because the parser
-  has not yet materialized a concrete `type_index` for the temporary
-  `TypeSpecifierNode`
-- the restored `int -> long` current-member static case no longer relies on a
-  per-argument codegen patch; sema now synchronizes the exact lowered
-  `CallExprNode` at whole-call granularity, and that retry is narrowly bounded
-  to definition-bound / qualified / static-member direct calls whose selected
-  target is already preserved on the AST
-- current-struct explicit member-template materialization now routes its
-  qualified-name override through the same shared direct-call metadata helper
-  that attaches the rest of the structured call metadata
-- the shared qualified member-template call helper now also preserves
-  `FunctionCallDefinitionLookupRecord` when it has a concrete direct-call
-  target plus typed arguments, instead of falling back to
-  `qualified_name`/`mangled_name` compatibility metadata alone
-- the final parser-selected non-receiver direct-call fallback in
-  `resolveCallArgAnnotationTarget(...)` is gone; ordinary direct calls now
-  resolve through semantic metadata, typed lookup, or explicit unresolved
-  terminals instead of reusing the parser-selected target late
-- ordinary direct-call parsing now performs one last structured
-  `appendFunctionCallArgType(...)` collection pass before falling back to
-  compatibility-only metadata when primary `get_expression_type(...)` typing
-  fails, reducing the remaining surface where parser materialization lag alone
-  strips away definition-bound call identity
-- that structured retry is now reused by the current-member static fast path
-  too, so definition-bound replay coverage no longer depends on a separate
-  weaker argument-typing branch there
-- string-literal user-defined literal calls now preserve
-  `FunctionCallDefinitionLookupRecord` using the synthesized literal-operator
-  name and argument list instead of carrying only `mangled_name`
-- ordinary direct calls to concrete template-origin functions now also
-  preserve `FunctionCallDefinitionLookupRecord` even when the call appears in
-  a non-template body, so sema-normalized wrapper calls no longer need a
-  parser-target compatibility path once the parser already knows the concrete
-  instantiated function
-- the remaining covered qualified/direct template-instantiation builders now
-  also adopt concrete function results through the same wrapper-aware helper,
-  so preserving structured call metadata no longer depends on whether a parser
-  branch received a bare `FunctionDeclarationNode` or a wrapped template node
-- untyped ordinary direct-call fallback exits no longer need a parser-selected
-  callee to keep parse-time typing alive: they now carry an explicit parser
-  return-type hint on the call node plus either a deferred
-  definition-context lookup record or a deferred dependent-unqualified lookup
-  record, so later semantic resolution can re-run the correct lookup instead of
-  leaning on mangled-name or parser-target compatibility
-- `resolveDeferredQualifiedTemplateCall(...)` no longer performs ordinary
-  static-member overload recovery for qualified type owners; non-template
-  qualified direct calls now stay on sema-owned owner/overload resolution
-  instead of inheriting a parser-side compatibility branch
-- constexpr evaluation now reuses sema-owned qualified direct-call resolution
-  before falling back to parser-owned deferred template instantiation, and that
-  shared resolver accepts an explicit current-type fallback so class-scope
-  `static constexpr` initializers participate in the same nested-owner/type-
-  owner-vs-namespace split as member-function sema
-- instantiation-time resolved-call materialization in `ExpressionSubstitutor`
-  now rebuilds `FunctionCallDefinitionLookupRecord` for qualified/member-
-  template direct calls once substitution has concrete arguments plus a
-  concrete `FunctionDeclarationNode`, instead of preserving only copied
-  `qualified_name`/`mangled_name` compatibility metadata in those paths
-- postfix qualified direct-call and concrete member-postfix fast paths in
-  `Parser_Expr_PostfixCalls.cpp` now attach structured call metadata whenever
-  they already hold a concrete `FunctionDeclarationNode`, instead of stopping
-  at copied `qualified_name`/`mangled_name` compatibility metadata in those
-  parser materializers
-- direct operator function-id calls in `Parser_Expr_PrimaryExpr.cpp`, including
-  the namespace-qualified `N::operator...(args)` helper plus the global-
-  qualified `::operator...(args)` entry path, and the postfix declaration-
-  address fast path in `Parser_Expr_PostfixCalls.cpp` now preserve structured
-  non-receiver call metadata too, so late sema no longer has to rediscover
-  their definition-bound target from a parser-selected callee alone
-- the main concrete receiver-call builders now preserve shared metadata too:
-  postfix `operator()` finalization plus the implicit-`this`, member-operator,
-  and callable-object `operator()` builders in `Parser_Expr_PrimaryExpr.cpp`
-  all attach structured receiver-call metadata once they already know the
-  exact `FunctionDeclarationNode`
-- template-parameter function-pointer direct-call materialization in
-  `Parser_Expr_PrimaryExpr.cpp` now preserves
-  `FunctionCallDefinitionLookupRecord` when definition-context lookup already
-  resolves the bound function, so late sema does not have to rebind that call
-  from compatibility data after later same-name overloads appear
-- explicit-qualified postfix member/operator call builders in
-  `Parser_Expr_PostfixCalls.cpp` now resolve concrete owner-qualified targets
-  for forms such as `this->Base::touch()` and `this->Base::operator()()` when
-  the receiver type and arguments are concrete, instead of materializing a
-  placeholder `auto` member call that later loses semantic identity
-- the shared qualified-owner member-call helper in
-  `Parser_Expr_QualLookup.cpp` now treats concrete `Type::member(...)` owner
-  calls more semantically too: non-template fallback selection is limited to
-  static members, uses real overload resolution once argument types are
-  concrete, and unresolved template-instantiation owners preserve a structured
-  dependent-qualified owner record even when `StructTypeInfo` is already
-  present instead of dropping back to `qualified_name` plus a parser return-type
-  hint alone
-- that qualified static-owner path now also stays conservative at the right
-  semantic boundary: if a concrete owner already has visible static-member
-  candidates but parser-time overload ranking still cannot prove the final
-  target, the call now defers with canonical owner identity plus structured
-  qualified-call metadata instead of either reviving a parser-selected fallback
-  or hard-rejecting a call that later semantic resolution can still complete
-- primary-template out-of-line constructor replay now synchronizes the
-  `StructTypeInfo` constructor copy through preserved source-member identity
-  when that identity is already known, instead of recovering it afterward
-- copied member-function-template stubs now preserve source-member identity in
-  `StructTypeInfo` at insertion time in the primary-template and covered
-  specialization paths, including operator overloads, so out-of-line replay
-  sync no longer depends on replay-source-key recovery there once semantic
-  matching already identified the source declaration
-- nested class-template member functions are now inserted into
-  `StructTypeInfo` before nested out-of-line replay with identity recorded at
-  insertion time, and lazy nested-member registration is split from that
-  structural insertion so nested constructor/member-template replay no longer
-  depends on positional `StructTypeInfo` back-filling in the covered path
-- parser-side call-argument pack expansion now preserves unmatched complex
-  `expr...` nodes until substitution instead of treating "no function-parameter
-  pack matched" as a successful expansion; that closes the standards-visible
-  leak where `typeCode<Rest>()...` in `add3(..., tail)` lost pack semantics
-  before sema could scalarize the bound template pack
-- deferred qualified/member-template calls now preserve explicit template
-  arguments, parser return-type hints, and dependent-qualified lookup records
-  as separate metadata so later semantic resolution can replay the correct
-  lookup instead of inheriting a parser-selected callee as final meaning
-- deferred namespace-qualified explicit-template calls now preserve exact
-  definition-bound replay metadata only when the visible function-template
-  candidate is unique and no exact specialization is registered for that same
-  qualified template name, so specialization-first lookup remains available
-  during later instantiation
-- the unqualified/current-owner explicit-member-template placeholder path in
-  `Parser_Expr_PrimaryExpr.cpp` now preserves the same split for deferred
-  class-scope member-template calls: it keeps a structured current-
-  instantiation `DependentQualifiedNameRecord`, and parser return-type hints
-  now come from the matched current-owner member-template declaration instead
-  of whichever unrelated same-name global template happened to be found first
-- the remaining dependent owner-template/member-template placeholder builders
-  in `Parser_Expr_PrimaryExpr.cpp` now also share one deferred qualified-call
-  materializer, so they preserve the structured dependent-qualified record,
-  exact template-argument AST, and any unambiguous exact qualified
-  member-template return-type hint instead of diverging across four separate
-  compatibility-only exits
-- sema now distinguishes real type owners from namespace qualifiers before it
-  consumes definition-bound compatibility metadata for qualified direct calls,
-  which fixes current-instantiation nested-owner cases like
-  `Runner<T>::Ops::read(value)` being stolen by an unrelated global
-  `Ops<T>::read`
-- explicit qualified member-template calls now preserve the full nested owner
-  identity in the parser/materialization layer when the owner spelling names a
-  real nested owner, so `Ops::template read<int>(value)` inside `Runner<T>`
-  no longer rebinds through an unrelated global `Ops<T>::read`
-- that owner recovery now also walks enclosing nested class/member-function
-  contexts from inner to outer, so a nested class body can still resolve an
-  owner declared on the enclosing current instantiation through the same
-  explicit qualified member-template path
-- that owner rewrite is now constrained to true nested-owner extensions only
-  (for example `Runner<int>::Ops` from `Ops`), preventing alias/self-owner
-  qualified calls from being eagerly collapsed onto unrelated concrete owner
-  names while still closing the standards-visible collision above
-- instantiated template class members now preserve function-pointer member
-  signatures through alias/template-argument recovery plus source
-  `StructTypeInfo` fallback, closing the standards-visible gap where indirect
-  calls through concrete function-pointer data members lost their return
-  signature during materialization
-- postfix function-pointer member-call placeholders now synthesize the real
-  return type from the member signature instead of carrying a fake scalar
-  return, so overload resolution on calls like `pick(this->callback())`
-  follows the actual C++ type system
-- `.*` / `->*` member-function-pointer postfix calls now preserve the pointed-
-  to return shape and parser return-type hint through template-body
-  materialization instead of degrading to fake scalar placeholders
-- member-function-pointer template arguments now preserve declaring-class
-  identity through substitution/materialization, MSVC mangling now covers
-  member-function-pointer cv/ref/noexcept qualifiers plus ordinary
-  pointer-to-member declarator forms, and `_Is_memfunptr`-style partial
-  specializations now deduce the owner class instead of treating it as opaque
-  text
-- qualified-owner parser lookup now has the first shared
-  `ResolvedQualifiedOwner` carrier and resolver entrypoint. The deferred
-  qualified-call resolver, qualified member-template parser path, and postfix
-  explicit-qualified member-template placeholder path consume it for current-
-  instantiation classification and nested-owner canonicalization, keeping that
-  standards-sensitive owner split out of per-call-site string reconstruction.
-- `ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(...)` now
-  also consumes the shared `ResolvedQualifiedOwner` current-context
-  classification before materializing dependent qualified owners, reducing the
-  remaining substitution-side duplication of parser owner canonicalization.
-- constexpr qualified member access and sema qualified-call target recovery
-  now also consult that same resolved-owner result before their
-  consumer-specific dependent-record prefix-chain and overload recovery logic,
-  so all currently identified consumers share the parser-owned
-  current-instantiation owner classification.
+- definition-bound non-dependent lookup in covered template bodies
+- semantic receiver-sensitive overload resolution for ordinary member calls,
+  `operator[]`, and callable `operator()`
+- viable direct-call conversion checks instead of parser-only optimistic
+  struct-to-scalar matches
+- structured direct-call metadata for covered ordinary, namespace-qualified,
+  dependent-unqualified, qualified/member-template, operator function-id,
+  postfix declaration-address, receiver-call, and function-pointer paths
+- deferred qualified/member-template calls preserving explicit template
+  arguments, dependent-qualified owner records, and parser return-type hints
+- current-instantiation and nested-owner qualified lookup split consistently
+  across parser, substitution, constexpr, and sema entry points via
+  `ResolvedQualifiedOwner`
+- identity-first replay/sync for the covered primary-template,
+  specialization, nested-class, constructor, and member-template paths
+- pack expansion preservation until substitution for unmatched complex call
+  expansions
+- member-function-pointer template arguments preserving declaring-class
+  identity through substitution/materialization and MSVC mangling
+- builtin type template arguments canonicalized for the MSVC `<type_traits>`
+  `is_integral_v` fundamental character type fold
 
-## Highest-value remaining standards gaps
+## Remaining standards gaps
 
-### 1. Replay must stay invariant-driven
+### 1. Standard-header failures
 
-The remaining standards risk is no longer textual dependent-name recovery. It
-is replay/materialization paths that may still succeed or sync through weak
-name/arity evidence instead of source identity plus canonical substituted
-signatures.
+The next conformance work should be driven by the remaining expected-failure
+standard-header tests:
 
-Why this matters:
+- `tests/std/test_cstddef.cpp`
+- `tests/std/test_cstdio_puts.cpp`
+- `tests/std/test_cstdlib.cpp`
 
-- replay that succeeds through shape-based repair can silently select the wrong
-  declaration
-- those weak paths tend to reopen non-conforming fallback behavior later in
-  sema or codegen
+Treat these as the active frontier. Run them individually, capture the first
+failure, and trace the standard rule involved before editing. Likely failure
+areas may include preprocessing/header modeling, builtin declarations, namespace
+lookup, constexpr evaluation, or remaining template argument materialization
+gaps. Do not preselect the layer.
 
-Near-term remaining scope:
+### 2. Deeper dependent-qualified owner materialization
 
-- in-loop member-function / constructor registration inside
-  `Parser::try_instantiate_class_template()` is now unified locally, so the
-  next cleanup target in this area is the remaining out-of-line replay/sync
-  helper duplication rather than more registration drift
-- top-level replay-driven `StructTypeInfo` sync now uses shared
-  identity-first helpers for plain members and constructors; the remaining
-  duplication is in nested/member-template-specific attachment paths that do
-  not all route through those helpers yet
-- partial-specialization constructor copies now use the same
-  source-member-to-`StructTypeInfo` index map as the primary-template path,
-  and the nested/member-template replay sites that already preserve a matched
-  source declaration now route through the shared identity-first helpers too
-- partial-specialization nested member-template replay now also syncs the
-  `StructTypeInfo` copy through the shared identity-first helper once the
-  matched source declaration is preserved
-- the previously highest-value replay/sync identity gaps for covered
-  member-template and nested constructor-template replay are now closed; any
-  remaining work in this bucket should be driven by a concrete uncovered
-  attachment failure rather than treated as the default next slice
+The direct owner-classification migration is complete for the identified parser
+and consumer entry points. Further extraction is only justified by a concrete
+failure showing that duplicate materialization still causes non-conforming
+behavior.
 
-### 2. Compatibility recovery is still covering direct-call metadata loss outside dependent-unqualified completion
+If needed, the next abstraction should return a shared resolved owner and
+member-prefix-chain result from a `DependentQualifiedNameRecord`, including:
 
-Dependent-unqualified replay/materialization now preserves both the
-definition-bound ordinary lookup and the final point-of-instantiation target.
-The remaining compatibility risk is therefore narrower: other instantiated
-ordinary direct calls can still lose structured semantic evidence and fall back
-to mangled-name recovery instead of carrying their final lookup result
-directly.
+- rebound owner-template arguments
+- materialized member-template prefix segments
+- current-instantiation vs unknown-specialization classification
+- canonical owner type/name for later ordinary member lookup and explicit
+  member-template lookup
 
-Latest progress:
+### 3. Replay identity edge cases
 
-- sema now consumes the structured `FunctionDeclarationNode*` already stored in
-  definition-lookup and dependent-unqualified records before considering
-  mangled-name canonicalization
-- the highest-traffic non-dependent ordinary direct-call branches now preserve
-  `FunctionCallDefinitionLookupRecord` directly, including unqualified
-  overload-resolution in template bodies and namespace-qualified direct calls
-- concrete template-origin ordinary direct calls in non-template bodies now
-  preserve that same structured lookup record too, so sema can keep hard
-  ownership of normalized direct-call target selection instead of accepting a
-  parser-selected compatibility fallback for wrapper-style calls
-- the covered qualified/direct template-instantiation branches now also share
-  a common concrete-function adoption rule, shrinking the remaining
-  branch-specific drift where wrapper instantiations could still erase
-  sema-owned call metadata before normalization
+Remaining replay work should be failure-driven. If a path still syncs
+`StructTypeInfo` copies through weak name/arity evidence, replace that path
+with source-member identity plus canonical substituted-signature matching.
 
-Why this matters:
+### 4. Member-object-pointer representation
 
-- a preserved mangled target is only a compatibility boundary
-- the real semantic model should still know why the call is definition-bound
-  and, when POI completion changes the winner, which final semantic target was
-  selected
-
-Remaining near-term scope:
-
-- the biggest ordinary identifier-call coupling is now gone: parse-time
-  return-type availability and final semantic call-target authority are
-  separated on the call node / lookup-record boundary instead of being tied to
-  a parser-selected callee
-- the remaining compatibility boundary is now concentrated in other parser
-  materialization paths that still carry only `mangled_name` or
-  `qualified_name`, especially niche qualified/member-template materializers
-  that do not yet route through the same deferred-lookup model; the main
-  postfix qualified/member fast paths plus the direct operator/declaration-
-  address non-receiver paths are now covered too, and the main concrete
-  receiver-call builders plus template-parameter function-pointer call
-  materialization are covered as well, and the explicit-qualified postfix
-  member/operator placeholder builders are now covered too, and ordinary
-  function-pointer member postfix placeholders plus the `.*` / `->*`
-  member-function-pointer fast paths now preserve the real return shape, and
-  the shared qualified static-owner helper no longer relies on a same-arity
-  shape match for its non-template fallback or drops structured owner metadata
-  just because the owner `StructTypeInfo` is already present, so the remaining
-  work is no longer that whole pointer-to-member surface; it is
-  the smaller set of still-uncovered placeholder/materializer exits plus the
-  canonical `TypeCategory::MemberObjectPointer` carrier gap where the
-  underlying member type is not yet preserved strongly enough for every
-  ABI-sensitive consumer
-- the just-fixed qualified-owner collision confirms the right ownership split:
-  non-template qualified calls must first decide whether the left-hand side is
-  a type owner or a namespace qualifier, and only then may compatibility
-  records participate; the old parser helper branch that did ordinary
-  static-member recovery inside `resolveDeferredQualifiedTemplateCall(...)` is
-  now gone, so the remaining work in this sub-area is preserving structured
-  semantic metadata in the qualified/member-template materializers that still
-  stop at compatibility-only records after that owner split
-- the explicit qualified member-template nested-owner collision is now closed
-  at the parser/materialization source rather than by adding a later semantic
-  compatibility branch; the old ordinary static-member recovery branch in
-  `resolveDeferredQualifiedTemplateCall(...)` is now gone too, and the main
-  postfix qualified/member parser path now preserves structured call metadata
-  as well, so the remaining work in this sub-area is the narrower set of
-  parser/materialization sites that still stop at compatibility metadata even
-  after the owner resolution has succeeded
-- the newly-covered current-owner explicit-member-template path confirms that
-  short class-scope spellings must follow the same rule too: deferred
-  `pick<int>(...)`-style calls inside a current instantiation cannot source
-  parser-time return-type visibility from an unrelated
-  `lookupAllTemplates(...)` result once the matching member-template owner is
-  already known
-- the newly-covered generic namespace-qualified explicit-template path confirms
-  the same rule for specialization-aware lookup: preserving a unique parse-time
-  primary template declaration is only conforming when no exact specialization
-  is registered for that qualified template name. Otherwise deferred
-  instantiation must remain free to select the explicit specialization first,
-  as in `ns::sum<Args...>()` with `template<> sum<int>()`
-- the postfix explicit-qualified member/operator path now follows the same rule
-  for concrete owner-qualified member-template ids: `this->Base::template pick<int>()`
-  and `this->Base::template operator()<int>()` now parse and instantiate through
-  the base-qualified owner instead of failing before overload selection
-- the unresolved explicit-base member-template placeholder in that postfix path
-  is now structural as well: `this->Base::template pick<T>()` preserves the
-  recovered base owner as deferred qualified metadata, keeps the matched
-  member-template return type on the placeholder instead of a raw `auto` stub,
-  and substitution instantiates the concrete base-qualified member template
-  once `T` becomes concrete instead of rebinding by unqualified member name
-- the next standards-facing cleanup in this bucket should be to route the
-  remaining ordinary template-instantiation call builders through the same
-  concrete-template direct-call record helper, then tighten the normalized
-  sema invariant so direct-call ownership always comes from structured lookup
-  records when parser-time resolution already succeeded; after the newly-
-  covered ordinary qualified/direct builders, the next likely targets are the
-  remaining member/callable-object template-instantiation exits that still
-  special-case bare `FunctionDeclarationNode` results
-- the sibling postfix explicit-qualified operator-template placeholder is now
-  structural too: short-owner `holder.Base::template operator()<int>()`
-  spellings canonicalize the nested owner before instantiation, preserve the
-  deferred qualified-owner record when parsing must remain deferred, and keep
-  the matched operator-template return type instead of letting a global
-  same-spelled owner satisfy the parse
-- the newly fixed explicit-template-argument pack-expansion leak confirms the
-  right layer for this class of problem: preserve the parser-only pack node
-  until substitution instead of teaching deeper sema/template-argument logic to
-  guess when a plain call expression was really meant to be expanded
-- the remaining whole-call sema synchronization hook for direct calls should
-  remain temporary; the remaining parser/materialization work should make even
-  that narrowed retry unnecessary by ensuring the structured call path already
-  owns the needed target and argument-conversion state
-
-### 3. Current-instantiation / unknown-specialization coverage
-
-This is still necessary, but it is no longer the immediate next task. Expand
-it only for concrete unresolved cases that block steps 1-2.
+If another pointer-to-member ABI/conformance failure appears, preserve the
+member object type explicitly in the canonical carrier rather than relying on
+declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Tighten the next remaining mangled-name compatibility path by preserving
-   structured direct-call metadata in the owning replay/materialization path
-   instead of relying on mangled recovery.
-
-Next direct-call target:
-
-- identify the remaining concrete direct-call builders outside the now-covered
-  postfix qualified/member helpers, then replace each typed case with
-  preserved structured target metadata before touching the sema fallback;
-  after the now-covered typed qualified-member, string-literal UDL, postfix
-  qualified/member, direct operator/declaration-address, and substitution-
-  materialization paths plus template-parameter function-pointer call
-  preservation, the `.*` / `->*` member-function-pointer pass, and
-  explicit-qualified postfix member/operator preservation, the next targets
-  are the remaining qualified/member-template compatibility-only materializers
-  plus any smaller placeholder builders that still return immediately without
-  a structured lookup record. The shared qualified static-owner helper is no
-  longer one of those weak spots: its non-template fallback now routes through
-  real static-member overload selection, and unresolved
-  template-instantiation owners keep structured owner metadata even when the
-  owner `StructTypeInfo` is already available
-
-2. Expand current-instantiation and unknown-specialization handling only where
-   it unblocks concrete replay or typed-lookup failures still remaining after
-   step 1.
-
-## Next steps
-
-1. Keep the parser/materialization side narrowed and move the next audit to
-   the consumer paths now that the remaining targeted
-   owner-template/member-template placeholder builders in
-   `Parser_Expr_PrimaryExpr.cpp` are covered too. The unqualified/current-owner
-   explicit-member-template placeholder path is now covered; it preserves
-   structured current-instantiation owner metadata and member-template-derived
-   parser return-type hints instead of deferring with only `qualified_name`.
-   The generic namespace-qualified explicit-template placeholder path is now
-   covered too, including the specialization-aware rule that suppresses exact
-   primary-template binding when a registered exact specialization must stay
-   visible; the concrete postfix explicit-qualified member/operator template-id
-   path without owner template arguments is now covered too, and the postfix
-   owner-template-id variant is covered as well: `parse_member_postfix()` now
-   preserves `Base<T>`-style owner template-ids through the `::template`
-   continuation for both member-template and operator-template calls instead
-   of dropping that structure before deferred lookup. The short-owner postfix
-   explicit-qualified operator-template placeholder is now covered too: nested
-   `Base::template operator()<int>()` spellings canonicalize the owner before
-   instantiation and preserve the same deferred qualified-owner metadata plus
-   parser return-type hints when parsing must stay deferred. The remaining
-   targeted deferred owner-template/member-template call builders in
-   `Parser_Expr_PrimaryExpr.cpp` now share the same structured deferred-call
-   helper too, so they no longer diverge on whether they preserve the
-   dependent-qualified record, template-argument AST, or exact qualified
-   member-template return-type hint. The next concrete audit target is
-   therefore `ExpressionSubstitutor.cpp`, constexpr, and the remaining
-   sema-qualified-call consumers: verify those paths consume the structured
-   deferred qualified metadata directly instead of re-splitting
-   `qualified_name` text or assuming the old missing-hint behavior. The
-   whole-call sema synchronization hook is now closed fully for this slice:
-   the qualified compatibility branch is gone, and the unrelated static-member
-   direct-call fallback in `resolveCallArgAnnotationTarget(...)` is removed as
-   well because the current-member static hiding regressions still resolve
-   correctly through the preserved definition-bound call metadata.
-2. If another pointer-to-member issue appears, close the remaining canonical
-   `TypeCategory::MemberObjectPointer` carrier gap by preserving the
-   underlying member type explicitly instead of relying on declarator-shaped
-   `member_class + pointer_depth` forms in ABI-sensitive paths.
-3. The parser-diagnostics follow-up exposed by this area is now covered too:
-   `parse_copy_initialization(...)` and `parse_direct_initialization(...)`
-   both preserve nested expression / qualified-call failures instead of
-   collapsing them to generic wrapper errors, and the dedicated `_fail`
-   anchors `test_copy_init_nested_qualified_call_error_fail.cpp` and
-   `test_direct_init_nested_qualified_call_error_fail.cpp` now keep that
-   behavior pinned.
-4. Keep replay/identity and broader
-   current-instantiation/unknown-specialization work in reserve for concrete
-   failures; the remaining conformance pressure is now centered on the last
-   parser compatibility boundaries rather than on broad replay drift.
+1. Fix the next concrete standard-header failure, starting with
+   `test_cstddef.cpp`.
+2. Add a focused non-std regression for the exposed rule when practical.
+3. Only extract deeper dependent-qualified owner materialization if that failure
+   proves the current consumer-specific prefix-chain handling is the blocker.
+4. Keep replay identity and member-object-pointer work opportunistic unless a
+   concrete regression points there.
 
 ## Standards rules for follow-up work
 
 - do not normalize textual reconstruction as acceptable semantics
-- prefer hard failure or proper diagnostics over silent repair in normalized
+- prefer hard failure or correct diagnostics over silent repair in normalized
   semantic flows
 - keep compatibility behavior explicit, narrow, and temporary
-- treat codegen-side recovery as debt to remove, not as architecture
-- when a late retry is still necessary, route it through typed semantic lookup
-  instead of rebuilding intent from strings or shallow shape matches
+- treat codegen-side recovery as debt to remove, not architecture
+- when a late retry is required, route it through typed semantic lookup or a
+  structured record rather than string/shape reconstruction
 
 ## Validation guidance
 
-For work in this area, rerun:
+For standard-conformance work, run:
 
-- the focused regression that motivated the slice
-- `test_template_ool_member_template_operator_identity_ret0.cpp`
-- `test_template_nested_ool_ctor_template_same_name_overload_ret0.cpp`
-- `test_template_nested_ool_ctor_template_outer_inner_param_rename_ret42.cpp`
-- `test_template_nested_ool_ctor_template_init_replay_ret42.cpp`
-- `template_lookup_non_dependent_no_rebind_ret0.cpp`
-- `test_template_explicit_function_id_definition_bound_ret0.cpp`
-- `test_template_current_member_static_hides_base_overload_ret0.cpp`
-- `test_template_current_member_static_hides_base_enum_conversion_ret0.cpp`
-- `test_template_qualified_member_template_hides_base_overload_ret0.cpp`
-- `test_template_qualified_static_member_same_arity_decltype_ret0.cpp`
+- the focused regression or std-header test that motivated the slice
+- adjacent template/lookup guards for the touched layer
+- `.\build_flashcpp.bat`
+- `pwsh ./tests/run_all_tests.ps1`
+
+Common adjacent guards:
+
 - `test_member_template_func_in_specialization_ret0.cpp`
-- `test_template_current_member_explicit_template_decltype_ret0.cpp`
+- `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
+- `test_sema_resolved_qualified_owner_template_nested_collision_ret0.cpp`
+- `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`
+- `test_var_template_replay_dependent_member_template_call_ret0.cpp`
 - `test_template_disambiguation_pack_ret40.cpp`
-- `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
-- `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
-- `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
-- `test_template_qualified_namespace_explicit_definition_bound_ret0.cpp`
-- `test_template_global_qualified_namespace_explicit_definition_bound_ret0.cpp`
-- `test_template_qualified_namespace_explicit_runtime_definition_bound_ret0.cpp`
-- `test_template_explicit_base_member_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_operator_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_operator_template_decltype_ret0.cpp`
-- `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`
-- `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`
-- `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`
-- `test_template_dependent_unqualified_mangled_recovery_ret0.cpp`
-- `test_template_dependent_unqualified_member_replay_ret0.cpp`
-- `test_template_dependent_unqualified_poi_adl_record_ret42.cpp`
-- `test_template_qualified_direct_call_inner_return_overload_ret0.cpp`
-- `test_template_dependent_unqualified_direct_call_nonviable_fail.cpp`
-- `test_operator_subscript_sema_receiver_and_arg_overload_ret0.cpp`
-- `test_operator_subscript_const_ambiguity_fail.cpp`
-- `test_constexpr_operator_bracket_const_nonconst_ret0.cpp`
-- `test_subscript_pointer_conversion_template_ret42.cpp`
-- full `pwsh tests/run_all_tests.ps1` before considering the slice complete
-
-## Next steps
-
-1. Continue eliminating compatibility-only parser metadata in the remaining
-   resolved direct-call sites, now focusing on the qualified/member-template
-   materializers that still have not adopted the deferred lookup + parser
-   return-type hint split.
-   Immediate follow-up: move those paths onto the same model now used by
-   untyped ordinary calls, and keep
-   `test_template_static_constexpr_dependent_hidden_friend_ret0.cpp` in the
-   guard set so parser-time constexpr users never again need a parser-selected
-   callee for return-type visibility. The old ordinary-static-member
-   compatibility branch in `resolveDeferredQualifiedTemplateCall(...)` is now
-   removed, and constexpr qualified direct calls reuse the same sema-owned
-   type-owner / namespace-qualifier split with explicit current-type fallback
-   for class-scope evaluation. The substitution-time qualified/member-template
-   materializer now also rebuilds `FunctionCallDefinitionLookupRecord` once the
-   substituted call is concrete, and the shared
-   `try_parse_member_template_function_call(...)` helper now uses real static-
-   member overload resolution plus structured deferred owner metadata instead of
-   a same-arity fallback. The current-owner explicit-member-template
-   placeholder path in `Parser_Expr_PrimaryExpr.cpp` is now on that model too:
-   it preserves a structured current-instantiation owner record and sources its
-   parser return-type hint from the matched member-template declaration instead
-   of an unrelated global template. This slice closes
-   the explicit-base postfix member-template placeholder and the sibling
-   postfix explicit-qualified operator-template placeholder: short nested-owner
-   `Base::template operator()<int>()` spellings no longer instantiate against
-   a global same-spelled owner during trailing `decltype(...)` parsing, and
-   deferred cases preserve the same structured owner metadata plus parser
-   return-type hints as the member-template branch. It also closes the
-   remaining compatibility-only explicit owner-qualified placeholder exits in
-   `Parser_Expr_PostfixCalls.cpp`, and `ExpressionSubstitutor.cpp` now consumes
-   those preserved owner records first instead of rebuilding meaning from
-   `qualified_name` text. That direct-call follow-up is now closed for the
-   remaining targeted non-receiver qualified builders in
-   `Parser_Expr_PrimaryExpr.cpp`: the global-qualified and namespace-qualified
-   explicit-function-id paths now use the same helper-based
-   definition-record preservation and parser return-type hints as the ordinary
-   direct-call path instead of stopping at compatibility `qualified_name` /
-   `mangled_name` metadata. The namespace-qualified operator function-id
-   helper and the leading global-qualified `::operator...` parser entry now
-   follow that same resolved/deferred qualified-call metadata model too, with
-   `test_template_namespace_qualified_operator_definition_bound_ret0.cpp`
-   and
-   `test_template_global_qualified_operator_definition_bound_ret0.cpp`
-   guarding the direct definition-bound paths. That last unrelated static-
-   member whole-call sema synchronization leg is now closed too, so the
-   remaining work in this area is no longer another in-slice compatibility
-   cleanup. Keep
-   `Parser_Expr_PostfixCalls.cpp`, `ExpressionSubstitutor.cpp`, and the
-   direct-call sema path in audit mode only for regressions that expose a
-   still-unstructured qualified/member-template materializer.
-   Immediate focused follow-up under that item:
-   the nested-owner explicit member-template instantiation bug is now fixed and
-   guarded by
-   `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
-   plus the multi-segment owner-chain regression
-   `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
-   and the enclosing-scope nested-class regression
-   `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`.
-   The new focused guard for class-scope constexpr nested-owner recovery is
-   `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`.
-   The new focused guard for current-owner explicit-member-template deferred
-   target preservation is
-   `test_template_current_member_explicit_template_decltype_ret0.cpp`.
-   The new focused guard for substitution-time qualified explicit-template
-   target preservation is
-   `test_template_qualified_explicit_function_id_definition_bound_ret0.cpp`.
-   The new focused guard for postfix qualified direct-call target preservation
-   is
-   `test_template_namespace_qualified_explicit_function_id_definition_bound_ret0.cpp`.
-   The new focused guards for non-receiver concrete-call target preservation
-   are `test_template_direct_operator_definition_bound_ret0.cpp` and
-   `test_template_postfix_address_call_definition_bound_ret0.cpp`.
-   The new focused guards for concrete receiver-call metadata preservation are
-   `test_template_postfix_call_operator_default_arg_ret0.cpp` and
-   `test_template_implicit_this_member_call_default_arg_ret0.cpp`.
-   The new focused guard for template-parameter function-pointer target
-   preservation is
-   `test_template_function_pointer_nttp_definition_bound_ret0.cpp`.
-   The new focused guards for explicit-qualified postfix member/operator target
-   preservation are
-   `test_template_explicit_base_member_call_default_arg_ret0.cpp`,
-   `test_template_explicit_base_operator_call_default_arg_ret0.cpp`,
-   `test_template_explicit_base_operator_template_decltype_ret0.cpp`,
-   `test_template_explicit_base_operator_template_nested_owner_collision_ret0.cpp`,
-   `test_template_explicit_base_owner_template_member_template_call_default_arg_ret0.cpp`,
-   and
-   `test_template_explicit_base_owner_template_operator_template_call_default_arg_ret0.cpp`.
-   The focused guard for the concrete-owner "candidate-bearing but not yet
-   parser-resolved" rule is
-   `test_member_template_func_in_specialization_ret0.cpp`.
-   The new focused guard for variable-template replay preserving the full
-   nested owner chain into the eventual direct-call target is
-   `test_var_template_replay_dependent_member_template_call_ret0.cpp`.
-   The member-function-pointer fast-path surface is now covered, including the
-   `.*` / `->*` postfix path, MSVC ABI mangling for member-function-pointer
-   qualifiers, and `_Is_memfunptr`-style owner-class deduction in partial
-   specializations. The remaining alias/materialization cluster from this slice
-   is now fixed too: direct non-deferred alias rebinding is again preferred for
-   simple aliases, which preserves concrete pointer/cv/ref surface modifiers
-   through plain and member alias templates. Focused guards:
-   `test_alias_template_pointer_modifiers_ret0.cpp`,
-   `test_alias_const_ptr_ret42.cpp`,
-   `test_alias_ptrptr_ret42.cpp`,
-   `test_alias_template_comprehensive_ret70.cpp`,
-   `test_alias_two_pointers_ret30.cpp`, and
-   `test_member_template_alias_ret250.cpp`. The full regular suite now passes
-   again via `pwsh ./tests/run_all_tests.ps1`. As cleanup on top of that
-   functional fix, the branch now centralizes definition-preferred
-   qualified-owner member lookup in `MemberFunctionLookupShared.h`, reuses
-   `TemplateArgumentMaterialization.h` for the remaining qualified-id
-   template-argument materialization path, and removes the helper header from
-   the vcxproj lists. The next concrete target in this
-   investigation is now adoption of the new shared structured qualified-owner
-   resolver before more standards-conformance growth. The first
-   `ResolvedQualifiedOwner` entrypoint keeps requested spelling, lookup
-   spelling, current-instantiation classification, nested-owner-extension
-   rewriting, and resolved `TypeInfo` together for the parser deferred-call
-   and postfix explicit-qualified member-template paths, and the substitutor,
-   constexpr, and sema consumer entry points now consume the same
-   current-instantiation owner classification. The remaining owner work is a
-   deeper extraction only if a future failure proves that
-   `DependentQualifiedNameRecord` owner-template argument rebinding or
-   member-prefix chain materialization must move into a shared helper too.
-   Until then, the next standards-conformance target shifts back outside the
-   green suite: the remaining expected-failure coverage
-   (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
-   future canonical member-object-pointer carrier gap if another ABI-sensitive
-   failure exposes it.
-   Long-term direction: replace these per-call-site parser repairs with one
-   shared structured qualified-owner representation plus a single resolver used
-   by both parser materialization and later sema fallback, so future
-   qualified/member-template paths do not regress by rebuilding owner meaning
-   from short spellings.
-   Standard-header follow-up: the builtin type template-argument surface is now
-   canonicalized in `TemplateArgumentMaterialization.h`. Parser substitution,
-   expression substitution, and constexpr variable-template evaluation all
-   share the same builtin spelling/category conversion instead of rebuilding
-   concrete type arguments from local strings or empty tokens. This is required
-   by the C++20 distinct fundamental character types and unblocks the
-   `is_any_of_v<remove_cv_t<T>, ...>` boolean fold used by MSVC
-   `<type_traits>` for `is_integral_v`. New guard:
-   `test_variable_template_fold_remove_cv_builtin_list_ret0.cpp`; focused std
-   validation: `std/test_std_type_traits.cpp`.
-   In parallel with that audit, finish deleting the remaining legacy
-   parser-side `expr...` loops that still duplicate pack-expansion behavior
-   instead of routing through the shared helper and the new "preserve when not
-   truly expandable" rule.
-
-2. Use any concrete failures left after step 1 to drive the next
-   current-instantiation / unknown-specialization expansion rather than
-   widening that model preemptively.
+- `std/test_std_type_traits.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -233,6 +233,15 @@ blocking areas:
   explicit-qualified member-template placeholder path consume it for current-
   instantiation classification and nested-owner canonicalization, keeping that
   standards-sensitive owner split out of per-call-site string reconstruction.
+- `ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(...)` now
+  also consumes the shared `ResolvedQualifiedOwner` current-context
+  classification before materializing dependent qualified owners, reducing the
+  remaining substitution-side duplication of parser owner canonicalization.
+- constexpr qualified member access and sema qualified-call target recovery
+  now also consult that same resolved-owner result before their
+  consumer-specific dependent-record prefix-chain and overload recovery logic,
+  so all currently identified consumers share the parser-owned
+  current-instantiation owner classification.
 
 ## Highest-value remaining standards gaps
 
@@ -646,15 +655,14 @@ For work in this area, rerun:
    `ResolvedQualifiedOwner` entrypoint keeps requested spelling, lookup
    spelling, current-instantiation classification, nested-owner-extension
    rewriting, and resolved `TypeInfo` together for the parser deferred-call
-   and postfix explicit-qualified member-template paths. Extend that result to
-   consume `DependentQualifiedNameRecord`
-   owner-template arguments and member-prefix chains, then make the explicit
-   member-template path, ordinary qualified-member path, constexpr member
-   access, and later sema fallback consume the same resolved-owner object
-   instead of re-canonicalizing owner meaning from `baseTemplateName()`,
-   instantiation patterns, or placeholder spellings. Once those consumers are
-   on the shared layer, the next standards-conformance target shifts back
-   outside the green suite: the remaining expected-failure coverage
+   and postfix explicit-qualified member-template paths, and the substitutor,
+   constexpr, and sema consumer entry points now consume the same
+   current-instantiation owner classification. The remaining owner work is a
+   deeper extraction only if a future failure proves that
+   `DependentQualifiedNameRecord` owner-template argument rebinding or
+   member-prefix chain materialization must move into a shared helper too.
+   Until then, the next standards-conformance target shifts back outside the
+   green suite: the remaining expected-failure coverage
    (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) and any
    future canonical member-object-pointer carrier gap if another ABI-sensitive
    failure exposes it.

--- a/src/ConstExprEvaluator_MemberAccess.cpp
+++ b/src/ConstExprEvaluator_MemberAccess.cpp
@@ -319,6 +319,17 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 					}
 				}
 				if (dependent_record->owner_name.isValid()) {
+					if (context.parser != nullptr) {
+						Parser::ResolvedQualifiedOwner resolved_owner =
+							context.parser->resolveQualifiedOwnerForLookup(
+								StringTable::getStringView(
+									dependent_record->owner_name));
+						if (resolved_owner.resolved_from_current_context &&
+							resolved_owner.lookupNameHandle().isValid()) {
+							return materializeOwnerMemberChainPrefix(
+								resolved_owner.lookupNameHandle());
+						}
+					}
 					return materializeOwnerMemberChainPrefix(dependent_record->owner_name);
 				}
 				if (context.struct_info != nullptr && context.struct_info->name.isValid()) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1084,20 +1084,19 @@ ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
 					if (candidate_owner_name.empty()) {
 						return false;
 					}
-					if (std::optional<Parser::AliasTemplateMaterializationResult>
-							current_context_owner =
-								parser_.tryResolveQualifiedTypeOwnerFromCurrentContext(
-									candidate_owner_name);
-						current_context_owner.has_value()) {
-						if (current_context_owner->resolved_type_info != nullptr) {
+					Parser::ResolvedQualifiedOwner current_context_owner =
+						parser_.resolveQualifiedOwnerForLookup(
+							candidate_owner_name);
+					if (current_context_owner.resolved_from_current_context) {
+						if (current_context_owner.type_info != nullptr) {
 							materialized_owner =
 								parser_.materializeCanonicalOwnerTypeForLookup(
-									*current_context_owner->resolved_type_info,
+									*current_context_owner.type_info,
 									owner_args);
-						} else if (!current_context_owner->instantiated_name.empty()) {
+						} else if (!current_context_owner.lookup_name.empty()) {
 							materialized_owner =
 								parser_.resolveCanonicalInstantiatedOwnerForLookup(
-									current_context_owner->instantiated_name,
+									current_context_owner.lookup_name,
 									owner_args);
 						}
 						if (!materialized_owner.instantiated_name.empty() ||

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -4848,16 +4848,12 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						parsed_qualified_name.substr(0, parsed_scope_sep);
 					const std::string_view member_name =
 						parsed_qualified_name.substr(parsed_scope_sep + 2);
-					if (std::optional<AliasTemplateMaterializationResult> resolved_owner =
-							tryResolveQualifiedTypeOwnerFromCurrentContext(
-								owner_name);
-						resolved_owner.has_value() &&
-						isNestedOwnerExtension(
-							owner_name,
-							resolved_owner->instantiated_name)) {
+					ResolvedQualifiedOwner resolved_owner =
+						resolveQualifiedOwnerForLookup(owner_name);
+					if (resolved_owner.resolved_as_nested_owner_extension) {
 						resolved_qualified_name =
 							StringBuilder()
-								.append(resolved_owner->instantiated_name)
+								.append(resolved_owner.lookup_name)
 								.append("::")
 								.append(member_name)
 								.commit();

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8167,6 +8167,27 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			}
 		}
 
+		Parser::ResolvedQualifiedOwner resolved_owner =
+			parser().resolveQualifiedOwnerForLookup(owner_name);
+		if (resolved_owner.type_info != nullptr) {
+			if (const TypeInfo* resolved_struct_owner =
+					tryResolveStructOwnerTypeInfo(resolved_owner.type_info);
+				resolved_struct_owner != nullptr) {
+				return resolved_struct_owner;
+			}
+		}
+		if (!resolved_owner.lookup_name.empty() &&
+			resolved_owner.lookup_name != owner_name) {
+			if (const TypeInfo* resolved_lookup_owner =
+					tryResolveStructOwnerTypeInfo(
+						findTypeByName(
+							StringTable::getOrInternStringHandle(
+								resolved_owner.lookup_name)));
+				resolved_lookup_owner != nullptr) {
+				return resolved_lookup_owner;
+			}
+		}
+
 		auto resolve_type_info = [&](StringHandle handle) -> const TypeInfo* {
 			auto it = getTypesByNameMap().find(handle);
 			return it != getTypesByNameMap().end() ? it->second : nullptr;


### PR DESCRIPTION
## Summary
- route the remaining qualified-owner consumer entry points through `ResolvedQualifiedOwner`
- update `ExpressionSubstitutor`, constexpr qualified member access, sema qualified-call recovery, and the remaining parser direct-call rewrite to share parser-owned current-instantiation owner classification
- update the template-argument planning docs with the completed consumer migration and the next standards-frontier direction

## Why
PR #1779 introduced the shared qualified-owner resolver but left consumer-side owner classification duplicated. This moves those consumers onto the shared entry point while leaving consumer-specific dependent-record prefix-chain and template-argument materialization logic in place.

## Validation
- `./build_flashcpp.bat`
- focused qualified-owner/substitution/constexpr/sema regression set
- `pwsh ./tests/run_all_tests.ps1` (2707 regular tests passed, 229 expected-fail tests failed as expected)

## Next
The direct consumer migration is now complete. The next useful slice should move back to the standard-header frontier (`test_cstddef.cpp`, `test_cstdio_puts.cpp`, `test_cstdlib.cpp`) unless a concrete future failure proves that `DependentQualifiedNameRecord` owner-template argument rebinding or member-prefix chain materialization needs to be extracted into a deeper shared helper.