### PR TITLE
[codex] Preserve inline metadata for std header wrappers

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-30
+**Last updated:** 2026-07-02
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -37,6 +37,11 @@ identity-preserving behavior:
 - builtin type template arguments are canonicalized through
   `TemplateArgumentMaterialization.h`, covering the MSVC `<type_traits>`
   `is_integral_v` fundamental-character-type fold shape
+- ordinary function declarations now preserve the C++ `inline` specifier through
+  parser copies and IR metadata; COFF emission gives C-linkage inline
+  definitions local/static symbol storage so UCRT wrapper definitions do not
+  collide with CRT library symbols while C++ inline header helpers remain
+  emitted
 
 ## Architectural invariants
 
@@ -55,21 +60,29 @@ Follow-up work should preserve these rules:
 
 ## Remaining architectural gaps
 
-### 1. Standard-header frontier
+### 1. Standard-header tracking cleanup
 
-The green core suite is no longer blocked by the qualified-owner/direct-call
-metadata work. The next high-value target is the remaining standard-header
-expected-failure frontier:
+The previously listed standard-header frontier is green on the current Windows
+baseline:
 
 - `tests/std/test_cstddef.cpp`
 - `tests/std/test_cstdio_puts.cpp`
 - `tests/std/test_cstdlib.cpp`
 
-Start by running each focused test and identifying the first compiler failure.
-Use the actual failure to decide whether the next slice belongs in
-preprocessing, namespace/header modeling, template argument materialization,
-constexpr evaluation, or semantic lookup. Do not assume the next failure is in
-qualified-owner infrastructure.
+The concrete blocker was `<cstdio>` link failure from strong definitions of
+MSVC UCRT C-linkage inline wrappers such as `vsnprintf`, `snprintf`, and
+`sprintf_s`. The parser now preserves ordinary `inline` metadata and codegen
+emits C-linkage inline definitions as local COFF symbols rather than public
+external definitions. Keep C++ inline header helpers emitted;
+`std/test_std_type_traits.cpp` depends on that for helpers such as
+`std::_Fnv1a_append_bytes`.
+
+The next high-value cleanup is to remove any remaining expected-failure
+classification for these three tests in the test harness or CI metadata, then
+use the next live standard-header failure as the driver. Do not assume it is in
+template-owner infrastructure; trace whether it belongs in preprocessing,
+namespace/header modeling, template argument materialization, constexpr
+evaluation, semantic lookup, or object/linkage emission.
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -107,13 +120,15 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Start with the standard-header frontier:
-   `test_cstddef.cpp`, `test_cstdio_puts.cpp`, then `test_cstdlib.cpp`.
-2. For the first concrete failure, trace the real layer responsible before
+1. Promote `test_cstddef.cpp`, `test_cstdio_puts.cpp`, and `test_cstdlib.cpp`
+   out of expected-failure tracking wherever the runner/CI records that status.
+2. Run the std-header subset again and identify the next concrete failing
+   header or harness mismatch.
+3. For the first concrete failure, trace the real layer responsible before
    editing.
-3. Add a focused regression that captures the standards-visible behavior outside
+4. Add a focused regression that captures the standards-visible behavior outside
    the std-header test when practical.
-4. Keep docs updates last and update this section with the next concrete
+5. Keep docs updates last and update this section with the next concrete
    frontier after validation.
 
 ## Validation guidance

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -77,12 +77,16 @@ external definitions. Keep C++ inline header helpers emitted;
 `std/test_std_type_traits.cpp` depends on that for helpers such as
 `std::_Fnv1a_append_bytes`.
 
-The next high-value cleanup is to remove any remaining expected-failure
-classification for these three tests in the test harness or CI metadata, then
-use the next live standard-header failure as the driver. Do not assume it is in
-template-owner infrastructure; trace whether it belongs in preprocessing,
-namespace/header modeling, template argument materialization, constexpr
-evaluation, semantic lookup, or object/linkage emission.
+This is a targeted COFF fix, not complete inline linkage architecture. Proper
+cross-translation-unit COFF inline semantics should move inline definitions into
+deduplicatable per-function COMDAT/weak-external sections once the object writer
+can split the current monolithic `.text` section by function.
+
+The next high-value cleanup is to use the next live standard-header failure as
+the driver. Do not assume it is in template-owner infrastructure; trace whether
+it belongs in preprocessing, namespace/header modeling, template argument
+materialization, constexpr evaluation, semantic lookup, or object/linkage
+emission.
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -66,11 +66,15 @@ library also provides the C-linkage symbol. FlashCpp's current targeted behavior
 is to retain and emit C++ inline header helpers when needed, while giving
 C-linkage inline definitions local COFF symbol storage.
 
-The next standards-facing task is test-tracking cleanup plus discovery: remove
-the stale expected-failure classification for these three tests, run the std
-subset again, and let the next concrete failure choose the layer. Likely future
-areas may include preprocessing/header modeling, builtin declarations, namespace
-lookup, constexpr evaluation, template argument materialization, or object/link
+This is enough for the current Windows standard-header frontier, but it is not
+the final C++20 linkage model. A later object-writer slice should replace the
+local-symbol workaround with per-function COFF COMDAT/weak-external emission so
+inline definitions deduplicate correctly across translation units.
+
+The next standards-facing task is discovery: run the std subset again and let
+the next concrete failure choose the layer. Likely future areas may include
+preprocessing/header modeling, builtin declarations, namespace lookup,
+constexpr evaluation, template argument materialization, or object/link
 semantics. Do not preselect the layer.
 
 ### 2. Deeper dependent-qualified owner materialization

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-06-30
+**Last updated:** 2026-07-02
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -45,23 +45,33 @@ The core suite now covers several formerly blocking standards-visible areas:
   identity through substitution/materialization and MSVC mangling
 - builtin type template arguments canonicalized for the MSVC `<type_traits>`
   `is_integral_v` fundamental character type fold
+- ordinary `inline` function metadata preserved through parser copies and IR,
+  with COFF C-linkage inline definitions emitted as local/static symbols to
+  avoid duplicate CRT definitions while preserving emitted C++ inline helpers
 
 ## Remaining standards gaps
 
-### 1. Standard-header failures
+### 1. Standard-header tracking and next failure discovery
 
-The next conformance work should be driven by the remaining expected-failure
-standard-header tests:
+The formerly active expected-failure standard-header tests now compile, link,
+and run on the current Windows baseline:
 
 - `tests/std/test_cstddef.cpp`
 - `tests/std/test_cstdio_puts.cpp`
 - `tests/std/test_cstdlib.cpp`
 
-Treat these as the active frontier. Run them individually, capture the first
-failure, and trace the standard rule involved before editing. Likely failure
+`test_cstdio_puts.cpp` exposed the relevant rule: C++ inline definitions in
+headers must not be emitted as ordinary strong external definitions when a CRT
+library also provides the C-linkage symbol. FlashCpp's current targeted behavior
+is to retain and emit C++ inline header helpers when needed, while giving
+C-linkage inline definitions local COFF symbol storage.
+
+The next standards-facing task is test-tracking cleanup plus discovery: remove
+the stale expected-failure classification for these three tests, run the std
+subset again, and let the next concrete failure choose the layer. Likely future
 areas may include preprocessing/header modeling, builtin declarations, namespace
-lookup, constexpr evaluation, or remaining template argument materialization
-gaps. Do not preselect the layer.
+lookup, constexpr evaluation, template argument materialization, or object/link
+semantics. Do not preselect the layer.
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -93,12 +103,13 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Fix the next concrete standard-header failure, starting with
-   `test_cstddef.cpp`.
-2. Add a focused non-std regression for the exposed rule when practical.
-3. Only extract deeper dependent-qualified owner materialization if that failure
+1. Remove stale expected-failure tracking for `test_cstddef.cpp`,
+   `test_cstdio_puts.cpp`, and `test_cstdlib.cpp`.
+2. Fix the next concrete standard-header failure exposed after that cleanup.
+3. Add a focused non-std regression for the exposed rule when practical.
+4. Only extract deeper dependent-qualified owner materialization if that failure
    proves the current consumer-specific prefix-chain handling is the blocker.
-4. Keep replay identity and member-object-pointer work opportunistic unless a
+5. Keep replay identity and member-object-pointer work opportunistic unless a
    concrete regression points there.
 
 ## Standards rules for follow-up work

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2873,6 +2873,11 @@ public:
 	void set_is_static(bool is_static) { is_static_ = is_static; }
 	bool is_static() const { return is_static_; }
 
+	// C++ inline specifier support. This is distinct from inline_always,
+	// which is an IR/codegen-only forced inlining marker.
+	void set_is_inline(bool is_inline) { is_inline_ = is_inline; }
+	bool is_inline() const { return is_inline_; }
+
 	// Const/volatile member function qualifiers (Itanium 'K'/'V' / MSVC QEBA/QECA)
 	void set_is_const_member_function(bool v) { is_const_member_function_ = v; }
 	bool is_const_member_function() const { return is_const_member_function_; }
@@ -2967,6 +2972,7 @@ private:
 	bool is_deleted_ = false;  // True if function is declared = delete
 	bool is_template_pattern_ = false;  // True for uninstantiated template pattern function nodes
 	bool is_static_ = false;	 // True if function is a static member function (no 'this' pointer)
+	bool is_inline_ = false;	 // True if function was declared with the C++ inline specifier
 	bool is_const_member_function_ = false;	// True if this function is a const member function (K qualifier)
 	bool is_volatile_member_function_ = false;  // True if this function is a volatile member function (V qualifier)
 	bool inline_always_ = false;	 // True if function should always be inlined (e.g., template pure expressions)

--- a/src/ElfFileWriter.h
+++ b/src/ElfFileWriter.h
@@ -106,7 +106,8 @@ public:
 	 * @brief Add a function symbol to the symbol table
 	 */
 	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset,
-							 [[maybe_unused]] uint32_t stack_space, [[maybe_unused]] Linkage linkage = Linkage::None) {
+							 [[maybe_unused]] uint32_t stack_space, [[maybe_unused]] Linkage linkage = Linkage::None,
+							 bool is_inline = false) {
 		if (g_enable_debug_output) {
 			std::cerr << "Adding function symbol: " << mangled_name
 					  << " at offset " << section_offset << std::endl;
@@ -125,7 +126,6 @@ public:
 
 		// Determine symbol binding based on whether the function is inline
 		// Inline functions need STB_WEAK so the linker can discard duplicates
-		bool is_inline = false;
 		auto it = function_signatures_.find(mangled_name);
 		if (it != function_signatures_.end()) {
 			is_inline = it->second.is_inline;

--- a/src/ElfFileWriter.h
+++ b/src/ElfFileWriter.h
@@ -106,8 +106,8 @@ public:
 	 * @brief Add a function symbol to the symbol table
 	 */
 	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset,
-							 [[maybe_unused]] uint32_t stack_space, [[maybe_unused]] Linkage linkage = Linkage::None,
-							 bool is_inline = false) {
+							 [[maybe_unused]] uint32_t stack_space, [[maybe_unused]] Linkage linkage,
+							 bool is_inline) {
 		if (g_enable_debug_output) {
 			std::cerr << "Adding function symbol: " << mangled_name
 					  << " at offset " << section_offset << std::endl;
@@ -128,7 +128,7 @@ public:
 		// Inline functions need STB_WEAK so the linker can discard duplicates
 		auto it = function_signatures_.find(mangled_name);
 		if (it != function_signatures_.end()) {
-			is_inline = it->second.is_inline;
+			is_inline = is_inline || it->second.is_inline;
 		}
 
 		// Add function symbol
@@ -364,9 +364,9 @@ public:
 	std::string_view addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage = Linkage::None, bool is_variadic = false);
 
 	// --- Method declarations (ElfFileWriter_FuncSig.cpp) ---
-	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline = false);
+	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline);
 	std::string_view addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage = Linkage::None, bool is_variadic = false);
-	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline = false);
+	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline);
 	void add_source_file(const std::string& filename);
 	void set_current_function_for_debug(const std::string& name, uint32_t file_id);
 	void add_line_mapping(uint32_t code_offset, uint32_t line_number);

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -7502,7 +7502,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 	current_function_prologue_offset_ = 0;
 
 	uint32_t func_offset = static_cast<uint32_t>(textSectionData.size());
-	writer.add_function_symbol(mangled_name, func_offset, total_stack_space, linkage);
+	writer.add_function_symbol(mangled_name, func_offset, total_stack_space, linkage, is_inline);
 	functionSymbols[std::string(func_name)] = func_offset;
 
 		// Track function for debug information

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -17093,7 +17093,7 @@ void IrToObjConverter<TWriterClass>::emit_dynamic_cast_check_function() {
 	uint32_t function_length = static_cast<uint32_t>(textSectionData.size()) - function_offset;
 
 		// Add function symbol (extern "C" linkage - no name mangling)
-	writer.add_function_symbol("__dynamic_cast_check", function_offset, 0, Linkage::C);
+	writer.add_function_symbol("__dynamic_cast_check", function_offset, 0, Linkage::C, /* is_inline */ false);
 	writer.update_function_length("__dynamic_cast_check", function_length);
 }
 
@@ -17138,7 +17138,7 @@ void IrToObjConverter<TWriterClass>::emit_dynamic_cast_throw_function() {
 	uint32_t function_length = static_cast<uint32_t>(textSectionData.size()) - function_offset;
 
 		// Add function symbol (extern "C" linkage - no name mangling)
-	writer.add_function_symbol("__dynamic_cast_throw_bad_cast", function_offset, 0, Linkage::C);
+	writer.add_function_symbol("__dynamic_cast_throw_bad_cast", function_offset, 0, Linkage::C, /* is_inline */ false);
 	writer.update_function_length("__dynamic_cast_throw_bad_cast", function_length);
 }
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -407,7 +407,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 	if (!current_namespace_stack_.empty()) {
 		is_in_std_namespace = (current_namespace_stack_[0] == "std");
 	}
-	func_decl_op.is_inline = node.is_member_function() || is_in_std_namespace;
+	func_decl_op.is_inline = node.is_inline() || node.is_member_function() || is_in_std_namespace;
 
 	// Use pre-computed mangled name from AST node if available (Phase 6 migration)
 	// Fall back to generating it here if not (for backward compatibility during migration)

--- a/src/ObjFileWriter.h
+++ b/src/ObjFileWriter.h
@@ -487,7 +487,7 @@ public:
 	// --- Method declarations (ObjFileWriter_Symbols.cpp) ---
 	std::string addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage = Linkage::None, bool is_variadic = false);
 	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline = false);
-	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage = Linkage::None);
+	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage = Linkage::None, bool is_inline = false);
 	void add_static_text_symbol(std::string_view symbol_name, uint32_t section_offset);
 	void add_data(std::span<const uint8_t> data, SectionType section_type);
 	void add_data(std::span<const char> data, SectionType section_type);

--- a/src/ObjFileWriter.h
+++ b/src/ObjFileWriter.h
@@ -476,7 +476,7 @@ public:
 	}
 
 	// Overload that accepts pre-computed mangled name (for function definitions from IR)
-	void addFunctionSignature([[maybe_unused]] std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline = false) {
+	void addFunctionSignature([[maybe_unused]] std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline) {
 		FunctionSignature sig(return_type, parameter_types);
 		sig.linkage = linkage;
 		sig.is_variadic = is_variadic;
@@ -486,8 +486,8 @@ public:
 
 	// --- Method declarations (ObjFileWriter_Symbols.cpp) ---
 	std::string addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage = Linkage::None, bool is_variadic = false);
-	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline = false);
-	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage = Linkage::None, bool is_inline = false);
+	void addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, std::string_view class_name, Linkage linkage, bool is_variadic, std::string_view mangled_name, bool is_inline);
+	void add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage, bool is_inline);
 	void add_static_text_symbol(std::string_view symbol_name, uint32_t section_offset);
 	void add_data(std::span<const uint8_t> data, SectionType section_type);
 	void add_data(std::span<const char> data, SectionType section_type);

--- a/src/ObjFileWriter_Symbols.cpp
+++ b/src/ObjFileWriter_Symbols.cpp
@@ -28,13 +28,13 @@ void ObjectFileWriter::addFunctionSignature([[maybe_unused]] std::string_view na
 	function_signatures_[std::string(mangled_name)] = sig;
 }
 
-void ObjectFileWriter::add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage) {
+void ObjectFileWriter::add_function_symbol(std::string_view mangled_name, uint32_t section_offset, uint32_t stack_space, Linkage linkage, bool is_inline) {
 	if (g_enable_debug_output)
 		std::cerr << "Adding function symbol: " << mangled_name << " at offset " << section_offset << " with linkage " << static_cast<int>(linkage) << std::endl;
 	auto section_text = coffi_.get_sections()[sectiontype_to_index[SectionType::TEXT]];
 	auto symbol_func = coffi_.add_symbol(mangled_name);
 	symbol_func->set_type(IMAGE_SYM_TYPE_FUNCTION);
-	symbol_func->set_storage_class(IMAGE_SYM_CLASS_EXTERNAL);
+	symbol_func->set_storage_class(is_inline && linkage == Linkage::C ? IMAGE_SYM_CLASS_STATIC : IMAGE_SYM_CLASS_EXTERNAL);
 	symbol_func->set_section_number(section_text->get_index() + 1);
 	symbol_func->set_value(section_offset);
 

--- a/src/ObjectFileCommon.h
+++ b/src/ObjectFileCommon.h
@@ -133,7 +133,7 @@ concept FileWriter = requires(T writer,
 							  std::span<const UnwindMapEntryInfo> unwind_map,
 							  std::span<const SehTryBlockInfo> seh_try_blocks) {
 		// Core function management
-	writer.add_function_symbol(name, offset, size, linkage);
+	writer.add_function_symbol(name, offset, size, linkage, false);
 	writer.finalize_current_function();
 	writer.finalize_debug_info();
 

--- a/src/ObjectFileCommon.h
+++ b/src/ObjectFileCommon.h
@@ -133,7 +133,7 @@ concept FileWriter = requires(T writer,
 							  std::span<const UnwindMapEntryInfo> unwind_map,
 							  std::span<const SehTryBlockInfo> seh_try_blocks) {
 		// Core function management
-	writer.add_function_symbol(name, offset, size, linkage, false);
+	writer.add_function_symbol(name, offset, size, linkage, /* is_inline */ false);
 	writer.finalize_current_function();
 	writer.finalize_debug_info();
 

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -673,6 +673,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 			func_node.set_is_constexpr(is_constexpr);
 			func_node.set_is_constinit(is_constinit);
 			func_node.set_is_consteval(is_consteval);
+			func_node.set_is_inline(is_inline);
 		}
 
 		// Continue with function-specific logic

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -566,6 +566,7 @@ void Parser::copy_function_properties(FunctionDeclarationNode& dest, const Funct
 	dest.set_is_variadic(src.is_variadic());
 	dest.set_is_deleted(src.is_deleted());
 	dest.set_is_static(src.is_static());
+	dest.set_is_inline(src.is_inline());
 	dest.set_is_const_member_function(src.is_const_member_function());
 	dest.set_is_volatile_member_function(src.is_volatile_member_function());
 	dest.set_is_implicit(src.is_implicit());
@@ -732,6 +733,9 @@ ParseResult Parser::parse_function_declaration_with_storage_specs(
 	func_ref.set_is_variadic(params.is_variadic);
 	if (storage_specs.is_static()) {
 		func_ref.set_is_static(true);
+	}
+	if (storage_specs.is_inline) {
+		func_ref.set_is_inline(true);
 	}
 	if (auto signature_result = validateOperatorSignature(func_ref, is_member);
 		signature_result.is_error()) {

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -1094,6 +1094,7 @@ ParseResult Parser::create_function_from_header(
 	// Set constexpr/consteval
 	func_ref.set_is_constexpr(header.storage.is_constexpr());
 	func_ref.set_is_consteval(header.storage.is_consteval());
+	func_ref.set_is_inline(header.storage.is_inline);
 
 	return func_node;
 }

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -91,6 +91,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 		const bool is_member = !struct_parsing_context_stack_.empty();
 		FlashCpp::StorageSpecifiers storage_specs;
 		storage_specs.storage_class = specs.storage_class;
+		storage_specs.is_inline = specs.is_inline;
 		auto func_result = parse_function_declaration_with_storage_specs(
 			decl_node,
 			CallingConvention::Default,
@@ -114,6 +115,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	func_decl.set_is_constexpr(is_constexpr);
 	func_decl.set_is_consteval(is_consteval);
 	func_decl.set_is_constinit(is_constinit);
+	func_decl.set_is_inline(specs.is_inline);
 	// Static storage class: needed for static member function templates so that
 	// codegen omits the implicit 'this' parameter and the call site doesn't pass one.
 	if (specs.storage_class == StorageClass::Static) {

--- a/tests/run_all_tests.ps1
+++ b/tests/run_all_tests.ps1
@@ -205,9 +205,6 @@ Write-Host ""
 #
 # Unimplemented features:
 $expectedCompileFailures = @(
-	"test_cstddef.cpp"
-	"test_cstdio_puts.cpp"
-	"test_cstdlib.cpp"
 )
 
 # Expected link failures - files that compile but have known link issues


### PR DESCRIPTION
## Summary
- preserve ordinary C++ inline metadata through parser copies, template functions, and IR
- pass inline metadata into object emission and make COFF C-linkage inline definitions local/static instead of public external symbols
- promote the now-green `<cstddef>`, `<cstdio>`, and `<cstdlib>` tests out of expected-failure tracking
- update the template-argument planning docs with the completed std-header frontier and next steps

## Root Cause
`<cstdio>` pulled in UCRT C-linkage inline wrapper definitions such as `vsnprintf`, `snprintf`, and `sprintf_s`. FlashCpp emitted those wrapper bodies as ordinary public external COFF symbols, colliding with the CRT library definitions at link time.