### PR TITLE
Template metadata, constexpr if, and constraint handling

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -8,6 +8,14 @@ appears to be a default-constructed `ConstructorDeclarationNode` whose `InlineVe
 data pointer is never initialized — the Sharded build's different TU arrangement
 happens to zero the memory. See `Parser_Templates_Inst_MemberFunc.cpp:1394`.
 
+## Dependent template pointer argument `sizeof` mismatch
+`tests/test_dependent_template_pointer_arg_ret0.cpp` returns 16 instead of 0.
+The `WrongOuterIntPointerTag` bit is set, meaning `Outer<int>::getPointerTag()`
+(which returns `Wrapper<T*>::tag` = `sizeof(int*)`) produces an incorrect value.
+The `T*` dependent template argument is not being correctly resolved when used
+in a `sizeof` inside a member function of a class template. This is a pre-existing
+issue unrelated to the lazy member body deferral fix.
+
 ## Missing ambiguity diagnostics in overload resolution
 Some overload sets that are ill-formed in standard C++20 due to ambiguity are not
 consistently diagnosed as compile errors yet.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -8,14 +8,6 @@ appears to be a default-constructed `ConstructorDeclarationNode` whose `InlineVe
 data pointer is never initialized — the Sharded build's different TU arrangement
 happens to zero the memory. See `Parser_Templates_Inst_MemberFunc.cpp:1394`.
 
-## Dependent template pointer argument `sizeof` mismatch
-`tests/test_dependent_template_pointer_arg_ret0.cpp` returns 16 instead of 0.
-The `WrongOuterIntPointerTag` bit is set, meaning `Outer<int>::getPointerTag()`
-(which returns `Wrapper<T*>::tag` = `sizeof(int*)`) produces an incorrect value.
-The `T*` dependent template argument is not being correctly resolved when used
-in a `sizeof` inside a member function of a class template. This is a pre-existing
-issue unrelated to the lazy member body deferral fix.
-
 ## Missing ambiguity diagnostics in overload resolution
 Some overload sets that are ill-formed in standard C++20 due to ambiguity are not
 consistently diagnosed as compile errors yet.

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1965,6 +1965,9 @@ std::optional<ASTNode> ExpressionSubstitutor::tryEvaluateConcreteConceptCall(con
 			return std::nullopt;
 		}
 	}
+	if (templateArgsStillDependent(*concrete_args)) {
+		return std::nullopt;
+	}
 
 	const ConstraintEvaluationResult constraint_result =
 		evaluateConstraint(concept_opt->as<ConceptDeclarationNode>(), *concrete_args, &parser_);

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3130,6 +3130,15 @@ public:	// Public methods for template instantiation
 		const ASTNode& node,
 		const TemplateInstantiationContext& context);
 
+	// Helper to substitute template parameters in lazy member function/constructor/destructor bodies
+	// Uses the stored outer template environment snapshot from lazy_info
+	ASTNode substituteLazyMemberBody(
+		const ASTNode& body,
+		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args,
+		const TemplateEnvironmentSnapshot& outer_snapshot,
+		StringHandle instantiated_owner_name);
+
 	// Helper to extract type from an expression for overload resolution.
 	// Public so codegen/constexpr consumers can reuse the parser's type deduction.
 	std::optional<TypeSpecifierNode> get_expression_type(const ASTNode& expr_node);

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -1543,10 +1543,10 @@ ParseResult Parser::parse_if_statement() {
 	// Skip C++20 [[likely]]/[[unlikely]] attributes on if branches
 	skip_cpp_attributes();
 
-	// For if constexpr during template body re-parsing with parameter packs,
-	// evaluate the condition at compile time and skip the dead branch
-	// (which may contain ill-formed code like unexpanded parameter packs)
-	if (is_constexpr && has_parameter_packs_ && condition.node().has_value()) {
+	// For if constexpr, evaluate the condition at parse time when possible and
+	// skip the dead branch. The discarded branch may be ill-formed for the
+	// selected specialization.
+	if (is_constexpr && condition.node().has_value()) {
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
 		auto eval_result = ConstExpr::Evaluator::evaluate(*condition.node(), eval_ctx);
 		if (eval_result.success()) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2063,23 +2063,34 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
+	// Defer body materialization only when we are inside a constraint/SFINAE
+	// probing context.  In a real (HardUse) instantiation the dependent-looking
+	// template args (e.g. a defaulted U = typename wrapper<T>::type where T is
+	// already bound to int) will be resolved by the lazy member function
+	// substitution path, so suppressing the body here would leave the emitted
+	// symbol with an unresolved dependent return type and cause a link error.
 	if (materialize_body) {
-		const bool has_dependent_template_arg =
-			std::ranges::any_of(template_args, [](const TemplateTypeArg& arg) {
-				if (arg.is_dependent ||
-					arg.dependent_name.isValid() ||
-					arg.dependent_expr.has_value()) {
-					return true;
-				}
-				if (!arg.is_value && arg.type_index.is_valid()) {
-					if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-						return arg_type_info->isDependentPlaceholder();
+		const TemplateSubstitutionFailurePolicy failure_policy =
+			currentTemplateSubstitutionFailurePolicy();
+		if (failure_policy == TemplateSubstitutionFailurePolicy::ShapeOnly ||
+			failure_policy == TemplateSubstitutionFailurePolicy::SfinaeProbe) {
+			const bool has_dependent_template_arg =
+				std::ranges::any_of(template_args, [](const TemplateTypeArg& arg) {
+					if (arg.is_dependent ||
+						arg.dependent_name.isValid() ||
+						arg.dependent_expr.has_value()) {
+						return true;
 					}
-				}
-				return false;
-			});
-		if (has_dependent_template_arg) {
-			materialize_body = false;
+					if (!arg.is_value && arg.type_index.is_valid()) {
+						if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+							return arg_type_info->isDependentPlaceholder();
+						}
+					}
+					return false;
+				});
+			if (has_dependent_template_arg) {
+				materialize_body = false;
+			}
 		}
 	}
 	const StringHandle current_owner_type_name = StringTable::getOrInternStringHandle(struct_name);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2063,6 +2063,25 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const TemplateFunctionDeclarationNode& template_func = template_node.as<TemplateFunctionDeclarationNode>();
 	const auto& template_params = template_func.template_parameters();
 	const FunctionDeclarationNode& func_decl = template_func.function_decl_node();
+	if (materialize_body) {
+		const bool has_dependent_template_arg =
+			std::ranges::any_of(template_args, [](const TemplateTypeArg& arg) {
+				if (arg.is_dependent ||
+					arg.dependent_name.isValid() ||
+					arg.dependent_expr.has_value()) {
+					return true;
+				}
+				if (!arg.is_value && arg.type_index.is_valid()) {
+					if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+						return arg_type_info->isDependentPlaceholder();
+					}
+				}
+				return false;
+			});
+		if (has_dependent_template_arg) {
+			materialize_body = false;
+		}
+	}
 	const StringHandle current_owner_type_name = StringTable::getOrInternStringHandle(struct_name);
 	const OuterTemplateBinding* outer_binding =
 		gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view());

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -3699,10 +3699,17 @@ ASTNode Parser::substitute_template_params_in_expression(
 	StringHandle substitution_owner) {
 	auto makeSubstitutedTypeNode =
 		[&](const TemplateTypeArg& arg, const Token& token) {
+		// Pointers are always 64 bits on x64 regardless of the pointee type.
+		// Using get_type_size_bits(arg.category()) alone would give the base
+		// type size (e.g. 32 for int) instead of the pointer size (64) when
+		// the template argument carries pointer modifiers (e.g. T* where T=int).
+		int size_bits = arg.pointer_depth > 0
+			? 64
+			: get_type_size_bits(arg.category());
 		TypeSpecifierNode new_type(
 			arg.typeEnum(),
 			TypeQualifier::None,
-			get_type_size_bits(arg.category()),
+			size_bits,
 			token,
 			arg.cv_qualifier);
 		new_type.set_type_index(arg.type_index);
@@ -4013,10 +4020,14 @@ ASTNode Parser::substitute_template_params_in_expression(
 
 				// Create a new type node with the substituted type
 				const TemplateTypeArg& arg = it->second;
+				// Pointers are always 64 bits on x64 regardless of the pointee type.
+				int size_bits = arg.pointer_depth > 0
+					? 64
+					: get_type_size_bits(arg.category());
 				TypeSpecifierNode new_type(
 					arg.typeEnum(),
 					TypeQualifier::None,
-					get_type_size_bits(arg.category()),
+					size_bits,
 					unop.get_token(), CVQualifier::None);
 				// Apply cv-qualifiers, references, and pointers from template argument
 				new_type.set_reference_qualifier(arg.ref_qualifier);

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -222,27 +222,42 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 					param_type_spec,
 					param_type_index);
 
+				const TemplateTypeArg* direct_template_arg =
+					findTemplateArgByName(
+						param_type_spec.token().value(),
+						lazy_info.template_params,
+						lazy_info.template_args);
 				TypeSpecifierNode substituted_param_type(
 					param_type_index.category(),
 					param_type_spec.qualifier(),
 					get_type_size_bits(param_type_index.category()),
 					param_decl.identifier_token(),
-					param_type_spec.cv_qualifier());
+					direct_template_arg != nullptr
+						? direct_template_arg->cv_qualifier
+						: param_type_spec.cv_qualifier());
 				substituted_param_type.set_type_index(param_type_index);
-				for (const auto& ptr_level : param_type_spec.pointer_levels()) {
-					substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
+				if (direct_template_arg != nullptr) {
+					for (CVQualifier ptr_cv : direct_template_arg->pointer_cv_qualifiers) {
+						substituted_param_type.add_pointer_level(ptr_cv);
+					}
+				} else {
+					for (const auto& ptr_level : param_type_spec.pointer_levels()) {
+						substituted_param_type.add_pointer_level(ptr_level.cv_qualifier);
+					}
 				}
-				substituted_param_type.set_reference_qualifier(param_type_spec.reference_qualifier());
+				substituted_param_type.set_reference_qualifier(
+					direct_template_arg != nullptr
+						? direct_template_arg->ref_qualifier
+						: param_type_spec.reference_qualifier());
 				if (param_type_spec.has_function_signature()) {
 					substituted_param_type.set_function_signature(param_type_spec.function_signature());
 				} else if (param_type_index.category() == TypeCategory::FunctionPointer ||
 						   param_type_index.category() == TypeCategory::MemberFunctionPointer) {
 					// The original param_type_spec is a dependent placeholder (e.g. "F")
 					// that has no function_signature.  Look up the concrete TemplateTypeArg.
-					if (const auto* arg = findTemplateArgByName(param_type_spec.token().value(),
-																lazy_info.template_params, lazy_info.template_args)) {
-						if (arg->function_signature.has_value())
-							substituted_param_type.set_function_signature(*arg->function_signature);
+					if (direct_template_arg != nullptr) {
+						if (direct_template_arg->function_signature.has_value())
+							substituted_param_type.set_function_signature(*direct_template_arg->function_signature);
 					}
 				}
 				normalizeSubstitutedTypeSpec(substituted_param_type);
@@ -282,47 +297,52 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				lazy_info.identity.instantiated_owner_name);
 		};
 
-		for (const auto& init : ctor_decl.member_initializers()) {
-			new_ctor_ref.add_member_initializer(init.member_name, substituteInitExpr(init.initializer_expr));
-		}
-		// Helper: substitute a single initializer argument, expanding PackExpansionExprNode
-		// into multiple arguments when present.  Mirrors the eager path's substituteInitArg.
-		auto substituteInitArg = [&](const ASTNode& arg, std::vector<ASTNode>& out) {
-			if (arg.is<ExpressionNode>()) {
-				const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
-				if (const auto* pack_exp = std::get_if<PackExpansionExprNode>(&arg_expr)) {
-					ChunkedVector<ASTNode> expanded;
-					if (expandPackExpansionArgs(*pack_exp, lazy_info.template_params, converted_template_args, expanded)) {
-						for (size_t ei = 0; ei < expanded.size(); ++ei) {
-							out.push_back(expanded[ei]);
+		{
+			FlashCpp::SymbolTableScope ctor_initializer_scope(ScopeType::Function);
+			register_parameters_in_scope(new_ctor_ref.parameter_nodes());
+
+			for (const auto& init : ctor_decl.member_initializers()) {
+				new_ctor_ref.add_member_initializer(init.member_name, substituteInitExpr(init.initializer_expr));
+			}
+			// Helper: substitute a single initializer argument, expanding PackExpansionExprNode
+			// into multiple arguments when present.  Mirrors the eager path's substituteInitArg.
+			auto substituteInitArg = [&](const ASTNode& arg, std::vector<ASTNode>& out) {
+				if (arg.is<ExpressionNode>()) {
+					const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
+					if (const auto* pack_exp = std::get_if<PackExpansionExprNode>(&arg_expr)) {
+						ChunkedVector<ASTNode> expanded;
+						if (expandPackExpansionArgs(*pack_exp, lazy_info.template_params, converted_template_args, expanded)) {
+							for (size_t ei = 0; ei < expanded.size(); ++ei) {
+								out.push_back(expanded[ei]);
+							}
+							return;
 						}
-						return;
 					}
 				}
-			}
-			out.push_back(substituteInitExpr(arg));
-		};
+				out.push_back(substituteInitExpr(arg));
+			};
 
-		for (const auto& init : ctor_decl.base_initializers()) {
-			std::vector<ASTNode> substituted_args;
-			substituted_args.reserve(init.arguments.size());
-			for (const auto& arg : init.arguments) {
-				substituteInitArg(arg, substituted_args);
+			for (const auto& init : ctor_decl.base_initializers()) {
+				std::vector<ASTNode> substituted_args;
+				substituted_args.reserve(init.arguments.size());
+				for (const auto& arg : init.arguments) {
+					substituteInitArg(arg, substituted_args);
+				}
+				new_ctor_ref.add_base_initializer(
+					resolveBaseInitializerNameForTemplateArgs(
+						init.getBaseClassName(),
+						lazy_info.template_params,
+						converted_template_args),
+					std::move(substituted_args));
 			}
-			new_ctor_ref.add_base_initializer(
-				resolveBaseInitializerNameForTemplateArgs(
-					init.getBaseClassName(),
-					lazy_info.template_params,
-					converted_template_args),
-				std::move(substituted_args));
-		}
-		if (ctor_decl.delegating_initializer().has_value()) {
-			std::vector<ASTNode> substituted_del_args;
-			substituted_del_args.reserve(ctor_decl.delegating_initializer()->arguments.size());
-			for (const auto& arg : ctor_decl.delegating_initializer()->arguments) {
-				substituteInitArg(arg, substituted_del_args);
+			if (ctor_decl.delegating_initializer().has_value()) {
+				std::vector<ASTNode> substituted_del_args;
+				substituted_del_args.reserve(ctor_decl.delegating_initializer()->arguments.size());
+				for (const auto& arg : ctor_decl.delegating_initializer()->arguments) {
+					substituteInitArg(arg, substituted_del_args);
+				}
+				new_ctor_ref.set_delegating_initializer(std::move(substituted_del_args));
 			}
-			new_ctor_ref.set_delegating_initializer(std::move(substituted_del_args));
 		}
 		new_ctor_ref.set_is_implicit(ctor_decl.is_implicit());
 		new_ctor_ref.set_is_explicitly_defaulted(ctor_decl.is_explicitly_defaulted());

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -40,6 +40,29 @@ TemplateEnvironment buildLazySubstitutionEnvironment(
 
 } // namespace
 
+ASTNode Parser::substituteLazyMemberBody(
+	const ASTNode& body,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args,
+	const TemplateEnvironmentSnapshot& outer_snapshot,
+	StringHandle instantiated_owner_name) {
+	std::optional<TemplateEnvironment> outer_environment;
+	TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
+		outer_snapshot,
+		template_params,
+		template_args,
+		outer_environment);
+	FlashCpp::TemplateParameterScope template_scope;
+	registerTypeParamsInScope(substitution_environment, template_scope, true);
+	FlashCpp::ScopedState guard_subs(template_param_substitutions_);
+	populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
+	return substituteTemplateParameters(
+		body,
+		template_params,
+		template_args,
+		instantiated_owner_name);
+}
+
 std::optional<ASTNode> Parser::instantiateLazyMemberIfNeeded(const LazyMemberKey& member_key) {
 	if (!member_key.hasExactConstness()) {
 		std::optional<ASTNode> first_instantiated;
@@ -418,10 +441,11 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			return std::nullopt;
 		}
 
-		ASTNode substituted_body = substituteTemplateParameters(
+		ASTNode substituted_body = substituteLazyMemberBody(
 			*body_to_substitute,
 			lazy_info.template_params,
 			converted_template_args,
+			lazy_info.outer_template_environment_snapshot,
 			lazy_info.identity.instantiated_owner_name);
 		new_ctor_ref.set_definition(substituted_body);
 		new_ctor_ref.set_mangled_name(NameMangling::generateMangledNameFromNode(
@@ -575,10 +599,11 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			new_dtor_ref.set_noexcept(dtor_decl.is_noexcept());
 		}
 
-		ASTNode substituted_body = substituteTemplateParameters(
+		ASTNode substituted_body = substituteLazyMemberBody(
 			*dtor_decl.get_definition(),
 			lazy_info.template_params,
 			converted_template_args,
+			lazy_info.outer_template_environment_snapshot,
 			lazy_info.identity.instantiated_owner_name);
 		new_dtor_ref.set_definition(substituted_body);
 
@@ -893,19 +918,18 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		FlashCpp::ScopedState guard_current_function(current_function_);
 		current_function_ = &new_func_ref;
 		register_parameters_in_scope(new_func_ref.parameter_nodes());
-		FlashCpp::ScopedState guard_subs(template_param_substitutions_);
+		ASTNode substituted_body = substituteLazyMemberBody(
+			*body_to_substitute,
+			std::span<const TemplateParameterNode>(substitution_params.data(), substitution_params.size()),
+			std::span<const TemplateTypeArg>(converted_template_args.data(), converted_template_args.size()),
+			lazy_info.outer_template_environment_snapshot,
+			lazy_info.identity.instantiated_owner_name);
 		std::optional<TemplateEnvironment> outer_environment;
 		TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
 			lazy_info.outer_template_environment_snapshot,
 			std::span<const TemplateParameterNode>(substitution_params.data(), substitution_params.size()),
 			std::span<const TemplateTypeArg>(converted_template_args.data(), converted_template_args.size()),
 			outer_environment);
-		populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
-		ASTNode substituted_body = substituteTemplateParameters(
-			*body_to_substitute,
-			substitution_params,
-			converted_template_args,
-			lazy_info.identity.instantiated_owner_name);
 		ExpressionSubstitutor owner_substitutor(substitution_environment, *this);
 		owner_substitutor.setCurrentOwnerTypeName(lazy_info.identity.instantiated_owner_name);
 		substituted_body = owner_substitutor.substitute(substituted_body);

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1377,37 +1377,41 @@ ASTNode Parser::substituteTemplateParameters(
 				if (type_or_expr.is<TypeSpecifierNode>()) {
 					const TypeSpecifierNode& type_spec = type_or_expr.as<TypeSpecifierNode>();
 
-					// Check if this is a user-defined or struct type that matches a template parameter
-					if ((is_struct_type(type_spec.category()))) {
-						if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
-							std::string_view type_name = StringTable::getStringView(type_info->name());
-							bool substituted_sizeof_type = false;
-							std::optional<ASTNode> substituted_sizeof_node;
+					// Try to find a matching template parameter and evaluate sizeof directly.
+					// This handles both struct types (matched by name) and non-struct dependent
+					// types (matched by type_index) where the template arg carries pointer_depth.
+					if (type_spec.type_index().is_valid()) {
+						bool substituted_sizeof_type = false;
+						std::optional<ASTNode> substituted_sizeof_node;
+						forEachNonPackTemplateParamArgBinding(
+							template_params,
+							template_args,
+							[&](const TemplateParameterNode& tparam, const TemplateTypeArg& arg, size_t) {
+								if (substituted_sizeof_type || !arg.isTypeArgument())
+									return;
+								// Match by name (struct types) or by type_index (dependent types)
+								const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
+								if (type_info == nullptr)
+									return;
+								std::string_view type_name = StringTable::getStringView(type_info->name());
+								if (tparam.name() != type_name && type_info->type_index_ != arg.type_index)
+									return;
 
-							forEachNonPackTemplateParamArgBinding(
-								template_params,
-								template_args,
-								[&](const TemplateParameterNode& tparam, const TemplateTypeArg& arg, size_t) {
-									if (substituted_sizeof_type || tparam.name() != type_name || !arg.isTypeArgument())
-										return;
-
-									size_t type_size = getSubstitutedTemplateArgumentSizeInBytes(arg);
-									if (type_size == 0) {
-										return;
-									}
-									StringBuilder size_builder;
-									std::string_view size_str = size_builder.append(type_size).commit();
-									Token literal_token(Token::Type::Literal, size_str,
-														sizeof_expr.sizeof_token().line(), sizeof_expr.sizeof_token().column(),
-														sizeof_expr.sizeof_token().file_index());
-									substituted_sizeof_node = emplace_node<ExpressionNode>(
-										NumericLiteralNode(literal_token, static_cast<unsigned long long>(type_size),
-														   TypeCategory::UnsignedLongLong, TypeQualifier::None, 64));
-									substituted_sizeof_type = true;
-								});
-							if (substituted_sizeof_type)
-								return *substituted_sizeof_node;
-						}
+								size_t type_size = getSubstitutedTemplateArgumentSizeInBytes(arg);
+								if (type_size == 0)
+									return;
+								StringBuilder size_builder;
+								std::string_view size_str = size_builder.append(type_size).commit();
+								Token literal_token(Token::Type::Literal, size_str,
+													sizeof_expr.sizeof_token().line(), sizeof_expr.sizeof_token().column(),
+													sizeof_expr.sizeof_token().file_index());
+								substituted_sizeof_node = emplace_node<ExpressionNode>(
+									NumericLiteralNode(literal_token, static_cast<unsigned long long>(type_size),
+													   TypeCategory::UnsignedLongLong, TypeQualifier::None, 64));
+								substituted_sizeof_type = true;
+							});
+						if (substituted_sizeof_type)
+							return *substituted_sizeof_node;
 					}
 
 					// Otherwise, recursively substitute the type node
@@ -1594,6 +1598,8 @@ ASTNode Parser::substituteTemplateParameters(
 
 	} else if (node.is<TypeSpecifierNode>()) {
 		const TypeSpecifierNode& type_spec = node.as<TypeSpecifierNode>();
+		FLASH_LOG(Templates, Debug, "  substituteTemplateParameters TypeSpecifierNode: cat=", static_cast<int>(type_spec.category()),
+			" token='", type_spec.token().value(), "' pointer_depth=", static_cast<int>(type_spec.pointer_depth()));
 		const auto makeTypeSpecifierFromTemplateArg = [&](const TemplateTypeArg& arg) -> ASTNode {
 			Token substituted_token = type_spec.token();
 			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
@@ -1686,12 +1692,14 @@ ASTNode Parser::substituteTemplateParameters(
 			}
 		}
 
-		// Check if this is a user-defined type that matches a template parameter
+		// Check if this is a user-defined type that matches a template parameter,
+		// or a dependent placeholder type (built-in category with placeholder type_index).
 		if (type_spec.category() == TypeCategory::UserDefined ||
 			type_spec.category() == TypeCategory::Struct ||
 			type_spec.category() == TypeCategory::TypeAlias ||
 			type_spec.category() == TypeCategory::Template ||
-			type_spec.category() == TypeCategory::Auto) {
+			type_spec.category() == TypeCategory::Auto ||
+			typeSpecStillUsesDependentPlaceholder(type_spec)) {
 			const TemplateTypeArg* matched_direct_template_arg = nullptr;
 			bool exact_template_param_substituted = false;
 			std::optional<ASTNode> exact_template_param_node;

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -1067,6 +1067,9 @@ inline ReferenceQualifier collapseReferenceQualifiers(
 }
 
 inline int computeTemplateTypeArgSizeBits(const TemplateTypeArg& arg) {
+	if (arg.pointer_depth > 0 || arg.ref_qualifier != ReferenceQualifier::None) {
+		return 64;
+	}
 	if (is_struct_type(arg.category())) {
 		if (arg.type_index.is_valid()) {
 			const ResolvedAliasTypeInfo resolved_arg = resolveAliasTypeInfo(arg.type_index);
@@ -1082,7 +1085,11 @@ inline int computeTemplateTypeArgSizeBits(const TemplateTypeArg& arg) {
 		}
 		return 0;
 	}
-	return get_type_size_bits(arg.category());
+	int base_size = get_type_size_bits(arg.category());
+	if (arg.pointer_depth > 0) {
+		return 64;
+	}
+	return base_size;
 }
 
 inline uint8_t checkedPointerDepthToUint8(size_t pointer_depth) {

--- a/tests/test_if_constexpr_active_branch_invalid_fail.cpp
+++ b/tests/test_if_constexpr_active_branch_invalid_fail.cpp
@@ -1,0 +1,13 @@
+template <class T>
+int select_active_invalid_branch() {
+	if constexpr (true) {
+		T value{};
+		return value.operator->();
+	} else {
+		return 0;
+	}
+}
+
+int main() {
+	return select_active_invalid_branch<int>();
+}

--- a/tests/test_template_cpo_begin_requires_ret0.cpp
+++ b/tests/test_template_cpo_begin_requires_ret0.cpp
@@ -1,0 +1,33 @@
+template <class T>
+concept HasMemberBegin = requires(T value) {
+	value.begin();
+};
+
+struct BeginCpo {
+	template <class T>
+		requires HasMemberBegin<T>
+	auto operator()(T& value) const {
+		return value.begin();
+	}
+};
+
+inline constexpr BeginCpo begin_cpo{};
+
+template <class T>
+concept Range = requires(T value) {
+	begin_cpo(value);
+};
+
+template <class It>
+struct Subrange {
+	It first{};
+
+	It begin() {
+		return first;
+	}
+};
+
+int main() {
+	static_assert(Range<Subrange<int*>>, "CPO begin should satisfy range");
+	return 0;
+}

--- a/tests/test_template_member_ctor_dependent_to_address_ret0.cpp
+++ b/tests/test_template_member_ctor_dependent_to_address_ret0.cpp
@@ -1,0 +1,27 @@
+template <class T>
+T* local_to_address(T* value) {
+	return value;
+}
+
+template <class Ptr>
+auto local_to_address(const Ptr& value) {
+	return local_to_address(value.operator->());
+}
+
+template <class T>
+concept AnyIterator = true;
+
+template <class Element>
+struct SpanLike {
+	Element* data;
+
+	template <AnyIterator It>
+	SpanLike(It first, int) : data(local_to_address(first)) {
+	}
+};
+
+int main() {
+	int value = 7;
+	SpanLike<int> span(&value, 1);
+	return *span.data == 7 ? 0 : 1;
+}

--- a/tests/test_template_member_ctor_dependent_wrapped_to_address_ret0.cpp
+++ b/tests/test_template_member_ctor_dependent_wrapped_to_address_ret0.cpp
@@ -1,0 +1,32 @@
+template <class T>
+T* local_to_address(T* value) {
+	return value;
+}
+
+template <class Ptr>
+auto local_to_address(const Ptr& value) {
+	return local_to_address(value.operator->());
+}
+
+template <class It>
+It get_unwrapped_n(It first, int) {
+	return first;
+}
+
+template <class T>
+concept AnyIterator = true;
+
+template <class Element>
+struct SpanLike {
+	Element* data;
+
+	template <AnyIterator It>
+	SpanLike(It first, int count) : data(local_to_address(get_unwrapped_n(first, count))) {
+	}
+};
+
+int main() {
+	int value = 7;
+	SpanLike<int> span(&value, 1);
+	return *span.data == 7 ? 0 : 1;
+}

--- a/tests/test_template_pointer_traits_to_address_specialization_ret0.cpp
+++ b/tests/test_template_pointer_traits_to_address_specialization_ret0.cpp
@@ -1,0 +1,40 @@
+template <class T>
+struct pointer_traits;
+
+template <class T>
+concept HasToAddress = requires(const T& value) {
+	pointer_traits<T>::to_address(value);
+};
+
+template <class T>
+T* local_to_address(T* value) {
+	return value;
+}
+
+template <class Ptr>
+auto local_to_address(const Ptr& value) {
+	if constexpr (HasToAddress<Ptr>) {
+		return pointer_traits<Ptr>::to_address(value);
+	} else {
+		return local_to_address(value.operator->());
+	}
+}
+
+template <class T>
+struct Iterator {
+	T* ptr;
+};
+
+template <class T>
+struct pointer_traits<Iterator<T>> {
+	static T* to_address(Iterator<T> value) {
+		return value.ptr;
+	}
+};
+
+int main() {
+	int value = 7;
+	Iterator<int> it{&value};
+	int* ptr = local_to_address(it);
+	return *ptr == 7 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR unifies three changes to template and constraint evaluation:

**1. Lazy constructor template parameter metadata preservation**
Ensures constructor template parameter metadata is retained during deferred/lazy evaluation, fixing cases where dependent expressions like `std::to_address` lose parameter info.

**2. Proper if constexpr branch discarding**
Inactive branches in `if constexpr` are now correctly discarded during template instantiation rather than being partially evaluated, preventing spurious errors in discarded branches.

**3. Deferred dependent member template bodies in constraints**
Member template bodies appearing in `requires` expressions (e.g., CPOs like `std::ranges::begin`) are now deferred until the constraint is actually evaluated, avoiding premature instantiation.

Together these changes improve correctness of template instantiation ordering and constraint satisfaction checking, particularly for standard library concepts and CPOs.

## Tests Added
- test_template_member_ctor_dependent_to_address_ret0.cpp
- test_template_member_ctor_dependent_wrapped_to_address_ret0.cpp
- test_if_constexpr_active_branch_invalid_fail.cpp
- test_template_pointer_traits_to_address_specialization_ret0.cpp
- test_template_cpo_begin_requires_ret0.cpp
