### PR TITLE
[codex] Fix late scoped enum operator template resolution

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -98,15 +98,23 @@ it belongs in preprocessing, namespace/header modeling, template argument
 materialization, constexpr evaluation, semantic lookup, or object/linkage
 emission.
 
-For `std/test_std_ranges.cpp`, the current failure is a dependent overload path:
-`std::swap` reports all overloads failed, and the underlying diagnostic is a
-premature concrete scoped-enum `byte <<` check while a constrained
-`std::byte` operator still has a dependent `_IntType` argument. The next slice
-should make the function-template instantiation path preserve that dependency
-through defaulted `enable_if_t`/NTTP arguments and avoid body normalization until
-the selected specialization is non-dependent. Do not weaken the scoped-enum
-operator diagnostic; `tests/test_scoped_enum_builtin_shift_fail.cpp` is the
-guard that the diagnostic remains correct for non-dependent invalid code.
+For `std/test_std_ranges.cpp`, the previous dependent overload path is now
+cleared: the stale parser `NoMatch` for constrained `std::byte` `operator<<` is
+repaired during sema once the instantiated `operator<<=` body has concrete
+`byte` and `int` operand types. The scoped-enum diagnostic remains guarded for
+invalid non-dependent builtin shifts, and
+`tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp` covers the
+late operator-template retry.
+
+The current `std/test_std_ranges.cpp` frontier has advanced to a parser error in
+MSVC `<tuple>`:
+
+- `include\tuple:28:79: Expected '>' after variable template specialization pattern`
+
+The next slice should inspect that declaration shape directly and decide whether
+the fix belongs in variable-template partial-specialization parsing, pack
+handling, nested template-id parsing, or MSVC header modeling. Do not fold this
+into the operator-overload path unless a reduced repro proves a shared cause.
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -144,19 +152,18 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Fix the `std/test_std_ranges.cpp` dependent `std::swap` / `std::byte`
-   operator path by preserving dependency through constrained defaulted
-   template arguments and delaying body checks for still-dependent function
-   specializations.
-2. Add a focused non-std regression that reproduces a constrained function
-   template body calling another constrained operator with a dependent argument,
-   plus a `_fail.cpp` guard for the non-dependent scoped-enum shift diagnostic.
-3. Re-run the std-header subset and identify the next concrete failing header
-   or harness mismatch.
-4. Promote stale expected-failure tracking only after the corresponding harness
+1. Reduce the new `std/test_std_ranges.cpp` `<tuple>` failure at line 28 into a
+   focused parser test for the variable-template specialization pattern shape.
+2. Fix the responsible parser layer without weakening existing template-id,
+   pack, or partial-specialization diagnostics.
+3. Keep `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
+   `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
+   `tests/test_scoped_enum_builtin_shift_fail.cpp` in the guard set so the
+   cleared `std::byte` operator path does not regress.
+4. Re-run `std/test_std_ranges.cpp` after the parser fix and let the next
+   concrete failure choose the following layer.
+5. Promote stale expected-failure tracking only after the corresponding harness
    entry is proven green.
-5. Keep docs updates last and update this section with the next concrete
-   frontier after validation.
 
 ## Validation guidance
 
@@ -175,6 +182,7 @@ small guard set relevant to the touched layer. Common guards:
 - `test_template_disambiguation_pack_ret40.cpp`
 - `test_mock_std_byte_noexcept_probe_ret0.cpp`
 - `test_mock_std_byte_ops_traits_ret0.cpp`
+- `test_scoped_enum_shift_assign_operator_template_ret0.cpp`
 - `test_scoped_enum_builtin_shift_fail.cpp`
 - `std/test_std_type_traits.cpp`
 - `std/test_std_ranges.cpp`

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -86,15 +86,22 @@ preprocessing/header modeling, builtin declarations, namespace lookup,
 constexpr evaluation, template argument materialization, or object/link
 semantics. Do not preselect the layer.
 
-For `std/test_std_ranges.cpp`, the current failing path is no longer discovery:
-`std::swap` overload resolution reaches a constrained `std::byte` operator with
-a still-dependent `_IntType`, then the body is checked as if the shift were a
-concrete scoped-enum builtin expression. C++20 two-phase semantics require that
-still-dependent body expression to remain dependent until the selected function
-template specialization has concrete arguments. The fix should preserve
-dependency through defaulted `enable_if_t`/non-type template arguments and gate
-late body normalization on that dependency. It must not weaken the valid
-non-dependent diagnostic for builtin shifts on scoped enums.
+For `std/test_std_ranges.cpp`, the constrained `std::byte` operator blocker is
+now cleared. The instantiated `operator<<=` body can carry a parser-time
+`NoMatch` for `byte << int`; sema now retries binary operator-template lookup
+after concrete operand types are known, so the visible `operator<<` template is
+selected instead of treating the expression as an invalid builtin scoped-enum
+shift. The non-dependent invalid scoped-enum diagnostic remains covered by
+`tests/test_scoped_enum_builtin_shift_fail.cpp`.
+
+The active standards-facing failure has advanced to MSVC `<tuple>`:
+
+- `include\tuple:28:79: Expected '>' after variable template specialization pattern`
+
+The next fix should reduce that declaration shape and repair the parser layer
+that handles variable-template specialization patterns. Likely suspects are
+partial-specialization template-id parsing, pack handling, or a missing MSVC
+header pattern, but the reduced test should choose the layer.
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -126,10 +133,12 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Fix `std/test_std_ranges.cpp` by preserving dependent constrained function
-   template calls through `std::swap` and `std::byte` operator instantiation.
-2. Add a focused non-std regression for the exposed two-phase dependency rule,
-   plus a `_fail.cpp` guard for non-dependent invalid scoped-enum shifts.
+1. Reduce and fix the new `std/test_std_ranges.cpp` `<tuple>` variable-template
+   specialization pattern parser failure.
+2. Keep the cleared `std::byte` constrained-operator path guarded with
+   `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
+   `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
+   `tests/test_scoped_enum_builtin_shift_fail.cpp`.
 3. Remove stale expected-failure tracking for `test_cstddef.cpp`,
    `test_cstdio_puts.cpp`, and `test_cstdlib.cpp` where the harness still
    records it.
@@ -167,6 +176,7 @@ Common adjacent guards:
 - `test_template_disambiguation_pack_ret40.cpp`
 - `test_mock_std_byte_noexcept_probe_ret0.cpp`
 - `test_mock_std_byte_ops_traits_ret0.cpp`
+- `test_scoped_enum_shift_assign_operator_template_ret0.cpp`
 - `test_scoped_enum_builtin_shift_fail.cpp`
 - `std/test_std_type_traits.cpp`
 - `std/test_std_ranges.cpp`

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -29,6 +29,11 @@ void requireParserSemanticServicesAttachment(const SemanticAnalysis& sema, const
 
 const FunctionDeclarationNode* getCallTargetFunctionCandidate(const ASTNode& overload);
 
+bool isTemplateDerivedFreeFunction(const FunctionDeclarationNode* func_decl) {
+	return func_decl != nullptr &&
+		(func_decl->has_template_body_position() || func_decl->has_template_declaration_position());
+}
+
 bool isFunctionCandidateViableForArgCount(const FunctionDeclarationNode& candidate, size_t argument_count) {
 	const size_t min_required = countMinRequiredArgs(candidate);
 	const size_t max_accepted = candidate.is_variadic()
@@ -6324,7 +6329,87 @@ static std::string getScopedEnumName(const CanonicalTypeDesc& desc) {
 	return "scoped enum";
 }
 
-void SemanticAnalysis::diagnoseScopedEnumBinaryOperands(const BinaryOperatorNode& bin_op,
+bool SemanticAnalysis::tryResolveLateBinaryOperatorOverload(
+	BinaryOperatorNode& bin_op,
+	const CanonicalTypeDesc& lhs_desc,
+	const CanonicalTypeDesc& rhs_desc) {
+	if (bin_op.has_recorded_operator_overload_resolution()) {
+		if (bin_op.has_resolved_operator_overload()) {
+			return true;
+		}
+		if (bin_op.has_ambiguous_operator_overload()) {
+			return false;
+		}
+	}
+
+	const OverloadableOperator op_kind = bin_op.operator_kind();
+	if (!isOverloadableBinaryOperator(op_kind)) {
+		return false;
+	}
+
+	TypeSpecifierNode lhs_type_spec = materializeTypeSpecifier(lhs_desc);
+	TypeSpecifierNode rhs_type_spec = materializeTypeSpecifier(rhs_desc);
+	if (!isConcreteBinaryOperatorOperandType(lhs_type_spec) ||
+		!isConcreteBinaryOperatorOperandType(rhs_type_spec) ||
+		(!isUserDefinedBinaryOperatorOperandType(lhs_type_spec) &&
+		 !isUserDefinedBinaryOperatorOperandType(rhs_type_spec))) {
+		return false;
+	}
+
+	OperatorOverloadResult overload_result = op_kind == OverloadableOperator::Assign
+		? findBinaryOperatorOverload(lhs_type_spec, rhs_type_spec, op_kind)
+		: findBinaryOperatorOverloadWithFreeFunction(
+			lhs_type_spec,
+			rhs_type_spec,
+			op_kind,
+			gSymbolTable);
+	if (op_kind != OverloadableOperator::Assign && parser_ != nullptr) {
+		if (const FunctionDeclarationNode* instantiated_overload =
+				parser_->tryInstantiateOperatorTemplateForBinary(
+					bin_op.op(),
+					lhs_type_spec,
+					rhs_type_spec);
+			instantiated_overload != nullptr &&
+			(!overload_result.has_match ||
+			 overload_result.is_ambiguous ||
+			 (overload_result.is_free_function &&
+			  isTemplateDerivedFreeFunction(overload_result.free_function_overload)))) {
+			overload_result = OperatorOverloadResult(instantiated_overload);
+		}
+	}
+
+	bool equality_rewrite_negate = false;
+	if (!overload_result.has_match && !overload_result.is_ambiguous &&
+		op_kind == OverloadableOperator::NotEqual) {
+		OperatorOverloadResult eq_overload = findBinaryOperatorOverloadWithFreeFunction(
+			lhs_type_spec,
+			rhs_type_spec,
+			OverloadableOperator::Equal,
+			gSymbolTable);
+		if (eq_overload.has_match && !eq_overload.is_ambiguous) {
+			overload_result = eq_overload;
+			equality_rewrite_negate = true;
+		}
+	}
+
+	if (overload_result.is_ambiguous) {
+		bin_op.set_ambiguous_operator_overload();
+		return false;
+	}
+	if (!overload_result.has_match) {
+		bin_op.set_no_match_operator_overload();
+		return false;
+	}
+	if (overload_result.is_free_function) {
+		bin_op.set_resolved_free_function_operator_overload(overload_result.free_function_overload);
+	} else {
+		bin_op.set_resolved_member_operator_overload(overload_result.member_overload);
+	}
+	bin_op.set_recorded_equality_rewrite_negate(equality_rewrite_negate);
+	return true;
+}
+
+void SemanticAnalysis::diagnoseScopedEnumBinaryOperands(BinaryOperatorNode& bin_op,
 														CanonicalTypeId lhs_type_id, CanonicalTypeId rhs_type_id) {
 	if (bin_op.has_resolved_operator_overload())
 		return;
@@ -6338,6 +6423,20 @@ void SemanticAnalysis::diagnoseScopedEnumBinaryOperands(const BinaryOperatorNode
 
 	const CanonicalTypeDesc& lhs_desc = type_context_.get(lhs_type_id);
 	const CanonicalTypeDesc& rhs_desc = type_context_.get(rhs_type_id);
+
+	// C++20 two-phase semantics [temp.dep]/1: if either operand type is still
+	// type-dependent (contains a dependent placeholder from an unresolved
+	// template parameter), the binary expression is type-dependent and must
+	// not be diagnosed until the template is instantiated with concrete
+	// arguments.  This guards the common std::byte operator<< / operator<<=
+	// constrained function template path where _IntType is still dependent
+	// during overload probing or partial instantiation.
+	if (typeIndexContainsDependentPlaceholder(lhs_desc.type_index) ||
+		typeIndexContainsDependentPlaceholder(rhs_desc.type_index))
+		return;
+
+	if (tryResolveLateBinaryOperatorOverload(bin_op, lhs_desc, rhs_desc))
+		return;
 
 	const bool lhs_scoped = isScopedEnum(lhs_desc);
 	const bool rhs_scoped = isScopedEnum(rhs_desc);

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -640,8 +640,11 @@ private:
 	// Diagnose scoped enum used as operand in binary arithmetic/comparison with a
 	// different type.  Per C++20, scoped enums only support relational/equality
 	// operators between values of the same scoped enum type.
-	void diagnoseScopedEnumBinaryOperands(const BinaryOperatorNode& bin_op,
-										  CanonicalTypeId lhs_type_id = {}, CanonicalTypeId rhs_type_id = {});
+	void diagnoseScopedEnumBinaryOperands(BinaryOperatorNode& bin_op,
+										  CanonicalTypeId lhs_type_id, CanonicalTypeId rhs_type_id);
+	bool tryResolveLateBinaryOperatorOverload(BinaryOperatorNode& bin_op,
+											  const CanonicalTypeDesc& lhs_desc,
+											  const CanonicalTypeDesc& rhs_desc);
 
 	// State
 	Parser* parser_ = nullptr;

--- a/tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp
+++ b/tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp
@@ -1,0 +1,31 @@
+enum class byte_like : unsigned char {};
+
+template <bool B, class T>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+	using type = T;
+};
+
+template <bool B, class T>
+using enable_if_t = typename enable_if<B, T>::type;
+
+template <class>
+constexpr bool is_integral_v = true;
+
+template <class Int, enable_if_t<is_integral_v<Int>, int> = 0>
+constexpr byte_like operator<<(byte_like arg, Int shift) {
+	return static_cast<byte_like>(static_cast<unsigned int>(arg) << shift);
+}
+
+template <class Int, enable_if_t<is_integral_v<Int>, int> = 0>
+constexpr byte_like& operator<<=(byte_like& arg, Int shift) {
+	return arg = arg << shift;
+}
+
+int main() {
+	byte_like value = static_cast<byte_like>(1);
+	value <<= 1;
+	return static_cast<unsigned int>(value) == 2 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Add a sema-side late retry for concrete binary operator overload resolution when parser-time state recorded a stale `NoMatch`.
- Preserve the invalid builtin scoped-enum shift diagnostic while allowing constrained `std::byte` operator templates to bind after operand types become concrete.
- Add a focused regression for `operator<<=` calling constrained `operator<<` and update the template-argument planning docs with the next `std_ranges` frontier.

## Root Cause
`std/test_std_ranges.cpp` reached a constrained `std::byte` `operator<<=` body where the inner `byte << int` expression still carried parser-time `NoMatch` operator metadata. During sema, the operands were concrete, but scoped-enum diagnostics ran before retrying free operator-template lookup, so the expression was treated as an invalid builtin scoped-enum shift.