### PR TITLE
[codex] Parse tuple variable-template pack patterns

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-04
+**Last updated:** 2026-07-05
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -48,6 +48,13 @@ identity-preserving behavior:
 - parser trailing-specifier handling now routes cv/ref qualifiers through
   `parse_cv_qualifiers()` and `parse_reference_qualifier()` in the common
   function-header, skip, and template-function paths
+- variable-template partial-specialization patterns now reuse the explicit
+  template-argument parser, so nested template-ids and pack patterns such as
+  `tuple<Dests...>` are preserved for matching; nested trailing packs can bind
+  against multi-argument concrete template-ids
+- template-argument skipping preserves C++ maximal-munch tokenization by
+  splitting `>>` only when a skipped template-id closes at depth one and the
+  caller still owns the outer `>`
 
 ## Architectural invariants
 
@@ -106,15 +113,21 @@ invalid non-dependent builtin shifts, and
 `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp` covers the
 late operator-template retry.
 
-The current `std/test_std_ranges.cpp` frontier has advanced to a parser error in
-MSVC `<tuple>`:
+The previous `<tuple>:28` variable-template specialization-pattern blocker is
+covered by `tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
 
-- `include\tuple:28:79: Expected '>' after variable template specialization pattern`
+The current `std/test_std_ranges.cpp` frontier remains in MSVC `<tuple>`, now at
+the allocator-aware constructor constraint:
 
-The next slice should inspect that declaration shape directly and decide whether
-the fix belongs in variable-template partial-specialization parsing, pack
-handling, nested template-id parsing, or MSVC header modeling. Do not fold this
-into the operator-overload path unless a reduced repro proves a shared cause.
+- `include\tuple:138:21: Expected identifier for non-type template parameter`
+
+The failing shape is an unqualified alias-template NTTP type in namespace `std`:
+`enable_if_t<conjunction_v<::std:: uses_allocator<...>, ::std:: is_constructible<...>>, int> = 0`.
+The reduced `::meta::enable_if_t<::meta::conjunction_v<...>>` form is covered by
+`tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`, so the next
+slice should focus on the unqualified current-namespace variable-template
+argument path rather than the already-fixed `>>` skip or variable-template
+specialization-pattern parser.
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -152,10 +165,11 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the new `std/test_std_ranges.cpp` `<tuple>` failure at line 28 into a
-   focused parser test for the variable-template specialization pattern shape.
+1. Reduce the current `std/test_std_ranges.cpp` `<tuple>:138` failure into a
+   focused parser test using unqualified `enable_if_t<conjunction_v<...>>`
+   inside the declaring namespace and globally qualified trait operands.
 2. Fix the responsible parser layer without weakening existing template-id,
-   pack, or partial-specialization diagnostics.
+   value-vs-type argument, pack, or partial-specialization diagnostics.
 3. Keep `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
    `tests/test_scoped_enum_builtin_shift_fail.cpp` in the guard set so the

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-04
+**Last updated:** 2026-07-05
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -53,6 +53,13 @@ The core suite now covers several formerly blocking standards-visible areas:
   are evaluated through the shared constexpr evaluator
 - scoped-enum/std::byte shift and swap probes are covered, including an
   expected-fail guard for non-dependent builtin scoped-enum shifts
+- MSVC `<tuple>` variable-template specialization patterns with nested
+  template-ids and trailing packs are parsed through the shared explicit
+  template-argument parser, and nested pack-pattern matching can bind a trailing
+  pack against a multi-argument concrete template-id
+- template-argument skipping preserves nested-template `>>` tokenization by
+  splitting only when the skipped template-id consumes the inner `>` and leaves
+  the caller-owned outer `>` available
 
 ## Remaining standards gaps
 
@@ -94,14 +101,20 @@ selected instead of treating the expression as an invalid builtin scoped-enum
 shift. The non-dependent invalid scoped-enum diagnostic remains covered by
 `tests/test_scoped_enum_builtin_shift_fail.cpp`.
 
-The active standards-facing failure has advanced to MSVC `<tuple>`:
+The previous MSVC `<tuple>:28` specialization-pattern failure is now covered by
+`tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
 
-- `include\tuple:28:79: Expected '>' after variable template specialization pattern`
+The active standards-facing failure remains in MSVC `<tuple>`, now at the
+allocator-aware constructor constraint:
 
-The next fix should reduce that declaration shape and repair the parser layer
-that handles variable-template specialization patterns. Likely suspects are
-partial-specialization template-id parsing, pack handling, or a missing MSVC
-header pattern, but the reduced test should choose the layer.
+- `include\tuple:138:21: Expected identifier for non-type template parameter`
+
+The failing shape is an unqualified `enable_if_t<conjunction_v<...>, int> = 0`
+inside namespace `std`, where the operands are globally qualified traits such as
+`::std:: uses_allocator<_Ty, _Alloc>`. A globally qualified reduced form is
+covered by `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`, so
+the remaining conformance task is the current-namespace/unqualified
+variable-template argument path.
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -133,8 +146,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the new `std/test_std_ranges.cpp` `<tuple>` variable-template
-   specialization pattern parser failure.
+1. Reduce and fix the current `std/test_std_ranges.cpp` `<tuple>:138`
+   unqualified alias-template NTTP parser failure.
 2. Keep the cleared `std::byte` constrained-operator path guarded with
    `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -1326,6 +1326,9 @@ void Parser::skip_template_arguments() {
 	const size_t MAX_TOKENS = 10000;	 // Safety limit to prevent infinite loops
 
 	while (!peek().is_eof() && token_count < MAX_TOKENS) {
+		if (peek() == ">>"_tok && angle_depth == 1) {
+			split_right_shift_token();
+		}
 		update_angle_depth(peek(), angle_depth);
 		advance();
 

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -1176,106 +1176,13 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 		std::vector<TemplateTypeArg> specialization_pattern;
 		bool is_partial_spec = false;
 		if (peek() == "<"_tok) {
-			advance(); // consume '<'
 			is_partial_spec = true;
 
-			// Parse the specialization pattern (e.g., T&, T*, T&&, or non-type values like 0)
-			// These are template argument patterns
-			while (peek() != ">"_tok) {
-				// Check for typename keyword (for dependent types)
-				if (peek() == "typename"_tok) {
-					advance(); // consume 'typename'
-				}
-
-				// Check if this is a non-type value (numeric or boolean literal)
-				if (peek() == "true"_tok || peek() == "false"_tok) {
-					bool bool_value = peek() == "true"_tok;
-					advance();
-
-					TemplateTypeArg arg;
-					arg.is_value = true;
-					arg.value = bool_value ? 1LL : 0LL;
-					arg.setCategory(TypeCategory::Bool);
-					specialization_pattern.push_back(arg);
-				} else if (peek().is_literal()) {
-					// It's a numeric literal - treat as non-type value
-					Token value_token = peek_info();
-					advance();
-
-					// Create template type argument for the value
-					TemplateTypeArg arg;
-					arg.is_value = true;
-					arg.value = std::stoll(std::string(value_token.value()));
-					arg.setCategory(TypeCategory::Int);
-					specialization_pattern.push_back(arg);
-				} else {
-					// Parse the pattern type
-					auto pattern_type = parse_type_specifier();
-					if (pattern_type.is_error()) {
-						return pattern_type;
-					}
-
-					// Check for reference modifiers
-					TypeSpecifierNode& type_spec = pattern_type.node()->as<TypeSpecifierNode>();
-					CVQualifier cv = parse_cv_qualifiers();
-					type_spec.add_cv_qualifier(cv);
-
-					// Parse pointer/reference declarators
-					while (peek() == "*"_tok) {
-						advance(); // consume '*'
-						CVQualifier ptr_cv = parse_cv_qualifiers();
-						type_spec.add_pointer_level(ptr_cv);
-					}
-
-					// Parse reference qualifier
-					ReferenceQualifier ref = parse_reference_qualifier();
-					if (ref != ReferenceQualifier::None) {
-						type_spec.set_reference_qualifier(ref);
-					}
-
-					// Parse array bounds: [_Nm] or []
-					bool is_array = false;
-					while (peek() == "["_tok) {
-						advance(); // consume '['
-						is_array = true;
-						// Skip the array bound expression (could be a template parameter like _Nm)
-						while (peek() != "]"_tok) {
-							advance();
-						}
-						if (peek() == "]"_tok) {
-							advance(); // consume ']'
-						}
-					}
-
-					// Create template type argument
-					TemplateTypeArg arg(type_spec);
-					arg.is_array = is_array;
-					// Mark as dependent only for partial specializations
-					// For full specializations (template<>), the types are concrete, not dependent
-					arg.is_dependent = !template_param_nodes.empty();
-
-					// Store the type name for pattern matching
-					// For template instantiations like ratio<_Num, _Den>, this will be "ratio"
-					// For simple types like T, this will be "T"
-					if (type_spec.token().value().size() > 0) {
-						arg.dependent_name = type_spec.token().handle();
-					}
-
-					specialization_pattern.push_back(arg);
-				}
-
-				// Check for comma or closing >
-				if (peek() == ","_tok) {
-					advance(); // consume ','
-				} else {
-					break;
-				}
-			}
-
-			if (peek() != ">"_tok) {
+			auto pattern_args_opt = parse_explicit_template_arguments();
+			if (!pattern_args_opt.has_value()) {
 				return ParseResult::error("Expected '>' after variable template specialization pattern", current_token_);
 			}
-			advance(); // consume '>'
+			specialization_pattern.assign(pattern_args_opt->begin(), pattern_args_opt->end());
 		}
 
 		// Create DeclarationNode

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1963,7 +1963,6 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							dependent_arg.is_pack = true;
 							FLASH_LOG(Templates, Debug, "Marked compile-time expression as pack expansion");
 						}
-
 						template_args.push_back(dependent_arg);
 						if (out_type_nodes && expr_result.node().has_value()) {
 							out_type_nodes->push_back(*expr_result.node());
@@ -2426,6 +2425,35 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		// Expression parsing failed or wasn't a numeric literal - try parsing a type
 try_type_template_argument_parse:
 		restore_token_position(arg_saved_pos);
+		auto sourceSpellsTemplateId = [&]() {
+			SaveHandle lookahead_pos = save_token_position();
+			ScopeGuard lookahead_guard([&]() {
+				discard_saved_token(lookahead_pos);
+			});
+			if (peek() == "::"_tok) {
+				advance();
+			}
+			if (!peek().is_identifier()) {
+				restore_token_position(lookahead_pos);
+				return false;
+			}
+			advance();
+			while (peek() == "::"_tok) {
+				advance();
+				if (peek() == "template"_tok) {
+					advance();
+				}
+				if (!peek().is_identifier()) {
+					restore_token_position(lookahead_pos);
+					return false;
+				}
+				advance();
+			}
+			const bool has_template_arguments = peek() == "<"_tok;
+			restore_token_position(lookahead_pos);
+			return has_template_arguments;
+		};
+		const bool source_spells_template_id = sourceSpellsTemplateId();
 		auto type_result = parse_type_specifier();
 		if (type_result.is_error() || !type_result.node().has_value()) {
 			// Neither type nor expression parsing worked
@@ -2812,6 +2840,7 @@ try_type_template_argument_parse:
 			if (template_name_handle.isValid() &&
 				token_names_entire_type &&
 				!parsed_type_is_template_id &&
+				!source_spells_template_id &&
 				(gTemplateRegistry.lookup_alias_template(template_name_handle).has_value() ||
 				 gTemplateRegistry.lookupTemplate(template_name_handle).has_value() ||
 				 gTemplateRegistry.isClassTemplate(template_name_handle))) {

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -158,6 +158,22 @@ struct TemplatePattern {
 		return true;
 	}
 
+	static std::optional<StringHandle> getNestedPatternParameterName(
+		const TypeInfo::TemplateArgInfo& pattern_arg,
+		const std::unordered_set<StringHandle, StringHandleHash>& template_param_names) {
+		if (pattern_arg.dependent_name.isValid() && template_param_names.count(pattern_arg.dependent_name)) {
+			return pattern_arg.dependent_name;
+		}
+		if (const TypeInfo* pattern_type_info = tryGetTypeInfo(pattern_arg.type_index);
+			pattern_type_info != nullptr) {
+			StringHandle name = pattern_type_info->name();
+			if (name.isValid() && template_param_names.count(name)) {
+				return name;
+			}
+		}
+		return std::nullopt;
+	}
+
 	// Maximum nesting depth for recursive template argument matching/scoring.
 	// Prevents stack overflow on pathological or circular TypeInfo chains.
 	// Real-world C++ template nesting is shallow; 64 is generous.
@@ -195,14 +211,34 @@ struct TemplatePattern {
 					}
 					const auto& np = p_ti->templateArgs();
 					const auto& nc = c_ti->templateArgs();
-					if (np.size() != nc.size()) {
+					const bool has_trailing_pack =
+						!np.empty() &&
+						np.back().is_pack &&
+						getNestedPatternParameterName(np.back(), template_param_names).has_value();
+					if (!has_trailing_pack && np.size() != nc.size()) {
 						FLASH_LOG(Templates, Trace, "  FAILED: nested inner arg count mismatch: pattern=",
 								  np.size(), " concrete=", nc.size());
 						return false;
 					}
-					for (size_t k = 0; k < np.size(); ++k) {
+					if (has_trailing_pack && nc.size() < np.size() - 1) {
+						FLASH_LOG(Templates, Trace, "  FAILED: nested pack pattern has too few concrete args");
+						return false;
+					}
+					const size_t fixed_inner_count = has_trailing_pack ? np.size() - 1 : np.size();
+					for (size_t k = 0; k < fixed_inner_count; ++k) {
 						if (!matchNestedArg(np[k], nc[k], template_param_names, param_substitutions, depth + 1))
 							return false;
+					}
+					if (has_trailing_pack) {
+						StringHandle pack_name = *getNestedPatternParameterName(np.back(), template_param_names);
+						TemplateTypeArg pack_representative;
+						if (fixed_inner_count < nc.size()) {
+							pack_representative = createDeducedArgFromConcrete(nc[fixed_inner_count]);
+						}
+						pack_representative.is_pack = true;
+						if (!recordDeduction(pack_name, pack_representative, param_substitutions)) {
+							return false;
+						}
 					}
 					return true;
 				}
@@ -612,13 +648,23 @@ struct TemplatePattern {
 						const auto& pattern_inner_args = pattern_type_info->templateArgs();
 						const auto& concrete_inner_args = concrete_type_info->templateArgs();
 
-						if (pattern_inner_args.size() != concrete_inner_args.size()) {
+						const bool has_trailing_pack =
+							!pattern_inner_args.empty() &&
+							pattern_inner_args.back().is_pack &&
+							getNestedPatternParameterName(pattern_inner_args.back(), template_param_names).has_value();
+						if (!has_trailing_pack && pattern_inner_args.size() != concrete_inner_args.size()) {
 							FLASH_LOG(Templates, Trace, "  FAILED: inner arg count mismatch: pattern=",
 									  pattern_inner_args.size(), " concrete=", concrete_inner_args.size());
 							return false;
 						}
+						if (has_trailing_pack && concrete_inner_args.size() < pattern_inner_args.size() - 1) {
+							FLASH_LOG(Templates, Trace, "  FAILED: inner pack pattern has too few concrete args");
+							return false;
+						}
 
-						for (size_t j = 0; j < pattern_inner_args.size(); ++j) {
+						const size_t fixed_inner_count =
+							has_trailing_pack ? pattern_inner_args.size() - 1 : pattern_inner_args.size();
+						for (size_t j = 0; j < fixed_inner_count; ++j) {
 							const auto& p_inner = pattern_inner_args[j];
 							const auto& c_inner = concrete_inner_args[j];
 
@@ -630,6 +676,19 @@ struct TemplatePattern {
 
 							if (!matchNestedArg(p_inner, c_inner, template_param_names, param_substitutions))
 								return false;
+						}
+						if (has_trailing_pack) {
+							StringHandle pack_name =
+								*getNestedPatternParameterName(pattern_inner_args.back(), template_param_names);
+							TemplateTypeArg pack_representative;
+							if (fixed_inner_count < concrete_inner_args.size()) {
+								pack_representative =
+									createDeducedArgFromConcrete(concrete_inner_args[fixed_inner_count]);
+							}
+							pack_representative.is_pack = true;
+							if (!recordDeduction(pack_name, pack_representative, param_substitutions)) {
+								return false;
+							}
 						}
 					}
 					// Advance param_index past inner-deduced parameters so that

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -174,6 +174,58 @@ struct TemplatePattern {
 		return std::nullopt;
 	}
 
+	static bool matchInnerArgs(
+		const InlineVector<TypeInfo::TemplateArgInfo, 4>& pattern_inner_args,
+		const InlineVector<TypeInfo::TemplateArgInfo, 4>& concrete_inner_args,
+		const std::unordered_set<StringHandle, StringHandleHash>& template_param_names,
+		std::unordered_map<StringHandle, TemplateTypeArg, StringHandleHash, std::equal_to<>>& param_substitutions,
+		int nested_arg_depth) {
+		const bool has_trailing_pack =
+			!pattern_inner_args.empty() &&
+			pattern_inner_args.back().is_pack &&
+			getNestedPatternParameterName(pattern_inner_args.back(), template_param_names).has_value();
+		if (!has_trailing_pack && pattern_inner_args.size() != concrete_inner_args.size()) {
+			FLASH_LOG(Templates, Trace, "  FAILED: inner arg count mismatch: pattern=",
+					  pattern_inner_args.size(), " concrete=", concrete_inner_args.size());
+			return false;
+		}
+		if (has_trailing_pack && concrete_inner_args.size() < pattern_inner_args.size() - 1) {
+			FLASH_LOG(Templates, Trace, "  FAILED: inner pack pattern has too few concrete args");
+			return false;
+		}
+
+		const size_t fixed_inner_count =
+			has_trailing_pack ? pattern_inner_args.size() - 1 : pattern_inner_args.size();
+		for (size_t inner_index = 0; inner_index < fixed_inner_count; ++inner_index) {
+			const auto& p_inner = pattern_inner_args[inner_index];
+			const auto& c_inner = concrete_inner_args[inner_index];
+
+			FLASH_LOG(Templates, Trace, "  Inner arg[", inner_index, "]: p_inner.is_value=", p_inner.is_value,
+					  " category=", static_cast<int>(p_inner.category()),
+					  " type_index=", p_inner.type_index,
+					  " | c_inner.is_value=", c_inner.is_value,
+					  " category=", static_cast<int>(c_inner.category()));
+
+			if (!matchNestedArg(p_inner, c_inner, template_param_names, param_substitutions, nested_arg_depth)) {
+				return false;
+			}
+		}
+		if (has_trailing_pack) {
+			StringHandle pack_name =
+				*getNestedPatternParameterName(pattern_inner_args.back(), template_param_names);
+			TemplateTypeArg pack_representative;
+			if (fixed_inner_count < concrete_inner_args.size()) {
+				pack_representative =
+					createDeducedArgFromConcrete(concrete_inner_args[fixed_inner_count]);
+			}
+			pack_representative.is_pack = true;
+			if (!recordDeduction(pack_name, pack_representative, param_substitutions)) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	// Maximum nesting depth for recursive template argument matching/scoring.
 	// Prevents stack overflow on pathological or circular TypeInfo chains.
 	// Real-world C++ template nesting is shallow; 64 is generous.
@@ -211,34 +263,8 @@ struct TemplatePattern {
 					}
 					const auto& np = p_ti->templateArgs();
 					const auto& nc = c_ti->templateArgs();
-					const bool has_trailing_pack =
-						!np.empty() &&
-						np.back().is_pack &&
-						getNestedPatternParameterName(np.back(), template_param_names).has_value();
-					if (!has_trailing_pack && np.size() != nc.size()) {
-						FLASH_LOG(Templates, Trace, "  FAILED: nested inner arg count mismatch: pattern=",
-								  np.size(), " concrete=", nc.size());
+					if (!matchInnerArgs(np, nc, template_param_names, param_substitutions, depth + 1)) {
 						return false;
-					}
-					if (has_trailing_pack && nc.size() < np.size() - 1) {
-						FLASH_LOG(Templates, Trace, "  FAILED: nested pack pattern has too few concrete args");
-						return false;
-					}
-					const size_t fixed_inner_count = has_trailing_pack ? np.size() - 1 : np.size();
-					for (size_t k = 0; k < fixed_inner_count; ++k) {
-						if (!matchNestedArg(np[k], nc[k], template_param_names, param_substitutions, depth + 1))
-							return false;
-					}
-					if (has_trailing_pack) {
-						StringHandle pack_name = *getNestedPatternParameterName(np.back(), template_param_names);
-						TemplateTypeArg pack_representative;
-						if (fixed_inner_count < nc.size()) {
-							pack_representative = createDeducedArgFromConcrete(nc[fixed_inner_count]);
-						}
-						pack_representative.is_pack = true;
-						if (!recordDeduction(pack_name, pack_representative, param_substitutions)) {
-							return false;
-						}
 					}
 					return true;
 				}
@@ -644,52 +670,13 @@ struct TemplatePattern {
 					// Uses matchNestedArg which handles arbitrary nesting depth,
 					// e.g., Pair<Pair<A,B>, Pair<C,D>> against pair<pair<int,float>, pair<double,bool>>.
 					const size_t subs_before_inner = param_substitutions.size();
-					{
-						const auto& pattern_inner_args = pattern_type_info->templateArgs();
-						const auto& concrete_inner_args = concrete_type_info->templateArgs();
-
-						const bool has_trailing_pack =
-							!pattern_inner_args.empty() &&
-							pattern_inner_args.back().is_pack &&
-							getNestedPatternParameterName(pattern_inner_args.back(), template_param_names).has_value();
-						if (!has_trailing_pack && pattern_inner_args.size() != concrete_inner_args.size()) {
-							FLASH_LOG(Templates, Trace, "  FAILED: inner arg count mismatch: pattern=",
-									  pattern_inner_args.size(), " concrete=", concrete_inner_args.size());
-							return false;
-						}
-						if (has_trailing_pack && concrete_inner_args.size() < pattern_inner_args.size() - 1) {
-							FLASH_LOG(Templates, Trace, "  FAILED: inner pack pattern has too few concrete args");
-							return false;
-						}
-
-						const size_t fixed_inner_count =
-							has_trailing_pack ? pattern_inner_args.size() - 1 : pattern_inner_args.size();
-						for (size_t j = 0; j < fixed_inner_count; ++j) {
-							const auto& p_inner = pattern_inner_args[j];
-							const auto& c_inner = concrete_inner_args[j];
-
-							FLASH_LOG(Templates, Trace, "  Inner arg[", j, "]: p_inner.is_value=", p_inner.is_value,
-									  " category=", static_cast<int>(p_inner.category()),
-									  " type_index=", p_inner.type_index,
-									  " | c_inner.is_value=", c_inner.is_value,
-									  " category=", static_cast<int>(c_inner.category()));
-
-							if (!matchNestedArg(p_inner, c_inner, template_param_names, param_substitutions))
-								return false;
-						}
-						if (has_trailing_pack) {
-							StringHandle pack_name =
-								*getNestedPatternParameterName(pattern_inner_args.back(), template_param_names);
-							TemplateTypeArg pack_representative;
-							if (fixed_inner_count < concrete_inner_args.size()) {
-								pack_representative =
-									createDeducedArgFromConcrete(concrete_inner_args[fixed_inner_count]);
-							}
-							pack_representative.is_pack = true;
-							if (!recordDeduction(pack_name, pack_representative, param_substitutions)) {
-								return false;
-							}
-						}
+					if (!matchInnerArgs(
+							pattern_type_info->templateArgs(),
+							concrete_type_info->templateArgs(),
+							template_param_names,
+							param_substitutions,
+							0)) {
+						return false;
 					}
 					// Advance param_index past inner-deduced parameters so that
 					// subsequent pattern args use the correct fallback index.

--- a/tests/test_template_nttp_global_qualified_alias_args_ret0.cpp
+++ b/tests/test_template_nttp_global_qualified_alias_args_ret0.cpp
@@ -1,0 +1,52 @@
+namespace meta {
+	template <bool Value>
+	struct bool_constant {
+		static constexpr bool value = Value;
+	};
+
+	template <class...>
+	struct conjunction : bool_constant<true> {};
+
+	template <class First>
+	struct conjunction<First> : First {};
+
+	template <class First, class... Rest>
+	struct conjunction<First, Rest...> : bool_constant<First::value && conjunction<Rest...>::value> {};
+
+	template <class... Types>
+	constexpr bool conjunction_v = conjunction<Types...>::value;
+
+	template <class Type, class Alloc>
+	struct uses_allocator : bool_constant<true> {};
+
+	template <class Type, class... Args>
+	struct is_constructible : bool_constant<true> {};
+
+	template <bool Condition, class Type>
+	struct enable_if {};
+
+	template <class Type>
+	struct enable_if<true, Type> {
+		using type = Type;
+	};
+
+	template <bool Condition, class Type>
+	using enable_if_t = typename enable_if<Condition, Type>::type;
+
+	struct allocator_arg_t {};
+}
+
+template <class Type>
+struct holder {
+	template <class Alloc, class... Other,
+		::meta::enable_if_t<::meta::conjunction_v<::meta:: uses_allocator<Type, Alloc>,
+								::meta:: is_constructible<Type, ::meta::allocator_arg_t, const Alloc&, Other...>>,
+			int> = 0>
+	int construct(const Alloc&, ::meta::allocator_arg_t, Other&&...) {
+		return 42;
+	}
+};
+
+int main() {
+	return 0;
+}

--- a/tests/test_variable_template_tuple_pack_pattern_ret0.cpp
+++ b/tests/test_variable_template_tuple_pack_pattern_ret0.cpp
@@ -1,0 +1,14 @@
+template <class... Types>
+struct tuple {};
+
+template <bool Same, class Dest, class... Sources>
+constexpr bool tuple_conditional_explicit_v0 = false;
+
+template <class... Dests, class... Sources>
+constexpr bool tuple_conditional_explicit_v0<true, tuple<Dests...>, Sources...> = true;
+
+int main() {
+	static_assert(tuple_conditional_explicit_v0<true, tuple<int, long>, int, long>);
+	static_assert(!tuple_conditional_explicit_v0<false, tuple<int, long>, int, long>);
+	return tuple_conditional_explicit_v0<true, tuple<int>, int> ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- parse variable-template partial-specialization patterns through the shared explicit template-argument parser
- allow nested trailing pack patterns such as `tuple<Dests...>` to match concrete multi-argument template-ids
- split `>>` while skipping template arguments only when the skipped template-id closes at depth one and the caller still owns the outer `>`
- update the template-argument planning docs with the new baseline and the remaining `<tuple>:138` frontier