### PR TITLE
[codex] Advance tuple template argument handling

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -116,18 +116,29 @@ late operator-template retry.
 The previous `<tuple>:28` variable-template specialization-pattern blocker is
 covered by `tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
 
-The current `std/test_std_ranges.cpp` frontier remains in MSVC `<tuple>`, now at
-the allocator-aware constructor constraint:
+The previous MSVC `<tuple>:138` allocator-aware constructor constraint is now
+covered:
 
-- `include\tuple:138:21: Expected identifier for non-type template parameter`
+- `tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp`
+- `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`
 
-The failing shape is an unqualified alias-template NTTP type in namespace `std`:
+The covered shape is an unqualified alias-template NTTP type in namespace `std`:
 `enable_if_t<conjunction_v<::std:: uses_allocator<...>, ::std:: is_constructible<...>>, int> = 0`.
-The reduced `::meta::enable_if_t<::meta::conjunction_v<...>>` form is covered by
-`tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`, so the next
-slice should focus on the unqualified current-namespace variable-template
-argument path rather than the already-fixed `>>` skip or variable-template
-specialization-pattern parser.
+The parser now recognizes current-namespace variable-template-ids as value-like
+arguments before falling through to type parsing.
+
+The subsequent MSVC `<tuple>` `_Equals` const-receiver failure is also covered:
+
+- `tests/test_template_const_member_function_template_receiver_ret0.cpp`
+
+Member-function-template cv metadata is now preserved from parsing through
+class-template instantiation and member-template materialization.
+
+The active `std/test_std_ranges.cpp` frontier has moved to `swap` overload
+selection and dependent-placeholder classification:
+
+- `All 5 template overload(s) failed for 'swap'`
+- `Fatal error: Unregistered dependent placeholder type reached template argument classification`
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -165,11 +176,12 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the current `std/test_std_ranges.cpp` `<tuple>:138` failure into a
-   focused parser test using unqualified `enable_if_t<conjunction_v<...>>`
-   inside the declaring namespace and globally qualified trait operands.
-2. Fix the responsible parser layer without weakening existing template-id,
-   value-vs-type argument, pack, or partial-specialization diagnostics.
+1. Reduce the current `std/test_std_ranges.cpp` `swap` failure into a focused
+   test that preserves the dependent placeholder reaching template-argument
+   classification.
+2. Trace whether the failure belongs in template argument materialization,
+   placeholder registration, `swap` overload selection, or a stale parser
+   fallback before changing parser behavior.
 3. Keep `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
    `tests/test_scoped_enum_builtin_shift_fail.cpp` in the guard set so the

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -104,17 +104,30 @@ shift. The non-dependent invalid scoped-enum diagnostic remains covered by
 The previous MSVC `<tuple>:28` specialization-pattern failure is now covered by
 `tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
 
-The active standards-facing failure remains in MSVC `<tuple>`, now at the
-allocator-aware constructor constraint:
+The previous MSVC `<tuple>:138` allocator-aware constructor constraint is now
+covered:
 
-- `include\tuple:138:21: Expected identifier for non-type template parameter`
+- `tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp`
+- `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`
 
-The failing shape is an unqualified `enable_if_t<conjunction_v<...>, int> = 0`
+The covered shape is an unqualified `enable_if_t<conjunction_v<...>, int> = 0`
 inside namespace `std`, where the operands are globally qualified traits such as
-`::std:: uses_allocator<_Ty, _Alloc>`. A globally qualified reduced form is
-covered by `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`, so
-the remaining conformance task is the current-namespace/unqualified
-variable-template argument path.
+`::std:: uses_allocator<_Ty, _Alloc>`. The parser now keeps the
+current-namespace `conjunction_v<...>` template-id on the value-like NTTP path
+instead of treating it as a type-specifier.
+
+The following MSVC `<tuple>` `_Equals` const-receiver failure is now covered by:
+
+- `tests/test_template_const_member_function_template_receiver_ret0.cpp`
+
+Member-function-template cv metadata now survives member-template registration,
+class-template instantiation, and member-template materialization.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+`swap` overload resolution and dependent-placeholder materialization:
+
+- `All 5 template overload(s) failed for 'swap'`
+- `Fatal error: Unregistered dependent placeholder type reached template argument classification`
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -146,8 +159,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` `<tuple>:138`
-   unqualified alias-template NTTP parser failure.
+1. Reduce and fix the current `std/test_std_ranges.cpp` `swap` failure where an
+   unregistered dependent placeholder reaches template-argument classification.
 2. Keep the cleared `std::byte` constrained-operator path guarded with
    `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2354,6 +2354,9 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						return signature_result;
 					}
 
+					member_func_ref.set_is_const_member_function(member_quals.is_const());
+					member_func_ref.set_is_volatile_member_function(member_quals.is_volatile());
+
 					// Propagate noexcept specifier to the function declaration node
 					if (func_specs.is_noexcept) {
 						member_func_ref.set_noexcept(true);

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -854,10 +854,28 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	// Add to struct as a member function template
 	// First, add to the struct's member functions list so it can be found for inheritance lookup
 	OverloadableOperator operator_kind = overloadableOperatorFromFunctionName(decl_node.identifier_token().value());
+	const CVQualifier member_template_cv = static_cast<CVQualifier>(
+		static_cast<uint8_t>(func_decl.is_const_member_function() ? CVQualifier::Const : CVQualifier::None) |
+		static_cast<uint8_t>(func_decl.is_volatile_member_function() ? CVQualifier::Volatile : CVQualifier::None));
 	if (operator_kind != OverloadableOperator::None) {
-		struct_node.add_operator_overload(operator_kind, template_func_node, access);
+		struct_node.add_operator_overload(
+			operator_kind,
+			template_func_node,
+			access,
+			false,
+			false,
+			false,
+			false,
+			member_template_cv);
 	} else {
-		struct_node.add_member_function(template_func_node, access);
+		struct_node.add_member_function(
+			template_func_node,
+			access,
+			false,
+			false,
+			false,
+			false,
+			member_template_cv);
 	}
 
 	// Register the template in the global registry with qualified name (ClassName::functionName)

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -24,6 +24,17 @@ static thread_local int g_template_inst_iteration_count = 0;
 static thread_local bool g_template_inst_iteration_limit_tripped = false;
 static constexpr int g_template_inst_max_iterations = 10000;
 
+static FunctionDeclarationNode& normalizeMemberTemplateFunctionCvFromWrapper(
+	const TemplateFunctionDeclarationNode& tmpl_func,
+	bool is_const_member,
+	bool is_volatile_member) {
+	FunctionDeclarationNode& inner_func =
+		const_cast<TemplateFunctionDeclarationNode&>(tmpl_func).function_decl_node();
+	inner_func.set_is_const_member_function(is_const_member);
+	inner_func.set_is_volatile_member_function(is_volatile_member);
+	return inner_func;
+}
+
 void resetTemplateInstantiationCounters() {
 	g_template_inst_iteration_count = 0;
 	g_template_inst_iteration_limit_tripped = false;
@@ -2404,7 +2415,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Member function template (e.g., template<typename _Up, typename... _Args> void construct(...))
 					// Add as-is without return type substitution - the template will handle it when instantiated
 					const TemplateFunctionDeclarationNode& tmpl_func = mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
-					const FunctionDeclarationNode& inner_func = tmpl_func.function_decl_node();
+					FunctionDeclarationNode& inner_func =
+						normalizeMemberTemplateFunctionCvFromWrapper(
+							tmpl_func,
+							mem_func.is_const(),
+							mem_func.is_volatile());
 					StringHandle func_name_handle = inner_func.decl_node().identifier_token().handle();
 					if (mem_func.operator_kind != OverloadableOperator::None) {
 						struct_info->addOperatorOverload(

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -24,17 +24,6 @@ static thread_local int g_template_inst_iteration_count = 0;
 static thread_local bool g_template_inst_iteration_limit_tripped = false;
 static constexpr int g_template_inst_max_iterations = 10000;
 
-static FunctionDeclarationNode& normalizeMemberTemplateFunctionCvFromWrapper(
-	const TemplateFunctionDeclarationNode& tmpl_func,
-	bool is_const_member,
-	bool is_volatile_member) {
-	FunctionDeclarationNode& inner_func =
-		const_cast<TemplateFunctionDeclarationNode&>(tmpl_func).function_decl_node();
-	inner_func.set_is_const_member_function(is_const_member);
-	inner_func.set_is_volatile_member_function(is_volatile_member);
-	return inner_func;
-}
-
 void resetTemplateInstantiationCounters() {
 	g_template_inst_iteration_count = 0;
 	g_template_inst_iteration_limit_tripped = false;
@@ -2415,11 +2404,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Member function template (e.g., template<typename _Up, typename... _Args> void construct(...))
 					// Add as-is without return type substitution - the template will handle it when instantiated
 					const TemplateFunctionDeclarationNode& tmpl_func = mem_func.function_declaration.as<TemplateFunctionDeclarationNode>();
-					FunctionDeclarationNode& inner_func =
-						normalizeMemberTemplateFunctionCvFromWrapper(
-							tmpl_func,
-							mem_func.is_const(),
-							mem_func.is_volatile());
+					const FunctionDeclarationNode& inner_func = tmpl_func.function_decl_node();
 					StringHandle func_name_handle = inner_func.decl_node().identifier_token().handle();
 					if (mem_func.operator_kind != OverloadableOperator::None) {
 						struct_info->addOperatorOverload(

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2563,12 +2563,13 @@ try_type_template_argument_parse:
 					if (out_type_nodes) {
 						out_type_nodes->push_back(*value_expr_result.node());
 					}
-					discard_saved_token(arg_saved_pos);
 					if (peek() == ">"_tok) {
+						discard_saved_token(arg_saved_pos);
 						advance();
 						break;
 					}
 					if (peek() == ","_tok) {
+						discard_saved_token(arg_saved_pos);
 						advance();
 						continue;
 					}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1278,6 +1278,26 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 			   target_param->kind() != TemplateParameterKind::NonType;
 	};
 
+	auto qualifiedIdNamesVariableTemplate = [&](const QualifiedIdentifierNode& qi) {
+		std::string_view qname = buildQualifiedNameFromHandle(qi.namespace_handle(), qi.name());
+		if (gTemplateRegistry.lookupVariableTemplate(qname).has_value() ||
+			gTemplateRegistry.lookupVariableTemplate(qi.nameHandle()).has_value()) {
+			return true;
+		}
+		if (qname.find("::") == std::string_view::npos) {
+			NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
+			if (!current_namespace.isGlobal()) {
+				StringHandle qualified_handle =
+					gNamespaceRegistry.buildQualifiedIdentifier(current_namespace, qi.nameHandle());
+				if (qualified_handle.isValid() &&
+					gTemplateRegistry.lookupVariableTemplate(qualified_handle).has_value()) {
+					return true;
+				}
+			}
+		}
+		return false;
+	};
+
 	auto hasConcreteSubstitutionForName = [&](StringHandle name) {
 		if (!name.isValid()) {
 			return false;
@@ -1872,8 +1892,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 						(peek() == ">"_tok || peek() == ","_tok)) {
 						const auto& qi = std::get<QualifiedIdentifierNode>(expr);
 						std::string_view qname = buildQualifiedNameFromHandle(qi.namespace_handle(), qi.name());
+						const bool variable_template_expression =
+							qi.has_template_arguments() && qualifiedIdNamesVariableTemplate(qi);
 						auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(qname));
-						if (type_it != getTypesByNameMap().end() &&
+						if (!variable_template_expression &&
+							type_it != getTypesByNameMap().end() &&
 							type_it->second != nullptr &&
 							(type_it->second->isTypeAlias() ||
 							 type_it->second->getStructInfo() != nullptr ||
@@ -2155,8 +2178,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							const auto& qual_id = std::get<QualifiedIdentifierNode>(expr);
 							// Build the qualified name and check if it exists in getTypesByNameMap()
 							std::string_view qualified_name = buildQualifiedNameFromHandle(qual_id.namespace_handle(), qual_id.name());
+							const bool variable_template_expression =
+								qual_id.has_template_arguments() && qualifiedIdNamesVariableTemplate(qual_id);
 							auto type_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(qualified_name));
-							if (type_it != getTypesByNameMap().end()) {
+							if (!variable_template_expression &&
+								type_it != getTypesByNameMap().end()) {
 								const TypeInfo* type_info = type_it->second;
 								if (type_info->struct_info_ != nullptr) {
 									is_concrete_type = true;
@@ -2454,6 +2480,102 @@ try_type_template_argument_parse:
 			return has_template_arguments;
 		};
 		const bool source_spells_template_id = sourceSpellsTemplateId();
+		auto sourceTemplateIdNamesVariableTemplate = [&]() {
+			SaveHandle lookahead_pos = save_token_position();
+			ScopeGuard lookahead_guard([&]() {
+				discard_saved_token(lookahead_pos);
+			});
+			if (peek() == "::"_tok) {
+				advance();
+			}
+			if (!peek().is_identifier()) {
+				restore_token_position(lookahead_pos);
+				return false;
+			}
+			StringHandle first_name = peek_info().handle();
+			StringHandle candidate_name = first_name;
+			advance();
+			StringBuilder qualified_name_builder;
+			qualified_name_builder.append(StringTable::getStringView(first_name));
+			while (peek() == "::"_tok) {
+				advance();
+				if (peek() == "template"_tok) {
+					advance();
+				}
+				if (!peek().is_identifier()) {
+					restore_token_position(lookahead_pos);
+					return false;
+				}
+				candidate_name = peek_info().handle();
+				qualified_name_builder.append("::").append(peek_info().value());
+				advance();
+			}
+			const bool has_template_arguments = peek() == "<"_tok;
+			std::string_view qualified_name = qualified_name_builder.commit();
+			bool names_variable_template =
+				gTemplateRegistry.lookupVariableTemplate(qualified_name).has_value() ||
+				gTemplateRegistry.lookupVariableTemplate(candidate_name).has_value();
+			if (!names_variable_template && qualified_name.find("::") == std::string_view::npos) {
+				NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
+				if (!current_namespace.isGlobal()) {
+					StringHandle qualified_handle =
+						gNamespaceRegistry.buildQualifiedIdentifier(current_namespace, candidate_name);
+					names_variable_template =
+						qualified_handle.isValid() &&
+						gTemplateRegistry.lookupVariableTemplate(qualified_handle).has_value();
+				}
+			}
+			restore_token_position(lookahead_pos);
+			return has_template_arguments && names_variable_template;
+		};
+		const bool source_spells_variable_template_id = sourceTemplateIdNamesVariableTemplate();
+		if (source_spells_variable_template_id && !currentArgRejectsValueLikeParsing()) {
+			auto value_expr_result = parse_expression(2, ExpressionContext::TemplateTypeArg);
+			if (!value_expr_result.is_error() && value_expr_result.node().has_value()) {
+				if (peek() == ">>"_tok) {
+					split_right_shift_token();
+				}
+				if (!peek().is_eof() &&
+					(peek() == ","_tok || peek() == ">"_tok || peek() == "..."_tok)) {
+					const ExpressionNode& value_expr =
+						value_expr_result.node()->as<ExpressionNode>();
+					StringHandle dependent_name;
+					if (const auto* id = std::get_if<IdentifierNode>(&value_expr)) {
+						dependent_name = StringTable::getOrInternStringHandle(id->name());
+					} else if (const auto* qual_id =
+								   std::get_if<QualifiedIdentifierNode>(&value_expr)) {
+						dependent_name = StringTable::getOrInternStringHandle(qual_id->full_name());
+					}
+					TemplateTypeArg dependent_arg = TemplateTypeArg::makeDependentValue(
+						dependent_name,
+						dependentExpressionValueCategory(
+							value_expr,
+							dependent_name.isValid()
+								? std::optional<StringHandle>(dependent_name)
+								: std::nullopt),
+						0,
+						*value_expr_result.node());
+					if (peek() == "..."_tok) {
+						advance();
+						dependent_arg.is_pack = true;
+					}
+					template_args.push_back(dependent_arg);
+					if (out_type_nodes) {
+						out_type_nodes->push_back(*value_expr_result.node());
+					}
+					discard_saved_token(arg_saved_pos);
+					if (peek() == ">"_tok) {
+						advance();
+						break;
+					}
+					if (peek() == ","_tok) {
+						advance();
+						continue;
+					}
+				}
+			}
+			restore_token_position(arg_saved_pos);
+		}
 		auto type_result = parse_type_specifier();
 		if (type_result.is_error() || !type_result.node().has_value()) {
 			// Neither type nor expression parsing worked

--- a/tests/test_template_const_member_function_template_receiver_ret0.cpp
+++ b/tests/test_template_const_member_function_template_receiver_ret0.cpp
@@ -1,0 +1,13 @@
+template <class T>
+struct Box {
+	template <class U>
+	int equals(const Box<U>&) const {
+		return 1;
+	}
+};
+
+int main() {
+	const Box<int> left;
+	Box<int> right;
+	return left.equals(right) == 1 ? 0 : 1;
+}

--- a/tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp
+++ b/tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp
@@ -1,0 +1,52 @@
+namespace meta {
+	template <bool Value>
+	struct bool_constant {
+		static constexpr bool value = Value;
+	};
+
+	template <class...>
+	struct conjunction : bool_constant<true> {};
+
+	template <class First>
+	struct conjunction<First> : First {};
+
+	template <class First, class... Rest>
+	struct conjunction<First, Rest...> : bool_constant<First::value && conjunction<Rest...>::value> {};
+
+	template <class... Types>
+	constexpr bool conjunction_v = conjunction<Types...>::value;
+
+	template <class Type, class Alloc>
+	struct uses_allocator : bool_constant<true> {};
+
+	template <class Type, class... Args>
+	struct is_constructible : bool_constant<true> {};
+
+	template <bool Condition, class Type>
+	struct enable_if {};
+
+	template <class Type>
+	struct enable_if<true, Type> {
+		using type = Type;
+	};
+
+	template <bool Condition, class Type>
+	using enable_if_t = typename enable_if<Condition, Type>::type;
+
+	struct allocator_arg_t {};
+
+	template <class Type>
+	struct holder {
+		template <class Alloc, class... Other,
+			enable_if_t<conjunction_v<::meta:: uses_allocator<Type, Alloc>,
+							::meta:: is_constructible<Type, ::meta::allocator_arg_t, const Alloc&, Other...>>,
+				int> = 0>
+		int construct(const Alloc&, allocator_arg_t, Other&&...) {
+			return 42;
+		}
+	};
+}
+
+int main() {
+	return 0;
+}


### PR DESCRIPTION
## Summary

- parse unqualified current-namespace variable-template-ids as value-like NTTP arguments before falling back to type parsing
- preserve member-function-template cv qualifiers through member-template registration, class-template instantiation, and materialization
- add focused regressions for the MSVC `<tuple>` allocator constraint shape and const member-template receiver calls
- update the template-argument planning docs with the new `std/test_std_ranges.cpp` frontier

## Root Cause

MSVC `<tuple>` exposed two template-infrastructure gaps after the previous ranges slice. First, `conjunction_v<...>` inside an alias-template NTTP type was treated as a type parse candidate when written unqualified in the declaring namespace. Second, member-function-template cv metadata was present on the parsed pattern but was not preserved in the wrapper metadata used when class-template instantiations copied and later materialized member templates.
