### PR TITLE
Support constrained partial specializations and brace-init member initializers in member struct templates

### DIFF
--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5660,10 +5660,24 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				if (!consume(";"_tok)) {
 					return ParseResult::error("Expected ';' after member initializer", current_token_);
 				}
-				member_struct_ref.add_member(*member_result.node(), current_access, init_result.node());
-			} else {
-				// Skip other complex cases (e.g., friend declarations)
-				int brace_depth = 0;
+			member_struct_ref.add_member(*member_result.node(), current_access, init_result.node());
+		} else if (peek() == "{"_tok) {
+			// Brace-init default member initializer: _Tp _M_tp{};
+			// Mirrors the primary-template body handling so partial specializations
+			// don't silently drop brace-initialized members via the fallback below.
+			const DeclarationNode& decl = member_result.node()->as<DeclarationNode>();
+			const TypeSpecifierNode& type_spec = decl.type_specifier_node();
+			auto init_result = parse_brace_initializer(type_spec);
+			if (init_result.is_error()) {
+				return init_result;
+			}
+			if (!consume(";"_tok)) {
+				return ParseResult::error("Expected ';' after member brace initializer", current_token_);
+			}
+			member_struct_ref.add_member(*member_result.node(), current_access, init_result.node());
+		} else {
+			// Skip other complex cases (e.g., friend declarations)
+			int brace_depth = 0;
 				while (!peek().is_eof()) {
 					if (peek() == "{"_tok) {
 						brace_depth++;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -6181,6 +6181,21 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				return ParseResult::error("Expected ';' after member initializer", peek_info());
 			}
 			member_struct_ref.add_member(*member_result.node(), current_access, init_result.node());
+		} else if (peek() == "{"_tok) {
+			// Brace-init default member initializer: _Tp _M_tp{};
+			// This mirrors the partial-specialization body handling and is required
+			// for MSVC STL patterns such as transform_view::_Iterator's
+			// _Parent_t* _Parent{};
+			const DeclarationNode& decl = member_result.node()->as<DeclarationNode>();
+			const TypeSpecifierNode& type_spec = decl.type_specifier_node();
+			auto init_result = parse_brace_initializer(type_spec);
+			if (init_result.is_error()) {
+				return init_result;
+			}
+			if (!consume(";"_tok)) {
+				return ParseResult::error("Expected ';' after member brace initializer", peek_info());
+			}
+			member_struct_ref.add_member(*member_result.node(), current_access, init_result.node());
 		} else {
 			return ParseResult::error("Expected '(' or ';' after member declaration", peek_info());
 		}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5134,7 +5134,14 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				}
 				return true;
 			};
-		if (is_exact_primary_parameter_pattern(std::span<const TemplateTypeArg>(pattern_args.data(), pattern_args.size()))) {
+		// C++20 [temp.class.spec.mfunc] allows a partial specialization whose
+		// argument list matches the primary template parameter list when a
+		// requires-clause makes it more specialized than the primary. The MSVC
+		// STL relies on this for transform_view::_Category_base. Only reject the
+		// unconstrained echo pattern; a constrained same-arg specialization is
+		// valid and is disambiguated via the constrained-pattern counter below.
+		if (!requires_clause.has_value() &&
+			is_exact_primary_parameter_pattern(std::span<const TemplateTypeArg>(pattern_args.data(), pattern_args.size()))) {
 			return ParseResult::error("Partial specialization argument list cannot match the primary template parameter list", current_token_);
 		}
 

--- a/tests/test_member_struct_template_partial_spec_pointer_brace_init_ret0.cpp
+++ b/tests/test_member_struct_template_partial_spec_pointer_brace_init_ret0.cpp
@@ -1,0 +1,31 @@
+// Test: Pointer-type member with brace default member initializer inside a
+// member struct template PARTIAL SPECIALIZATION body. This mirrors the
+// transform_view::_Iterator pattern but on the partial-specialization path
+// of parse_member_struct_template, which previously fell into the fallback
+// "Skip other complex cases" else block and silently dropped the member.
+//
+//   template<typename T> struct Outer::Inner<T*> { int* ptr{}; };
+//
+// The test verifies the members are actually registered by checking that
+// the partial specialization has a non-zero size that accounts for both
+// the pointer and the dependent type member.
+
+struct outer {
+	template <typename T>
+	struct inner {};
+
+	template <typename T>
+	struct inner<T*> {
+		int* ptr{};
+		T value{};
+	};
+};
+
+int main() {
+	// If the fallback else block silently dropped both members, the partial
+	// specialization would be an empty struct (size 1). With both members
+	// registered, it must be at least sizeof(int*) + sizeof(int).
+	static_assert(sizeof(outer::inner<int*>) >= sizeof(int*) + sizeof(int),
+		"partial specialization members with brace-init were dropped");
+	return 0;
+}

--- a/tests/test_member_struct_template_pointer_brace_init_ret0.cpp
+++ b/tests/test_member_struct_template_pointer_brace_init_ret0.cpp
@@ -1,0 +1,19 @@
+// Test: Pointer-type member with brace default member initializer inside a
+// member struct template body. This mirrors the MSVC STL
+// transform_view::_Iterator pattern:
+//   _Parent_t* _Parent{};
+// which previously failed with "Expected '(' or ';' after member declaration".
+
+struct outer {
+	template <bool Const>
+	struct iterator {
+		int* current{};
+		outer* parent{};
+	};
+};
+
+int main() {
+	outer::iterator<true> it;
+	(void)it;
+	return 0;
+}

--- a/tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp
+++ b/tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp
@@ -1,0 +1,26 @@
+// Test: A constrained partial specialization of a member class template is
+// valid even when its argument list matches the primary template parameter
+// list, because the requires clause makes it more specialized.
+// This mirrors the MSVC STL transform_view::_Category_base pattern.
+
+template <typename T>
+concept Integral = requires { typename T::value_type; };
+
+template <typename T>
+concept Forward = requires(T t) { ++t; };
+
+struct outer {
+	template <bool Const>
+	struct category_base {};
+
+	template <bool Const>
+		requires Forward<int>
+	struct category_base<Const> {
+		using type = int;
+	};
+};
+
+int main() {
+	using cat = outer::category_base<true>;
+	return sizeof(cat) - sizeof(outer::category_base<true>);
+}


### PR DESCRIPTION
## Summary

This PR continues the template argument refactoring described in `docs/2026-05-12-template-argument-architecture-audit.md` and `docs/2026-05-12-template-argument-standard-conformance-investigation.md`, targeting the highest-impact blockers preventing the MSVC STL `<ranges>` header from parsing. All three fixes are small, focused slices that unblock the `transform_view` template in `__msvc_ranges_to.hpp`.

## Slice 1: Allow constrained member template partial specializations with same args

**Commit:** `62ab426d`

A C++20 partial specialization of a member class template is valid even when its argument list matches the primary template parameter list, as long as a `requires`-clause makes it more specialized than the primary. The MSVC STL relies on this for `transform_view::_Category_base`:

```cpp
template <bool _Const>
struct _Category_base {};

template <bool _Const>
    requires forward_range<_Maybe_const<_Const, _Vw>>
struct _Category_base<_Const> { ... };
```

Previously the parser rejected any member struct template partial specialization whose argument list echoed the primary parameter list, regardless of whether a `requires`-clause was present. This blocked `<ranges>` at `__msvc_ranges_to.hpp:659`.

**Fix:** Skip the "exact primary parameter pattern" rejection when a `requires`-clause is present. The constrained-pattern counter already disambiguates multiple constrained specializations with the same pattern. The unconstrained echo guard tests (`test_member_template_partial_specialization_same_args_fail.cpp` and `test_member_template_partial_specialization_pack_echo_fail.cpp`) still fail as expected.

**Test:** `tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp`

## Slice 2: Add brace-init default member initializers to member struct template bodies

**Commit:** `7f4b82eb`

The primary member struct template body parser only handled data members with `=` initializers or no initializer. The MSVC STL `transform_view::_Iterator` uses pointer members with brace default initialization:

```cpp
iterator_t<_Base> _Current{};
_Parent_t* _Parent{};
```

This previously failed with `Expected '(' or ';' after member declaration` at `__msvc_ranges_to.hpp:676`.

**Fix:** Added a brace-init branch that mirrors the partial-specialization body handling, calling `parse_brace_initializer` with the member type specifier.

**Test:** `tests/test_member_struct_template_pointer_brace_init_ret0.cpp`

## Slice 3: Add brace-init default member initializers to member struct template partial specializations

**Commit:** `bbfe807a`

The partial specialization body of `parse_member_struct_template` had the same gap as the primary template body: data members with brace default initializers (e.g., `int* ptr{};`) fell into the fallback "Skip other complex cases" else block and were silently dropped from the struct. This meant partial specializations compiled but were missing members, producing incorrect layouts.

**Fix:** Added the same brace-init branch that mirrors the primary-template body handling, calling `parse_brace_initializer` with the member type specifier.

**Test:** `tests/test_member_struct_template_partial_spec_pointer_brace_init_ret0.cpp` — uses a `static_assert` on `sizeof` to verify the members are actually registered rather than silently dropped.

## Progress on `<ranges>`

After these three slices, the `test_std_ranges.cpp` frontier has moved from `__msvc_ranges_to.hpp:659` past the `_Parent_t* _Parent{}` blocker to a later parser error at `__msvc_ranges_to.hpp:705` (`Expected type specifier`), which is the next slice to tackle.

## Verification

- `build_flashcpp.bat` succeeds with 0 warnings and 0 errors.
- New focused tests compile, link, and return the expected values.
- Existing `_fail` guard tests still fail as expected (no regressions in the unconstrained echo rejection).