### PR TITLE
[codex] Advance ranges member template parsing frontier

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -145,12 +145,23 @@ later used as template arguments. The focused regression is:
 
 - `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`
 
-The active `std/test_std_ranges.cpp` frontier has moved to a later parser error
-in MSVC `__msvc_ranges_to.hpp`:
+The previous `std/test_std_ranges.cpp` member-template parser blockers are now
+covered:
 
-- `__msvc_ranges_to.hpp:676:40: Expected '(' or ';' after member declaration`
-- first visible shape: `_Parent_t* _Parent{};` inside
-  `transform_view::_Iterator`
+- `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
+- `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
+
+These guard the `transform_view::_Iterator` shapes where a skipped member class
+template constructor ends with a braced member initializer before the function
+body, and where an inline hidden-friend `operator==` appears inside the member
+class template body.
+
+The active `std/test_std_ranges.cpp` frontier has moved to semantic/template
+return-type consistency:
+
+- `function 'end' has inconsistent deduced auto return types`
+- first visible conflict: `_Iterator<...>` versus `_Sentinel<...>` from
+  `std::ranges::end`
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -188,18 +199,20 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the current `std/test_std_ranges.cpp` parser failure around
-   `_Parent_t* _Parent{};` into a focused member declaration test.
-2. Trace whether the failure belongs in member declarator parsing, brace
-   default member initializers, alias-to-pointer metadata, or template-body
-   context setup before changing parser behavior.
+1. Reduce the current `std/test_std_ranges.cpp` inconsistent deduced `auto`
+   return failure into a focused range/end overload or conditional-return test.
+2. Trace whether the failure belongs in constrained overload viability,
+   function-template instantiation reuse, `if constexpr` pruning, or auto return
+   deduction before changing return-type behavior.
 3. Keep `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+   `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
+   `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
    `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
    `tests/test_scoped_enum_builtin_shift_fail.cpp` in the guard set so the
    cleared `std::byte` operator and dependent-alias paths do not regress.
-4. Re-run `std/test_std_ranges.cpp` after the parser fix and let the next
-   concrete failure choose the following layer.
+4. Re-run `std/test_std_ranges.cpp` after the semantic/template fix and let the
+   next concrete failure choose the following layer.
 5. Promote stale expected-failure tracking only after the corresponding harness
    entry is proven green.
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -134,12 +134,18 @@ regression is:
 
 - `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to a
-later parser diagnostic in MSVC `__msvc_ranges_to.hpp`:
+The later `std/test_std_ranges.cpp` member-template parser blockers are now
+covered:
 
-- `__msvc_ranges_to.hpp:676:40: Expected '(' or ';' after member declaration`
-- first visible shape: `_Parent_t* _Parent{};` inside
-  `transform_view::_Iterator`
+- `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
+- `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+semantic/template consistency:
+
+- `function 'end' has inconsistent deduced auto return types`
+- first visible conflict: `_Iterator<...>` versus `_Sentinel<...>` from
+  `std::ranges::end`
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -171,10 +177,12 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` member declaration
-   parser failure around `_Parent_t* _Parent{};`.
+1. Reduce and fix the current `std/test_std_ranges.cpp` inconsistent deduced
+   `auto` return failure around `std::ranges::end`.
 2. Keep the cleared dependent-alias and `std::byte` constrained-operator paths
-   guarded with `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+    guarded with `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+   `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
+   `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
    `tests/test_member_struct_template_dependent_alias_const_assign_fail.cpp`,
    `tests/test_member_template_partial_specialization_same_args_fail.cpp`,
    `tests/test_member_template_partial_specialization_pack_echo_fail.cpp`,

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -180,7 +180,7 @@ declarator-shaped pointer-depth/member-class metadata.
 1. Reduce and fix the current `std/test_std_ranges.cpp` inconsistent deduced
    `auto` return failure around `std::ranges::end`.
 2. Keep the cleared dependent-alias and `std::byte` constrained-operator paths
-    guarded with `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+   guarded with `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
    `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
    `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
    `tests/test_member_struct_template_dependent_alias_const_assign_fail.cpp`,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -4186,6 +4186,7 @@ private:	 // Resume private methods
 	void skip_template_arguments();	// Skip over template arguments <...>
 	void skip_qualified_name_parts();  // Skip namespace-qualified name parts (e.g., ::Class after 'ns')
 	std::string_view consume_qualified_name_suffix(std::string_view base_name);	// Same but builds and returns full qualified name
+	void skip_constructor_member_initializer_list();	 // Skip constructor member-initializer-list after ':'
 	void skip_member_declaration_to_semicolon();	 // Skip member declaration until ';' or end of struct
 	void skip_function_body();  // Skip over '{...}' or function-try-block 'try {...} catch...'
 	void skip_catch_clauses();  // Skip over one or more 'catch(...){}' clauses

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -1373,6 +1373,40 @@ std::string_view Parser::consume_qualified_name_suffix(std::string_view base_nam
 	return builder.commit();
 }
 
+void Parser::skip_constructor_member_initializer_list() {
+	if (peek() != ":"_tok) {
+		return;
+	}
+	advance(); // consume ':'
+
+	while (!peek().is_eof()) {
+		if (peek() == "typename"_tok) {
+			advance();
+		}
+		while (!peek().is_eof() && peek() != "("_tok && peek() != "{"_tok && peek() != ";"_tok) {
+			if (peek() == "<"_tok) {
+				skip_template_arguments();
+			} else if (peek() == "::"_tok) {
+				advance();
+			} else {
+				advance();
+			}
+		}
+		if (peek() == "("_tok) {
+			skip_balanced_parens();
+		} else if (peek() == "{"_tok) {
+			skip_balanced_braces();
+		} else {
+			break;
+		}
+		if (peek() == ","_tok) {
+			advance();
+		} else {
+			break;
+		}
+	}
+}
+
 void Parser::skip_member_declaration_to_semicolon() {
 	// Skip tokens until we reach ';' at top level, or an unmatched '}'
 	// Handles nested parentheses, angle brackets, and braces

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -618,49 +618,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				if (peek() == ":"_tok) {
 					initializer_list_start = save_token_position();
 					has_initializer_list = true;
-					advance(); // consume ':'
-					// Skip member initializer list entries: name(expr), name(expr), ...
-					while (!peek().is_eof()) {
-						// Skip initializer name (possibly qualified: typename X<T>::type() or Base<T>(...))
-						if (peek() == "typename"_tok) {
-							advance(); // consume 'typename'
-						}
-						// Skip tokens until we find '(' or '{' of the initializer
-						while (!peek().is_eof() && peek() != "("_tok && peek() != "{"_tok && peek() != ";"_tok) {
-							if (peek() == "<"_tok) {
-								skip_template_arguments();
-							} else if (peek() == "::"_tok) {
-								advance();
-							} else {
-								advance();
-							}
-						}
-						// Skip the initializer arguments
-						if (peek() == "("_tok) {
-							skip_balanced_parens();
-						} else if (peek() == "{"_tok) {
-							// Could be brace-init for a member, or the start of the function body
-							// If followed by a comma or another initializer, it's brace-init
-							auto check_save = save_token_position();
-							skip_balanced_braces();
-							if (peek() == ","_tok) {
-								// Brace-init member, continue
-								discard_saved_token(check_save);
-							} else {
-								// This was the function body (or end) - restore and break
-								restore_token_position(check_save);
-								break;
-							}
-						} else {
-							break;
-						}
-						// Check for more initializers
-						if (peek() == ","_tok) {
-							advance(); // consume ','
-						} else {
-							break;
-						}
-					}
+					skip_constructor_member_initializer_list();
 				}
 
 				// Save the delayed-parse position right before the function body.
@@ -4899,33 +4857,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		}
 
 		if (peek() == ":"_tok) {
-			advance(); // consume ':'
-			while (!peek().is_eof()) {
-				if (peek() == "typename"_tok) {
-					advance();
-				}
-				while (!peek().is_eof() && peek() != "("_tok && peek() != "{"_tok && peek() != ";"_tok) {
-					if (peek() == "<"_tok) {
-						skip_template_arguments();
-					} else if (peek() == "::"_tok) {
-						advance();
-					} else {
-						advance();
-					}
-				}
-				if (peek() == "("_tok) {
-					skip_balanced_parens();
-				} else if (peek() == "{"_tok) {
-					skip_balanced_braces();
-				} else {
-					break;
-				}
-				if (peek() == ","_tok) {
-					advance();
-				} else {
-					break;
-				}
-			}
+			skip_constructor_member_initializer_list();
 		}
 
 		skipMemberTemplateFunctionTail();

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -4916,14 +4916,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				if (peek() == "("_tok) {
 					skip_balanced_parens();
 				} else if (peek() == "{"_tok) {
-					auto check_save = save_token_position();
 					skip_balanced_braces();
-					if (peek() == ","_tok) {
-						discard_saved_token(check_save);
-					} else {
-						restore_token_position(check_save);
-						break;
-					}
 				} else {
 					break;
 				}
@@ -6022,6 +6015,16 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				auto alias_result = parse_member_type_alias("typedef", &member_struct_ref, current_access);
 				if (alias_result.is_error()) {
 					return alias_result;
+				}
+				continue;
+			}
+			if (keyword == "friend") {
+				auto friend_result = parse_friend_declaration();
+				if (friend_result.is_error()) {
+					return friend_result;
+				}
+				if (auto friend_node = friend_result.node()) {
+					member_struct_ref.add_friend(*friend_node);
 				}
 				continue;
 			}

--- a/tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp
+++ b/tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp
@@ -1,0 +1,18 @@
+template <class View>
+struct outer {
+	template <bool Const>
+	struct iterator {
+		int current;
+		outer* parent;
+
+		constexpr iterator(outer& parent_, int current_) noexcept(true)
+			: current{current_}, parent{&parent_} {
+			current = current + 1;
+		}
+	};
+};
+
+int main() {
+	outer<int>::iterator<true>* it = nullptr;
+	return it == nullptr ? 0 : 1;
+}

--- a/tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp
+++ b/tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp
@@ -1,0 +1,16 @@
+template <class View>
+struct outer {
+	template <bool Const>
+	struct iterator {
+		int value;
+
+		friend constexpr bool operator==(const iterator& left, const iterator& right) {
+			return left.value == right.value;
+		}
+	};
+};
+
+int main() {
+	outer<int>::iterator<true>* it = nullptr;
+	return it == nullptr ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- fix member class template constructor skipping when the final member initializer uses braced initialization before the function body
- route hidden friend declarations inside primary member class template bodies through friend parsing instead of member-function parsing
- update template-argument planning docs with the new std::ranges frontier