### PR TITLE
[codex] Defer dependent if constexpr auto returns

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -156,12 +156,15 @@ template constructor ends with a braced member initializer before the function
 body, and where an inline hidden-friend `operator==` appears inside the member
 class template body.
 
-The active `std/test_std_ranges.cpp` frontier has moved to semantic/template
-return-type consistency:
+The `std::ranges::end` inconsistent auto-return frontier is now covered by:
 
-- `function 'end' has inconsistent deduced auto return types`
-- first visible conflict: `_Iterator<...>` versus `_Sentinel<...>` from
-  `std::ranges::end`
+- `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
+
+The active `std/test_std_ranges.cpp` frontier has moved to constrained
+template overload viability:
+
+- `All 5 template overload(s) failed for 'swap'`
+- `All 2 template overload(s) failed for 'std::invoke'`
 
 ### 2. Dependent-qualified owner prefix-chain extraction
 
@@ -199,12 +202,13 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the current `std/test_std_ranges.cpp` inconsistent deduced `auto`
-   return failure into a focused range/end overload or conditional-return test.
-2. Trace whether the failure belongs in constrained overload viability,
-   function-template instantiation reuse, `if constexpr` pruning, or auto return
-   deduction before changing return-type behavior.
-3. Keep `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+1. Reduce the current `std/test_std_ranges.cpp` `swap` / `std::invoke`
+   overload failures into focused constrained-call tests.
+2. Trace whether the failure belongs in overload viability, constraint
+   substitution, function-template instantiation reuse, or `invoke_result`
+   style return-type formation before changing call resolution behavior.
+3. Keep `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
+   `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
    `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
    `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
    `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -140,12 +140,15 @@ covered:
 - `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
 - `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to
-semantic/template consistency:
+The `std::ranges::end` inconsistent auto-return path is now covered by:
 
-- `function 'end' has inconsistent deduced auto return types`
-- first visible conflict: `_Iterator<...>` versus `_Sentinel<...>` from
-  `std::ranges::end`
+- `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+constrained template overload viability:
+
+- `All 5 template overload(s) failed for 'swap'`
+- `All 2 template overload(s) failed for 'std::invoke'`
 
 ### 2. Deeper dependent-qualified owner materialization
 
@@ -177,10 +180,12 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` inconsistent deduced
-   `auto` return failure around `std::ranges::end`.
-2. Keep the cleared dependent-alias and `std::byte` constrained-operator paths
-   guarded with `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
+1. Reduce and fix the current `std/test_std_ranges.cpp` `swap` / `std::invoke`
+   overload failures.
+2. Keep the cleared auto-return, dependent-alias, and `std::byte`
+   constrained-operator paths guarded with
+   `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
+   `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
    `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
    `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
    `tests/test_member_struct_template_dependent_alias_const_assign_fail.cpp`,

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -3576,9 +3576,24 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 			});
 		} else if (node.is<IfStatementNode>()) {
 			const IfStatementNode& if_stmt = node.as<IfStatementNode>();
-			if (if_stmt.get_then_statement().has_value()) {
-				self(self, if_stmt.get_then_statement());
+			if (if_stmt.is_constexpr()) {
+				ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
+				ConstExpr::EvalResult eval_result =
+					ConstExpr::Evaluator::evaluate(if_stmt.get_condition(), eval_ctx);
+				if (eval_result.success()) {
+					if (eval_result.as_bool()) {
+						self(self, if_stmt.get_then_statement());
+					} else if (if_stmt.get_else_statement().has_value()) {
+						self(self, *if_stmt.get_else_statement());
+					}
+					return;
+				}
+				if (expressionTypeDeductionIsStillDependent(if_stmt.get_condition(), currentTemplateParamNames())) {
+					has_still_dependent_return = true;
+					return;
+				}
 			}
+			self(self, if_stmt.get_then_statement());
 			if (if_stmt.get_else_statement().has_value()) {
 				self(self, *if_stmt.get_else_statement());
 			}
@@ -3653,7 +3668,8 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 		}
 	}
 
-	if (has_still_dependent_return && func_decl.is_template_pattern()) {
+	if (has_still_dependent_return &&
+		(func_decl.is_template_pattern() || isDependentTemplateContext() || !currentTemplateParamNames().empty())) {
 		FLASH_LOG(Parser, Debug, "  Keeping auto return type unresolved in dependent template context");
 		return;
 	}

--- a/tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp
+++ b/tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp
@@ -1,0 +1,18 @@
+template <bool Common>
+struct range_like {
+	auto end() {
+		if constexpr (Common) {
+			return 1;
+		} else {
+			return 2LL;
+		}
+	}
+};
+
+int main() {
+	range_like<true> common;
+	range_like<false> non_common;
+	auto it = common.end();
+	auto last = non_common.end();
+	return (it - 1) + static_cast<int>(last - 2);
+}


### PR DESCRIPTION
## Summary
- keep dependent `if constexpr` auto-return deduction unresolved during template-pattern parsing
- prune discarded `if constexpr` branches once the condition can be evaluated in an instantiated body
- add a focused regression for class-template members whose concrete specializations return different types from different `if constexpr` arms
- update the template-argument docs with the new `std::ranges` frontier

## Validation
- `./build_flashcpp.bat`
- `pwsh ./tests/run_all_tests.ps1 test_auto_return_if_constexpr_branch_prune_ret0.cpp`
- `pwsh ./tests/run_all_tests.ps1 test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
- `pwsh ./tests/run_all_tests.ps1 test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
- `pwsh ./tests/run_all_tests.ps1`

## Notes
- `tests/std/test_std_ranges.cpp` now moves past the previous `std::ranges::end` inconsistent deduced `auto` return failure.
- The next non-passing frontier is constrained overload viability: `swap` and `std::invoke` template overloads fail.