### PR TITLE
[codex] Handle ranges local proxy classes

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-05
+**Last updated:** 2026-07-07
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -178,11 +178,24 @@ The `std::ranges::end` inconsistent auto-return frontier is now covered by:
 
 - `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
 
-The active `std/test_std_ranges.cpp` frontier has moved to constrained
-template overload viability:
+The previous `std/test_std_ranges.cpp` `common_iterator` local proxy-class
+frontier is now covered:
 
-- `All 5 template overload(s) failed for 'swap'`
-- `All 2 template overload(s) failed for 'std::invoke'`
+- `tests/test_template_member_local_proxy_class_ret0.cpp`
+
+Local classes parsed inside instantiated template member bodies now keep their
+own delayed function-body queue instead of replaying the enclosing member body
+recursively. They are also marked as local classes so template class
+instantiation does not copy them as owner member classes. Inheriting
+constructors declared by local classes, such as `using _Proxy_base::_Proxy_base`,
+are materialized during instantiated member-body parsing so brace-initialized
+proxy objects can select the inherited base constructor.
+
+The active `std/test_std_ranges.cpp` frontier has moved to template
+instantiation loop control:
+
+- `Template instantiation iteration limit exceeded (10000). Last template:
+  'std::char_traits' with 1 args. Possible infinite loop.`
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline
@@ -226,11 +239,12 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the current `std/test_std_ranges.cpp` `swap` / `std::invoke`
-   overload failures into focused constrained-call tests.
-2. Trace whether the failure belongs in overload viability, constraint
-   substitution, function-template instantiation reuse, or `invoke_result`
-   style return-type formation before changing call resolution behavior.
+1. Reduce the current `std/test_std_ranges.cpp` `std::char_traits`
+   instantiation loop into a focused cache/reuse or recursion guard test.
+2. Trace whether repeated `char_traits` materialization is caused by missing
+   class-template instantiation reuse, a stale failed-instantiation state,
+   specialization lookup drift, or a replay side effect before changing the
+   iteration limit.
 3. Keep `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_fail.cpp`,

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-05
+**Last updated:** 2026-07-07
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -161,11 +161,22 @@ The `std::ranges::end` inconsistent auto-return path is now covered by:
 
 - `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to
-constrained template overload viability:
+The previous standards-facing `std/test_std_ranges.cpp` local proxy-class
+failure is now covered:
 
-- `All 5 template overload(s) failed for 'swap'`
-- `All 2 template overload(s) failed for 'std::invoke'`
+- `tests/test_template_member_local_proxy_class_ret0.cpp`
+
+The covered C++20 rule is that classes declared inside an instantiated member
+function body are local classes, not nested member classes of the enclosing
+class template. Their delayed bodies must not replay the enclosing member body,
+and inheriting constructors declared by the local class remain usable for
+brace-initialized local proxy objects.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+template instantiation reuse/loop control:
+
+- `Template instantiation iteration limit exceeded (10000). Last template:
+  'std::char_traits' with 1 args. Possible infinite loop.`
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -203,8 +214,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` `swap` / `std::invoke`
-   overload failures.
+1. Reduce and fix the current `std/test_std_ranges.cpp` `std::char_traits`
+   instantiation loop.
 2. Keep the cleared auto-return, dependent-alias, and `std::byte`
    constrained-operator paths guarded with
    `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
@@ -226,8 +237,9 @@ declarator-shaped pointer-depth/member-class metadata.
 3. Remove stale expected-failure tracking for `test_cstddef.cpp`,
    `test_cstdio_puts.cpp`, and `test_cstdlib.cpp` where the harness still
    records it.
-4. Only extract deeper dependent-qualified owner materialization if that failure
-   proves the current consumer-specific prefix-chain handling is the blocker.
+4. Only extract deeper dependent-qualified owner materialization if a concrete
+   failure proves the current consumer-specific prefix-chain handling is the
+   blocker.
 5. Keep replay identity and member-object-pointer work opportunistic unless a
    concrete regression points there.
 

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1085,6 +1085,8 @@ public:
 	void set_is_final(bool final) { is_final_ = final; }
 	bool is_forward_declaration() const { return is_forward_declaration_; }
 	void set_is_forward_declaration(bool value) { is_forward_declaration_ = value; }
+	bool is_local_class() const { return is_local_class_; }
+	void set_is_local_class(bool value) { is_local_class_ = value; }
 	AccessSpecifier default_access() const {
 		return is_class_ ? AccessSpecifier::Private : AccessSpecifier::Public;
 	}
@@ -1434,6 +1436,7 @@ private:
 	bool is_union_;	// true for union, false for struct/class
 	bool is_final_ = false;	// true if declared with 'final' keyword
 	bool is_forward_declaration_ = false;  // true for forward declarations without body
+	bool is_local_class_ = false;
 	bool has_deleted_default_constructor_ = false;  // Track deleted default constructor
 	bool has_deleted_copy_constructor_ = false;		// Track deleted copy constructor
 	bool has_deleted_move_constructor_ = false;		// Track deleted move constructor

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -347,6 +347,17 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 	}
 
 	auto struct_name = name_token.handle();
+	const bool is_local_class_declaration = current_function_ != nullptr;
+	std::vector<DelayedFunctionBody> saved_local_class_parent_delayed_bodies;
+	if (is_local_class_declaration) {
+		saved_local_class_parent_delayed_bodies = std::move(delayed_function_bodies_);
+		delayed_function_bodies_.clear();
+	}
+	ScopeGuard restore_parent_delayed_bodies([&]() {
+		if (is_local_class_declaration) {
+			delayed_function_bodies_ = std::move(saved_local_class_parent_delayed_bodies);
+		}
+	});
 
 	// Handle out-of-line nested class definitions and template specializations.
 	// Patterns: class Outer::Inner { ... }
@@ -453,6 +464,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 
 	// Create struct declaration node - string_view points directly into source text
 	auto [struct_node, struct_ref] = emplace_node_ref<StructDeclarationNode>(struct_name, is_class);
+	struct_ref.set_is_local_class(is_local_class_declaration);
 
 	// Push struct parsing context for nested class support
 	struct_parsing_context_stack_.push_back({StringTable::getStringView(struct_name),
@@ -1624,6 +1636,9 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 						if (auto nested_node = nested_result.node()) {
 							// Set enclosing class relationship
 							auto& nested_struct = nested_node->as<StructDeclarationNode>();
+							if (nested_struct.is_local_class()) {
+								continue;
+							}
 							nested_struct.set_enclosing_class(&struct_ref);
 
 							// Add to outer class
@@ -3297,7 +3312,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 	// This must happen before implicit constructor generation
 	if (!struct_parsing_context_stack_.empty() &&
 		struct_parsing_context_stack_.back().has_inherited_constructors &&
-		!parsing_template_class_) {
+		(!parsing_template_class_ || is_local_class_declaration)) {
 		// Iterate through base classes and generate forwarding constructors
 		for (const auto& base_class : struct_info->base_classes) {
 			const TypeInfo* base_type_info = tryGetTypeInfo(base_class.type_index);

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1636,9 +1636,6 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 						if (auto nested_node = nested_result.node()) {
 							// Set enclosing class relationship
 							auto& nested_struct = nested_node->as<StructDeclarationNode>();
-							if (nested_struct.is_local_class()) {
-								continue;
-							}
 							nested_struct.set_enclosing_class(&struct_ref);
 
 							// Add to outer class

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7928,6 +7928,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	for (const auto& nested_class : class_decl.nested_classes()) {
 		if (nested_class.is<StructDeclarationNode>()) {
 			const StructDeclarationNode& nested_struct = nested_class.as<StructDeclarationNode>();
+			if (nested_struct.is_local_class()) {
+				continue;
+			}
 			auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(instantiated_name).append("::"sv).append(nested_struct.name()));
 
 			// Create a new StructTypeInfo for the nested class

--- a/tests/test_template_member_local_nested_class_ret0.cpp
+++ b/tests/test_template_member_local_nested_class_ret0.cpp
@@ -1,0 +1,18 @@
+template <typename T>
+struct Holder {
+	int read(T value) {
+		struct Local {
+			struct Nested {
+				T stored;
+			};
+		};
+
+		typename Local::Nested nested{value};
+		return nested.stored;
+	}
+};
+
+int main() {
+	Holder<int> holder;
+	return holder.read(42) == 42 ? 0 : 1;
+}

--- a/tests/test_template_member_local_proxy_class_ret0.cpp
+++ b/tests/test_template_member_local_proxy_class_ret0.cpp
@@ -1,0 +1,24 @@
+template<typename Iter>
+struct common_like {
+	Iter value;
+
+	int read() {
+		struct ProxyBase {
+			Iter keep;
+			explicit ProxyBase(Iter value) : keep(value) {}
+		};
+
+		struct ArrowProxy : private ProxyBase {
+			friend common_like;
+			using ProxyBase::ProxyBase;
+		};
+
+		ArrowProxy proxy{value};
+		return 42;
+	}
+};
+
+int main() {
+	common_like<int> iter{42};
+	return iter.read() == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This PR fixes the next `std/test_std_ranges.cpp` frontier around MSVC `common_iterator` local proxy classes.

Local classes declared while parsing an instantiated template member body are now marked as local classes, keep their own delayed function-body queue, and are not copied as nested member classes during class-template instantiation. Local classes can also materialize inherited constructors during instantiated member-body parsing, which covers STL proxy shapes such as `using _Proxy_base::_Proxy_base` followed by brace initialization.

The planning docs were updated after validation to record the new baseline and the next frontier: `std::char_traits` repeatedly instantiates until the template iteration guard trips.
