### PR TITLE
[codex] Cache exact class specializations

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -191,11 +191,26 @@ constructors declared by local classes, such as `using _Proxy_base::_Proxy_base`
 are materialized during instantiated member-body parsing so brace-initialized
 proxy objects can select the inherited base constructor.
 
-The active `std/test_std_ranges.cpp` frontier has moved to template
-instantiation loop control:
+The previous `std/test_std_ranges.cpp` `std::char_traits` instantiation loop is
+now covered:
 
-- `Template instantiation iteration limit exceeded (10000). Last template:
-  'std::char_traits' with 1 args. Possible infinite loop.`
+- `tests/test_template_exact_specialization_reuse_ret0.cpp`
+
+Exact class-template specializations now register in the class-template
+instantiation cache after materialization, including the unqualified cache key
+used by namespace-qualified templates. Repeated `std::char_traits<char>` probes
+therefore hit the existing early cache instead of consuming the global
+instantiation-iteration budget.
+
+The active `std/test_std_ranges.cpp` frontier has moved to parsing a defaulted
+constructor with a trailing requires-clause in MSVC `<ranges>`:
+
+- `single_view() requires default_initializable<_Ty> = default;`
+
+Investigate the constructor/function declarator path that accepts a
+requires-clause before a defaulted/deleted function definition. Keep this as a
+parser grammar fix unless the live trace proves the parsed declaration shape is
+already correct and a later semantic path is misreporting the error.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -172,11 +172,25 @@ class template. Their delayed bodies must not replay the enclosing member body,
 and inheriting constructors declared by the local class remain usable for
 brace-initialized local proxy objects.
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to
-template instantiation reuse/loop control:
+The previous standards-facing `std/test_std_ranges.cpp` `std::char_traits`
+instantiation loop is now covered:
 
-- `Template instantiation iteration limit exceeded (10000). Last template:
-  'std::char_traits' with 1 args. Possible infinite loop.`
+- `tests/test_template_exact_specialization_reuse_ret0.cpp`
+
+Exact class-template specializations participate in the same class-template
+instantiation cache as primary-template materializations, so repeated
+standard-header probes of a full specialization do not exhaust the global
+instantiation-iteration budget.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+parsing a defaulted constructor with a trailing requires-clause in MSVC
+`<ranges>`:
+
+- `single_view() requires default_initializable<_Ty> = default;`
+
+The C++20 grammar permits constrained non-template functions and constructors.
+The next slice should verify the parser path that handles a constructor
+declarator followed by a requires-clause and then `= default` or `= delete`.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -214,8 +228,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` `std::char_traits`
-   instantiation loop.
+1. Reduce and fix the current `std/test_std_ranges.cpp` trailing-requires
+   defaulted-constructor parse failure.
 2. Keep the cleared auto-return, dependent-alias, and `std::byte`
    constrained-operator paths guarded with
    `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -4772,6 +4772,23 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 
 	StructDeclarationNode& spec_struct = spec_node.as<StructDeclarationNode>();
 	InlineVector<TemplateParameterNode, 4> no_template_params;
+	auto register_exact_specialization_instantiation = [&]() {
+		const StringHandle qualified_template_name =
+			StringTable::getOrInternStringHandle(template_name);
+		gTemplateRegistry.registerInstantiation(
+			qualified_template_name,
+			template_args,
+			spec_node);
+		if (size_t last_colon = template_name.rfind("::");
+			last_colon != std::string_view::npos) {
+			const StringHandle unqualified_template_name =
+				StringTable::getOrInternStringHandle(template_name.substr(last_colon + 2));
+			gTemplateRegistry.registerInstantiation(
+				unqualified_template_name,
+				template_args,
+				spec_node);
+		}
+	};
 
 	// Helper lambda to register type aliases with qualified names
 	auto register_type_aliases = [&]() {
@@ -5023,6 +5040,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 		// with qualified names if they haven't been registered yet
 		register_type_aliases();
 		register_nested_class_aliases();
+		register_exact_specialization_instantiation();
 
 		return std::nullopt;	 // Already instantiated
 	}
@@ -5270,6 +5288,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 	if (struct_type_info.getStructInfo()) {
 		struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 	}
+	register_exact_specialization_instantiation();
 
 	return std::nullopt;	 // Return nullopt since we don't need to add anything to AST
 }

--- a/tests/test_template_exact_specialization_reuse_ret0.cpp
+++ b/tests/test_template_exact_specialization_reuse_ret0.cpp
@@ -1,0 +1,23 @@
+template <typename T>
+struct traits {
+	using value_type = T;
+};
+
+template <>
+struct traits<char> {
+	using value_type = char;
+	static constexpr int marker = 7;
+};
+
+template <typename T>
+struct wrapper {
+	using first = typename traits<T>::value_type;
+	using second = typename traits<T>::value_type;
+	static constexpr int value = traits<T>::marker + traits<T>::marker;
+};
+
+int main() {
+	wrapper<char>::first a = 'A';
+	wrapper<char>::second b = 'B';
+	return wrapper<char>::value == 14 && a == 'A' && b == 'B' ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- register exact class-template specializations in the existing class-template instantiation cache
- add a regression for repeated exact-specialization reuse
- update the template-argument planning docs with the new std::ranges frontier