### PR TITLE
[codex] Accept declaration-only variable templates

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -202,15 +202,25 @@ used by namespace-qualified templates. Repeated `std::char_traits<char>` probes
 therefore hit the existing early cache instead of consuming the global
 instantiation-iteration budget.
 
-The active `std/test_std_ranges.cpp` frontier has moved to parsing a defaulted
-constructor with a trailing requires-clause in MSVC `<ranges>`:
+The previous `std/test_std_ranges.cpp` variable-template declaration blocker is
+now covered:
 
-- `single_view() requires default_initializable<_Ty> = default;`
+- `tests/test_variable_template_declaration_no_initializer_ret0.cpp`
 
-Investigate the constructor/function declarator path that accepts a
-requires-clause before a defaulted/deleted function definition. Keep this as a
-parser grammar fix unless the live trace proves the parsed declaration shape is
-already correct and a later semantic path is misreporting the error.
+Template declaration lookahead now recognizes declaration-only variable
+templates such as `template <class T> constexpr empty_view<T> empty;` as
+variable templates instead of falling through to function-template parsing.
+
+The active `std/test_std_ranges.cpp` frontier has moved to constrained member
+class-template partial specialization parsing in MSVC `<ranges>`:
+
+- `template <forward_range _View> struct _Category_base<_View> { ... };`
+
+Investigate why the partial-specialization guard treats this constrained
+parameter-list pattern as exactly echoing the primary template parameter list.
+The earlier "primary parameter list" rejection is still correct for genuinely
+non-specialized member class templates, so keep the fix specific to constrained
+or otherwise more-specialized patterns.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -182,15 +182,25 @@ instantiation cache as primary-template materializations, so repeated
 standard-header probes of a full specialization do not exhaust the global
 instantiation-iteration budget.
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to
-parsing a defaulted constructor with a trailing requires-clause in MSVC
-`<ranges>`:
+The previous standards-facing `std/test_std_ranges.cpp` variable-template
+declaration failure is now covered:
 
-- `single_view() requires default_initializable<_Ty> = default;`
+- `tests/test_variable_template_declaration_no_initializer_ret0.cpp`
 
-The C++20 grammar permits constrained non-template functions and constructors.
-The next slice should verify the parser path that handles a constructor
-declarator followed by a requires-clause and then `= default` or `= delete`.
+C++14 variable templates can be declarations without an initializer; C++20
+standard headers use this form for CPO-like objects such as
+`std::views::empty`. Template declaration lookahead now recognizes the trailing
+semicolon form before falling through to function-template parsing.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to a
+constrained member class-template partial specialization in MSVC `<ranges>`:
+
+- `template <forward_range _View> struct _Category_base<_View> { ... };`
+
+The next slice should preserve the valid rejection of a partial-specialization
+argument list that merely repeats the primary parameters, while accepting a
+constrained parameter pattern that is more specialized than the unconstrained
+primary.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -228,8 +238,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` trailing-requires
-   defaulted-constructor parse failure.
+1. Reduce and fix the current `std/test_std_ranges.cpp` constrained member
+   class-template partial-specialization parse failure.
 2. Keep the cleared auto-return, dependent-alias, and `std::byte`
    constrained-operator paths guarded with
    `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -746,10 +746,10 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 							advance();
 						}
 						// Now check what follows the closing >
-						// If it's '=' or '{', it's a variable template partial spec
+						// If it's ';', '=' or '{', it's a variable template partial spec
 						// If it's '::', it's a static member definition (NOT variable template)
 						if (!peek().is_eof() &&
-							(peek() == "="_tok || peek() == "{"_tok)) {
+							(peek() == ";"_tok || peek() == "="_tok || peek() == "{"_tok)) {
 							is_variable_template = true;
 						}
 						// If it's '::', fall through (is_variable_template stays false)
@@ -829,7 +829,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 								advance();
 							}
 							if (!peek().is_eof() &&
-								(peek() == "="_tok || peek() == "{"_tok)) {
+								(peek() == ";"_tok || peek() == "="_tok || peek() == "{"_tok)) {
 								is_variable_template = true;
 								FLASH_LOG(Parser, Debug, "Re-detected variable template partial spec after requires clause");
 							}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -721,13 +721,14 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				advance();
 
 				// After identifier, check what comes next:
+				// - ';' : variable template declaration with no initializer
 				// - '=' : variable template primary definition
 				// - '{' : variable template with brace initialization (C++11)
 				// - '<' followed by '...>' and then '=' or '{' : variable template partial specialization
 				// - '<' followed by '...>' and then '::' : NOT a variable template (static member definition)
 				// - '(' : function, not variable template
 				if (!peek().is_eof()) {
-					if (peek() == "="_tok || peek() == "{"_tok) {
+					if (peek() == ";"_tok || peek() == "="_tok || peek() == "{"_tok) {
 						is_variable_template = true;
 					} else if (peek() == "<"_tok) {
 						// Could be partial spec or static member definition
@@ -814,9 +815,9 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				if (peek().is_identifier()) {
 					advance();
 
-					// Check for '=', '{', or '<' followed by pattern and '=' or '{'
+					// Check for ';', '=', '{', or '<' followed by pattern and '=' or '{'
 					if (!peek().is_eof()) {
-						if (peek() == "="_tok || peek() == "{"_tok) {
+						if (peek() == ";"_tok || peek() == "="_tok || peek() == "{"_tok) {
 							is_variable_template = true;
 							FLASH_LOG(Parser, Debug, "Re-detected variable template after requires clause");
 						} else if (peek() == "<"_tok) {

--- a/tests/test_variable_template_declaration_no_initializer_ret0.cpp
+++ b/tests/test_variable_template_declaration_no_initializer_ret0.cpp
@@ -1,0 +1,13 @@
+template <typename T>
+struct EmptyView {
+};
+
+namespace views {
+	template <typename T>
+	constexpr EmptyView<T> empty;
+}
+
+int main() {
+	(void) views::empty<int>;
+	return 0;
+}

--- a/tests/test_variable_template_declaration_no_initializer_ret0.cpp
+++ b/tests/test_variable_template_declaration_no_initializer_ret0.cpp
@@ -5,6 +5,16 @@ struct EmptyView {
 namespace views {
 	template <typename T>
 	constexpr EmptyView<T> empty;
+
+	template <typename T>
+	constexpr EmptyView<T*> empty<T*>;
+
+	template <typename T>
+	concept PointerLike = true;
+
+	template <typename T>
+		requires PointerLike<T>
+	constexpr EmptyView<const T*> constrained_empty<const T*>;
 }
 
 int main() {


### PR DESCRIPTION
## Summary
- recognize declaration-only variable templates during template declaration lookahead
- add a focused regression for 	emplate <T> constexpr Type<T> name; without an initializer
- update the template-argument planning docs with the new std::ranges frontier