### PR TITLE
[codex] Accept constrained member partial echo patterns

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -211,16 +211,25 @@ Template declaration lookahead now recognizes declaration-only variable
 templates such as `template <class T> constexpr empty_view<T> empty;` as
 variable templates instead of falling through to function-template parsing.
 
-The active `std/test_std_ranges.cpp` frontier has moved to constrained member
-class-template partial specialization parsing in MSVC `<ranges>`:
+The previous `std/test_std_ranges.cpp` constrained member class-template
+partial-specialization blocker is now covered:
 
-- `template <forward_range _View> struct _Category_base<_View> { ... };`
+- `tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp`
 
-Investigate why the partial-specialization guard treats this constrained
-parameter-list pattern as exactly echoing the primary template parameter list.
-The earlier "primary parameter list" rejection is still correct for genuinely
-non-specialized member class templates, so keep the fix specific to constrained
-or otherwise more-specialized patterns.
+The member class-template partial-specialization guard now treats constrained
+template parameters as a specialization discriminator, matching the existing
+explicit `requires` handling while preserving the rejection of unconstrained
+argument lists that merely echo the primary template parameter list.
+
+The active `std/test_std_ranges.cpp` frontier has moved to template
+instantiation depth:
+
+- `Max template instantiation depth (40) exceeded for 'std::remove_cv'.`
+
+Investigate whether `std::remove_cv` is being recursively re-entered because
+an exact specialization or alias substitution path is not cached/canonicalized
+early enough. Do not raise the depth limit unless the live trace proves a real
+valid instantiation chain needs it.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -192,15 +192,24 @@ standard headers use this form for CPO-like objects such as
 `std::views::empty`. Template declaration lookahead now recognizes the trailing
 semicolon form before falling through to function-template parsing.
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to a
-constrained member class-template partial specialization in MSVC `<ranges>`:
+The previous standards-facing `std/test_std_ranges.cpp` constrained member
+class-template partial-specialization failure is now covered:
 
-- `template <forward_range _View> struct _Category_base<_View> { ... };`
+- `tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp`
 
-The next slice should preserve the valid rejection of a partial-specialization
-argument list that merely repeats the primary parameters, while accepting a
-constrained parameter pattern that is more specialized than the unconstrained
-primary.
+The parser now accepts same-argument member class-template partial
+specializations when either an explicit `requires` clause or constrained
+template parameter makes the specialization more constrained than the primary.
+The unconstrained same-argument rejection remains in place.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved to
+template instantiation depth:
+
+- `Max template instantiation depth (40) exceeded for 'std::remove_cv'.`
+
+The next slice should trace whether `std::remove_cv` recursion comes from
+missing early caching, non-canonicalized template arguments, or alias/specialty
+materialization re-entry before changing recursion limits.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -238,8 +247,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` constrained member
-   class-template partial-specialization parse failure.
+1. Reduce and fix the current `std/test_std_ranges.cpp` `std::remove_cv`
+   instantiation-depth failure.
 2. Keep the cleared auto-return, dependent-alias, and `std::byte`
    constrained-operator paths guarded with
    `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5060,13 +5060,24 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				}
 				return true;
 			};
+		auto has_constrained_template_parameter =
+			[&template_param_nodes]() -> bool {
+				for (const TemplateParameterNode& param : template_param_nodes) {
+					if (param.has_concept_constraint()) {
+						return true;
+					}
+				}
+				return false;
+			};
 		// C++20 [temp.class.spec.mfunc] allows a partial specialization whose
-		// argument list matches the primary template parameter list when a
-		// requires-clause makes it more specialized than the primary. The MSVC
-		// STL relies on this for transform_view::_Category_base. Only reject the
+		// argument list matches the primary template parameter list when either
+		// a requires-clause or a constrained template parameter makes it more
+		// specialized than the primary. The MSVC STL relies on the constrained
+		// parameter form for transform_view::_Category_base. Only reject the
 		// unconstrained echo pattern; a constrained same-arg specialization is
 		// valid and is disambiguated via the constrained-pattern counter below.
 		if (!requires_clause.has_value() &&
+			!has_constrained_template_parameter() &&
 			is_exact_primary_parameter_pattern(std::span<const TemplateTypeArg>(pattern_args.data(), pattern_args.size()))) {
 			return ParseResult::error("Partial specialization argument list cannot match the primary template parameter list", current_token_);
 		}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -5077,8 +5077,8 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		// unconstrained echo pattern; a constrained same-arg specialization is
 		// valid and is disambiguated via the constrained-pattern counter below.
 		if (!requires_clause.has_value() &&
-			!has_constrained_template_parameter() &&
-			is_exact_primary_parameter_pattern(std::span<const TemplateTypeArg>(pattern_args.data(), pattern_args.size()))) {
+			is_exact_primary_parameter_pattern(std::span<const TemplateTypeArg>(pattern_args.data(), pattern_args.size())) &&
+			!has_constrained_template_parameter()) {
 			return ParseResult::error("Partial specialization argument list cannot match the primary template parameter list", current_token_);
 		}
 

--- a/tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp
+++ b/tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp
@@ -20,7 +20,19 @@ struct outer {
 	};
 };
 
+struct constrained_parameter_outer {
+	template <typename View>
+	struct category_base {};
+
+	template <Forward View>
+	struct category_base<View> {
+		using type = int;
+	};
+};
+
 int main() {
 	using cat = outer::category_base<true>;
-	return sizeof(cat) - sizeof(outer::category_base<true>);
+	using constrained_cat = constrained_parameter_outer::category_base<int>;
+	return (sizeof(cat) - sizeof(outer::category_base<true>)) +
+		   (sizeof(constrained_cat) - sizeof(constrained_parameter_outer::category_base<int>));
 }


### PR DESCRIPTION
## Summary
- accept same-argument member class-template partial specializations when constrained template parameters make them more specialized
- extend the existing constrained member partial specialization regression to cover constrained parameter syntax
- update the template-argument planning docs with the new std::remove_cv frontier

## Validation
- .\\build_flashcpp.bat
- pwsh ./tests/run_all_tests.ps1 test_member_template_constrained_partial_spec_same_args_ret0.cpp
- pwsh ./tests/run_all_tests.ps1 std/test_std_ranges.cpp (progresses to std::remove_cv instantiation-depth frontier)
- git diff --check