### PR TITLE
[codex] Materialize dependent alias type identities

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-07
+**Last updated:** 2026-07-09
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -62,6 +62,10 @@ identity-preserving behavior:
   the member-call path when the qualified receiver is a concrete struct object,
   so instantiated `operator()` member templates receive the implicit object
   argument and preserve reference-argument mutation
+- dependent alias-template brace construction now preserves a structured
+  template-instantiation type through substitution, so function-template
+  deduction can see the resolved argument type instead of an `auto`
+  placeholder in the covered class-template member path
 
 ## Architectural invariants
 
@@ -230,15 +234,26 @@ chain of constrained class-template viability checks. The parser nesting guard
 now has enough headroom for those conforming chains while still retaining a
 finite runaway-recursion diagnostic.
 
-The active `std/test_std_ranges.cpp` frontier has moved to constrained CPO
-overload viability:
+Dependent alias-template brace construction used by `std::exchange`-like calls
+is now covered by:
 
-- `[depth=1]: All 4 template overload(s) failed for 'iter_swap'`
+- `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
+
+This preserves the alias template-id through `difference_t<Range>{...}`,
+materializes the alias target after the enclosing class-template argument is
+known, and lets ordinary function-template deduction consume the concrete
+argument type.
+
+The active `std/test_std_ranges.cpp` frontier has moved again:
+
 - `[depth=1]: All 2 template overload(s) failed for 'std::invoke'`
+- `function 'size' has inconsistent deduced auto return types: first return has
+  type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
 
 Reduce the next slice without hardcoding standard-library names. Start from the
-generic overload-resolution/constraints path used by `iter_swap` and `invoke`,
-then keep a non-`std` regression for the accepted language rule.
+generic overload-resolution/constraints path used by `invoke`, and separately
+reduce the CPO-object auto-return deduction issue behind `ranges::size`. Keep a
+non-`std` regression for each accepted language rule.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-09
+**Last updated:** 2026-07-10
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -62,10 +62,10 @@ identity-preserving behavior:
   the member-call path when the qualified receiver is a concrete struct object,
   so instantiated `operator()` member templates receive the implicit object
   argument and preserve reference-argument mutation
-- dependent alias-template brace construction now preserves a structured
-  template-instantiation type through substitution, so function-template
-  deduction can see the resolved argument type instead of an `auto`
-  placeholder in the covered class-template member path
+- direct dependent alias template-ids preserve the alias identity and argument
+  binding through member-function signature and body materialization; resolved
+  builtin targets use canonical native type indices rather than an invalid
+  category-only index
 
 ## Architectural invariants
 
@@ -78,6 +78,9 @@ Follow-up work should preserve these rules:
   silently recovering through compatibility metadata
 - keep substitution, deduction, overload ranking, replay/materialization, and
   constexpr evaluation as separate responsibilities
+- do not replace a concrete substituted type with an unresolved placeholder
+  index, and do not use a category-only builtin type where a native `TypeIndex`
+  is available
 - prefer identity-first replay attachment over `StructTypeInfo` repair scans
 - add abstractions only when they remove real repeated owner/replay logic or
   prevent standards-visible fallback behavior from reappearing
@@ -234,15 +237,16 @@ chain of constrained class-template viability checks. The parser nesting guard
 now has enough headroom for those conforming chains while still retaining a
 finite runaway-recursion diagnostic.
 
-Dependent alias-template brace construction used by `std::exchange`-like calls
-is now covered by:
+Dependent alias-template type-ids and brace construction used by
+`std::exchange`-like calls are now covered by:
 
 - `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
 
-This preserves the alias template-id through `difference_t<Range>{...}`,
-materializes the alias target after the enclosing class-template argument is
-known, and lets ordinary function-template deduction consume the concrete
-argument type.
+This preserves direct aliases such as `select_first_t<Left, FirstTail>` through
+member-function signature materialization, materializes the target after the
+enclosing class-template argument is known, and lets ordinary
+function-template deduction consume the concrete argument type on both Windows
+and Linux.
 
 The active `std/test_std_ranges.cpp` frontier has moved again:
 
@@ -321,6 +325,11 @@ declarator-shaped `member_class + pointer_depth` forms.
    next concrete failure choose the following layer.
 5. Promote stale expected-failure tracking only after the corresponding harness
    entry is proven green.
+6. Consolidate the direct dependent-alias placeholder factory and materializer
+   so parse, member-function shell substitution, and body substitution share a
+   single structured contract. Add focused coverage for direct aliases with
+   cv/ref/pointer modifiers and for aliases whose targets are intentionally
+   independent of one or more arguments.
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-07
+**Last updated:** 2026-07-09
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -65,6 +65,9 @@ The core suite now covers several formerly blocking standards-visible areas:
 - namespace-qualified callable objects keep member-call semantics when the
   receiver is a concrete struct object, including the implicit object argument
   for instantiated constrained `operator()` member templates
+- dependent alias-template brace construction keeps template identity until the
+  enclosing template arguments are concrete, allowing ordinary
+  function-template deduction to consume the resolved alias target type
 
 ## Remaining standards gaps
 
@@ -212,15 +215,26 @@ viability checks, not a `std::remove_cv` semantic shortcut or recursive alias
 bug. The parser depth guard remains finite but now has enough headroom for that
 kind of conforming C++20 template chain.
 
-The active standards-facing `std/test_std_ranges.cpp` failure has moved to CPO
-overload viability:
+Dependent alias-template brace construction used by `std::exchange`-like calls
+is now covered by:
 
-- `[depth=1]: All 4 template overload(s) failed for 'iter_swap'`
+- `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
+
+The reduced rule is generic: an alias template-id such as
+`difference_t<Range>{...}` remains a dependent template-instantiation type
+until `Range` is known, then materializes to its alias target before
+function-template deduction.
+
+The active standards-facing `std/test_std_ranges.cpp` failure has moved again:
+
 - `[depth=1]: All 2 template overload(s) failed for 'std::invoke'`
+- `function 'size' has inconsistent deduced auto return types: first return has
+  type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
 
-The next slice should reduce the generic constrained overload-resolution path
-behind `iter_swap`/`invoke`, with a non-`std` regression before touching the
-compiler implementation.
+The next slices should reduce the generic constrained overload-resolution path
+behind `invoke` and the CPO-object auto-return deduction path behind
+`ranges::size`, with non-`std` regressions before touching the compiler
+implementation.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -258,11 +272,15 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` `iter_swap` /
-   `std::invoke` constrained overload-viability failure.
-2. Keep the cleared auto-return, dependent-alias, and `std::byte`
+1. Reduce and fix the current `std/test_std_ranges.cpp` `std::invoke`
+   constrained overload-viability failure.
+2. Reduce and fix the `ranges::size` CPO-object auto-return deduction issue
+   without hardcoding standard-library names.
+3. Keep the cleared auto-return, dependent-alias, alias-brace construction, and
+   `std::byte`
    constrained-operator paths guarded with
    `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
+   `tests/test_template_exchange_dependent_alias_default_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_fail.cpp`,
    `tests/test_constrained_cpo_call_operator_ret0.cpp`,
@@ -278,13 +296,13 @@ declarator-shaped pointer-depth/member-class metadata.
    `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
    `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
    `tests/test_scoped_enum_builtin_shift_fail.cpp`.
-3. Remove stale expected-failure tracking for `test_cstddef.cpp`,
+4. Remove stale expected-failure tracking for `test_cstddef.cpp`,
    `test_cstdio_puts.cpp`, and `test_cstdlib.cpp` where the harness still
    records it.
-4. Only extract deeper dependent-qualified owner materialization if a concrete
+5. Only extract deeper dependent-qualified owner materialization if a concrete
    failure proves the current consumer-specific prefix-chain handling is the
    blocker.
-5. Keep replay identity and member-object-pointer work opportunistic unless a
+6. Keep replay identity and member-object-pointer work opportunistic unless a
    concrete regression points there.
 
 ## Standards rules for follow-up work

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-09
+**Last updated:** 2026-07-10
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -65,9 +65,9 @@ The core suite now covers several formerly blocking standards-visible areas:
 - namespace-qualified callable objects keep member-call semantics when the
   receiver is a concrete struct object, including the implicit object argument
   for instantiated constrained `operator()` member templates
-- dependent alias-template brace construction keeps template identity until the
-  enclosing template arguments are concrete, allowing ordinary
-  function-template deduction to consume the resolved alias target type
+- direct dependent alias template-ids and brace construction keep template
+  identity until enclosing arguments are concrete; a materialized builtin
+  target carries its canonical native type identity
 
 ## Remaining standards gaps
 
@@ -215,15 +215,16 @@ viability checks, not a `std::remove_cv` semantic shortcut or recursive alias
 bug. The parser depth guard remains finite but now has enough headroom for that
 kind of conforming C++20 template chain.
 
-Dependent alias-template brace construction used by `std::exchange`-like calls
-is now covered by:
+Dependent alias-template type-ids and brace construction used by
+`std::exchange`-like calls are now covered by:
 
 - `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
 
-The reduced rule is generic: an alias template-id such as
-`difference_t<Range>{...}` remains a dependent template-instantiation type
-until `Range` is known, then materializes to its alias target before
-function-template deduction.
+The reduced rule is generic: a direct alias template-id such as
+`select_first_t<Left, FirstTail>` remains a structured instantiation until the
+enclosing arguments are known, then materializes to its alias target before
+function-template deduction and code generation. A concrete builtin target
+must use its native type index, not an invalid category-only placeholder.
 
 The active standards-facing `std/test_std_ranges.cpp` failure has moved again:
 
@@ -304,6 +305,9 @@ declarator-shaped pointer-depth/member-class metadata.
    blocker.
 6. Keep replay identity and member-object-pointer work opportunistic unless a
    concrete regression points there.
+7. Unify direct dependent-alias placeholder creation and materialization across
+   declaration, signature, and expression entry points; add non-`std` coverage
+   for qualifier-bearing direct aliases and unused alias parameters.
 
 ## Standards rules for follow-up work
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2051,12 +2051,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		if (target_func.has_mangled_name()) {
 			setCallMangledName(new_expr, target_func.mangled_name());
 		}
-		const bool needs_structured_qualified_record =
-			call.has_qualified_name() ||
-			(qualified_call_name.has_value() && !qualified_call_name->empty()) ||
-			infer_qualified_name_from_parent;
-		if (needs_structured_qualified_record &&
-			!call.has_definition_lookup_record() &&
+		if (!call.has_definition_lookup_record() &&
 			!call.has_dependent_unqualified_lookup_record()) {
 			CallExprNode* materialized_call = std::get_if<CallExprNode>(&new_expr);
 			if (materialized_call != nullptr) {
@@ -2071,7 +2066,7 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 								false,
 								target_func,
 								true,
-								false);
+								call.has_dependent_unqualified_lookup_record());
 						record.has_value()) {
 						setCallDefinitionLookupRecord(*materialized_call, *record);
 					}
@@ -4520,6 +4515,146 @@ TypeSpecifierNode ExpressionSubstitutor::substituteInType(const TypeSpecifierNod
 				applyResolvedAliasModifiers(substituted_alias, resolved_alias);
 				applyOuterTypeModifiers(substituted_alias, type);
 				return substituted_alias;
+			}
+		}
+		if (type_info != nullptr && type_info->isTemplateInstantiation()) {
+			MaterializedStoredTemplateArgs materialized_args =
+				materializeStoredTemplateArgs(
+					*type_info,
+					/*evaluate_dependent_member_values=*/false,
+					kInitialDependentMemberTypeResolutionDepth);
+			if (templateArgsStillDependent(materialized_args.args) &&
+				current_owner_type_name_.isValid()) {
+				const TypeInfo* owner_type_info =
+					findTypeByName(current_owner_type_name_);
+				OuterTemplateBinding owner_binding =
+					parser_.buildAccumulatedOuterTemplateBinding(
+						owner_type_info,
+						nullptr,
+						current_owner_type_name_);
+				for (TemplateTypeArg& materialized_arg : materialized_args.args) {
+					if (!materialized_arg.dependent_name.isValid()) {
+						continue;
+					}
+					for (size_t i = 0;
+						 i < owner_binding.param_names.size() &&
+						 i < owner_binding.param_args.size();
+						 ++i) {
+						if (owner_binding.param_names[i] ==
+							materialized_arg.dependent_name) {
+							materialized_arg =
+								rebindDependentTemplateTypeArg(
+									owner_binding.param_args[i],
+									materialized_arg);
+							materialized_args.had_substitution = true;
+							break;
+						}
+					}
+				}
+			}
+			if (materialized_args.had_substitution &&
+				!materialized_args.args.empty() &&
+				!templateArgsStillDependent(materialized_args.args)) {
+				StringHandle qualified_base_template_name =
+					gNamespaceRegistry.buildQualifiedIdentifier(
+						type_info->sourceNamespace(),
+						type_info->baseTemplateName());
+				std::string_view base_template_name =
+					StringTable::getStringView(qualified_base_template_name);
+				if (base_template_name.empty()) {
+					base_template_name =
+						StringTable::getStringView(type_info->baseTemplateName());
+				}
+				if (!base_template_name.empty()) {
+					std::optional<ASTNode> alias_entry =
+						gTemplateRegistry.lookup_alias_template(base_template_name);
+					if (!alias_entry.has_value() &&
+						qualified_base_template_name != type_info->baseTemplateName()) {
+						alias_entry =
+							gTemplateRegistry.lookup_alias_template(
+								StringTable::getStringView(type_info->baseTemplateName()));
+					}
+					if (alias_entry.has_value() &&
+						alias_entry->is<TemplateAliasNode>()) {
+						const TemplateAliasNode& alias_node =
+							alias_entry->as<TemplateAliasNode>();
+						if (std::optional<TemplateTypeArg> rebound_arg =
+								parser_.tryRebindAliasTargetTemplateArg(
+									alias_node,
+									materialized_args.args);
+							rebound_arg.has_value() &&
+							!rebound_arg->is_value) {
+							TypeSpecifierNode substituted_type =
+								makeTypeSpecifierFromTemplateTypeArg(
+									*rebound_arg,
+									type.token());
+							applyOuterTypeModifiers(substituted_type, type);
+							return substituted_type;
+						}
+						TypeSpecifierNode substituted_type =
+							substituteInType(alias_node.target_type_node());
+						if (substituted_type.category() != TypeCategory::Invalid &&
+							substituted_type.category() != TypeCategory::Template &&
+							!isPlaceholderAutoType(substituted_type.category())) {
+							applyOuterTypeModifiers(substituted_type, type);
+							return substituted_type;
+						}
+					}
+					Parser::AliasTemplateMaterializationResult materialized_type =
+						parser_.materializeAliasTemplateInstantiation(
+							base_template_name,
+							materialized_args.args);
+					const TypeInfo* resolved_type_info =
+						materialized_type.resolved_type_info;
+					if (resolved_type_info == nullptr) {
+						materialized_type =
+							parser_.materializeTemplateInstantiationForLookup(
+								base_template_name,
+								materialized_args.args);
+						resolved_type_info = materialized_type.resolved_type_info;
+					}
+					if (resolved_type_info == nullptr &&
+						qualified_base_template_name != type_info->baseTemplateName()) {
+						materialized_type =
+							parser_.materializeAliasTemplateInstantiation(
+								StringTable::getStringView(type_info->baseTemplateName()),
+								materialized_args.args);
+						resolved_type_info = materialized_type.resolved_type_info;
+						if (resolved_type_info == nullptr) {
+							materialized_type =
+								parser_.materializeTemplateInstantiationForLookup(
+									StringTable::getStringView(type_info->baseTemplateName()),
+									materialized_args.args);
+							resolved_type_info = materialized_type.resolved_type_info;
+						}
+					}
+					if (resolved_type_info == nullptr &&
+						materialized_type.canonicalNameHandle().isValid()) {
+						resolved_type_info =
+							findTypeByName(materialized_type.canonicalNameHandle());
+					}
+					if (resolved_type_info != nullptr) {
+						ResolvedAliasTypeInfo resolved_alias =
+							resolveAliasTypeInfo(
+								resolved_type_info->registeredTypeIndex().withCategory(
+									resolved_type_info->typeEnum()));
+						TypeSpecifierNode substituted_type =
+							resolved_alias.type_index.is_valid()
+								? buildTerminalTypeFromResolvedAlias(resolved_alias, type.token())
+								: TypeSpecifierNode(
+									resolved_type_info->registeredTypeIndex().withCategory(
+										resolved_type_info->typeEnum()),
+									resolved_type_info->sizeInBits(),
+									type.token(),
+									type.cv_qualifier(),
+									type.reference_qualifier());
+						if (resolved_alias.type_index.is_valid()) {
+							applyResolvedAliasModifiers(substituted_type, resolved_alias);
+						}
+						applyOuterTypeModifiers(substituted_type, type);
+						return substituted_type;
+					}
+				}
 			}
 		}
 	}

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -442,6 +442,11 @@ ASTNode ExpressionSubstitutor::substitute(const ASTNode& expr) {
 	}
 }
 
+TypeSpecifierNode ExpressionSubstitutor::substituteTypeSpecifier(
+	const TypeSpecifierNode& type) {
+	return substituteInType(type);
+}
+
 ASTNode ExpressionSubstitutor::substituteConstructorCall(const ConstructorCallNode& ctor) {
 	FLASH_LOG(Templates, Debug, "ExpressionSubstitutor: Processing constructor call");
 

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -100,6 +100,9 @@ public:
 	/// @return A new expression with template parameters substituted
 	ASTNode substitute(const ASTNode& expr);
 
+	// Substitute a type-id without routing it through expression-node wrapping.
+	TypeSpecifierNode substituteTypeSpecifier(const TypeSpecifierNode& type);
+
 	const TypeInfo* resolveDependentMemberTypeForSubstitution(const TypeInfo& type_info);
 
 	void setCurrentOwnerTypeName(StringHandle owner_type_name) {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1954,6 +1954,10 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		std::string_view qualified_name,
 		std::string_view simple_name,
 		const ChunkedVector<ASTNode>& arguments);
+	std::optional<ASTNode> tryInstantiateFunctionTemplateFromArgTypes(
+		std::string_view qualified_name,
+		std::string_view simple_name,
+		std::span<const TypeSpecifierNode> arg_types);
 	std::optional<ASTNode> tryInstantiateAdlTemplateCandidates(
 		StringHandle callee_name,
 		bool argument_dependent_lookup_included,

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -1094,9 +1094,15 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 			  getSubstitutedTypeSizeBits(substituted_type_index),
 			  fallback_token,
 			  original_type_spec.cv_qualifier());
+	const bool full_substitution_is_type =
+		full_substituted_node.is<TypeSpecifierNode>();
+	const bool substituted_index_is_concrete =
+		substituted_type_index.is_valid() &&
+		!typeIndexContainsDependentPlaceholder(substituted_type_index);
 	if (substituted_type_index.is_valid() &&
-		(apply_resolved_index_to_full_substitution ||
-		 !full_substituted_node.is<TypeSpecifierNode>())) {
+		(!full_substitution_is_type ||
+		 (apply_resolved_index_to_full_substitution &&
+		  substituted_index_is_concrete))) {
 		substituted_type.set_type_index(substituted_type_index.withCategory(substituted_type_index.category()));
 		substituted_type.set_category(substituted_type_index.category());
 	}

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -370,24 +370,47 @@ Parser::tryBuildCurrentFunctionCallDefinitionLookupRecord(
 		argument_dependent_lookup_included);
 }
 
-// Try template instantiation from call arguments by first using collected
-// argument types (qualified name first, then simple name) and then falling back
-// to constructor-wrapper deduction such as __type_identity<T>{}.
+std::optional<ASTNode> Parser::tryInstantiateFunctionTemplateFromArgTypes(
+	std::string_view qualified_name,
+	std::string_view simple_name,
+	std::span<const TypeSpecifierNode> arg_types) {
+	if (arg_types.empty()) {
+		return std::nullopt;
+	}
+
+	if (!qualified_name.empty()) {
+		if (std::optional<ASTNode> instantiated =
+				try_instantiate_template(qualified_name, arg_types);
+			instantiated.has_value()) {
+			return instantiated;
+		}
+	}
+	if (!simple_name.empty() && simple_name != qualified_name) {
+		if (std::optional<ASTNode> instantiated =
+				try_instantiate_template(simple_name, arg_types);
+			instantiated.has_value()) {
+			return instantiated;
+		}
+	}
+	return std::nullopt;
+}
+
+// Try ordinary function-template deduction from the call argument types. The
+// final branch still handles old placeholder constructor-wrapper nodes that
+// predate structured expression typing.
 std::optional<ASTNode> Parser::tryInstantiateTemplateFromCallArguments(
 	std::string_view qualified_name,
 	std::string_view simple_name,
 	const ChunkedVector<ASTNode>& arguments) {
 	std::vector<TypeSpecifierNode> arg_types;
 	if (tryCollectFunctionCallArgTypes(arguments, arg_types)) {
-		if (!qualified_name.empty()) {
-			if (std::optional<ASTNode> instantiated = try_instantiate_template(qualified_name, arg_types)) {
-				return instantiated;
-			}
-		}
-		if (!simple_name.empty() && simple_name != qualified_name) {
-			if (std::optional<ASTNode> instantiated = try_instantiate_template(simple_name, arg_types)) {
-				return instantiated;
-			}
+		if (std::optional<ASTNode> instantiated =
+				tryInstantiateFunctionTemplateFromArgTypes(
+					qualified_name,
+					simple_name,
+					arg_types);
+			instantiated.has_value()) {
+			return instantiated;
 		}
 	}
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -628,10 +628,10 @@ std::optional<ASTNode> Parser::resolveDependentUnqualifiedCallAtPointOfInstantia
 	}
 
 	if (std::optional<ASTNode> instantiated =
-			tryInstantiateTemplateFromCallArguments(
+			tryInstantiateFunctionTemplateFromArgTypes(
 				{},
 				StringTable::getStringView(record.callee_name),
-				arguments);
+				arg_types);
 		instantiated.has_value()) {
 		return instantiated;
 	}
@@ -7973,11 +7973,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								FLASH_LOG(Parser, Debug, "Template brace initialization detected for '", identifier_token.value(), "', has_dependent_args=", has_dependent_args);
 
 								if (has_dependent_args) {
-									// Dependent template arguments - create a placeholder for now
-									// The actual instantiation will happen when the outer template is instantiated
 									advance(); // consume '{'
-
-									// Skip the brace content - should be empty {} for value-initialization
 									ChunkedVector<ASTNode> args;
 									while (!peek().is_eof() && peek() != "}"_tok) {
 										auto argResult = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
@@ -7999,11 +7995,58 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 										return ParseResult::error("Expected '}' after brace initializer", current_token_);
 									}
 
-									// For dependent args, create a placeholder ConstructorCallNode
-									// The actual type will be resolved during template instantiation
-									// Use a placeholder type for now
-									auto placeholder_type_node = emplace_node<TypeSpecifierNode>(TypeIndex{}.withCategory(TypeCategory::Auto), 0, identifier_token, CVQualifier::None, ReferenceQualifier::None);
-									result = emplace_node<ExpressionNode>(ConstructorCallNode(placeholder_type_node, std::move(args), identifier_token));
+									InlineVector<TypeInfo::TemplateArgInfo, 4> dependent_template_args =
+										toTemplateArgInfoList(*explicit_template_args);
+									StringBuilder dependent_type_builder;
+									dependent_type_builder.append(identifier_token.value());
+									dependent_type_builder.append("<");
+									for (size_t i = 0;
+										 i < dependent_template_args.size();
+										 ++i) {
+										if (i != 0) {
+											dependent_type_builder.append(", ");
+										}
+										appendDependentTemplateArgSpelling(
+											dependent_type_builder,
+											dependent_template_args[i]);
+									}
+									dependent_type_builder.append(">");
+									StringHandle dependent_type_handle =
+										StringTable::getOrInternStringHandle(
+											dependent_type_builder.commit());
+									TypeInfo* dependent_type_info = nullptr;
+									auto dependent_type_it = getTypesByNameMap().find(dependent_type_handle);
+									if (dependent_type_it != getTypesByNameMap().end()) {
+										dependent_type_info = dependent_type_it->second;
+									}
+									if (dependent_type_info == nullptr) {
+										dependent_type_info = &add_template_param_type(
+											dependent_type_handle,
+											TypeCategory::Template,
+											0);
+									}
+									QualifiedIdentifier base_template_name =
+										QualifiedIdentifier::fromQualifiedName(
+											identifier_token.value(),
+											gSymbolTable.get_current_namespace_handle());
+									dependent_type_info->setTemplateInstantiationInfo(
+										base_template_name,
+										dependent_template_args);
+									dependent_type_info->setInstantiationContext(
+										{},
+										dependent_template_args,
+										nullptr);
+									auto dependent_type_node = emplace_node<TypeSpecifierNode>(
+										dependent_type_info->registeredTypeIndex().withCategory(TypeCategory::Template),
+										0,
+										identifier_token,
+										CVQualifier::None,
+										ReferenceQualifier::None);
+									result = emplace_node<ExpressionNode>(
+										ConstructorCallNode(
+											dependent_type_node,
+											std::move(args),
+											identifier_token));
 									return ParseResult::success(*result);
 								}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1976,7 +1976,15 @@ TypeIndex Parser::substitute_template_parameter(
 	};
 	auto tryResolveConcreteTemplatePlaceholder = [&]() -> bool {
 		const TypeInfo* placeholder_info = tryGetTypeInfo(current_type_index);
-		if (!placeholder_info || !placeholder_info->isTemplateInstantiation()) {
+		if (placeholder_info != nullptr && !placeholder_info->isTemplateInstantiation()) {
+			const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+				placeholder_info->registeredTypeIndex().withCategory(
+					placeholder_info->typeEnum()));
+			if (resolved_alias.terminal_type_info != nullptr) {
+				placeholder_info = resolved_alias.terminal_type_info;
+			}
+		}
+		if (placeholder_info == nullptr || !placeholder_info->isTemplateInstantiation()) {
 			return false;
 		}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1994,6 +1994,30 @@ TypeIndex Parser::substitute_template_parameter(
 		if (!areTemplateArgsConcrete(concrete_args)) {
 			return false;
 		}
+		AliasTemplateMaterializationResult materialized_alias =
+			materializeAliasTemplateInstantiation(
+				base_template_name,
+				concrete_args);
+		if ((materialized_alias.resolved_type_info == nullptr ||
+			 materialized_alias.instantiated_name.empty()) &&
+			placeholder_info->baseTemplateName().isValid() &&
+			base_template_name !=
+				StringTable::getStringView(placeholder_info->baseTemplateName())) {
+			materialized_alias =
+				materializeAliasTemplateInstantiation(
+					StringTable::getStringView(placeholder_info->baseTemplateName()),
+					concrete_args);
+		}
+		if (materialized_alias.resolved_type_info != nullptr) {
+			assignResolvedType(*materialized_alias.resolved_type_info);
+			FLASH_LOG_FORMAT(
+				Templates,
+				Debug,
+				"Resolved alias-template placeholder '{}' -> '{}'",
+				StringTable::getStringView(placeholder_info->name()),
+				StringTable::getStringView(materialized_alias.resolved_type_info->name()));
+			return true;
+		}
 		const TypeInfo* instantiated_type_info = resolveConcreteInstantiatedMemberChain(
 			base_template_name,
 			concrete_args,

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -4478,9 +4478,15 @@ std::optional<ASTNode> Parser::try_instantiate_template(std::string_view templat
 		return deferred_forward_declaration_result;
 	}
 
-	// All overloads failed
-	FLASH_LOG_FORMAT(Templates, Error, "[depth={}]: All {} template overload(s) failed for '{}'",
-					 recursion_depth, all_templates.size(), template_name);
+	// All overloads failed. In SFINAE/constraint probes, that is an ordinary
+	// not-viable result, not a hard program diagnostic.
+	if (isTemplateInstantiationFailureProbeMode()) {
+		FLASH_LOG_FORMAT(Templates, Debug, "[depth={}]: All {} template overload(s) failed for '{}'",
+						 recursion_depth, all_templates.size(), template_name);
+	} else {
+		FLASH_LOG_FORMAT(Templates, Error, "[depth={}]: All {} template overload(s) failed for '{}'",
+						 recursion_depth, all_templates.size(), template_name);
+	}
 	return std::nullopt;
 }
 

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1692,6 +1692,65 @@ ASTNode Parser::substituteTemplateParameters(
 			}
 		}
 
+		// A direct dependent alias parameter is represented by a structured alias-id
+		// placeholder. Materialize it through the active environment before the
+		// generic TypeIndex path can retain its unresolved storage type.
+		if (type_spec.type_index().is_valid()) {
+			if (const TypeInfo* dependent_alias_info = tryGetTypeInfo(type_spec.type_index());
+				dependent_alias_info != nullptr &&
+				dependent_alias_info->isTemplateInstantiation()) {
+				StringHandle qualified_alias_name =
+					gNamespaceRegistry.buildQualifiedIdentifier(
+						dependent_alias_info->sourceNamespace(),
+						dependent_alias_info->baseTemplateName());
+				std::optional<ASTNode> alias_entry =
+					gTemplateRegistry.lookup_alias_template(
+						StringTable::getStringView(qualified_alias_name));
+				if (!alias_entry.has_value()) {
+					alias_entry = gTemplateRegistry.lookup_alias_template(
+						StringTable::getStringView(dependent_alias_info->baseTemplateName()));
+				}
+				if (alias_entry.has_value() && alias_entry->is<TemplateAliasNode>()) {
+					const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
+					const TypeSpecifierNode& alias_target = alias_node.target_type_node();
+					const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target.type_index());
+					const bool is_unmodified_direct_target =
+						!alias_node.is_deferred() &&
+						alias_target.cv_qualifier() == CVQualifier::None &&
+						alias_target.pointer_depth() == 0 &&
+						alias_target.reference_qualifier() == ReferenceQualifier::None &&
+						!alias_target.is_array() &&
+						(alias_target_info == nullptr ||
+							(!alias_target_info->isTemplateInstantiation() &&
+							 !alias_target_info->isDependentMemberType() &&
+							 !alias_target_info->hasDependentQualifiedName()));
+					if (is_unmodified_direct_target) {
+						TemplateEnvironment substitution_environment =
+							buildTemplateEnvironment(template_params, template_args, nullptr);
+						ExpressionSubstitutor substitutor(substitution_environment, *this);
+						TypeSpecifierNode substituted_type =
+							substitutor.substituteTypeSpecifier(type_spec);
+						if (!substituted_type.type_index().is_valid() &&
+							is_builtin_type(substituted_type.type())) {
+							TypeIndex native_type_index =
+								nativeTypeIndex(substituted_type.type());
+							if (native_type_index.is_valid()) {
+								substituted_type.set_type_index(native_type_index);
+								substituted_type.set_size_in_bits(
+									get_type_size_bits(substituted_type.type()));
+							}
+						}
+						if (!typeSpecStillUsesDependentPlaceholder(substituted_type) &&
+							substituted_type.type() != TypeCategory::Template &&
+							(substituted_type.type() != type_spec.type() ||
+							 substituted_type.type_index() != type_spec.type_index())) {
+							return emplace_node<TypeSpecifierNode>(substituted_type);
+						}
+					}
+				}
+			}
+		}
+
 		// Check if this is a user-defined type that matches a template parameter,
 		// or a dependent placeholder type (built-in category with placeholder type_index).
 		if (type_spec.category() == TypeCategory::UserDefined ||

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2015,8 +2015,80 @@ ParseResult Parser::parse_type_specifier() {
 							}
 						}
 					}
+					const TypeSpecifierNode& alias_target = alias_node.target_type_node();
+					const TypeInfo* alias_target_info =
+						tryGetTypeInfo(alias_target.type_index());
+					const StringHandle alias_target_name = alias_target_info != nullptr
+						? alias_target_info->name()
+						: alias_target.token().handle();
+					const bool alias_target_is_template_parameter = [&] {
+						for (StringHandle param_name : alias_node.template_param_names()) {
+							if (param_name == alias_target_name) {
+								return true;
+							}
+						}
+						return false;
+					}();
+					const bool is_unmodified_direct_alias_target =
+						!alias_node.is_deferred() &&
+						alias_target_name.isValid() &&
+						alias_target.cv_qualifier() == CVQualifier::None &&
+						alias_target.pointer_depth() == 0 &&
+						alias_target.reference_qualifier() == ReferenceQualifier::None &&
+						!alias_target.is_array() &&
+						(alias_target_info == nullptr ||
+							(!alias_target_info->isTemplateInstantiation() &&
+							 !alias_target_info->isDependentMemberType() &&
+							 !alias_target_info->hasDependentQualifiedName())) &&
+						alias_target_is_template_parameter;
 					if (has_dependent_alias_args && peek() != "::"_tok) {
-						return ParseResult::success(emplace_node<TypeSpecifierNode>(instantiated_type));
+						if (!is_unmodified_direct_alias_target) {
+							return ParseResult::success(emplace_node<TypeSpecifierNode>(instantiated_type));
+						}
+						// Keep the alias-id and its dependent arguments together until the
+						// enclosing template is substituted. Returning the alias target here
+						// would erase the binding between arguments such as Left and First,
+						// leaving the dependent alias parameter as an unresolved type.
+						StringHandle dependent_alias_handle =
+							StringTable::getOrInternStringHandle(
+								get_instantiated_class_name(type_name, *template_args));
+						TypeInfo* dependent_alias_info = nullptr;
+						auto dependent_alias_it = getTypesByNameMap().find(dependent_alias_handle);
+						if (dependent_alias_it != getTypesByNameMap().end()) {
+							dependent_alias_info = dependent_alias_it->second;
+						}
+						if (dependent_alias_info == nullptr) {
+							TypeInfo& placeholder_type = add_empty_type_entry();
+							placeholder_type.fallback_size_bits_ = 0;
+							placeholder_type.name_ = dependent_alias_handle;
+							placeholder_type.is_incomplete_instantiation_ = true;
+							placeholder_type.placeholder_kind_ =
+								DependentPlaceholderKind::DependentArgs;
+							InlineVector<StringHandle, 4> alias_param_names;
+							for (const TemplateParameterNode& param : alias_node.template_parameters()) {
+								alias_param_names.push_back(param.nameHandle());
+							}
+							InlineVector<TypeInfo::TemplateArgInfo, 4> alias_args =
+								toTemplateArgInfoList(*template_args);
+							placeholder_type.setTemplateInstantiationInfo(
+								QualifiedIdentifier::fromQualifiedName(
+									type_name,
+									gSymbolTable.get_current_namespace_handle()),
+								alias_args);
+							placeholder_type.setInstantiationContext(
+								std::move(alias_param_names),
+								alias_args,
+								nullptr);
+							getTypesByNameMap()[dependent_alias_handle] = &placeholder_type;
+							dependent_alias_info = &placeholder_type;
+						}
+						return ParseResult::success(emplace_node<TypeSpecifierNode>(
+							dependent_alias_info->registeredTypeIndex().withCategory(
+								TypeCategory::Template),
+							0,
+							type_name_token,
+							cv_qualifier,
+							ReferenceQualifier::None));
 					}
 
 					if (const TypeInfo* instantiated_type_info =

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2385,13 +2385,26 @@ void SemanticAnalysis::resolveRemainingAutoReturnsInNode(ASTNode& node) {
 }
 
 std::optional<TypeSpecifierNode> SemanticAnalysis::resolveCallableReturnType(const FunctionDeclarationNode& callable) {
+	if (std::optional<TypeSpecifierNode> concrete_return_type =
+			FlashCpp::ParserFunctionTypeHelpers::
+				tryGetConcreteReturnTypeFromFunctionDeclaration(
+					callable,
+					callable.decl_node().identifier_token());
+		concrete_return_type.has_value() &&
+		concrete_return_type->category() != TypeCategory::Invalid &&
+		concrete_return_type->category() != TypeCategory::Template &&
+		!isPlaceholderAutoType(concrete_return_type->type())) {
+		return concrete_return_type;
+	}
+
 	ASTNode resolved_return_type = callable.decl_node().type_node();
 	if (!resolved_return_type.has_value() || !resolved_return_type.is<TypeSpecifierNode>()) {
 		return std::nullopt;
 	}
 
 	TypeSpecifierNode return_type = resolved_return_type.as<TypeSpecifierNode>();
-	if (!isPlaceholderAutoType(return_type.type())) {
+	if (!isPlaceholderAutoType(return_type.type()) &&
+		return_type.category() != TypeCategory::Template) {
 		return return_type;
 	}
 
@@ -8440,14 +8453,20 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			}
 			return nullptr;
 		};
-	auto fallbackToEarlyParserSelectedTarget = [&]() -> const FunctionDeclarationNode* {
-		if (normalized_call) {
+	auto useParserResolvedDirectTarget = [&]() -> const FunctionDeclarationNode* {
+		if (call_info.function_declaration == nullptr) {
+			return nullptr;
+		}
+		if (normalized_call &&
+			!isFunctionCandidateViableForArgCount(
+				*call_info.function_declaration,
+				arguments.size())) {
 			return nullptr;
 		}
 		return call_info.function_declaration;
 	};
 	// Resolution order:
-	// 1. receiver-member direct lookup, including receiver-side parser-selected fallback
+	// 1. receiver-member direct lookup, including parser-resolved direct targets
 	// 2. non-receiver definition-bound direct-call recovery
 	// 3. callable operator / local callable resolution
 	// 4. dependent-unqualified POI / definition-bound recovery
@@ -8535,12 +8554,18 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			}
 		}
 		if (const FunctionDeclarationNode* parser_selected_target =
-				fallbackToEarlyParserSelectedTarget();
+				useParserResolvedDirectTarget();
 			parser_selected_target != nullptr) {
 			return parser_selected_target;
 		}
 
 		return nullptr;
+	}
+	if (const FunctionDeclarationNode* parser_selected_target =
+			useParserResolvedDirectTarget();
+		parser_selected_target != nullptr &&
+		isTemplateDerivedFreeFunction(parser_selected_target)) {
+		return parser_selected_target;
 	}
 	if (!call_info.is_indirect &&
 		!call_info.has_receiver &&
@@ -8549,8 +8574,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		definition_lookup_record_target != nullptr) {
 		return definition_lookup_record_target;
 	}
-	if (!normalized_call &&
-		!call_info.is_indirect &&
+	if (!call_info.is_indirect &&
 		!call_info.has_receiver &&
 		(!call_info.qualified_name.isValid() ||
 		 qualified_name_targets_namespace) &&
@@ -8589,8 +8613,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		return nullptr;
 	}
 
-	if (!normalized_call &&
-		!call_info.has_receiver &&
+	if (!call_info.has_receiver &&
 		call_info.dependent_unqualified_lookup_record != nullptr &&
 		call_info.dependent_unqualified_lookup_record->has_value()) {
 		const DependentUnqualifiedCallLookupRecord& dependent_record =

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -29,7 +29,7 @@ void requireParserSemanticServicesAttachment(const SemanticAnalysis& sema, const
 
 const FunctionDeclarationNode* getCallTargetFunctionCandidate(const ASTNode& overload);
 
-bool isTemplateDerivedFreeFunction(const FunctionDeclarationNode* func_decl) {
+bool isTemplateDerivedFreeFunctionTarget(const FunctionDeclarationNode* func_decl) {
 	return func_decl != nullptr &&
 		(func_decl->has_template_body_position() || func_decl->has_template_declaration_position());
 }
@@ -6386,7 +6386,7 @@ bool SemanticAnalysis::tryResolveLateBinaryOperatorOverload(
 			(!overload_result.has_match ||
 			 overload_result.is_ambiguous ||
 			 (overload_result.is_free_function &&
-			  isTemplateDerivedFreeFunction(overload_result.free_function_overload)))) {
+			  isTemplateDerivedFreeFunctionTarget(overload_result.free_function_overload)))) {
 			overload_result = OperatorOverloadResult(instantiated_overload);
 		}
 	}
@@ -8564,7 +8564,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	if (const FunctionDeclarationNode* parser_selected_target =
 			useParserResolvedDirectTarget();
 		parser_selected_target != nullptr &&
-		isTemplateDerivedFreeFunction(parser_selected_target)) {
+		isTemplateDerivedFreeFunctionTarget(parser_selected_target)) {
 		return parser_selected_target;
 	}
 	if (!call_info.is_indirect &&

--- a/tests/test_constrained_cpo_variable_choice_ret0.cpp
+++ b/tests/test_constrained_cpo_variable_choice_ret0.cpp
@@ -1,0 +1,64 @@
+enum class strategy {
+	none,
+	exchange
+};
+
+template<typename Type>
+struct choice {
+	strategy selected;
+};
+
+template<typename Type>
+struct iter {
+	Type* value;
+};
+
+template<typename Type>
+Type& operator*(iter<Type> it) {
+	return *it.value;
+}
+
+namespace detail {
+	template<typename Left, typename Right>
+	void iter_swap(Left, Right) = delete;
+
+	template<typename Left, typename Right>
+	concept has_adl_iter_swap = requires(Left left, Right right) {
+		iter_swap(left, right);
+	};
+}
+
+struct iter_swap_fn {
+	template<typename Left, typename Right>
+	static constexpr choice<Left> choose() {
+		if constexpr (detail::has_adl_iter_swap<Left, Right>) {
+			return {strategy::none};
+		}
+		return {strategy::exchange};
+	}
+
+	template<typename Left, typename Right>
+	static constexpr choice<Left> selected = choose<Left, Right>();
+
+	template<typename Left, typename Right>
+		requires (selected<Left, Right>.selected != strategy::none)
+	void operator()(Left left, Right right) const {
+		constexpr strategy active = selected<Left, Right>.selected;
+		if constexpr (active == strategy::exchange) {
+			auto temp = *left;
+			*left = *right;
+			*right = temp;
+		}
+	}
+};
+
+namespace ranges {
+	inline constexpr iter_swap_fn iter_swap{};
+}
+
+int main() {
+	int left = 1;
+	int right = 2;
+	ranges::iter_swap(iter<int>{&left}, iter<int>{&right});
+	return left == 2 && right == 1 ? 0 : 1;
+}

--- a/tests/test_requires_failed_function_template_probe_ret0.cpp
+++ b/tests/test_requires_failed_function_template_probe_ret0.cpp
@@ -1,0 +1,13 @@
+template<typename Type>
+void pointer_only(Type*);
+
+template<typename Type>
+concept has_pointer_call = requires(Type value) {
+	pointer_only(value);
+};
+
+static_assert(!has_pointer_call<int>);
+
+int main() {
+	return has_pointer_call<int> ? 1 : 0;
+}

--- a/tests/test_template_exchange_dependent_alias_default_ret0.cpp
+++ b/tests/test_template_exchange_dependent_alias_default_ret0.cpp
@@ -1,0 +1,53 @@
+template<typename Type>
+Type exchange_value(Type& value, Type new_value) {
+	Type old_value = value;
+	value = new_value;
+	return old_value;
+}
+
+template<typename Range>
+using difference_t = int;
+
+template<typename First, typename Second>
+using select_first_t = First;
+
+template<typename Range>
+struct CachedPosition {
+	difference_t<Range> run() {
+		difference_t<Range> value = 7;
+		return exchange_value(value, difference_t<Range>{-1});
+	}
+};
+
+template<typename Left, typename FirstTail, typename SecondTail>
+struct DualAliasUse {
+	select_first_t<Left, FirstTail> take_first() {
+		select_first_t<Left, FirstTail> value = 5;
+		return exchange_value(value, select_first_t<Left, FirstTail>{6});
+	}
+
+	select_first_t<Left, SecondTail> take_second() {
+		select_first_t<Left, SecondTail> value = 3;
+		return exchange_value(value, select_first_t<Left, SecondTail>{4});
+	}
+};
+
+struct Input {};
+struct Output {};
+
+int main() {
+	CachedPosition<Input> position;
+	if (position.run() != 7) {
+		return 1;
+	}
+	DualAliasUse<int, Input, Output> dual;
+	int first = dual.take_first();
+	int second = dual.take_second();
+	if (first != 5) {
+		return 2;
+	}
+	if (second != 3) {
+		return 3;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

- Treat SFINAE-style function-template probe failures as non-errors while a requires/viability probe is active.
- Preserve dependent alias template-ids as structured metadata when a non-deferred alias directly names one of its parameters, then materialize that identity in member-function signatures and bodies.
- Keep composite and deferred alias targets on their existing materialization paths; do not substitute them through the direct-parameter path.
- Preserve concrete full substitutions instead of overwriting them with a dependent placeholder index, and resolve aliases when following template-placeholder records.
- Keep normalized non-receiver parser target reuse narrowed to materialized template-derived functions so ordinary ADL calls stay on sema-owned resolution.
- Rename a unity-build-local semantic helper to keep the Linux Clang build valid.
- Update the template-argument planning docs with the invariant and next consolidation task.

`std/test_std_ranges.cpp` remains at the documented `std::invoke` constrained-overload and `ranges::size` auto-return frontiers.