### PR TITLE
Unify dependent direct alias materialization

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-10
+**Last updated:** 2026-07-11
 
 This document is a planning aid for the remaining template-infrastructure work.
 It is intentionally forward-looking: keep it focused on the current baseline,
@@ -62,10 +62,10 @@ identity-preserving behavior:
   the member-call path when the qualified receiver is a concrete struct object,
   so instantiated `operator()` member templates receive the implicit object
   argument and preserve reference-argument mutation
-- direct dependent alias template-ids preserve the alias identity and argument
-  binding through member-function signature and body materialization; resolved
-  builtin targets use canonical native type indices rather than an invalid
-  category-only index
+- direct dependent alias template-ids use one classifier, structured placeholder
+  factory, and materializer across parsing and substitution; full
+  `TypeSpecifierNode` metadata carries alias-introduced cv/ref/pointer structure
+  through signatures, bodies, and class-template member layout
 
 ## Architectural invariants
 
@@ -81,6 +81,8 @@ Follow-up work should preserve these rules:
 - do not replace a concrete substituted type with an unresolved placeholder
   index, and do not use a category-only builtin type where a native `TypeIndex`
   is available
+- do not collapse a substituted alias target to `TypeIndex` before consumers
+  have retained its cv/ref/pointer/array/function declarator metadata
 - prefer identity-first replay attachment over `StructTypeInfo` repair scans
 - add abstractions only when they remove real repeated owner/replay logic or
   prevent standards-visible fallback behavior from reappearing
@@ -238,15 +240,19 @@ now has enough headroom for those conforming chains while still retaining a
 finite runaway-recursion diagnostic.
 
 Dependent alias-template type-ids and brace construction used by
-`std::exchange`-like calls are now covered by:
+`std::exchange`-like calls, including modifier-bearing direct aliases and
+unused alias parameters, are now covered by:
 
 - `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
+- `tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp`
 
 This preserves direct aliases such as `select_first_t<Left, FirstTail>` through
 member-function signature materialization, materializes the target after the
 enclosing class-template argument is known, and lets ordinary
 function-template deduction consume the concrete argument type on both Windows
-and Linux.
+and Linux. Class-template member layout now consumes the full substituted type
+specifier, so modifiers introduced by a member alias are not lost when its base
+identity is canonicalized to a `TypeIndex`.
 
 The active `std/test_std_ranges.cpp` frontier has moved again:
 
@@ -325,11 +331,6 @@ declarator-shaped `member_class + pointer_depth` forms.
    next concrete failure choose the following layer.
 5. Promote stale expected-failure tracking only after the corresponding harness
    entry is proven green.
-6. Consolidate the direct dependent-alias placeholder factory and materializer
-   so parse, member-function shell substitution, and body substitution share a
-   single structured contract. Add focused coverage for direct aliases with
-   cv/ref/pointer modifiers and for aliases whose targets are intentionally
-   independent of one or more arguments.
 
 ## Validation guidance
 

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-10
+**Last updated:** 2026-07-11
 
 This document tracks the standards-facing target for the remaining template
 infrastructure work. Keep it focused on the intended semantic model, active
@@ -65,9 +65,10 @@ The core suite now covers several formerly blocking standards-visible areas:
 - namespace-qualified callable objects keep member-call semantics when the
   receiver is a concrete struct object, including the implicit object argument
   for instantiated constrained `operator()` member templates
-- direct dependent alias template-ids and brace construction keep template
-  identity until enclosing arguments are concrete; a materialized builtin
-  target carries its canonical native type identity
+- direct dependent alias template-ids use shared classification, placeholder,
+  and materialization infrastructure; substitution retains the complete type
+  specifier so alias-introduced cv/ref/pointer structure survives every covered
+  declaration, signature, expression, and class-member consumer
 
 ## Remaining standards gaps
 
@@ -216,15 +217,19 @@ bug. The parser depth guard remains finite but now has enough headroom for that
 kind of conforming C++20 template chain.
 
 Dependent alias-template type-ids and brace construction used by
-`std::exchange`-like calls are now covered by:
+`std::exchange`-like calls, including modifier-bearing direct aliases and
+unused alias parameters, are now covered by:
 
 - `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
+- `tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp`
 
 The reduced rule is generic: a direct alias template-id such as
 `select_first_t<Left, FirstTail>` remains a structured instantiation until the
 enclosing arguments are known, then materializes to its alias target before
 function-template deduction and code generation. A concrete builtin target
-must use its native type index, not an invalid category-only placeholder.
+must use its native type index, not an invalid category-only placeholder, while
+the surrounding `TypeSpecifierNode` remains the carrier for declarator
+modifiers that cannot be represented by `TypeIndex` alone.
 
 The active standards-facing `std/test_std_ranges.cpp` failure has moved again:
 
@@ -305,13 +310,12 @@ declarator-shaped pointer-depth/member-class metadata.
    blocker.
 6. Keep replay identity and member-object-pointer work opportunistic unless a
    concrete regression points there.
-7. Unify direct dependent-alias placeholder creation and materialization across
-   declaration, signature, and expression entry points; add non-`std` coverage
-   for qualifier-bearing direct aliases and unused alias parameters.
 
 ## Standards rules for follow-up work
 
 - do not normalize textual reconstruction as acceptable semantics
+- do not reduce a substituted alias target to base `TypeIndex` identity before
+  preserving its complete declarator metadata
 - prefer hard failure or correct diagnostics over silent repair in normalized
   semantic flows
 - keep compatibility behavior explicit, narrow, and temporary

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -200,8 +200,9 @@ static TypeSpecifierNode normalizeCallReturnType(TypeSpecifierNode return_type) 
 
 	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(return_type.type_index());
 	if (resolved_alias.terminal_type_info) {
-		return_type.set_type_index(resolved_alias.terminal_type_info->type_index_);
-		return_type.set_category(resolved_alias.terminal_type_info->category());
+		return_type.set_type_index(
+			resolved_alias.terminal_type_info->type_index_.withCategory(
+				resolved_alias.terminal_type_info->category()));
 	}
 	return_type.add_pointer_levels(static_cast<int>(resolved_alias.pointer_depth));
 	if (return_type.reference_qualifier() == ReferenceQualifier::None &&

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2588,12 +2588,24 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		std::span<const TemplateTypeArg> template_args,
 		std::string_view instantiated_name);
 	StringHandle getAliasTargetNameHandle(const TypeSpecifierNode& alias_target) const;
+	std::optional<size_t> findDirectAliasTargetParameterIndex(
+		const TemplateAliasNode& alias_node) const;
 	std::optional<size_t> findAliasTargetTemplateParamIndex(
 		const TemplateAliasNode& alias_node,
 		std::span<const TemplateTypeArg> concrete_args) const;
 	std::optional<TemplateTypeArg> tryRebindAliasTargetTemplateArg(
 		const TemplateAliasNode& alias_node,
 		std::span<const TemplateTypeArg> concrete_args) const;
+	TypeSpecifierNode buildDependentDirectAliasTypeSpecifier(
+		std::string_view alias_name,
+		const TemplateAliasNode& alias_node,
+		std::span<const TemplateTypeArg> template_args,
+		const Token& source_token,
+		CVQualifier cv_qualifier);
+	std::optional<TypeSpecifierNode> tryMaterializeDependentDirectAliasTypeSpecifier(
+		const TypeSpecifierNode& type_spec,
+		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args);
 	// Substitute template parameters in an expression.
 	// substitution_owner: when valid, member aliases of that instantiation are resolved for sizeof/alignof.
 	ASTNode substitute_template_params_in_expression(

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -61,7 +61,6 @@ inline void normalizeSubstitutedTypeSpec(TypeSpecifierNode& type_spec) {
 	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_spec.type_index());
 	if (resolved_alias.type_index.is_valid()) {
 		type_spec.set_type_index(resolved_alias.type_index.withCategory(resolved_alias.typeEnum()));
-		type_spec.set_category(resolved_alias.typeEnum());
 	}
 	type_spec.add_pointer_levels(static_cast<int>(resolved_alias.pointer_depth));
 	if (type_spec.reference_qualifier() == ReferenceQualifier::None &&
@@ -1103,8 +1102,7 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 		(!full_substitution_is_type ||
 		 (apply_resolved_index_to_full_substitution &&
 		  substituted_index_is_concrete))) {
-		substituted_type.set_type_index(substituted_type_index.withCategory(substituted_type_index.category()));
-		substituted_type.set_category(substituted_type_index.category());
+		substituted_type.set_type_index(substituted_type_index);
 	}
 	if (!full_substituted_node.is<TypeSpecifierNode>()) {
 		for (const auto& ptr_level : original_type_spec.pointer_levels()) {

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -3488,9 +3488,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			}
 			if (dependent_member_type_index.is_valid() &&
 				dependent_member_type_index != substituted_param_type.type_index()) {
-				substituted_param_type.set_type_index(
-					dependent_member_type_index.withCategory(dependent_member_type_index.category()));
-				substituted_param_type.set_category(dependent_member_type_index.category());
+				substituted_param_type.set_type_index(dependent_member_type_index);
 				if (!preserve_dependent_member_template_identity) {
 					normalizeSubstitutedTypeSpec(substituted_param_type);
 				}
@@ -3513,8 +3511,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 		if (self_type_from_index.is_valid() &&
 			self_type_to_index.is_valid() &&
 			substituted_param_type.type_index() == self_type_from_index) {
-			substituted_param_type.set_type_index(self_type_to_index.withCategory(self_type_to_index.category()));
-			substituted_param_type.set_category(self_type_to_index.category());
+			substituted_param_type.set_type_index(self_type_to_index);
 			normalizeSubstitutedTypeSpec(substituted_param_type);
 		}
 

--- a/src/Parser_FunctionTypeHelpers.h
+++ b/src/Parser_FunctionTypeHelpers.h
@@ -202,7 +202,6 @@ inline std::optional<TypeSpecifierNode> tryResolveTypeFromRegisteredAlias(
 	TypeSpecifierNode outer_spec = type_spec;
 	outer_spec.set_type_index(
 		type_info->registeredTypeIndex().withCategory(type_info->typeEnum()));
-	outer_spec.set_category(type_info->typeEnum());
 	TypeSpecifierNode resolved_type =
 		resolveTypeInfoToTypeSpec(*type_info, outer_spec);
 	if (const int resolved_size_bits = getTypeSpecSizeBits(resolved_type);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -733,9 +733,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							param_type_spec.cv_qualifier());
 			// Apply the resolved TypeIndex (self-type rewrite or alias resolution).
 			if (param_type_index.is_valid()) {
-				substituted_param_type.set_type_index(
-					param_type_index.withCategory(param_type_index.category()));
-				substituted_param_type.set_category(param_type_index.category());
+				substituted_param_type.set_type_index(param_type_index);
 			}
 			if (!full_substituted_param_node.is<TypeSpecifierNode>()) {
 				for (const auto& ptr_level : param_type_spec.pointer_levels()) {
@@ -1091,7 +1089,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			type_alias.type_node.as<TypeSpecifierNode>();
 		TypeSpecifierNode substituted_type_spec = alias_decl_pattern_spec;
 		substituted_type_spec.set_type_index(substituted_type_index.withCategory(substituted_type));
-		substituted_type_spec.set_category(substituted_type);
 		std::optional<TemplateTypeArg> rebound_arg;
 		// Function-pointer aliases carry their dependent parameter use inside the
 		// signature; the existing alias-resolution path below preserves that full
@@ -7062,6 +7059,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	for (const auto& member_decl : class_decl.members()) {
 		const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 		const TypeSpecifierNode& type_spec = decl.type_specifier_node();
+		ASTNode full_substituted_type_node = substituteTemplateParameters(
+			decl.type_node(), template_params, template_args_to_use);
 
 		// Substitute template parameter if the member type is a template parameter
 		TypeIndex member_type_index = substitute_template_parameter(
@@ -7219,27 +7218,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 		}
 
-		// Create the substituted type specifier
-		// IMPORTANT: Preserve the base CV qualifier from the original type!
-		// For example: const T* should become const int* when T=int
-		auto substituted_type = emplace_node<TypeSpecifierNode>(
-			member_type_index,
-			get_type_size_bits(member_type_index.category()),
-			Token(),
-			type_spec.cv_qualifier(), // Preserve const/volatile qualifier
-			ReferenceQualifier::None);
-
-		// Copy pointer levels from the original type specifier
-		auto& substituted_type_spec = substituted_type.as<TypeSpecifierNode>();
-		const TemplateTypeArg* resolved_member_arg =
-			findResolvedTypeTemplateArg(type_spec, template_params, template_args_to_use);
-		for (const auto& ptr_level : type_spec.pointer_levels()) {
-			substituted_type_spec.add_pointer_level(ptr_level.cv_qualifier);
-		}
-
-		// Preserve reference qualifiers from the original type
-		substituted_type_spec.set_reference_qualifier(type_spec.reference_qualifier());
-		applyResolvedTemplateArgTypeMetadata(substituted_type_spec, resolved_member_arg);
+		TypeSpecifierNode substituted_type_spec = full_substituted_type_node.is<TypeSpecifierNode>()
+			? full_substituted_type_node.as<TypeSpecifierNode>()
+			: type_spec;
+		substituted_type_spec.set_type_index(member_type_index);
+		substituted_type_spec.set_size_in_bits(
+			get_type_size_bits(member_type_index.category()));
 
 		// Add to the instantiated struct
 		// new_struct_ref.add_member(new_member_decl, member_decl.access, member_decl.default_initializer);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -2505,7 +2505,6 @@ bool Parser::materializeTemplateFunctionParameters(
 			(resolved_param_alias_index != resolved_param_type.type_index() ||
 			 resolved_param_type.category() != param_alias_info.typeEnum())) {
 			resolved_param_type.set_type_index(resolved_param_alias_index.withCategory(param_alias_info.typeEnum()));
-			resolved_param_type.set_category(param_alias_info.typeEnum());
 		}
 		resolved_param_type.add_pointer_levels(static_cast<int>(param_alias_info.pointer_depth));
 		if (resolved_param_type.reference_qualifier() == ReferenceQualifier::None &&
@@ -2693,7 +2692,6 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			(resolved_alias_index != type_spec.type_index() ||
 			 type_spec.category() != alias_info.typeEnum())) {
 			type_spec.set_type_index(resolved_alias_index.withCategory(alias_info.typeEnum()));
-			type_spec.set_category(alias_info.typeEnum());
 		}
 		type_spec.add_pointer_levels(static_cast<int>(alias_info.pointer_depth));
 		if (type_spec.reference_qualifier() == ReferenceQualifier::None &&
@@ -3831,8 +3829,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 					template_args);
 				if (substituted_index.is_valid() &&
 					substituted_index.category() != TypeCategory::Invalid) {
-					substituted_type.set_type_index(substituted_index.withCategory(substituted_index.category()));
-					substituted_type.set_category(substituted_index.category());
+					substituted_type.set_type_index(substituted_index);
 				}
 
 				ASTNode substituted_type_node = emplace_node<TypeSpecifierNode>(substituted_type);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2358,9 +2358,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		}
 
 		TypeSpecifierNode concrete_alias_spec = *alias_type_spec;
-		concrete_alias_spec.set_type_index(
-			concrete_alias_index.withCategory(concrete_alias_index.category()));
-		concrete_alias_spec.set_category(concrete_alias_index.category());
+		concrete_alias_spec.set_type_index(concrete_alias_index);
 		normalizeSubstitutedTypeSpec(concrete_alias_spec);
 		return concrete_alias_spec;
 	};

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -1532,22 +1532,47 @@ StringHandle Parser::getAliasTargetNameHandle(const TypeSpecifierNode& alias_tar
 	return {};
 }
 
-std::optional<size_t> Parser::findAliasTargetTemplateParamIndex(
-	const TemplateAliasNode& alias_node,
-	std::span<const TemplateTypeArg> concrete_args) const {
-	StringHandle alias_target_name = getAliasTargetNameHandle(alias_node.target_type_node());
+std::optional<size_t> Parser::findDirectAliasTargetParameterIndex(
+	const TemplateAliasNode& alias_node) const {
+	if (alias_node.is_deferred()) {
+		return std::nullopt;
+	}
+
+	const TypeSpecifierNode& alias_target = alias_node.target_type_node();
+	const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target.type_index());
+	if (alias_target_info != nullptr &&
+		(alias_target_info->isTemplateInstantiation() ||
+		 alias_target_info->isDependentMemberType() ||
+		 alias_target_info->hasDependentQualifiedName())) {
+		return std::nullopt;
+	}
+
+	StringHandle alias_target_name = getAliasTargetNameHandle(alias_target);
 	if (!alias_target_name.isValid()) {
 		return std::nullopt;
 	}
 
 	const auto& alias_param_names = alias_node.template_param_names();
-	size_t max_alias_param_index = std::min(alias_param_names.size(), concrete_args.size());
-	for (size_t alias_param_index = 0; alias_param_index < max_alias_param_index; ++alias_param_index) {
+	for (size_t alias_param_index = 0;
+		 alias_param_index < alias_param_names.size();
+		 ++alias_param_index) {
 		if (alias_param_names[alias_param_index] == alias_target_name) {
 			return alias_param_index;
 		}
 	}
 	return std::nullopt;
+}
+
+std::optional<size_t> Parser::findAliasTargetTemplateParamIndex(
+	const TemplateAliasNode& alias_node,
+	std::span<const TemplateTypeArg> concrete_args) const {
+	std::optional<size_t> alias_param_index =
+		findDirectAliasTargetParameterIndex(alias_node);
+	if (!alias_param_index.has_value() ||
+		*alias_param_index >= concrete_args.size()) {
+		return std::nullopt;
+	}
+	return alias_param_index;
 }
 
 std::optional<TemplateTypeArg> Parser::tryRebindAliasTargetTemplateArg(
@@ -1561,6 +1586,61 @@ std::optional<TemplateTypeArg> Parser::tryRebindAliasTargetTemplateArg(
 	return rebindDependentTemplateTypeArg(
 		concrete_args[*alias_param_index],
 		TemplateTypeArg(alias_node.target_type_node()));
+}
+
+TypeSpecifierNode Parser::buildDependentDirectAliasTypeSpecifier(
+	std::string_view alias_name,
+	const TemplateAliasNode& alias_node,
+	std::span<const TemplateTypeArg> template_args,
+	const Token& source_token,
+	CVQualifier cv_qualifier) {
+	if (!findDirectAliasTargetParameterIndex(alias_node).has_value()) {
+		throw InternalError(
+			"Dependent direct-alias placeholder requested for a non-direct alias target");
+	}
+
+	StringHandle dependent_alias_handle =
+		StringTable::getOrInternStringHandle(
+			get_instantiated_class_name(alias_name, template_args));
+	const TypeInfo* dependent_alias_info = findTypeByName(dependent_alias_handle);
+	if (dependent_alias_info == nullptr) {
+		TypeInfo& placeholder_type = add_empty_type_entry();
+		placeholder_type.fallback_size_bits_ = 0;
+		placeholder_type.name_ = dependent_alias_handle;
+		placeholder_type.is_incomplete_instantiation_ = true;
+		placeholder_type.placeholder_kind_ =
+			DependentPlaceholderKind::DependentArgs;
+		InlineVector<StringHandle, 4> alias_param_names;
+		for (const TemplateParameterNode& param : alias_node.template_parameters()) {
+			alias_param_names.push_back(param.nameHandle());
+		}
+		InlineVector<TypeInfo::TemplateArgInfo, 4> alias_args =
+			toTemplateArgInfoList(template_args);
+		placeholder_type.setTemplateInstantiationInfo(
+			QualifiedIdentifier::fromQualifiedName(
+				alias_name,
+				gSymbolTable.get_current_namespace_handle()),
+			alias_args);
+		placeholder_type.setInstantiationContext(
+			std::move(alias_param_names),
+			alias_args,
+			nullptr);
+		getTypesByNameMap()[dependent_alias_handle] = &placeholder_type;
+		dependent_alias_info = &placeholder_type;
+	}
+
+	if (!dependent_alias_info->isTemplateInstantiation()) {
+		throw InternalError(
+			"Dependent direct-alias placeholder collided with a non-template type");
+	}
+
+	return TypeSpecifierNode(
+		dependent_alias_info->registeredTypeIndex().withCategory(
+			TypeCategory::Template),
+		0,
+		source_token,
+		cv_qualifier,
+		ReferenceQualifier::None);
 }
 
 
@@ -2224,8 +2304,8 @@ Parser::AliasTemplateMaterializationResult Parser::materializeAliasTemplateInsta
 					resolved_type_info,
 					alias_target_type_spec);
 			if (!alias_registration_type_spec.type_index().is_valid()) {
-				alias_registration_type_spec.set_type_index(alias_target_index);
-				alias_registration_type_spec.set_category(resolved_type_info.typeEnum());
+				alias_registration_type_spec.set_type_index(
+					alias_target_index.withCategory(resolved_type_info.typeEnum()));
 				alias_registration_type_spec.set_size_in_bits(resolved_type_info.sizeInBits());
 			}
 		}
@@ -4859,8 +4939,6 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 					alias_registration_type_spec = *concrete_alias_spec;
 				} else {
 					alias_registration_type_spec.set_type_index(alias_target_index);
-					alias_registration_type_spec.set_category(
-						concrete_sibling_alias->typeEnum());
 					alias_registration_type_spec.set_size_in_bits(
 						concrete_sibling_alias->sizeInBits());
 				}
@@ -4881,7 +4959,6 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 					alias_registration_type_spec = *concrete_alias_spec;
 				} else {
 					alias_registration_type_spec.set_type_index(alias_target_index);
-					alias_registration_type_spec.set_category(concrete_member_info->typeEnum());
 					alias_registration_type_spec.set_size_in_bits(
 						concrete_member_info->sizeInBits());
 				}
@@ -5002,8 +5079,6 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 						original_nested_info->registeredTypeIndex().withCategory(
 							original_nested_info->typeEnum());
 					alias_registration_type_spec.set_type_index(alias_target_index);
-					alias_registration_type_spec.set_category(
-						original_nested_info->typeEnum());
 					alias_registration_type_spec.set_size_in_bits(
 						original_nested_info->sizeInBits());
 				}

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2890,7 +2890,6 @@ try_type_template_argument_parse:
 				TypeIndex substituted_index = subst_it->second;
 				TypeCategory substituted_category = substituted_index.category();
 				type_node.set_type_index(substituted_index.withCategory(substituted_category));
-				type_node.set_category(substituted_category);
 				const int substituted_size_bits = getTypeSpecSizeBits(type_node);
 				if (substituted_size_bits > 0) {
 					type_node.set_size_in_bits(substituted_size_bits);
@@ -2992,7 +2991,6 @@ try_type_template_argument_parse:
 					if (substituted_index.is_valid()) {
 						TypeCategory substituted_category = substituted_arg.typeEnum();
 						type_node.set_type_index(substituted_index.withCategory(substituted_category));
-						type_node.set_category(substituted_category);
 						for (const CVQualifier cv : substituted_arg.pointer_cv_qualifiers) {
 							type_node.add_pointer_level(cv);
 						}

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -300,6 +300,60 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 
 }
 
+std::optional<TypeSpecifierNode>
+Parser::tryMaterializeDependentDirectAliasTypeSpecifier(
+	const TypeSpecifierNode& type_spec,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	const TypeInfo* dependent_alias_info = tryGetTypeInfo(type_spec.type_index());
+	if (dependent_alias_info == nullptr ||
+		!dependent_alias_info->isTemplateInstantiation()) {
+		return std::nullopt;
+	}
+
+	StringHandle qualified_alias_name =
+		gNamespaceRegistry.buildQualifiedIdentifier(
+			dependent_alias_info->sourceNamespace(),
+			dependent_alias_info->baseTemplateName());
+	std::optional<ASTNode> alias_entry =
+		gTemplateRegistry.lookup_alias_template(
+			StringTable::getStringView(qualified_alias_name));
+	if (!alias_entry.has_value()) {
+		alias_entry = gTemplateRegistry.lookup_alias_template(
+			StringTable::getStringView(dependent_alias_info->baseTemplateName()));
+	}
+	if (!alias_entry.has_value() || !alias_entry->is<TemplateAliasNode>()) {
+		return std::nullopt;
+	}
+
+	const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
+	if (!findDirectAliasTargetParameterIndex(alias_node).has_value()) {
+		return std::nullopt;
+	}
+
+	TemplateEnvironment substitution_environment =
+		buildTemplateEnvironment(template_params, template_args, nullptr);
+	ExpressionSubstitutor substitutor(substitution_environment, *this);
+	TypeSpecifierNode substituted_type =
+		substitutor.substituteTypeSpecifier(type_spec);
+	if (!substituted_type.type_index().is_valid() &&
+		is_builtin_type(substituted_type.type())) {
+		TypeIndex native_type_index = nativeTypeIndex(substituted_type.type());
+		if (native_type_index.is_valid()) {
+			substituted_type.set_type_index(native_type_index);
+			substituted_type.set_size_in_bits(
+				get_type_size_bits(substituted_type.type()));
+		}
+	}
+	if (typeSpecStillUsesDependentPlaceholder(substituted_type) ||
+		substituted_type.type() == TypeCategory::Template ||
+		(substituted_type.type() == type_spec.type() &&
+		 substituted_type.type_index() == type_spec.type_index())) {
+		return std::nullopt;
+	}
+	return substituted_type;
+}
+
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	std::span<const TemplateParameterNode> template_params,
@@ -1692,63 +1746,12 @@ ASTNode Parser::substituteTemplateParameters(
 			}
 		}
 
-		// A direct dependent alias parameter is represented by a structured alias-id
-		// placeholder. Materialize it through the active environment before the
-		// generic TypeIndex path can retain its unresolved storage type.
-		if (type_spec.type_index().is_valid()) {
-			if (const TypeInfo* dependent_alias_info = tryGetTypeInfo(type_spec.type_index());
-				dependent_alias_info != nullptr &&
-				dependent_alias_info->isTemplateInstantiation()) {
-				StringHandle qualified_alias_name =
-					gNamespaceRegistry.buildQualifiedIdentifier(
-						dependent_alias_info->sourceNamespace(),
-						dependent_alias_info->baseTemplateName());
-				std::optional<ASTNode> alias_entry =
-					gTemplateRegistry.lookup_alias_template(
-						StringTable::getStringView(qualified_alias_name));
-				if (!alias_entry.has_value()) {
-					alias_entry = gTemplateRegistry.lookup_alias_template(
-						StringTable::getStringView(dependent_alias_info->baseTemplateName()));
-				}
-				if (alias_entry.has_value() && alias_entry->is<TemplateAliasNode>()) {
-					const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
-					const TypeSpecifierNode& alias_target = alias_node.target_type_node();
-					const TypeInfo* alias_target_info = tryGetTypeInfo(alias_target.type_index());
-					const bool is_unmodified_direct_target =
-						!alias_node.is_deferred() &&
-						alias_target.cv_qualifier() == CVQualifier::None &&
-						alias_target.pointer_depth() == 0 &&
-						alias_target.reference_qualifier() == ReferenceQualifier::None &&
-						!alias_target.is_array() &&
-						(alias_target_info == nullptr ||
-							(!alias_target_info->isTemplateInstantiation() &&
-							 !alias_target_info->isDependentMemberType() &&
-							 !alias_target_info->hasDependentQualifiedName()));
-					if (is_unmodified_direct_target) {
-						TemplateEnvironment substitution_environment =
-							buildTemplateEnvironment(template_params, template_args, nullptr);
-						ExpressionSubstitutor substitutor(substitution_environment, *this);
-						TypeSpecifierNode substituted_type =
-							substitutor.substituteTypeSpecifier(type_spec);
-						if (!substituted_type.type_index().is_valid() &&
-							is_builtin_type(substituted_type.type())) {
-							TypeIndex native_type_index =
-								nativeTypeIndex(substituted_type.type());
-							if (native_type_index.is_valid()) {
-								substituted_type.set_type_index(native_type_index);
-								substituted_type.set_size_in_bits(
-									get_type_size_bits(substituted_type.type()));
-							}
-						}
-						if (!typeSpecStillUsesDependentPlaceholder(substituted_type) &&
-							substituted_type.type() != TypeCategory::Template &&
-							(substituted_type.type() != type_spec.type() ||
-							 substituted_type.type_index() != type_spec.type_index())) {
-							return emplace_node<TypeSpecifierNode>(substituted_type);
-						}
-					}
-				}
-			}
+		if (std::optional<TypeSpecifierNode> direct_alias_type =
+				tryMaterializeDependentDirectAliasTypeSpecifier(
+					type_spec,
+					template_params,
+					template_args)) {
+			return emplace_node<TypeSpecifierNode>(*direct_alias_type);
 		}
 
 		// Check if this is a user-defined type that matches a template parameter,

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2015,80 +2015,17 @@ ParseResult Parser::parse_type_specifier() {
 							}
 						}
 					}
-					const TypeSpecifierNode& alias_target = alias_node.target_type_node();
-					const TypeInfo* alias_target_info =
-						tryGetTypeInfo(alias_target.type_index());
-					const StringHandle alias_target_name = alias_target_info != nullptr
-						? alias_target_info->name()
-						: alias_target.token().handle();
-					const bool alias_target_is_template_parameter = [&] {
-						for (StringHandle param_name : alias_node.template_param_names()) {
-							if (param_name == alias_target_name) {
-								return true;
-							}
-						}
-						return false;
-					}();
-					const bool is_unmodified_direct_alias_target =
-						!alias_node.is_deferred() &&
-						alias_target_name.isValid() &&
-						alias_target.cv_qualifier() == CVQualifier::None &&
-						alias_target.pointer_depth() == 0 &&
-						alias_target.reference_qualifier() == ReferenceQualifier::None &&
-						!alias_target.is_array() &&
-						(alias_target_info == nullptr ||
-							(!alias_target_info->isTemplateInstantiation() &&
-							 !alias_target_info->isDependentMemberType() &&
-							 !alias_target_info->hasDependentQualifiedName())) &&
-						alias_target_is_template_parameter;
 					if (has_dependent_alias_args && peek() != "::"_tok) {
-						if (!is_unmodified_direct_alias_target) {
+						if (!findDirectAliasTargetParameterIndex(alias_node).has_value()) {
 							return ParseResult::success(emplace_node<TypeSpecifierNode>(instantiated_type));
 						}
-						// Keep the alias-id and its dependent arguments together until the
-						// enclosing template is substituted. Returning the alias target here
-						// would erase the binding between arguments such as Left and First,
-						// leaving the dependent alias parameter as an unresolved type.
-						StringHandle dependent_alias_handle =
-							StringTable::getOrInternStringHandle(
-								get_instantiated_class_name(type_name, *template_args));
-						TypeInfo* dependent_alias_info = nullptr;
-						auto dependent_alias_it = getTypesByNameMap().find(dependent_alias_handle);
-						if (dependent_alias_it != getTypesByNameMap().end()) {
-							dependent_alias_info = dependent_alias_it->second;
-						}
-						if (dependent_alias_info == nullptr) {
-							TypeInfo& placeholder_type = add_empty_type_entry();
-							placeholder_type.fallback_size_bits_ = 0;
-							placeholder_type.name_ = dependent_alias_handle;
-							placeholder_type.is_incomplete_instantiation_ = true;
-							placeholder_type.placeholder_kind_ =
-								DependentPlaceholderKind::DependentArgs;
-							InlineVector<StringHandle, 4> alias_param_names;
-							for (const TemplateParameterNode& param : alias_node.template_parameters()) {
-								alias_param_names.push_back(param.nameHandle());
-							}
-							InlineVector<TypeInfo::TemplateArgInfo, 4> alias_args =
-								toTemplateArgInfoList(*template_args);
-							placeholder_type.setTemplateInstantiationInfo(
-								QualifiedIdentifier::fromQualifiedName(
-									type_name,
-									gSymbolTable.get_current_namespace_handle()),
-								alias_args);
-							placeholder_type.setInstantiationContext(
-								std::move(alias_param_names),
-								alias_args,
-								nullptr);
-							getTypesByNameMap()[dependent_alias_handle] = &placeholder_type;
-							dependent_alias_info = &placeholder_type;
-						}
 						return ParseResult::success(emplace_node<TypeSpecifierNode>(
-							dependent_alias_info->registeredTypeIndex().withCategory(
-								TypeCategory::Template),
-							0,
-							type_name_token,
-							cv_qualifier,
-							ReferenceQualifier::None));
+							buildDependentDirectAliasTypeSpecifier(
+								type_name,
+								alias_node,
+								*template_args,
+								type_name_token,
+								cv_qualifier)));
 					}
 
 					if (const TypeInfo* instantiated_type_info =

--- a/src/TypeSizeQuery.h
+++ b/src/TypeSizeQuery.h
@@ -197,7 +197,6 @@ inline ConcreteTypeSizeQueryResult queryConcreteAliasResolvedTypeSizeBitsImpl(co
 
 	TypeSpecifierNode alias_resolved_type = type_spec;
 	alias_resolved_type.set_type_index(alias_info.type_index.withCategory(alias_info.typeEnum()));
-	alias_resolved_type.set_category(alias_info.typeEnum());
 	applyResolvedAliasShapeForSizeQuery(alias_resolved_type, alias_info);
 	const int alias_spec_size_bits = getTypeSpecSizeBits(alias_resolved_type);
 	if (alias_spec_size_bits > 0) {

--- a/tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp
+++ b/tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp
@@ -1,0 +1,71 @@
+template<typename Selected, typename Unused>
+using select_t = Selected;
+
+template<typename Selected, typename Unused>
+using select_pointer_t = Selected*;
+
+template<typename Selected, typename Unused>
+using select_reference_t = Selected&;
+
+template<typename Selected, typename Unused>
+using select_const_pointer_t = const Selected*;
+
+struct Payload {
+	long long value;
+};
+
+template<typename T, typename Ignored>
+struct AliasUser {
+	select_t<T, Ignored> copy(select_t<T, Ignored> value) {
+		return value;
+	}
+
+	select_pointer_t<T, Ignored> pointer(select_pointer_t<T, Ignored> value) {
+		return value;
+	}
+
+	select_reference_t<T, Ignored> reference(select_reference_t<T, Ignored> value) {
+		return value;
+	}
+
+	select_const_pointer_t<T, Ignored> constPointer(
+		select_const_pointer_t<T, Ignored> value) {
+		return value;
+	}
+};
+
+int main() {
+	AliasUser<int, short> native_user;
+	int value = 17;
+	if (native_user.copy(value) != 17) {
+		return 1;
+	}
+	if (native_user.pointer(&value) != &value) {
+		return 2;
+	}
+	native_user.reference(value) = 23;
+	if (value != 23) {
+		return 3;
+	}
+	if (native_user.constPointer(&value) != &value) {
+		return 4;
+	}
+
+	AliasUser<Payload, unsigned char> struct_user;
+	Payload payload{41};
+	Payload copied = struct_user.copy(payload);
+	if (copied.value != 41) {
+		return 5;
+	}
+	if (struct_user.pointer(&payload)->value != 41) {
+		return 6;
+	}
+	struct_user.reference(payload).value = 47;
+	if (payload.value != 47) {
+		return 7;
+	}
+	if (struct_user.constPointer(&payload)->value != 47) {
+		return 8;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary
- centralize direct dependent-alias classification, placeholder creation, and materialization
- preserve full type-specifier metadata through class-template member substitution so alias-introduced cv/ref/pointer structure reaches layout and codegen
- remove redundant TypeSpecifierNode type/category double assignments across the codebase
- add generic coverage for modifier-bearing aliases and unused alias parameters, and update the template architecture plans

## C++20 rule
A dependent alias template-id must retain its argument binding until substitution. Substitution produces the complete aliased type, including declarator modifiers; TypeIndex is only the canonical base identity and cannot replace cv/ref/pointer/array/function metadata.

Note: the first Windows full-suite run had one transient access violation in constructor-template lookup under parallel execution; the exact test passed immediately in isolation and the complete suite passed on rerun.