### PR TITLE
Preserve inherited qualified calls across empty packs

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -260,10 +260,19 @@ The active `std/test_std_ranges.cpp` frontier has moved again:
 - `function 'size' has inconsistent deduced auto return types: first return has
   type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
 
-Reduce the next slice without hardcoding standard-library names. Start from the
-generic overload-resolution/constraints path used by `invoke`, and separately
-reduce the CPO-object auto-return deduction issue behind `ranges::size`. Keep a
-non-`std` regression for each accepted language rule.
+Dependent qualified calls now preserve a concrete owner when only their call
+argument pack remains dependent. Substitution can therefore deduce and
+materialize inherited static member-function templates, and trailing-return
+SFINAE treats a known empty function parameter pack as a zero-element
+expansion. This is covered by:
+
+- `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
+
+The remaining `std::invoke` trace is narrower: its two-argument overload is
+rejected with `argument count 2 > parameter count 1` before viability because
+the raw function-parameter count does not account for the trailing parameter
+pack. Fix that generic count/shape rule next, then separately reduce the
+CPO-object auto-return issue behind `ranges::size`.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline
@@ -307,12 +316,12 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Reduce the current `std/test_std_ranges.cpp` `std::char_traits`
-   instantiation loop into a focused cache/reuse or recursion guard test.
-2. Trace whether repeated `char_traits` materialization is caused by missing
-   class-template instantiation reuse, a stale failed-instantiation state,
-   specialization lookup drift, or a replay side effect before changing the
-   iteration limit.
+1. Replace the raw function-parameter count rejection in template candidate
+   viability with the existing pack-aware argument-count rule; add a non-`std`
+   regression matching a fixed leading parameter plus a trailing function
+   parameter pack.
+2. Re-run `std/test_std_ranges.cpp`; once `std::invoke` advances, reduce the
+   independent `ranges::size` CPO-object auto-return deduction failure.
 3. Keep `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_ret0.cpp`,
    `tests/test_deleted_rvalue_template_overload_fail.cpp`,

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -237,10 +237,19 @@ The active standards-facing `std/test_std_ranges.cpp` failure has moved again:
 - `function 'size' has inconsistent deduced auto return types: first return has
   type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
 
-The next slices should reduce the generic constrained overload-resolution path
-behind `invoke` and the CPO-object auto-return deduction path behind
-`ranges::size`, with non-`std` regressions before touching the compiler
-implementation.
+Dependent qualified calls with concrete owners now retain structured lookup
+identity while their call argument packs remain dependent. Known empty
+function parameter packs expand to an empty argument list during
+trailing-return SFINAE, and inherited static member-function templates are
+deduced after substitution. The generic regression is:
+
+- `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
+
+The remaining `std::invoke` failure occurs earlier in candidate viability: the
+two-argument overload is rejected with `argument count 2 > parameter count 1`
+because a raw parameter count ignores its trailing function parameter pack.
+The next slice should fix that generic pack-aware count/shape rule. Keep the
+`ranges::size` auto-return issue separate.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -278,8 +287,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Reduce and fix the current `std/test_std_ranges.cpp` `std::invoke`
-   constrained overload-viability failure.
+1. Make function-template candidate argument-count viability account for
+   function parameter packs, then rerun the current `std::invoke` frontier.
 2. Reduce and fix the `ranges::size` CPO-object auto-return deduction issue
    without hardcoding standard-library names.
 3. Keep the cleared auto-return, dependent-alias, alias-brace construction, and

--- a/src/ChunkedAnyVector.h
+++ b/src/ChunkedAnyVector.h
@@ -172,6 +172,14 @@ public:
 		return emplace_back(value);
 	}
 
+	void pop_back() {
+		assert(!empty() && "ChunkedVector::pop_back called on empty container");
+		data.back().pop_back();
+		if (data.back().empty()) {
+			data.pop_back();
+		}
+	}
+
 	template <typename... Args>
 	T& emplace_back(Args&&... args) {
 		if (data.empty() || data.back().size() == ChunkSize) {

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -2132,9 +2132,25 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			definition_target != nullptr) {
 			return definition_target;
 		}
-		return resolveUniqueFunctionOverload(
-			owner_overloads.all,
-			substituted_arg_types);
+		if (const FunctionDeclarationNode* materialized_target =
+				resolveUniqueFunctionOverload(
+					owner_overloads.all,
+					substituted_arg_types);
+			materialized_target != nullptr) {
+			return materialized_target;
+		}
+
+		std::optional<ASTNode> instantiated_member_template =
+			parser_.try_instantiate_member_function_template(
+				owner_name,
+				member_name,
+				substituted_arg_types);
+		if (!instantiated_member_template.has_value() ||
+			!instantiated_member_template->is<FunctionDeclarationNode>()) {
+			return nullptr;
+		}
+		normalizePendingSemanticRoots();
+		return &instantiated_member_template->as<FunctionDeclarationNode>();
 	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
 		CallExprNode substituted_call(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3323,6 +3323,8 @@ private:	 // Resume private methods
 		}
 		return std::nullopt;
 	}
+	bool expressionReferencesKnownEmptyFunctionParameterPack(
+		const ASTNode& expression) const;
 
 	// Get the per-template-parameter-pack element count set by try_instantiate_template_explicit.
 	// This is the authoritative count for sizeof...(P) when multiple packs are present,

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -6378,7 +6378,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 						if (matching_pack->pack_size == 0) {
 							args.pop_back();
-							if (!arg_types.empty()) {
+							if (arg_types.size() > args.size()) {
 								arg_types.pop_back();
 							}
 						}
@@ -6390,7 +6390,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						if (expands_known_empty_pack) {
 							advance(); // consume '...'
 							args.pop_back();
-							if (!arg_types.empty()) {
+							if (arg_types.size() > args.size()) {
 								arg_types.pop_back();
 							}
 						} else {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1,4 +1,5 @@
 #include "Parser.h"
+#include "AstTraversal.h"
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
 #include "ExpressionSubstitutor.h"
@@ -20,6 +21,26 @@ void applyDeclarationArrayBoundsToTypeSpec(
 	const DeclarationNode& decl,
 	TypeSpecifierNode& type_spec,
 	Parser& parser);
+
+bool Parser::expressionReferencesKnownEmptyFunctionParameterPack(
+	const ASTNode& expression) const {
+	return AstTraversal::visitASTUntil(
+		expression,
+		[&](const ASTNode& node) {
+			if (!node.is<IdentifierNode>()) {
+				return false;
+			}
+			const std::string_view identifier_name =
+				node.as<IdentifierNode>().name();
+			return std::any_of(
+				pack_param_info_.begin(),
+				pack_param_info_.end(),
+				[&](const PackParamInfo& pack_info) {
+					return pack_info.pack_size == 0 &&
+						identifier_name == pack_info.original_name;
+				});
+		});
+}
 
 namespace {
 bool expressionYieldsOrdinaryCallLValue(const ExpressionNode& arg_expr) {
@@ -6303,7 +6324,7 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							if (std::holds_alternative<IdentifierNode>(expr)) {
 								const auto& id = std::get<IdentifierNode>(expr);
 								for (const auto& pack_info : pack_param_info_) {
-									if (id.name() == pack_info.original_name && pack_info.pack_size > 0) {
+									if (id.name() == pack_info.original_name) {
 										matching_pack = &pack_info;
 										break;
 									}
@@ -6355,16 +6376,34 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 								}
 							}
 						}
+						if (matching_pack->pack_size == 0) {
+							args.pop_back();
+							if (!arg_types.empty()) {
+								arg_types.pop_back();
+							}
+						}
 					} else {
-						// Complex pack expansion: the argument is a complex expression
-						// containing a pack parameter (e.g., identity(args)..., static_cast<Args>(args)...)
-						// Wrap the expression in a PackExpansionExprNode for expansion during template substitution
-						advance(); // consume '...'
-						Token ellipsis_token(Token::Type::Punctuator, "..."sv, 0, 0, 0);
-						ASTNode& last_arg_ref = args[args.size() - 1];
-						auto pack_expansion = emplace_node<ExpressionNode>(
-							PackExpansionExprNode(last_arg_ref, ellipsis_token));
-						last_arg_ref = pack_expansion;
+						const ASTNode& pack_pattern = args[args.size() - 1];
+						const bool expands_known_empty_pack =
+							expressionReferencesKnownEmptyFunctionParameterPack(
+								pack_pattern);
+						if (expands_known_empty_pack) {
+							advance(); // consume '...'
+							args.pop_back();
+							if (!arg_types.empty()) {
+								arg_types.pop_back();
+							}
+						} else {
+							// Complex pack expansion: the argument is a complex expression
+							// containing a pack parameter (e.g., identity(args)..., static_cast<Args>(args)...)
+							// Wrap the expression in a PackExpansionExprNode for expansion during template substitution
+							advance(); // consume '...'
+							Token ellipsis_token(Token::Type::Punctuator, "..."sv, 0, 0, 0);
+							ASTNode& last_arg_ref = args[args.size() - 1];
+							auto pack_expansion = emplace_node<ExpressionNode>(
+								PackExpansionExprNode(last_arg_ref, ellipsis_token));
+							last_arg_ref = pack_expansion;
+						}
 					}
 				}
 

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -252,9 +252,12 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			if (peek() == "..."_tok) {
 				Token ellipsis_token = peek_info();
 				advance(); // consume '...'
-				auto pack_expr = emplace_node<ExpressionNode>(
-					PackExpansionExprNode(*argResult.node(), ellipsis_token));
-				args.push_back(pack_expr);
+				if (!expressionReferencesKnownEmptyFunctionParameterPack(
+						*argResult.node())) {
+					auto pack_expr = emplace_node<ExpressionNode>(
+						PackExpansionExprNode(*argResult.node(), ellipsis_token));
+					args.push_back(pack_expr);
+				}
 			} else {
 				args.push_back(*argResult.node());
 			}
@@ -296,6 +299,12 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 		}
 		deduced_arg_types.push_back(*type_opt);
 	}
+	has_dependent_call_arg =
+		deduced_arg_types.size() != args.size() ||
+		argsHaveDeferredTemplateDependency(args, currentTemplateParamNames()) ||
+		argTypesAreDeferredTemplateDependent(
+			deduced_arg_types,
+			currentTemplateParamNames());
 	AliasTemplateMaterializationResult canonical_owner =
 		resolveCanonicalInstantiatedOwnerForLookup(instantiated_class_name);
 	if (!canonical_owner.instantiated_name.empty()) {
@@ -538,10 +547,15 @@ std::optional<ParseResult> Parser::try_parse_member_template_function_call(
 			std::move(member_template_arg_nodes));
 	}
 	if (resolved_function == nullptr) {
-		if (owner_is_dependent_instantiation) {
+		const bool preserve_qualified_owner_for_deferred_call =
+			owner_type_info != nullptr &&
+			(owner_is_dependent_instantiation ||
+			 has_deferred_template_call_args);
+		if (preserve_qualified_owner_for_deferred_call) {
 			TypeInfo::DependentQualifiedNameRecord dependent_record;
-			dependent_record.owner_kind =
-				TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation;
+			dependent_record.owner_kind = owner_type_info->isTemplateInstantiation()
+				? TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation
+				: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization;
 			dependent_record.owner_name = owner_name_handle;
 			dependent_record.owner_type =
 				owner_type_info->registeredTypeIndex();

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3764,6 +3764,31 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 			FlashCpp::ScopedState guard_param_names(currentTemplateParamState());
 			FlashCpp::ScopedState guard_subs(template_param_substitutions_);
 			FlashCpp::ScopedState guard_sfinae_map(sfinae_type_map_);
+			auto saved_pack_param_info = std::move(pack_param_info_);
+			pack_param_info_.clear();
+			auto restore_pack_param_info = ScopeGuard([&]() {
+				pack_param_info_ = std::move(saved_pack_param_info);
+			});
+			if (deduction_info.has_value() &&
+				deduction_info->function_pack_call_arg_start != SIZE_MAX &&
+				deduction_info->function_pack_call_arg_end != SIZE_MAX) {
+				const size_t function_pack_size =
+					deduction_info->function_pack_call_arg_end -
+					deduction_info->function_pack_call_arg_start;
+				for (const ASTNode& param_node : func_decl.parameter_nodes()) {
+					if (!param_node.is<DeclarationNode>()) {
+						continue;
+					}
+					const DeclarationNode& param_decl =
+						param_node.as<DeclarationNode>();
+					if (param_decl.is_parameter_pack()) {
+						pack_param_info_.push_back({
+							param_decl.identifier_token().value(),
+							deduction_info->function_pack_call_arg_start,
+							function_pack_size});
+					}
+				}
+			}
 			ScopedParserInstantiationContext guard_instantiation_mode(*this, TemplateInstantiationMode::SoftProbe, StringHandle{});
 			parsing_template_depth_ = 0;	 // suppress template body context during SFINAE
 			clearCurrentTemplateParameters();  // No dependent names during SFINAE

--- a/tests/test_template_dependent_inherited_static_call_pack_ret0.cpp
+++ b/tests/test_template_dependent_inherited_static_call_pack_ret0.cpp
@@ -1,0 +1,39 @@
+struct InvokeFunctor {
+	template <class Callable, class... Args>
+	static constexpr auto call(Callable&& callable, Args&&... args)
+		noexcept(noexcept(static_cast<Callable&&>(callable)(static_cast<Args&&>(args)...)))
+		-> decltype(static_cast<Callable&&>(callable)(static_cast<Args&&>(args)...)) {
+		return static_cast<Callable&&>(callable)(static_cast<Args&&>(args)...);
+	}
+};
+
+template <class Callable, class First>
+struct SelectInvoker : InvokeFunctor {};
+
+template <class Callable, class First, class... Rest>
+constexpr auto invokeLike(Callable&& callable, First&& first, Rest&&... rest)
+	noexcept(noexcept(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)))
+	-> decltype(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)) {
+	return SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...);
+}
+
+struct ReadValue {
+	constexpr int operator()(int& value) const {
+		return value;
+	}
+};
+
+int main() {
+	ReadValue function;
+	int value = 42;
+	return invokeLike(function, value) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- preserve structured qualified-owner identity when a concrete owner call remains dependent only because of call arguments
- materialize inherited static member-function templates after substitution using concrete argument types
- treat known empty function parameter packs as zero-element argument expansions in ordinary and qualified call parsing
- register function-pack cardinality during trailing-return SFINAE reparsing
- add a generic forwarding/trailing-decltype regression and update the template architecture plans

## C++20 rule
A pack expansion with an empty pack produces an empty list. A qualified dependent call must also retain its owner until substitution so member lookup, including inherited member-function templates, occurs at the point of instantiation rather than degrading to a free-function placeholder.

## Next slice
Replace that raw template-candidate count rejection with the existing pack-aware argument-count/shape rule, then rerun the ranges frontier. Keep the independent ranges::size auto-return issue separate.