### PR TITLE
Preserve template parameter identity during deduction

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -272,12 +272,19 @@ Function-template parameter types now preserve direct template-parameter
 identity on `TypeSpecifierNode`. Downstream deduction and member-template
 materialization consume that identity through `getStructuredTypeName(...)`
 instead of reconstructing it from a token spelling or depending on a transient
-dependent `TypeInfo` entry. Fixed forwarding-reference parameters are deduced
+dependent `TypeInfo` entry. Central direct substitution uses the same scoped
+binding, and rebinding a type specifier to a different concrete `TypeIndex`
+invalidates the old parameter identity. Fixed forwarding-reference parameters are deduced
 against their exact call-argument slots before a trailing function parameter
 pack, with the C++20 lvalue/rvalue adjustment applied explicitly. This is
 covered by:
 
 - `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+- `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
+
+The positive regression distinguishes lvalue, const-lvalue, and rvalue
+deduction, exercises non-empty packs and an explicit `T&` argument, and the
+negative regression keeps `const T&&` out of the forwarding-reference path.
 
 The one-argument `std::invoke` candidate is still correctly rejected for the
 two-argument call. The variadic candidate now passes pack-aware count/shape

--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -268,11 +268,23 @@ expansion. This is covered by:
 
 - `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
 
-The remaining `std::invoke` trace is narrower: its two-argument overload is
-rejected with `argument count 2 > parameter count 1` before viability because
-the raw function-parameter count does not account for the trailing parameter
-pack. Fix that generic count/shape rule next, then separately reduce the
-CPO-object auto-return issue behind `ranges::size`.
+Function-template parameter types now preserve direct template-parameter
+identity on `TypeSpecifierNode`. Downstream deduction and member-template
+materialization consume that identity through `getStructuredTypeName(...)`
+instead of reconstructing it from a token spelling or depending on a transient
+dependent `TypeInfo` entry. Fixed forwarding-reference parameters are deduced
+against their exact call-argument slots before a trailing function parameter
+pack, with the C++20 lvalue/rvalue adjustment applied explicitly. This is
+covered by:
+
+- `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+
+The one-argument `std::invoke` candidate is still correctly rejected for the
+two-argument call. The variadic candidate now passes pack-aware count/shape
+viability and preserves `_Callable`, `_Ty1`, and `_Types2` identities, but fails
+later while substituting its `_Invoker1<...>::_Call` trailing return/noexcept
+shape. Reduce that substitution failure next. Keep the independent
+`ranges::size` CPO-object auto-return issue separate.
 
 A standalone `<utility>` `std::addressof` probe now gets past the deleted
 `const T&&` overload selection issue and exposes duplicate emitted std inline
@@ -316,10 +328,9 @@ declarator-shaped `member_class + pointer_depth` forms.
 
 ## Recommended next task
 
-1. Replace the raw function-parameter count rejection in template candidate
-   viability with the existing pack-aware argument-count rule; add a non-`std`
-   regression matching a fixed leading parameter plus a trailing function
-   parameter pack.
+1. Reduce the variadic `std::invoke` candidate's later substitution failure,
+   centered on `_Invoker1<...>::_Call` in its trailing return/noexcept shape;
+   preserve structured identities rather than adding spelling recovery.
 2. Re-run `std/test_std_ranges.cpp`; once `std::invoke` advances, reduce the
    independent `ranges::size` CPO-object auto-return deduction failure.
 3. Keep `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -245,11 +245,21 @@ deduced after substitution. The generic regression is:
 
 - `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
 
-The remaining `std::invoke` failure occurs earlier in candidate viability: the
-two-argument overload is rejected with `argument count 2 > parameter count 1`
-because a raw parameter count ignores its trailing function parameter pack.
-The next slice should fix that generic pack-aware count/shape rule. Keep the
-`ranges::size` auto-return issue separate.
+Direct function-parameter types now preserve their type-template-parameter
+identity on `TypeSpecifierNode`, and shared deduction/materialization consumers
+use `getStructuredTypeName(...)` instead of reconstructing identity from token
+spelling. Fixed forwarding references before a trailing function parameter
+pack use their exact parameter-to-argument mapping and the C++20 lvalue/rvalue
+deduction adjustment. The generic regression is:
+
+- `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+
+The one-argument `std::invoke` overload is correctly rejected for a
+two-argument call. Its variadic overload passes pack-aware count/shape
+viability with structured `_Callable`, `_Ty1`, and `_Types2` identities, then
+fails later during substitution of the `_Invoker1<...>::_Call` trailing
+return/noexcept shape. The next slice should reduce that generic substitution
+failure. Keep the `ranges::size` auto-return issue separate.
 
 A reduced `<utility>` `std::addressof` probe now reaches a separate link
 frontier: duplicate emitted definitions for std inline objects such as
@@ -287,8 +297,8 @@ declarator-shaped pointer-depth/member-class metadata.
 
 ## Priority order
 
-1. Make function-template candidate argument-count viability account for
-   function parameter packs, then rerun the current `std::invoke` frontier.
+1. Reduce and fix the variadic `std::invoke` trailing return/noexcept
+   substitution failure without hardcoding the standard-library name.
 2. Reduce and fix the `ranges::size` CPO-object auto-return deduction issue
    without hardcoding standard-library names.
 3. Keep the cleared auto-return, dependent-alias, alias-brace construction, and

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -248,11 +248,17 @@ deduced after substitution. The generic regression is:
 Direct function-parameter types now preserve their type-template-parameter
 identity on `TypeSpecifierNode`, and shared deduction/materialization consumers
 use `getStructuredTypeName(...)` instead of reconstructing identity from token
-spelling. Fixed forwarding references before a trailing function parameter
+spelling. Direct substitution uses that same scoped binding, while a concrete
+`TypeIndex` rebind clears obsolete parameter identity. Fixed forwarding references before a trailing function parameter
 pack use their exact parameter-to-argument mapping and the C++20 lvalue/rvalue
 deduction adjustment. The generic regression is:
 
 - `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+- `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
+
+Coverage distinguishes lvalue, const-lvalue, and rvalue deduction, includes a
+non-empty trailing pack and an explicit `T&`, and verifies that `const T&&`
+cannot bind an lvalue.
 
 The one-argument `std::invoke` overload is correctly rejected for a
 two-argument call. Its variadic overload passes pack-aware count/shape

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1776,6 +1776,14 @@ public:
 	bool is_pack_expansion() const { return is_pack_expansion_; }
 	void set_pack_expansion(bool is_pack) { is_pack_expansion_ = is_pack; }
 
+	// Structured identity for a type template parameter such as T in T&&.
+	// This remains stable when a dependent TypeInfo entry is unavailable during
+	// replay and avoids reconstructing semantic identity from token spelling.
+	bool has_template_parameter_identity() const { return template_parameter_name_.isValid(); }
+	StringHandle template_parameter_name() const { return template_parameter_name_; }
+	void set_template_parameter_identity(StringHandle name) { template_parameter_name_ = name; }
+	void clear_template_parameter_identity() { template_parameter_name_ = {}; }
+
 	// Pointer-to-member support (for types like int Class::*)
 	bool has_member_class() const { return member_class_name_.has_value(); }
 	StringHandle member_class_name() const { return *member_class_name_; }
@@ -1825,6 +1833,7 @@ private:
 	bool has_unsized_outer_array_dimension_ = false;	// True for parser-only shapes like T[][N]
 	std::optional<FunctionSignature> function_signature_;  // For function pointers
 	bool is_pack_expansion_ = false;	 // True if this type is followed by ... (pack expansion)
+	StringHandle template_parameter_name_; // Bound type-template parameter identity
 	std::optional<StringHandle> member_class_name_;	// For pointer-to-member types (int Class::*)
 	std::string_view concept_constraint_;  // Non-empty if this was a constrained auto parameter (e.g., IsInt auto x)
 
@@ -1834,6 +1843,19 @@ public:
 	std::string_view concept_constraint() const { return concept_constraint_; }
 	void set_concept_constraint(std::string_view constraint) { concept_constraint_ = constraint; }
 };
+
+// Return the structured identity carried by a type specifier. Direct template
+// parameters keep their declaration identity on the node; other dependent
+// types use their registered semantic TypeInfo identity.
+inline StringHandle getStructuredTypeName(const TypeSpecifierNode& type_spec) {
+	if (type_spec.has_template_parameter_identity()) {
+		return type_spec.template_parameter_name();
+	}
+	if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index())) {
+		return type_info->name();
+	}
+	return {};
+}
 
 inline void TypeInfo::clearAliasTypeSpecifier() {
 	alias_type_spec_.reset();

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1776,9 +1776,9 @@ public:
 	bool is_pack_expansion() const { return is_pack_expansion_; }
 	void set_pack_expansion(bool is_pack) { is_pack_expansion_ = is_pack; }
 
-	// Structured identity for a type template parameter such as T in T&&.
-	// This remains stable when a dependent TypeInfo entry is unavailable during
-	// replay and avoids reconstructing semantic identity from token spelling.
+	// Scoped binding identity for a type template parameter such as T in T&&.
+	// Consumers resolve this handle against the active template parameter list,
+	// so replay does not depend on token spelling or a transient TypeInfo entry.
 	bool has_template_parameter_identity() const { return template_parameter_name_.isValid(); }
 	StringHandle template_parameter_name() const { return template_parameter_name_; }
 	void set_template_parameter_identity(StringHandle name) { template_parameter_name_ = name; }
@@ -1796,7 +1796,12 @@ public:
 		}
 	}
 
-	void set_type_index(TypeIndex index) { type_index_ = index; }
+	void set_type_index(TypeIndex index) {
+		if (template_parameter_name_.isValid() && index.index() != type_index_.index()) {
+			clear_template_parameter_identity();
+		}
+		type_index_ = index;
+	}
 	void set_category(TypeCategory cat) { type_index_ = type_index_.withCategory(cat); }
 	const Token& token() const { return token_; }
 	void copy_indirection_from(const TypeSpecifierNode& other) {
@@ -1833,7 +1838,7 @@ private:
 	bool has_unsized_outer_array_dimension_ = false;	// True for parser-only shapes like T[][N]
 	std::optional<FunctionSignature> function_signature_;  // For function pointers
 	bool is_pack_expansion_ = false;	 // True if this type is followed by ... (pack expansion)
-	StringHandle template_parameter_name_; // Bound type-template parameter identity
+	StringHandle template_parameter_name_; // Scoped type-template parameter binding
 	std::optional<StringHandle> member_class_name_;	// For pointer-to-member types (int Class::*)
 	std::string_view concept_constraint_;  // Non-empty if this was a constrained auto parameter (e.g., IsInt auto x)
 
@@ -1844,9 +1849,9 @@ public:
 	void set_concept_constraint(std::string_view constraint) { concept_constraint_ = constraint; }
 };
 
-// Return the structured identity carried by a type specifier. Direct template
-// parameters keep their declaration identity on the node; other dependent
-// types use their registered semantic TypeInfo identity.
+// Return the structured name carried by a type specifier. Direct template
+// parameters keep their scoped binding on the node; other dependent types use
+// their registered semantic TypeInfo identity.
 inline StringHandle getStructuredTypeName(const TypeSpecifierNode& type_spec) {
 	if (type_spec.has_template_parameter_identity()) {
 		return type_spec.template_parameter_name();

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -149,11 +149,7 @@ inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 	if (source_member != nullptr && source_member->function_signature.has_value())
 		return source_member->function_signature;
 
-	StringHandle type_name_handle;
-	if (const TypeInfo* ts_ti = tryGetTypeInfo(type_spec.type_index()))
-		type_name_handle = ts_ti->name();
-	if (!type_name_handle.isValid())
-		type_name_handle = type_spec.token().handle();
+	StringHandle type_name_handle = getStructuredTypeName(type_spec);
 	if (!type_name_handle.isValid())
 		return std::nullopt;
 
@@ -171,11 +167,7 @@ inline void applyBoundTemplateArgMetadata(
 	const ParamContainer& template_params,
 	const ArgContainer& template_args) {
 
-	StringHandle type_name_handle;
-	if (const TypeInfo* ts_ti = tryGetTypeInfo(original_type.type_index()))
-		type_name_handle = ts_ti->name();
-	if (!type_name_handle.isValid())
-		type_name_handle = original_type.token().handle();
+	StringHandle type_name_handle = getStructuredTypeName(original_type);
 	if (!type_name_handle.isValid())
 		return;
 

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -4005,7 +4005,10 @@ inline std::optional<StringHandle> findUnresolvedHardUseTypeSpecifier(const ASTN
 
 		const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
 		if (typeSpecStillUsesDependentPlaceholder(type_spec)) {
-			unresolved_name = type_info ? type_info->name() : type_spec.token().handle();
+			StringHandle structured_name = getStructuredTypeName(type_spec);
+			unresolved_name = structured_name.isValid()
+				? structured_name
+				: type_spec.token().handle();
 			return;
 		}
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -166,13 +166,7 @@ bool Parser::isTemplateFunctionParameterPack(
 		return false;
 	}
 
-	StringHandle fp_type_name;
-	if (const TypeInfo* ti = tryGetTypeInfo(fp_ts.type_index())) {
-		fp_type_name = ti->name();
-	}
-	if (!fp_type_name.isValid()) {
-		fp_type_name = fp_ts.token().handle();
-	}
+	StringHandle fp_type_name = getStructuredTypeName(fp_ts);
 	if (!fp_type_name.isValid()) {
 		return false;
 	}
@@ -1799,13 +1793,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 				++abbreviated_auto_param_index;
 			}
 		}
-		StringHandle direct_fp_type_name;
-		if (const TypeInfo* direct_type_info = tryGetTypeInfo(direct_fp_type.type_index())) {
-			direct_fp_type_name = direct_type_info->name();
-		}
-		if (!direct_fp_type_name.isValid()) {
-			direct_fp_type_name = direct_fp_type.token().handle();
-		}
+		StringHandle direct_fp_type_name = getStructuredTypeName(direct_fp_type);
 		auto direct_param_it = tparam_nodes_by_name.find(direct_fp_type_name);
 		if (direct_param_it != tparam_nodes_by_name.end() &&
 			direct_param_it->second->kind() == TemplateParameterKind::Type &&
@@ -1846,13 +1834,7 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 				// inner member function template pack parameters the token handle is
 				// often invalid/empty, while the TypeInfo name is always populated.
 				// This matches the priority order used in the detection block above.
-				StringHandle pack_type_name;
-				if (const TypeInfo* ti = tryGetTypeInfo(fp_type.type_index())) {
-					pack_type_name = ti->name();
-				}
-				if (!pack_type_name.isValid()) {
-					pack_type_name = fp_type.token().handle();
-				}
+				StringHandle pack_type_name = getStructuredTypeName(fp_type);
 				if (!tparam_nodes_by_name.count(pack_type_name)) {
 					pack_type_name = {};
 				}
@@ -2033,12 +2015,10 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 		if (fp_type.pointer_depth() != 0 || fp_type.is_array() || fp_decl.is_array())
 			continue;
 
-		TypeIndex fp_idx = fp_type.type_index();
-		const TypeInfo* fp_type_info = tryGetTypeInfo(fp_idx);
-		if (!fp_type_info)
+		StringHandle fp_name = getStructuredTypeName(fp_type);
+		if (!fp_name.isValid()) {
 			continue;
-
-		StringHandle fp_name = fp_type_info->name();
+		}
 		if (!tparam_nodes_by_name.count(fp_name))
 			continue;  // not a template parameter
 		if (param_name_to_arg.count(fp_name))
@@ -2064,17 +2044,22 @@ std::optional<Parser::CallArgDeductionInfo> Parser::buildDeductionMapFromCallArg
 			const bool is_forwarding_reference =
 				isForwardingReferenceParameter(fp_type, template_params);
 			if (is_forwarding_reference) {
-				// Forwarding-reference deduction needs the full T&& vs lvalue/rvalue rules.
-				// Let the main deduction path handle it instead of pre-deducing the wrong shape.
-				continue;
+				// C++20 [temp.deduct.call]: when P is a forwarding reference and the
+				// argument is an lvalue, deduction uses an lvalue reference to the
+				// argument type. For an rvalue, T is the non-reference argument type.
+				new_arg.ref_qualifier = ca_type.is_lvalue_reference()
+					? ReferenceQualifier::LValueReference
+					: ReferenceQualifier::None;
+				new_arg.cv_qualifier = ca_type.cv_qualifier();
+			} else {
+				if (ca_type.is_lvalue_reference()) {
+					return std::nullopt;
+				}
+				new_arg.ref_qualifier = ReferenceQualifier::None;
+				const auto argument_cv = static_cast<uint8_t>(new_arg.cv_qualifier);
+				const auto parameter_cv = static_cast<uint8_t>(fp_type.cv_qualifier());
+				new_arg.cv_qualifier = static_cast<CVQualifier>(argument_cv & ~parameter_cv);
 			}
-			if (ca_type.is_lvalue_reference()) {
-				return std::nullopt;
-			}
-			new_arg.ref_qualifier = ReferenceQualifier::None;
-			const auto argument_cv = static_cast<uint8_t>(new_arg.cv_qualifier);
-			const auto parameter_cv = static_cast<uint8_t>(fp_type.cv_qualifier());
-			new_arg.cv_qualifier = static_cast<CVQualifier>(argument_cv & ~parameter_cv);
 		}
 		param_name_to_arg.emplace(fp_name, new_arg);
 		pre_deduced_arg_indices.insert(concrete_arg_index);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -45,11 +45,10 @@ static bool isForwardingReferenceParameter(
 	if (!type.is_rvalue_reference() || type.cv_qualifier() != CVQualifier::None)
 		return false;
 
-	const TypeInfo* type_info = tryGetTypeInfo(type.type_index());
-	if (type_info == nullptr)
+	const StringHandle type_name = getStructuredTypeName(type);
+	if (!type_name.isValid())
 		return false;
 
-	const StringHandle type_name = type_info->name();
 	for (const TemplateParameterNode& template_param : template_params) {
 		if (template_param.kind() == TemplateParameterKind::Type &&
 			template_param.nameHandle() == type_name) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -697,19 +697,6 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 			tparam_names.insert(tp.nameHandle());
 		}
 
-		// Resolve the base name of a function-parameter type (possibly U, U*, U**, etc.).
-		// Uses TypeInfo name first, then the token handle as a fallback.
-		auto getBaseName = [&](const TypeSpecifierNode& fp_type) -> StringHandle {
-			StringHandle base_name;
-			if (const TypeInfo* ti = tryGetTypeInfo(fp_type.type_index())) {
-				base_name = ti->name();
-			}
-			if (!base_name.isValid()) {
-				base_name = fp_type.token().handle();
-			}
-			return base_name;
-		};
-
 		// For each function parameter whose base type is a template parameter, record how many
 		// pointer levels the pattern adds on top of U (e.g. pick(U*) → depth["U"]=1).
 		// This is used for two purposes:
@@ -733,7 +720,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 				const TypeSpecifierNode& fp_type = fp_decl.type_specifier_node();
 				const TypeSpecifierNode& ca_type = arg_types[call_idx];
 
-				StringHandle base_name = getBaseName(fp_type);
+				StringHandle base_name = getStructuredTypeName(fp_type);
 				if (base_name.isValid() && tparam_names.count(base_name) > 0) {
 					// Viability check: a parameter pattern U*^N (e.g. U*, U**) requires at least
 					// N pointer levels in the call argument.  Without this, pick(U*) would be
@@ -1744,13 +1731,7 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template_explicit
 				// depth 1 for `Apply<U>*`) that the pre-filter should honour.
 				if (typeSpecStillUsesDependentPlaceholder(pts)) {
 					// Determine the base type name of the parameter.
-					StringHandle base_name;
-					if (const TypeInfo* ti = tryGetTypeInfo(pts.type_index())) {
-						base_name = ti->name();
-					}
-					if (!base_name.isValid()) {
-						base_name = pts.token().handle();
-					}
+					StringHandle base_name = getStructuredTypeName(pts);
 					bool is_direct_tparam = false;
 					if (base_name.isValid()) {
 						for (const auto& tp : template_params) {
@@ -2434,10 +2415,9 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			type_spec.category() != TypeCategory::Template) {
 			return {};
 		}
-		if (type_spec.type_index().is_valid()) {
-			if (const TypeInfo* ti = tryGetTypeInfo(type_spec.type_index())) {
-				return ti->name();
-			}
+		StringHandle structured_name = getStructuredTypeName(type_spec);
+		if (structured_name.isValid()) {
+			return structured_name;
 		}
 		return type_spec.token().handle();
 	};

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1765,19 +1765,14 @@ ASTNode Parser::substituteTemplateParameters(
 			const TemplateTypeArg* matched_direct_template_arg = nullptr;
 			bool exact_template_param_substituted = false;
 			std::optional<ASTNode> exact_template_param_node;
-			std::string_view direct_type_name = type_spec.token().value();
-			if (direct_type_name.empty()) {
-				if (const TypeInfo* direct_type_info = tryGetTypeInfo(type_spec.type_index())) {
-					direct_type_name = StringTable::getStringView(direct_type_info->name());
-				}
-			}
+			const StringHandle direct_type_name = getStructuredTypeName(type_spec);
 			forEachNonPackTemplateParamArgBinding(
 				template_params,
 				template_args,
 				[&](const TemplateParameterNode& template_param, const TemplateTypeArg& template_arg, size_t) {
 					if (exact_template_param_substituted ||
 						template_param.kind() != TemplateParameterKind::Type ||
-						template_param.name() != direct_type_name ||
+						template_param.nameHandle() != direct_type_name ||
 						!template_arg.isTypeArgument()) {
 						return;
 					}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -3536,8 +3536,10 @@ ParseResult Parser::parse_type_specifier() {
 						FLASH_LOG_FORMAT(Templates, Debug,
 										 "parse_type_specifier: '{}' is a template parameter, returning dependent type at index {}",
 										 type_name, param_type_idx);
-						return ParseResult::success(emplace_node<TypeSpecifierNode>(
-							param_type_idx.withCategory(TypeCategory::UserDefined), 0, type_name_token, cv_qualifier, ReferenceQualifier::None));
+						TypeSpecifierNode param_type(
+							param_type_idx.withCategory(TypeCategory::UserDefined), 0, type_name_token, cv_qualifier, ReferenceQualifier::None);
+						param_type.set_template_parameter_identity(type_name_handle);
+						return ParseResult::success(emplace_node<TypeSpecifierNode>(param_type));
 					} else {
 						// Template parameter not yet in getTypesByNameMap() - create a placeholder
 						// This can happen when parsing the template parameter list itself
@@ -3550,8 +3552,10 @@ ParseResult Parser::parse_type_specifier() {
 						type_info.is_incomplete_instantiation_ = true;
 						type_info.placeholder_kind_ = DependentPlaceholderKind::DependentArgs;
 						getTypesByNameMap()[type_name_handle] = &type_info;
-						return ParseResult::success(emplace_node<TypeSpecifierNode>(
-							type_info.type_index_.withCategory(TypeCategory::UserDefined), 0, type_name_token, cv_qualifier, ReferenceQualifier::None));
+						TypeSpecifierNode param_type(
+							type_info.type_index_.withCategory(TypeCategory::UserDefined), 0, type_name_token, cv_qualifier, ReferenceQualifier::None);
+						param_type.set_template_parameter_identity(type_name_handle);
+						return ParseResult::success(emplace_node<TypeSpecifierNode>(param_type));
 					}
 				}
 			}

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -101,6 +101,31 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
 
+### 2026-07-11 Windows/MSVC structured template-parameter identity follow-up
+
+Function-parameter type template identities now travel on `TypeSpecifierNode`
+and are consumed through the shared `getStructuredTypeName(...)` helper during
+deduction and member-template materialization. Fixed forwarding references
+before a trailing function parameter pack use their exact call-argument slots
+and the C++20 lvalue/rvalue deduction rule. Regression:
+
+- `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+
+Fresh individual runner wall times (`x64/Sharded/FlashCppMSVC.exe`, MSVC STL
+14.44; includes FlashCpp compile, MSVC link, and execution) were:
+
+| Header/Test | Status | Runner wall time | Current note |
+|-------------|--------|------------------|--------------|
+| `<cstddef>` (`test_cstddef.cpp`) | ✅ Pass | ~35.7s cold / includes ~30.5s compiler rebuild | Returned 3 as expected. |
+| `<cstdio>` (`test_cstdio_puts.cpp`) | ✅ Pass | ~8.7s warm | Compiles, links, and returns 0. |
+| `<cstdlib>` (`test_cstdlib.cpp`) | ✅ Pass | ~3.9s warm | Compiles, links, and returns 0. |
+| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~4.8s warm | Compiles, links, and returns 0. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.5s warm | Current first diagnostics are all three `ranges::empty` template overloads failing, followed by unresolved `auto` reaching MSVC mangling in `view_interface`. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~28.4s warm before the fix / ~29.0s after | The one-argument `std::invoke` candidate is correctly rejected; the variadic candidate reaches later `_Invoker1<...>::_Call` substitution failure. The independent `ranges::size` inconsistent-auto-return diagnostic remains. |
+
+Full Windows validation after the change: 2750 regular tests passed, all 235
+expected-fail tests failed as expected, with no crashes or return mismatches.
+
 ### 2026-05-28 Linux/libstdc++ template-substitution metadata follow-up
 
 Fix landed:

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -107,9 +107,12 @@ Function-parameter type template identities now travel on `TypeSpecifierNode`
 and are consumed through the shared `getStructuredTypeName(...)` helper during
 deduction and member-template materialization. Fixed forwarding references
 before a trailing function parameter pack use their exact call-argument slots
-and the C++20 lvalue/rvalue deduction rule. Regression:
+and the C++20 lvalue/rvalue deduction rule. Direct substitution consumes the
+same scoped binding, and concrete type rebinding clears stale parameter
+identity. Regressions:
 
 - `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
+- `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
 
 Fresh individual runner wall times (`x64/Sharded/FlashCppMSVC.exe`, MSVC STL
 14.44; includes FlashCpp compile, MSVC link, and execution) were:
@@ -123,7 +126,7 @@ Fresh individual runner wall times (`x64/Sharded/FlashCppMSVC.exe`, MSVC STL
 | `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.5s warm | Current first diagnostics are all three `ranges::empty` template overloads failing, followed by unresolved `auto` reaching MSVC mangling in `view_interface`. |
 | `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~28.4s warm before the fix / ~29.0s after | The one-argument `std::invoke` candidate is correctly rejected; the variadic candidate reaches later `_Invoker1<...>::_Call` substitution failure. The independent `ranges::size` inconsistent-auto-return diagnostic remains. |
 
-Full Windows validation after the change: 2750 regular tests passed, all 235
+Full Windows validation after the change: 2750 regular tests passed, all 236
 expected-fail tests failed as expected, with no crashes or return mismatches.
 
 ### 2026-05-28 Linux/libstdc++ template-substitution metadata follow-up

--- a/tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp
+++ b/tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp
@@ -1,0 +1,12 @@
+// A const T&& parameter is not a forwarding reference and cannot bind an lvalue,
+// including when a trailing function parameter pack can consume later arguments.
+
+template <class T, class... Rest>
+constexpr int acceptConstRvalue(const T&&, Rest&&...) {
+	return sizeof...(Rest);
+}
+
+int main() {
+	int value = 1;
+	return acceptConstRvalue(value, 2);
+}

--- a/tests/test_function_template_fixed_param_before_pack_ret0.cpp
+++ b/tests/test_function_template_fixed_param_before_pack_ret0.cpp
@@ -23,13 +23,46 @@ struct Sum {
 	}
 };
 
+template <class T>
+struct ReferenceKind {
+	static constexpr int value = 0;
+};
+
+template <class T>
+struct ReferenceKind<T&> {
+	static constexpr int value = 1;
+};
+
+template <class T>
+struct ReferenceKind<const T&> {
+	static constexpr int value = 2;
+};
+
+template <class First, class... Rest>
+constexpr int deductionCode(First&&, Rest&&...) {
+	return ReferenceKind<First>::value * 10 + sizeof...(Rest);
+}
+
 int main() {
 	Sum sum;
 	int value = 42;
+	const int const_value = 42;
 	using LvalueResult = decltype(invokeLike(sum, value));
 	using RvalueResult = decltype(invokeLike(Sum{}, 42));
 	if (sizeof(LvalueResult) != sizeof(int)) {
 		return 1;
 	}
-	return sizeof(RvalueResult) == sizeof(int) ? 0 : 2;
+	if (sizeof(RvalueResult) != sizeof(int)) {
+		return 2;
+	}
+	if (deductionCode(value, static_cast<short>(1), Sum{}) != 12) {
+		return 3;
+	}
+	if (deductionCode(const_value, 1) != 21) {
+		return 4;
+	}
+	if (deductionCode(42, 1) != 1) {
+		return 5;
+	}
+	return deductionCode<int&>(value) == 10 ? 0 : 6;
 }

--- a/tests/test_function_template_fixed_param_before_pack_ret0.cpp
+++ b/tests/test_function_template_fixed_param_before_pack_ret0.cpp
@@ -1,0 +1,35 @@
+// Regression: function-template deduction must preserve and use fixed function
+// parameters that precede a trailing function parameter pack.
+
+template <class Callable>
+constexpr auto invokeLike(Callable&& callable)
+	-> decltype(static_cast<Callable&&>(callable)()) {
+	return static_cast<Callable&&>(callable)();
+}
+
+template <class Callable, class First, class... Rest>
+constexpr auto invokeLike(Callable&& callable, First&& first, Rest&&... rest)
+	noexcept(noexcept(static_cast<Callable&&>(callable)(
+		static_cast<First&&>(first), static_cast<Rest&&>(rest)...)))
+	-> decltype(static_cast<Callable&&>(callable)(
+		static_cast<First&&>(first), static_cast<Rest&&>(rest)...)) {
+	return static_cast<Callable&&>(callable)(
+		static_cast<First&&>(first), static_cast<Rest&&>(rest)...);
+}
+
+struct Sum {
+	constexpr int operator()(int value) const {
+		return value;
+	}
+};
+
+int main() {
+	Sum sum;
+	int value = 42;
+	using LvalueResult = decltype(invokeLike(sum, value));
+	using RvalueResult = decltype(invokeLike(Sum{}, 42));
+	if (sizeof(LvalueResult) != sizeof(int)) {
+		return 1;
+	}
+	return sizeof(RvalueResult) == sizeof(int) ? 0 : 2;
+}


### PR DESCRIPTION
## Summary
- preserve scoped type-template-parameter bindings on `TypeSpecifierNode`
- centralize downstream identity lookup in `getStructuredTypeName(...)` and remove repeated token-spelling reconstruction from deduction, substitution, and materialization paths
- invalidate a parameter binding when its type specifier is rebound to a different concrete `TypeIndex`
- apply C++20 forwarding-reference deduction to fixed parameters before a trailing function parameter pack
- add reference-sensitive positive and negative regressions and refresh standard-header timings/planning docs

## C++20 behavior
For a forwarding-reference parameter `T&&`, an lvalue argument deduces `T` as an lvalue reference; an rvalue deduces the underlying non-reference type. Fixed parameters retain their exact function-parameter-to-call-argument mapping when followed by a function parameter pack. `const T&&` remains an ordinary rvalue reference and cannot bind an lvalue.

Template-parameter bindings now travel as scoped structured metadata rather than being recovered from token spelling or requiring a transient dependent `TypeInfo` entry. Central direct substitution and forwarding-reference classification consume the same metadata. Rebinding the carrier to another type entity clears the obsolete binding.

## Regression coverage
- `test_function_template_fixed_param_before_pack_ret0.cpp`
  - lvalue, const-lvalue, and rvalue deduction
  - non-empty trailing pack
  - explicit `T&` template argument
- `test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
  - verifies that `const T&&` before a trailing pack rejects an lvalue

## Validation
- `build_flashcpp.bat`
- focused forwarding, deleted-rvalue, explicit-pack, multi-dependent-pack, and dependent-alias guards
- `std/test_std_ranges.cpp` and `std/test_std_iterator.cpp` frontier checks
- full Windows suite: 2750 regular tests passed; all 236 expected-fail tests failed as expected
- fresh individual std-header timing/status recorded in `tests/std/README_STANDARD_HEADERS.md`

## Remaining frontier
`std/test_std_ranges.cpp` still reports the independent `ranges::size` inconsistent-auto-return diagnostic. For `std::invoke`, the one-argument overload is correctly rejected for the two-argument call; the variadic overload passes pack-aware count/shape viability with preserved `_Callable`, `_Ty1`, and `_Types2` bindings, then fails later while substituting its `_Invoker1<...>::_Call` trailing return/noexcept shape. That later substitution issue is intentionally left for a separate slice.