### PR TITLE
Preserve C++20 partial-specialization semantic bindings

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,391 +1,112 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-11
+**Last updated:** 2026-07-12
 
-This document is a planning aid for the remaining template-infrastructure work.
-It is intentionally forward-looking: keep it focused on the current baseline,
-the architectural invariants, and the next tasks. Avoid turning it into a
-history of completed branches.
+This is a forward-looking planning reference for template infrastructure. Keep
+it limited to the current architecture, invariants, live failures, and next
+tasks; completed branch history belongs in tests and version control.
 
-## Current architectural baseline
+## Current architecture
 
-The template implementation has moved substantially toward sema-owned,
-identity-preserving behavior:
+- `TypeSpecifierNode`, `TemplateTypeArg`, and structured lookup records carry
+  semantic identity through parsing, deduction, substitution, instantiation,
+  replay, and sema. Consumers should not reconstruct it from token spelling or
+  qualified names.
+- Sema owns final overload selection once concrete types are available. Parser
+  decisions are provisional and must not become compatibility fallbacks.
+- Class-template partial-specialization matching distinguishes a bare dependent
+  type parameter from an explicitly shaped pattern. Bare `T` deduces the whole
+  argument, including cv/ref identity; `T&`, `const T`, `T*`, arrays, function
+  signatures, and member pointers impose structural requirements.
+- The selected specialization carries its named deduction map into
+  materialization. Reordered, repeated, non-type array-bound, and
+  template-template parameters are not reconstructed by position.
+- Partial-specialization argument parsing uses the declared primary template's
+  parameter kinds, so function types and template-template arguments are parsed
+  into their semantic forms before matching.
+- Member-function parameter substitution preserves both the complete type
+  specifier and declaration metadata. In particular, a function-parameter pack
+  remains a pack after class-template substitution, including when it expands
+  to zero arguments.
+- Direct dependent alias template-ids remain structured until their enclosing
+  arguments are known, then materialize before deduction and code generation.
+- `ResolvedQualifiedOwner` and structured dependent-call records are the shared
+  owner/lookup representation across parser, substitution, constexpr, and sema
+  paths.
+- Replay and instantiated-member synchronization use source identity and
+  canonical substituted signatures instead of name/arity repair.
 
-- non-dependent template-body lookup remains definition-bound through covered
-  replay/materialization paths
-- dependent aliases and qualified owners preserve structured metadata instead
-  of relying on textual reconstruction where covered
-- direct-call resolution is increasingly represented by
-  `FunctionCallDefinitionLookupRecord`,
-  `DependentUnqualifiedCallLookupRecord`, or
-  `DependentQualifiedNameRecord`, not by parser-selected callee fallbacks
-- sema owns final overload selection for normalized direct/member calls,
-  including const-aware receiver lookup, `operator[]`, callable `operator()`,
-  and qualified direct calls in the covered paths
-- replay and `StructTypeInfo` synchronization now prefer source-member
-  identity plus canonical substituted-signature evidence over name/arity repair
-- pack expansion in call arguments now preserves unmatched complex `expr...`
-  nodes until substitution instead of flattening them early
-- qualified/member-template parser paths now preserve explicit template
-  arguments, parser return-type hints, dependent-qualified owner records, and
-  definition-bound call metadata where concrete targets are known
-- `ResolvedQualifiedOwner` is the shared owner-classification entry point for
-  the parser, `ExpressionSubstitutor`, constexpr qualified member access, and
-  sema qualified-call target recovery
-- builtin type template arguments are canonicalized through
-  `TemplateArgumentMaterialization.h`, covering the MSVC `<type_traits>`
-  `is_integral_v` fundamental-character-type fold shape
-- ordinary function declarations now preserve the C++ `inline` specifier through
-  parser copies and IR metadata; COFF emission gives C-linkage inline
-  definitions local/static symbol storage so UCRT wrapper definitions do not
-  collide with CRT library symbols while C++ inline header helpers remain
-  emitted
-- function-template redeclarations merge default template arguments into later
-  definitions, and function-template `noexcept(expr)` metadata is preserved
-  through the shared constexpr evaluator for the covered std-header probes
-- parser trailing-specifier handling now routes cv/ref qualifiers through
-  `parse_cv_qualifiers()` and `parse_reference_qualifier()` in the common
-  function-header, skip, and template-function paths
-- variable-template partial-specialization patterns now reuse the explicit
-  template-argument parser, so nested template-ids and pack patterns such as
-  `tuple<Dests...>` are preserved for matching; nested trailing packs can bind
-  against multi-argument concrete template-ids
-- template-argument skipping preserves C++ maximal-munch tokenization by
-  splitting `>>` only when a skipped template-id closes at depth one and the
-  caller still owns the outer `>`
-- member class template partial specializations reject argument lists that
-  exactly echo the primary template parameter list; the remaining positive
-  member-specialization guards use standards-valid discriminator patterns
-- namespace-qualified callable-object calls such as `ranges::swap(...)` keep
-  the member-call path when the qualified receiver is a concrete struct object,
-  so instantiated `operator()` member templates receive the implicit object
-  argument and preserve reference-argument mutation
-- direct dependent alias template-ids use one classifier, structured placeholder
-  factory, and materializer across parsing and substitution; full
-  `TypeSpecifierNode` metadata carries alias-introduced cv/ref/pointer structure
-  through signatures, bodies, and class-template member layout
+## Invariants
 
-## Architectural invariants
+- Preserve semantic identity and declarator metadata end to end.
+- Do not hardcode standard-library or vendor helper names in compiler logic.
+- Do not introduce parser, sema, or codegen fallbacks for valid C++ constructs;
+  implement the language rule at the first layer that owns it.
+- Keep deduction, substitution, overload ranking, replay, constexpr evaluation,
+  and code generation as separate responsibilities.
+- A bare template parameter binds the complete concrete argument. Strip only
+  modifiers explicitly contributed by the pattern.
+- Partial-specialization deduction binds by semantic parameter identity, never
+  by the parameter's position in the declaration.
+- A copied declaration must preserve semantic flags such as parameter-pack,
+  deleted/defaulted, cv/ref, and `noexcept` state as applicable to that copy.
+- Do not replace a concrete substituted type with an unresolved placeholder or
+  collapse a structured alias target to a base `TypeIndex` too early.
+- Add a reduced non-`std` regression before fixing a standard-header failure.
 
-Follow-up work should preserve these rules:
+## Current standard-header snapshot
 
-- preserve semantic identity end to end; do not rebuild meaning from strings
-  when a structured record exists
-- keep parser-selected compatibility paths explicit, narrow, and temporary
-- when sema has enough typed evidence, reject stale parser choices rather than
-  silently recovering through compatibility metadata
-- keep substitution, deduction, overload ranking, replay/materialization, and
-  constexpr evaluation as separate responsibilities
-- do not replace a concrete substituted type with an unresolved placeholder
-  index, and do not use a category-only builtin type where a native `TypeIndex`
-  is available
-- do not collapse a substituted alias target to `TypeIndex` before consumers
-  have retained its cv/ref/pointer/array/function declarator metadata
-- prefer identity-first replay attachment over `StructTypeInfo` repair scans
-- add abstractions only when they remove real repeated owner/replay logic or
-  prevent standards-visible fallback behavior from reappearing
+Fresh Windows/MSVC individual runner wall times after the 2026-07-12 rebuild:
 
-## Remaining architectural gaps
+| Test | Status | Time | Current frontier |
+|------|--------|------|------------------|
+| `std/test_cstddef.cpp` | Pass | 3.22s | Green control |
+| `std/test_cstdio_puts.cpp` | Pass | 9.39s | Green control |
+| `std/test_cstdlib.cpp` | Pass | 3.71s | Green control |
+| `std/test_std_type_traits.cpp` | Pass | 5.07s | Green control |
+| `std/test_std_iterator.cpp` | Fail | 22.97s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
+| `std/test_std_ranges.cpp` | Fail | 20.80s | `make_signed<T>` constraint/static-assert path and scoped-enum `_St` equality in tuple `_Equals` |
 
-### 1. Standard-header tracking cleanup
+The full Windows suite passes: 2753 regular tests compile, link, and run; all
+236 expected-failure tests fail as expected.
 
-The previously listed Windows std-header frontier is green on the current
-baseline:
+The current slice is guarded by:
 
-- `tests/std/test_cstddef.cpp`
-- `tests/std/test_cstdio_puts.cpp`
-- `tests/std/test_cstdlib.cpp`
-
-The active std-header frontier is now:
-
-- `tests/std/test_std_ranges.cpp`
-
-The concrete blocker was `<cstdio>` link failure from strong definitions of
-MSVC UCRT C-linkage inline wrappers such as `vsnprintf`, `snprintf`, and
-`sprintf_s`. The parser now preserves ordinary `inline` metadata and codegen
-emits C-linkage inline definitions as local COFF symbols rather than public
-external definitions. Keep C++ inline header helpers emitted;
-`std/test_std_type_traits.cpp` depends on that for helpers such as
-`std::_Fnv1a_append_bytes`.
-
-This is a targeted COFF fix, not complete inline linkage architecture. Proper
-cross-translation-unit COFF inline semantics should move inline definitions into
-deduplicatable per-function COMDAT/weak-external sections once the object writer
-can split the current monolithic `.text` section by function.
-
-The next high-value cleanup is to use the next live standard-header failure as
-the driver. Do not assume it is in template-owner infrastructure; trace whether
-it belongs in preprocessing, namespace/header modeling, template argument
-materialization, constexpr evaluation, semantic lookup, or object/linkage
-emission.
-
-For `std/test_std_ranges.cpp`, the previous dependent overload path is now
-cleared: the stale parser `NoMatch` for constrained `std::byte` `operator<<` is
-repaired during sema once the instantiated `operator<<=` body has concrete
-`byte` and `int` operand types. The scoped-enum diagnostic remains guarded for
-invalid non-dependent builtin shifts, and
-`tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp` covers the
-late operator-template retry.
-
-The previous `<tuple>:28` variable-template specialization-pattern blocker is
-covered by `tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
-
-The previous MSVC `<tuple>:138` allocator-aware constructor constraint is now
-covered:
-
-- `tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp`
-- `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`
-
-The covered shape is an unqualified alias-template NTTP type in namespace `std`:
-`enable_if_t<conjunction_v<::std:: uses_allocator<...>, ::std:: is_constructible<...>>, int> = 0`.
-The parser now recognizes current-namespace variable-template-ids as value-like
-arguments before falling through to type parsing.
-
-The subsequent MSVC `<tuple>` `_Equals` const-receiver failure is also covered:
-
-- `tests/test_template_const_member_function_template_receiver_ret0.cpp`
-
-Member-function-template cv metadata is now preserved from parsing through
-class-template instantiation and member-template materialization.
-
-The previous `std/test_std_ranges.cpp` `swap` overload and dependent-placeholder
-classification blocker is now covered by preserving full member-struct-template
-parameter metadata while parsing partial-specialization patterns and dependent
-bases, and by keeping dependent member aliases marked as dependent when they are
-later used as template arguments. The focused regression is:
-
-- `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`
-
-The previous `std/test_std_ranges.cpp` member-template parser blockers are now
-covered:
-
-- `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
-- `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
-
-These guard the `transform_view::_Iterator` shapes where a skipped member class
-template constructor ends with a braced member initializer before the function
-body, and where an inline hidden-friend `operator==` appears inside the member
-class template body.
-
-The namespace-qualified callable-object receiver path is now covered by:
-
-- `tests/test_constrained_cpo_call_operator_ret0.cpp`
-- `tests/test_if_constexpr_static_enum_strategy_prune_ret0.cpp`
-- `tests/test_qualified_cpo_nested_type_receiver_ret0.cpp`
-- `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp`
-
-Deleted rvalue-reference function-template sentinels now preserve their
-`= delete` metadata and no longer accept lvalue arguments through accidental
-forwarding-reference treatment:
-
-- `tests/test_deleted_rvalue_template_overload_ret0.cpp`
-- `tests/test_deleted_rvalue_template_overload_fail.cpp`
-
-The `std::ranges::end` inconsistent auto-return frontier is now covered by:
-
-- `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
-
-The previous `std/test_std_ranges.cpp` `common_iterator` local proxy-class
-frontier is now covered:
-
-- `tests/test_template_member_local_proxy_class_ret0.cpp`
-
-Local classes parsed inside instantiated template member bodies now keep their
-own delayed function-body queue instead of replaying the enclosing member body
-recursively. They are also marked as local classes so template class
-instantiation does not copy them as owner member classes. Inheriting
-constructors declared by local classes, such as `using _Proxy_base::_Proxy_base`,
-are materialized during instantiated member-body parsing so brace-initialized
-proxy objects can select the inherited base constructor.
-
-The previous `std/test_std_ranges.cpp` `std::char_traits` instantiation loop is
-now covered:
-
-- `tests/test_template_exact_specialization_reuse_ret0.cpp`
-
-Exact class-template specializations now register in the class-template
-instantiation cache after materialization, including the unqualified cache key
-used by namespace-qualified templates. Repeated `std::char_traits<char>` probes
-therefore hit the existing early cache instead of consuming the global
-instantiation-iteration budget.
-
-The previous `std/test_std_ranges.cpp` variable-template declaration blocker is
-now covered:
-
-- `tests/test_variable_template_declaration_no_initializer_ret0.cpp`
-
-Template declaration lookahead now recognizes declaration-only variable
-templates such as `template <class T> constexpr empty_view<T> empty;` as
-variable templates instead of falling through to function-template parsing.
-
-The previous `std/test_std_ranges.cpp` constrained member class-template
-partial-specialization blocker is now covered:
-
-- `tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp`
-
-The member class-template partial-specialization guard now treats constrained
-template parameters as a specialization discriminator, matching the existing
-explicit `requires` handling while preserving the rejection of unconstrained
-argument lists that merely echo the primary template parameter list.
-
-The previous `std/test_std_ranges.cpp` template-depth blocker is now covered:
-
-- `tests/test_member_template_self_specialization_param_no_eager_depth_ret0.cpp`
-
-`std::remove_cv` was not the root cause; it appeared inside a valid finite
-chain of constrained class-template viability checks. The parser nesting guard
-now has enough headroom for those conforming chains while still retaining a
-finite runaway-recursion diagnostic.
-
-Dependent alias-template type-ids and brace construction used by
-`std::exchange`-like calls, including modifier-bearing direct aliases and
-unused alias parameters, are now covered by:
-
-- `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
-- `tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp`
-
-This preserves direct aliases such as `select_first_t<Left, FirstTail>` through
-member-function signature materialization, materializes the target after the
-enclosing class-template argument is known, and lets ordinary
-function-template deduction consume the concrete argument type on both Windows
-and Linux. Class-template member layout now consumes the full substituted type
-specifier, so modifiers introduced by a member alias are not lost when its base
-identity is canonicalized to a `TypeIndex`.
-
-The active `std/test_std_ranges.cpp` frontier has moved again:
-
-- `[depth=1]: All 2 template overload(s) failed for 'std::invoke'`
-- `function 'size' has inconsistent deduced auto return types: first return has
-  type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
-
-Dependent qualified calls now preserve a concrete owner when only their call
-argument pack remains dependent. Substitution can therefore deduce and
-materialize inherited static member-function templates, and trailing-return
-SFINAE treats a known empty function parameter pack as a zero-element
-expansion. This is covered by:
-
+- `tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
+- `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
+- `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 - `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
+- existing partial-specialization qualifier/pointer/array/function-pointer tests
 
-Function-template parameter types now preserve direct template-parameter
-identity on `TypeSpecifierNode`. Downstream deduction and member-template
-materialization consume that identity through `getStructuredTypeName(...)`
-instead of reconstructing it from a token spelling or depending on a transient
-dependent `TypeInfo` entry. Central direct substitution uses the same scoped
-binding, and rebinding a type specifier to a different concrete `TypeIndex`
-invalidates the old parameter identity. Fixed forwarding-reference parameters are deduced
-against their exact call-argument slots before a trailing function parameter
-pack, with the C++20 lvalue/rvalue adjustment applied explicitly. This is
-covered by:
+## Remaining work
 
-- `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
-- `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
+1. Reduce the variadic `std::invoke` trailing return/noexcept substitution
+   failure around `_Invoker1<...>::_Call`. The one-argument candidate is
+   correctly rejected for the two-argument call; the variadic candidate passes
+   pack-aware viability, so this is a later substitution problem. Keep it
+   separate from the completed empty-pack and partial-specialization fix.
+2. Reduce the current `std/test_std_ranges.cpp` `make_signed<T>` and scoped-enum
+   equality diagnostics. Determine whether the generic fault is constraint
+   substitution, canonical enum identity, or overload selection before editing.
+3. Reduce the `std/test_std_iterator.cpp` `ranges::empty` overload failure and
+   unresolved-auto mangling path at the sema/return-type layer.
+4. Re-isolate the independent `ranges::size` inconsistent-auto-return issue
+   after earlier failures advance.
+5. Replace the targeted local-symbol treatment for C-linkage inline wrappers
+   with proper per-function COFF COMDAT/weak-external emission when the object
+   writer can split the monolithic text section.
+6. Extract deeper dependent-qualified owner or replay helpers only when a
+   concrete failure proves repeated consumer logic is the blocker.
 
-The positive regression distinguishes lvalue, const-lvalue, and rvalue
-deduction, exercises non-empty packs and an explicit `T&` argument, and the
-negative regression keeps `const T&&` out of the forwarding-reference path.
+## Validation
 
-The one-argument `std::invoke` candidate is still correctly rejected for the
-two-argument call. The variadic candidate now passes pack-aware count/shape
-viability and preserves `_Callable`, `_Ty1`, and `_Types2` identities, but fails
-later while substituting its `_Invoker1<...>::_Call` trailing return/noexcept
-shape. Reduce that substitution failure next. Keep the independent
-`ranges::size` CPO-object auto-return issue separate.
+For each standards slice:
 
-A standalone `<utility>` `std::addressof` probe now gets past the deleted
-`const T&&` overload selection issue and exposes duplicate emitted std inline
-objects such as `std::less`, `std::greater`, and `std::equivalent`. Treat that
-as the next object/linkage std-header reduction after the active
-`std::ranges::end` semantic frontier is cleared or merged forward.
-
-### 2. Dependent-qualified owner prefix-chain extraction
-
-Do not do this speculatively. The direct consumer migration to
-`ResolvedQualifiedOwner` is complete for the currently identified parser,
-substitution, constexpr, and sema entry points.
-
-Extract deeper shared helpers only if a concrete failure proves that duplicate
-handling of one of these is now the blocker:
-
-- `DependentQualifiedNameRecord` owner-template argument rebinding
-- member-prefix chain materialization
-- current-instantiation vs unknown-specialization owner binding across
-  substitution, constexpr, and sema
-
-If extracted, the helper should consume the preserved dependent-qualified
-record and return a resolved owner/prefix result that consumers can use without
-re-splitting `qualified_name` or rebuilding owner identity from
-`baseTemplateName()`.
-
-### 3. Replay / `StructTypeInfo` sync debt
-
-Most high-value replay identity gaps are closed in the covered template member
-and nested constructor paths. Keep this bucket opportunistic unless a concrete
-failure shows a remaining path syncing by weak name/arity evidence. When it
-does, prefer routing the replay site through existing identity-first helpers
-before adding new repair scans.
-
-### 4. Member-object-pointer carrier
-
-If a future ABI-sensitive pointer-to-member regression appears, close the
-remaining canonical `TypeCategory::MemberObjectPointer` carrier gap by
-preserving the underlying member type explicitly instead of relying on
-declarator-shaped `member_class + pointer_depth` forms.
-
-## Recommended next task
-
-1. Reduce the variadic `std::invoke` candidate's later substitution failure,
-   centered on `_Invoker1<...>::_Call` in its trailing return/noexcept shape;
-   preserve structured identities rather than adding spelling recovery.
-2. Re-run `std/test_std_ranges.cpp`; once `std::invoke` advances, reduce the
-   independent `ranges::size` CPO-object auto-return deduction failure.
-3. Keep `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
-   `tests/test_deleted_rvalue_template_overload_ret0.cpp`,
-   `tests/test_deleted_rvalue_template_overload_fail.cpp`,
-   `tests/test_constrained_cpo_call_operator_ret0.cpp`,
-   `tests/test_if_constexpr_static_enum_strategy_prune_ret0.cpp`,
-   `tests/test_qualified_cpo_nested_type_receiver_ret0.cpp`,
-   `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp`,
-   `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
-   `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
-   `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
-   `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
-   `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
-   `tests/test_scoped_enum_builtin_shift_fail.cpp` in the guard set so the
-   cleared `std::byte` operator and dependent-alias paths do not regress.
-4. Re-run `std/test_std_ranges.cpp` after the semantic/template fix and let the
-   next concrete failure choose the following layer.
-5. Promote stale expected-failure tracking only after the corresponding harness
-   entry is proven green.
-
-## Validation guidance
-
-For template-infrastructure changes, run the motivating focused test plus the
-small guard set relevant to the touched layer. Common guards:
-
-- `test_member_template_func_in_specialization_ret0.cpp`
-- `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
-- `test_template_qualified_owner_template_nested_decltype_collision_ret0.cpp`
-- `test_sema_resolved_qualified_owner_template_nested_collision_ret0.cpp`
-- `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`
-- `test_var_template_replay_dependent_member_template_call_ret0.cpp`
-- `test_template_qualified_member_template_nested_owner_collision_ret0.cpp`
-- `test_template_qualified_member_template_nested_owner_chain_collision_ret0.cpp`
-- `test_template_qualified_member_template_enclosing_owner_collision_ret0.cpp`
-- `test_template_disambiguation_pack_ret40.cpp`
-- `test_mock_std_byte_noexcept_probe_ret0.cpp`
-- `test_mock_std_byte_ops_traits_ret0.cpp`
-- `test_scoped_enum_shift_assign_operator_template_ret0.cpp`
-- `test_scoped_enum_builtin_shift_fail.cpp`
-- `test_member_struct_template_dependent_alias_const_assign_fail.cpp`
-- `test_member_template_partial_specialization_same_args_fail.cpp`
-- `test_member_template_partial_specialization_pack_echo_fail.cpp`
-- `std/test_std_type_traits.cpp`
-- `std/test_std_ranges.cpp`
-
-Before closing a slice, run:
-
-- `.\build_flashcpp.bat`
-- focused regressions for the changed behavior
-- `pwsh ./tests/run_all_tests.ps1`
+1. Add and run a reduced non-`std` regression.
+2. Run adjacent guards for every semantic shape affected by the change.
+3. Rebuild with `.\build_flashcpp.bat`.
+4. Re-run the motivating standard-header file and green controls.
+5. Run `pwsh ./tests/run_all_tests.ps1` before publication.
+6. Inspect the compiler-source diff for standard-library/vendor spellings and
+   run `git diff --check`.

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,376 +1,125 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-11
-
-This document tracks the standards-facing target for the remaining template
-infrastructure work. Keep it focused on the intended semantic model, active
-conformance gaps, and the next concrete tasks. Do not use it as a branch log.
-
-## Target model
-
-FlashCpp should move toward a C++20 template implementation where:
-
-- dependency classification is explicit
-- non-dependent lookup remains definition-bound through instantiation
-- dependent names preserve semantic identity end to end
-- substitution, deduction, overload ranking, replay/materialization, and
-  constexpr evaluation stay separate
-- semantic analysis owns final call-target selection in normalized flows
-- replay succeeds because invariant evidence matches, not because repair scans
-  guessed a compatible declaration
-
-## Current conformance baseline
-
-The core suite now covers several formerly blocking standards-visible areas:
-
-- definition-bound non-dependent lookup in covered template bodies
-- semantic receiver-sensitive overload resolution for ordinary member calls,
-  `operator[]`, and callable `operator()`
-- viable direct-call conversion checks instead of parser-only optimistic
-  struct-to-scalar matches
-- structured direct-call metadata for covered ordinary, namespace-qualified,
-  dependent-unqualified, qualified/member-template, operator function-id,
-  postfix declaration-address, receiver-call, and function-pointer paths
-- deferred qualified/member-template calls preserving explicit template
-  arguments, dependent-qualified owner records, and parser return-type hints
-- current-instantiation and nested-owner qualified lookup split consistently
-  across parser, substitution, constexpr, and sema entry points via
-  `ResolvedQualifiedOwner`
-- identity-first replay/sync for the covered primary-template,
-  specialization, nested-class, constructor, and member-template paths
-- pack expansion preservation until substitution for unmatched complex call
-  expansions
-- member-function-pointer template arguments preserving declaring-class
-  identity through substitution/materialization and MSVC mangling
-- builtin type template arguments canonicalized for the MSVC `<type_traits>`
-  `is_integral_v` fundamental character type fold
-- ordinary `inline` function metadata preserved through parser copies and IR,
-  with COFF C-linkage inline definitions emitted as local/static symbols to
-  avoid duplicate CRT definitions while preserving emitted C++ inline helpers
-- function-template redeclaration default arguments are merged into later
-  definitions, and covered function-template `noexcept(expr)` specifications
-  are evaluated through the shared constexpr evaluator
-- scoped-enum/std::byte shift and swap probes are covered, including an
-  expected-fail guard for non-dependent builtin scoped-enum shifts
-- MSVC `<tuple>` variable-template specialization patterns with nested
-  template-ids and trailing packs are parsed through the shared explicit
-  template-argument parser, and nested pack-pattern matching can bind a trailing
-  pack against a multi-argument concrete template-id
-- template-argument skipping preserves nested-template `>>` tokenization by
-  splitting only when the skipped template-id consumes the inner `>` and leaves
-  the caller-owned outer `>` available
-- member class template partial-specialization parsing now rejects argument
-  lists that are not more specialized than the primary parameter list
-- namespace-qualified callable objects keep member-call semantics when the
-  receiver is a concrete struct object, including the implicit object argument
-  for instantiated constrained `operator()` member templates
-- direct dependent alias template-ids use shared classification, placeholder,
-  and materialization infrastructure; substitution retains the complete type
-  specifier so alias-introduced cv/ref/pointer structure survives every covered
-  declaration, signature, expression, and class-member consumer
-
-## Remaining standards gaps
-
-### 1. Standard-header tracking and next failure discovery
-
-The formerly active expected-failure standard-header tests now compile, link,
-and run on the current Windows baseline:
-
-- `tests/std/test_cstddef.cpp`
-- `tests/std/test_cstdio_puts.cpp`
-- `tests/std/test_cstdlib.cpp`
-
-The active standards-facing std-header failure is:
-
-- `tests/std/test_std_ranges.cpp`
-
-`test_cstdio_puts.cpp` exposed the relevant rule: C++ inline definitions in
-headers must not be emitted as ordinary strong external definitions when a CRT
-library also provides the C-linkage symbol. FlashCpp's current targeted behavior
-is to retain and emit C++ inline header helpers when needed, while giving
-C-linkage inline definitions local COFF symbol storage.
-
-This is enough for the current Windows standard-header frontier, but it is not
-the final C++20 linkage model. A later object-writer slice should replace the
-local-symbol workaround with per-function COFF COMDAT/weak-external emission so
-inline definitions deduplicate correctly across translation units.
-
-The next standards-facing task is discovery: run the std subset again and let
-the next concrete failure choose the layer. Likely future areas may include
-preprocessing/header modeling, builtin declarations, namespace lookup,
-constexpr evaluation, template argument materialization, or object/link
-semantics. Do not preselect the layer.
-
-For `std/test_std_ranges.cpp`, the constrained `std::byte` operator blocker is
-now cleared. The instantiated `operator<<=` body can carry a parser-time
-`NoMatch` for `byte << int`; sema now retries binary operator-template lookup
-after concrete operand types are known, so the visible `operator<<` template is
-selected instead of treating the expression as an invalid builtin scoped-enum
-shift. The non-dependent invalid scoped-enum diagnostic remains covered by
-`tests/test_scoped_enum_builtin_shift_fail.cpp`.
+**Last updated:** 2026-07-12
+
+This document defines the standards-facing behavior still being pursued. It is
+not a chronology of completed fixes.
 
-The previous MSVC `<tuple>:28` specialization-pattern failure is now covered by
-`tests/test_variable_template_tuple_pack_pattern_ret0.cpp`.
+## Semantic target
+
+### Partial-specialization deduction
 
-The previous MSVC `<tuple>:138` allocator-aware constructor constraint is now
-covered:
+For a class-template partial specialization, a bare type parameter slot deduces
+the complete corresponding template argument. Thus `Select<T, true>` can bind
+`T` to `int&`, `const int`, an array, or another complete type. Pattern syntax
+contributes only the structure it explicitly contains:
 
-- `tests/test_template_nttp_unqualified_conjunction_alias_args_ret0.cpp`
-- `tests/test_template_nttp_global_qualified_alias_args_ret0.cpp`
+- `Box<T&>` requires an lvalue-reference argument and deduces the referred type.
+- `Box<const T>` requires the matching cv qualification and removes only that
+  contributed qualification from the deduction.
+- Pointer, array, function, and member-pointer patterns follow the same rule.
 
-The covered shape is an unqualified `enable_if_t<conjunction_v<...>, int> = 0`
-inside namespace `std`, where the operands are globally qualified traits such as
-`::std:: uses_allocator<_Ty, _Alloc>`. The parser now keeps the
-current-namespace `conjunction_v<...>` template-id on the value-like NTTP path
-instead of treating it as a type-specifier.
+Matching must use the structured pattern identity. A dependent template-id or
+qualified dependent type is not interchangeable with a bare parameter merely
+because it contains one. Reordered and repeated parameters bind by identity,
+not by their declaration position.
+
+### Function-parameter-pack substitution
+
+A function-parameter pack is a property of its declaration, not an inference
+from argument count or the substituted type. Every declaration-copy path used
+by class/member-template substitution must retain that property. An empty pack
+is a valid zero-argument expansion and must participate correctly in viability,
+deduction, trailing return types, `noexcept`, and body substitution.
+
+### Layer ownership
+
+- Parsing records template parameters, declarator structure, and pack metadata.
+- Deduction matches structured patterns and produces complete bindings.
+- Substitution creates declarations that preserve source semantics while
+  replacing dependent identities.
+- Specialization materialization consumes the matcher's named bindings; it
+  never infers a binding from declaration or argument position.
+- Sema performs final lookup, overload viability, and return-type analysis.
+- Code generation consumes resolved semantics and must not repair them.
+
+No layer may recognize standard-library or vendor helper names to make a header
+compile.
+
+## Covered behavior
+
+`tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
+combines the two rules above:
+
+- forwarding-reference arguments instantiate a class template with reference
+  template arguments;
+- a partial specialization with bare parameters must match those complete
+  reference arguments;
+- an inherited static member-function template retains its trailing pack after
+  class-template substitution;
+- an empty pack is valid in the call, trailing return type, and `noexcept`.
+
+The neighboring
+`tests/test_template_dependent_inherited_static_call_pack_ret0.cpp` and existing
+partial-specialization cv/ref/pointer/array/function-pointer tests guard the
+adjacent semantics. `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
+guards reordered parameter identity after positional matcher recovery was
+removed, and `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
+verifies that a direct `T[N]` bound is deduced into the specialization body.
+
+## Live standard-header frontier
+
+Windows/MSVC runner snapshot from 2026-07-12:
+
+| Test | Status | Time | First captured issue |
+|------|--------|------|----------------------|
+| `test_cstddef.cpp` | Pass | 3.22s | — |
+| `test_cstdio_puts.cpp` | Pass | 9.39s | — |
+| `test_cstdlib.cpp` | Pass | 3.71s | — |
+| `test_std_type_traits.cpp` | Pass | 5.07s | — |
+| `test_std_iterator.cpp` | Fail | 22.97s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
+| `test_std_ranges.cpp` | Fail | 20.80s | `make_signed<T>` constraint/static-assert path and scoped-enum `_St` equality in tuple `_Equals` |
+
+Full-suite result: 2753 regular tests pass and all 236 expected-failure tests
+fail as expected.
+
+## Active investigations
+
+1. Variadic trailing-return substitution
+
+   The one-argument `std::invoke` overload is correctly rejected for a
+   two-argument call. The variadic overload passes pack-aware count/shape
+   viability with preserved `_Callable`, `_Ty1`, and `_Types2` bindings, then
+   fails while substituting `_Invoker1<...>::_Call` in its trailing
+   return/noexcept shape. Reduce this with a non-`std` non-empty-pack test and
+   fix substitution at the structured expression/type layer.
+
+2. Current ranges failure
+
+   Trace the `make_signed<T>` constraint/static-assert and tuple `_Equals`
+   scoped-enum comparison independently. Establish whether the enum operands
+   should have one canonical type, whether a constraint should have removed the
+   candidate, or whether overload lookup selected the wrong operation.
+
+3. Iterator return-type frontier
 
-The following MSVC `<tuple>` `_Equals` const-receiver failure is now covered by:
+   Reduce `ranges::empty` candidate viability separately from the unresolved
+   `auto` that reaches `view_interface` mangling. Resolved return types must be
+   established before code generation.
 
-- `tests/test_template_const_member_function_template_receiver_ret0.cpp`
+4. Independent `ranges::size` issue
 
-Member-function-template cv metadata now survives member-template registration,
-class-template instantiation, and member-template materialization.
+   Reconfirm the inconsistent-auto-return diagnostic after the earlier ranges
+   failures are removed. Keep it separate from variadic call substitution.
 
-The previous standards-facing `std/test_std_ranges.cpp` `swap` overload and
-dependent-placeholder materialization blocker is now covered. Member struct
-template parameter kind metadata is preserved through partial-specialization
-pattern parsing and dependent base parsing, and dependent member aliases remain
-marked as dependent when used later as template arguments. The focused
-regression is:
+## Acceptance criteria
 
-- `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`
-
-The later `std/test_std_ranges.cpp` member-template parser blockers are now
-covered:
-
-- `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`
-- `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
-
-The namespace-qualified CPO receiver path is now covered by:
-
-- `tests/test_constrained_cpo_call_operator_ret0.cpp`
-- `tests/test_if_constexpr_static_enum_strategy_prune_ret0.cpp`
-- `tests/test_qualified_cpo_nested_type_receiver_ret0.cpp`
-- `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp`
-
-Deleted rvalue-reference function-template sentinels now preserve their deleted
-status and participate in C++20 reference binding correctly: `const T&&` is not
-a forwarding reference and cannot bind an lvalue argument.
-
-- `tests/test_deleted_rvalue_template_overload_ret0.cpp`
-- `tests/test_deleted_rvalue_template_overload_fail.cpp`
-
-The `std::ranges::end` inconsistent auto-return path is now covered by:
-
-- `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`
-
-The previous standards-facing `std/test_std_ranges.cpp` local proxy-class
-failure is now covered:
-
-- `tests/test_template_member_local_proxy_class_ret0.cpp`
-
-The covered C++20 rule is that classes declared inside an instantiated member
-function body are local classes, not nested member classes of the enclosing
-class template. Their delayed bodies must not replay the enclosing member body,
-and inheriting constructors declared by the local class remain usable for
-brace-initialized local proxy objects.
-
-The previous standards-facing `std/test_std_ranges.cpp` `std::char_traits`
-instantiation loop is now covered:
-
-- `tests/test_template_exact_specialization_reuse_ret0.cpp`
-
-Exact class-template specializations participate in the same class-template
-instantiation cache as primary-template materializations, so repeated
-standard-header probes of a full specialization do not exhaust the global
-instantiation-iteration budget.
-
-The previous standards-facing `std/test_std_ranges.cpp` variable-template
-declaration failure is now covered:
-
-- `tests/test_variable_template_declaration_no_initializer_ret0.cpp`
-
-C++14 variable templates can be declarations without an initializer; C++20
-standard headers use this form for CPO-like objects such as
-`std::views::empty`. Template declaration lookahead now recognizes the trailing
-semicolon form before falling through to function-template parsing.
-
-The previous standards-facing `std/test_std_ranges.cpp` constrained member
-class-template partial-specialization failure is now covered:
-
-- `tests/test_member_template_constrained_partial_spec_same_args_ret0.cpp`
-
-The parser now accepts same-argument member class-template partial
-specializations when either an explicit `requires` clause or constrained
-template parameter makes the specialization more constrained than the primary.
-The unconstrained same-argument rejection remains in place.
-
-The previous standards-facing `std/test_std_ranges.cpp` template-depth failure
-is now covered:
-
-- `tests/test_member_template_self_specialization_param_no_eager_depth_ret0.cpp`
-
-The live trace showed a valid finite chain of constrained class-template
-viability checks, not a `std::remove_cv` semantic shortcut or recursive alias
-bug. The parser depth guard remains finite but now has enough headroom for that
-kind of conforming C++20 template chain.
-
-Dependent alias-template type-ids and brace construction used by
-`std::exchange`-like calls, including modifier-bearing direct aliases and
-unused alias parameters, are now covered by:
-
-- `tests/test_template_exchange_dependent_alias_default_ret0.cpp`
-- `tests/test_dependent_direct_alias_modifiers_unused_ret0.cpp`
-
-The reduced rule is generic: a direct alias template-id such as
-`select_first_t<Left, FirstTail>` remains a structured instantiation until the
-enclosing arguments are known, then materializes to its alias target before
-function-template deduction and code generation. A concrete builtin target
-must use its native type index, not an invalid category-only placeholder, while
-the surrounding `TypeSpecifierNode` remains the carrier for declarator
-modifiers that cannot be represented by `TypeIndex` alone.
-
-The active standards-facing `std/test_std_ranges.cpp` failure has moved again:
-
-- `[depth=1]: All 2 template overload(s) failed for 'std::invoke'`
-- `function 'size' has inconsistent deduced auto return types: first return has
-  type 'unknown', but another return has type 'std::ranges::_Size::_Cpo'`
-
-Dependent qualified calls with concrete owners now retain structured lookup
-identity while their call argument packs remain dependent. Known empty
-function parameter packs expand to an empty argument list during
-trailing-return SFINAE, and inherited static member-function templates are
-deduced after substitution. The generic regression is:
-
-- `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
-
-Direct function-parameter types now preserve their type-template-parameter
-identity on `TypeSpecifierNode`, and shared deduction/materialization consumers
-use `getStructuredTypeName(...)` instead of reconstructing identity from token
-spelling. Direct substitution uses that same scoped binding, while a concrete
-`TypeIndex` rebind clears obsolete parameter identity. Fixed forwarding references before a trailing function parameter
-pack use their exact parameter-to-argument mapping and the C++20 lvalue/rvalue
-deduction adjustment. The generic regression is:
-
-- `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
-- `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
-
-Coverage distinguishes lvalue, const-lvalue, and rvalue deduction, includes a
-non-empty trailing pack and an explicit `T&`, and verifies that `const T&&`
-cannot bind an lvalue.
-
-The one-argument `std::invoke` overload is correctly rejected for a
-two-argument call. Its variadic overload passes pack-aware count/shape
-viability with structured `_Callable`, `_Ty1`, and `_Types2` identities, then
-fails later during substitution of the `_Invoker1<...>::_Call` trailing
-return/noexcept shape. The next slice should reduce that generic substitution
-failure. Keep the `ranges::size` auto-return issue separate.
-
-A reduced `<utility>` `std::addressof` probe now reaches a separate link
-frontier: duplicate emitted definitions for std inline objects such as
-`std::less`, `std::greater`, and `std::equivalent`. Keep that as an
-object/linkage follow-up after the active `std::ranges::end` issue is merged or
-otherwise no longer blocks `test_std_ranges.cpp`.
-
-### 2. Deeper dependent-qualified owner materialization
-
-The direct owner-classification migration is complete for the identified parser
-and consumer entry points. Further extraction is only justified by a concrete
-failure showing that duplicate materialization still causes non-conforming
-behavior.
-
-If needed, the next abstraction should return a shared resolved owner and
-member-prefix-chain result from a `DependentQualifiedNameRecord`, including:
-
-- rebound owner-template arguments
-- materialized member-template prefix segments
-- current-instantiation vs unknown-specialization classification
-- canonical owner type/name for later ordinary member lookup and explicit
-  member-template lookup
-
-### 3. Replay identity edge cases
-
-Remaining replay work should be failure-driven. If a path still syncs
-`StructTypeInfo` copies through weak name/arity evidence, replace that path
-with source-member identity plus canonical substituted-signature matching.
-
-### 4. Member-object-pointer representation
-
-If another pointer-to-member ABI/conformance failure appears, preserve the
-member object type explicitly in the canonical carrier rather than relying on
-declarator-shaped pointer-depth/member-class metadata.
-
-## Priority order
-
-1. Reduce and fix the variadic `std::invoke` trailing return/noexcept
-   substitution failure without hardcoding the standard-library name.
-2. Reduce and fix the `ranges::size` CPO-object auto-return deduction issue
-   without hardcoding standard-library names.
-3. Keep the cleared auto-return, dependent-alias, alias-brace construction, and
-   `std::byte`
-   constrained-operator paths guarded with
-   `tests/test_auto_return_if_constexpr_branch_prune_ret0.cpp`,
-   `tests/test_template_exchange_dependent_alias_default_ret0.cpp`,
-   `tests/test_deleted_rvalue_template_overload_ret0.cpp`,
-   `tests/test_deleted_rvalue_template_overload_fail.cpp`,
-   `tests/test_constrained_cpo_call_operator_ret0.cpp`,
-   `tests/test_if_constexpr_static_enum_strategy_prune_ret0.cpp`,
-   `tests/test_qualified_cpo_nested_type_receiver_ret0.cpp`,
-   `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp`,
-   `tests/test_member_struct_template_dependent_alias_template_arg_ret0.cpp`,
-   `tests/test_member_struct_template_ctor_brace_init_tail_ret0.cpp`,
-   `tests/test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`,
-   `tests/test_member_struct_template_dependent_alias_const_assign_fail.cpp`,
-   `tests/test_member_template_partial_specialization_same_args_fail.cpp`,
-   `tests/test_member_template_partial_specialization_pack_echo_fail.cpp`,
-   `tests/test_scoped_enum_shift_assign_operator_template_ret0.cpp`,
-   `tests/test_mock_std_byte_ops_traits_ret0.cpp`, and
-   `tests/test_scoped_enum_builtin_shift_fail.cpp`.
-4. Remove stale expected-failure tracking for `test_cstddef.cpp`,
-   `test_cstdio_puts.cpp`, and `test_cstdlib.cpp` where the harness still
-   records it.
-5. Only extract deeper dependent-qualified owner materialization if a concrete
-   failure proves the current consumer-specific prefix-chain handling is the
-   blocker.
-6. Keep replay identity and member-object-pointer work opportunistic unless a
-   concrete regression points there.
-
-## Standards rules for follow-up work
-
-- do not normalize textual reconstruction as acceptable semantics
-- do not reduce a substituted alias target to base `TypeIndex` identity before
-  preserving its complete declarator metadata
-- prefer hard failure or correct diagnostics over silent repair in normalized
-  semantic flows
-- keep compatibility behavior explicit, narrow, and temporary
-- treat codegen-side recovery as debt to remove, not architecture
-- when a late retry is required, route it through typed semantic lookup or a
-  structured record rather than string/shape reconstruction
-
-## Validation guidance
-
-For standard-conformance work, run:
-
-- the focused regression or std-header test that motivated the slice
-- adjacent template/lookup guards for the touched layer
-- `.\build_flashcpp.bat`
-- `pwsh ./tests/run_all_tests.ps1`
-
-Common adjacent guards:
-
-- `test_member_template_func_in_specialization_ret0.cpp`
-- `test_template_qualified_owner_member_template_postfix_decltype_ret0.cpp`
-- `test_sema_resolved_qualified_owner_template_nested_collision_ret0.cpp`
-- `test_template_static_constexpr_qualified_nested_owner_collision_ret0.cpp`
-- `test_var_template_replay_dependent_member_template_call_ret0.cpp`
-- `test_template_disambiguation_pack_ret40.cpp`
-- `test_mock_std_byte_noexcept_probe_ret0.cpp`
-- `test_mock_std_byte_ops_traits_ret0.cpp`
-- `test_scoped_enum_shift_assign_operator_template_ret0.cpp`
-- `test_scoped_enum_builtin_shift_fail.cpp`
-- `test_member_struct_template_dependent_alias_const_assign_fail.cpp`
-- `test_member_template_partial_specialization_same_args_fail.cpp`
-- `test_member_template_partial_specialization_pack_echo_fail.cpp`
-- `std/test_std_type_traits.cpp`
-- `std/test_std_ranges.cpp`
+- The reduced valid C++20 program passes because generic deduction and
+  substitution work, not because of spelling-based dispatch.
+- Explicitly structured patterns continue to reject non-matching types.
+- Invalid programs receive a semantic diagnostic rather than reaching codegen
+  with unresolved types.
+- Focused regressions, standard-header controls, and the full suite pass.
+- The compiler-source diff contains no new `std::`, vendor helper, or
+  compatibility-fallback logic.

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1080,6 +1080,7 @@ struct TypeInfo {
 		bool is_pack;
 		bool is_array;
 		InlineVector<size_t, 2> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
+		InlineVector<StringHandle, 2> array_dimension_parameter_names; // Direct dependent bound for each dimension, if any
 		StringHandle dependent_name;	 // Name of the dependent template parameter (for inner deduction)
 		std::optional<FunctionSignature> function_signature; // For function pointer template arguments
 		std::optional<ASTNode> dependent_expr;  // Original AST for dependent NTTP expressions (e.g., sizeof(T))
@@ -1121,6 +1122,7 @@ struct TypeInfo {
 			  is_pack(other.is_pack),
 			  is_array(other.is_array),
 			  array_dimensions(other.array_dimensions),
+			  array_dimension_parameter_names(other.array_dimension_parameter_names),
 			  dependent_name(other.dependent_name),
 			  function_signature(other.function_signature),
 			  dependent_expr(other.dependent_expr),
@@ -1147,6 +1149,7 @@ struct TypeInfo {
 				is_pack = other.is_pack;
 				is_array = other.is_array;
 				array_dimensions = other.array_dimensions;
+				array_dimension_parameter_names = other.array_dimension_parameter_names;
 				dependent_name = other.dependent_name;
 				function_signature = other.function_signature;
 				dependent_expr = other.dependent_expr;

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -3519,6 +3519,8 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 		auto substituted_param_decl = emplace_node<DeclarationNode>(
 			substituted_param_type_node,
 			param_decl.identifier_token());
+		substituted_param_decl.as<DeclarationNode>().set_parameter_pack(
+			param_decl.is_parameter_pack());
 		if (param_decl.has_default_value()) {
 			if (default_argument_policy == SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters) {
 				ASTNode substituted_default = substituteTemplateParameters(

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2751,7 +2751,17 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			advance();
 
 			// Parse the specialization pattern: <T&>, <T*, U>, etc.
-			auto pattern_args_opt = parse_explicit_template_arguments();
+			std::vector<ASTNode> pattern_arg_syntax_nodes;
+			auto class_template_opt = gTemplateRegistry.lookupTemplate(template_name);
+			if (!class_template_opt.has_value() ||
+				!class_template_opt->is<TemplateClassDeclarationNode>()) {
+				return ParseResult::error(
+					"Partial specialization requires a declared primary class template",
+					class_name_token);
+			}
+			auto pattern_args_opt = parse_explicit_template_arguments(
+				class_template_opt->as<TemplateClassDeclarationNode>().template_parameters(),
+				&pattern_arg_syntax_nodes);
 			if (!pattern_args_opt.has_value()) {
 				return ParseResult::error("Expected template argument pattern in partial specialization", current_token_);
 			}
@@ -5010,7 +5020,17 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		pushMemberStructTemplateParameters();
 
 		// Parse the specialization pattern: <T, Rest...>, etc.
-		auto pattern_args_opt = parse_explicit_template_arguments();
+		std::vector<ASTNode> pattern_arg_syntax_nodes;
+		auto class_template_opt = gTemplateRegistry.lookupTemplate(struct_name);
+		if (!class_template_opt.has_value() ||
+			!class_template_opt->is<TemplateClassDeclarationNode>()) {
+			return ParseResult::error(
+				"Member partial specialization requires a declared primary class template",
+				struct_name_token);
+		}
+		auto pattern_args_opt = parse_explicit_template_arguments(
+			class_template_opt->as<TemplateClassDeclarationNode>().template_parameters(),
+			&pattern_arg_syntax_nodes);
 
 		if (!pattern_args_opt.has_value()) {
 			return ParseResult::error("Expected template argument pattern in partial specialization", current_token_);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1620,13 +1620,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Try to match a specialization pattern and get the substitution mapping
 	{
 		PROFILE_TEMPLATE_SPECIALIZATION_MATCH();
-		std::unordered_map<std::string, TemplateTypeArg> param_substitutions;
 		FLASH_LOG(Templates, Debug, "Looking for pattern match for ", template_name, " with ", filled_args_for_pattern_match.size(), " args (after default fill-in)");
-		auto pattern_match_opt = gTemplateRegistry.matchSpecializationPattern(template_name, filled_args_for_pattern_match);
+		auto pattern_match_opt = gTemplateRegistry.matchSpecializationPatternWithBindings(
+			template_name,
+			filled_args_for_pattern_match);
 		if (pattern_match_opt.has_value()) {
 			FLASH_LOG(Templates, Debug, "Found pattern match!");
 			// Found a matching pattern - we need to instantiate it with concrete types
-			ASTNode& pattern_node = *pattern_match_opt;
+			ASTNode& pattern_node = pattern_match_opt->node;
+			const TemplatePattern& matched_pattern = *pattern_match_opt->pattern;
 
 			// Handle both StructDeclarationNode (top-level partial specialization) and
 			// TemplateClassDeclarationNode (member template partial specialization)
@@ -1653,130 +1655,50 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					StringTable::getOrInternStringHandle(template_name));
 			}
 
-			// Get template parameters from the pattern (partial specialization), NOT the primary template
-			// The pattern stores its own template parameters (e.g., <typename First, typename... Rest>)
-			InlineVector<TemplateParameterNode, 4> pattern_template_params;
-			auto patterns_it = gTemplateRegistry.specialization_patterns_.find(template_name);
-			if (patterns_it != gTemplateRegistry.specialization_patterns_.end()) {
-				// Find the matching pattern to get its template params
-				for (const auto& pattern : patterns_it->second) {
-					// Handle both StructDeclarationNode and TemplateClassDeclarationNode patterns
-					const StructDeclarationNode* spec_struct_ptr = nullptr;
-					if (pattern.specialized_node.is<StructDeclarationNode>()) {
-						spec_struct_ptr = &pattern.specialized_node.as<StructDeclarationNode>();
-					} else if (pattern.specialized_node.is<TemplateClassDeclarationNode>()) {
-						spec_struct_ptr = &pattern.specialized_node.as<TemplateClassDeclarationNode>().class_decl_node();
-					}
-					if (spec_struct_ptr && spec_struct_ptr == &pattern_struct) {
-						pattern_template_params = pattern.template_params;
-						break;
-					}
-				}
-			}
-
-			// Fall back to primary template params if pattern params not found
-			if (pattern_template_params.empty()) {
-				// Check ALL template overloads to find one with named parameters
-				// Forward declarations like `template<typename...> class tuple;` register with
-				// anonymous names (e.g., __anon_type_64), while definitions have real names (e.g., _Elements).
-				// Prefer the definition's parameters for correct sizeof...() resolution.
-				const auto* all_tmpls = gTemplateRegistry.lookupAllTemplates(template_name);
-				if (all_tmpls) {
-					const TemplateClassDeclarationNode* best = nullptr;
-					for (const auto& tmpl_node : *all_tmpls) {
-						if (tmpl_node.is<TemplateClassDeclarationNode>()) {
-							const auto& tmpl_class = tmpl_node.as<TemplateClassDeclarationNode>();
-							if (!best) {
-								best = &tmpl_class;
-							} else {
-								// Prefer template with named parameters (not __anon_type_)
-								bool current_has_anon = false;
-								bool best_has_anon = false;
-								for (const auto& param : tmpl_class.template_parameters()) {
-									if (param.name().starts_with("__anon_type_"))
-										current_has_anon = true;
-								}
-								for (const auto& param : best->template_parameters()) {
-									if (param.name().starts_with("__anon_type_"))
-										best_has_anon = true;
-								}
-								if (best_has_anon && !current_has_anon)
-									best = &tmpl_class;
-							}
-						}
-					}
-					if (best) {
-						pattern_template_params = best->template_parameters();
-					}
-				}
-			}
-			const auto& template_params = pattern_template_params;
-
-			InlineVector<TemplateTypeArg, 4> pattern_args_for_member_copy;
-			if (patterns_it != gTemplateRegistry.specialization_patterns_.end()) {
-				for (const auto& pattern : patterns_it->second) {
-					const StructDeclarationNode* spec_struct_ptr = nullptr;
-					if (pattern.specialized_node.is<StructDeclarationNode>()) {
-						spec_struct_ptr = &pattern.specialized_node.as<StructDeclarationNode>();
-					} else if (pattern.specialized_node.is<TemplateClassDeclarationNode>()) {
-						spec_struct_ptr = &pattern.specialized_node.as<TemplateClassDeclarationNode>().class_decl_node();
-					}
-					if (spec_struct_ptr &&
-						(spec_struct_ptr == &pattern_struct || spec_struct_ptr->name() == pattern_struct.name())) {
-						pattern_args_for_member_copy = pattern.pattern_args;
-						break;
-					}
-				}
-			}
+			const auto& template_params = matched_pattern.template_params;
+			const auto& pattern_args = matched_pattern.pattern_args;
 			std::vector<TemplateTypeArg> template_args_for_member_copy_storage;
-			if (!pattern_args_for_member_copy.empty()) {
-				template_args_for_member_copy_storage.reserve(template_params.size());
-				// Use filled_args_for_pattern_match (primary-template-aligned, with defaults filled
-				// in) as the source of concrete values and as the loop upper bound.  Using the raw
-				// template_args span instead caused a deduction failure when the leading pattern
-				// arguments are concrete (e.g. enable_if<true, T>) and the instantiation relies on
-				// default arguments (e.g. enable_if<true> -> T=void): the loop would terminate
-				// before reaching the dependent position, leaving the storage empty and falling
-				// back to the wrong arg vector.
-				std::span<const TemplateTypeArg> concrete_args = filled_args_for_pattern_match;
-				for (size_t template_param_slot = 0; template_param_slot < template_params.size(); ++template_param_slot) {
-					std::optional<TemplateTypeArg> deduced_arg;
-					for (size_t pattern_idx = 0;
-						 pattern_idx < pattern_args_for_member_copy.size() && pattern_idx < concrete_args.size();
-						 ++pattern_idx) {
-						const TemplateTypeArg& pattern_arg = pattern_args_for_member_copy[pattern_idx];
-						if (!pattern_arg.is_dependent) {
-							continue;
-						}
-
-						size_t dependent_param_index = 0;
-						for (size_t i = 0; i < pattern_idx; ++i) {
-							if (pattern_args_for_member_copy[i].is_dependent) {
-								dependent_param_index++;
-							}
-						}
-
-						if (dependent_param_index == template_param_slot) {
-							if (template_params[template_param_slot].is_variadic()) {
-								for (size_t pack_idx = pattern_idx; pack_idx < concrete_args.size(); ++pack_idx) {
-									template_args_for_member_copy_storage.push_back(
-										deduceArgFromPattern(concrete_args[pack_idx], pattern_arg));
-								}
-								deduced_arg.reset();
-								break;
-							}
-							deduced_arg = deduceArgFromPattern(concrete_args[pattern_idx], pattern_arg);
-							break;
-						}
+			template_args_for_member_copy_storage.reserve(template_params.size());
+			for (const TemplateParameterNode& template_param : template_params) {
+				const StringHandle parameter_name = template_param.nameHandle();
+				if (!template_param.is_variadic()) {
+					auto binding = pattern_match_opt->substitutions.find(parameter_name);
+					if (binding == pattern_match_opt->substitutions.end()) {
+						throw InternalError("Partial-specialization parameter has no deduced semantic binding");
 					}
+					template_args_for_member_copy_storage.push_back(binding->second);
+					continue;
+				}
 
-					if (deduced_arg.has_value()) {
-						template_args_for_member_copy_storage.push_back(*deduced_arg);
+				bool found_pack_pattern = false;
+				for (size_t pattern_idx = 0; pattern_idx < pattern_args.size(); ++pattern_idx) {
+					auto pattern_parameter_name = TemplatePattern::getPatternParameterName(
+						pattern_args[pattern_idx],
+						matched_pattern.getTemplateParamNames());
+					if (!pattern_parameter_name.has_value() ||
+						*pattern_parameter_name != parameter_name) {
+						continue;
+					}
+					found_pack_pattern = true;
+					for (size_t pack_idx = pattern_idx;
+						 pack_idx < filled_args_for_pattern_match.size();
+						 ++pack_idx) {
+						template_args_for_member_copy_storage.push_back(
+							deduceArgFromPattern(
+								filled_args_for_pattern_match[pack_idx],
+								pattern_args[pattern_idx]));
+					}
+					break;
+				}
+				if (!found_pack_pattern) {
+					auto binding = pattern_match_opt->substitutions.find(parameter_name);
+					if (binding != pattern_match_opt->substitutions.end()) {
+						template_args_for_member_copy_storage.push_back(binding->second);
 					}
 				}
 			}
 			std::span<const TemplateTypeArg> template_args_for_member_copy =
-				template_args_for_member_copy_storage.empty() ? template_args : std::span<const TemplateTypeArg>(template_args_for_member_copy_storage);
+				template_args_for_member_copy_storage;
 			// Push class template pack info for specialization path
 			ClassTemplatePackGuard spec_pack_guard(class_template_pack_stack_);
 			bool has_spec_pack_info = false;
@@ -1786,8 +1708,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				for (size_t i = 0; i < template_params.size(); ++i) {
 					const auto& tparam = template_params[i];
 					if (tparam.is_variadic()) {
-						size_t pack_size = template_args.size() >= non_variadic_count
-											   ? template_args.size() - non_variadic_count
+						size_t pack_size = template_args_for_member_copy_storage.size() >= non_variadic_count
+											   ? template_args_for_member_copy_storage.size() - non_variadic_count
 											   : 0;
 						pack_infos.push_back({tparam.name(), pack_size});
 					} else {
@@ -2582,7 +2504,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 												non_variadic_count++;
 											}
 										}
-										return template_args.size() - non_variadic_count;
+										return template_args_for_member_copy.size() - non_variadic_count;
 									}
 								}
 								return std::nullopt;
@@ -2715,7 +2637,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							if (std::holds_alternative<TemplateParameterReferenceNode>(expr)) {
 								const TemplateParameterReferenceNode& tparam_ref = std::get<TemplateParameterReferenceNode>(expr);
 								FLASH_LOG(Templates, Debug, "Static member initializer contains template parameter reference: ", tparam_ref.param_name());
-								if (auto subst = substitute_template_param_in_initializer(tparam_ref.param_name().view(), template_args, template_params)) {
+								if (auto subst = substitute_template_param_in_initializer(tparam_ref.param_name().view(), template_args_for_member_copy, template_params)) {
 									substituted_initializer = subst;
 									FLASH_LOG(Templates, Debug, "Substituted static member initializer template parameter '", tparam_ref.param_name(), "'");
 								}
@@ -2725,7 +2647,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								const IdentifierNode& id_node = std::get<IdentifierNode>(expr);
 								std::string_view id_name = id_node.name();
 								FLASH_LOG(Templates, Debug, "Static member initializer contains IdentifierNode: ", id_name);
-								if (auto subst = substitute_template_param_in_initializer(id_name, template_args, template_params)) {
+								if (auto subst = substitute_template_param_in_initializer(id_name, template_args_for_member_copy, template_params)) {
 									substituted_initializer = subst;
 									FLASH_LOG(Templates, Debug, "Substituted static member initializer identifier '", id_name, "' (template parameter)");
 								}
@@ -2760,10 +2682,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										}
 									}
 
-									for (size_t i = non_variadic_count; i < template_args.size() && all_values_found; ++i) {
-										if (template_args[i].is_value) {
-											pack_values.push_back(template_args[i].value);
-											FLASH_LOG(Templates, Debug, "Pack value[", i - non_variadic_count, "] = ", template_args[i].value);
+									for (size_t i = non_variadic_count; i < template_args_for_member_copy.size() && all_values_found; ++i) {
+										if (template_args_for_member_copy[i].is_value) {
+											pack_values.push_back(template_args_for_member_copy[i].value);
+											FLASH_LOG(Templates, Debug, "Pack value[", i - non_variadic_count, "] = ", template_args_for_member_copy[i].value);
 										} else {
 											all_values_found = false;
 										}
@@ -2795,8 +2717,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										for (size_t p = 0; p < template_params.size(); ++p) {
 											const TemplateParameterNode& tparam = template_params[p];
 											if (tparam.name() == tparam_ref.param_name() && tparam.kind() == TemplateParameterKind::NonType) {
-												if (p < template_args.size() && template_args[p].is_value) {
-													cond_value = template_args[p].value;
+												if (p < template_args_for_member_copy.size() && template_args_for_member_copy[p].is_value) {
+													cond_value = template_args_for_member_copy[p].value;
 													FLASH_LOG(Templates, Debug, "Found template param value: ", *cond_value);
 												}
 												break;
@@ -2811,8 +2733,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 										for (size_t p = 0; p < template_params.size(); ++p) {
 											const TemplateParameterNode& tparam = template_params[p];
 											if (tparam.name() == id_name && tparam.kind() == TemplateParameterKind::NonType) {
-												if (p < template_args.size() && template_args[p].is_value) {
-													cond_value = template_args[p].value;
+												if (p < template_args_for_member_copy.size() && template_args_for_member_copy[p].is_value) {
+													cond_value = template_args_for_member_copy[p].value;
 													FLASH_LOG(Templates, Debug, "Found template param value: ", *cond_value);
 												}
 												break;
@@ -2852,7 +2774,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
  // still need template parameter substitution (e.g., T → int).
 						if (substituted_initializer.has_value()) {
 							substituted_initializer = substituteTemplateParameters(
-							substituted_initializer.value(), template_params, template_args);
+							substituted_initializer.value(), template_params, template_args_for_member_copy);
 							FLASH_LOG(Templates, Debug, "Substituted template parameters in static member '",
 									  static_member.getName(), "' initializer");
 						}
@@ -2870,7 +2792,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							TypeSpecifierNode original_type_spec(static_member.memberType(), TypeQualifier::None, static_member.size * 8, Token{}, CVQualifier::None);
 							original_type_spec.set_type_index(static_member.type_index);
 							TypeIndex new_type_index = substitute_template_parameter(
-								original_type_spec, template_params, template_args);
+								original_type_spec, template_params, template_args_for_member_copy);
 							if (new_type_index != static_member.type_index) {
 								substituted_type_index = new_type_index;
 								substituted_size = get_substituted_type_size_bytes(new_type_index);
@@ -3224,79 +3146,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 			}
 
-			// Register type aliases from the pattern with qualified names
-			// We need the pattern_args to map template parameters to template arguments
-			InlineVector<TemplateTypeArg, 4> pattern_args;
-			auto patterns_it_for_alias = gTemplateRegistry.specialization_patterns_.find(template_name);
-			if (patterns_it_for_alias != gTemplateRegistry.specialization_patterns_.end()) {
-				for (const auto& pattern : patterns_it_for_alias->second) {
-					// Handle both StructDeclarationNode and TemplateClassDeclarationNode patterns
-					const StructDeclarationNode* spec_struct_ptr_alias = nullptr;
-					if (pattern.specialized_node.is<StructDeclarationNode>()) {
-						spec_struct_ptr_alias = &pattern.specialized_node.as<StructDeclarationNode>();
-					} else if (pattern.specialized_node.is<TemplateClassDeclarationNode>()) {
-						spec_struct_ptr_alias = &pattern.specialized_node.as<TemplateClassDeclarationNode>().class_decl_node();
-					}
-					if (spec_struct_ptr_alias &&
-						(spec_struct_ptr_alias == &pattern_struct || spec_struct_ptr_alias->name() == pattern_struct.name())) {
-						pattern_args = pattern.pattern_args;
-						break;
-					}
-				}
-			}
-
-			// Partial specializations receive raw concrete instantiation args
-			// (e.g. [int, double] for Box<int, double>) while template_params describe
-			// only the specialization's deduced parameters (e.g. [T] for Box<int, T>).
-			// Build one arg vector aligned with template_params and reuse it across the
-			// sema-owned AST copy path so bindings stay positional.
-			std::vector<TemplateTypeArg> template_args_for_pattern_storage;
-			if (!pattern_args.empty()) {
-				template_args_for_pattern_storage.reserve(template_params.size());
-				// Use filled_args_for_pattern_match (primary-template-aligned, with defaults filled
-				// in) as the concrete-arg source and loop bound.  The raw template_args span only
-				// covers explicitly supplied arguments; when a leading pattern argument is concrete
-				// (e.g. enable_if<true, T>) and the trailing dependent argument maps to a
-				// defaulted primary-template parameter, the old bound cut the loop short before the
-				// dependent position, leaving the storage empty and causing the fallback below to
-				// yield an incorrect specialization-aligned arg vector.
-				std::span<const TemplateTypeArg> concrete_args = filled_args_for_pattern_match;
-				for (size_t template_param_slot = 0; template_param_slot < template_params.size(); ++template_param_slot) {
-					std::optional<TemplateTypeArg> deduced_arg;
-					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < concrete_args.size(); ++pattern_idx) {
-						const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
-						if (!pattern_arg.is_dependent) {
-							continue;
-						}
-
-						size_t dependent_param_index = 0;
-						for (size_t i = 0; i < pattern_idx; ++i) {
-							if (pattern_args[i].is_dependent) {
-								dependent_param_index++;
-							}
-						}
-
-						if (dependent_param_index == template_param_slot) {
-							if (template_params[template_param_slot].is_variadic()) {
-								for (size_t pack_idx = pattern_idx; pack_idx < concrete_args.size(); ++pack_idx) {
-									template_args_for_pattern_storage.push_back(
-										deduceArgFromPattern(concrete_args[pack_idx], pattern_arg));
-								}
-								deduced_arg.reset();
-								break;
-							}
-							deduced_arg = deduceArgFromPattern(concrete_args[pattern_idx], pattern_arg);
-							break;
-						}
-					}
-
-					if (deduced_arg.has_value()) {
-						template_args_for_pattern_storage.push_back(*deduced_arg);
-					}
-				}
-			}
+			// Reuse the matcher-produced, specialization-parameter-aligned bindings
+			// across member copying, aliases, and semantic substitution.
 			std::span<const TemplateTypeArg> template_args_for_pattern =
-				template_args_for_pattern_storage.empty() ? template_args : std::span<const TemplateTypeArg>(template_args_for_pattern_storage);
+				template_args_for_member_copy;
 			StructTypeInfo* instantiated_struct_info_mut = struct_info.get();
 			const StructTypeInfo* instantiated_struct_info = instantiated_struct_info_mut;
 			auto [effective_pattern_template_params, effective_pattern_template_args_storage] =
@@ -3337,96 +3190,35 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituted_size);
 
 				// Check if the alias type is a template parameter that needs substitution
-				if ((alias_type_spec.category() == TypeCategory::UserDefined || alias_type_spec.category() == TypeCategory::TypeAlias || alias_type_spec.category() == TypeCategory::Template) &&
-					!filled_args_for_pattern_match.empty() &&
-					!pattern_args.empty()) {
-					bool alias_refers_to_template_parameter = false;
+				if (alias_type_spec.category() == TypeCategory::UserDefined ||
+					alias_type_spec.category() == TypeCategory::TypeAlias ||
+					alias_type_spec.category() == TypeCategory::Template) {
 					StringHandle alias_target_name{};
 					if (const TypeInfo* alias_target_info = tryGetTypeInfo(alias_type_spec.type_index())) {
 						alias_target_name = alias_target_info->name();
 					}
-					StringHandle alias_token_name = alias_type_spec.token().handle();
-					auto applyTemplateArgAliasSubstitution = [&](size_t pattern_idx, std::string_view parameter_name) {
-						const TemplateTypeArg& concrete_arg = filled_args_for_pattern_match[pattern_idx];
+					const StringHandle alias_token_name = alias_type_spec.token().handle();
+					for (size_t param_idx = 0; param_idx < template_params.size(); ++param_idx) {
+						const StringHandle parameter_name = template_params[param_idx].nameHandle();
+						if (parameter_name != alias_token_name && parameter_name != alias_target_name) {
+							continue;
+						}
+						if (param_idx >= template_args_for_pattern.size()) {
+							throw InternalError("Partial-specialization alias parameter has no semantic binding");
+						}
+						const TemplateTypeArg& concrete_arg = template_args_for_pattern[param_idx];
 						substituted_type = concrete_arg.typeEnum();
 						substituted_type_index = concrete_arg.type_index;
-						if (!is_struct_type(substituted_type)) {
-							substituted_size = get_type_size_bits(substituted_type);
-						} else {
-							substituted_size = 0;
-							if (const TypeInfo* sub_ti = tryGetTypeInfo(substituted_type_index)) {
-								substituted_size = sub_ti->sizeInBits().value;
-							}
+						substituted_size = is_struct_type(substituted_type)
+							? 0
+							: get_type_size_bits(substituted_type);
+						if (const TypeInfo* substituted_type_info = tryGetTypeInfo(substituted_type_index)) {
+							substituted_size = substituted_type_info->sizeInBits().value;
 						}
-						FLASH_LOG(Templates, Debug, "Substituted template parameter '",
-								  parameter_name,
-								  "' at pattern position ", pattern_idx, " with type=", static_cast<int>(substituted_type));
-					};
-					for (const TemplateParameterNode& template_param_node : template_params) {
-						StringHandle param_name = template_param_node.nameHandle();
-						if (param_name == alias_token_name || param_name == alias_target_name) {
-							alias_refers_to_template_parameter = true;
-							break;
-						}
+						FLASH_LOG(Templates, Debug, "Substituted partial-specialization alias parameter '",
+							StringTable::getStringView(parameter_name), "' from its semantic binding");
+						break;
 					}
-					if (!alias_refers_to_template_parameter) {
-						goto substitution_done;
-					}
-
-					// The alias_type_spec.type_index() identifies which template parameter this is
-					// We need to find which pattern_arg corresponds to this template parameter,
-					// then map to the corresponding template_arg
-
-					// For enable_if<true, T>:
-					// - pattern_args = [true (is_value=true), T (is_value=false, is_dependent=true)]
-					// - template_params = [T] (template parameter at index 0)
-					// - filled_args_for_pattern_match = [true (is_value=true), int (is_value=false)]
-					// - The alias "using type = T" has T which is template_params[0]
-					// - T appears at pattern_args[1]
-					// - So we substitute with filled_args_for_pattern_match[1] = int
-
-					// Find which template parameter index this alias type corresponds to
-					for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < filled_args_for_pattern_match.size(); ++pattern_idx) {
-						const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
-						if (!pattern_arg.is_value && pattern_arg.is_dependent && pattern_arg.dependent_name.isValid()) {
-							StringHandle pattern_param_name = pattern_arg.dependent_name;
-							if (pattern_param_name == alias_token_name || pattern_param_name == alias_target_name) {
-								applyTemplateArgAliasSubstitution(
-									pattern_idx,
-									StringTable::getStringView(pattern_param_name));
-								goto substitution_done;
-							}
-						}
-					}
-
-					for (size_t param_idx = 0; param_idx < template_params.size(); ++param_idx) {
-						// Find which pattern_arg position this template parameter appears at
-						for (size_t pattern_idx = 0; pattern_idx < pattern_args.size() && pattern_idx < filled_args_for_pattern_match.size(); ++pattern_idx) {
-							const TemplateTypeArg& pattern_arg = pattern_args[pattern_idx];
-
-							// Check if this pattern_arg is a template parameter (not a concrete value/type)
-							if (!pattern_arg.is_value && pattern_arg.is_dependent) {
-								// This is a template parameter position
-								// Check if it's the parameter we're looking for
-								// We can match by counting dependent parameters
-								size_t dependent_param_index = 0;
-								for (size_t i = 0; i < pattern_idx; ++i) {
-									if (!pattern_args[i].is_value && pattern_args[i].is_dependent) {
-										dependent_param_index++;
-									}
-								}
-
-								if (dependent_param_index == param_idx) {
-									// Found it! Substitute with template_args[pattern_idx]
-									applyTemplateArgAliasSubstitution(
-										pattern_idx,
-										template_params[param_idx].name());
-									goto substitution_done;
-								}
-							}
-						}
-					}
-				substitution_done:;
 				}
 
 				const TypeInfo* alias_semantic_source =

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3198,15 +3198,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						alias_target_name = alias_target_info->name();
 					}
 					const StringHandle alias_token_name = alias_type_spec.token().handle();
-					for (size_t param_idx = 0; param_idx < template_params.size(); ++param_idx) {
-						const StringHandle parameter_name = template_params[param_idx].nameHandle();
-						if (parameter_name != alias_token_name && parameter_name != alias_target_name) {
-							continue;
-						}
-						if (param_idx >= template_args_for_pattern.size()) {
-							throw InternalError("Partial-specialization alias parameter has no semantic binding");
-						}
-						const TemplateTypeArg& concrete_arg = template_args_for_pattern[param_idx];
+					auto binding = pattern_match_opt->substitutions.find(alias_token_name);
+					if (binding == pattern_match_opt->substitutions.end() &&
+						alias_target_name.isValid()) {
+						binding = pattern_match_opt->substitutions.find(alias_target_name);
+					}
+					if (binding != pattern_match_opt->substitutions.end()) {
+						const TemplateTypeArg& concrete_arg = binding->second;
 						substituted_type = concrete_arg.typeEnum();
 						substituted_type_index = concrete_arg.type_index;
 						substituted_size = is_struct_type(substituted_type)
@@ -3216,8 +3214,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							substituted_size = substituted_type_info->sizeInBits().value;
 						}
 						FLASH_LOG(Templates, Debug, "Substituted partial-specialization alias parameter '",
-							StringTable::getStringView(parameter_name), "' from its semantic binding");
-						break;
+							StringTable::getStringView(binding->first), "' from its semantic binding");
 					}
 				}
 

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2900,9 +2900,11 @@ try_type_template_argument_parse:
 		// Check for array declarators (e.g., T[], T[N])
 		bool is_array_type = false;
 		std::optional<size_t> parsed_array_size;
+		InlineVector<StringHandle, 4> parsed_array_dimension_parameter_names;
 		while (peek() == "["_tok) {
 			is_array_type = true;
 			advance(); // consume '['
+			StringHandle dimension_parameter_name{};
 
 			// Optional size expression
 			if (peek() != "]"_tok) {
@@ -2922,6 +2924,22 @@ try_type_template_argument_parse:
 					// Use SIZE_MAX as a sentinel to indicate "sized array with unknown size"
 					parsed_array_size = SIZE_MAX;
 				}
+				if (size_result.node()->is<ExpressionNode>()) {
+					const ExpressionNode& dimension_expr = size_result.node()->as<ExpressionNode>();
+					if (const auto* parameter_ref =
+							std::get_if<TemplateParameterReferenceNode>(&dimension_expr)) {
+						dimension_parameter_name = parameter_ref->param_name();
+					} else if (const auto* identifier =
+							   std::get_if<IdentifierNode>(&dimension_expr)) {
+						const StringHandle identifier_name =
+							StringTable::getOrInternStringHandle(identifier->name());
+						auto parameter_kind = currentTemplateParamKind(identifier_name);
+						if (parameter_kind.has_value() &&
+							*parameter_kind == TemplateParameterKind::NonType) {
+							dimension_parameter_name = identifier_name;
+						}
+					}
+				}
 			}
 
 			if (!consume("]"_tok)) {
@@ -2929,6 +2947,7 @@ try_type_template_argument_parse:
 				last_failed_template_arg_parse_handle_ = saved_pos;
 				return std::nullopt;
 			}
+			parsed_array_dimension_parameter_names.push_back(dimension_parameter_name);
 		}
 
 		if (is_array_type) {
@@ -2944,6 +2963,8 @@ try_type_template_argument_parse:
 
 		// Create TemplateTypeArg from the fully parsed type
 		TemplateTypeArg arg(type_node);
+		arg.array_dimension_parameter_names =
+			std::move(parsed_array_dimension_parameter_names);
 		arg.is_pack = is_pack_expansion;
 		arg.member_pointer_kind = member_pointer_kind;
 		if (dependent_member_probe.isValid()) {

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -36,6 +36,9 @@ TypeInfo::TemplateArgInfo toTemplateArgInfo(const TemplateTypeArg& arg) {
 	info.cv_qualifier = arg.cv_qualifier;
 	info.is_array = arg.is_array;
 	info.array_dimensions.assign(arg.array_dimensions.begin(), arg.array_dimensions.end());
+	info.array_dimension_parameter_names.assign(
+		arg.array_dimension_parameter_names.begin(),
+		arg.array_dimension_parameter_names.end());
 	info.is_value = arg.is_value;
 	info.is_pack = arg.is_pack;
 	info.dependent_name = arg.dependent_name;
@@ -78,6 +81,9 @@ TemplateTypeArg toTemplateTypeArg(const TypeInfo::TemplateArgInfo& arg) {
 	ta.pointer_depth = static_cast<uint8_t>(arg.pointer_depth);
 	ta.is_array = arg.is_array;
 	ta.array_dimensions.assign(arg.array_dimensions.begin(), arg.array_dimensions.end());
+	ta.array_dimension_parameter_names.assign(
+		arg.array_dimension_parameter_names.begin(),
+		arg.array_dimension_parameter_names.end());
 	ta.pointer_cv_qualifiers = arg.pointer_cv_qualifiers;
 	ta.dependent_name = arg.dependent_name;
 	ta.dependent_expr = arg.dependent_expr;

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -498,16 +498,17 @@ struct TemplatePattern {
 			const TypeInfo* pattern_arg_type_info = tryGetTypeInfo(pattern_arg.type_index);
 			const std::optional<StringHandle> pattern_parameter_name =
 				getPatternParameterName(pattern_arg, template_param_names);
+			const bool pattern_arg_is_template_instantiation =
+				pattern_arg_type_info && pattern_arg_type_info->isTemplateInstantiation();
 			const bool is_direct_type_template_parameter =
 				pattern_arg.is_dependent &&
 				pattern_arg.isTypeArgument() &&
 				pattern_parameter_name.has_value();
 			const bool pattern_arg_is_deduced_type_param =
 				is_direct_type_template_parameter ||
-				(pattern_arg.category() == TypeCategory::UserDefined) ||
-				(pattern_arg.category() == TypeCategory::Invalid &&
-				 pattern_arg_type_info &&
-				 !pattern_arg_type_info->isTemplateInstantiation());
+				((pattern_arg.category() == TypeCategory::UserDefined ||
+				  pattern_arg.category() == TypeCategory::Invalid) &&
+				 !pattern_arg_is_template_instantiation);
 			// A bare dependent type parameter represents the complete template
 			// argument.  For example, the pattern `Invoker<Callable, First>` must
 			// match `Invoker<F&, T&>` and preserve those reference qualifiers in the
@@ -625,9 +626,10 @@ struct TemplatePattern {
 			// Struct-type template instantiation patterns (e.g., Pair<A,B> where Pair is a struct
 			// template) must reach the template instantiation handler below, not the concrete
 			// type check. Detect that case up front.
-			bool is_struct_template_inst = (is_struct_type(pattern_arg.category()) || pattern_arg.category() == TypeCategory::Invalid) &&
-										   pattern_arg_type_info &&
-										   pattern_arg_type_info->isTemplateInstantiation();
+			const bool is_struct_template_inst =
+				(is_struct_type(pattern_arg.category()) ||
+				 pattern_arg.category() == TypeCategory::Invalid) &&
+				pattern_arg_is_template_instantiation;
 
 			// pattern_arg is a template parameter placeholder if it is UserDefined, or if category is
 			// Invalid (legacy TypeIndex) and the type_index points to a non-instantiation struct entry.

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -158,8 +158,9 @@ struct TemplatePattern {
 		return true;
 	}
 
-	static std::optional<StringHandle> getNestedPatternParameterName(
-		const TypeInfo::TemplateArgInfo& pattern_arg,
+	template <typename PatternArg>
+	static std::optional<StringHandle> getPatternParameterName(
+		const PatternArg& pattern_arg,
 		const std::unordered_set<StringHandle, StringHandleHash>& template_param_names) {
 		if (pattern_arg.dependent_name.isValid() && template_param_names.count(pattern_arg.dependent_name)) {
 			return pattern_arg.dependent_name;
@@ -183,7 +184,7 @@ struct TemplatePattern {
 		const bool has_trailing_pack =
 			!pattern_inner_args.empty() &&
 			pattern_inner_args.back().is_pack &&
-			getNestedPatternParameterName(pattern_inner_args.back(), template_param_names).has_value();
+			getPatternParameterName(pattern_inner_args.back(), template_param_names).has_value();
 		if (!has_trailing_pack && pattern_inner_args.size() != concrete_inner_args.size()) {
 			FLASH_LOG(Templates, Trace, "  FAILED: inner arg count mismatch: pattern=",
 					  pattern_inner_args.size(), " concrete=", concrete_inner_args.size());
@@ -212,7 +213,7 @@ struct TemplatePattern {
 		}
 		if (has_trailing_pack) {
 			StringHandle pack_name =
-				*getNestedPatternParameterName(pattern_inner_args.back(), template_param_names);
+				*getPatternParameterName(pattern_inner_args.back(), template_param_names);
 			TemplateTypeArg pack_representative;
 			if (fixed_inner_count < concrete_inner_args.size()) {
 				pack_representative =
@@ -421,12 +422,10 @@ struct TemplatePattern {
 		// Handle variadic templates: pattern may have fewer args if last template param is a pack
 		// Check if the last template parameter is variadic (a pack)
 		bool has_variadic_pack = false;
-		[[maybe_unused]] size_t pack_param_index = 0;
 		for (size_t i = 0; i < template_params.size(); ++i) {
 			const TemplateParameterNode& param = template_params[i];
 			if (param.is_variadic()) {
 				has_variadic_pack = true;
-				pack_param_index = i;
 				break;
 			}
 		}
@@ -455,24 +454,27 @@ struct TemplatePattern {
 		const auto& template_param_names = getTemplateParamNames();
 
 		// Check each pattern argument against the corresponding concrete argument
-		// Track template parameter index separately from pattern argument index
-		size_t param_index = 0; // Tracks which template parameter we're binding
 		for (size_t i = 0; i < pattern_args.size(); ++i) {
 			const TemplateTypeArg& pattern_arg = pattern_args[i];
 
 			// Handle variadic pack case: if i >= concrete_args.size(),
 			// this pattern arg corresponds to a pack that matches 0 args (empty pack)
 			if (i >= concrete_args.size()) {
-				// This should only happen for the variadic pack parameter
-				// Check if this pattern position corresponds to a variadic pack
-				if (param_index < template_params.size()) {
-					const TemplateParameterNode& param = template_params[param_index];
-					if (param.is_variadic()) {
-						// Empty pack is valid - continue without error
-						continue;
-					}
+				auto pattern_param_name =
+					getPatternParameterName(pattern_arg, template_param_names);
+				const bool is_empty_pack_pattern =
+					pattern_arg.is_pack &&
+					pattern_param_name.has_value() &&
+					std::any_of(
+						template_params.begin(),
+						template_params.end(),
+						[pattern_param_name](const TemplateParameterNode& param) {
+							return param.nameHandle() == *pattern_param_name && param.is_variadic();
+						});
+				if (is_empty_pack_pattern) {
+					continue;
 				}
-				// Not a variadic pack but no concrete arg - pattern doesn't match
+				FLASH_LOG(Templates, Trace, "  FAILED: missing concrete argument is not an identified parameter pack");
 				return false;
 			}
 
@@ -491,17 +493,38 @@ struct TemplatePattern {
 			// 4. If pattern is "T**" and concrete is "int**", then T=int (double pointer match)
 			// 5. If pattern is "const T" and concrete is "const int", then T=int (const match)
 			// 6. If pattern is "T" and concrete is "int", then T=int (exact match)
-			// 7. Reference/pointer/const modifiers must match
+			// 7. Explicit reference/pointer/const modifiers must match
 
-			const TypeInfo* pattern_arg_type_info_for_modifiers = tryGetTypeInfo(pattern_arg.type_index);
+			const TypeInfo* pattern_arg_type_info = tryGetTypeInfo(pattern_arg.type_index);
+			const std::optional<StringHandle> pattern_parameter_name =
+				getPatternParameterName(pattern_arg, template_param_names);
+			const bool is_direct_type_template_parameter =
+				pattern_arg.is_dependent &&
+				pattern_arg.isTypeArgument() &&
+				pattern_parameter_name.has_value();
 			const bool pattern_arg_is_deduced_type_param =
+				is_direct_type_template_parameter ||
 				(pattern_arg.category() == TypeCategory::UserDefined) ||
 				(pattern_arg.category() == TypeCategory::Invalid &&
-				 pattern_arg_type_info_for_modifiers &&
-				 !pattern_arg_type_info_for_modifiers->isTemplateInstantiation());
+				 pattern_arg_type_info &&
+				 !pattern_arg_type_info->isTemplateInstantiation());
+			// A bare dependent type parameter represents the complete template
+			// argument.  For example, the pattern `Invoker<Callable, First>` must
+			// match `Invoker<F&, T&>` and preserve those reference qualifiers in the
+			// deduction.  Qualifiers written around the parameter (`T&`, `const T`,
+			// `T*`, ...) remain structural pattern requirements below.
+			const bool direct_whole_type_deduction =
+				is_direct_type_template_parameter &&
+				pattern_arg.ref_qualifier == ReferenceQualifier::None &&
+				pattern_arg.cv_qualifier == CVQualifier::None &&
+				pattern_arg.pointer_depth == 0 &&
+				!pattern_arg.is_array &&
+				pattern_arg.member_pointer_kind == MemberPointerKind::None &&
+				!pattern_arg.function_signature.has_value();
 
 			// Check if modifiers match
-			if (pattern_arg.ref_qualifier != concrete_arg.ref_qualifier) {
+			if (!direct_whole_type_deduction &&
+				pattern_arg.ref_qualifier != concrete_arg.ref_qualifier) {
 				FLASH_LOG(Templates, Trace, "  FAILED: ref_qualifier mismatch");
 				return false;
 			}
@@ -512,11 +535,13 @@ struct TemplatePattern {
 				FLASH_LOG(Templates, Trace, "  FAILED: pointer_depth mismatch");
 				return false;
 			}
-			if (pattern_arg.cv_qualifier != concrete_arg.cv_qualifier) {
+			if (!direct_whole_type_deduction &&
+				pattern_arg.cv_qualifier != concrete_arg.cv_qualifier) {
 				FLASH_LOG(Templates, Trace, "  FAILED: cv_qualifier mismatch");
 				return false;
 			}
-			if (pattern_arg.is_array != concrete_arg.is_array) {
+			if (!direct_whole_type_deduction &&
+				pattern_arg.is_array != concrete_arg.is_array) {
 				FLASH_LOG(Templates, Trace, "  FAILED: array-ness mismatch");
 				return false;
 			}
@@ -525,11 +550,35 @@ struct TemplatePattern {
 			// - If pattern has SIZE_MAX (T[N] where N is template param), it matches any sized array but not unsized arrays
 			// - If pattern has a specific size (T[3]), it must match exactly
 			if (pattern_arg.is_array && pattern_arg.array_size().has_value() && concrete_arg.array_size().has_value()) {
-				// Both have sizes - check if they match
-				// SIZE_MAX in pattern means "any size" (template parameter like N)
+				// Both have sizes - check if they match and deduce a direct bound parameter.
 				if (*pattern_arg.array_size() != SIZE_MAX && *pattern_arg.array_size() != *concrete_arg.array_size()) {
 					FLASH_LOG(Templates, Trace, "  FAILED: array size mismatch");
 					return false;
+				}
+				if (*pattern_arg.array_size() == SIZE_MAX &&
+					!pattern_arg.array_dimension_parameter_names.empty() &&
+					pattern_arg.array_dimension_parameter_names[0].isValid()) {
+					const StringHandle dimension_parameter_name =
+						pattern_arg.array_dimension_parameter_names[0];
+					TypeCategory dimension_type = TypeCategory::Int;
+					for (const TemplateParameterNode& template_param : template_params) {
+						if (template_param.nameHandle() == dimension_parameter_name &&
+							template_param.kind() == TemplateParameterKind::NonType) {
+							if (template_param.has_type()) {
+								dimension_type = template_param.type_specifier_node().type();
+							}
+							break;
+						}
+					}
+					TemplateTypeArg dimension_arg(
+						static_cast<int64_t>(*concrete_arg.array_size()),
+						dimension_type);
+					if (!recordDeduction(
+							dimension_parameter_name,
+							dimension_arg,
+							param_substitutions)) {
+						return false;
+					}
 				}
 			} else if (pattern_arg.is_array && pattern_arg.array_size().has_value() && *pattern_arg.array_size() == SIZE_MAX) {
 				// Pattern has SIZE_MAX (like T[N]) but concrete has no size (like int[])
@@ -539,11 +588,13 @@ struct TemplatePattern {
 					return false;
 				}
 			}
-			if (pattern_arg.member_pointer_kind != concrete_arg.member_pointer_kind) {
+			if (!direct_whole_type_deduction &&
+				pattern_arg.member_pointer_kind != concrete_arg.member_pointer_kind) {
 				FLASH_LOG(Templates, Trace, "  FAILED: member pointer kind mismatch");
 				return false;
 			}
-			if (!matchMemberPointerClassName(
+			if (!direct_whole_type_deduction &&
+				!matchMemberPointerClassName(
 					pattern_arg.member_class_name,
 					concrete_arg.member_class_name,
 					template_param_names,
@@ -574,31 +625,44 @@ struct TemplatePattern {
 			// Struct-type template instantiation patterns (e.g., Pair<A,B> where Pair is a struct
 			// template) must reach the template instantiation handler below, not the concrete
 			// type check. Detect that case up front.
-			const TypeInfo* p_arg_ti = tryGetTypeInfo(pattern_arg.type_index);
 			bool is_struct_template_inst = (is_struct_type(pattern_arg.category()) || pattern_arg.category() == TypeCategory::Invalid) &&
-										   p_arg_ti &&
-										   p_arg_ti->isTemplateInstantiation();
+										   pattern_arg_type_info &&
+										   pattern_arg_type_info->isTemplateInstantiation();
 
 			// pattern_arg is a template parameter placeholder if it is UserDefined, or if category is
 			// Invalid (legacy TypeIndex) and the type_index points to a non-instantiation struct entry.
-			bool is_userdefined_param = (pattern_arg.category() == TypeCategory::UserDefined) ||
-										(pattern_arg.category() == TypeCategory::Invalid && p_arg_ti &&
-										 !p_arg_ti->isTemplateInstantiation());
+			bool is_userdefined_param = is_direct_type_template_parameter ||
+										(pattern_arg.category() == TypeCategory::UserDefined) ||
+										(pattern_arg.category() == TypeCategory::Invalid && pattern_arg_type_info &&
+										 !pattern_arg_type_info->isTemplateInstantiation());
 
-			if (pattern_arg.is_dependent && pattern_arg.is_value) {
-				StringHandle param_name = pattern_arg.dependent_name;
-				if (!param_name.isValid()) {
-					if (param_index >= template_params.size()) {
-						FLASH_LOG(Templates, Trace, "  FAILED: dependent value param_index ", param_index,
-								  " >= template_params.size() ", template_params.size());
-						return false;
-					}
-					param_name = template_params[param_index].nameHandle();
-				}
-				if (!recordDeduction(param_name, concrete_arg, param_substitutions)) {
+			if (pattern_arg.is_dependent && pattern_arg.is_template_template_arg) {
+				auto template_parameter_name =
+					getPatternParameterName(pattern_arg, template_param_names);
+				if (!template_parameter_name.has_value() ||
+					!concrete_arg.is_template_template_arg) {
+					FLASH_LOG(Templates, Trace, "  FAILED: template-template pattern identity mismatch");
 					return false;
 				}
-				++param_index;
+				if (!recordDeduction(
+						*template_parameter_name,
+						concrete_arg,
+						param_substitutions)) {
+					return false;
+				}
+				continue;
+			}
+
+			if (pattern_arg.is_dependent && pattern_arg.is_value) {
+				auto value_parameter_name =
+					getPatternParameterName(pattern_arg, template_param_names);
+				if (!value_parameter_name.has_value()) {
+					FLASH_LOG(Templates, Trace, "  FAILED: dependent value pattern has no deducible parameter identity");
+					return false;
+				}
+				if (!recordDeduction(*value_parameter_name, concrete_arg, param_substitutions)) {
+					return false;
+				}
 				continue;
 			}
 
@@ -637,7 +701,7 @@ struct TemplatePattern {
 					return false; // One is value, one is type - no match
 				}
 				FLASH_LOG(Templates, Trace, "    SUCCESS: concrete type/value matches");
-				continue; // No substitution needed for concrete types/values - don't increment param_index
+				continue; // Concrete pattern arguments do not produce substitutions.
 			}
 
 			// Check if this UserDefined/Struct pattern arg is a dependent template instantiation
@@ -669,7 +733,6 @@ struct TemplatePattern {
 					// Recursively match inner template args to deduce parameters.
 					// Uses matchNestedArg which handles arbitrary nesting depth,
 					// e.g., Pair<Pair<A,B>, Pair<C,D>> against pair<pair<int,float>, pair<double,bool>>.
-					const size_t subs_before_inner = param_substitutions.size();
 					if (!matchInnerArgs(
 							pattern_type_info->templateArgs(),
 							concrete_type_info->templateArgs(),
@@ -678,9 +741,6 @@ struct TemplatePattern {
 							0)) {
 						return false;
 					}
-					// Advance param_index past inner-deduced parameters so that
-					// subsequent pattern args use the correct fallback index.
-					param_index += param_substitutions.size() - subs_before_inner;
 					continue;
 				}
 			}
@@ -688,27 +748,13 @@ struct TemplatePattern {
 			// Find the template parameter name for this pattern arg
 			// First, try to get the name from the pattern arg's type_index (for reused parameters)
 			// For is_same<T, T>, both pattern args point to the same TypeInfo for T
-			StringHandle param_name;
-			bool found_param = false;
-
-			if (const TypeInfo* param_type_info = tryGetTypeInfo(pattern_arg.type_index)) {
-				param_name = param_type_info->name();
-				found_param = true;
-				FLASH_LOG(Templates, Trace, "  Found parameter name '", StringTable::getStringView(param_name), "' from pattern_arg.type_index=", pattern_arg.type_index);
+			if (!is_direct_type_template_parameter) {
+				FLASH_LOG(Templates, Trace, "  FAILED: dependent type pattern has no deducible parameter identity");
+				return false;
 			}
-
-			if (!found_param) {
-				// Fallback: use param_index to get the template parameter
-				// This is needed when type_index isn't set properly
-				if (param_index >= template_params.size()) {
-					FLASH_LOG(Templates, Trace, "  FAILED: param_index ", param_index, " >= template_params.size() ", template_params.size());
-					return false; // More template params needed than available - invalid pattern
-				}
-
-				const TemplateParameterNode& template_param = template_params[param_index];
-				param_name = template_param.nameHandle();
-				found_param = true;
-			}
+			StringHandle param_name = *pattern_parameter_name;
+			FLASH_LOG(Templates, Trace, "  Found structured parameter name '",
+				StringTable::getStringView(param_name), "'");
 
 			// Check if we've already seen this parameter
 			// For consistency checking, we need to compare the BASE TYPE only,
@@ -724,14 +770,11 @@ struct TemplatePattern {
 					return false;
 				}
 				FLASH_LOG(Templates, Trace, "  SUCCESS: Reused parameter ", StringTable::getStringView(param_name), " - consistency check passed");
-				// Don't increment param_index - we reused an existing parameter binding
 			} else {
 				// Bind this parameter to the concrete type, stripping pattern qualifiers.
 				TemplateTypeArg deduced_arg = deduceArgFromPattern(concrete_arg, pattern_arg);
 				param_substitutions[param_name] = deduced_arg;
 				FLASH_LOG(Templates, Trace, "  SUCCESS: Bound parameter ", StringTable::getStringView(param_name), " to concrete type (qualifiers stripped)");
-				// Increment param_index since we bound a new template parameter
-				++param_index;
 			}
 		}
 

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -4,6 +4,12 @@
 
 class TemplateRegistry {
 public:
+	struct SpecializationPatternMatch {
+		const TemplatePattern* pattern;
+		ASTNode node;
+		std::unordered_map<StringHandle, TemplateTypeArg, StringHandleHash, std::equal_to<>> substitutions;
+	};
+
 	// Register a template function declaration
 	void registerTemplate(std::string_view name, ASTNode template_node) {
 		registerTemplate(StringTable::getOrInternStringHandle(name), template_node);
@@ -793,49 +799,22 @@ public:
 
 	// Find a matching specialization pattern (StringHandle overload)
 	std::optional<ASTNode> matchSpecializationPattern(StringHandle template_name,
-													  std::span<const TemplateTypeArg> concrete_args) const {
-		auto patterns_it = specialization_patterns_.find(template_name);
-		if (patterns_it == specialization_patterns_.end()) {
-			FLASH_LOG(Templates, Debug, "    No patterns registered for template '", StringTable::getStringView(template_name), "'");
-			return std::nullopt;	 // No patterns for this template
-		}
-
-		std::span<const TemplatePattern> patterns = patterns_it->second;
-		FLASH_LOG(Templates, Debug, "    Found ", patterns.size(), " pattern(s) for template '", StringTable::getStringView(template_name), "'");
-
-		const TemplatePattern* best_match = nullptr;
-		int best_specificity = -1;
-
-		// Find the most specific matching pattern
-		for (size_t i = 0; i < patterns.size(); ++i) {
-			const auto& pattern = patterns[i];
-			FLASH_LOG(Templates, Debug, "    Checking pattern #", i, " (specificity=", pattern.specificity(), ")");
-			std::unordered_map<StringHandle, TemplateTypeArg, StringHandleHash, std::equal_to<>> substitutions;
-			if (pattern.matches(concrete_args, substitutions)) {
-				FLASH_LOG(Templates, Debug, "      Pattern #", i, " MATCHES!");
-				int spec = pattern.specificity();
-				if (spec > best_specificity) {
-					best_match = &pattern;
-					best_specificity = spec;
-					FLASH_LOG(Templates, Debug, "      New best match (specificity=", spec, ")");
-				}
-			} else {
-				FLASH_LOG(Templates, Debug, "      Pattern #", i, " does not match");
-			}
-		}
-
-		if (best_match) {
-			FLASH_LOG(Templates, Debug, "    Selected best pattern (specificity=", best_specificity, ")");
-			return best_match->specialized_node;
-		}
-
-		FLASH_LOG(Templates, Debug, "    No matching pattern found");
-		return std::nullopt;
+											  std::span<const TemplateTypeArg> concrete_args) const {
+		return matchSpecializationPattern(StringTable::getStringView(template_name), concrete_args);
 	}
 
 	// Find a matching specialization pattern (string_view overload)
 	std::optional<ASTNode> matchSpecializationPattern(std::string_view template_name,
-													  std::span<const TemplateTypeArg> concrete_args) const {
+											  std::span<const TemplateTypeArg> concrete_args) const {
+		auto match = matchSpecializationPatternWithBindings(template_name, concrete_args);
+		return match.has_value()
+			? std::optional<ASTNode>(match->node)
+			: std::nullopt;
+	}
+
+	std::optional<SpecializationPatternMatch> matchSpecializationPatternWithBindings(
+		std::string_view template_name,
+		std::span<const TemplateTypeArg> concrete_args) const {
 		// Heterogeneous lookup - string_view accepted directly
 		auto patterns_it = specialization_patterns_.find(template_name);
 		if (patterns_it == specialization_patterns_.end()) {
@@ -847,6 +826,7 @@ public:
 		FLASH_LOG(Templates, Debug, "    Found ", patterns.size(), " pattern(s) for template '", template_name, "'");
 
 		const TemplatePattern* best_match = nullptr;
+		std::unordered_map<StringHandle, TemplateTypeArg, StringHandleHash, std::equal_to<>> best_substitutions;
 		int best_specificity = -1;
 
 		// Find the most specific matching pattern
@@ -859,6 +839,7 @@ public:
 				int spec = pattern.specificity();
 				if (spec > best_specificity) {
 					best_match = &pattern;
+					best_substitutions = std::move(substitutions);
 					best_specificity = spec;
 					FLASH_LOG(Templates, Debug, "      New best match (specificity=", spec, ")");
 				}
@@ -869,7 +850,10 @@ public:
 
 		if (best_match) {
 			FLASH_LOG(Templates, Debug, "    Selected best pattern (specificity=", best_specificity, ")");
-			return best_match->specialized_node;
+			return SpecializationPatternMatch{
+				best_match,
+				best_match->specialized_node,
+				std::move(best_substitutions)};
 		}
 
 		FLASH_LOG(Templates, Debug, "    No matching pattern found");

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -165,6 +165,7 @@ struct TemplateTypeArg {
 	CVQualifier cv_qualifier;  // const/volatile qualifiers
 	bool is_array;
 	std::vector<size_t> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
+	InlineVector<StringHandle, 4> array_dimension_parameter_names; // Direct dependent bound for each dimension, if any
 	MemberPointerKind member_pointer_kind;
 	StringHandle member_class_name;
 
@@ -390,6 +391,11 @@ struct TemplateTypeArg {
 		for (size_t dim : array_dimensions) {
 			h ^= std::hash<size_t>{}(dim) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		}
+		if (is_dependent) {
+			for (StringHandle dimension_parameter_name : array_dimension_parameter_names) {
+				h ^= std::hash<StringHandle>{}(dimension_parameter_name) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			}
+		}
 		h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(member_pointer_kind)) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		h ^= std::hash<bool>{}(member_class_name.isValid()) + 0x9e3779b9 + (h << 6) + (h >> 2);
 		if (member_class_name.isValid()) {
@@ -439,6 +445,7 @@ struct TemplateTypeArg {
 			  cv_qualifier == other.cv_qualifier &&
 			  is_array == other.is_array &&
 			  array_dimensions == other.array_dimensions &&
+			  (!is_dependent || array_dimension_parameter_names == other.array_dimension_parameter_names) &&
 			  member_pointer_kind == other.member_pointer_kind &&
 			  member_class_name == other.member_class_name &&
 			  is_value == other.is_value &&
@@ -765,6 +772,7 @@ inline TemplateTypeArg deduceArgFromPattern(const TemplateTypeArg& concrete_arg,
 	if (pattern_arg.is_array) {
 		deduced.is_array = false;
 		deduced.array_dimensions.clear();
+		deduced.array_dimension_parameter_names.clear();
 	}
 	// Strip cv_qualifier contributed by the pattern (e.g., const T → T=int, not T=const int)
 	if (pattern_arg.cv_qualifier != CVQualifier::None) {
@@ -1234,6 +1242,9 @@ inline TemplateTypeArg rebindDependentTemplateTypeArg(
 	pattern_arg.array_dimensions.assign(
 		dependent_pattern.array_dimensions.begin(),
 		dependent_pattern.array_dimensions.end());
+	pattern_arg.array_dimension_parameter_names.assign(
+		dependent_pattern.array_dimension_parameter_names.begin(),
+		dependent_pattern.array_dimension_parameter_names.end());
 	pattern_arg.is_array = dependent_pattern.is_array;
 	pattern_arg.function_signature = dependent_pattern.function_signature;
 	pattern_arg.dependent_name = dependent_pattern.dependent_name;

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -101,32 +101,37 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
 
-### 2026-07-11 Windows/MSVC structured template-parameter identity follow-up
+### Current Windows/MSVC snapshot (2026-07-12)
 
-Function-parameter type template identities now travel on `TypeSpecifierNode`
-and are consumed through the shared `getStructuredTypeName(...)` helper during
-deduction and member-template materialization. Fixed forwarding references
-before a trailing function parameter pack use their exact call-argument slots
-and the C++20 lvalue/rvalue deduction rule. Direct substitution consumes the
-same scoped binding, and concrete type rebinding clears stale parameter
-identity. Regressions:
+Structured template-parameter identity is preserved through deduction and
+substitution. Bare partial-specialization parameters now bind complete template
+arguments, including references, while explicit pattern qualifiers remain
+structural requirements. Substituted member-function declarations also retain
+their function-parameter-pack metadata, including for empty packs. Regressions:
 
 - `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
 - `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
+- `tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
+- `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
+- `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 
-Fresh individual runner wall times (`x64/Sharded/FlashCppMSVC.exe`, MSVC STL
-14.44; includes FlashCpp compile, MSVC link, and execution) were:
+Individual runner wall times (`x64/Sharded/FlashCppMSVC.exe`, MSVC STL 14.44;
+compiler, link, and execution included):
 
 | Header/Test | Status | Runner wall time | Current note |
 |-------------|--------|------------------|--------------|
-| `<cstddef>` (`test_cstddef.cpp`) | ✅ Pass | ~35.7s cold / includes ~30.5s compiler rebuild | Returned 3 as expected. |
-| `<cstdio>` (`test_cstdio_puts.cpp`) | ✅ Pass | ~8.7s warm | Compiles, links, and returns 0. |
-| `<cstdlib>` (`test_cstdlib.cpp`) | ✅ Pass | ~3.9s warm | Compiles, links, and returns 0. |
-| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~4.8s warm | Compiles, links, and returns 0. |
-| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.5s warm | Current first diagnostics are all three `ranges::empty` template overloads failing, followed by unresolved `auto` reaching MSVC mangling in `view_interface`. |
-| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~28.4s warm before the fix / ~29.0s after | The one-argument `std::invoke` candidate is correctly rejected; the variadic candidate reaches later `_Invoker1<...>::_Call` substitution failure. The independent `ranges::size` inconsistent-auto-return diagnostic remains. |
+| `<cstddef>` (`test_cstddef.cpp`) | ✅ Pass | ~3.22s | Returned 3 as expected. |
+| `<cstdio>` (`test_cstdio_puts.cpp`) | ✅ Pass | ~9.39s | Compiles, links, and returns 0. |
+| `<cstdlib>` (`test_cstdlib.cpp`) | ✅ Pass | ~3.71s | Compiles, links, and returns 0. |
+| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~5.07s | Compiles, links, and returns 0. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~22.97s | `ranges::empty` overload viability, then unresolved `auto` during `view_interface` mangling. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~20.80s | Current diagnostics are the `make_signed<T>` constraint/static-assert path and a scoped-enum `_St` equality diagnostic in tuple `_Equals`; the independent `ranges::size` issue is not yet isolated by this run. |
 
-Full Windows validation after the change: 2750 regular tests passed, all 236
+The separate `std::invoke` frontier remains its variadic
+`_Invoker1<...>::_Call` trailing-return/noexcept substitution. The one-argument
+candidate is correctly rejected for the two-argument call.
+
+Full Windows validation after the change: 2753 regular tests passed, all 236
 expected-fail tests failed as expected, with no crashes or return mismatches.
 
 ### 2026-05-28 Linux/libstdc++ template-substitution metadata follow-up

--- a/tests/test_template_partial_specialization_array_bound_identity_ret0.cpp
+++ b/tests/test_template_partial_specialization_array_bound_identity_ret0.cpp
@@ -1,0 +1,13 @@
+template <class T>
+struct ArrayExtent;
+
+template <class T, int Bound>
+struct ArrayExtent<T[Bound]> {
+	static constexpr int value = Bound;
+};
+
+int main() {
+	return ArrayExtent<long long[7]>::value == 7
+		? 0
+		: 1;
+}

--- a/tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp
+++ b/tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp
@@ -1,0 +1,45 @@
+template <class Callable, class First>
+struct InvokeBase {
+	template <class C, class T, class... Rest>
+	static constexpr auto call(C&& callable, T&& first, Rest&&... rest)
+		noexcept(noexcept(static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...)))
+		-> decltype(static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...)) {
+		return static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...);
+	}
+};
+
+template <class Callable, class First, bool IsCallable = true>
+struct SelectInvoker;
+
+template <class Callable, class First>
+struct SelectInvoker<Callable, First, true> : InvokeBase<Callable, First> {};
+
+template <class Callable, class First, class... Rest>
+constexpr auto invokeLike(Callable&& callable, First&& first, Rest&&... rest)
+	noexcept(noexcept(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)))
+	-> decltype(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)) {
+	return SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...);
+}
+
+struct ReadValue {
+	constexpr int operator()(int& value) const {
+		return value;
+	}
+};
+
+int main() {
+	ReadValue function;
+	int value = 42;
+	return invokeLike(function, value) == 42
+		? 0
+		: 1;
+}

--- a/tests/test_template_partial_specialization_pack_before_alias_identity_ret0.cpp
+++ b/tests/test_template_partial_specialization_pack_before_alias_identity_ret0.cpp
@@ -1,0 +1,23 @@
+template<typename... Ts>
+struct Types {};
+
+template<typename Packed, typename Tail>
+struct SelectTail;
+
+template<typename... Elements, typename Tail>
+struct SelectTail<Types<Elements...>, Tail> {
+	using type = Tail;
+};
+
+struct Large {
+	long long values[3];
+};
+
+int main() {
+	using NonEmptyTail = SelectTail<Types<char, short, int>, Large>::type;
+	using EmptyTail = SelectTail<Types<>, long long>::type;
+	return sizeof(NonEmptyTail) == sizeof(Large) &&
+		sizeof(EmptyTail) == sizeof(long long)
+		? 0
+		: 1;
+}

--- a/tests/test_template_partial_specialization_reordered_identity_ret0.cpp
+++ b/tests/test_template_partial_specialization_reordered_identity_ret0.cpp
@@ -1,0 +1,24 @@
+template <class Left, class Right, bool Enabled>
+struct Reordered;
+
+template <class First, class Second>
+struct Reordered<Second, First, true> {
+	static constexpr int first_size = sizeof(First);
+	static constexpr int second_size = sizeof(Second);
+};
+
+struct Small {
+	char value;
+};
+
+struct Large {
+	long long values[2];
+};
+
+int main() {
+	using Selected = Reordered<Small, Large, true>;
+	return Selected::first_size == sizeof(Large) &&
+		Selected::second_size == sizeof(Small)
+		? 0
+		: 1;
+}

--- a/tests/test_template_partial_specialization_template_id_pointer_shape_ret0.cpp
+++ b/tests/test_template_partial_specialization_template_id_pointer_shape_ret0.cpp
@@ -1,0 +1,16 @@
+template<typename T>
+struct Apply {};
+
+template<typename T>
+struct Classify {
+	static constexpr int value = 0;
+};
+
+template<typename U>
+struct Classify<Apply<U>> {
+	static constexpr int value = 1;
+};
+
+int main() {
+	return Classify<Apply<int>*>::value;
+}


### PR DESCRIPTION
## Summary
- preserve complete dependent type shape and function parameter-pack semantics through partial-specialization matching and substitution
- replace positional specialization recovery with named semantic bindings, including template-template parameters and dependent array bounds
- parse partial-specialization arguments using the primary template parameter kinds and reuse matcher-produced semantic bindings during materialization
- add generic regressions and reduce the template/std-header documents to current architecture, live frontiers, and validation criteria

## Architectural review
Positional recovery is not a C++20 language rule. This change removes it from the affected path: parsing records semantic identity, deduction binds by parameter identity, registry selection returns those bindings, and specialization materialization consumes them. No standard-library or vendor helper names are hardcoded in compiler logic.

The review follow-up also keeps dependent template-id pointer shape structural (`Apply<U>` no longer matches `Apply<int>*`) and makes partial-specialization alias substitution consume named matcher bindings directly.

Refreshed individual std-header timings and recorded the remaining independent `iterator`, `ranges`, and `invoke` semantic frontiers
