### PR TITLE
Preserve C++20 static member template class scope

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -36,6 +36,12 @@ tasks; completed branch history belongs in tests and version control.
   paths.
 - Replay and instantiated-member synchronization use source identity and
   canonical substituted signatures instead of name/arity repair.
+- Class-scope ownership is independent of the implicit object parameter.
+  Static member-function templates retain their qualified declaring scope
+  through declaration copying so sema performs nested-type lookup in the
+  correct class.
+- Nested enum registration uses the declaration's `TypeIndex`; same-spelled
+  enums are never recovered through an unqualified type-map lookup.
 
 ## Invariants
 
@@ -65,10 +71,10 @@ Fresh Windows/MSVC individual runner wall times after the 2026-07-12 rebuild:
 | `std/test_cstdio_puts.cpp` | Pass | 9.39s | Green control |
 | `std/test_cstdlib.cpp` | Pass | 3.71s | Green control |
 | `std/test_std_type_traits.cpp` | Pass | 5.07s | Green control |
-| `std/test_std_iterator.cpp` | Fail | 22.97s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
-| `std/test_std_ranges.cpp` | Fail | 20.80s | `make_signed<T>` constraint/static-assert path and scoped-enum `_St` equality in tuple `_Equals` |
+| `std/test_std_iterator.cpp` | Fail | 19.23s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
+| `std/test_std_ranges.cpp` | Fail | 33.16s | variadic `std::invoke` substitution, then `ranges::size` inconsistent `auto` deduction |
 
-The full Windows suite passes: 2753 regular tests compile, link, and run; all
+The full Windows suite passes: 2756 regular tests compile, link, and run; all
 236 expected-failure tests fail as expected.
 
 The current slice is guarded by:
@@ -77,6 +83,7 @@ The current slice is guarded by:
 - `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
 - `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 - `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
+- `tests/test_member_template_nested_enum_identity_ret0.cpp`
 - existing partial-specialization qualifier/pointer/array/function-pointer tests
 
 ## Remaining work
@@ -86,17 +93,14 @@ The current slice is guarded by:
    correctly rejected for the two-argument call; the variadic candidate passes
    pack-aware viability, so this is a later substitution problem. Keep it
    separate from the completed empty-pack and partial-specialization fix.
-2. Reduce the current `std/test_std_ranges.cpp` `make_signed<T>` and scoped-enum
-   equality diagnostics. Determine whether the generic fault is constraint
-   substitution, canonical enum identity, or overload selection before editing.
-3. Reduce the `std/test_std_iterator.cpp` `ranges::empty` overload failure and
+2. Reduce the `std/test_std_iterator.cpp` `ranges::empty` overload failure and
    unresolved-auto mangling path at the sema/return-type layer.
-4. Re-isolate the independent `ranges::size` inconsistent-auto-return issue
-   after earlier failures advance.
-5. Replace the targeted local-symbol treatment for C-linkage inline wrappers
+3. Reduce the now-live `ranges::size` inconsistent-auto-return issue without
+   coupling it to the independent `std::invoke` substitution failure.
+4. Replace the targeted local-symbol treatment for C-linkage inline wrappers
    with proper per-function COFF COMDAT/weak-external emission when the object
    writer can split the monolithic text section.
-6. Extract deeper dependent-qualified owner or replay helpers only when a
+5. Extract deeper dependent-qualified owner or replay helpers only when a
    concrete failure proves repeated consumer logic is the blocker.
 
 ## Validation

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -47,6 +47,12 @@ deduction, trailing return types, `noexcept`, and body substitution.
 No layer may recognize standard-library or vendor helper names to make a header
 compile.
 
+Static member functions remain members of their declaring class even though
+they have no implicit object parameter. Their declaration and every
+instantiated copy must therefore retain class-scope identity for unqualified
+and nested-type lookup. Nested enum identity comes from the enum declaration,
+not a same-spelled global registry entry.
+
 ## Covered behavior
 
 `tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
@@ -78,10 +84,10 @@ Windows/MSVC runner snapshot from 2026-07-12:
 | `test_cstdio_puts.cpp` | Pass | 9.39s | — |
 | `test_cstdlib.cpp` | Pass | 3.71s | — |
 | `test_std_type_traits.cpp` | Pass | 5.07s | — |
-| `test_std_iterator.cpp` | Fail | 22.97s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
-| `test_std_ranges.cpp` | Fail | 20.80s | `make_signed<T>` constraint/static-assert path and scoped-enum `_St` equality in tuple `_Equals` |
+| `test_std_iterator.cpp` | Fail | 19.23s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
+| `test_std_ranges.cpp` | Fail | 33.16s | variadic `std::invoke` substitution, then `ranges::size` inconsistent `auto` deduction |
 
-Full-suite result: 2753 regular tests pass and all 236 expected-failure tests
+Full-suite result: 2756 regular tests pass and all 236 expected-failure tests
 fail as expected.
 
 ## Active investigations
@@ -95,23 +101,17 @@ fail as expected.
    return/noexcept shape. Reduce this with a non-`std` non-empty-pack test and
    fix substitution at the structured expression/type layer.
 
-2. Current ranges failure
-
-   Trace the `make_signed<T>` constraint/static-assert and tuple `_Equals`
-   scoped-enum comparison independently. Establish whether the enum operands
-   should have one canonical type, whether a constraint should have removed the
-   candidate, or whether overload lookup selected the wrong operation.
-
-3. Iterator return-type frontier
+2. Iterator return-type frontier
 
    Reduce `ranges::empty` candidate viability separately from the unresolved
    `auto` that reaches `view_interface` mangling. Resolved return types must be
    established before code generation.
 
-4. Independent `ranges::size` issue
+3. Independent `ranges::size` issue
 
-   Reconfirm the inconsistent-auto-return diagnostic after the earlier ranges
-   failures are removed. Keep it separate from variadic call substitution.
+   The earlier `make_signed<T>` and scoped-enum diagnostics are removed. Reduce
+   the now-live inconsistent-auto-return diagnostic separately from variadic
+   call substitution.
 
 ## Acceptance criteria
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2837,6 +2837,8 @@ public:
 	// Member function support
 	bool is_member_function() const { return is_member_function_; }
 	std::string_view parent_struct_name() const { return parent_struct_name_; }
+	void set_semantic_owner_name(StringHandle owner_name) { semantic_owner_name_ = owner_name; }
+	StringHandle semantic_owner_name() const { return semantic_owner_name_; }
 
 	// Implicit function support (for compiler-generated functions like operator=)
 	void set_is_implicit(bool implicit) { is_implicit_ = implicit; }
@@ -2982,6 +2984,7 @@ private:
 	std::vector<ASTNode> parameter_nodes_;
 	std::optional<ASTNode> definition_block_;  // Store ASTNode to keep BlockNode alive
 	std::string_view parent_struct_name_;  // Points directly into source text from lexer token or ChunkedStringAllocator
+	StringHandle semantic_owner_name_;  // Declaring class scope, independent of an implicit object parameter
 	NamespaceHandle namespace_handle_;  // Namespace this function was declared in (default: INVALID = not yet set)
 	bool is_member_function_;
 	bool is_implicit_;  // True if this is an implicitly generated function (e.g., operator=)

--- a/src/MemberFunctionLookupShared.h
+++ b/src/MemberFunctionLookupShared.h
@@ -50,6 +50,28 @@ inline bool sameMemberCandidateSet(
 	return std::ranges::equal(lhs, rhs);
 }
 
+template <typename VisitFn>
+void visitStructHierarchyDepthFirst(
+	const StructTypeInfo* root_struct_info,
+	VisitFn&& visit) {
+	InlineVector<const StructTypeInfo*, 8> visited;
+	auto recurse = [&](const StructTypeInfo* current_struct_info,
+		const auto& self) -> void {
+		if (current_struct_info == nullptr ||
+			std::ranges::find(visited, current_struct_info) != visited.end()) {
+			return;
+		}
+		visited.push_back(current_struct_info);
+		if (!visit(*current_struct_info)) {
+			return;
+		}
+		for (const BaseClassSpecifier& base_spec : current_struct_info->base_classes) {
+			self(tryGetStructTypeInfo(base_spec.type_index), self);
+		}
+	};
+	recurse(root_struct_info, recurse);
+}
+
 inline void appendUniqueMemberFunctionOverloadNodes(
 	InlineVector<ASTNode, 8>& target,
 	std::span<const StructMemberFunction* const> members) {
@@ -77,18 +99,9 @@ DefinitionPreferredMemberOverloadSet collectVisibleMemberFunctionOverloadNodes(
 		return result;
 	}
 
-	InlineVector<const StructTypeInfo*, 8> visited;
-	auto recurse = [&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
-		if (current_struct_info == nullptr) {
-			return;
-		}
-		if (std::ranges::find(visited, current_struct_info) != visited.end()) {
-			return;
-		}
-		visited.push_back(current_struct_info);
-
+	visitStructHierarchyDepthFirst(root_struct_info, [&](const StructTypeInfo& current_struct_info) {
 		bool found_local_overload = false;
-		for (const auto& member_func : current_struct_info->member_functions) {
+		for (const auto& member_func : current_struct_info.member_functions) {
 			if (member_func.getName() != member_name_handle ||
 				!member_func.function_decl.is<FunctionDeclarationNode>()) {
 				continue;
@@ -116,18 +129,10 @@ DefinitionPreferredMemberOverloadSet collectVisibleMemberFunctionOverloadNodes(
 		}
 
 		if (found_local_overload && stop_at_first_local_name_set) {
-			return;
+			return false;
 		}
-
-		for (const auto& base_spec : current_struct_info->base_classes) {
-			if (const StructTypeInfo* base_struct =
-					tryGetStructTypeInfo(base_spec.type_index)) {
-				self(base_struct, self);
-			}
-		}
-	};
-
-	recurse(root_struct_info, recurse);
+		return true;
+	});
 	return result;
 }
 
@@ -205,18 +210,9 @@ ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
 		return result;
 	}
 
-	InlineVector<const StructTypeInfo*, 8> visited;
-	auto recurse = [&](const StructTypeInfo* current_struct_info, const auto& self) -> void {
-		if (current_struct_info == nullptr) {
-			return;
-		}
-		if (std::ranges::find(visited, current_struct_info) != visited.end()) {
-			return;
-		}
-		visited.push_back(current_struct_info);
-
+	visitStructHierarchyDepthFirst(root_struct_info, [&](const StructTypeInfo& current_struct_info) {
 		bool found_local_overload = false;
-		for (const auto& member_func : current_struct_info->member_functions) {
+		for (const auto& member_func : current_struct_info.member_functions) {
 			if (member_func.is_constructor ||
 				member_func.is_destructor ||
 				member_func.getName() != member_name_handle ||
@@ -252,17 +248,9 @@ ConstAwareMemberCandidateSet collectConstAwareVisibleMemberFunctionCandidates(
 		}
 
 		if (found_local_overload && stop_at_first_local_name_set) {
-			return;
+			return false;
 		}
-
-		for (const auto& base_spec : current_struct_info->base_classes) {
-			if (const StructTypeInfo* base_struct =
-					tryGetStructTypeInfo(base_spec.type_index)) {
-				self(base_struct, self);
-			}
-		}
-	};
-
-	recurse(root_struct_info, recurse);
+		return true;
+	});
 	return result;
 }

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1078,40 +1078,44 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				// Track the enum's TypeIndex in the struct for nested enum enumerator lookup during codegen
 				if (auto enum_node = enum_result.node(); enum_node.has_value() && enum_node->is<EnumDeclarationNode>()) {
 					const auto& enum_decl = enum_node->as<EnumDeclarationNode>();
-					auto enum_it = getTypesByNameMap().find(StringTable::getOrInternStringHandle(enum_decl.name()));
-					if (enum_it != getTypesByNameMap().end()) {
-						struct_info->addNestedEnumIndex(enum_it->second->type_index_);
+					if (!enum_decl.type_index().is_valid()) {
+						throw InternalError("Nested enum declaration has no semantic type identity");
+					}
+					TypeInfo* enum_type_info = &getTypeInfoMut(enum_decl.type_index());
+					if (!enum_type_info->isEnum()) {
+						throw InternalError("Nested enum declaration semantic identity is not an enum");
+					}
+					struct_info->addNestedEnumIndex(enum_decl.type_index());
 
-						// Register the enum under every qualified name a caller might use.
-						// Per C++20 [basic.lookup.qual], a nested enum is accessed by
-						// qualifying through the enclosing class name(s).
-						// Per [basic.lookup.argdep]/2 the associated namespace is the
-						// innermost enclosing namespace.
-						//
-						// Walk struct_parsing_context_stack_ (which already includes the
-						// current struct pushed above) from outermost to innermost to
-						// build the full struct chain.  This correctly handles any depth
-						// of struct nesting, e.g.:
-						//   ns::A::B::C::E   (3 levels: A > B > C, enum E)
-						//   ns::Container::Status (1 level)
-						StringBuilder struct_chain_builder;
-						for (const auto& ctx : struct_parsing_context_stack_) {
-							struct_chain_builder.append(ctx.struct_name).append("::");
-						}
-						struct_chain_builder.append(enum_decl.name());
-						StringHandle struct_relative_handle = StringTable::getOrInternStringHandle(
-							struct_chain_builder.commit());
-						// Register struct-relative name ("A::B::C::E", "Container::Status")
-						getTypesByNameMap().emplace(struct_relative_handle, enum_it->second);
+					// Register the enum under every qualified name a caller might use.
+					// Per C++20 [basic.lookup.qual], a nested enum is accessed by
+					// qualifying through the enclosing class name(s).
+					// Per [basic.lookup.argdep]/2 the associated namespace is the
+					// innermost enclosing namespace.
+					//
+					// Walk struct_parsing_context_stack_ (which already includes the
+					// current struct pushed above) from outermost to innermost to
+					// build the full struct chain.  This correctly handles any depth
+					// of struct nesting, e.g.:
+					//   ns::A::B::C::E   (3 levels: A > B > C, enum E)
+					//   ns::Container::Status (1 level)
+					StringBuilder struct_chain_builder;
+					for (const auto& ctx : struct_parsing_context_stack_) {
+						struct_chain_builder.append(ctx.struct_name).append("::");
+					}
+					struct_chain_builder.append(enum_decl.name());
+					StringHandle struct_relative_handle = StringTable::getOrInternStringHandle(
+						struct_chain_builder.commit());
+					// Register struct-relative name ("A::B::C::E", "Container::Status")
+					getTypesByNameMap().emplace(struct_relative_handle, enum_type_info);
 
-						// Also register namespace-fully-qualified name using NamespaceHandle
-						// ("ns::A::B::C::E", "ns::Container::Status")
-						if (!qualified_namespace.empty()) {
-							StringHandle ns_qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(
-								current_namespace_handle, struct_relative_handle);
-							if (ns_qualified_handle != struct_relative_handle) {
-								getTypesByNameMap().emplace(ns_qualified_handle, enum_it->second);
-							}
+					// Also register namespace-fully-qualified name using NamespaceHandle
+					// ("ns::A::B::C::E", "ns::Container::Status")
+					if (!qualified_namespace.empty()) {
+						StringHandle ns_qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(
+							current_namespace_handle, struct_relative_handle);
+						if (ns_qualified_handle != struct_relative_handle) {
+							getTypesByNameMap().emplace(ns_qualified_handle, enum_type_info);
 						}
 					}
 				}

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -556,6 +556,9 @@ FlashCpp::SignatureValidationResult Parser::validate_signature_match(
 
 void Parser::copy_function_properties(FunctionDeclarationNode& dest, const FunctionDeclarationNode& src) {
 	dest.set_namespace_handle(src.namespace_handle());
+	if (src.semantic_owner_name().isValid()) {
+		dest.set_semantic_owner_name(src.semantic_owner_name());
+	}
 	dest.set_is_constexpr(src.is_constexpr());
 	dest.set_is_consteval(src.is_consteval());
 	dest.set_is_constinit(src.is_constinit());

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -556,9 +556,7 @@ FlashCpp::SignatureValidationResult Parser::validate_signature_match(
 
 void Parser::copy_function_properties(FunctionDeclarationNode& dest, const FunctionDeclarationNode& src) {
 	dest.set_namespace_handle(src.namespace_handle());
-	if (src.semantic_owner_name().isValid()) {
-		dest.set_semantic_owner_name(src.semantic_owner_name());
-	}
+	dest.set_semantic_owner_name(src.semantic_owner_name());
 	dest.set_is_constexpr(src.is_constexpr());
 	dest.set_is_consteval(src.is_consteval());
 	dest.set_is_constinit(src.is_constinit());

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -784,8 +784,11 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 						}
 
 						// Create a function declaration for the conversion operator
+						StringHandle owner_qualified_name =
+							getStructQualifiedNameForRegistration(struct_node);
 						auto [func_node, func_ref] = emplace_node_ref<FunctionDeclarationNode>(
-							decl_node.as<DeclarationNode>(), identifier_token.value());
+							decl_node.as<DeclarationNode>(), owner_qualified_name);
+						func_ref.set_semantic_owner_name(owner_qualified_name);
 						for (const auto& param : params.parameters) {
 							func_ref.add_parameter_node(param);
 						}
@@ -830,7 +833,6 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 														false, false, false, false,
 														member_quals.cv_qualifier);
 
-						StringHandle owner_qualified_name = getStructQualifiedNameForRegistration(struct_node);
 						auto qualified_name = StringTable::getOrInternStringHandle(
 							StringBuilder().append(owner_qualified_name).append("::"sv).append(operator_name));
 						gTemplateRegistry.registerTemplate(qualified_name, template_func_node);

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -859,9 +859,11 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	}
 
 	// Get the function name for registration
-	const TemplateFunctionDeclarationNode& template_decl = template_func_node.as<TemplateFunctionDeclarationNode>();
-	const FunctionDeclarationNode& func_decl = template_decl.function_declaration().as<FunctionDeclarationNode>();
+	TemplateFunctionDeclarationNode& template_decl = template_func_node.as<TemplateFunctionDeclarationNode>();
+	FunctionDeclarationNode& func_decl = template_decl.function_decl_node();
 	const DeclarationNode& decl_node = func_decl.decl_node();
+	StringHandle owner_qualified_name = getStructQualifiedNameForRegistration(struct_node);
+	func_decl.set_semantic_owner_name(owner_qualified_name);
 
 	// Add to struct as a member function template
 	// First, add to the struct's member functions list so it can be found for inheritance lookup
@@ -891,7 +893,6 @@ ParseResult Parser::parse_member_function_template(StructDeclarationNode& struct
 	}
 
 	// Register the template in the global registry with qualified name (ClassName::functionName)
-	StringHandle owner_qualified_name = getStructQualifiedNameForRegistration(struct_node);
 	auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(owner_qualified_name).append("::"sv).append(decl_node.identifier_token().value()));
 	gTemplateRegistry.registerTemplate(qualified_name, template_func_node);
 

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2732,9 +2732,20 @@ void SemanticAnalysis::normalizeFunctionDeclaration(const FunctionDeclarationNod
 	SemanticContext ctx;
 
 	std::optional<MemberContext> member_context;
-	if (func.is_member_function()) {
-		if (const TypeInfo* type_info = findStructTypeInfoByNameFragment(func.parent_struct_name());
-			type_info && type_info->getStructInfo()) {
+	const std::string_view semantic_owner_name = func.semantic_owner_name().isValid()
+		? func.semantic_owner_name().view()
+		: func.parent_struct_name();
+	if (!semantic_owner_name.empty()) {
+		const StringHandle parent_name =
+			StringTable::getOrInternStringHandle(semantic_owner_name);
+		const StringHandle qualified_parent_name =
+			gNamespaceRegistry.buildQualifiedIdentifier(
+				func.namespace_handle(), parent_name);
+		auto qualified_parent = getTypesByNameMap().find(qualified_parent_name);
+		const TypeInfo* type_info = qualified_parent != getTypesByNameMap().end()
+				? qualified_parent->second
+				: findStructTypeInfoByNameFragment(semantic_owner_name);
+		if (type_info && type_info->getStructInfo()) {
 			member_context = MemberContext{type_info->type_index_, !func.is_static(), CVQualifier::None};
 			if (func.is_const_member_function()) {
 				member_context->this_base_cv |= CVQualifier::Const;
@@ -4935,7 +4946,7 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 			return type_info;
 		};
 
-		auto resolve_owner_type = [&resolve_alias_target](NamespaceHandle owner_ns) -> const TypeInfo* {
+		auto resolve_owner_type = [this, &resolve_alias_target](NamespaceHandle owner_ns) -> const TypeInfo* {
 			std::vector<StringHandle> components;
 			NamespaceHandle current = owner_ns;
 			while (current.isValid() && !current.isGlobal()) {
@@ -4948,7 +4959,26 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 				return nullptr;
 			}
 
-			const TypeInfo* owner_type_info = lookupTypeInCurrentContext(components.front());
+			const TypeInfo* owner_type_info = nullptr;
+			if (components.size() == 1) {
+				if (const MemberContext* member_context = getCurrentMemberContext()) {
+					if (const StructTypeInfo* struct_info =
+						tryGetStructTypeInfo(member_context->type_index)) {
+						for (TypeIndex nested_enum_index : struct_info->getNestedEnumIndices()) {
+							const TypeInfo* nested_enum_type_info = tryGetTypeInfo(nested_enum_index);
+							const EnumTypeInfo* nested_enum_info =
+								nested_enum_type_info ? nested_enum_type_info->getEnumInfo() : nullptr;
+							if (nested_enum_info && nested_enum_info->name == components.front()) {
+								owner_type_info = nested_enum_type_info;
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (!owner_type_info) {
+				owner_type_info = lookupTypeInCurrentContext(components.front());
+			}
 			auto owner_it = getTypesByNameMap().end();
 			if (!owner_type_info) {
 				owner_it = getTypesByNameMap().find(components.front());

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4967,45 +4967,30 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 				if (const MemberContext* member_context = getCurrentMemberContext()) {
 					if (const StructTypeInfo* struct_info =
 						tryGetStructTypeInfo(member_context->type_index)) {
-						std::unordered_set<const StructTypeInfo*> visited;
-						auto find_nested_enum = [&](const StructTypeInfo* current,
-							const auto& self) -> std::pair<const TypeInfo*, bool> {
-							if (!current || !visited.insert(current).second) {
-								return {nullptr, false};
-							}
-							for (TypeIndex nested_enum_index : current->getNestedEnumIndices()) {
+						InlineVector<const TypeInfo*, 2> nested_enum_matches;
+						visitStructHierarchyDepthFirst(struct_info, [&](const StructTypeInfo& current) {
+							for (TypeIndex nested_enum_index : current.getNestedEnumIndices()) {
 								const TypeInfo* nested_enum_type_info = tryGetTypeInfo(nested_enum_index);
 								const EnumTypeInfo* nested_enum_info =
 									nested_enum_type_info ? nested_enum_type_info->getEnumInfo() : nullptr;
 								if (nested_enum_info && nested_enum_info->name == components.front()) {
-									return {nested_enum_type_info, false};
+									if (std::ranges::find(nested_enum_matches, nested_enum_type_info) ==
+										nested_enum_matches.end()) {
+										nested_enum_matches.push_back(nested_enum_type_info);
+									}
+									return false;
 								}
 							}
-
-							const TypeInfo* inherited_match = nullptr;
-							for (const BaseClassSpecifier& base : current->base_classes) {
-								auto [candidate, ambiguous] =
-									self(tryGetStructTypeInfo(base.type_index), self);
-								if (ambiguous) {
-									return {nullptr, true};
-								}
-								if (candidate && inherited_match && candidate != inherited_match) {
-									return {nullptr, true};
-								}
-								if (candidate) {
-									inherited_match = candidate;
-								}
-							}
-							return {inherited_match, false};
-						};
-						auto [nested_enum_type_info, ambiguous] =
-							find_nested_enum(struct_info, find_nested_enum);
-						if (ambiguous) {
+							return true;
+						});
+						if (nested_enum_matches.size() > 1) {
 							throw CompileError(
 								"ambiguous nested enum type '" +
 								std::string(components.front().view()) + "'");
 						}
-						owner_type_info = nested_enum_type_info;
+						if (!nested_enum_matches.empty()) {
+							owner_type_info = nested_enum_matches.front();
+						}
 					}
 				}
 			}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -2738,13 +2738,16 @@ void SemanticAnalysis::normalizeFunctionDeclaration(const FunctionDeclarationNod
 	if (!semantic_owner_name.empty()) {
 		const StringHandle parent_name =
 			StringTable::getOrInternStringHandle(semantic_owner_name);
-		const StringHandle qualified_parent_name =
-			gNamespaceRegistry.buildQualifiedIdentifier(
-				func.namespace_handle(), parent_name);
-		auto qualified_parent = getTypesByNameMap().find(qualified_parent_name);
-		const TypeInfo* type_info = qualified_parent != getTypesByNameMap().end()
-				? qualified_parent->second
-				: findStructTypeInfoByNameFragment(semantic_owner_name);
+		auto owner_type = getTypesByNameMap().find(parent_name);
+		if (owner_type == getTypesByNameMap().end()) {
+			const StringHandle qualified_parent_name =
+				gNamespaceRegistry.buildQualifiedIdentifier(
+					func.namespace_handle(), parent_name);
+			owner_type = getTypesByNameMap().find(qualified_parent_name);
+		}
+		const TypeInfo* type_info = owner_type != getTypesByNameMap().end()
+			? owner_type->second
+			: findStructTypeInfoByNameFragment(semantic_owner_name);
 		if (type_info && type_info->getStructInfo()) {
 			member_context = MemberContext{type_info->type_index_, !func.is_static(), CVQualifier::None};
 			if (func.is_const_member_function()) {
@@ -4964,15 +4967,45 @@ std::optional<SemanticAnalysis::ResolvedQualifiedIdentifierInfo> SemanticAnalysi
 				if (const MemberContext* member_context = getCurrentMemberContext()) {
 					if (const StructTypeInfo* struct_info =
 						tryGetStructTypeInfo(member_context->type_index)) {
-						for (TypeIndex nested_enum_index : struct_info->getNestedEnumIndices()) {
-							const TypeInfo* nested_enum_type_info = tryGetTypeInfo(nested_enum_index);
-							const EnumTypeInfo* nested_enum_info =
-								nested_enum_type_info ? nested_enum_type_info->getEnumInfo() : nullptr;
-							if (nested_enum_info && nested_enum_info->name == components.front()) {
-								owner_type_info = nested_enum_type_info;
-								break;
+						std::unordered_set<const StructTypeInfo*> visited;
+						auto find_nested_enum = [&](const StructTypeInfo* current,
+							const auto& self) -> std::pair<const TypeInfo*, bool> {
+							if (!current || !visited.insert(current).second) {
+								return {nullptr, false};
 							}
+							for (TypeIndex nested_enum_index : current->getNestedEnumIndices()) {
+								const TypeInfo* nested_enum_type_info = tryGetTypeInfo(nested_enum_index);
+								const EnumTypeInfo* nested_enum_info =
+									nested_enum_type_info ? nested_enum_type_info->getEnumInfo() : nullptr;
+								if (nested_enum_info && nested_enum_info->name == components.front()) {
+									return {nested_enum_type_info, false};
+								}
+							}
+
+							const TypeInfo* inherited_match = nullptr;
+							for (const BaseClassSpecifier& base : current->base_classes) {
+								auto [candidate, ambiguous] =
+									self(tryGetStructTypeInfo(base.type_index), self);
+								if (ambiguous) {
+									return {nullptr, true};
+								}
+								if (candidate && inherited_match && candidate != inherited_match) {
+									return {nullptr, true};
+								}
+								if (candidate) {
+									inherited_match = candidate;
+								}
+							}
+							return {inherited_match, false};
+						};
+						auto [nested_enum_type_info, ambiguous] =
+							find_nested_enum(struct_info, find_nested_enum);
+						if (ambiguous) {
+							throw CompileError(
+								"ambiguous nested enum type '" +
+								std::string(components.front().view()) + "'");
 						}
+						owner_type_info = nested_enum_type_info;
 					}
 				}
 			}

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -124,14 +124,19 @@ compiler, link, and execution included):
 | `<cstdio>` (`test_cstdio_puts.cpp`) | ✅ Pass | ~9.39s | Compiles, links, and returns 0. |
 | `<cstdlib>` (`test_cstdlib.cpp`) | ✅ Pass | ~3.71s | Compiles, links, and returns 0. |
 | `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~5.07s | Compiles, links, and returns 0. |
-| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~22.97s | `ranges::empty` overload viability, then unresolved `auto` during `view_interface` mangling. |
-| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~20.80s | Current diagnostics are the `make_signed<T>` constraint/static-assert path and a scoped-enum `_St` equality diagnostic in tuple `_Equals`; the independent `ranges::size` issue is not yet isolated by this run. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.23s | `ranges::empty` overload viability, then unresolved `auto` during `view_interface` mangling. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~33.16s | The nested-enum identity and `make_signed<T>` stops are gone; the live diagnostics are variadic `std::invoke` substitution and the independent `ranges::size` inconsistent-`auto` return. |
 
 The separate `std::invoke` frontier remains its variadic
 `_Invoker1<...>::_Call` trailing-return/noexcept substitution. The one-argument
 candidate is correctly rejected for the two-argument call.
 
-Full Windows validation after the change: 2753 regular tests passed, all 236
+Class-scope identity for static member-function templates is now preserved
+separately from implicit-object semantics, and nested enums are registered from
+their declaration `TypeIndex`. Regression:
+`tests/test_member_template_nested_enum_identity_ret0.cpp`.
+
+Full Windows validation after the change: 2756 regular tests passed, all 236
 expected-fail tests failed as expected, with no crashes or return mismatches.
 
 ### 2026-05-28 Linux/libstdc++ template-substitution metadata follow-up

--- a/tests/test_member_template_nested_enum_identity_ret0.cpp
+++ b/tests/test_member_template_nested_enum_identity_ret0.cpp
@@ -21,7 +21,22 @@ struct Cpo {
 };
 }
 
+namespace inherited {
+struct Base {
+	enum class State { none, selected };
+};
+
+struct Cpo : Base {
+	template<typename T>
+	static constexpr bool selected() {
+		constexpr State strategy = State::selected;
+		return strategy == State::selected && sizeof(T) != 0;
+	}
+};
+}
+
 int main() {
 	return target::Cpo::selected<int>() &&
-		target::Cpo::selected<target::Payload>() ? 0 : 1;
+		target::Cpo::selected<target::Payload>() &&
+		inherited::Cpo::selected<long long>() ? 0 : 1;
 }

--- a/tests/test_member_template_nested_enum_identity_ret0.cpp
+++ b/tests/test_member_template_nested_enum_identity_ret0.cpp
@@ -1,0 +1,27 @@
+namespace unrelated {
+struct Cpo {
+	enum class State { none, selected, other };
+};
+}
+
+namespace target {
+struct Payload {
+	short tag;
+	long long value;
+};
+
+struct Cpo {
+	enum class State { none, selected };
+
+	template<typename T>
+	static constexpr bool selected() {
+		constexpr State strategy = State::selected;
+		return strategy == State::selected && sizeof(T) != 0;
+	}
+};
+}
+
+int main() {
+	return target::Cpo::selected<int>() &&
+		target::Cpo::selected<target::Payload>() ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- preserve a member-function template's declaring class scope independently from implicit-object semantics, including through declaration copying and conversion-function templates
- register nested enums from their declaration `TypeIndex` and resolve direct or inherited nested enum types through semantic class-scope lookup, with ambiguity detection
- add a reduced non-`std` regression covering same-spelled enum collisions, mixed template arguments, and inherited nested enum lookup
- refresh the current Windows std-header timings and forward-looking template architecture notes

## C++20 rationale

A static member function has no implicit object parameter, but it remains a member of its declaring class and performs unqualified lookup in that class scope. The compiler now models those properties separately instead of treating static member templates as free functions or recovering owner identity from an unqualified spelling. Nested enum identity is carried by the declaration's semantic `TypeIndex` rather than reconstructed by name.