### PR TITLE
Advance dependent auto return and trailing return substitution

### DIFF
--- a/docs/2026-05-12-template-argument-architecture-audit.md
+++ b/docs/2026-05-12-template-argument-architecture-audit.md
@@ -1,7 +1,7 @@
 # Template Argument Architecture Audit
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-12
+**Last updated:** 2026-07-13
 
 This is a forward-looking planning reference for template infrastructure. Keep
 it limited to the current architecture, invariants, live failures, and next
@@ -29,8 +29,16 @@ tasks; completed branch history belongs in tests and version control.
   specifier and declaration metadata. In particular, a function-parameter pack
   remains a pack after class-template substitution, including when it expands
   to zero arguments.
-- Direct dependent alias template-ids remain structured until their enclosing
-  arguments are known, then materialize before deduction and code generation.
+- Dependent alias template-ids remain structured until their enclosing
+  arguments are known, then materialize through the shared alias/substitution
+  path before deduction and code generation, including deferred `decltype`
+  targets.
+- Placeholder-`auto` return analysis defers consistency checks while any return
+  remains dependent. Once concrete, it compares canonical builtin/alias
+  identities without replacing the original deduced node.
+- Reparsed trailing return types pass through the same structured type
+  substitution used by other instantiated declarations before member-alias
+  resolution.
 - `ResolvedQualifiedOwner` and structured dependent-call records are the shared
   owner/lookup representation across parser, substitution, constexpr, and sema
   paths.
@@ -63,23 +71,25 @@ tasks; completed branch history belongs in tests and version control.
 
 ## Current standard-header snapshot
 
-Fresh Windows/MSVC individual runner wall times after the 2026-07-12 rebuild:
+Fresh Windows/MSVC individual runner wall times after the 2026-07-13 rebuild:
 
 | Test | Status | Time | Current frontier |
 |------|--------|------|------------------|
-| `std/test_cstddef.cpp` | Pass | 3.22s | Green control |
-| `std/test_cstdio_puts.cpp` | Pass | 9.39s | Green control |
-| `std/test_cstdlib.cpp` | Pass | 3.71s | Green control |
-| `std/test_std_type_traits.cpp` | Pass | 5.07s | Green control |
-| `std/test_std_iterator.cpp` | Fail | 19.23s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
-| `std/test_std_ranges.cpp` | Fail | 33.16s | variadic `std::invoke` substitution, then `ranges::size` inconsistent `auto` deduction |
+| `std/test_std_cstddef.cpp` | Pass | 2.73s | Green control |
+| `std/test_std_cstdio.cpp` | Pass | 2.76s | Green control |
+| `std/test_std_cstdlib.cpp` | Pass | 2.62s | Green control |
+| `std/test_std_type_traits.cpp` | Pass | 4.48s | Green control |
+| `std/test_std_iterator.cpp` | Fail | 19.04s | `ranges::empty` viability, then missing `operator==` semantic annotation in `view_interface`; unresolved-`auto` mangling is gone |
+| `std/test_std_ranges.cpp` | Fail | 32.40s | deferred `_Traits::compare`, `basic_string_view` `is_same_v` validation, and variadic `std::invoke`; inconsistent `ranges::size` auto deduction is gone |
 
-The full Windows suite passes: 2756 regular tests compile, link, and run; all
+The full Windows suite passes: 2758 regular tests compile, link, and run; all
 236 expected-failure tests fail as expected.
 
 The current slice is guarded by:
 
 - `tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
+- `tests/test_template_partial_specialization_inherited_static_call_nonempty_pack_ret0.cpp`
+- `tests/test_dependent_decltype_cpo_alias_auto_return_ret0.cpp`
 - `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
 - `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 - `tests/test_template_dependent_inherited_static_call_pack_ret0.cpp`
@@ -88,19 +98,22 @@ The current slice is guarded by:
 
 ## Remaining work
 
-1. Reduce the variadic `std::invoke` trailing return/noexcept substitution
-   failure around `_Invoker1<...>::_Call`. The one-argument candidate is
-   correctly rejected for the two-argument call; the variadic candidate passes
-   pack-aware viability, so this is a later substitution problem. Keep it
-   separate from the completed empty-pack and partial-specialization fix.
+1. Reduce the variadic `std::invoke` deferred-body replay failure around
+   `_Invoker1<...>::_Call`. Structured trailing-return substitution and the
+   non-empty pack work in isolation, so inspect body replay and inherited
+   static-call lookup rather than adding another signature fallback.
 2. Reduce the `std/test_std_iterator.cpp` `ranges::empty` overload failure and
-   unresolved-auto mangling path at the sema/return-type layer.
-3. Reduce the now-live `ranges::size` inconsistent-auto-return issue without
-   coupling it to the independent `std::invoke` substitution failure.
-4. Replace the targeted local-symbol treatment for C-linkage inline wrappers
+   missing `operator==` annotation at sema before the codegen visitor. The old
+   unresolved-auto mangling path is complete.
+3. Reduce the newly exposed `<ranges>` deferred `_Traits::compare` lookup and
+   `basic_string_view` `is_same_v` validation independently of `std::invoke`.
+4. Reduce the discovered templated-callable codegen path that emits
+   `range.size()` as an unresolved free `size` symbol; preserve the resolved
+   member-call metadata instead of repairing the name during emission.
+5. Replace the targeted local-symbol treatment for C-linkage inline wrappers
    with proper per-function COFF COMDAT/weak-external emission when the object
    writer can split the monolithic text section.
-5. Extract deeper dependent-qualified owner or replay helpers only when a
+6. Extract deeper dependent-qualified owner or replay helpers only when a
    concrete failure proves repeated consumer logic is the blocker.
 
 ## Validation

--- a/docs/2026-05-12-template-argument-standard-conformance-investigation.md
+++ b/docs/2026-05-12-template-argument-standard-conformance-investigation.md
@@ -1,7 +1,7 @@
 # Template Argument Standard-Conformance Investigation
 
 **Date:** 2026-05-12  
-**Last updated:** 2026-07-12
+**Last updated:** 2026-07-13
 
 This document defines the standards-facing behavior still being pursued. It is
 not a chronology of completed fixes.
@@ -32,6 +32,16 @@ from argument count or the substituted type. Every declaration-copy path used
 by class/member-template substitution must retain that property. An empty pack
 is a valid zero-argument expansion and must participate correctly in viability,
 deduction, trailing return types, `noexcept`, and body substitution.
+
+### Dependent placeholder return deduction
+
+An `auto` return type in a dependent function body cannot be validated from a
+mixture of concrete and still-dependent return expressions. Consistency waits
+until substitution makes every participating type concrete. Comparison uses
+canonical builtin/alias identity, but the original deduced node remains the
+semantic result so validation does not perturb later lambda/member codegen.
+Deferred `decltype` alias template-ids and braced constructions participate in
+the same structured substitution path.
 
 ### Layer ownership
 
@@ -73,45 +83,58 @@ adjacent semantics. `tests/test_template_partial_specialization_reordered_identi
 guards reordered parameter identity after positional matcher recovery was
 removed, and `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 verifies that a direct `T[N]` bound is deduced into the specialization body.
+`tests/test_template_partial_specialization_inherited_static_call_nonempty_pack_ret0.cpp`
+guards trailing-return substitution with a non-empty pack, and
+`tests/test_dependent_decltype_cpo_alias_auto_return_ret0.cpp` guards deferred
+`decltype` alias materialization plus canonical `auto` return comparison.
 
 ## Live standard-header frontier
 
-Windows/MSVC runner snapshot from 2026-07-12:
+Windows/MSVC runner snapshot from 2026-07-13:
 
 | Test | Status | Time | First captured issue |
 |------|--------|------|----------------------|
-| `test_cstddef.cpp` | Pass | 3.22s | — |
-| `test_cstdio_puts.cpp` | Pass | 9.39s | — |
-| `test_cstdlib.cpp` | Pass | 3.71s | — |
-| `test_std_type_traits.cpp` | Pass | 5.07s | — |
-| `test_std_iterator.cpp` | Fail | 19.23s | `ranges::empty` overload viability, then unresolved `auto` in `view_interface` mangling |
-| `test_std_ranges.cpp` | Fail | 33.16s | variadic `std::invoke` substitution, then `ranges::size` inconsistent `auto` deduction |
+| `test_std_cstddef.cpp` | Pass | 2.73s | — |
+| `test_std_cstdio.cpp` | Pass | 2.76s | — |
+| `test_std_cstdlib.cpp` | Pass | 2.62s | — |
+| `test_std_type_traits.cpp` | Pass | 4.48s | — |
+| `test_std_iterator.cpp` | Fail | 19.04s | `ranges::empty` viability, then missing `operator==` semantic annotation in `view_interface` |
+| `test_std_ranges.cpp` | Fail | 32.40s | deferred `_Traits::compare`, `basic_string_view` `is_same_v` validation, and variadic `std::invoke` |
 
-Full-suite result: 2756 regular tests pass and all 236 expected-failure tests
+Full-suite result: 2758 regular tests pass and all 236 expected-failure tests
 fail as expected.
 
 ## Active investigations
 
-1. Variadic trailing-return substitution
+1. Variadic deferred-body replay
 
    The one-argument `std::invoke` overload is correctly rejected for a
    two-argument call. The variadic overload passes pack-aware count/shape
-   viability with preserved `_Callable`, `_Ty1`, and `_Types2` bindings, then
-   fails while substituting `_Invoker1<...>::_Call` in its trailing
-   return/noexcept shape. Reduce this with a non-`std` non-empty-pack test and
-   fix substitution at the structured expression/type layer.
+   viability with preserved `_Callable`, `_Ty1`, and `_Types2` bindings. The
+   reduced non-empty-pack trailing-return/noexcept shape now passes, but the
+   standard-header candidate still fails while replaying the inherited
+   `_Invoker1<...>::_Call` body. Investigate replay lookup and materialized
+   owner identity at the structured expression/type layer.
 
 2. Iterator return-type frontier
 
-   Reduce `ranges::empty` candidate viability separately from the unresolved
-   `auto` that reaches `view_interface` mangling. Resolved return types must be
-   established before code generation.
+   Reduce `ranges::empty` candidate viability and the missing `operator==`
+   semantic annotation in `view_interface`. The unresolved-`auto` mangling
+   diagnostic is gone; codegen must receive a resolved overload annotation.
 
-3. Independent `ranges::size` issue
+3. Newly exposed ranges/string-view lookup
 
-   The earlier `make_signed<T>` and scoped-enum diagnostics are removed. Reduce
-   the now-live inconsistent-auto-return diagnostic separately from variadic
-   call substitution.
+   The earlier `make_signed<T>`, scoped-enum, and inconsistent `ranges::size`
+   auto-return diagnostics are removed. Reduce deferred `_Traits::compare`
+   lookup and `basic_string_view` `is_same_v` validation separately from
+   variadic call substitution.
+
+4. Templated callable member-call codegen
+
+   A reduced CPO-alias probe with a defined templated call operator exposed a
+   later bug: `range.size()` can be emitted as an unresolved free `size`
+   symbol. Preserve the member-call semantic binding through emission; do not
+   add a spelling-based codegen fallback.
 
 ## Acceptance criteria
 

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -424,6 +424,8 @@ ASTNode ExpressionSubstitutor::substitute(const ASTNode& expr) {
 		return substituteTypeTraitExpr(expr.as<TypeTraitExprNode>());
 	} else if (expr.is<StaticCastNode>()) {
 		return substituteStaticCast(expr.as<StaticCastNode>());
+	} else if (expr.is<InitializerListConstructionNode>()) {
+		return substituteInitializerListConstruction(expr.as<InitializerListConstructionNode>());
 	} else if (expr.is<NumericLiteralNode>()) {
 		// Literals don't need content substitution, but always return wrapped in ExpressionNode
 		// so downstream evaluators (which require is<ExpressionNode>()) see a consistent result.
@@ -4514,6 +4516,25 @@ ASTNode ExpressionSubstitutor::substituteStaticCast(const StaticCastNode& cast_n
 
 	// Wrap in ExpressionNode
 	ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(new_cast);
+	return ASTNode(&new_expr);
+}
+
+ASTNode ExpressionSubstitutor::substituteInitializerListConstruction(
+	const InitializerListConstructionNode& init_list) {
+	ASTNode substituted_element_type = substitute(init_list.element_type());
+	ASTNode substituted_target_type = substitute(init_list.target_type());
+	std::vector<ASTNode> substituted_elements;
+	substituted_elements.reserve(init_list.size());
+	for (const ASTNode& element : init_list.elements()) {
+		substituted_elements.push_back(substitute(element));
+	}
+
+	ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(
+		InitializerListConstructionNode(
+			substituted_element_type,
+			substituted_target_type,
+			std::move(substituted_elements),
+			init_list.called_from()));
 	return ASTNode(&new_expr);
 }
 

--- a/src/ExpressionSubstitutor.h
+++ b/src/ExpressionSubstitutor.h
@@ -140,6 +140,7 @@ private:
 	ASTNode substituteSizeofExpr(const SizeofExprNode& sizeof_expr);
 	ASTNode substituteTypeTraitExpr(const TypeTraitExprNode& trait_expr);
 	ASTNode substituteStaticCast(const StaticCastNode& cast_node);
+	ASTNode substituteInitializerListConstruction(const InitializerListConstructionNode& init_list);
 	ASTNode substituteLiteral(const ASTNode& literal);
 	void captureParserPackState();
 	void substituteCallArgumentPreservingPackExpansion(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2602,7 +2602,7 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		std::span<const TemplateTypeArg> template_args,
 		const Token& source_token,
 		CVQualifier cv_qualifier);
-	std::optional<TypeSpecifierNode> tryMaterializeDependentDirectAliasTypeSpecifier(
+	std::optional<TypeSpecifierNode> tryMaterializeDependentAliasTypeSpecifier(
 		const TypeSpecifierNode& type_spec,
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args);

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -9,6 +9,7 @@
 #include "NameMangling.h"
 #include "OverloadResolution.h"
 #include "Parser_FunctionTypeHelpers.h"
+#include "TemplateArgumentMaterialization.h"
 #include "TypeTraitEvaluator.h"
 #include "StringLiteralTokenUtils.h"
 
@@ -3578,6 +3579,23 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 		void_type.set_type_index(nativeTypeIndex(TypeCategory::Void));
 		return void_type;
 	};
+	auto normalize_return_type_identity = [](TypeSpecifierNode type) {
+		if (std::optional<TypeSpecifierNode> canonical_builtin =
+				makeCanonicalBuiltinTypeSpecifier(type)) {
+			return *canonical_builtin;
+		}
+		const TypeInfo* type_info = tryGetTypeInfo(type.type_index());
+		if (type_info == nullptr) {
+			return type;
+		}
+		ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+			type_info->registeredTypeIndex().withCategory(type_info->typeEnum()));
+		if (resolved_alias.terminal_type_info == nullptr ||
+			typeIndexContainsDependentPlaceholder(resolved_alias.type_index)) {
+			return type;
+		}
+		return resolveTypeInfoToTypeSpec(*resolved_alias.terminal_type_info, type);
+	};
 
 	// Recursive lambda to search for return statements
 	auto find_return_statements = [&](const auto& self, const ASTNode& node) -> void {
@@ -3589,12 +3607,19 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 					// Store this return type for validation
 					TypeSpecifierNode normalized_type =
 						finalizePlaceholderTypeDeduction(return_type.type(), *expr_type_opt);
-					if (isPlaceholderAutoType(normalized_type.type())) {
+					if (isPlaceholderAutoType(normalized_type.type()) ||
+						typeSpecStillUsesDependentPlaceholder(normalized_type) ||
+						(isDependentTemplateContext() &&
+						 expressionTypeDeductionIsStillDependent(
+							 *ret.expression(),
+							 currentTemplateParamNames()))) {
 						// Expression type could be formed but remains dependent at this
 						// stage; defer hard deduction/consistency checks for now.
 						has_still_dependent_return = true;
 					} else {
-						all_return_types.emplace_back(normalized_type, decl_node.identifier_token());
+						all_return_types.emplace_back(
+							normalize_return_type_identity(normalized_type),
+							decl_node.identifier_token());
 
 						// Set deduced type from first return
 						if (!deduced_type.has_value()) {
@@ -3695,6 +3720,15 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 	// Search the function body
 	find_return_statements(find_return_statements, body);
 
+	if (has_still_dependent_return &&
+		(func_decl.is_template_pattern() || isDependentTemplateContext() || !currentTemplateParamNames().empty())) {
+		// A dependent return may become the same type as the concrete returns
+		// after substitution. Validate the complete set when the specialization
+		// is instantiated instead of comparing a partially materialized set.
+		FLASH_LOG(Parser, Debug, "  Keeping auto return type unresolved in dependent template context");
+		return;
+	}
+
 	// Validate that all return statements have compatible types
 	if (all_return_types.size() > 1) {
 		const TypeSpecifierNode& first_type = all_return_types[0].first;
@@ -3716,12 +3750,6 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 					.commit()));
 			}
 		}
-	}
-
-	if (has_still_dependent_return &&
-		(func_decl.is_template_pattern() || isDependentTemplateContext() || !currentTemplateParamNames().empty())) {
-		FLASH_LOG(Parser, Debug, "  Keeping auto return type unresolved in dependent template context");
-		return;
 	}
 
 	if (!deduced_type.has_value()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -3579,7 +3579,7 @@ void Parser::deduce_and_update_auto_return_type(FunctionDeclarationNode& func_de
 		void_type.set_type_index(nativeTypeIndex(TypeCategory::Void));
 		return void_type;
 	};
-	auto normalize_return_type_identity = [](TypeSpecifierNode type) {
+	auto normalize_return_type_identity = [](const TypeSpecifierNode& type) {
 		if (std::optional<TypeSpecifierNode> canonical_builtin =
 				makeCanonicalBuiltinTypeSpecifier(type)) {
 			return *canonical_builtin;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -2806,6 +2806,27 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			}
 
 			ASTNode resolved_return_type = *return_type_result.node();
+			const TypeSpecifierNode& parsed_return_type =
+				resolved_return_type.as<TypeSpecifierNode>();
+			TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
+				parsed_return_type,
+				resolved_return_type,
+				parsed_return_type.token(),
+				template_params,
+				template_args,
+				[this](const ASTNode& node, const auto& params, const auto& args) {
+					return substituteTemplateParameters(node, params, args);
+				},
+				[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+					return substitute_template_parameter(type_spec, params, args);
+				},
+				nullptr,
+				TypeIndex{},
+				TypeIndex{},
+				false,
+				true);
+			resolved_return_type =
+				emplace_node<TypeSpecifierNode>(substituted_return_type);
 			resolveDependentMemberAlias(resolved_return_type, template_params, template_args);
 			TypeSpecifierNode& resolved_type = resolved_return_type.as<TypeSpecifierNode>();
 			resolveAliasTemplateInstantiation(resolved_type);

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -301,7 +301,7 @@ bool exprContainsIdentifier(const ASTNode& expr, std::string_view pack_name) {
 }
 
 std::optional<TypeSpecifierNode>
-Parser::tryMaterializeDependentDirectAliasTypeSpecifier(
+Parser::tryMaterializeDependentAliasTypeSpecifier(
 	const TypeSpecifierNode& type_spec,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args) {
@@ -323,11 +323,6 @@ Parser::tryMaterializeDependentDirectAliasTypeSpecifier(
 			StringTable::getStringView(dependent_alias_info->baseTemplateName()));
 	}
 	if (!alias_entry.has_value() || !alias_entry->is<TemplateAliasNode>()) {
-		return std::nullopt;
-	}
-
-	const TemplateAliasNode& alias_node = alias_entry->as<TemplateAliasNode>();
-	if (!findDirectAliasTargetParameterIndex(alias_node).has_value()) {
 		return std::nullopt;
 	}
 
@@ -1372,6 +1367,8 @@ ASTNode Parser::substituteTemplateParameters(
 								   TypeCategory::Int, TypeQualifier::None, 32));
 			FLASH_LOG(Templates, Debug, "*** Created NumericLiteralNode, returning");
 			return result;
+		} else if (std::holds_alternative<InitializerListConstructionNode>(expr)) {
+			return substituteWithExpressionSubstitutor(node);
 		} else if (const auto* static_cast_node = std::get_if<StaticCastNode>(&expr)) {
 			// static_cast<Type>(expr) - recursively substitute in both target type and expression
 			const StaticCastNode& cast_node = *static_cast_node;
@@ -1746,12 +1743,12 @@ ASTNode Parser::substituteTemplateParameters(
 			}
 		}
 
-		if (std::optional<TypeSpecifierNode> direct_alias_type =
-				tryMaterializeDependentDirectAliasTypeSpecifier(
+		if (std::optional<TypeSpecifierNode> materialized_alias_type =
+				tryMaterializeDependentAliasTypeSpecifier(
 					type_spec,
 					template_params,
 					template_args)) {
-			return emplace_node<TypeSpecifierNode>(*direct_alias_type);
+			return emplace_node<TypeSpecifierNode>(*materialized_alias_type);
 		}
 
 		// Check if this is a user-defined type that matches a template parameter,

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -101,17 +101,23 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
 
-### Current Windows/MSVC snapshot (2026-07-12)
+### Current Windows/MSVC snapshot (2026-07-13)
 
 Structured template-parameter identity is preserved through deduction and
 substitution. Bare partial-specialization parameters now bind complete template
 arguments, including references, while explicit pattern qualifiers remain
 structural requirements. Substituted member-function declarations also retain
-their function-parameter-pack metadata, including for empty packs. Regressions:
+their function-parameter-pack metadata, including for empty packs. Reparsed
+trailing return types now run through structured substitution before alias
+resolution, including non-empty packs. Dependent `auto` return validation waits
+for complete specialization types and compares canonical builtin/alias identity
+without replacing the original deduced node. Regressions:
 
 - `tests/test_function_template_fixed_param_before_pack_ret0.cpp`
 - `tests/test_const_rvalue_reference_before_pack_lvalue_fail.cpp`
 - `tests/test_template_partial_specialization_inherited_static_call_pack_ret0.cpp`
+- `tests/test_template_partial_specialization_inherited_static_call_nonempty_pack_ret0.cpp`
+- `tests/test_dependent_decltype_cpo_alias_auto_return_ret0.cpp`
 - `tests/test_template_partial_specialization_reordered_identity_ret0.cpp`
 - `tests/test_template_partial_specialization_array_bound_identity_ret0.cpp`
 
@@ -120,23 +126,27 @@ compiler, link, and execution included):
 
 | Header/Test | Status | Runner wall time | Current note |
 |-------------|--------|------------------|--------------|
-| `<cstddef>` (`test_cstddef.cpp`) | ✅ Pass | ~3.22s | Returned 3 as expected. |
-| `<cstdio>` (`test_cstdio_puts.cpp`) | ✅ Pass | ~9.39s | Compiles, links, and returns 0. |
-| `<cstdlib>` (`test_cstdlib.cpp`) | ✅ Pass | ~3.71s | Compiles, links, and returns 0. |
-| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~5.07s | Compiles, links, and returns 0. |
-| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.23s | `ranges::empty` overload viability, then unresolved `auto` during `view_interface` mangling. |
-| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~33.16s | The nested-enum identity and `make_signed<T>` stops are gone; the live diagnostics are variadic `std::invoke` substitution and the independent `ranges::size` inconsistent-`auto` return. |
+| `<cstddef>` (`test_std_cstddef.cpp`) | ✅ Pass | ~2.73s | Compiles, links, and returns the expected value. |
+| `<cstdio>` (`test_std_cstdio.cpp`) | ✅ Pass | ~2.76s | Compiles, links, and returns the expected value. |
+| `<cstdlib>` (`test_std_cstdlib.cpp`) | ✅ Pass | ~2.62s | Compiles, links, and returns the expected value. |
+| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~4.48s | Compiles, links, and returns 0. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Compile error | ~19.04s | The unresolved-`auto` mangling stop is gone. Current diagnostics are `ranges::empty` overload viability and a later missing `operator==` semantic annotation in `view_interface`. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile error | ~32.40s | The `ranges::size` inconsistent-`auto` diagnostic is gone. Current diagnostics are deferred `_Traits::compare`, `basic_string_view` trait validation through `is_same_v`, and the independent variadic `std::invoke` failure. |
 
-The separate `std::invoke` frontier remains its variadic
-`_Invoker1<...>::_Call` trailing-return/noexcept substitution. The one-argument
-candidate is correctly rejected for the two-argument call.
+The separate `std::invoke` frontier remains after structured trailing-return
+substitution: the variadic candidate reaches deferred body replay and still
+fails to materialize `_Invoker1<...>::_Call`. The one-argument candidate is
+correctly rejected for the two-argument call. A reduced CPO-alias probe also
+found a later codegen issue where a templated callable body containing
+`range.size()` can be emitted as an unresolved free `size` symbol; keep that
+separate from the resolved alias/`auto` semantic slice.
 
 Class-scope identity for static member-function templates is now preserved
 separately from implicit-object semantics, and nested enums are registered from
 their declaration `TypeIndex`. Regression:
 `tests/test_member_template_nested_enum_identity_ret0.cpp`.
 
-Full Windows validation after the change: 2756 regular tests passed, all 236
+Full Windows validation after the change: 2758 regular tests passed, all 236
 expected-fail tests failed as expected, with no crashes or return mismatches.
 
 ### 2026-05-28 Linux/libstdc++ template-substitution metadata follow-up

--- a/tests/test_dependent_decltype_cpo_alias_auto_return_ret0.cpp
+++ b/tests/test_dependent_decltype_cpo_alias_auto_return_ret0.cpp
@@ -1,0 +1,43 @@
+template <class T>
+T&& declval();
+
+namespace api {
+	struct SizeFunction {
+		template <class Range>
+		constexpr unsigned long long operator()(Range& range) const;
+	};
+
+	inline constexpr SizeFunction size;
+
+	template <class Range>
+	using range_size_t = decltype(size(declval<Range&>()));
+
+	template <class Range>
+	struct DropView {
+		Range range;
+		range_size_t<Range> count;
+
+		constexpr auto size() {
+			const auto current = range.size();
+			if (current < count) {
+				return range_size_t<Range>{0};
+			} else {
+				return static_cast<range_size_t<Range>>(current - count);
+			}
+		}
+	};
+}
+
+struct SmallRange {
+	unsigned long long count;
+
+	constexpr unsigned long long size() {
+		return count;
+	}
+};
+
+int main() {
+	api::DropView<SmallRange> view{{7}, 2};
+	using Result = decltype(view.size());
+	return sizeof(Result) == sizeof(unsigned long long) && view.size() == 5 ? 0 : 1;
+}

--- a/tests/test_template_partial_specialization_inherited_static_call_nonempty_pack_ret0.cpp
+++ b/tests/test_template_partial_specialization_inherited_static_call_nonempty_pack_ret0.cpp
@@ -1,0 +1,48 @@
+// Regression: a non-empty function parameter pack must remain materialized
+// while reparsing a dependent inherited static call in a trailing return type.
+
+template <class Callable, class First>
+struct InvokeBase {
+	template <class C, class T, class... Rest>
+	static constexpr auto call(C&& callable, T&& first, Rest&&... rest)
+		noexcept(noexcept(static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...)))
+		-> decltype(static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...)) {
+		return static_cast<C&&>(callable)(static_cast<T&&>(first), static_cast<Rest&&>(rest)...);
+	}
+};
+
+template <class Callable, class First, bool IsCallable = true>
+struct SelectInvoker;
+
+template <class Callable, class First>
+struct SelectInvoker<Callable, First, true> : InvokeBase<Callable, First> {};
+
+template <class Callable, class First, class... Rest>
+constexpr auto invokeLike(Callable&& callable, First&& first, Rest&&... rest)
+	noexcept(noexcept(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)))
+	-> decltype(SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...)) {
+	return SelectInvoker<Callable, First>::call(
+		static_cast<Callable&&>(callable),
+		static_cast<First&&>(first),
+		static_cast<Rest&&>(rest)...);
+}
+
+struct AddValues {
+	constexpr int operator()(int& first, short second) const {
+		return first + second;
+	}
+};
+
+int main() {
+	AddValues function;
+	int first = 40;
+	short second = 2;
+	using Result = decltype(invokeLike(function, first, second));
+	return sizeof(Result) == sizeof(int) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- substitute reparsed trailing return types through the existing structured type-substitution path, including inherited static calls with non-empty packs
- defer dependent `auto` return validation until substitution can resolve the type, while preserving canonical type identity for consistency comparisons
- materialize deferred `decltype` aliases and initializer-list constructions through shared substitution helpers
- add reduced non-`std` regressions and refresh the standard-header frontier documentation and timings

## Standard-header progress

- `<ranges>` no longer reports the inconsistent `auto` return deduction failure in `ranges::size`
- `<iterator>` no longer reaches the unresolved-`auto` mangling failure
- the headers still expose later independent frontiers: `ranges::empty` overload resolution / `view_interface` equality annotation, `_Traits::compare` / `is_same_v`, `std::invoke` body replay, and a later CPO member-call codegen issue

## Validation

- standard-header controls: `cstddef` 2.73s, `cstdio` 2.76s, `cstdlib` 2.62s, `type_traits` 4.48s
- frontier probes: `iterator` 19.04s and `ranges` 32.40s, both advancing to later diagnostics