### PR TITLE
Canonicalize instantiated function and lazy member types

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,15 @@
 # Known Issues
 
+## Namespace-qualified lazy class-template self-copy miscompiles
+Wrapping the fixture in
+`tests/test_explicit_ctor_same_template_copy_init_ret0.cpp` in a non-global
+namespace and qualifying both `ReverseIter<int*>` uses in `main` compiles and
+links, but returns 1 instead of 0 because `copy_self()` does not preserve the
+stored pointer value. The same deferred member-body self-copy works in the
+global namespace. This is a separate namespace-sensitive runtime/codegen issue;
+the local declaration's current-instantiation `TypeIndex` is already rebound to
+the concrete owner before codegen.
+
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner
 pointer in `InlineVector::size()` during `materializeMatchingConstructorTemplate`.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,15 @@
 # Known Issues
 
+## Nested member lazy identity is shared across outer instantiations
+When two outer class-template instantiations contain the same nested class,
+their lazy nested member functions still share the pattern declaration identity.
+In `tests/test_nested_class_constructor_template_param_ret42.cpp`, replacing the
+final field reads with `i.get()` and `d.get()` causes the lookup for the first
+owner to materialize the second owner's `get()` body. The first call then retains
+the dependent `T` return metadata and compilation fails during `operator+`
+resolution. Lazy nested-member registry/cache identity must include the concrete
+owner independently of the shared source declaration.
+
 ## Namespace-qualified lazy class-template self-copy miscompiles
 Wrapping the fixture in
 `tests/test_explicit_ctor_same_template_copy_init_ret0.cpp` in a non-global

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -2,6 +2,7 @@
 #include "LazyMemberResolver.h"
 #include "StringBuilder.h"
 #include "NameMangling.h"
+#include "NamespaceRegistry.h"
 #include "Log.h"
 #include <algorithm>
 #include <cstring>
@@ -1439,11 +1440,22 @@ bool StructTypeInfo::isOwnTypeIndex(TypeIndex param_type_index) const {
 		return true;
 	}
 
-	// Template instantiation fallback: allow matching the underlying base template pattern.
-	if (own_info.isTemplateInstantiation() && own_info.baseTemplateName() == param_info.name()) {
-		return true;
-	}
-	if (param_info.isTemplateInstantiation() && param_info.baseTemplateName() == own_info.name()) {
+	const auto namesPrimaryTemplate = [](const TypeInfo& instantiation, const TypeInfo& primary) {
+		if (!instantiation.isTemplateInstantiation()) {
+			return false;
+		}
+		StringHandle primary_name = instantiation.baseTemplateName();
+		if (instantiation.sourceNamespace().isValid() &&
+			!instantiation.sourceNamespace().isGlobal()) {
+			primary_name = gNamespaceRegistry.buildQualifiedIdentifier(
+				instantiation.sourceNamespace(),
+				primary_name);
+		}
+		return primary_name == primary.name();
+	};
+
+	if (namesPrimaryTemplate(own_info, param_info) ||
+		namesPrimaryTemplate(param_info, own_info)) {
 		return true;
 	}
 

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -1073,6 +1073,12 @@ public:
 		: name_(name), is_class_(is_class), is_union_(is_union) {}
 
 	StringHandle name() const { return name_; }
+	StringHandle semantic_name() const {
+		return semantic_name_.isValid() ? semantic_name_ : name_;
+	}
+	void set_semantic_name(StringHandle semantic_name) {
+		semantic_name_ = semantic_name;
+	}
 	std::span<const StructMemberDecl> members() const { return members_; }
 	std::span<const StructMemberFunctionDecl> member_functions() const { return member_functions_; }
 	std::vector<StructMemberFunctionDecl>& member_functions() { return member_functions_; }
@@ -1421,6 +1427,7 @@ public:
 
 private:
 	StringHandle name_;	// Points directly into source text from lexer token
+	StringHandle semantic_name_; // Canonical identity for replayed local classes
 	std::vector<StructMemberDecl> members_;
 	std::vector<StructMemberFunctionDecl> member_functions_;
 	std::vector<BaseClassSpecifier> base_classes_;  // Base classes for inheritance

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -57,6 +57,29 @@ struct ConstAwareMemberCandidateSet;
 
 namespace ConstExpr {
 
+inline std::optional<size_t> tryGetConstexprTypeSizeBytes(const TypeSpecifierNode& type_spec) {
+	if (type_spec.is_array()) {
+		const std::span<const size_t> dimensions = type_spec.array_dimensions();
+		TypeSpecifierNode element_type = type_spec;
+		element_type.set_array_dimensions({});
+		const int element_size_bits = getTypeSpecSizeBits(element_type);
+		if (element_size_bits <= 0) {
+			return std::nullopt;
+		}
+		size_t total_size = static_cast<size_t>(element_size_bits) / 8;
+		for (size_t dimension : dimensions) {
+			total_size *= dimension;
+		}
+		return total_size;
+	}
+
+	const int size_bits = getTypeSpecSizeBits(type_spec);
+	if (size_bits <= 0) {
+		return std::nullopt;
+	}
+	return static_cast<size_t>(size_bits) / 8;
+}
+
 inline thread_local std::unordered_set<const StructStaticMember*> gEvaluatingStaticMembers;
 
 struct StaticMemberEvaluationGuard {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -185,29 +185,6 @@ std::optional<EvalResult> tryEvaluateSimpleConstexprTypeHelperCall(
 }
 
 
-std::optional<size_t> tryGetConstexprTypeSizeBytes(const TypeSpecifierNode& type_spec) {
-	if (type_spec.is_array()) {
-		const std::span<const size_t> dimensions = type_spec.array_dimensions();
-		TypeSpecifierNode element_type = type_spec;
-		element_type.set_array_dimensions({});
-		const int element_size_bits = getTypeSpecSizeBits(element_type);
-		if (element_size_bits <= 0) {
-			return std::nullopt;
-		}
-		size_t total_size = static_cast<size_t>(element_size_bits) / 8;
-		for (size_t dimension : dimensions) {
-			total_size *= dimension;
-		}
-		return total_size;
-	}
-
-	const int size_bits = getTypeSpecSizeBits(type_spec);
-	if (size_bits <= 0) {
-		return std::nullopt;
-	}
-	return static_cast<size_t>(size_bits) / 8;
-}
-
 // Returns the total element count for an array declaration when constexpr evaluation can
 // determine it immediately. Handles both explicit dimensions (`int a[2][3]`) and
 // inferred-size arrays backed by an initializer list (`int a[] = {1, 2, 3}`).

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1037,7 +1037,8 @@ InlineVector<TemplateTypeArg, 4> ExpressionSubstitutor::materializeDependentReco
 				context_binding.has_value()) {
 				arg = rebindDependentTemplateTypeArg(*context_binding, arg);
 			}
-		} else if (!arg.is_value && arg.type_index.is_valid()) {
+		}
+		if (!arg.is_value && arg.type_index.is_valid()) {
 			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
 				if (arg_type_info->isDependentMemberType()) {
 					if (const TypeInfo* resolved_member_type =
@@ -1056,6 +1057,43 @@ InlineVector<TemplateTypeArg, 4> ExpressionSubstitutor::materializeDependentReco
 				if (auto subst_it = param_map_.find(arg_type_name);
 					subst_it != param_map_.end()) {
 					arg = rebindDependentTemplateTypeArg(subst_it->second, arg);
+				}
+			}
+		}
+		if (!arg.is_value && arg.type_index.is_valid() &&
+			depth < kMaxDependentMemberTypeResolutionDepth) {
+			if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index);
+				arg_type_info != nullptr &&
+				arg_type_info->isTemplateInstantiation() &&
+				arg_type_info->is_incomplete_instantiation_ &&
+				!arg_type_info->templateArgs().empty()) {
+				MaterializedStoredTemplateArgs nested_args = materializeStoredTemplateArgs(
+					*arg_type_info,
+					/*evaluate_dependent_member_values=*/true,
+					depth + 1);
+				if (!templateArgsStillDependent(nested_args.args)) {
+					Parser::AliasTemplateMaterializationResult materialized_type =
+						parser_.materializeCanonicalOwnerTypeForLookup(
+							*arg_type_info,
+							nested_args.args);
+					const TypeInfo* resolved_type_info = materialized_type.resolved_type_info;
+					if (resolved_type_info == nullptr) {
+						StringHandle canonical_name = materialized_type.canonicalNameHandle();
+						if (canonical_name.isValid()) {
+							resolved_type_info = findTypeByName(canonical_name);
+						}
+					}
+					if (resolved_type_info != nullptr) {
+						TypeIndex resolved_index =
+							resolved_type_info->registeredTypeIndex().withCategory(
+								resolved_type_info->typeEnum());
+						TemplateTypeArg resolved_arg = makeTemplateTypeArgFromResolvedAlias(
+							resolveAliasTypeInfo(resolved_index),
+							resolved_index);
+						arg = rebindDependentTemplateTypeArg(resolved_arg, arg);
+						arg.dependent_name = {};
+						arg.is_dependent = false;
+					}
 				}
 			}
 		}

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1321,7 +1321,9 @@ bool AstToIr::beginStructDeclarationCodegen(const StructDeclarationNode& node) {
 	// For nested classes, we need to use the fully qualified name from TypeInfo
 	// If current_struct_name_ is valid, this is a nested class, so construct fully qualified name
 	StringHandle lookup_name;
-	if (frame.saved_struct_name.isValid()) {
+	if (is_local_struct && node.semantic_name() != node.name()) {
+		lookup_name = node.semantic_name();
+	} else if (frame.saved_struct_name.isValid()) {
 		// This is a nested class - construct fully qualified name like "Outer::Inner"
 		StringBuilder qualified_name_builder;
 		qualified_name_builder.append(StringTable::getStringView(frame.saved_struct_name))

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -87,6 +87,10 @@ class Evaluator;
 struct EvalResult;
 }
 
+namespace SemanticValidation {
+std::optional<StringHandle> findInvalidConcreteSizeofTypeOperand(const ASTNode& root);
+}
+
 class SemanticAnalysis;
 
 // RAII helper to execute a cleanup function on scope exit

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1559,6 +1559,10 @@ private:
 	// whose return type is itself a function pointer.
 	ParseResult parse_function_pointer_parameter_types(std::vector<TypeIndex>& out_param_types, bool& out_is_variadic);
 	bool parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::string_view log_context);
+	void bindLocalTypeAlias(
+		const Token& alias_token,
+		const TypeCreationResult& alias_type,
+		const TypeSpecifierNode& resolved_type_spec);
 	ParseResult parse_member_function_declarator_result(ParseResult& member_result, FunctionDeclarationNode*& out_func_decl, DeclarationNode*& out_decl);
 	ParseResult validateOperatorSignature(const FunctionDeclarationNode& func_decl, bool is_member) const;
 	ParseResult validateMemberOperatorSignature(const FunctionDeclarationNode& func_decl) const;

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1127,6 +1127,9 @@ private:
 	// Use FlashCpp::TemplateDepthGuard to increment/decrement; use ScopedState to temporarily
 	// suppress (set to 0) during SFINAE and lazy instantiation.
 	size_t parsing_template_depth_ = 0;
+	// True only while token-replaying a materialized template member body whose
+	// parsed AST contains a block-scope class declaration.
+	bool replaying_template_member_local_classes_ = false;
 
 	// Phase 1 two-phase name lookup enforcement (C++20 [temp.res]/9).
 	// Set to the opening-brace line of the template body being re-parsed.

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -206,13 +206,17 @@ inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 	if (type_spec.has_function_signature()) {
 		signature = type_spec.function_signature();
 	}
-	if (ResolvedAliasTypeInfo substituted_alias = resolveAliasTypeInfo(substituted_type_index);
-		!signature.has_value() && substituted_alias.function_signature.has_value()) {
-		signature = substituted_alias.function_signature;
+	if (!signature.has_value()) {
+		if (ResolvedAliasTypeInfo substituted_alias = resolveAliasTypeInfo(substituted_type_index);
+			substituted_alias.function_signature.has_value()) {
+			signature = substituted_alias.function_signature;
+		}
 	}
-	if (ResolvedAliasTypeInfo original_alias = resolveAliasTypeInfo(type_spec.type_index());
-		!signature.has_value() && original_alias.function_signature.has_value()) {
-		signature = original_alias.function_signature;
+	if (!signature.has_value()) {
+		if (ResolvedAliasTypeInfo original_alias = resolveAliasTypeInfo(type_spec.type_index());
+			original_alias.function_signature.has_value()) {
+			signature = original_alias.function_signature;
+		}
 	}
 	if (!signature.has_value() &&
 		source_member != nullptr &&

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -127,6 +127,72 @@ inline const StructMember* findDirectStructMemberByName(
 }
 
 template <typename ParamContainer, typename ArgContainer>
+inline TypeIndex substituteTemplateParameterTypeIndex(
+	TypeIndex original_type_index,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args) {
+	TypeIndex substituted_type_index = original_type_index;
+	bool substituted = false;
+	forEachNonPackTemplateParamArgBinding(
+		template_params,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (substituted ||
+				param.kind() != TemplateParameterKind::Type ||
+				!arg.isTypeArgument() ||
+				!FlashCpp::equalTypeIndexIdentity(
+					original_type_index,
+					param.registered_type_index()) ||
+				!FlashCpp::hasConcreteTemplateIdentity(arg.type_index)) {
+				return;
+			}
+			substituted_type_index =
+				FlashCpp::canonicalizeTemplateIdentityTypeIndex(arg.type_index);
+			substituted = true;
+		});
+	return substituted_type_index;
+}
+
+template <typename ParamContainer, typename ArgContainer>
+inline const TemplateTypeArg* findTemplateArgByRegisteredTypeIndex(
+	TypeIndex type_index,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args) {
+	const TemplateTypeArg* matched_arg = nullptr;
+	forEachNonPackTemplateParamArgBinding(
+		template_params,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (matched_arg == nullptr &&
+				param.kind() == TemplateParameterKind::Type &&
+				FlashCpp::equalTypeIndexIdentity(
+					type_index,
+					param.registered_type_index())) {
+				matched_arg = &arg;
+			}
+		});
+	return matched_arg;
+}
+
+template <typename ParamContainer, typename ArgContainer>
+inline FunctionSignature substituteTemplateFunctionSignature(
+	FunctionSignature signature,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args) {
+	signature.return_type_index = substituteTemplateParameterTypeIndex(
+		signature.return_type_index,
+		template_params,
+		template_args);
+	for (TypeIndex& parameter_type_index : signature.parameter_type_indices) {
+		parameter_type_index = substituteTemplateParameterTypeIndex(
+			parameter_type_index,
+			template_params,
+			template_args);
+	}
+	return signature;
+}
+
+template <typename ParamContainer, typename ArgContainer>
 inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 	const TypeSpecifierNode& type_spec,
 	TypeIndex substituted_type_index,
@@ -136,28 +202,36 @@ inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 	if (substituted_type_index.category() != TypeCategory::FunctionPointer &&
 		substituted_type_index.category() != TypeCategory::MemberFunctionPointer)
 		return std::nullopt;
-	if (type_spec.has_function_signature())
-		return type_spec.function_signature();
+	std::optional<FunctionSignature> signature;
+	if (type_spec.has_function_signature()) {
+		signature = type_spec.function_signature();
+	}
 	if (ResolvedAliasTypeInfo substituted_alias = resolveAliasTypeInfo(substituted_type_index);
-		substituted_alias.function_signature.has_value()) {
-		return substituted_alias.function_signature;
+		!signature.has_value() && substituted_alias.function_signature.has_value()) {
+		signature = substituted_alias.function_signature;
 	}
 	if (ResolvedAliasTypeInfo original_alias = resolveAliasTypeInfo(type_spec.type_index());
-		original_alias.function_signature.has_value()) {
-		return original_alias.function_signature;
+		!signature.has_value() && original_alias.function_signature.has_value()) {
+		signature = original_alias.function_signature;
 	}
-	if (source_member != nullptr && source_member->function_signature.has_value())
-		return source_member->function_signature;
+	if (!signature.has_value() &&
+		source_member != nullptr &&
+		source_member->function_signature.has_value()) {
+		signature = source_member->function_signature;
+	}
 
-	StringHandle type_name_handle = getStructuredTypeName(type_spec);
-	if (!type_name_handle.isValid())
+	if (!signature.has_value()) {
+		if (const auto* arg = findTemplateArgByRegisteredTypeIndex(
+				type_spec.type_index(), template_params, template_args)) {
+			signature = arg->function_signature;
+		}
+	}
+	if (!signature.has_value())
 		return std::nullopt;
-
-	if (const auto* arg = findTemplateArgByName(type_name_handle.view(), template_params, template_args)) {
-		if (arg->function_signature.has_value())
-			return arg->function_signature;
-	}
-	return std::nullopt;
+	return substituteTemplateFunctionSignature(
+		*signature,
+		template_params,
+		template_args);
 }
 
 template <typename ParamContainer, typename ArgContainer>
@@ -1110,9 +1184,7 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 			template_params,
 			template_args);
 	}
-	if (original_type_spec.has_function_signature()) {
-		substituted_type.set_function_signature(original_type_spec.function_signature());
-	} else if (auto signature = resolveTemplateFunctionPointerSignature(
+	if (auto signature = resolveTemplateFunctionPointerSignature(
 				   original_type_spec,
 				   substituted_type.type_index(),
 				   nullptr,
@@ -1442,16 +1514,13 @@ inline void propagateFunctionSignatureFromTemplateArg(
 	TypeIndex substituted_type_index,
 	const ParamContainer& template_params,
 	const ArgContainer& template_args) {
-	if (orig_type.has_function_signature()) {
-		substituted_type.set_function_signature(orig_type.function_signature());
-	} else if (substituted_type_index.category() == TypeCategory::FunctionPointer ||
-			   substituted_type_index.category() == TypeCategory::MemberFunctionPointer) {
-		if (const auto* arg = findTemplateArgByName(
-				orig_type.token().value(), template_params, template_args)) {
-			if (arg->function_signature.has_value()) {
-				substituted_type.set_function_signature(*arg->function_signature);
-			}
-		}
+	if (auto signature = resolveTemplateFunctionPointerSignature(
+			orig_type,
+			substituted_type_index,
+			nullptr,
+			template_params,
+			template_args)) {
+		substituted_type.set_function_signature(*signature);
 	}
 }
 

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -1344,15 +1344,17 @@ LazyMemberFunctionInfo buildLazyNestedMemberFunctionInfo(
 	return lazy_mem_info;
 }
 
+template <typename MaterializeConstructorFn>
 inline void addNestedMemberFunctionsToStructInfo(
 	const StructDeclarationNode& nested_struct,
 	StructTypeInfo& nested_struct_info,
-	SourceMemberStructInfoIndexMaps* struct_info_index_maps) {
+	SourceMemberStructInfoIndexMaps* struct_info_index_maps,
+	MaterializeConstructorFn&& materialize_constructor) {
 	for (const StructMemberFunctionDecl& mem_func : nested_struct.member_functions()) {
 		if (mem_func.is_constructor || mem_func.is_destructor) {
 			if (mem_func.is_constructor) {
 				nested_struct_info.addConstructor(
-					mem_func.function_declaration,
+					materialize_constructor(mem_func),
 					mem_func.access);
 			} else {
 				nested_struct_info.addDestructor(
@@ -1480,7 +1482,10 @@ inline void registerNestedMemberFunctionsForLazy(
 	addNestedMemberFunctionsToStructInfo(
 		nested_struct,
 		nested_struct_info,
-		nullptr);
+		nullptr,
+		[](const StructMemberFunctionDecl& mem_func) {
+			return mem_func.function_declaration;
+		});
 	registerNestedMemberFunctionsLazyEntries(
 		nested_struct,
 		class_template_name,

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -3872,6 +3872,11 @@ inline void instantiateDeferredStaticInitializerCalls(
 	});
 }
 
+enum class UnresolvedSizeofPolicy {
+	AllowDependent,
+	RejectAfterSubstitution,
+};
+
 template <typename TemplateParamsContainer>
 inline std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMemberInitializer(
 	std::optional<ASTNode>& initializer,
@@ -3883,7 +3888,8 @@ inline std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 	TypeIndex type_index,
 	size_t size_in_bytes,
 	ReferenceQualifier reference_qualifier,
-	int pointer_depth) {
+	int pointer_depth,
+	UnresolvedSizeofPolicy unresolved_sizeof_policy) {
 	if (!initializer.has_value()) {
 		return std::nullopt;
 	}
@@ -3915,6 +3921,16 @@ inline std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 			ExpressionSubstitutor substitutor(substitution_environment, parser);
 			substitutor.setCurrentOwnerTypeName(struct_info->getName());
 			initializer = substitutor.substitute(initializer.value());
+		}
+	}
+	if (unresolved_sizeof_policy == UnresolvedSizeofPolicy::RejectAfterSubstitution) {
+		if (std::optional<StringHandle> invalid_type =
+				SemanticValidation::findInvalidConcreteSizeofTypeOperand(*initializer);
+			invalid_type.has_value()) {
+			throw CompileError(
+				std::string("sizeof operand '") +
+				std::string(StringTable::getStringView(*invalid_type)) +
+				"' is incomplete or unresolved after template substitution");
 		}
 	}
 
@@ -3987,7 +4003,10 @@ inline void retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 				static_member.type_index,
 				static_member.size,
 				static_member.reference_qualifier,
-				static_member.pointer_depth);
+				static_member.pointer_depth,
+				static_member.is_constexpr
+					? UnresolvedSizeofPolicy::RejectAfterSubstitution
+					: UnresolvedSizeofPolicy::AllowDependent);
 		if (!normalized_initializer.has_value()) {
 			continue;
 		}

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -348,6 +348,10 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 
 	auto struct_name = name_token.handle();
 	const bool is_local_class_declaration = current_function_ != nullptr;
+	bool owns_replayed_local_class_identity =
+		replaying_template_member_local_classes_ &&
+		is_local_class_declaration &&
+		struct_parsing_context_stack_.empty();
 	std::vector<DelayedFunctionBody> saved_local_class_parent_delayed_bodies;
 	if (is_local_class_declaration) {
 		saved_local_class_parent_delayed_bodies = std::move(delayed_function_bodies_);
@@ -382,7 +386,16 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			break;
 		}
 	}
-
+	if (owns_replayed_local_class_identity &&
+		peek() != "{"_tok &&
+		peek() != ":"_tok &&
+		peek() != "final"_tok &&
+		peek() != "alignas"_tok &&
+		peek() != ";"_tok) {
+		// An elaborated type specifier such as `struct Point value` refers to
+		// an existing type; it does not declare a new block-scope class.
+		owns_replayed_local_class_identity = false;
+	}
 	// Register the struct type in the global type system EARLY
 	// This allows member functions (like constructors) to reference the struct type
 	// We'll fill in the struct info later after parsing all members
@@ -440,7 +453,26 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 		qualified_struct_name = full_qualified_name; // Also update qualified_struct_name for implicit constructors
 		type_name = full_qualified_name; // TypeInfo should also use fully qualified name
 	}
-
+	if (owns_replayed_local_class_identity) {
+		const Token function_token = current_function_->decl_node().identifier_token();
+		StringBuilder local_identity;
+		if (!current_function_->parent_struct_name().empty()) {
+			local_identity.append(current_function_->parent_struct_name()).append("::");
+		}
+		local_identity
+			.append(function_token.handle())
+			.append("::$local$")
+			.append(static_cast<int64_t>(name_token.file_index()))
+			.append('_')
+			.append(static_cast<int64_t>(name_token.line()))
+			.append('_')
+			.append(static_cast<int64_t>(name_token.column()))
+			.append("::")
+			.append(struct_name);
+		type_name = StringTable::getOrInternStringHandle(local_identity.commit());
+		qualified_struct_name = type_name;
+		full_qualified_name = type_name;
+	}
 	TypeInfo& struct_type_info = add_struct_type(type_name, current_namespace_handle);
 
 	// For nested classes and namespace classes, register lookup aliases that mirror
@@ -456,7 +488,30 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 		true,
 		true,
 		!parsing_template_class_);
-
+	if (owns_replayed_local_class_identity) {
+		getTypesByNameMap().insert_or_assign(struct_name, &struct_type_info);
+	} else if (replaying_template_member_local_classes_ && is_nested_class) {
+		bool nested_in_replayed_local_class = false;
+		StringBuilder lexical_nested_name;
+		for (const StructParsingContext& context : struct_parsing_context_stack_) {
+			if (context.struct_node != nullptr) {
+				lexical_nested_name.append(context.struct_node->name());
+				nested_in_replayed_local_class =
+					nested_in_replayed_local_class ||
+					context.struct_node->semantic_name() != context.struct_node->name();
+			} else {
+				lexical_nested_name.append(context.struct_name);
+			}
+			lexical_nested_name.append("::");
+		}
+		lexical_nested_name.append(struct_name);
+		StringHandle lexical_nested_handle = StringTable::getOrInternStringHandle(
+			lexical_nested_name.commit());
+		if (nested_in_replayed_local_class) {
+			getTypesByNameMap().insert_or_assign(struct_name, &struct_type_info);
+			getTypesByNameMap().insert_or_assign(lexical_nested_handle, &struct_type_info);
+		}
+	}
 	// Check for alignas specifier after struct name (if not already specified)
 	if (!custom_alignment.has_value()) {
 		custom_alignment = parse_alignas_specifier();
@@ -465,9 +520,12 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 	// Create struct declaration node - string_view points directly into source text
 	auto [struct_node, struct_ref] = emplace_node_ref<StructDeclarationNode>(struct_name, is_class);
 	struct_ref.set_is_local_class(is_local_class_declaration);
+	if (owns_replayed_local_class_identity) {
+		struct_ref.set_semantic_name(type_name);
+	}
 
 	// Push struct parsing context for nested class support
-	struct_parsing_context_stack_.push_back({StringTable::getStringView(struct_name),
+	struct_parsing_context_stack_.push_back({StringTable::getStringView(struct_ref.semantic_name()),
 											 &struct_ref,
 											 nullptr,
 											 gSymbolTable.get_current_namespace_handle(),
@@ -3918,19 +3976,29 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 
 	// Parse all delayed function bodies using unified helper (Phase 5)
 	for (auto& delayed : delayed_function_bodies_) {
-		// Member function templates (e.g., template<typename U> ClassName(U arg) {...})
-		// must always defer body parsing until instantiation. Parsing them while the
-		// surrounding class template still has unbound parameters incorrectly forces
-		// lookup and deduction in a non-instantiated context.
-		if (delayed.is_member_function_template) {
+		// Keep the token-backed definition for every class-template member. The
+		// pattern body is still parsed below for early semantic checks, while lazy
+		// instantiation can replay the definition with concrete template bindings.
+		// This is required for declarations inside the body, including local
+		// classes, whose types belong to the function-template specialization.
+		if (parsing_template_class_ || delayed.is_member_function_template) {
 			if (delayed.is_constructor && delayed.ctor_node) {
 				delayed.ctor_node->set_template_body_position(delayed.body_start);
 				if (delayed.has_initializer_list) {
 					delayed.ctor_node->set_template_initializer_list_position(delayed.initializer_list_start);
 				}
+			} else if (delayed.is_destructor && delayed.dtor_node) {
+				delayed.dtor_node->set_template_body_position(delayed.body_start);
 			} else if (delayed.func_node) {
 				delayed.func_node->set_template_body_position(delayed.body_start);
 			}
+		}
+
+		// Member function templates (e.g., template<typename U> ClassName(U arg) {...})
+		// must always defer body parsing until instantiation. Parsing them while the
+		// surrounding class template still has unbound parameters incorrectly forces
+		// lookup and deduction in a non-instantiated context.
+		if (delayed.is_member_function_template) {
 			continue; // body deferred to instantiation time
 		}
 

--- a/src/Parser_Decl_TopLevel.cpp
+++ b/src/Parser_Decl_TopLevel.cpp
@@ -947,7 +947,9 @@ ParseResult Parser::parse_using_directive_or_declaration() {
 						resolveAliasTemplateInstantiation(resolved_type_spec);
 					}
 
-					TypeInfo& alias_type_info = register_type_alias(alias_token.handle(), resolved_type_spec);
+					TypeCreationResult alias_type = register_type_alias(alias_token.handle(), resolved_type_spec);
+					TypeInfo& alias_type_info = alias_type.info;
+					bindLocalTypeAlias(alias_token, alias_type, resolved_type_spec);
 
 					// Also register with namespace-qualified name for type aliases defined in namespaces
 					NamespaceHandle namespace_handle = gSymbolTable.get_current_namespace_handle();

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -4,6 +4,20 @@
 #include "OverloadResolution.h"
 #include "TypeTraitEvaluator.h"
 
+void Parser::bindLocalTypeAlias(
+	const Token& alias_token,
+	const TypeCreationResult& alias_type,
+	const TypeSpecifierNode& resolved_type_spec) {
+	const ScopeType scope_type = gSymbolTable.get_current_scope_type();
+	if (scope_type != ScopeType::Function && scope_type != ScopeType::Block) {
+		return;
+	}
+	TypeSpecifierNode alias_symbol_type = resolved_type_spec;
+	alias_symbol_type.set_type_index(alias_type.index);
+	ASTNode alias_symbol = emplace_node<TypedefDeclarationNode>(alias_symbol_type, alias_token);
+	gSymbolTable.insert(alias_token.handle(), alias_symbol);
+}
+
 // Parse the function type suffix used in aliases such as ReturnType (*)(Args...),
 // including vendor calling conventions, variadic ellipses, and trailing noexcept.
 // Returns false after restoring the token position when the next tokens are not
@@ -2101,7 +2115,9 @@ ParseResult Parser::parse_typedef_declaration() {
 	// Register the typedef alias in the type system
 	// The typedef should resolve to the underlying type, not be a new UserDefined type
 	// We create a TypeInfo entry that mirrors the underlying type
-	register_type_alias(StringTable::getOrInternStringHandle(qualified_alias_name), type_spec);
+	TypeCreationResult alias_type = register_type_alias(
+		StringTable::getOrInternStringHandle(qualified_alias_name), type_spec);
+	bindLocalTypeAlias(*alias_token, alias_type, type_spec);
 
 	// Create and return typedef declaration node
 	auto typedef_node = emplace_node<TypedefDeclarationNode>(type_spec, *alias_token);

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -1,4 +1,5 @@
 #include "Parser.h"
+#include "AstTraversal.h"
 #include "CallNodeHelpers.h"
 #include "ConstExprEvaluator.h"
 #include "LazyMemberResolver.h"
@@ -67,6 +68,70 @@ bool qualifiedNameNamesDataMember(std::string_view qualified_name) {
 }
 
 } // namespace
+
+std::optional<StringHandle> SemanticValidation::findInvalidConcreteSizeofTypeOperand(
+	const ASTNode& root) {
+	std::optional<StringHandle> invalid_type_name;
+	AstTraversal::visitASTWithDecisions(root, [&](const ASTNode& current) {
+		const SizeofExprNode* sizeof_expression = nullptr;
+		if (current.is<SizeofExprNode>()) {
+			sizeof_expression = &current.as<SizeofExprNode>();
+		} else if (current.is<ExpressionNode>()) {
+			sizeof_expression = std::get_if<SizeofExprNode>(&current.as<ExpressionNode>());
+		}
+		if (sizeof_expression == nullptr || !sizeof_expression->is_type() ||
+			!sizeof_expression->type_or_expr().is<TypeSpecifierNode>()) {
+			return AstTraversal::VisitDecision::Continue;
+		}
+
+		const TypeSpecifierNode& type_spec =
+			sizeof_expression->type_or_expr().as<TypeSpecifierNode>();
+		if (type_spec.pointer_depth() > 0) {
+			return AstTraversal::VisitDecision::Continue;
+		}
+
+		auto reject_type = [&]() {
+			StringHandle structured_name = getStructuredTypeName(type_spec);
+			invalid_type_name = structured_name.isValid()
+				? structured_name
+				: type_spec.token().handle();
+			return AstTraversal::VisitDecision::Stop;
+		};
+
+		if (typeSpecStillUsesDependentPlaceholder(type_spec)) {
+			return reject_type();
+		}
+
+		const ResolvedAliasTypeInfo resolved_alias =
+			resolveAliasTypeInfo(type_spec.type_index());
+		const TypeCategory category = resolved_alias.type_index.is_valid()
+			? resolved_alias.typeEnum()
+			: type_spec.category();
+		if (category == TypeCategory::Void || category == TypeCategory::Function ||
+			type_spec.has_unsized_outer_array_dimension()) {
+			return reject_type();
+		}
+		for (size_t extent : type_spec.array_dimensions()) {
+			if (extent == 0) {
+				return reject_type();
+			}
+		}
+
+		const TypeInfo* terminal_type_info = resolved_alias.terminal_type_info;
+		if (terminal_type_info == nullptr && resolved_alias.type_index.is_valid()) {
+			terminal_type_info = tryGetTypeInfo(resolved_alias.type_index);
+		}
+		if (terminal_type_info != nullptr && terminal_type_info->isStruct()) {
+			const StructTypeInfo* struct_info = terminal_type_info->getStructInfo();
+			if (struct_info == nullptr || !struct_info->hasCompleteObjectLayout()) {
+				return reject_type();
+			}
+		}
+
+		return AstTraversal::VisitDecision::Continue;
+	});
+	return invalid_type_name;
+}
 
 ParseResult Parser::parse_return_statement() {
 	auto current_token_opt = peek_info();
@@ -840,6 +905,13 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 				}
 
 				auto sizeof_expr = emplace_node<ExpressionNode>(SizeofExprNode(*type_result.node(), sizeof_token));
+				if (!typeSpecStillUsesDependentPlaceholder(type_spec)) {
+					if (std::optional<StringHandle> invalid_type =
+							SemanticValidation::findInvalidConcreteSizeofTypeOperand(sizeof_expr);
+						invalid_type.has_value()) {
+						throw CompileError("sizeof operand is an incomplete or invalid type");
+					}
+				}
 				return ParseResult::success(sizeof_expr);
 			} else {
 				// Not a type (or doesn't look like one), try parsing as expression

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -6820,11 +6820,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 		const TypeSpecifierNode& type_spec = decl.type_specifier_node();
 		ASTNode full_substituted_type_node = substituteTemplateParameters(
-			decl.type_node(), template_params, template_args_to_use);
+			decl.type_node(), effective_template_params, effective_template_args);
 
 		// Substitute template parameter if the member type is a template parameter
 		TypeIndex member_type_index = substitute_template_parameter(
-			type_spec, template_params, template_args_to_use);
+			type_spec, effective_template_params, effective_template_args);
 
 		// WORKAROUND: If member type is a Struct or UserDefined that is actually a template (not an instantiation),
 		// try to instantiate it with the current template arguments.
@@ -6836,7 +6836,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (const TypeInfo* member_type_info = (is_struct_type(member_type_index.category())) ? tryGetTypeInfo(member_type_index) : nullptr) {
 			std::string_view member_struct_name = StringTable::getStringView(member_type_info->name());
 			auto materializeMemberTemplateArgs = [&]() {
-				return materializeTemplateArgs(*member_type_info, template_params, template_args_to_use);
+				return materializeTemplateArgs(*member_type_info, effective_template_params, effective_template_args);
 			};
 
 			FLASH_LOG(Templates, Debug, "Member type_info: name='", member_struct_name,
@@ -6950,15 +6950,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// If we found an identifier, try to substitute it with a non-type template parameter value
 				if (identifier_name.has_value()) {
 					// Try to find which non-type template parameter this is
-					for (size_t i = 0; i < template_params.size(); ++i) {
-						const TemplateParameterNode* tparam = tryGetTemplateParameterNode(template_params[i]);
+					for (size_t i = 0; i < effective_template_params.size(); ++i) {
+						const TemplateParameterNode* tparam = tryGetTemplateParameterNode(effective_template_params[i]);
 						if (tparam != nullptr &&
 							tparam->kind() == TemplateParameterKind::NonType &&
 							tparam->name() == *identifier_name) {
 							// Found the non-type parameter - substitute with the actual value
-							if (i < template_args_to_use.size() && template_args_to_use[i].is_value) {
+							if (i < effective_template_args.size() && effective_template_args[i].is_value) {
 								// Create a numeric literal node with the substituted value
-								int64_t val = template_args_to_use[i].value;
+								int64_t val = effective_template_args[i].value;
 								Token num_token(Token::Type::Literal, StringBuilder().append(val).commit(), 0, 0, 0);
 								auto num_literal = emplace_node<ExpressionNode>(
 									NumericLiteralNode(num_token, static_cast<unsigned long long>(val), TypeCategory::Int, TypeQualifier::None, 32));
@@ -6990,7 +6990,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		// Calculate member size - for arrays, multiply element size by array size
 		ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(member_type_index);
-		std::vector<size_t> resolved_array_dimensions = resolve_array_dimensions(decl, template_params, template_args_to_use);
+		std::vector<size_t> resolved_array_dimensions = resolve_array_dimensions(
+			decl, effective_template_params, effective_template_args);
 		if (resolved_array_dimensions.empty()) {
 			resolved_array_dimensions = resolved_member_alias.array_dimensions;
 		}
@@ -7038,7 +7039,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		// Substitute template parameters in default member initializers
 		std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
-			member_decl.default_initializer, template_args_to_use, template_params);
+			member_decl.default_initializer, effective_template_args, effective_template_params);
 
 		// For function pointer members instantiated from a template parameter (e.g., F func
 		// where F=int(*)(int)), the pattern TypeSpecifierNode won't have a function_signature
@@ -7059,13 +7060,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			is_array_member,
 			std::move(resolved_array_dimensions),
 			static_cast<int>(substituted_type_spec.pointer_depth()),
-			resolve_bitfield_width(member_decl, template_params, template_args_to_use),
+			resolve_bitfield_width(member_decl, effective_template_params, effective_template_args),
 			resolveTemplateFunctionPointerSignature(
 				substituted_type_spec,
 				member_type_index,
 				source_member,
-				template_params,
-				template_args_to_use),
+				effective_template_params,
+				effective_template_args),
 			member_decl.is_no_unique_address);
 	}
 
@@ -7593,7 +7594,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituted_type_index,
 					substituted_size,
 					static_member.reference_qualifier,
-					static_member.pointer_depth);
+					static_member.pointer_depth,
+					UnresolvedSizeofPolicy::AllowDependent);
 
 			FLASH_LOG(Templates, Debug, "Static member type substitution: original type=", (int)static_member.memberType(),
 					  " -> substituted type=", (int)substituted_type_index.category(), ", size=", substituted_size);
@@ -9161,7 +9163,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						instantiated_static_member->type_index,
 						instantiated_static_member->size,
 						instantiated_static_member->reference_qualifier,
-						instantiated_static_member->pointer_depth);
+						instantiated_static_member->pointer_depth,
+						UnresolvedSizeofPolicy::AllowDependent);
 				if (!normalized_initializer.has_value()) {
 					continue;
 				}
@@ -9364,17 +9367,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		false // is_class
 	);
 	StructDeclarationNode& instantiated_struct_ref = instantiated_struct.as<StructDeclarationNode>();
-	setOuterTemplateBindingsFromParams(instantiated_struct_ref, template_params, template_args_to_use);
+	setOuterTemplateBindingsFromParams(
+		instantiated_struct_ref, effective_template_params, effective_template_args);
 
 	for (const auto& member_decl : class_decl.members()) {
 		ASTNode substituted_member_decl = substituteTemplateParameters(
-			member_decl.declaration, template_params, template_args_to_use);
+			member_decl.declaration, effective_template_params, effective_template_args);
 		std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
-			member_decl.default_initializer, template_args_to_use, template_params);
-		std::optional<ASTNode> substituted_bitfield_width_expr = member_decl.bitfield_width_expr.has_value()
-																	 ? std::optional<ASTNode>(substituteTemplateParameters(
-																		   *member_decl.bitfield_width_expr, template_params, template_args_to_use))
-																	 : std::nullopt;
+			member_decl.default_initializer, effective_template_args, effective_template_params);
+		std::optional<ASTNode> substituted_bitfield_width_expr;
+		if (member_decl.bitfield_width_expr.has_value()) {
+			substituted_bitfield_width_expr = substituteTemplateParameters(
+				*member_decl.bitfield_width_expr,
+				effective_template_params,
+				effective_template_args);
+		}
 		instantiated_struct_ref.add_member(
 			substituted_member_decl,
 			member_decl.access,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1117,40 +1117,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			substituted_type = substituted_type_spec.type();
 		}
 		if (substituted_type_spec.has_function_signature()) {
-			auto substitute_signature_type_index = [&](TypeIndex signature_type_index) {
-				const TypeInfo* signature_type_info = tryGetTypeInfo(signature_type_index);
-				if (signature_type_info == nullptr) {
-					return signature_type_index;
-				}
-				TypeIndex substituted_signature_index = signature_type_index;
-				forEachNonPackTemplateParamArgBinding(
+			substituted_type_spec.set_function_signature(
+				substituteTemplateFunctionSignature(
+					substituted_type_spec.function_signature(),
 					params,
-					args,
-					[&](const TemplateParameterNode& param, const TemplateTypeArg& concrete_arg, size_t) {
-						if (substituted_signature_index != signature_type_index ||
-							concrete_arg.is_value ||
-							param.nameHandle() != signature_type_info->name()) {
-							return;
-						}
-						if (concrete_arg.type_index.is_valid()) {
-							substituted_signature_index =
-								concrete_arg.type_index.withCategory(concrete_arg.typeEnum());
-							return;
-						}
-						TypeIndex native_index = nativeTypeIndex(concrete_arg.typeEnum());
-						substituted_signature_index = native_index.is_valid()
-							? native_index.withCategory(concrete_arg.typeEnum())
-							: TypeIndex{0, concrete_arg.typeEnum()};
-					});
-				return substituted_signature_index;
-			};
-			FunctionSignature substituted_signature = substituted_type_spec.function_signature();
-			substituted_signature.return_type_index =
-				substitute_signature_type_index(substituted_signature.return_type_index);
-			for (TypeIndex& parameter_type_index : substituted_signature.parameter_type_indices) {
-				parameter_type_index = substitute_signature_type_index(parameter_type_index);
-			}
-			substituted_type_spec.set_function_signature(substituted_signature);
+					args));
 		}
 
 		FLASH_LOG(Templates, Debug, "buildSubstitutedTypeAliasSpecifier: alias_name=", StringTable::getStringView(type_alias.alias_name),

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8117,7 +8117,65 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			addNestedMemberFunctionsToStructInfo(
 				nested_struct,
 				*nested_struct_info,
-				&nested_struct_info_member_identity_maps);
+				&nested_struct_info_member_identity_maps,
+				[&](const StructMemberFunctionDecl& source_member) -> ASTNode {
+					const ConstructorDeclarationNode& original_ctor =
+						source_member.function_declaration.as<ConstructorDeclarationNode>();
+					if (!original_ctor.is_materialized()) {
+						return source_member.function_declaration;
+					}
+
+					auto [substituted_ctor_node, substituted_ctor] =
+						emplace_node_ref<ConstructorDeclarationNode>(
+							qualified_name,
+							original_ctor.name());
+					setOuterTemplateBindingsFromParams(
+						substituted_ctor,
+						template_params,
+						template_args_to_use);
+					substituted_ctor.set_template_parameters(
+						original_ctor.template_parameters());
+
+					const size_t saved_pack_info = pack_param_info_.size();
+					substituteAndCopyParams(
+						original_ctor.parameter_nodes(),
+						substituted_ctor,
+						template_params,
+						template_args_to_use);
+					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
+					substituteAndCopyInitializers(
+						original_ctor,
+						substituted_ctor,
+						template_params,
+						template_args_to_use,
+						std::span<const PackParamInfo>(
+							ctor_pack_param_info.data(),
+							ctor_pack_param_info.size()));
+					substituted_ctor.set_definition(substituteTemplateParameters(
+						*original_ctor.get_definition(),
+						template_params,
+						template_args_to_use,
+						qualified_name));
+					pack_param_info_.resize(saved_pack_info);
+
+					substituted_ctor.set_is_implicit(original_ctor.is_implicit());
+					substituted_ctor.set_is_explicitly_defaulted(
+						original_ctor.is_explicitly_defaulted());
+					substituted_ctor.set_noexcept(original_ctor.is_noexcept());
+					substituted_ctor.set_explicit(original_ctor.is_explicit());
+					substituted_ctor.set_constexpr(original_ctor.is_constexpr());
+					if (original_ctor.has_requires_clause()) {
+						substituted_ctor.set_requires_clause(substituteTemplateParameters(
+							*original_ctor.requires_clause(),
+							template_params,
+							template_args_to_use,
+							qualified_name));
+					}
+					instantiated_nested_struct_ref.add_constructor(
+						substituted_ctor_node,
+						source_member.access);
+					return substituted_ctor_node;
+				});
 			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
 				registerSourceMemberStubIdentity(
 					nested_source_member_identity_maps,

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -934,6 +934,23 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		owner_substitutor.setCurrentOwnerTypeName(lazy_info.identity.instantiated_owner_name);
 		substituted_body = owner_substitutor.substitute(substituted_body);
 		new_func_ref.set_definition(substituted_body);
+
+		ASTNode resolved_return_type_node = new_func_ref.decl_node().type_node();
+		const TypeInfo* return_type_info = tryGetTypeInfo(
+			new_func_ref.decl_node().type_specifier_node().type_index());
+		if (return_type_info != nullptr &&
+			return_type_info->isDependentMemberType() &&
+			return_type_info->hasDependentQualifiedName() &&
+			resolveDependentMemberAlias(
+				resolved_return_type_node,
+				std::span<const TemplateParameterNode>(
+					substitution_params.data(), substitution_params.size()),
+				std::span<const TemplateTypeArg>(
+					converted_template_args.data(), converted_template_args.size())) ==
+				DependentAliasResolutionStatus::Resolved) {
+			new_func_ref.decl_node().set_type_node(
+				resolved_return_type_node.as<TypeSpecifierNode>());
+		}
 	}
 
 	copy_function_properties(new_func_ref, func_decl);

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1,4 +1,5 @@
 #include "Parser.h"
+#include "AstTraversal.h"
 #include "ConstExprEvaluator.h"
 #include "NameMangling.h"
 #include "OverloadResolution.h"
@@ -706,12 +707,24 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 
 	const bool has_saved_body_position = func_decl.has_template_body_position();
 	const bool has_parsed_body = func_decl.is_materialized();
+	const bool parsed_body_has_local_class =
+		has_parsed_body &&
+		AstTraversal::visitASTUntil(
+			*func_decl.get_definition(),
+			[](const ASTNode& body_node) {
+				return body_node.is<StructDeclarationNode>() &&
+					body_node.as<StructDeclarationNode>().is_local_class();
+			});
+	const bool replay_saved_body =
+		has_saved_body_position && (!has_parsed_body || parsed_body_has_local_class);
 	if (has_saved_body_position && has_parsed_body) {
-		FLASH_LOG(Templates, Debug,
-				  "Lazy member function has both parsed body and saved body position; reparsing with concrete template bindings");
+		FLASH_LOG(Templates, Debug, "Lazy member function has both parsed body and saved body position; ",
+			parsed_body_has_local_class
+				? "replaying local class declarations with concrete template bindings"
+				: "using the parsed body for structural substitution");
 	}
 
-	if (has_saved_body_position) {
+	if (replay_saved_body) {
 		FLASH_LOG(Templates, Debug, "Lazy member function body: re-parsing from saved position");
 		FLASH_LOG(
 			Templates,
@@ -775,6 +788,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				pushCurrentTemplateParamName(pn);
 			}
 
+			FlashCpp::ScopedState guard_local_class_replay(replaying_template_member_local_classes_);
+			replaying_template_member_local_classes_ = parsed_body_has_local_class;
 			auto block_result = parse_function_body();	// handles function-try-blocks
 
 			if (!block_result.is_error() && block_result.node().has_value()) {

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -131,36 +131,14 @@ std::optional<ASTNode> tryFoldSubstitutedSizeofTypeNode(
 	}
 
 	const TypeSpecifierNode& type_spec = type_node.as<TypeSpecifierNode>();
-	size_t size_in_bytes = 0;
-
-	if (type_spec.is_array()) {
-		size_t element_size = static_cast<size_t>(type_spec.size_in_bits()) / 8;
-		if (type_spec.array_size().has_value()) {
-			size_in_bytes = element_size * *type_spec.array_size();
-		} else {
-			size_in_bytes = element_size;
-		}
-	} else if (type_spec.is_reference() || type_spec.is_rvalue_reference()) {
-		size_in_bytes = static_cast<size_t>(type_spec.size_in_bits()) / 8;
-	} else if (type_spec.category() == TypeCategory::Struct && type_spec.type_index().is_valid()) {
-		if (const StructTypeInfo* struct_info = tryGetStructTypeInfo(type_spec.type_index())) {
-			size_in_bytes = toSizeT(struct_info->sizeInBytes());
-		}
-	} else {
-		size_in_bytes = static_cast<size_t>(type_spec.size_in_bits()) / 8;
-		if (size_in_bytes == 0 && type_spec.type_index().is_valid()) {
-			if (const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index()); type_info && type_info->hasStoredSize()) {
-				size_in_bytes = toSizeT(type_info->sizeInBytes());
-			}
-		}
-	}
-
-	if (size_in_bytes == 0) {
+	const std::optional<size_t> size_in_bytes =
+		ConstExpr::tryGetConstexprTypeSizeBytes(type_spec);
+	if (!size_in_bytes.has_value() || *size_in_bytes == 0) {
 		return std::nullopt;
 	}
 
 	StringBuilder size_builder;
-	std::string_view size_str = size_builder.append(size_in_bytes).commit();
+	std::string_view size_str = size_builder.append(*size_in_bytes).commit();
 	Token literal_token(
 		Token::Type::Literal,
 		size_str,
@@ -170,7 +148,7 @@ std::optional<ASTNode> tryFoldSubstitutedSizeofTypeNode(
 	return ASTNode::emplace_node<ExpressionNode>(
 		NumericLiteralNode(
 			literal_token,
-			static_cast<unsigned long long>(size_in_bytes),
+		static_cast<unsigned long long>(*size_in_bytes),
 			TypeCategory::UnsignedLongLong,
 			TypeQualifier::None,
 			64));
@@ -1428,10 +1406,10 @@ ASTNode Parser::substituteTemplateParameters(
 				if (type_or_expr.is<TypeSpecifierNode>()) {
 					const TypeSpecifierNode& type_spec = type_or_expr.as<TypeSpecifierNode>();
 
-					// Try to find a matching template parameter and evaluate sizeof directly.
-					// This handles both struct types (matched by name) and non-struct dependent
-					// types (matched by type_index) where the template arg carries pointer_depth.
-					if (type_spec.type_index().is_valid()) {
+					// A direct template parameter carries an explicit scoped binding identity.
+					// Do not infer that identity from a matching terminal type index: aliases
+					// can denote the same element type while adding array or indirection shape.
+					if (type_spec.has_template_parameter_identity()) {
 						bool substituted_sizeof_type = false;
 						std::optional<ASTNode> substituted_sizeof_node;
 						forEachNonPackTemplateParamArgBinding(
@@ -1440,12 +1418,7 @@ ASTNode Parser::substituteTemplateParameters(
 							[&](const TemplateParameterNode& tparam, const TemplateTypeArg& arg, size_t) {
 								if (substituted_sizeof_type || !arg.isTypeArgument())
 									return;
-								// Match by name (struct types) or by type_index (dependent types)
-								const TypeInfo* type_info = tryGetTypeInfo(type_spec.type_index());
-								if (type_info == nullptr)
-									return;
-								std::string_view type_name = StringTable::getStringView(type_info->name());
-								if (tparam.name() != type_name && type_info->type_index_ != arg.type_index)
+								if (tparam.nameHandle() != type_spec.template_parameter_name())
 									return;
 
 								size_t type_size = getSubstitutedTemplateArgumentSizeInBytes(arg);
@@ -2162,14 +2135,21 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 	const std::string_view type_name = StringTable::getStringView(type_handle);
 
 	// Prefer declarations from the active symbol scope for unqualified type names.
-	// This keeps block/function-local enum tags authoritative even when
+	// This keeps block/function-local types authoritative even when
 	// getTypesByNameMap() still holds an older outer-scope type under the same key.
 	if (type_name.find("::") == std::string_view::npos) {
 		if (std::optional<ASTNode> symbol = gSymbolTable.lookup(type_name);
-			symbol.has_value() && symbol->is<EnumDeclarationNode>()) {
-			const TypeIndex enum_type_index = symbol->as<EnumDeclarationNode>().type_index();
-			if (const TypeInfo* enum_type_info = tryGetTypeInfo(enum_type_index)) {
-				return enum_type_info;
+			symbol.has_value()) {
+			TypeIndex scoped_type_index;
+			if (symbol->is<EnumDeclarationNode>()) {
+				scoped_type_index = symbol->as<EnumDeclarationNode>().type_index();
+			} else if (symbol->is<TypedefDeclarationNode>()) {
+				scoped_type_index = symbol->as<TypedefDeclarationNode>()
+					.type_specifier_node()
+					.type_index();
+			}
+			if (const TypeInfo* scoped_type_info = tryGetTypeInfo(scoped_type_index)) {
+				return scoped_type_info;
 			}
 		}
 	}
@@ -2210,8 +2190,8 @@ const TypeInfo* lookupTypeInCurrentContext(StringHandle type_handle) {
 	}
 
 	// Then try direct unqualified lookup, subject to namespace visibility rules.
-	// Note: local enum shadowing is already handled by the symbol-table lookup above
-	// (lines 2020-2028), which is scope-aware and always returns the innermost declaration.
+	// Note: local type shadowing is already handled by the symbol-table lookup above,
+	// which is scope-aware and always returns the innermost declaration.
 	auto it = getTypesByNameMap().find(type_handle);
 	if (it != getTypesByNameMap().end() && isDirectlyVisibleUnqualified(it->second)) {
 		return it->second;

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1722,6 +1722,18 @@ ASTNode Parser::substituteTemplateParameters(
 			return emplace_node<TypeSpecifierNode>(substituted_spec);
 		};
 
+		if (current_owner_type_name.isValid() && type_spec.type_index().is_valid()) {
+			if (const TypeInfo* current_owner_type_info =
+					findTypeByName(current_owner_type_name)) {
+				const StructTypeInfo* current_owner_struct_info =
+					current_owner_type_info->getStructInfo();
+				if (current_owner_struct_info != nullptr &&
+					current_owner_struct_info->isOwnTypeIndex(type_spec.type_index())) {
+					return makeTypeSpecifier(*current_owner_type_info);
+				}
+			}
+		}
+
 		if (type_spec.type_index().is_valid()) {
 			if (const TypeInfo* dependent_type_info = tryGetTypeInfo(type_spec.type_index());
 				dependent_type_info != nullptr &&

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -2503,7 +2503,7 @@ ParseResult Parser::parse_type_specifier() {
 						return qualified_type_name_builder.append("::").append(qualified_node.identifier_token().value()).commit();
 					};
 					auto buildResolvedTypeNode = [&](const TypeInfo& resolved_type_info) -> ASTNode {
-						if (resolved_type_info.isStruct()) {
+						if (resolved_type_info.isStruct() && !resolved_type_info.isTypeAlias()) {
 							const StructTypeInfo* struct_info = resolved_type_info.getStructInfo();
 							int resolved_type_size = struct_info
 								? static_cast<int>(struct_info->sizeInBits().value)
@@ -3571,6 +3571,7 @@ ParseResult Parser::parse_type_specifier() {
 								cv_qualifier,
 								ReferenceQualifier::None);
 							TypeSpecifierNode concrete_type = resolveTypeInfoToTypeSpec(*param_type_info, outer_spec);
+							concrete_type.set_template_parameter_identity(type_name_handle);
 							if (const int concrete_size_bits = getTypeSpecSizeBits(concrete_type); concrete_size_bits > 0) {
 								concrete_type.set_size_in_bits(concrete_size_bits);
 							}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1648,19 +1648,25 @@ ParseResult Parser::parse_type_specifier() {
 						StringHandle qualified_member_handle = buildQualifiedMemberNameHandle(
 							StringTable::getOrInternStringHandle(base_type_name),
 							StringTable::getOrInternStringHandle(member_name));
-						auto member_type_it = getTypesByNameMap().find(qualified_member_handle);
-						if (member_type_it == getTypesByNameMap().end()) {
-							TypeInfo& placeholder_type = add_empty_type_entry();
-							placeholder_type.fallback_size_bits_ = 0;
-							placeholder_type.name_ = qualified_member_handle;
-							placeholder_type.is_incomplete_instantiation_ = true;
-							placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
-							if (auto base_type_it = getTypesByNameMap().find(
-									StringTable::getOrInternStringHandle(base_type_name));
-								base_type_it != getTypesByNameMap().end() &&
-								base_type_it->second != nullptr &&
-								base_type_it->second->isTemplateInstantiation()) {
-								const TypeInfo& base_type_info = *base_type_it->second;
+						auto refreshDependentMemberMetadata =
+							[&](TypeInfo& member_type_info) {
+							if (!member_type_info.isDependentMemberType()) {
+								return;
+							}
+							auto base_type_it = getTypesByNameMap().find(
+								StringTable::getOrInternStringHandle(base_type_name));
+							if (base_type_it == getTypesByNameMap().end() ||
+								base_type_it->second == nullptr) {
+								return;
+							}
+							const TypeInfo& base_type_info = *base_type_it->second;
+							if (base_type_info.hasDependentQualifiedName()) {
+								TypeInfo::DependentQualifiedNameRecord dependent_record =
+									*base_type_info.dependentQualifiedName();
+								appendDependentMemberPathComponents(dependent_record, member_name);
+								member_type_info.setDependentQualifiedName(std::move(dependent_record));
+							} else if (!member_type_info.hasDependentQualifiedName() &&
+								base_type_info.isTemplateInstantiation()) {
 								StringHandle owner_name = base_type_info.baseTemplateName();
 								if (!owner_name.isValid()) {
 									owner_name = base_type_info.name();
@@ -1668,7 +1674,7 @@ ParseResult Parser::parse_type_specifier() {
 								InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arguments =
 									base_type_info.templateArgs();
 								DependentMemberSegmentInfo terminal_segment_info;
-								placeholder_type.setDependentQualifiedName(
+								member_type_info.setDependentQualifiedName(
 									makeDependentQualifiedNameRecord(
 										owner_name,
 										base_type_info.registeredTypeIndex(),
@@ -1679,8 +1685,46 @@ ParseResult Parser::parse_type_specifier() {
 											&terminal_segment_info,
 											1)));
 							}
+							const TypeInfo::InstantiationContext* base_context =
+								base_type_info.instantiationContext();
+							if (template_args.has_value()) {
+								InlineVector<StringHandle, 4> alias_param_names;
+								InlineVector<TypeInfo::TemplateArgInfo, 4> alias_context_args;
+								const auto& alias_params = alias_node.template_parameters();
+								const size_t binding_count = std::min(
+									alias_params.size(),
+									template_args->size());
+								alias_param_names.reserve(binding_count);
+								alias_context_args.reserve(binding_count);
+								for (size_t i = 0; i < binding_count; ++i) {
+									alias_param_names.push_back(alias_params[i].nameHandle());
+									alias_context_args.push_back(toTemplateArgInfo(
+										enrichTemplateArgForParameter(alias_params[i], (*template_args)[i])));
+								}
+								member_type_info.setInstantiationContext(
+									std::move(alias_param_names),
+									std::move(alias_context_args),
+									base_context);
+							} else if (base_context != nullptr) {
+								member_type_info.setInstantiationContext(
+									base_context->param_names,
+									base_context->param_args,
+									base_context->parent);
+							}
+						};
+						auto member_type_it = getTypesByNameMap().find(qualified_member_handle);
+						if (member_type_it == getTypesByNameMap().end()) {
+							TypeInfo& placeholder_type = add_empty_type_entry();
+							placeholder_type.fallback_size_bits_ = 0;
+							placeholder_type.name_ = qualified_member_handle;
+							placeholder_type.is_incomplete_instantiation_ = true;
+							placeholder_type.placeholder_kind_ = DependentPlaceholderKind::DependentMemberType;
+							refreshDependentMemberMetadata(placeholder_type);
 							getTypesByNameMap()[qualified_member_handle] = &placeholder_type;
 							return placeholder_type;
+						}
+						if (member_type_it->second != nullptr) {
+							refreshDependentMemberMetadata(*member_type_it->second);
 						}
 						return *member_type_it->second;
 					};

--- a/tests/test_alias_template_member_type_ret42.cpp
+++ b/tests/test_alias_template_member_type_ret42.cpp
@@ -73,6 +73,7 @@ struct result_of {
 };
 
 int main() {
-	result_of<int, int>::type x = 42;  // Should resolve to int
-	return x;  // Returns 42
+	result_of<int, int>::type same = 42;
+	result_of<int, double>::type different = 3.5;
+	return same == 42 && different == 3.5 ? 42 : 0;
 }

--- a/tests/test_explicit_ctor_same_template_copy_init_ret0.cpp
+++ b/tests/test_explicit_ctor_same_template_copy_init_ret0.cpp
@@ -32,7 +32,6 @@ struct ReverseIter {
 int main() {
 	int a = 1;
 	ReverseIter<int*> ri(&a);
-	(void)ri;
-	return 0;
+	ReverseIter<int*> copy = ri.copy_self();
+	return copy.current == &a ? 0 : 1;
 }
-

--- a/tests/test_layout_alias_exact_size_ret0.cpp
+++ b/tests/test_layout_alias_exact_size_ret0.cpp
@@ -1,0 +1,32 @@
+enum class ByteTag : unsigned char {
+	Value = 1
+};
+
+struct Payload {
+	long long wide;
+	short narrow;
+};
+
+using PayloadAlias = Payload;
+using ScalarAlias = long long;
+using EnumAlias = ByteTag;
+
+struct Aggregate {
+	PayloadAlias nested;
+	PayloadAlias grid[2][3];
+};
+
+static_assert(sizeof(PayloadAlias) == sizeof(Payload));
+static_assert(sizeof(ScalarAlias) == sizeof(long long));
+static_assert(sizeof(EnumAlias) == sizeof(unsigned char));
+
+int main() {
+	Aggregate value{};
+
+	return sizeof(value.nested) == sizeof(Payload) &&
+			sizeof(value.grid) == sizeof(Payload) * 6 &&
+			sizeof(value.grid[0]) == sizeof(Payload) * 3 &&
+			sizeof(value.grid[0][0]) == sizeof(Payload)
+		? 0
+		: 1;
+}

--- a/tests/test_layout_dependent_alias_exact_size_ret0.cpp
+++ b/tests/test_layout_dependent_alias_exact_size_ret0.cpp
@@ -1,0 +1,33 @@
+template <typename T>
+struct AliasProvider {
+	using value_type = T;
+	using row_type = T[3];
+	using grid_type = T[2][3];
+};
+
+template <typename T>
+int verifyDependentAliasLayout() {
+	using Value = typename AliasProvider<T>::value_type;
+	using Row = typename AliasProvider<T>::row_type;
+	using Grid = typename AliasProvider<T>::grid_type;
+
+	Grid values{};
+	int result = 0;
+	if (sizeof(Value) != sizeof(T)) result |= 1;
+	if (sizeof(Row) != sizeof(T) * 3) result |= 2;
+	if (sizeof(Grid) != sizeof(T) * 6) result |= 4;
+	if (sizeof(values[0]) != sizeof(T) * 3) result |= 8;
+	if (sizeof(values[0][0]) != sizeof(T)) result |= 16;
+	return result;
+}
+
+struct Mixed {
+	long long wide;
+	char narrow;
+};
+
+int main() {
+	return verifyDependentAliasLayout<char>() |
+		verifyDependentAliasLayout<long long>() |
+		verifyDependentAliasLayout<Mixed>();
+}

--- a/tests/test_layout_incomplete_alias_sizeof_fail.cpp
+++ b/tests/test_layout_incomplete_alias_sizeof_fail.cpp
@@ -1,0 +1,9 @@
+struct ForwardDeclared;
+
+using IncompleteAlias = ForwardDeclared;
+
+constexpr unsigned long long invalid_size = sizeof(IncompleteAlias);
+
+int main() {
+	return static_cast<int>(invalid_size);
+}

--- a/tests/test_layout_unresolved_dependent_alias_sizeof_fail.cpp
+++ b/tests/test_layout_unresolved_dependent_alias_sizeof_fail.cpp
@@ -1,0 +1,13 @@
+template <typename T>
+struct AliasConsumer {
+	using Missing = typename T::missing_type;
+	static constexpr unsigned long long size = sizeof(Missing);
+};
+
+struct CompleteObject {
+	int value;
+};
+
+int main() {
+	return static_cast<int>(AliasConsumer<CompleteObject>::size);
+}

--- a/tests/test_nested_class_constructor_template_param_ret42.cpp
+++ b/tests/test_nested_class_constructor_template_param_ret42.cpp
@@ -16,5 +16,6 @@ struct Container {
 
 int main() {
 	Container<int>::Inner i(42);
-	return i.get(); // Expected: 42
+	Container<double>::Inner d(3.5);
+	return i.value + static_cast<int>(d.value) - 3; // Expected: 42
 }

--- a/tests/test_template_member_local_proxy_class_ret0.cpp
+++ b/tests/test_template_member_local_proxy_class_ret0.cpp
@@ -14,11 +14,12 @@ struct common_like {
 		};
 
 		ArrowProxy proxy{value};
-		return 42;
+		return proxy.keep == value ? 42 : 0;
 	}
 };
 
 int main() {
-	common_like<int> iter{42};
-	return iter.read() == 42 ? 0 : 1;
+	common_like<int> int_iter{7};
+	common_like<double> double_iter{3.5};
+	return int_iter.read() == 42 && double_iter.read() == 42 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- add reduced non-`std` regressions that capture exact alias-layout and incomplete-`sizeof` requirements from the fallback-removal audit
- substitute function-pointer signature return and parameter types through registered template-parameter identity, then attach canonical bound-argument metadata to instantiated `TypeSpecifierNode` results
- rebind lazy member return aliases after body replay materializes nested member types
- rebind current-instantiation type metadata in materialized lazy member bodies to the concrete owner and complete layout, with namespace-aware own-type matching
- produce fresh, fully substituted constructor AST and signature metadata for materialized nested classes
- replay member bodies containing local classes with concrete bindings and give each specialization its own semantic local-type identity
- preserve structured dependent-qualified member-alias chains and their composed template bindings
- materialize incomplete nested template arguments before dependent member selection while preserving complete specialization identity
- scope instantiated local `using` and `typedef` aliases to their function/block specialization instead of sharing the first global binding
- follow canonical alias chains for qualified struct lookup, preserve array shape during alias materialization, and retain direct template-parameter identity after concretization
- substitute ordinary member types, arrays, initializers, bit-fields, function-pointer signatures, and retained AST metadata with the combined enclosing and inner template environment
- diagnose concrete invalid `sizeof(type-id)` operands from structured type metadata, including unresolved placeholders after required substitution, incomplete object types, functions, `void`, and incomplete arrays
- make dependent-`sizeof` normalization intent explicit at callsites with `UnresolvedSizeofPolicy` rather than opaque Boolean arguments
- document the separate namespace-qualified self-copy and nested-member lazy-identity issues

## Implementation boundaries

- keep layout and substitution fixes in parser, semantic-analysis, and template producers
- leave `TypeSizeQuery` and downstream `sizeof` consumers unchanged
- avoid standard-library/vendor name checks, token reconstruction, symbol-table guesses, invented sizes, and best-effort layout acceptance

## Remaining producer frontiers

- deferred dependent `decltype` materialization
- nested template default-argument member aliases
- pointer-to-member/static-member category metadata