### PR TITLE
Require canonical template function signatures

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -99,10 +99,6 @@ constant value or an ill-formed program.
 ## Function types lack one canonical semantic owner
 Complete function-type metadata is currently copied among `TypeSpecifierNode`,
 alias `TypeInfo`, `TemplateTypeArg`, and `FunctionSignature`.
-`resolveTemplateFunctionPointerSignature(...)` still searches those stores in
-precedence order when an instantiated type is missing metadata. This is recovery
-for an incomplete producer contract, not a C++20 type-substitution rule; an older
-source can mask a more concrete substituted signature.
 
 The first canonical-owner slice removed `StructMember` as a signature source,
 deleted the associated member-name scans, made substituted alias metadata take
@@ -110,6 +106,15 @@ precedence, and requires every concrete function-pointer type reaching member
 registration to already have a complete signature. `StructMember` remains a
 consumer copy used by later lowering, but it can no longer repair an incomplete
 template producer.
+
+The second slice removed the remaining registration-time original-type and
+template-argument search. Template substitution now resolves an alias to its
+terminal template-parameter identity, applies the bound `TemplateTypeArg`, and
+attaches the substituted `FunctionSignature` to the produced `TypeSpecifierNode`.
+Registration consumes only that node and treats a concrete callable without a
+signature as an internal producer error. Reading the original pattern and its
+bound argument during substitution is part of the semantic substitution step;
+doing the same lookup later from a member consumer would be recovery.
 
 The current representation can fail for alias-category function pointers, packs,
 transformed template parameters, dependent member-function-pointer owners,
@@ -122,6 +127,7 @@ The remaining intended invariant is that substitution produces one canonical
 callable `TypeSpecifierNode`/`TypeInfo` containing the complete substituted
 function type.
 Member registration, mangling, overload resolution, and code generation should
-consume that object directly. The remaining original-type/template-argument
-search cascade can then be removed; a concrete callable type without complete
-metadata is already treated as an internal producer error.
+consume that object directly. Remaining work should reduce the parallel metadata
+copies and extend structured substitution to the unsupported function-type
+components above; a concrete callable type without complete metadata is already
+treated as an internal producer error.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -57,3 +57,71 @@ pedantic C++20 compiler.
 - `tests/test_outofline_nested_pack_ret0.cpp`
 - `tests/test_outofline_nested_union_ret0.cpp`
 - `tests/test_sizeof_offsetof.cpp`
+
+## Constexpr evaluation does not yet expose standard semantic outcomes
+The constant-expression pipeline still reports most unsuccessful evaluations as
+one generic evaluator failure. It does not consistently distinguish these C++20
+outcomes:
+
+- the expression is still dependent and must be checked after substitution;
+- substitution produced an ill-formed expression that requires a diagnostic;
+- the expression is well-formed but is not a constant expression;
+- the expression is a valid constant expression that the evaluator does not yet
+  implement.
+
+Template static-member normalization therefore still has phase-specific recovery.
+`tryEarlyNormalizeTemplateStaticMemberInitializer(...)` returns no normalized
+initializer for a generic evaluation failure, while `UnresolvedSizeofPolicy`
+only makes unresolved/incomplete `sizeof(type-id)` a hard error during the final
+retry for `constexpr` static members. C++20 validity is not determined by that
+declaration flag or retry phase: a non-dependent invalid `sizeof` operand is
+ill-formed whenever the specialization requires it.
+
+The compatibility boundary is exercised by dependent NTTPs, recursive static
+members, hidden-friend calls, and nested constexpr member/helper access, including:
+
+- `tests/test_function_template_dependent_identifier_nttp_ret0.cpp`
+- `tests/test_template_recursive_static_constexpr_member_ret0.cpp`
+- `tests/test_template_static_constexpr_dependent_hidden_friend_ret0.cpp`
+- `tests/test_template_static_member_initializer_helper_member_access_ret42.cpp`
+- `tests/test_template_static_member_initializer_nested_constexpr_member_call_ret42.cpp`
+- `tests/test_template_static_member_initializer_nested_helper_access_ret42.cpp`
+
+These tests pass through the current staged replay/substitution/evaluation
+pipeline, but a blanket conversion of every unsuccessful early evaluation into a
+diagnostic regresses them. The long-term fix is a structured evaluation result,
+standard point-of-instantiation checking for dependent expressions, and complete
+constexpr call/member-access evaluation. Invalid semantic states should then
+produce `CompileError`; missing canonical compiler metadata should produce
+`InternalError`; unsupported evaluator coverage must not be accepted as either a
+constant value or an ill-formed program.
+
+## Function types lack one canonical semantic owner
+Complete function-type metadata is currently copied among `TypeSpecifierNode`,
+alias `TypeInfo`, `TemplateTypeArg`, and `FunctionSignature`.
+`resolveTemplateFunctionPointerSignature(...)` still searches those stores in
+precedence order when an instantiated type is missing metadata. This is recovery
+for an incomplete producer contract, not a C++20 type-substitution rule; an older
+source can mask a more concrete substituted signature.
+
+The first canonical-owner slice removed `StructMember` as a signature source,
+deleted the associated member-name scans, made substituted alias metadata take
+precedence, and requires every concrete function-pointer type reaching member
+registration to already have a complete signature. `StructMember` remains a
+consumer copy used by later lowering, but it can no longer repair an incomplete
+template producer.
+
+The current representation can fail for alias-category function pointers, packs,
+transformed template parameters, dependent member-function-pointer owners,
+dependent `noexcept` expressions, and nested callable parameter/return types.
+Missing metadata is often detected only during indirect-call code generation;
+stale metadata can instead affect specialization identity, mangling, or ABI
+lowering without an immediate error.
+
+The remaining intended invariant is that substitution produces one canonical
+callable `TypeSpecifierNode`/`TypeInfo` containing the complete substituted
+function type.
+Member registration, mangling, overload resolution, and code generation should
+consume that object directly. The remaining original-type/template-argument
+search cascade can then be removed; a concrete callable type without complete
+metadata is already treated as an internal producer error.

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -114,18 +114,6 @@ inline int getSubstitutedTypeSizeBits(TypeIndex substituted_type_index) {
 	return get_type_size_bits(size_type_index.category());
 }
 
-inline const StructMember* findDirectStructMemberByName(
-	const StructTypeInfo* struct_info,
-	StringHandle member_name) {
-	if (struct_info == nullptr || !member_name.isValid())
-		return nullptr;
-	for (const StructMember& member : struct_info->members) {
-		if (member.name == member_name)
-			return &member;
-	}
-	return nullptr;
-}
-
 template <typename ParamContainer, typename ArgContainer>
 inline TypeIndex substituteTemplateParameterTypeIndex(
 	TypeIndex original_type_index,
@@ -196,21 +184,24 @@ template <typename ParamContainer, typename ArgContainer>
 inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 	const TypeSpecifierNode& type_spec,
 	TypeIndex substituted_type_index,
-	const StructMember* source_member,
 	const ParamContainer& template_params,
 	const ArgContainer& template_args) {
-	if (substituted_type_index.category() != TypeCategory::FunctionPointer &&
-		substituted_type_index.category() != TypeCategory::MemberFunctionPointer)
+	const ResolvedAliasTypeInfo substituted_alias =
+		resolveAliasTypeInfo(substituted_type_index);
+	const TypeCategory substituted_category = substituted_alias.type_index.is_valid()
+		? substituted_alias.typeEnum()
+		: substituted_type_index.category();
+	if (substituted_category != TypeCategory::FunctionPointer &&
+		substituted_category != TypeCategory::MemberFunctionPointer) {
 		return std::nullopt;
-	std::optional<FunctionSignature> signature;
-	if (type_spec.has_function_signature()) {
-		signature = type_spec.function_signature();
 	}
-	if (!signature.has_value()) {
-		if (ResolvedAliasTypeInfo substituted_alias = resolveAliasTypeInfo(substituted_type_index);
-			substituted_alias.function_signature.has_value()) {
-			signature = substituted_alias.function_signature;
-		}
+
+	std::optional<FunctionSignature> signature;
+	if (substituted_alias.function_signature.has_value()) {
+		signature = substituted_alias.function_signature;
+	}
+	if (!signature.has_value() && type_spec.has_function_signature()) {
+		signature = type_spec.function_signature();
 	}
 	if (!signature.has_value()) {
 		if (ResolvedAliasTypeInfo original_alias = resolveAliasTypeInfo(type_spec.type_index());
@@ -218,20 +209,16 @@ inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
 			signature = original_alias.function_signature;
 		}
 	}
-	if (!signature.has_value() &&
-		source_member != nullptr &&
-		source_member->function_signature.has_value()) {
-		signature = source_member->function_signature;
-	}
-
 	if (!signature.has_value()) {
 		if (const auto* arg = findTemplateArgByRegisteredTypeIndex(
 				type_spec.type_index(), template_params, template_args)) {
 			signature = arg->function_signature;
 		}
 	}
-	if (!signature.has_value())
-		return std::nullopt;
+	if (!signature.has_value()) {
+		throw InternalError(
+			"Concrete function pointer type is missing canonical FunctionSignature metadata");
+	}
 	return substituteTemplateFunctionSignature(
 		*signature,
 		template_params,
@@ -1191,7 +1178,6 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 	if (auto signature = resolveTemplateFunctionPointerSignature(
 				   original_type_spec,
 				   substituted_type.type_index(),
-				   nullptr,
 				   template_params,
 				   template_args)) {
 		substituted_type.set_function_signature(*signature);
@@ -1526,7 +1512,6 @@ inline void propagateFunctionSignatureFromTemplateArg(
 	if (auto signature = resolveTemplateFunctionPointerSignature(
 			orig_type,
 			substituted_type_index,
-			nullptr,
 			template_params,
 			template_args)) {
 		substituted_type.set_function_signature(*signature);

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -181,48 +181,67 @@ inline FunctionSignature substituteTemplateFunctionSignature(
 }
 
 template <typename ParamContainer, typename ArgContainer>
-inline std::optional<FunctionSignature> resolveTemplateFunctionPointerSignature(
-	const TypeSpecifierNode& type_spec,
-	TypeIndex substituted_type_index,
+inline void materializeSubstitutedFunctionTypeMetadata(
+	TypeSpecifierNode& substituted_type,
+	const TypeSpecifierNode& original_type,
 	const ParamContainer& template_params,
 	const ArgContainer& template_args) {
+	normalizeSubstitutedTypeSpec(substituted_type);
 	const ResolvedAliasTypeInfo substituted_alias =
-		resolveAliasTypeInfo(substituted_type_index);
+		resolveAliasTypeInfo(substituted_type.type_index());
 	const TypeCategory substituted_category = substituted_alias.type_index.is_valid()
 		? substituted_alias.typeEnum()
-		: substituted_type_index.category();
+		: substituted_type.type_index().category();
 	if (substituted_category != TypeCategory::FunctionPointer &&
 		substituted_category != TypeCategory::MemberFunctionPointer) {
-		return std::nullopt;
+		return;
 	}
 
 	std::optional<FunctionSignature> signature;
-	if (substituted_alias.function_signature.has_value()) {
+	if (substituted_type.has_function_signature()) {
+		signature = substituted_type.function_signature();
+	} else if (substituted_alias.function_signature.has_value()) {
 		signature = substituted_alias.function_signature;
-	}
-	if (!signature.has_value() && type_spec.has_function_signature()) {
-		signature = type_spec.function_signature();
-	}
-	if (!signature.has_value()) {
-		if (ResolvedAliasTypeInfo original_alias = resolveAliasTypeInfo(type_spec.type_index());
-			original_alias.function_signature.has_value()) {
+	} else if (original_type.has_function_signature()) {
+		signature = original_type.function_signature();
+	} else {
+		const ResolvedAliasTypeInfo original_alias =
+			resolveAliasTypeInfo(original_type.type_index());
+		if (original_alias.function_signature.has_value()) {
 			signature = original_alias.function_signature;
-		}
-	}
-	if (!signature.has_value()) {
-		if (const auto* arg = findTemplateArgByRegisteredTypeIndex(
-				type_spec.type_index(), template_params, template_args)) {
-			signature = arg->function_signature;
+		} else {
+			const TypeIndex binding_type_index = original_alias.type_index.is_valid()
+				? original_alias.type_index
+				: original_type.type_index();
+			if (const auto* arg = findTemplateArgByRegisteredTypeIndex(
+					binding_type_index, template_params, template_args)) {
+				signature = arg->function_signature;
+			}
 		}
 	}
 	if (!signature.has_value()) {
 		throw InternalError(
 			"Concrete function pointer type is missing canonical FunctionSignature metadata");
 	}
-	return substituteTemplateFunctionSignature(
-		*signature,
-		template_params,
-		template_args);
+	substituted_type.set_function_signature(substituteTemplateFunctionSignature(
+		*signature, template_params, template_args));
+}
+
+inline std::optional<FunctionSignature> getCanonicalFunctionPointerSignature(
+	const TypeSpecifierNode& type_spec) {
+	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(type_spec.type_index());
+	const TypeCategory resolved_category = resolved_alias.type_index.is_valid()
+		? resolved_alias.typeEnum()
+		: type_spec.type_index().category();
+	if (resolved_category != TypeCategory::FunctionPointer &&
+		resolved_category != TypeCategory::MemberFunctionPointer) {
+		return std::nullopt;
+	}
+	if (!type_spec.has_function_signature()) {
+		throw InternalError(
+			"Concrete function pointer type is missing canonical FunctionSignature metadata");
+	}
+	return type_spec.function_signature();
 }
 
 template <typename ParamContainer, typename ArgContainer>
@@ -1175,14 +1194,11 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 			template_params,
 			template_args);
 	}
-	if (auto signature = resolveTemplateFunctionPointerSignature(
-				   original_type_spec,
-				   substituted_type.type_index(),
-				   template_params,
-				   template_args)) {
-		substituted_type.set_function_signature(*signature);
-	}
-	normalizeSubstitutedTypeSpec(substituted_type);
+	materializeSubstitutedFunctionTypeMetadata(
+		substituted_type,
+		original_type_spec,
+		template_params,
+		template_args);
 	return substituted_type;
 }
 
@@ -1500,22 +1516,6 @@ inline ReferenceQualifier collapseTemplateArgumentReferenceQualifier(
 		return ReferenceQualifier::LValueReference;
 	}
 	return ReferenceQualifier::RValueReference;
-}
-
-template <typename ParamContainer, typename ArgContainer>
-inline void propagateFunctionSignatureFromTemplateArg(
-	TypeSpecifierNode& substituted_type,
-	const TypeSpecifierNode& orig_type,
-	TypeIndex substituted_type_index,
-	const ParamContainer& template_params,
-	const ArgContainer& template_args) {
-	if (auto signature = resolveTemplateFunctionPointerSignature(
-			orig_type,
-			substituted_type_index,
-			template_params,
-			template_args)) {
-		substituted_type.set_function_signature(*signature);
-	}
 }
 
 template <typename ParamContainer, typename ArgContainer>

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2111,12 +2111,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 			}
 
-			const StructTypeInfo* pattern_struct_layout_info = nullptr;
-			if (auto pattern_struct_it = getTypesByNameMap().find(pattern_struct.name());
-				pattern_struct_it != getTypesByNameMap().end()) {
-				pattern_struct_layout_info = pattern_struct_it->second->getStructInfo();
-			}
-
 			// Copy members from pattern
 			FLASH_LOG(Templates, Debug, "Pattern struct '", pattern_struct.name(), "' has ", pattern_struct.members().size(), " members");
 			for (const auto& member_decl : pattern_struct.members()) {
@@ -2203,8 +2197,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// — it only carries the placeholder.  Retrieve it from the matching TemplateTypeArg.
 				// Phase 7B: Intern member name and use StringHandle overload
 				StringHandle member_name_handle = decl.identifier_token().handle();
-				const StructMember* source_member =
-					findDirectStructMemberByName(pattern_struct_layout_info, member_name_handle);
 				struct_info->addMember(
 					member_name_handle,
 					stored_member_type_index,
@@ -2221,7 +2213,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					resolveTemplateFunctionPointerSignature(
 						*effective_type_spec,
 						member_type_index,
-						source_member,
 						template_params,
 						template_args_for_member_copy),
 					member_decl.is_no_unique_address);
@@ -6800,22 +6791,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	// Copy members from the template, substituting template parameters with concrete types
-	const StructTypeInfo* source_template_struct_info = nullptr;
-	{
-		auto source_template_type_it =
-			getTypesByNameMap().find(StringTable::getOrInternStringHandle(template_name));
-		if (source_template_type_it == getTypesByNameMap().end()) {
-			std::string_view template_name_view = template_name;
-			size_t last_colon = template_name_view.rfind("::");
-			if (last_colon != std::string_view::npos) {
-				source_template_type_it = getTypesByNameMap().find(
-					StringTable::getOrInternStringHandle(template_name_view.substr(last_colon + 2)));
-			}
-		}
-		if (source_template_type_it != getTypesByNameMap().end()) {
-			source_template_struct_info = source_template_type_it->second->getStructInfo();
-		}
-	}
 	for (const auto& member_decl : class_decl.members()) {
 		const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 		const TypeSpecifierNode& type_spec = decl.type_specifier_node();
@@ -7046,8 +7021,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// — it only carries the placeholder.  Retrieve it from the matching TemplateTypeArg.
 		// Phase 7B: Intern member name and use StringHandle overload
 		StringHandle member_name_handle = decl.identifier_token().handle();
-		const StructMember* source_member =
-			findDirectStructMemberByName(source_template_struct_info, member_name_handle);
 		struct_info->addMember(
 			member_name_handle,
 			stored_member_type_index,
@@ -7064,7 +7037,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			resolveTemplateFunctionPointerSignature(
 				substituted_type_spec,
 				member_type_index,
-				source_member,
 				effective_template_params,
 				effective_template_args),
 			member_decl.is_no_unique_address);
@@ -7931,23 +7903,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				}
 			}
 
-			const StructTypeInfo* source_nested_struct_info = nullptr;
-			{
-				StringBuilder original_nested_name_builder;
-				original_nested_name_builder.append(template_name).append("::"sv).append(nested_struct.name());
-				std::string_view original_nested_name = original_nested_name_builder.commit();
-				auto original_nested_it = getTypesByNameMap().find(
-					StringTable::getOrInternStringHandle(original_nested_name));
-				if (original_nested_it != getTypesByNameMap().end()) {
-					source_nested_struct_info = original_nested_it->second->getStructInfo();
-				} else {
-					auto simple_nested_it = getTypesByNameMap().find(nested_struct.name());
-					if (simple_nested_it != getTypesByNameMap().end()) {
-						source_nested_struct_info = simple_nested_it->second->getStructInfo();
-					}
-				}
-			}
-
 			// Copy and substitute members from the nested class
 			for (const auto& member_decl : nested_struct.members()) {
 				const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
@@ -8013,8 +7968,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 																			 : std::nullopt;
 
 				StringHandle member_name_handle = decl.identifier_token().handle();
-				const StructMember* source_member =
-					findDirectStructMemberByName(source_nested_struct_info, member_name_handle);
 				nested_struct_info->addMember(
 					member_name_handle,
 					stored_member_type_index,
@@ -8031,7 +7984,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					resolveTemplateFunctionPointerSignature(
 						type_spec,
 						substituted_type_spec.type_index(),
-						source_member,
 						template_params,
 						template_args_to_use),
 					member_decl.is_no_unique_address);

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2157,7 +2157,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Use substitute_template_parameter to properly match template parameters by name
 				TypeIndex member_type_index = substitute_template_parameter(
 					*effective_type_spec, template_params, template_args_for_member_copy);
-				size_t ptr_depth = effective_type_spec->pointer_depth();
+				TypeSpecifierNode substituted_member_type_spec = *effective_type_spec;
+				substituted_member_type_spec.set_type_index(member_type_index);
+				materializeSubstitutedFunctionTypeMetadata(
+					substituted_member_type_spec,
+					*effective_type_spec,
+					template_params,
+					template_args_for_member_copy);
+				size_t ptr_depth = substituted_member_type_spec.pointer_depth();
 				ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(member_type_index);
 				std::vector<size_t> resolved_array_dimensions = resolve_array_dimensions(
 					decl, template_params, template_args_for_member_copy);
@@ -2192,9 +2199,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
 					member_decl.default_initializer, template_args_for_member_copy, template_params);
 
-				// For function pointer members instantiated from a template parameter (e.g., F func
-				// where F=int(*)(int)), the pattern TypeSpecifierNode won't have a function_signature
-				// — it only carries the placeholder.  Retrieve it from the matching TemplateTypeArg.
+				// Member registration consumes the canonical substituted type metadata materialized above.
 				// Phase 7B: Intern member name and use StringHandle overload
 				StringHandle member_name_handle = decl.identifier_token().handle();
 				struct_info->addMember(
@@ -2210,11 +2215,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::move(resolved_array_dimensions),
 					static_cast<int>(ptr_depth),
 					resolve_bitfield_width(member_decl, template_params, template_args_for_member_copy),
-					resolveTemplateFunctionPointerSignature(
-						*effective_type_spec,
-						member_type_index,
-						template_params,
-						template_args_for_member_copy),
+					getCanonicalFunctionPointerSignature(substituted_member_type_spec),
 					member_decl.is_no_unique_address);
 			}
 
@@ -6959,6 +6960,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		substituted_type_spec.set_type_index(member_type_index);
 		substituted_type_spec.set_size_in_bits(
 			get_type_size_bits(member_type_index.category()));
+		materializeSubstitutedFunctionTypeMetadata(
+			substituted_type_spec,
+			type_spec,
+			effective_template_params,
+			effective_template_args);
 
 		// Add to the instantiated struct
 		// new_struct_ref.add_member(new_member_decl, member_decl.access, member_decl.default_initializer);
@@ -7016,9 +7022,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
 			member_decl.default_initializer, effective_template_args, effective_template_params);
 
-		// For function pointer members instantiated from a template parameter (e.g., F func
-		// where F=int(*)(int)), the pattern TypeSpecifierNode won't have a function_signature
-		// — it only carries the placeholder.  Retrieve it from the matching TemplateTypeArg.
+		// Member registration consumes the canonical substituted type metadata materialized above.
 		// Phase 7B: Intern member name and use StringHandle overload
 		StringHandle member_name_handle = decl.identifier_token().handle();
 		struct_info->addMember(
@@ -7034,11 +7038,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			std::move(resolved_array_dimensions),
 			static_cast<int>(substituted_type_spec.pointer_depth()),
 			resolve_bitfield_width(member_decl, effective_template_params, effective_template_args),
-			resolveTemplateFunctionPointerSignature(
-				substituted_type_spec,
-				member_type_index,
-				effective_template_params,
-				effective_template_args),
+			getCanonicalFunctionPointerSignature(substituted_type_spec),
 			member_decl.is_no_unique_address);
 	}
 
@@ -7930,6 +7930,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				for (const auto& ptr_level : type_spec.pointer_levels()) {
 					substituted_type_spec.add_pointer_level(ptr_level.cv_qualifier);
 				}
+				materializeSubstitutedFunctionTypeMetadata(
+					substituted_type_spec,
+					type_spec,
+					template_params,
+					template_args_to_use);
 
 				size_t member_size;
 				if (is_array_member) {
@@ -7981,11 +7986,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					resolved_array_dimensions,
 					static_cast<int>(substituted_type_spec.pointer_depth()),
 					resolve_bitfield_width(member_decl, template_params, template_args_to_use),
-					resolveTemplateFunctionPointerSignature(
-						type_spec,
-						substituted_type_spec.type_index(),
-						template_params,
-						template_args_to_use),
+					getCanonicalFunctionPointerSignature(substituted_type_spec),
 					member_decl.is_no_unique_address);
 
 				ASTNode substituted_member_decl = substituteTemplateParameters(

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3031,10 +3031,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				orig_return_type.cv_qualifier());
 			new_return_type.set_type_index(return_type_index);
 			new_return_type.set_reference_qualifier(orig_return_type.reference_qualifier());
-			propagateFunctionSignatureFromTemplateArg(
+			materializeSubstitutedFunctionTypeMetadata(
 				new_return_type,
 				orig_return_type,
-				return_type_index,
 				template_params,
 				template_args);
 			applyTemplateArgIndirection(new_return_type, orig_return_type, template_params, template_args,

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1989,13 +1989,11 @@ ASTNode Parser::buildMaterializedParamType(
 	for (const auto& ptr_level : original_param_type.pointer_levels()) {
 		param_type_ref.add_pointer_level(ptr_level.cv_qualifier);
 	}
-	propagateFunctionSignatureFromTemplateArg(
+	materializeSubstitutedFunctionTypeMetadata(
 		param_type_ref,
 		original_param_type,
-		substituted_type_index,
 		materialized_template_params,
 		materialized_template_args);
-	normalizeSubstitutedTypeSpec(param_type_ref);
 	return param_type;
 }
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1657,6 +1657,13 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 		// Substitute template parameters using parent's template args
 		TypeIndex substituted_type_index = substitute_template_parameter(
 			type_spec, parent_template_params_inline, lazy_info->parent_template_args);
+		TypeSpecifierNode substituted_type_spec = type_spec;
+		substituted_type_spec.set_type_index(substituted_type_index);
+		materializeSubstitutedFunctionTypeMetadata(
+			substituted_type_spec,
+			type_spec,
+			lazy_info->parent_template_params,
+			lazy_info->parent_template_args);
 
 		// Get size and alignment for the member
 		size_t member_size = get_type_size_bits(substituted_type_index.category()) / 8;
@@ -1685,9 +1692,7 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 			{},		// array_dimensions
 			static_cast<int>(type_spec.pointer_depth()),
 			member_decl.bitfield_width,
-			resolveTemplateFunctionPointerSignature(
-				type_spec, substituted_type_index,
-				lazy_info->parent_template_params, lazy_info->parent_template_args),
+			getCanonicalFunctionPointerSignature(substituted_type_spec),
 			member_decl.is_no_unique_address);
 	}
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1687,7 +1687,6 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 			member_decl.bitfield_width,
 			resolveTemplateFunctionPointerSignature(
 				type_spec, substituted_type_index,
-				nullptr,
 				lazy_info->parent_template_params, lazy_info->parent_template_args),
 			member_decl.is_no_unique_address);
 	}

--- a/tests/test_funcptr_template_member_alias_canonical_owner_ret0.cpp
+++ b/tests/test_funcptr_template_member_alias_canonical_owner_ret0.cpp
@@ -1,0 +1,22 @@
+int increment(int value) {
+	return value + 1;
+}
+
+long long widen(long long value) {
+	return value + 2;
+}
+
+template <typename Function>
+struct CallbackHolder {
+	using callback_type = Function;
+	callback_type callback;
+};
+
+int main() {
+	CallbackHolder<int (*)(int)> narrow;
+	CallbackHolder<long long (*)(long long)> wide;
+	narrow.callback = increment;
+	wide.callback = widen;
+
+	return narrow.callback(41) == 42 && wide.callback(40) == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- remove `StructMember` name scans and member-record recovery as template function-signature sources
- materialize callable metadata during template substitution by resolving alias terminal identity and applying the bound type argument
- make member registration consume only the canonical substituted `TypeSpecifierNode` and reject missing concrete signatures
- cover distinct alias-backed callback signatures across template specializations
- document the remaining constexpr and structured function-type representation gaps

## Architecture
Template patterns and their bound arguments are semantic inputs to substitution. The substitution producer now uses them once to build a fully substituted callable type. Registration and later phases no longer search original declarations, template arguments, or member names to repair missing signature metadata.

Remaining work is limited to function-type components the current `FunctionSignature` representation cannot yet express or substitute structurally, including packs, transformed template parameters, dependent member owners, dependent `noexcept`, and nested callable types.
