### PR TITLE
Give nested lazy members concrete owner identity

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,15 +1,5 @@
 # Known Issues
 
-## Nested member lazy identity is shared across outer instantiations
-When two outer class-template instantiations contain the same nested class,
-their lazy nested member functions still share the pattern declaration identity.
-In `tests/test_nested_class_constructor_template_param_ret42.cpp`, replacing the
-final field reads with `i.get()` and `d.get()` causes the lookup for the first
-owner to materialize the second owner's `get()` body. The first call then retains
-the dependent `T` return metadata and compilation fails during `operator+`
-resolution. Lazy nested-member registry/cache identity must include the concrete
-owner independently of the shared source declaration.
-
 ## Namespace-qualified lazy class-template self-copy miscompiles
 Wrapping the fixture in
 `tests/test_explicit_ctor_same_template_copy_init_ret0.cpp` in a non-global

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -2270,30 +2270,44 @@ EvalResult Evaluator::evaluate_resolved_function_call(
 		return *builtin_result;
 	}
 
-	if (!func_decl.is_constexpr() && !func_decl.is_consteval() &&
+	const FunctionDeclarationNode* resolved_func = &func_decl;
+	if (!resolved_func->get_definition().has_value() &&
+		!resolved_func->parent_struct_name().empty()) {
+		StringHandle owner_name = StringTable::getOrInternStringHandle(
+			resolved_func->parent_struct_name());
+		if (std::optional<ASTNode> materialized =
+				context
+					.requireParserAttachedSema("resolved member-function call materialization")
+					.ensureMemberFunctionMaterialized(owner_name, *resolved_func);
+			materialized.has_value() && materialized->is<FunctionDeclarationNode>()) {
+			resolved_func = &materialized->as<FunctionDeclarationNode>();
+		}
+	}
+
+	if (!resolved_func->is_constexpr() && !resolved_func->is_consteval() &&
 		context.storage_duration != ConstExpr::StorageDuration::Static) {
 		return EvalResult::error(
 			"Function in constant expression must be constexpr or consteval: " + std::string(func_name),
 			EvalErrorType::NotConstantExpression);
 	}
 
-	const auto& definition = func_decl.get_definition();
+	const auto& definition = resolved_func->get_definition();
 	if (!definition.has_value()) {
 		return EvalResult::error("Constexpr function has no body: " + std::string(func_name));
 	}
 
-	const size_t parameter_count = func_decl.parameter_nodes().size();
-	const size_t min_required = countMinRequiredArgs(func_decl);
+	const size_t parameter_count = resolved_func->parameter_nodes().size();
+	const size_t min_required = countMinRequiredArgs(*resolved_func);
 	if (arguments.size() < min_required || arguments.size() > parameter_count) {
 		return EvalResult::error("Function argument count mismatch in constant expression");
 	}
 
 	if (outer_bindings) {
-		return evaluate_function_call_with_bindings(func_decl, arguments, *outer_bindings, context, nullptr);
+		return evaluate_function_call_with_bindings(*resolved_func, arguments, *outer_bindings, context, nullptr);
 	}
 
 	std::unordered_map<std::string_view, EvalResult> empty_bindings;
-	return evaluate_function_call_with_template_context(func_decl, arguments, empty_bindings, context);
+	return evaluate_function_call_with_template_context(*resolved_func, arguments, empty_bindings, context);
 }
 
 bool Evaluator::is_expression_noexcept(const ExpressionNode& expr, EvaluationContext& context) {

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -462,7 +462,9 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 						continue;
 					}
 					if (!lazy_info.registry_key.isValid() ||
-						getLazyMemberRegistryKey(member_func.function_decl) != lazy_info.registry_key) {
+						getLazyMemberRegistryKeyForOwner(
+							lazy_info.identity.instantiated_owner_name,
+							member_func.function_decl) != lazy_info.registry_key) {
 						continue;
 					}
 					member_func.function_decl = new_ctor_node;
@@ -497,7 +499,9 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 					continue;
 				}
 				if (!lazy_info.registry_key.isValid() ||
-					getLazyMemberRegistryKey(member_func.function_declaration) != lazy_info.registry_key) {
+					getLazyMemberRegistryKeyForOwner(
+						lazy_info.identity.instantiated_owner_name,
+						member_func.function_declaration) != lazy_info.registry_key) {
 					continue;
 				}
 				member_func.function_declaration = new_ctor_node;
@@ -1017,7 +1021,9 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		if (struct_info) {
 			// Find and update the member function
 			for (auto& member_func : struct_info->member_functions) {
-				if (getLazyMemberRegistryKey(member_func.function_decl) == lazy_info.registry_key) {
+				if (getLazyMemberRegistryKeyForOwner(
+						lazy_info.identity.instantiated_owner_name,
+						member_func.function_decl) == lazy_info.registry_key) {
 					// Replace with the instantiated function
 					member_func.function_decl = new_func_node;
 					FLASH_LOG(Templates, Debug, "Updated StructTypeInfo with instantiated function body");

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -9564,6 +9564,24 @@ void SemanticAnalysis::markResolvedOperatorOverloadOdrUsed(
 		LazyMemberKey::exact(struct_name, fdecl));
 }
 
+namespace {
+const ASTNode* findConcreteOwnerMemberByLazyRegistryKey(
+	StringHandle owner_name,
+	StringHandle registry_key) {
+	if (auto owner_it = getTypesByNameMap().find(owner_name);
+		owner_it != getTypesByNameMap().end() && owner_it->second != nullptr) {
+		if (const StructTypeInfo* struct_info = owner_it->second->getStructInfo()) {
+			for (const StructMemberFunction& member_function : struct_info->member_functions) {
+				if (getLazyMemberRegistryKey(member_function.function_decl) == registry_key) {
+					return &member_function.function_decl;
+				}
+			}
+		}
+	}
+	return nullptr;
+}
+} // namespace
+
 std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	StringHandle struct_name,
 	const FunctionDeclarationNode& function_decl) {
@@ -9581,16 +9599,10 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 	// A prior semantic action may already have consumed the lazy registry entry.
 	// Refresh through the concrete owner's exact declaration key so callers never
 	// retain the shared template-pattern node after its body is materialized.
-	if (auto owner_it = getTypesByNameMap().find(struct_name);
-		owner_it != getTypesByNameMap().end() && owner_it->second != nullptr) {
-		if (const StructTypeInfo* struct_info = owner_it->second->getStructInfo()) {
-			for (const StructMemberFunction& member_function : struct_info->member_functions) {
-				if (getLazyMemberRegistryKey(member_function.function_decl) ==
-						member_key.exact_registry_key) {
-					return member_function.function_decl;
-				}
-			}
-		}
+	if (const ASTNode* concrete_member = findConcreteOwnerMemberByLazyRegistryKey(
+			struct_name,
+			member_key.exact_registry_key)) {
+		return *concrete_member;
 	}
 	return instantiated;
 }

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -9571,12 +9571,27 @@ std::optional<ASTNode> SemanticAnalysis::ensureMemberFunctionMaterialized(
 		return std::nullopt;
 	}
 
+	const LazyMemberKey member_key = LazyMemberKey::exact(struct_name, function_decl);
 	auto instantiated = parser().instantiateLazyMemberIfNeeded(
-		LazyMemberKey::exact(struct_name, function_decl));
-	if (!instantiated.has_value()) {
-		return std::nullopt;
+		member_key);
+	if (instantiated.has_value()) {
+		parser().normalizePendingSemanticRoots();
 	}
-	parser().normalizePendingSemanticRoots();
+
+	// A prior semantic action may already have consumed the lazy registry entry.
+	// Refresh through the concrete owner's exact declaration key so callers never
+	// retain the shared template-pattern node after its body is materialized.
+	if (auto owner_it = getTypesByNameMap().find(struct_name);
+		owner_it != getTypesByNameMap().end() && owner_it->second != nullptr) {
+		if (const StructTypeInfo* struct_info = owner_it->second->getStructInfo()) {
+			for (const StructMemberFunction& member_function : struct_info->member_functions) {
+				if (getLazyMemberRegistryKey(member_function.function_decl) ==
+						member_key.exact_registry_key) {
+					return member_function.function_decl;
+				}
+			}
+		}
+	}
 	return instantiated;
 }
 

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -7,7 +7,8 @@
 class Parser;
 
 // Strip namespace prefix from a class name handle (e.g., "ns::Foo$hash" -> "Foo$hash").
-// Used by lazy registries so lookups match regardless of qualification.
+// Lazy function-member identity must not use this because nested concrete owners
+// can share the same unqualified class name.
 static StringHandle normalizeClassName(StringHandle handle) {
 	std::string_view name = StringTable::getStringView(handle);
 	if (size_t pos = name.rfind("::"); pos != std::string_view::npos) {
@@ -22,7 +23,6 @@ inline StringHandle makeLazyMemberExactKey(
 	bool is_const,
 	const void* declaration_identity) {
 	StringBuilder key_builder;
-	class_name = normalizeClassName(class_name);
 	key_builder.append(class_name).append("::").append(member_name);
 	if (is_const) {
 		key_builder.append("$const");
@@ -109,20 +109,6 @@ inline StringHandle getLazyMemberRegistryKey(const ASTNode& node) {
 		return node.as<DestructorDeclarationNode>().lazy_member_registry_key();
 	}
 	return {};
-}
-
-inline void stampLazyMemberRegistryKey(ASTNode& node, StringHandle key) {
-	if (auto* fn = get_function_decl_node_mut(node)) {
-		fn->set_lazy_member_registry_key(key);
-		return;
-	}
-	if (node.is<ConstructorDeclarationNode>()) {
-		node.as<ConstructorDeclarationNode>().set_lazy_member_registry_key(key);
-		return;
-	}
-	if (node.is<DestructorDeclarationNode>()) {
-		node.as<DestructorDeclarationNode>().set_lazy_member_registry_key(key);
-	}
 }
 
 struct LazyMemberKey {
@@ -230,6 +216,37 @@ struct LazyMemberKey {
 	}
 };
 
+inline StringHandle getLazyMemberRegistryKeyForOwner(
+	StringHandle instantiated_owner_name,
+	const ASTNode& node) {
+	if (StringHandle stored_key = getLazyMemberRegistryKey(node); stored_key.isValid()) {
+		return stored_key;
+	}
+
+	if (const FunctionDeclarationNode* function_decl = get_function_decl_node(node)) {
+		return makeLazyMemberExactKey(
+			instantiated_owner_name,
+			function_decl->decl_node().identifier_token().handle(),
+			function_decl->is_const_member_function(),
+			node.raw_pointer());
+	}
+	if (node.is<ConstructorDeclarationNode>()) {
+		return makeLazyMemberExactKey(
+			instantiated_owner_name,
+			node.as<ConstructorDeclarationNode>().name(),
+			false, // Constructors cannot be const-qualified.
+			node.raw_pointer());
+	}
+	if (node.is<DestructorDeclarationNode>()) {
+		return makeLazyMemberExactKey(
+			instantiated_owner_name,
+			node.as<DestructorDeclarationNode>().name(),
+			false, // Destructors cannot be const-qualified.
+			node.raw_pointer());
+	}
+	return {};
+}
+
 // Registry for tracking uninstantiated template member functions
 // Allows lazy (on-demand) instantiation for better compilation performance
 class LazyMemberInstantiationRegistry {
@@ -241,7 +258,6 @@ public:
 
 	// Append the shared "instantiated_class_name::member_function_name" prefix.
 	static StringBuilder& appendMemberKeyPrefix(StringBuilder& key_builder, StringHandle class_name, StringHandle member_name) {
-		class_name = normalizeClassName(class_name);
 		return key_builder.append(class_name).append("::").append(member_name);
 	}
 
@@ -284,7 +300,6 @@ public:
 			? info.registry_key
 			: makeExactKey(info.identity);
 		info.registry_key = key;
-		stampLazyMemberRegistryKey(info.identity.original_member_node, key);
 		StringHandle lookup_key = makeLookupKey(
 			info.identity.instantiated_owner_name,
 			lookup_name,

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -223,28 +223,28 @@ inline StringHandle getLazyMemberRegistryKeyForOwner(
 		return stored_key;
 	}
 
+	StringHandle member_name;
+	bool is_const_member = false;
 	if (const FunctionDeclarationNode* function_decl = get_function_decl_node(node)) {
-		return makeLazyMemberExactKey(
-			instantiated_owner_name,
-			function_decl->decl_node().identifier_token().handle(),
-			function_decl->is_const_member_function(),
-			node.raw_pointer());
+		member_name = function_decl->decl_node().identifier_token().handle();
+		is_const_member = function_decl->is_const_member_function();
+	} else if (node.is<ConstructorDeclarationNode>()) {
+		member_name = node.as<ConstructorDeclarationNode>().name();
+		// Constructors cannot be const-qualified.
+		is_const_member = false;
+	} else if (node.is<DestructorDeclarationNode>()) {
+		member_name = node.as<DestructorDeclarationNode>().name();
+		// Destructors cannot be const-qualified.
+		is_const_member = false;
+	} else {
+		return {};
 	}
-	if (node.is<ConstructorDeclarationNode>()) {
-		return makeLazyMemberExactKey(
-			instantiated_owner_name,
-			node.as<ConstructorDeclarationNode>().name(),
-			false, // Constructors cannot be const-qualified.
-			node.raw_pointer());
-	}
-	if (node.is<DestructorDeclarationNode>()) {
-		return makeLazyMemberExactKey(
-			instantiated_owner_name,
-			node.as<DestructorDeclarationNode>().name(),
-			false, // Destructors cannot be const-qualified.
-			node.raw_pointer());
-	}
-	return {};
+
+	return makeLazyMemberExactKey(
+		instantiated_owner_name,
+		member_name,
+		is_const_member,
+		node.raw_pointer());
 }
 
 // Registry for tracking uninstantiated template member functions

--- a/tests/test_nested_class_constructor_template_param_ret42.cpp
+++ b/tests/test_nested_class_constructor_template_param_ret42.cpp
@@ -17,5 +17,5 @@ struct Container {
 int main() {
 	Container<int>::Inner i(42);
 	Container<double>::Inner d(3.5);
-	return i.value + static_cast<int>(d.value) - 3; // Expected: 42
+	return i.get() + static_cast<int>(d.get()) - 3; // Expected: 42
 }


### PR DESCRIPTION
## Summary

- key lazy function members by the complete concrete owner and immutable source declaration identity
- replace owner metadata through the exact lazy registry key without mutating the shared template-pattern AST
- refresh constexpr direct-call targets from the canonical concrete owner after lazy body materialization
- strengthen the nested-class regression to invoke both outer-instantiation member bodies and retire the resolved known issue

## Architecture

Overload resolution continues to select the function signature before its body is needed. When constant evaluation ODR-uses a selected lazy member, semantic analysis materializes that exact owner/declaration pair and returns the function now stored in the concrete owner's StructTypeInfo. This avoids unqualified owner collisions, shared-pattern state, name reconstruction, and fallback lookup.