### PR TITLE
Preserve canonical aggregate member semantics through codegen

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,17 +1,23 @@
 # Known Issues
 
-## Nested aggregate template-parameter members miscompile during value construction and copy
-For `template<typename T> struct Outer { struct Inner { T current; }; };`,
-instantiating `Outer<Payload>::Inner` with a multi-field `Payload` records the
-correct aggregate width but does not preserve its fields through a nested
-value-construction and copy sequence. Native 32-bit and 64-bit values and
-pointer template arguments now preserve their layout and value correctly.
+## Aggregate return transport can lose trailing fields
+A nested current-instantiation function that returns a multi-field aggregate by
+value can preserve construction and direct copy-construction but lose trailing
+fields while transporting the result through its hidden return slot. The
+aggregate member metadata, by-value argument classification, and memberwise copy
+are canonical before this point. Trace the non-RVO return copy and hidden
+return-slot destination as object representations; do not reinterpret either as
+a scalar register value or add a nested-template special case.
 
-The constructor signature and nested member `TypeSpecifierNode` producers are
-already canonical at this point. Trace the aggregate through by-value argument
-lowering and aggregate member load/store lowering to find the first incomplete
-or incorrectly classified value operation. Do not repair it with byte-count
-guesses or a codegen-only special case for nested members.
+## Implicit anonymous-union construction initializes inactive members
+The implicit default-constructor IR for an anonymous union can emit stores for
+both the active member with a default member initializer and later overlapping
+members. `test_anonymous_union_member_brace_init_ret0.cpp` currently succeeds
+only because the backend ignores the unsupported wide scalar store emitted for
+the inactive aggregate member. The constructor producer must select and
+initialize only the union member whose lifetime begins under C++20; the backend
+must then reject aggregate values that have neither object storage nor a proper
+aggregate-initialization operation.
 
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,17 +1,22 @@
 # Known Issues
 
-## Nested class-template members lack a canonical current-instantiation owner during constructor substitution
-When a nested class is instantiated as part of its enclosing class template,
-its constructors are copied before the nested `TypeInfo` is registered. A
-user-written copy constructor such as `Inner(const Inner&)` therefore cannot
-rewrite the pattern's injected-class-name type to the concrete nested owner.
-Copy initialization inside a nested member can then reject the valid copy
-constructor and diagnose an unrelated `explicit` converting constructor.
+## Nested template-parameter pointer and aggregate members miscompile
+For `template<typename T> struct Outer { struct Inner { T current; }; };`,
+instantiating `Outer<int*>::Inner` records `current` as a 32-bit member instead
+of a 64-bit pointer member. Instantiating the same pattern with a multi-field
+aggregate records the aggregate width but does not preserve its value through a
+nested value-construction and copy sequence. Native 32-bit and 64-bit value
+members copy correctly.
 
-The sustainable fix is to register the nested semantic type and owner identity
-before copying constructor signatures, then use that typed identity in the
-shared current-instantiation rewrite. Do not repair this with nested-name scans
-or overload-resolution guesses.
+The pointer case shows that the nested member producer substitutes the concrete
+`TypeIndex` without consistently propagating the bound template argument's
+pointer depth and pointer-sized layout metadata. The aggregate case needs to be
+traced separately from signature production into aggregate member load/store
+lowering before deciding whether it shares that producer.
+
+Fix the nested member `TypeSpecifierNode` producer so registration consumes the
+canonical substituted pointer metadata. Do not repair the resulting layout in
+codegen or with a pointer-size fallback.
 
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,14 +1,5 @@
 # Known Issues
 
-## Aggregate return transport can lose trailing fields
-A nested current-instantiation function that returns a multi-field aggregate by
-value can preserve construction and direct copy-construction but lose trailing
-fields while transporting the result through its hidden return slot. The
-aggregate member metadata, by-value argument classification, and memberwise copy
-are canonical before this point. Trace the non-RVO return copy and hidden
-return-slot destination as object representations; do not reinterpret either as
-a scalar register value or add a nested-template special case.
-
 ## Implicit anonymous-union construction initializes inactive members
 The implicit default-constructor IR for an anonymous union can emit stores for
 both the active member with a default member initializer and later overlapping

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,14 +1,17 @@
 # Known Issues
 
-## Namespace-qualified lazy class-template self-copy miscompiles
-Wrapping the fixture in
-`tests/test_explicit_ctor_same_template_copy_init_ret0.cpp` in a non-global
-namespace and qualifying both `ReverseIter<int*>` uses in `main` compiles and
-links, but returns 1 instead of 0 because `copy_self()` does not preserve the
-stored pointer value. The same deferred member-body self-copy works in the
-global namespace. This is a separate namespace-sensitive runtime/codegen issue;
-the local declaration's current-instantiation `TypeIndex` is already rebound to
-the concrete owner before codegen.
+## Nested class-template members lack a canonical current-instantiation owner during constructor substitution
+When a nested class is instantiated as part of its enclosing class template,
+its constructors are copied before the nested `TypeInfo` is registered. A
+user-written copy constructor such as `Inner(const Inner&)` therefore cannot
+rewrite the pattern's injected-class-name type to the concrete nested owner.
+Copy initialization inside a nested member can then reject the valid copy
+constructor and diagnose an unrelated `explicit` converting constructor.
+
+The sustainable fix is to register the nested semantic type and owner identity
+before copying constructor signatures, then use that typed identity in the
+shared current-instantiation rewrite. Do not repair this with nested-name scans
+or overload-resolution guesses.
 
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,15 +1,5 @@
 # Known Issues
 
-## Implicit anonymous-union construction initializes inactive members
-The implicit default-constructor IR for an anonymous union can emit stores for
-both the active member with a default member initializer and later overlapping
-members. `test_anonymous_union_member_brace_init_ret0.cpp` currently succeeds
-only because the backend ignores the unsupported wide scalar store emitted for
-the inactive aggregate member. The constructor producer must select and
-initialize only the union member whose lifetime begins under C++20; the backend
-must then reject aggregate values that have neither object storage nor a proper
-aggregate-initialization operation.
-
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner
 pointer in `InlineVector::size()` during `materializeMatchingConstructorTemplate`.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,22 +1,17 @@
 # Known Issues
 
-## Nested template-parameter pointer and aggregate members miscompile
+## Nested aggregate template-parameter members miscompile during value construction and copy
 For `template<typename T> struct Outer { struct Inner { T current; }; };`,
-instantiating `Outer<int*>::Inner` records `current` as a 32-bit member instead
-of a 64-bit pointer member. Instantiating the same pattern with a multi-field
-aggregate records the aggregate width but does not preserve its value through a
-nested value-construction and copy sequence. Native 32-bit and 64-bit value
-members copy correctly.
+instantiating `Outer<Payload>::Inner` with a multi-field `Payload` records the
+correct aggregate width but does not preserve its fields through a nested
+value-construction and copy sequence. Native 32-bit and 64-bit values and
+pointer template arguments now preserve their layout and value correctly.
 
-The pointer case shows that the nested member producer substitutes the concrete
-`TypeIndex` without consistently propagating the bound template argument's
-pointer depth and pointer-sized layout metadata. The aggregate case needs to be
-traced separately from signature production into aggregate member load/store
-lowering before deciding whether it shares that producer.
-
-Fix the nested member `TypeSpecifierNode` producer so registration consumes the
-canonical substituted pointer metadata. Do not repair the resulting layout in
-codegen or with a pointer-size fallback.
+The constructor signature and nested member `TypeSpecifierNode` producers are
+already canonical at this point. Trace the aggregate through by-value argument
+lowering and aggregate member load/store lowering to find the first incomplete
+or incorrectly classified value operation. Do not repair it with byte-count
+guesses or a codegen-only special case for nested members.
 
 ## Modular-build-only crash: test_template_partial_spec_ool_ctor_template_same_name_overload_ret0.cpp
 `ConstructorDeclarationNode::has_template_parameters()` dereferences a null inner

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -1916,11 +1916,13 @@ void StructTypeInfo::recalculateLayout() {
 	alignment = max_alignment;
 
 	auto addExistingMember = [this](StructMember& member) {
+		const std::optional<size_t> anonymous_union_group_index = member.anonymous_union_group_index;
 		addMember(member.name, member.type_index, member.size, member.alignment, member.access,
 				  std::move(member.default_initializer), member.reference_qualifier,
 				  member.referenced_size_bits, member.is_array, std::move(member.array_dimensions),
 				  member.pointer_depth, member.bitfield_width, std::move(member.function_signature),
 				  member.is_no_unique_address);
+		members.back().anonymous_union_group_index = anonymous_union_group_index;
 	};
 
 	for (auto& member : old_members) {
@@ -1985,11 +1987,13 @@ bool StructTypeInfo::finalizeWithBases() {
 	active_bitfield_bits_used = 0;
 	active_bitfield_type = TypeCategory::Invalid;
 	for (auto& member : old_members) {
+		const std::optional<size_t> anonymous_union_group_index = member.anonymous_union_group_index;
 		addMember(member.name, member.type_index, member.size, member.alignment, member.access,
 				  std::move(member.default_initializer), member.reference_qualifier,
 				  member.referenced_size_bits, member.is_array, std::move(member.array_dimensions),
 				  member.pointer_depth, member.bitfield_width, std::move(member.function_signature),
 				  member.is_no_unique_address);
+		members.back().anonymous_union_group_index = anonymous_union_group_index;
 	}
 
 	current_offset = currentLayoutOffset();

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -100,6 +100,14 @@ struct StructTypeInfo {
 		return namespace_handle;
 	}
 
+	bool isVariantMember(const StructMember& member) const {
+		return is_union || member.anonymous_union_group_index.has_value();
+	}
+
+	bool isPotentiallyConstructedByDefaultConstructor(const StructMember& member) const {
+		return !isVariantMember(member) || member.default_initializer.has_value();
+	}
+
 	void addMember(StringHandle member_name, TypeIndex type_index,
 				   size_t member_size, size_t member_alignment, AccessSpecifier access,
 				   std::optional<ASTNode> default_initializer,

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -886,6 +886,7 @@ struct AnonymousUnionMemberInfo {
 	size_t member_size;					// Size in bytes (including array size if applicable)
 	size_t member_alignment;			 // Alignment requirement in bytes
 	std::optional<size_t> bitfield_width; // Width in bits for bitfield members
+	std::optional<ASTNode> default_initializer;
 	size_t referenced_size_bits;		 // Size in bits of referenced type (for references)
 	ReferenceQualifier reference_qualifier = ReferenceQualifier::None;  // None, LValueReference, or RValueReference
 	bool is_array;					   // True if member is an array
@@ -898,12 +899,14 @@ struct AnonymousUnionMemberInfo {
 
 	AnonymousUnionMemberInfo(StringHandle name, TypeIndex tidx, size_t size, size_t align,
 							 std::optional<size_t> bitfield_w,
+							 std::optional<ASTNode> initializer,
 							 size_t ref_size_bits, ReferenceQualifier ref_qual,
 							 bool is_arr,
 							 int ptr_depth,
 							 std::vector<size_t> arr_dims)
 		: member_name(name), type_index(tidx), member_size(size),
-		  member_alignment(align), bitfield_width(bitfield_w), referenced_size_bits(ref_size_bits), reference_qualifier(ref_qual),
+		  member_alignment(align), bitfield_width(bitfield_w), default_initializer(std::move(initializer)),
+		  referenced_size_bits(ref_size_bits), reference_qualifier(ref_qual),
 		  is_array(is_arr), array_dimensions(std::move(arr_dims)),
 		  pointer_depth(ptr_depth) {}
 };
@@ -1283,6 +1286,7 @@ public:
 	// Must be called after add_anonymous_union_marker()
 	void add_anonymous_union_member(StringHandle member_name, TypeIndex type_index,
 									size_t member_size, size_t member_alignment, std::optional<size_t> bitfield_width,
+									std::optional<ASTNode> default_initializer,
 									size_t referenced_size_bits, ReferenceQualifier reference_qualifier,
 									bool is_array,
 									int pointer_depth,
@@ -1291,7 +1295,7 @@ public:
 		if (!anonymous_unions_.empty()) {
 			anonymous_unions_.back().union_members.emplace_back(
 				member_name, type_index, member_size, member_alignment,
-				bitfield_width, referenced_size_bits, reference_qualifier, is_array,
+				bitfield_width, std::move(default_initializer), referenced_size_bits, reference_qualifier, is_array,
 				pointer_depth,
 				std::move(array_dimensions));
 		}

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -1152,6 +1152,8 @@ struct StructMember {
 	int pointer_depth;	   // Pointer indirection level (e.g., int* = 1, int** = 2)
 	std::optional<FunctionSignature> function_signature;	 // For FunctionPointer members: stores return type and parameter types
 	bool is_no_unique_address = false;
+	// Identifies variants flattened from the same anonymous union; absent for non-variant members.
+	std::optional<size_t> anonymous_union_group_index;
 
 	// Convenience helpers for common checks
 	bool is_reference() const { return reference_qualifier != ReferenceQualifier::None; }

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -2645,7 +2645,7 @@ void IrToObjConverter<TWriterClass>::emitMovFromFrameBySize(X64Register destinat
 
 template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitFrameMemoryCopy(FrameMemoryLocation source, FrameMemoryLocation destination, SizeInBytes size) {
-	if (!size.is_set()) {
+	if (!size.is_positive()) {
 		throw InternalError("Aggregate copy requires a positive object size");
 	}
 

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -4091,6 +4091,37 @@ bool IrToObjConverter<TWriterClass>::shouldPassStructByAddress(const TypedValue&
 }
 
 template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::emitIntegerOrAggregateReturnValue(
+	TypeIndex type_index, SizeInBits size_in_bits,
+	int32_t frame_offset, std::optional<X64Register> live_value_register) {
+	const bool uses_two_registers = isTwoRegisterStructRaw(
+		toIrType(type_index.category()), size_in_bits.value, false, 0);
+	if (uses_two_registers) {
+		spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
+		spillAndInvalidateRegisterForManualOverwrite(X64Register::RDX);
+		emitMovFromFrame(X64Register::RAX, frame_offset);
+		const SizeInBits upper_eightbyte_size{size_in_bits.value - 64};
+		emitMovFromFrameBySize(X64Register::RDX, frame_offset + 8, upper_eightbyte_size.value);
+		return;
+	}
+
+	if (live_value_register.has_value()) {
+		if (*live_value_register != X64Register::RAX) {
+			spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
+			auto move_to_rax = regAlloc.get_reg_reg_move_op_code(
+				X64Register::RAX, *live_value_register, size_in_bits.value / 8);
+			logAsmEmit("emitIntegerOrAggregateReturnValue", move_to_rax.op_codes.data(), move_to_rax.size_in_bytes);
+			textSectionData.insert(textSectionData.end(), move_to_rax.op_codes.begin(),
+							   move_to_rax.op_codes.begin() + move_to_rax.size_in_bytes);
+		}
+		return;
+	}
+
+	spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
+	emitMovFromFrameBySize(X64Register::RAX, frame_offset, size_in_bits.value);
+}
+
+template <class TWriterClass>
 int32_t IrToObjConverter<TWriterClass>::getVariableOffsetOrThrow(StringHandle var_handle, std::string_view context) const {
 	const VariableInfo* var_info = findVariableInfo(var_handle);
 	if (!var_info) {
@@ -4747,8 +4778,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 					// SystemV AMD64 ABI: structs 9-16 bytes return in RAX (low 8 bytes) and RDX (high 8 bytes)
 				if (call_op.return_type_index.category() == TypeCategory::Struct && return_size_bits > 64 && return_size_bits <= 128) {
 						// Two-register struct return: first 8 bytes in RAX, next 8 bytes in RDX
-					emitMovToFrame(X64Register::RAX, result_offset, return_size_bits);  // Store low 8 bytes
-					emitMovToFrame(X64Register::RDX, result_offset + 8, return_size_bits - 64);	// Store high 8 bytes
+					emitMovToFrameBySize(X64Register::RAX, result_offset, 64);
+					emitMovToFrameBySize(X64Register::RDX, result_offset + 8, return_size_bits - 64);
 					FLASH_LOG_FORMAT(Codegen, Debug,
 									 "Storing two-register struct return ({} bits): RAX->offset {}, RDX->offset {}",
 									 return_size_bits, result_offset, result_offset + 8);
@@ -9041,59 +9072,10 @@ void IrToObjConverter<TWriterClass>::handleReturn(const IrInstruction& instructi
 							bool is_float = (ret_op.return_size == 32);
 							spillAndInvalidateRegisterForManualOverwrite(X64Register::XMM0);
 							emitFloatMovFromFrame(X64Register::XMM0, var_offset, is_float);
-						} else if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-								// SystemV AMD64 ABI: check if this is a two-register struct return (9-16 bytes)
-							if (ret_op.return_type_index.category() == TypeCategory::Struct &&
-								var_size > 64 && var_size <= 128) {
-									// Two-register struct return: first 8 bytes in RAX, next 8 bytes in RDX
-								spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-								spillAndInvalidateRegisterForManualOverwrite(X64Register::RDX);
-								emitMovFromFrame(X64Register::RAX, var_offset);	// Load low 8 bytes
-								emitMovFromFrame(X64Register::RDX, var_offset + 8);	// Load high 8 bytes
-								FLASH_LOG_FORMAT(Codegen, Debug,
-												 "TempVar two-register struct return ({} bits): RAX from offset {}, RDX from offset {}",
-												 var_size, var_offset, var_offset + 8);
-								regAlloc.flushSingleDirtyRegister(X64Register::RAX);
-								regAlloc.flushSingleDirtyRegister(X64Register::RDX);
-							} else {
-									// Single-register return (≤64 bits) in RAX - integer/pointer return
-								if (auto reg_var = regAlloc.tryGetStackVariableRegister(var_offset); reg_var.has_value()) {
-									if (reg_var.value() != X64Register::RAX) {
-										spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-										auto movResultToRax = regAlloc.get_reg_reg_move_op_code(X64Register::RAX, reg_var.value(), ret_op.return_size / 8);
-										for (size_t i = 0; i < movResultToRax.size_in_bytes; ++i) {
-										}
-										logAsmEmit("handleReturn mov to RAX", movResultToRax.op_codes.data(), movResultToRax.size_in_bytes);
-										textSectionData.insert(textSectionData.end(), movResultToRax.op_codes.begin(), movResultToRax.op_codes.begin() + movResultToRax.size_in_bytes);
-									} else {
-									}
-								} else {
-										// Load from stack using RBP-relative addressing
-										// Use actual variable size for proper zero/sign extension
-									spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-									emitMovFromFrameBySize(X64Register::RAX, var_offset, var_size);
-									regAlloc.flushSingleDirtyRegister(X64Register::RAX);
-								}
-							}
 						} else {
-								// Windows x64 ABI: small structs (≤64 bits) return in RAX only - integer/pointer return
-							if (auto reg_var = regAlloc.tryGetStackVariableRegister(var_offset); reg_var.has_value()) {
-								if (reg_var.value() != X64Register::RAX) {
-									spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-									auto movResultToRax = regAlloc.get_reg_reg_move_op_code(X64Register::RAX, reg_var.value(), ret_op.return_size / 8);
-									for (size_t i = 0; i < movResultToRax.size_in_bytes; ++i) {
-									}
-									logAsmEmit("handleReturn mov to RAX", movResultToRax.op_codes.data(), movResultToRax.size_in_bytes);
-									textSectionData.insert(textSectionData.end(), movResultToRax.op_codes.begin(), movResultToRax.op_codes.begin() + movResultToRax.size_in_bytes);
-								} else {
-								}
-							} else {
-									// Load from stack using RBP-relative addressing
-									// Use actual variable size for proper zero/sign extension
-								spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-								emitMovFromFrameBySize(X64Register::RAX, var_offset, var_size);
-								regAlloc.flushSingleDirtyRegister(X64Register::RAX);
-							}
+							emitIntegerOrAggregateReturnValue(
+								ret_op.return_type_index, SizeInBits{var_size}, var_offset,
+								regAlloc.tryGetStackVariableRegister(var_offset));
 						}
 					}
 				} else {
@@ -9119,31 +9101,9 @@ void IrToObjConverter<TWriterClass>::handleReturn(const IrInstruction& instructi
 						bool is_float = (ret_op.return_size == 32);
 						spillAndInvalidateRegisterForManualOverwrite(X64Register::XMM0);
 						emitFloatMovFromFrame(X64Register::XMM0, var_offset, is_float);
-					} else if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-							// SystemV AMD64 ABI: check if this is a two-register struct return (9-16 bytes)
-						if (ret_op.return_type_index.category() == TypeCategory::Struct &&
-							var_size > 64 && var_size <= 128) {
-								// Two-register struct return: first 8 bytes in RAX, next 8 bytes in RDX
-							spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-							spillAndInvalidateRegisterForManualOverwrite(X64Register::RDX);
-							emitMovFromFrame(X64Register::RAX, var_offset);	// Load low 8 bytes
-							emitMovFromFrame(X64Register::RDX, var_offset + 8);	// Load high 8 bytes
-							FLASH_LOG_FORMAT(Codegen, Debug,
-											 "Fallback two-register struct return ({} bits): RAX from offset {}, RDX from offset {}",
-											 var_size, var_offset, var_offset + 8);
-							regAlloc.flushSingleDirtyRegister(X64Register::RAX);
-							regAlloc.flushSingleDirtyRegister(X64Register::RDX);
-						} else {
-								// Single-register return (≤64 bits) in RAX
-							spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-							emitMovFromFrameBySize(X64Register::RAX, var_offset, var_size);
-							regAlloc.flushSingleDirtyRegister(X64Register::RAX);
-						}
 					} else {
-							// Windows x64 ABI: small structs (≤64 bits) return in RAX only
-						spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-						emitMovFromFrameBySize(X64Register::RAX, var_offset, var_size);
-						regAlloc.flushSingleDirtyRegister(X64Register::RAX);
+						emitIntegerOrAggregateReturnValue(
+							ret_op.return_type_index, SizeInBits{var_size}, var_offset, std::nullopt);
 					}
 				}
 			} else if (std::holds_alternative<StringHandle>(ret_val)) {
@@ -9242,11 +9202,8 @@ void IrToObjConverter<TWriterClass>::handleReturn(const IrInstruction& instructi
 							spillAndInvalidateRegisterForManualOverwrite(X64Register::XMM0);
 							emitFloatMovFromFrame(X64Register::XMM0, var_offset, is_float);
 						} else {
-								// Load integer/pointer value into RAX
-								// Use actual variable size for proper zero/sign extension
-							spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-							emitMovFromFrameBySize(X64Register::RAX, var_offset, var_size);
-							regAlloc.flushSingleDirtyRegister(X64Register::RAX);
+							emitIntegerOrAggregateReturnValue(
+								ret_op.return_type_index, SizeInBits{var_size}, var_offset, std::nullopt);
 						}
 					}
 				} else {

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -13742,13 +13742,15 @@ void IrToObjConverter<TWriterClass>::handleMemberStore(const IrInstruction& inst
 	// Calculate member size in bytes
 	int member_size_bytes = op.value.size_in_bits.value / 8;
 
-	const bool is_non_scalar_struct_copy =
+	const bool is_non_scalar_struct_value =
 		isIrStructType(op.value.effectiveIrType()) &&
 		!op.value.pointer_depth.is_pointer() &&
 		!op.is_reference() &&
-		op.value.size_in_bits.value > 64 &&
-		!is_literal;
-	if (is_non_scalar_struct_copy) {
+		op.value.size_in_bits > SizeInBits{64};
+	if (is_non_scalar_struct_value && is_literal) {
+		throw InternalError("Non-scalar aggregate member value must have object storage");
+	}
+	if (is_non_scalar_struct_value) {
 		int32_t source_offset = 0;
 		FrameMemoryStorage source_storage = FrameMemoryStorage::Direct;
 		if (is_variable) {

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -2644,6 +2644,60 @@ void IrToObjConverter<TWriterClass>::emitMovFromFrameBySize(X64Register destinat
 }
 
 template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::emitFrameMemoryCopy(FrameMemoryLocation source, FrameMemoryLocation destination, SizeInBytes size) {
+	if (!size.is_set()) {
+		throw InternalError("Aggregate copy requires a positive object size");
+	}
+
+	X64Register source_address = X64Register::Count;
+	if (source.storage == FrameMemoryStorage::Indirect) {
+		source_address = allocateRegisterWithSpilling();
+		emitMovFromFrame(source_address, source.frame_offset);
+	}
+
+	X64Register destination_address = X64Register::Count;
+	if (destination.storage == FrameMemoryStorage::Indirect) {
+		destination_address = allocateRegisterWithSpilling();
+		emitMovFromFrame(destination_address, destination.frame_offset);
+	}
+
+	X64Register copy_register = allocateRegisterWithSpilling();
+	for (int byte_offset = 0; byte_offset < size.value;) {
+		const SizeInBytes remaining{size.value - byte_offset};
+		const SizeInBytes chunk_size{
+			remaining.value >= 8 ? 8 : remaining.value >= 4 ? 4 : remaining.value >= 2 ? 2 : 1};
+		const SizeInBits chunk_size_bits = toBits(chunk_size);
+
+		if (source.storage == FrameMemoryStorage::Indirect) {
+			emitMovFromMemory(copy_register, source_address, source.displacement + byte_offset, chunk_size.value);
+		} else {
+			emitMovFromFrameSized(
+				SizedRegister{copy_register, 64, false},
+				SizedStackSlot{source.frame_offset + source.displacement + byte_offset, chunk_size_bits.value, false});
+		}
+
+		if (destination.storage == FrameMemoryStorage::Indirect) {
+			emitStoreToMemory(textSectionData, copy_register, destination_address,
+							  destination.displacement + byte_offset, chunk_size.value);
+		} else {
+			emitMovToFrameSized(
+				SizedRegister{copy_register, 64, false},
+				SizedStackSlot{destination.frame_offset + destination.displacement + byte_offset, chunk_size_bits.value, false});
+		}
+
+		byte_offset += chunk_size.value;
+	}
+
+	regAlloc.release(copy_register);
+	if (destination_address != X64Register::Count) {
+		regAlloc.release(destination_address);
+	}
+	if (source_address != X64Register::Count) {
+		regAlloc.release(source_address);
+	}
+}
+
+template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitMovFromFrame(X64Register destinationRegister, int32_t offset) {
 	auto opcodes = generateMovFromFrameBySize(destinationRegister, offset, 64);
 	textSectionData.insert(textSectionData.end(), opcodes.op_codes.begin(), opcodes.op_codes.begin() + opcodes.size_in_bytes);
@@ -13685,8 +13739,46 @@ void IrToObjConverter<TWriterClass>::handleMemberStore(const IrInstruction& inst
 		member_stack_offset = object_base_offset + op.offset;
 	}
 
-		// Calculate member size in bytes
+	// Calculate member size in bytes
 	int member_size_bytes = op.value.size_in_bits.value / 8;
+
+	const bool is_non_scalar_struct_copy =
+		isIrStructType(op.value.effectiveIrType()) &&
+		!op.value.pointer_depth.is_pointer() &&
+		!op.is_reference() &&
+		op.value.size_in_bits.value > 64 &&
+		!is_literal;
+	if (is_non_scalar_struct_copy) {
+		int32_t source_offset = 0;
+		FrameMemoryStorage source_storage = FrameMemoryStorage::Direct;
+		if (is_variable) {
+			auto source_it = current_scope.variables.find(variable_name);
+			if (source_it == current_scope.variables.end()) {
+				throw InternalError("Aggregate member initializer variable not found in scope");
+			}
+			source_offset = source_it->second.offset;
+			if (isPointerBaseStorage(source_offset)) {
+				source_storage = FrameMemoryStorage::Indirect;
+			}
+		} else {
+			const TempVar source_temp = std::get<TempVar>(op.value.value);
+			source_offset = getStackOffsetFromTempVar(source_temp, op.value.size_in_bits.value);
+			if (isPointerBaseStorage(source_offset, source_temp)) {
+				source_storage = FrameMemoryStorage::Indirect;
+			}
+		}
+
+		const FrameMemoryLocation source{
+			.frame_offset = source_offset,
+			.displacement = 0,
+			.storage = source_storage};
+		const FrameMemoryLocation destination{
+			.frame_offset = is_pointer_access ? object_base_offset : member_stack_offset,
+			.displacement = is_pointer_access ? op.offset : 0,
+			.storage = is_pointer_access ? FrameMemoryStorage::Indirect : FrameMemoryStorage::Direct};
+		emitFrameMemoryCopy(source, destination, toBytesExact(op.value.size_in_bits));
+		return;
+	}
 
 	const bool is_float_pointer_store = is_pointer_access && !op.is_reference() && !op.bitfield_width.has_value() && isIrFloatingPointType(op.value.effectiveIrType());
 	if (is_float_pointer_store) {

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -470,6 +470,11 @@ private:
 	void emitTwoRegStructToRegs(int src_offset, X64Register target_reg,
 								size_t& int_reg_index, size_t max_int_regs);
 
+	/// Materialize a non-floating return value in the target ABI's return registers.
+	/// SysV aggregates spanning two eightbytes use RAX and RDX; other values use RAX.
+	void emitIntegerOrAggregateReturnValue(TypeIndex type_index, SizeInBits size_in_bits,
+										 int32_t frame_offset, std::optional<X64Register> live_value_register);
+
 	void handleFunctionCall(const IrInstruction& instruction);
 
 	bool emitSameTypeCopyOrMoveConstructorCall(TypeIndex type_index, int object_offset, bool object_is_pointer, const TypedValue& source_arg, bool prefer_move = false);

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -241,6 +241,21 @@ private:
 	// This makes both source and destination sizes explicit for clarity
 	void emitMovFromFrameSized(SizedRegister dest, SizedStackSlot source);
 
+	enum class FrameMemoryStorage {
+		Direct,
+		Indirect
+	};
+
+	struct FrameMemoryLocation {
+		int32_t frame_offset;
+		int32_t displacement;
+		FrameMemoryStorage storage;
+	};
+
+	// Copy an object representation between direct frame storage and frame slots
+	// that contain an address, preserving every byte of aggregate values.
+	void emitFrameMemoryCopy(FrameMemoryLocation source, FrameMemoryLocation destination, SizeInBytes size);
+
 	// Helper to generate and emit LEA from frame
 	void emitLeaFromFrame(X64Register destinationRegister, int32_t offset);
 

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -1822,7 +1822,7 @@ ExprResult AstToIr::generateUnaryOperatorIr(const UnaryOperatorNode& unaryOperat
 			return makeExprResult(operandIrOperands.type_index.withCategory(operandType), SizeInBits{64}, IrOperand{lvalue_temp}, PointerDepth{static_cast<int>(result_ptr_depth)}, ValueStorage::ContainsAddress);
 		}
 
-		int element_size = 64; // Default to pointer size
+		int element_size = POINTER_SIZE_BITS;
 		int pointer_depth = 0;
 
 		// First, try to get pointer depth from operandIrOperands (for TempVar results from previous operations)
@@ -1851,32 +1851,17 @@ ExprResult AstToIr::generateUnaryOperatorIr(const UnaryOperatorNode& unaryOperat
 		// If still > 0, result is a pointer (64 bits)
 		// If == 0, result is the base type
 		if (pointer_depth <= 1) {
-				// Single-level pointer or less: result is base type size
-			switch (operandType) {
-			case TypeCategory::Bool:
-				element_size = 8;
-				break;
-			case TypeCategory::Char:
-				element_size = 8;
-				break;
-			case TypeCategory::Short:
-				element_size = 16;
-				break;
-			case TypeCategory::Int:
-				element_size = 32;
-				break;
-			case TypeCategory::Long:
-				element_size = 64;
-				break;
-			case TypeCategory::Float:
-				element_size = 32;
-				break;
-			case TypeCategory::Double:
-				element_size = 64;
-				break;
-			default:
-				element_size = 64;
-				break;  // Fallback for unknown types
+			// A single dereference produces the semantic pointee object. Its
+			// representation comes from the canonical TypeInfo, including complete
+			// aggregate layout, rather than from the pointer's register width.
+			const TypeIndex pointee_type_index =
+				operandIrOperands.type_index.withCategory(operandType);
+			element_size = getRuntimeValueSizeBits(
+				pointee_type_index,
+				get_type_size_bits(operandType),
+				PointerDepth{});
+			if (element_size <= 0) {
+				throw InternalError("Dereference requires a complete pointee object size");
 			}
 		}
 		// else: multi-level pointer, element_size stays 64 (pointer)

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -449,6 +449,14 @@ int AstToIr::getRuntimeValueSizeBits(TypeIndex type_index, int semantic_size_bit
 
 	TypeCategory lowered_cat = resolve_type_alias(type_index);
 	const TypeCategory semantic_cat = type_index.category();
+	if (isIrStructType(toIrType(semantic_cat))) {
+		const TypeInfo* type_info = tryGetTypeInfo(type_index);
+		const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
+		if (!struct_info || !struct_info->hasCompleteObjectLayout()) {
+			throw InternalError("Runtime aggregate value requires complete canonical layout metadata");
+		}
+		return struct_info->sizeInBits().value;
+	}
 
 	if (lowered_cat == TypeCategory::Enum) {
 		if (const TypeInfo* ti = tryGetTypeInfo(type_index)) {

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -429,10 +429,12 @@ TypeCategory AstToIr::getRuntimeValueType(TypeIndex semantic_type_index, Pointer
 		return semantic_type;
 	}
 
-	TypeCategory lowered_cat = resolve_type_alias(semantic_type_index);
+	const CanonicalTypeAlias canonical_type = canonicalize_type_alias(semantic_type_index);
+	const TypeIndex runtime_type_index = canonical_type.resolvedTypeIndex();
+	const TypeCategory lowered_cat = canonical_type.typeEnum();
 
 	if (lowered_cat == TypeCategory::Enum) {
-		if (const TypeInfo* ti = tryGetTypeInfo(semantic_type_index)) {
+		if (const TypeInfo* ti = tryGetTypeInfo(runtime_type_index)) {
 			if (const EnumTypeInfo* enum_info = ti->getEnumInfo()) {
 				return enum_info->underlying_type;
 			}
@@ -447,10 +449,12 @@ int AstToIr::getRuntimeValueSizeBits(TypeIndex type_index, int semantic_size_bit
 		return semantic_size_bits;
 	}
 
-	TypeCategory lowered_cat = resolve_type_alias(type_index);
+	const CanonicalTypeAlias canonical_type = canonicalize_type_alias(type_index);
+	const TypeIndex runtime_type_index = canonical_type.resolvedTypeIndex();
+	const TypeCategory lowered_cat = canonical_type.typeEnum();
 	const TypeCategory semantic_cat = type_index.category();
-	if (isIrStructType(toIrType(semantic_cat))) {
-		const TypeInfo* type_info = tryGetTypeInfo(type_index);
+	if (isIrStructType(toIrType(lowered_cat))) {
+		const TypeInfo* type_info = tryGetTypeInfo(runtime_type_index);
 		const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
 		if (!struct_info || !struct_info->hasCompleteObjectLayout()) {
 			throw InternalError("Runtime aggregate value requires complete canonical layout metadata");
@@ -459,7 +463,7 @@ int AstToIr::getRuntimeValueSizeBits(TypeIndex type_index, int semantic_size_bit
 	}
 
 	if (lowered_cat == TypeCategory::Enum) {
-		if (const TypeInfo* ti = tryGetTypeInfo(type_index)) {
+		if (const TypeInfo* ti = tryGetTypeInfo(runtime_type_index)) {
 			if (const EnumTypeInfo* enum_info = ti->getEnumInfo()) {
 				return enum_info->sizeInBits().value;
 			}

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -2459,6 +2459,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 					// In that case skip generating the body entirely — the function is effectively deleted.
 					bool is_implicitly_deleted = false;
 					for (const auto& member : struct_info->members) {
+						if (!struct_info->isPotentiallyConstructedByDefaultConstructor(member)) {
+							continue;
+						}
 						if (member.type_index.category() == TypeCategory::Struct) {
 							const TypeInfo* mti = tryGetTypeInfo(member.type_index);
 							if (mti && mti->struct_info_ &&
@@ -2477,6 +2480,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 							std::unordered_map<size_t, unsigned long long> combined_bitfield_values;
 							std::unordered_set<size_t> bitfield_offsets;
 							for (const auto& member : struct_info->members) {
+								if (!struct_info->isPotentiallyConstructedByDefaultConstructor(member)) {
+									continue;
+								}
 								if (member.bitfield_width.has_value()) {
 									bitfield_offsets.insert(member.offset);
 									unsigned long long val = 0;
@@ -2500,7 +2506,8 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 							}
 							for (auto offset : bitfield_offsets) {
 								for (const auto& member : struct_info->members) {
-									if (member.offset == offset && member.bitfield_width.has_value()) {
+									if (member.offset == offset && member.bitfield_width.has_value() &&
+										struct_info->isPotentiallyConstructedByDefaultConstructor(member)) {
 										MemberStoreOp combined_store;
 										combined_store.value.setType(member.type_index.category());
 										combined_store.value.size_in_bits = SizeInBits{static_cast<int>(member.size * 8)};
@@ -2521,6 +2528,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 						for (const auto& member : struct_info->members) {
 							if (member.bitfield_width.has_value())
 								continue; // handled above
+							if (!struct_info->isPotentiallyConstructedByDefaultConstructor(member)) {
+								continue;
+							}
 
 							// Generate MemberStore IR to initialize the member
 							// Format: [member_type, member_size, object_name, member_name, offset, value]

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -3104,27 +3104,33 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			size_t aligned_union_start = ((union_start_offset + union_max_alignment - 1) & ~(union_max_alignment - 1));
 
 			// Second pass: add all union members at the same aligned offset
-			for (const auto& union_member : union_info.union_members) {
+			for (size_t union_member_index = 0; union_member_index < union_info.union_members.size(); ++union_member_index) {
+				const auto& union_member = union_info.union_members[union_member_index];
+				const StructMemberDecl& union_member_decl =
+					struct_ref.members()[union_info.member_index_in_ast + union_member_index];
 				size_t effective_alignment = union_member.member_alignment;
 				if (struct_info->pack_alignment > 0 && struct_info->pack_alignment < union_member.member_alignment) {
 					effective_alignment = struct_info->pack_alignment;
 				}
 
 				// Manually add member to struct_info at the aligned offset
-				struct_info->members.emplace_back(
+				StructMember& semantic_member = struct_info->members.emplace_back(
 					union_member.member_name,
 					union_member.type_index,
 					aligned_union_start, // Same offset for all union members
 					union_member.member_size,
 					effective_alignment,
 					AccessSpecifier::Public, // Anonymous union members are always public
-					std::nullopt, // No default initializer
+					union_member_decl.default_initializer,
 					union_member.reference_qualifier,
 					union_member.referenced_size_bits,
 					union_member.is_array,
 					union_member.array_dimensions,
 					union_member.pointer_depth,
 					union_member.bitfield_width);
+				if (union_info.is_union) {
+					semantic_member.anonymous_union_group_index = next_union_idx;
+				}
 
 				// Update struct alignment
 				struct_info->alignment = std::max(struct_info->alignment, effective_alignment);

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1612,19 +1612,6 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 							referenced_size_bits = referenced_size_bits ? referenced_size_bits : (anon_member_type_spec.size_in_bits());
 						}
 
-						StringHandle member_name_handle = anon_member_name_token.handle();
-						struct_ref.add_anonymous_union_member(
-							member_name_handle,
-							anon_member_type_spec.type_index().withCategory(anon_member_type_spec.type()),
-							member_size,
-							member_alignment,
-							bitfield_width,
-							referenced_size_bits,
-							ref_qual,
-							is_array,
-							static_cast<int>(anon_member_type_spec.pointer_depth()),
-							std::move(array_dimensions));
-
 						// Add DeclarationNode to struct_ref for symbol table and AST purposes
 						// During layout phase, these will be skipped (already processed as union members)
 						std::optional<ASTNode> anon_default_initializer;
@@ -1640,6 +1627,20 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 								anon_default_initializer = *init_result.node();
 							}
 						}
+
+						StringHandle member_name_handle = anon_member_name_token.handle();
+						struct_ref.add_anonymous_union_member(
+							member_name_handle,
+							anon_member_type_spec.type_index().withCategory(anon_member_type_spec.type()),
+							member_size,
+							member_alignment,
+							bitfield_width,
+							anon_default_initializer,
+							referenced_size_bits,
+							ref_qual,
+							is_array,
+							static_cast<int>(anon_member_type_spec.pointer_depth()),
+							std::move(array_dimensions));
 
 						ASTNode anon_member_decl_node;
 						if (!anon_array_dimensions.empty()) {
@@ -3104,10 +3105,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			size_t aligned_union_start = ((union_start_offset + union_max_alignment - 1) & ~(union_max_alignment - 1));
 
 			// Second pass: add all union members at the same aligned offset
-			for (size_t union_member_index = 0; union_member_index < union_info.union_members.size(); ++union_member_index) {
-				const auto& union_member = union_info.union_members[union_member_index];
-				const StructMemberDecl& union_member_decl =
-					struct_ref.members()[union_info.member_index_in_ast + union_member_index];
+			for (const auto& union_member : union_info.union_members) {
 				size_t effective_alignment = union_member.member_alignment;
 				if (struct_info->pack_alignment > 0 && struct_info->pack_alignment < union_member.member_alignment) {
 					effective_alignment = struct_info->pack_alignment;
@@ -3121,7 +3119,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 					union_member.member_size,
 					effective_alignment,
 					AccessSpecifier::Public, // Anonymous union members are always public
-					union_member_decl.default_initializer,
+					union_member.default_initializer,
 					union_member.reference_qualifier,
 					union_member.referenced_size_bits,
 					union_member.is_array,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7643,8 +7643,31 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 			auto qualified_name = StringTable::getOrInternStringHandle(StringBuilder().append(instantiated_name).append("::"sv).append(nested_struct.name()));
 
-			// Create a new StructTypeInfo for the nested class
-			auto nested_struct_info = std::make_unique<StructTypeInfo>((qualified_name), nested_struct.default_access(), nested_struct.is_union(), decl_ns);
+			// Register the nested semantic owner before producing members and signatures.
+			// Constructor current-instantiation substitution requires both the pattern
+			// and instantiated owner TypeIndex values to be canonical at this point.
+			auto nested_struct_info_owner = std::make_unique<StructTypeInfo>(
+				qualified_name,
+				nested_struct.default_access(),
+				nested_struct.is_union(),
+				decl_ns);
+			auto& nested_type_info = add_instantiated_type(
+				qualified_name,
+				TypeCategory::Struct,
+				0); // Layout is finalized after member production.
+			nested_type_info.setStructInfo(std::move(nested_struct_info_owner));
+			StructTypeInfo* nested_struct_info = nested_type_info.getStructInfo();
+			if (nested_struct_info == nullptr || !nested_struct_info->own_type_index_.has_value()) {
+				throw InternalError("Nested class registration did not establish a canonical semantic owner");
+			}
+			nested_type_info.setInstantiationContext(
+				collectParamNameHandles(
+					effective_template_params,
+					effective_template_args.size()),
+				collectEnrichedTemplateArgInfos(
+					effective_template_params,
+					effective_template_args),
+				struct_type_info.instantiationContext());
 			auto instantiated_nested_struct = emplace_node<StructDeclarationNode>(
 				nested_struct.name(),
 				nested_struct.is_class(),
@@ -8090,8 +8113,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						substituted_ctor,
 						template_params,
 						template_args_to_use,
-						// The nested type receives its semantic owner after this copy phase.
-						std::nullopt);
+						makeCurrentInstantiationTypeRewrite(
+							original_ctor,
+							nested_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct)));
 					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 					substituteAndCopyInitializers(
 						original_ctor,
@@ -8282,7 +8306,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					if (nested_struct_info != nullptr) {
 						OutOfLineConstructorStubResolution info_ctor_resolution =
 							findReplayedOutOfLineConstructorInStructInfo(
-								nested_struct_info.get(),
+								nested_struct_info,
 								nested_struct_info_member_identity_maps,
 								ctor_resolution.source_member,
 								ctor_decl,
@@ -8511,24 +8535,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				nested_struct_info->needs_default_constructor = true;
 			}
 
-			// Register the nested class in the type system
-			auto& nested_type_info = add_instantiated_type(qualified_name, TypeCategory::Struct, 0); // Placeholder size
-			nested_type_info.setStructInfo(std::move(nested_struct_info));
 			if (nested_type_info.getStructInfo()) {
 				nested_type_info.fallback_size_bits_ = nested_type_info.getStructInfo()->sizeInBits().value;
 			}
-
- // Propagate the outer type's instantiation context to the nested type.
- // The nested type isn't itself a template instantiation, but it lives inside
- // one and needs the enclosing template's bindings for constexpr evaluation.
-			nested_type_info.setInstantiationContext(
-				collectParamNameHandles(
-					effective_template_params,
-					effective_template_args.size()),
-				collectEnrichedTemplateArgInfos(
-					effective_template_params,
-					effective_template_args),
-				struct_type_info.instantiationContext());
 
 			struct_info->addNestedClass(nested_type_info.getStructInfo());
 			FLASH_LOG(Templates, Debug, "Registered nested class: ", StringTable::getStringView(qualified_name));

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -588,33 +588,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// Helper: substitute template parameter types in a function/constructor parameter list
 	// and add the substituted parameters to a target node.
 	// Consolidates the ~25-line pattern repeated across all instantiation paths.
-	struct SelfTypeRewriteInfo {
+	struct CurrentInstantiationTypeRewrite {
 		TypeIndex from_type_index;
 		TypeIndex to_type_index;
 	};
-	auto makeImplicitCtorSelfTypeRewrite = [&](StringHandle pattern_struct_name, TypeIndex instantiated_struct_type_index)
-		-> std::optional<SelfTypeRewriteInfo> {
-		if (!instantiated_struct_type_index.is_valid()) {
-			return std::nullopt;
-		}
-		auto it = getTypesByNameMap().find(pattern_struct_name);
-		if (it == getTypesByNameMap().end() || it->second == nullptr) {
-			return std::nullopt;
-		}
-		TypeIndex pattern_struct_type_index = it->second->registeredTypeIndex();
-		if (!pattern_struct_type_index.is_valid()) {
-			return std::nullopt;
+	// An injected class name denotes the current instantiation in every constructor
+	// signature, including user-written copy and move constructors.
+	auto makeCurrentInstantiationTypeRewrite = [](
+		const ConstructorDeclarationNode& pattern_constructor,
+		TypeIndex instantiated_struct_type_index) -> CurrentInstantiationTypeRewrite {
+		TypeIndex pattern_struct_type_index = pattern_constructor.owning_type_index();
+		if (!pattern_struct_type_index.is_valid() || !instantiated_struct_type_index.is_valid()) {
+			throw InternalError(
+				"Constructor parameter substitution requires canonical pattern and instantiated owner types");
 		}
 		pattern_struct_type_index.setCategory(TypeCategory::Struct);
 		instantiated_struct_type_index.setCategory(TypeCategory::Struct);
-		return SelfTypeRewriteInfo{pattern_struct_type_index, instantiated_struct_type_index};
+		return CurrentInstantiationTypeRewrite{pattern_struct_type_index, instantiated_struct_type_index};
 	};
 	auto substituteAndCopyParams = [&](
 									   std::span<const ASTNode> orig_params,
 									   auto& target_node,
 									   const auto& tmpl_params,
 									   const auto& tmpl_args,
-									   std::optional<SelfTypeRewriteInfo> self_type_rewrite = std::nullopt) {
+									   std::optional<CurrentInstantiationTypeRewrite> current_instantiation_rewrite) {
 		for (const auto& param : orig_params) {
 			if (!param.is<DeclarationNode>()) {
 				target_node.add_parameter_node(param);
@@ -690,8 +687,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				continue;
 			// Use substituteTemplateParameters as the primary substitution to correctly
 			// propagate pointer depth from template args (e.g. I→int* gives ptr_depth=1).
-			// The TypeIndex from substitute_template_parameter+self_type_rewrite is applied
-			// on top to handle self-referential types.
+			// The TypeIndex from substitution plus the current-instantiation rewrite is
+			// applied on top to handle self-referential types.
 			ASTNode original_param_type_node = param_decl.type_node();
 			const bool preserve_dependent_member_template_identity =
 				typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
@@ -700,9 +697,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				original_param_type_node, tmpl_params, tmpl_args);
 			TypeIndex param_type_index = substitute_template_parameter(
 				param_type_spec, tmpl_params, tmpl_args);
-			if (self_type_rewrite.has_value() &&
-				param_type_index == self_type_rewrite->from_type_index) {
-				param_type_index = self_type_rewrite->to_type_index;
+			if (current_instantiation_rewrite.has_value() &&
+				param_type_index == current_instantiation_rewrite->from_type_index) {
+				param_type_index = current_instantiation_rewrite->to_type_index;
 			}
 			param_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
 				original_param_type_node,
@@ -2246,11 +2243,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_ctor_ref,
 						template_params,
 						template_args_for_member_copy,
-						orig_ctor.is_implicit()
-							? makeImplicitCtorSelfTypeRewrite(
-								pattern_struct.name(),
-								struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct))
-							: std::nullopt);
+						makeCurrentInstantiationTypeRewrite(
+							orig_ctor,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct)));
 					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 					substituteAndCopyInitializers(
 						orig_ctor,
@@ -3482,11 +3477,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_ctor_ref,
 						template_params,
 						template_args_for_pattern,
-						orig_ctor.is_implicit()
-							? makeImplicitCtorSelfTypeRewrite(
-								pattern_struct.name(),
-								struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct))
-							: std::nullopt);
+						makeCurrentInstantiationTypeRewrite(
+							orig_ctor,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct)));
 					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 
 					// Copy initializers (member, base, delegating)
@@ -8096,7 +8089,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						original_ctor.parameter_nodes(),
 						substituted_ctor,
 						template_params,
-						template_args_to_use);
+						template_args_to_use,
+						// The nested type receives its semantic owner after this copy phase.
+						std::nullopt);
 					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 					substituteAndCopyInitializers(
 						original_ctor,
@@ -9949,7 +9944,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Substitute and copy parameters — may add function-pack info to pack_param_info_
 					// so that pack expansions in the body and initializers resolve correctly.
 					size_t saved_pack_info = pack_param_info_.size();
-					substituteAndCopyParams(ctor_decl.parameter_nodes(), new_ctor_ref, template_params, template_args_to_use);
+					substituteAndCopyParams(
+						ctor_decl.parameter_nodes(),
+						new_ctor_ref,
+						template_params,
+						template_args_to_use,
+						makeCurrentInstantiationTypeRewrite(
+							ctor_decl,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct)));
 					const std::vector<PackParamInfo> ctor_pack_param_info = pack_param_info_;
 
 					std::optional<ASTNode> substituted_body;
@@ -10040,7 +10042,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 					// Substitute and copy parameters so the stub has concrete types.
 					size_t saved_pack_info = pack_param_info_.size();
-					substituteAndCopyParams(ctor_decl.parameter_nodes(), new_ctor_ref, template_params, template_args_to_use);
+					substituteAndCopyParams(
+						ctor_decl.parameter_nodes(),
+						new_ctor_ref,
+						template_params,
+						template_args_to_use,
+						makeCurrentInstantiationTypeRewrite(
+							ctor_decl,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct)));
 					pack_param_info_.resize(saved_pack_info);
 
 					new_ctor_ref.set_is_implicit(ctor_decl.is_implicit());

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -7923,6 +7923,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			for (const auto& member_decl : nested_struct.members()) {
 				const DeclarationNode& decl = member_decl.declaration.as<DeclarationNode>();
 				const TypeSpecifierNode& type_spec = decl.type_specifier_node();
+				ASTNode full_substituted_type_node = substituteTemplateParameters(
+					decl.type_node(), template_params, template_args_to_use);
 				TypeIndex substituted_type_index = substitute_template_parameter(
 					type_spec, template_params, template_args_to_use);
 				ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(substituted_type_index);
@@ -7935,47 +7937,31 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				TypeIndex member_size_type_index = resolved_member_alias.isArray() ? resolved_member_alias.type_index : substituted_type_index;
 				TypeIndex stored_member_type_index = resolved_member_alias.isArray() ? resolved_member_alias.type_index : substituted_type_index;
 
-				TypeSpecifierNode substituted_type_spec(
-					substituted_type_index.category(),
-					type_spec.qualifier(),
-					get_type_size_bits(substituted_type_index.category()),
-					Token(), // Empty token
-					CVQualifier::None);
+				TypeSpecifierNode substituted_type_spec = full_substituted_type_node.is<TypeSpecifierNode>()
+					? full_substituted_type_node.as<TypeSpecifierNode>()
+					: type_spec;
 				substituted_type_spec.set_type_index(substituted_type_index);
-
-				for (const auto& ptr_level : type_spec.pointer_levels()) {
-					substituted_type_spec.add_pointer_level(ptr_level.cv_qualifier);
-				}
+				substituted_type_spec.set_size_in_bits(
+					get_type_size_bits(substituted_type_index.category()));
 				materializeSubstitutedFunctionTypeMetadata(
 					substituted_type_spec,
 					type_spec,
 					template_params,
 					template_args_to_use);
 
-				size_t member_size;
+				const MemberSizeAndAlignment element_layout =
+					calculateResolvedMemberSizeAndAlignment(
+						substituted_type_spec,
+						member_size_type_index);
+				size_t member_size = element_layout.size;
 				if (is_array_member) {
 					size_t total_elements = 1;
 					for (size_t dim_size : resolved_array_dimensions) {
 						total_elements *= dim_size;
 					}
-
-					size_t element_size = calculateResolvedMemberSizeAndAlignment(
-											  substituted_type_spec, member_size_type_index)
-											  .size;
-					member_size = element_size * total_elements;
-				} else if (type_spec.is_pointer() || type_spec.is_reference() || type_spec.is_rvalue_reference()) {
-					member_size = 8;
-				} else {
-					member_size = calculateResolvedMemberSizeAndAlignment(
-									  substituted_type_spec, member_size_type_index)
-									  .size;
+					member_size *= total_elements;
 				}
-				size_t member_alignment = get_type_alignment(member_size_type_index.category(), member_size);
-				if (type_spec.is_pointer() || type_spec.is_reference() || type_spec.is_rvalue_reference()) {
-					member_alignment = 8;
-				} else if (const StructTypeInfo* member_struct_info = tryGetStructTypeInfo(member_size_type_index)) {
-					member_alignment = member_struct_info->alignment;
-				}
+				const size_t member_alignment = element_layout.alignment;
 
 				ReferenceQualifier ref_qual = substituted_type_spec.reference_qualifier();
 				size_t referenced_size_bits = ref_qual != ReferenceQualifier::None

--- a/src/SizeTypes.h
+++ b/src/SizeTypes.h
@@ -33,6 +33,7 @@ struct SizeInBytes {
 	constexpr explicit SizeInBytes(int v) noexcept : value(v) {}
 	constexpr auto operator<=>(const SizeInBytes&) const noexcept = default;
 	constexpr bool is_set() const noexcept { return value != 0; }
+	constexpr bool is_positive() const noexcept { return value > 0; }
 };
 
 template <>

--- a/tests/test_aggregate_pointer_dereference_copy_ret0.cpp
+++ b/tests/test_aggregate_pointer_dereference_copy_ret0.cpp
@@ -1,0 +1,65 @@
+// Regression: dereferencing a pointer to a complete aggregate must preserve
+// its canonical object size through copy construction and non-RVO return.
+
+struct Payload {
+	long long wide;
+	int narrow;
+};
+
+struct CompactPayload {
+	int first;
+	int second;
+	int third;
+};
+
+Payload return_payload(Payload value) {
+	Payload copy = value;
+	return copy;
+}
+
+CompactPayload return_compact(CompactPayload value) {
+	CompactPayload copy = value;
+	return copy;
+}
+
+Payload return_pointer_copy(const Payload* value) {
+	Payload copy = *value;
+	return copy;
+}
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		T current;
+
+		explicit Inner(T value) : current(value) {}
+		Inner(const Inner& other) : current(other.current) {}
+
+		Inner copy_self() const {
+			Inner copy = *this;
+			return copy;
+		}
+	};
+};
+
+int main() {
+	Payload payload{0x123456789LL, 17};
+	CompactPayload compact{23, 29, 31};
+	Payload returned_payload = return_payload(payload);
+	CompactPayload returned_compact = return_compact(compact);
+	Payload returned_pointer_copy = return_pointer_copy(&payload);
+	Outer<Payload>::Inner original(payload);
+	Outer<Payload>::Inner returned_inner = original.copy_self();
+
+	int result = 0;
+	if (returned_payload.wide != payload.wide) result |= 1;
+	if (returned_payload.narrow != payload.narrow) result |= 2;
+	if (returned_compact.first != compact.first) result |= 4;
+	if (returned_compact.second != compact.second) result |= 8;
+	if (returned_compact.third != compact.third) result |= 16;
+	if (returned_inner.current.wide != payload.wide) result |= 32;
+	if (returned_inner.current.narrow != payload.narrow) result |= 64;
+	if (returned_pointer_copy.wide != payload.wide ||
+		returned_pointer_copy.narrow != payload.narrow) result |= 128;
+	return result;
+}

--- a/tests/test_aggregate_pointer_dereference_copy_ret0.cpp
+++ b/tests/test_aggregate_pointer_dereference_copy_ret0.cpp
@@ -12,6 +12,13 @@ struct CompactPayload {
 	int third;
 };
 
+using PayloadAlias = Payload;
+
+template<typename T>
+using Identity = T;
+
+using ChainedPayloadAlias = Identity<PayloadAlias>;
+
 Payload return_payload(Payload value) {
 	Payload copy = value;
 	return copy;
@@ -24,6 +31,11 @@ CompactPayload return_compact(CompactPayload value) {
 
 Payload return_pointer_copy(const Payload* value) {
 	Payload copy = *value;
+	return copy;
+}
+
+ChainedPayloadAlias return_alias_pointer_copy(const ChainedPayloadAlias* value) {
+	ChainedPayloadAlias copy = *value;
 	return copy;
 }
 
@@ -48,6 +60,7 @@ int main() {
 	Payload returned_payload = return_payload(payload);
 	CompactPayload returned_compact = return_compact(compact);
 	Payload returned_pointer_copy = return_pointer_copy(&payload);
+	ChainedPayloadAlias returned_alias_pointer_copy = return_alias_pointer_copy(&payload);
 	Outer<Payload>::Inner original(payload);
 	Outer<Payload>::Inner returned_inner = original.copy_self();
 
@@ -61,5 +74,7 @@ int main() {
 	if (returned_inner.current.narrow != payload.narrow) result |= 64;
 	if (returned_pointer_copy.wide != payload.wide ||
 		returned_pointer_copy.narrow != payload.narrow) result |= 128;
+	if (returned_alias_pointer_copy.wide != payload.wide ||
+		returned_alias_pointer_copy.narrow != payload.narrow) result |= 256;
 	return result;
 }

--- a/tests/test_anonymous_union_active_default_member_ret0.cpp
+++ b/tests/test_anonymous_union_active_default_member_ret0.cpp
@@ -1,0 +1,24 @@
+struct Payload {
+	short head;
+	long long tail;
+};
+
+struct ScalarVariant {
+	union {
+		Payload inactive;
+		int tag{42};
+	};
+};
+
+struct AggregateVariant {
+	union {
+		int inactive;
+		Payload payload{7, 35};
+	};
+};
+
+int main() {
+	ScalarVariant scalar{};
+	AggregateVariant aggregate{};
+	return (scalar.tag - 42) + (aggregate.payload.head + aggregate.payload.tail - 42);
+}

--- a/tests/test_namespaced_lazy_same_template_self_copy_ret0.cpp
+++ b/tests/test_namespaced_lazy_same_template_self_copy_ret0.cpp
@@ -1,0 +1,31 @@
+// Regression: a namespace-qualified class-template specialization must keep
+// the same complete object value when a deferred member copies *this through
+// the current-instantiation type.
+
+namespace sample {
+
+struct Other;
+
+template<typename T>
+struct ReverseIter {
+	T current;
+
+	ReverseIter() : current() {}
+	explicit ReverseIter(T value) : current(value) {}
+	ReverseIter(const ReverseIter& other) : current(other.current) {}
+	explicit ReverseIter(const Other& other);
+
+	ReverseIter copy_self() const {
+		ReverseIter copy = *this;
+		return copy;
+	}
+};
+
+} // namespace sample
+
+int main() {
+	int value = 42;
+	sample::ReverseIter<int*> original(&value);
+	sample::ReverseIter<int*> copy = original.copy_self();
+	return copy.current == &value ? 0 : 1;
+}

--- a/tests/test_nested_aggregate_template_member_copy_ret0.cpp
+++ b/tests/test_nested_aggregate_template_member_copy_ret0.cpp
@@ -1,0 +1,55 @@
+// Regression: an aggregate bound to an outer template parameter must retain
+// all fields through nested value construction and current-instantiation copy.
+
+struct Payload {
+	long long wide;
+	int narrow;
+};
+
+struct CompactPayload {
+	int first;
+	int second;
+	int third;
+};
+
+struct DirectHolder {
+	Payload current;
+
+	explicit DirectHolder(Payload value) : current(value) {}
+};
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		T current;
+
+		explicit Inner(T value) : current(value) {}
+		Inner(const Inner& other) : current(other.current) {}
+
+	};
+};
+
+int main() {
+	Payload payload{0x123456789LL, 17};
+	CompactPayload compact_payload{23, 29, 31};
+	DirectHolder direct(payload);
+	Outer<Payload>::Inner original(payload);
+	Outer<Payload>::Inner constructor_copy(original);
+	Outer<CompactPayload>::Inner compact_original(compact_payload);
+	Outer<CompactPayload>::Inner compact_copy(compact_original);
+
+	int result = 0;
+	if (original.current.wide != payload.wide) result |= 1;
+	if (original.current.narrow != payload.narrow) result |= 2;
+	if (constructor_copy.current.wide != payload.wide) result |= 4;
+	if (constructor_copy.current.narrow != payload.narrow) result |= 8;
+	if (direct.current.wide != payload.wide) result |= 16;
+	if (direct.current.narrow != payload.narrow) result |= 32;
+	if (compact_original.current.first != compact_payload.first ||
+		compact_original.current.second != compact_payload.second ||
+		compact_original.current.third != compact_payload.third) result |= 64;
+	if (compact_copy.current.first != compact_payload.first ||
+		compact_copy.current.second != compact_payload.second ||
+		compact_copy.current.third != compact_payload.third) result |= 128;
+	return result;
+}

--- a/tests/test_nested_current_instantiation_self_copy_ret0.cpp
+++ b/tests/test_nested_current_instantiation_self_copy_ret0.cpp
@@ -1,0 +1,32 @@
+// Regression: nested classes must acquire their concrete semantic owner before
+// constructor signatures substitute the injected class name.
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		T current;
+
+		explicit Inner(T value) : current(value) {}
+		Inner(const Inner& other) : current(other.current) {}
+
+		Inner copy_self() const {
+			Inner copy = *this;
+			return copy;
+		}
+	};
+};
+
+int main() {
+	long long wide_value = 0x123456789LL;
+	Outer<long long>::Inner wide_original(wide_value);
+	Outer<long long>::Inner wide_copy = wide_original.copy_self();
+
+	int narrow_value = 17;
+	Outer<int>::Inner narrow_original(narrow_value);
+	Outer<int>::Inner narrow_copy = narrow_original.copy_self();
+
+	int result = 0;
+	if (wide_copy.current != wide_value) result |= 1;
+	if (narrow_copy.current != narrow_value) result |= 2;
+	return result;
+}

--- a/tests/test_nested_template_parameter_pointer_member_ret0.cpp
+++ b/tests/test_nested_template_parameter_pointer_member_ret0.cpp
@@ -1,0 +1,25 @@
+// Regression: pointer metadata from an outer template argument must survive
+// member production for a nested class.
+
+template<typename T>
+struct Outer {
+	struct Inner {
+		T current;
+
+		explicit Inner(T value) : current(value) {}
+	};
+};
+
+int main() {
+	int narrow = 17;
+	long long wide = 0x123456789LL;
+	Outer<int*>::Inner narrow_pointer(&narrow);
+	Outer<long long*>::Inner wide_pointer(&wide);
+
+	int result = 0;
+	if (sizeof(narrow_pointer) != sizeof(int*)) result |= 1;
+	if (sizeof(wide_pointer) != sizeof(long long*)) result |= 2;
+	if (narrow_pointer.current != &narrow) result |= 4;
+	if (wide_pointer.current != &wide) result |= 8;
+	return result;
+}


### PR DESCRIPTION
## Summary

- give instantiated constructors their canonical current-instantiation owner before substituting nested self types
- preserve pointer, reference, and function-signature metadata for nested template members
- keep non-scalar aggregate values in object storage and copy their full representation through member access and pointer dereference
- return two-register SysV aggregates through both ABI-classified result registers
- retain anonymous-union variant/default-initializer metadata, initialize only the active variant, and reject storage-less aggregate IR
- canonicalize aliases before runtime layout lookup and enforce positive aggregate-copy sizes through the strong size type
- add reduced regressions and remove the resolved known-issue entries