### PR TITLE
Classify SysV aggregates from canonical layouts

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -111,3 +111,35 @@ consume that object directly. Remaining work should reduce the parallel metadata
 copies and extend structured substitution to the unsupported function-type
 components above; a concrete callable type without complete metadata is already
 treated as an internal producer error.
+
+## SysV MEMORY-class aggregate returns need deferred ABI planning
+
+SysV aggregate argument and direct register-return lowering classifies concrete
+types from canonical layout metadata. Unaligned aggregates and other MEMORY-class
+values are also classified correctly for parameter passing. Return-slot selection,
+however, is still decided while IR is generated from a size threshold. Replacing
+that threshold directly with strict layout classification exposes function
+templates and deferred lambda signatures whose return types are not concrete at
+that phase.
+
+The remaining C++20-compliant fix is to represent return ABI disposition as
+`direct`, `indirect`, or `dependent`, defer the last case until substitution has
+produced a complete canonical return type, and require concrete call/function IR
+to carry the resulting ABI plan. Treating an unresolved type as direct, guessing
+from its category or size, or reconstructing it during code generation would hide
+the producer defect. Until that planning boundary exists, a small unaligned
+aggregate return can still use the wrong direct-return convention on SysV.
+
+The first shared-classifier lowering slice is deliberately limited to concrete
+two-eightbyte aggregates (9–16 bytes). Single-eightbyte aggregate lowering still
+uses the legacy scalar path, which is correct for INTEGER-class values but does
+not yet select an SSE register for aggregates containing only `float`/`double`.
+Enabling strict classification for that path currently exposes several IR
+producers that omit canonical type identity for small class values. Those
+producers must be closed before the scalar path is replaced; accepting an absent
+`TypeIndex` as INTEGER would only preserve the same non-standard guess.
+
+Aggregate returns containing `long double` also remain on the legacy path. Their
+SysV result classification uses the X87/X87UP classes, which the current backend
+return-register abstraction cannot represent yet. Aggregate parameters containing
+`long double` are still classified as MEMORY as required.

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1286,7 +1286,7 @@ private:
 	// ============================================================================
 	// Return IR helper
 	// ============================================================================
-	void emitReturn(IrValue return_value, TypeCategory return_type, int return_size, const Token& token);
+	void emitReturn(IrValue return_value, TypeIndex return_type_index, int return_size, const Token& token);
 
 	void emitVoidReturn(const Token& token) {
 		ReturnOp ret_op;

--- a/src/IRConverter.h
+++ b/src/IRConverter.h
@@ -18,6 +18,7 @@
 #include "ElfFileWriter.h"
 #include "ProfilingTimer.h"
 #include "ChunkedString.h"
+#include "TargetABI.h"
 
 // Global exception handling control (defined in main.cpp)
 extern bool g_enable_exceptions;

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -2036,36 +2036,40 @@ typename IrToObjConverter<TWriterClass>::StackSpaceSize IrToObjConverter<TWriter
 
 			// Lambda: compute outgoing stack bytes for a set of arguments on Linux SysV AMD64.
 			// int_slots_start: number of integer register slots already consumed (e.g., 1 for 'this').
-		auto computeSysVOutgoingBytes = [](std::span<const TypedValue> args, size_t int_slots_start) -> size_t {
+		auto computeSysVOutgoingBytes = [this](std::span<const TypedValue> args, size_t int_slots_start) -> size_t {
 			size_t int_slots_used = int_slots_start;
 			size_t float_slots_used = 0;
-			size_t int_stack_slots = 0;
-			size_t float_stack_slots = 0;
+			size_t stack_slots = 0;
 			constexpr size_t max_int_regs = 6;
 			constexpr size_t max_float_regs = 8;
 			for (const auto& arg : args) {
 				bool arg_is_float = isIrFloatingPointType(arg.effectiveIrType()) && !arg.is_reference() && !arg.pointer_depth.is_pointer();
-				bool arg_is_two_reg = isIrStructType(arg.effectiveIrType()) && arg.size_in_bits.value > 64 && arg.size_in_bits.value <= 128 &&
-									  !arg.is_reference() && !arg.pointer_depth.is_pointer();
-				size_t slots = arg_is_two_reg ? 2 : 1;
-				if (arg_is_float) {
+				const std::optional<SysVAbiValueLayout> aggregate_layout = classifySysVAggregate(arg);
+				if (aggregate_layout.has_value()) {
+					const size_t integer_register_count = aggregate_layout->integerRegisterCount();
+					const size_t sse_register_count = aggregate_layout->sseRegisterCount();
+					if (aggregate_layout->isMemory() ||
+						int_slots_used + integer_register_count > max_int_regs ||
+						float_slots_used + sse_register_count > max_float_regs) {
+						stack_slots += static_cast<size_t>((arg.size_in_bits.value + 63) / 64);
+					} else {
+						int_slots_used += integer_register_count;
+						float_slots_used += sse_register_count;
+					}
+				} else if (arg_is_float) {
 					if (float_slots_used < max_float_regs)
 						float_slots_used++;
 					else
-						float_stack_slots++;
+						stack_slots++;
 				} else {
-					if (int_slots_used + slots <= max_int_regs) {
-						int_slots_used += slots;
-					} else if (int_slots_used < max_int_regs) {
-							// Partial overflow: struct needs 2 but only 1 slot left — all goes to stack
-						int_stack_slots += slots;
-						int_slots_used = max_int_regs;
+					if (int_slots_used < max_int_regs) {
+						int_slots_used++;
 					} else {
-						int_stack_slots += slots;
+						stack_slots++;
 					}
 				}
 			}
-			return (int_stack_slots + float_stack_slots) * 8;
+			return stack_slots * 8;
 		};
 
 		if (instruction.getOpcode() == IrOpcode::FunctionCall && instruction.hasTypedPayload()) {
@@ -4060,33 +4064,26 @@ X64Register IrToObjConverter<TWriterClass>::allocateXMMRegisterWithSpilling(X64R
 }
 
 template <class TWriterClass>
-bool IrToObjConverter<TWriterClass>::isTwoRegisterStructRaw(IrType ir_type, int size_in_bits, bool is_reference, int pointer_depth) {
+std::optional<SysVAbiValueLayout> IrToObjConverter<TWriterClass>::classifySysVAggregate(const TypedValue& arg) const {
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-		return isIrStructType(ir_type) && size_in_bits > 64 && size_in_bits <= 128 && !is_reference && pointer_depth == 0;
+		if (isIrStructType(arg.effectiveIrType()) && arg.size_in_bits.value > 64 &&
+			!arg.pointer_depth.is_pointer() && !arg.is_reference()) {
+			return TargetABI::classifySysVValue(
+				arg.type_index, arg.size_in_bits, arg.pointer_depth.value, arg.is_reference());
+		}
 	}
-	(void)ir_type;
-	(void)size_in_bits;
-	(void)is_reference;
-	(void)pointer_depth;
-	return false;
+	return std::nullopt;
 }
 
 template <class TWriterClass>
-bool IrToObjConverter<TWriterClass>::isTwoRegisterStruct(const TypedValue& arg, [[maybe_unused]] bool is_variadic_call) const {
-	return isTwoRegisterStructRaw(arg.effectiveIrType(), arg.size_in_bits.value, arg.is_reference(), arg.pointer_depth.value);
-}
-
-template <class TWriterClass>
-bool IrToObjConverter<TWriterClass>::shouldPassStructByAddress(const TypedValue& arg, bool is_two_register_struct) const {
+bool IrToObjConverter<TWriterClass>::shouldPassStructByAddress(const TypedValue& arg) const {
 	if (!isIrStructType(arg.effectiveIrType()) || arg.is_reference())
 		return false;
-		// SysV AMD64 two-register structs (9-16 bytes) must pass their bytes in
-		// registers, NOT a pointer.
-	if (is_two_register_struct)
+	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+		// SysV passes MEMORY-class aggregates in the overflow area by value. A pointer
+		// is used only for an indirect result, not as a replacement parameter ABI.
 		return false;
-		// FlashCpp passes all other structs > 64 bits by pointer on both Linux and Windows,
-		// matching the callee prologue which always dereferences the incoming pointer for
-		// structs whose size exceeds one general-purpose register.
+	}
 	return arg.size_in_bits.value > 64;
 }
 
@@ -4094,15 +4091,39 @@ template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitIntegerOrAggregateReturnValue(
 	TypeIndex type_index, SizeInBits size_in_bits,
 	int32_t frame_offset, std::optional<X64Register> live_value_register) {
-	const bool uses_two_registers = isTwoRegisterStructRaw(
-		toIrType(type_index.category()), size_in_bits.value, false, 0);
-	if (uses_two_registers) {
-		spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
-		spillAndInvalidateRegisterForManualOverwrite(X64Register::RDX);
-		emitMovFromFrame(X64Register::RAX, frame_offset);
-		const SizeInBits upper_eightbyte_size{size_in_bits.value - 64};
-		emitMovFromFrameBySize(X64Register::RDX, frame_offset + 8, upper_eightbyte_size.value);
-		return;
+	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 64) {
+			const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
+				type_index, size_in_bits, /*pointer_depth=*/0, /*is_reference=*/false);
+			// x87 aggregate returns stay on the legacy direct-return path until the
+			// backend models the SysV X87/X87UP return register classes.
+			if (!layout.contains_x87) {
+				if (layout.isMemory()) {
+					throw InternalError("MEMORY-class SysV aggregate reached direct return lowering");
+				}
+				static constexpr std::array<X64Register, 2> integer_return_regs{X64Register::RAX, X64Register::RDX};
+				static constexpr std::array<X64Register, 2> sse_return_regs{X64Register::XMM0, X64Register::XMM1};
+				size_t integer_index = 0;
+				size_t sse_index = 0;
+				for (size_t eightbyte_index = 0; eightbyte_index < layout.eightbyte_count; ++eightbyte_index) {
+					const int slot_size_bits = std::min(64, size_in_bits.value - static_cast<int>(eightbyte_index * 64));
+					if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Integer) {
+						X64Register target_reg = integer_return_regs[integer_index++];
+						spillAndInvalidateRegisterForManualOverwrite(target_reg);
+						emitMovFromFrameBySize(target_reg, frame_offset + static_cast<int32_t>(eightbyte_index * 8), slot_size_bits);
+					} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Sse) {
+						X64Register target_reg = sse_return_regs[sse_index++];
+						spillAndInvalidateRegisterForManualOverwrite(target_reg);
+						emitFloatMovFromFrame(target_reg, frame_offset + static_cast<int32_t>(eightbyte_index * 8), slot_size_bits <= 32);
+					} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::None) {
+						continue;
+					} else {
+						throw InternalError("Unsupported SysV aggregate return register class");
+					}
+				}
+				return;
+			}
+		}
 	}
 
 	if (live_value_register.has_value()) {
@@ -4119,6 +4140,45 @@ void IrToObjConverter<TWriterClass>::emitIntegerOrAggregateReturnValue(
 
 	spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
 	emitMovFromFrameBySize(X64Register::RAX, frame_offset, size_in_bits.value);
+}
+
+template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::emitStoreReturnValue(
+	TypeIndex type_index, SizeInBits size_in_bits, int32_t frame_offset) {
+	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 64) {
+			const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
+				type_index, size_in_bits, /*pointer_depth=*/0, /*is_reference=*/false);
+			// Keep caller result materialization paired with the callee x87 path above.
+			if (!layout.contains_x87) {
+				if (layout.isMemory()) {
+					throw InternalError("MEMORY-class SysV aggregate reached direct call-result lowering");
+				}
+				static constexpr std::array<X64Register, 2> integer_return_regs{X64Register::RAX, X64Register::RDX};
+				static constexpr std::array<X64Register, 2> sse_return_regs{X64Register::XMM0, X64Register::XMM1};
+				size_t integer_index = 0;
+				size_t sse_index = 0;
+				for (size_t eightbyte_index = 0; eightbyte_index < layout.eightbyte_count; ++eightbyte_index) {
+					const int slot_size_bits = std::min(64, size_in_bits.value - static_cast<int>(eightbyte_index * 64));
+					if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Integer) {
+						emitMovToFrameBySize(integer_return_regs[integer_index++],
+							frame_offset + static_cast<int32_t>(eightbyte_index * 8), slot_size_bits);
+					} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Sse) {
+						emitFloatMovToFrame(sse_return_regs[sse_index++],
+							frame_offset + static_cast<int32_t>(eightbyte_index * 8), slot_size_bits <= 32);
+					} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::None) {
+						continue;
+					} else {
+						throw InternalError("Unsupported SysV aggregate call-result register class");
+					}
+				}
+				return;
+			}
+		}
+	}
+	emitMovToFrameSized(
+		SizedRegister{X64Register::RAX, 64, false},
+		SizedStackSlot{frame_offset, size_in_bits.value, isSignedType(type_index.category())});
 }
 
 template <class TWriterClass>
@@ -4192,27 +4252,36 @@ bool IrToObjConverter<TWriterClass>::emitLoadAddressLikeArgument(X64Register tar
 }
 
 template <class TWriterClass>
-void IrToObjConverter<TWriterClass>::emitTwoRegStructToStack(const TypedValue& arg, int stack_offset) {
+void IrToObjConverter<TWriterClass>::emitAggregateToStack(const TypedValue& arg, int stack_offset) {
 	int src_offset = resolveTypedValueFrameOffset(arg);
-	X64Register lo_reg = allocateRegisterWithSpilling();
-	X64Register hi_reg = allocateRegisterWithSpilling();
-	emitMovFromFrame(lo_reg, src_offset);
-	emitMovFromFrame(hi_reg, src_offset + 8);
-	emitStoreToRSP(textSectionData, lo_reg, stack_offset);
-	emitStoreToRSP(textSectionData, hi_reg, stack_offset + 8);
-	regAlloc.release(lo_reg);
-	regAlloc.release(hi_reg);
+	const size_t slot_count = static_cast<size_t>((arg.size_in_bits.value + 63) / 64);
+	for (size_t slot_index = 0; slot_index < slot_count; ++slot_index) {
+		X64Register temp_reg = allocateRegisterWithSpilling();
+		const int slot_size_bits = std::min(64, arg.size_in_bits.value - static_cast<int>(slot_index * 64));
+		emitMovFromFrameBySize(temp_reg, src_offset + static_cast<int>(slot_index * 8), slot_size_bits);
+		emitStoreToRSP(textSectionData, temp_reg, stack_offset + static_cast<int>(slot_index * 8));
+		regAlloc.release(temp_reg);
+	}
 }
 
 template <class TWriterClass>
-void IrToObjConverter<TWriterClass>::emitTwoRegStructToRegs(int src_offset, X64Register target_reg,
-															size_t& int_reg_index, size_t max_int_regs) {
-	emitMovFromFrame(target_reg, src_offset);
-	if (int_reg_index < max_int_regs) {
-		X64Register second_reg = getIntParamReg<TWriterClass>(int_reg_index++);
-		emitMovFromFrame(second_reg, src_offset + 8);
-	} else {
-		FLASH_LOG(Codegen, Warning, "Two-register struct has no second register available");
+void IrToObjConverter<TWriterClass>::emitSysVAggregateToRegisters(
+	const TypedValue& arg, const SysVAbiValueLayout& layout,
+	size_t& int_reg_index, size_t& sse_reg_index) {
+	const int src_offset = resolveTypedValueFrameOffset(arg);
+	for (size_t eightbyte_index = 0; eightbyte_index < layout.eightbyte_count; ++eightbyte_index) {
+		const int slot_size_bits = std::min(64, arg.size_in_bits.value - static_cast<int>(eightbyte_index * 64));
+		if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Integer) {
+			X64Register target_reg = getIntParamReg<TWriterClass>(int_reg_index++);
+			emitMovFromFrameBySize(target_reg, src_offset + static_cast<int>(eightbyte_index * 8), slot_size_bits);
+		} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::Sse) {
+			X64Register target_reg = getFloatParamReg<TWriterClass>(sse_reg_index++);
+			emitFloatMovFromFrame(target_reg, src_offset + static_cast<int>(eightbyte_index * 8), slot_size_bits <= 32);
+		} else if (layout.eightbytes[eightbyte_index] == SysVRegisterClass::None) {
+			continue;
+		} else {
+			throw InternalError("Unsupported SysV aggregate argument register class");
+		}
 	}
 }
 
@@ -4302,7 +4371,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 			bool promote_vararg_float = call_op.is_variadic &&
 										i >= call_op.fixed_argument_count &&
 										arg.effectiveIrType() == IrType::Float;
-			bool is_two_reg_struct = isTwoRegisterStruct(arg, call_op.is_variadic);
+			const std::optional<SysVAbiValueLayout> sysv_aggregate = classifySysVAggregate(arg);
 
 				// Determine if this argument goes on stack (overflows register file)
 			bool goes_on_stack = false;
@@ -4315,6 +4384,17 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 					temp_float_idx++;
 				else
 					temp_int_idx++;
+			} else if (sysv_aggregate.has_value()) {
+				const size_t integer_register_count = sysv_aggregate->integerRegisterCount();
+				const size_t sse_register_count = sysv_aggregate->sseRegisterCount();
+				if (sysv_aggregate->isMemory() ||
+					temp_int_idx + integer_register_count > max_int_regs ||
+					temp_float_idx + sse_register_count > max_float_regs) {
+					goes_on_stack = true;
+				} else {
+					temp_int_idx += integer_register_count;
+					temp_float_idx += sse_register_count;
+				}
 			} else {
 					// Linux SysV (all calls) and Windows non-variadic: separate register banks.
 					// Both caller and callee agree on this sequential convention, so it works.
@@ -4324,12 +4404,10 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 					}
 					temp_float_idx++;
 				} else {
-						// For two-register structs, need two consecutive int registers
-					size_t regs_needed = is_two_reg_struct ? 2 : 1;
-					if (temp_int_idx + regs_needed > max_int_regs) {
+					if (temp_int_idx + 1 > max_int_regs) {
 						goes_on_stack = true;
 					}
-					temp_int_idx += regs_needed;
+					temp_int_idx++;
 				}
 			}
 
@@ -4342,7 +4420,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 					// Determine if this stack argument needs to pass an address instead of its value.
 					// For SysV variadic two-register structs, pass bytes directly (not a pointer) —
 					// the callee's va_arg reads from the overflow area by value.
-				bool stack_pass_address = arg.is_reference() || shouldPassStructByAddress(arg, is_two_reg_struct);
+				bool stack_pass_address = arg.is_reference() || shouldPassStructByAddress(arg);
 
 				if (stack_pass_address) {
 						// Store address of the argument on the stack
@@ -4402,9 +4480,9 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 
 					regAlloc.release(temp_xmm);
 					stack_arg_count++;
-				} else if (is_two_reg_struct) {
-					emitTwoRegStructToStack(arg, stack_offset);
-					stack_arg_count += 2;
+				} else if (sysv_aggregate.has_value()) {
+					emitAggregateToStack(arg, stack_offset);
+					stack_arg_count += static_cast<size_t>((arg.size_in_bits.value + 63) / 64);
 				} else {
 						// For integer arguments, use the existing code path
 					X64Register temp_reg = loadTypedValueIntoRegister(arg);
@@ -4437,7 +4515,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 			bool promote_vararg_float = call_op.is_variadic &&
 										i >= call_op.fixed_argument_count &&
 										arg.effectiveIrType() == IrType::Float;
-			bool is_potential_two_reg_struct = isTwoRegisterStruct(arg, call_op.is_variadic);
+			const std::optional<SysVAbiValueLayout> sysv_aggregate = classifySysVAggregate(arg);
 
 				// Check if this argument fits in a register (accounting for param_shift)
 				// Windows x64 variadic: unified position counter — int and float share the same 4 slots.
@@ -4446,27 +4524,35 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 			if (is_coff_format && call_op.is_variadic) {
 					// Windows x64 VARIADIC: position (i + param_shift) determines register use
 				use_register = (i + param_shift < max_int_regs);
+			} else if (sysv_aggregate.has_value()) {
+				use_register = !sysv_aggregate->isMemory() &&
+					int_reg_index + sysv_aggregate->integerRegisterCount() <= max_int_regs &&
+					float_reg_index + sysv_aggregate->sseRegisterCount() <= max_float_regs;
 			} else if (is_float_arg) {
 				if (float_reg_index < max_float_regs) {
 					use_register = true;
 				}
 			} else {
-					// For two-register structs, need two consecutive int registers
-				size_t regs_needed = is_potential_two_reg_struct ? 2 : 1;
-				if (int_reg_index + regs_needed <= max_int_regs) {
+				if (int_reg_index + 1 <= max_int_regs) {
 					use_register = true;
 				}
 			}
 
 				// Skip arguments that go on stack (already handled)
 			if (!use_register) {
-				if (is_float_arg)
+				if (sysv_aggregate.has_value()) {
+					// SysV reverts tentative aggregate register assignments when either
+					// register bank lacks room, so later arguments may still use them.
+				} else if (is_float_arg)
 					float_reg_index++;
 				else {
-						// Two-register structs count as 2 slots, matching the first-pass increment.
-					size_t regs_needed = is_potential_two_reg_struct ? 2 : 1;
-					int_reg_index += regs_needed;
+					int_reg_index++;
 				}
+				continue;
+			}
+
+			if (sysv_aggregate.has_value()) {
+				emitSysVAggregateToRegisters(arg, *sysv_aggregate, int_reg_index, float_reg_index);
 				continue;
 			}
 
@@ -4501,17 +4587,12 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 				//   - Structs of 1, 2, 4, or 8 bytes: pass by value in one register
 				//   - All other structs: pass by pointer
 			bool should_pass_address = false;
-			bool is_two_register_struct = false;
 			if (call_op.is_member_function && i == 0) {
 					// First argument of member function is always "this" pointer
 				should_pass_address = true;
 			} else if (arg.is_reference()) {
 					// Parameter is explicitly a reference - always pass by address
 				should_pass_address = true;
-			} else if (is_potential_two_reg_struct) {
-					// SysV AMD64: 9-16 byte structs go in two consecutive GP registers (all calls).
-					// Must check before shouldPassStructByAddress (which would wrongly return true).
-				is_two_register_struct = true;
 			} else if (shouldPassStructByAddress(arg)) {
 				should_pass_address = true;
 			}
@@ -4520,13 +4601,6 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 				if (!emitLoadAddressLikeArgument(target_reg, arg)) {
 					throw InternalError("Register call argument marked pass-by-address is not addressable");
 				}
-				continue;
-			}
-
-				// Handle System V AMD64 ABI: Structs 9-16 bytes passed in TWO consecutive registers
-			if (is_two_register_struct && (std::holds_alternative<StringHandle>(arg.value) || std::holds_alternative<TempVar>(arg.value))) {
-				int src_offset = resolveTypedValueFrameOffset(arg);
-				emitTwoRegStructToRegs(src_offset, target_reg, int_reg_index, max_int_regs);
 				continue;
 			}
 
@@ -4686,18 +4760,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 			// For varargs functions on System V AMD64, set AL to number of XMM registers actually used
 		if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
 			if (call_op.is_variadic) {
-					// Count XMM registers actually allocated (need to track float_reg_index)
-				size_t xmm_count = 0;
-				size_t va_temp_float_idx = 0;
-				for (size_t i = 0; i < call_op.args.size(); ++i) {
-					const auto& arg = call_op.args[i];
-					if (is_floating_point_type(arg.category())) {
-						if (va_temp_float_idx < max_float_regs) {
-							xmm_count++;
-							va_temp_float_idx++;
-						}
-					}
-				}
+				const size_t xmm_count = std::min(float_reg_index, max_float_regs);
 					// Set AL (lower 8 bits of RAX) to the count
 					// MOV AL, imm8: B0 + imm8
 				textSectionData.push_back(0xB0);
@@ -4774,28 +4837,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 					// Float return value is in XMM0
 				bool is_float = (call_op.return_type_index.category() == TypeCategory::Float);
 				emitFloatMovToFrame(X64Register::XMM0, result_offset, is_float);
-			} else if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-					// SystemV AMD64 ABI: structs 9-16 bytes return in RAX (low 8 bytes) and RDX (high 8 bytes)
-				if (call_op.return_type_index.category() == TypeCategory::Struct && return_size_bits > 64 && return_size_bits <= 128) {
-						// Two-register struct return: first 8 bytes in RAX, next 8 bytes in RDX
-					emitMovToFrameBySize(X64Register::RAX, result_offset, 64);
-					emitMovToFrameBySize(X64Register::RDX, result_offset + 8, return_size_bits - 64);
-					FLASH_LOG_FORMAT(Codegen, Debug,
-									 "Storing two-register struct return ({} bits): RAX->offset {}, RDX->offset {}",
-									 return_size_bits, result_offset, result_offset + 8);
-				} else {
-						// Single-register return (≤64 bits) in RAX
-					emitMovToFrameSized(
-						SizedRegister{X64Register::RAX, 64, false},	// source: 64-bit register
-						SizedStackSlot{result_offset, return_size_bits, isSignedType(call_op.returnType())}	// dest
-					);
-				}
 			} else {
-					// Windows x64 ABI: small structs (≤64 bits) return in RAX only
-				emitMovToFrameSized(
-					SizedRegister{X64Register::RAX, 64, false},	// source: 64-bit register
-					SizedStackSlot{result_offset, return_size_bits, isSignedType(call_op.returnType())}	// dest
-				);
+				emitStoreReturnValue(call_op.return_type_index, SizeInBits{return_size_bits}, result_offset);
 			}
 		} else if (call_op.usesReturnSlot()) {
 			FLASH_LOG_FORMAT(Codegen, Debug,
@@ -5127,21 +5170,30 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 			const bool is_float_arg = param_type_spec
 										  ? (isIrFloatingPointType(toIrType(param_type_spec->type())) && param_type_spec->pointer_depth() == 0 && !is_reference_param)
 										  : (isIrFloatingPointType(arg.effectiveIrType()) && !arg.is_reference());
-			bool is_two_reg_sysv = isTwoRegisterStruct(arg, false /* non-variadic */);
+			const std::optional<SysVAbiValueLayout> sysv_aggregate =
+				is_reference_param ? std::nullopt : classifySysVAggregate(arg);
 			const int source_base_adjustment = (i == 0) ? ctor_op.source_base_class_offset : 0;
 
 			bool goes_on_stack = false;
-			if (is_float_arg) {
+			if (sysv_aggregate.has_value()) {
+				if (sysv_aggregate->isMemory() ||
+					temp_int_idx + sysv_aggregate->integerRegisterCount() > max_int_regs ||
+					temp_float_idx + sysv_aggregate->sseRegisterCount() > max_float_regs) {
+					goes_on_stack = true;
+				} else {
+					temp_int_idx += sysv_aggregate->integerRegisterCount();
+					temp_float_idx += sysv_aggregate->sseRegisterCount();
+				}
+			} else if (is_float_arg) {
 				if (temp_float_idx >= max_float_regs) {
 					goes_on_stack = true;
 				}
 				temp_float_idx++;
 			} else {
-				size_t regs_needed = is_two_reg_sysv ? 2 : 1;
-				if (temp_int_idx + regs_needed > max_int_regs) {
+				if (temp_int_idx + 1 > max_int_regs) {
 					goes_on_stack = true;
 				}
-				temp_int_idx += regs_needed;
+				temp_int_idx++;
 			}
 
 			if (goes_on_stack) {
@@ -5174,7 +5226,7 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 					emitFloatStoreToRSP(textSectionData, temp_xmm, stack_offset, arg.effectiveIrType() == IrType::Float);
 					regAlloc.release(temp_xmm);
 					stack_arg_count++;
-				} else if (is_reference_param || shouldPassStructByAddress(arg, is_two_reg_sysv)) {
+				} else if (is_reference_param || shouldPassStructByAddress(arg)) {
 						// Match handleFunctionCall: references and ABI-required by-address
 						// struct arguments must spill their address, not their value.
 					X64Register temp_reg = allocateRegisterWithSpilling();
@@ -5184,9 +5236,9 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 					emitStoreToRSP(textSectionData, temp_reg, stack_offset);
 					regAlloc.release(temp_reg);
 					stack_arg_count++;
-				} else if (is_two_reg_sysv) {
-					emitTwoRegStructToStack(arg, stack_offset);
-					stack_arg_count += 2;
+				} else if (sysv_aggregate.has_value()) {
+					emitAggregateToStack(arg, stack_offset);
+					stack_arg_count += static_cast<size_t>((arg.size_in_bits.value + 63) / 64);
 				} else {
 					X64Register temp_reg = loadTypedValueIntoRegister(arg);
 					emitStoreToRSP(textSectionData, temp_reg, stack_offset);
@@ -5216,6 +5268,18 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 
 		bool is_float_arg = (paramType == TypeCategory::Float || paramType == TypeCategory::Double) && (!param_type_spec || param_type_spec->pointer_depth() == 0) && !arg_is_reference;
 		bool is_reference_param = arg_is_reference;
+		const std::optional<SysVAbiValueLayout> sysv_aggregate =
+			is_reference_param ? std::nullopt : classifySysVAggregate(arg);
+
+		if (sysv_aggregate.has_value()) {
+			const bool fits_registers = !sysv_aggregate->isMemory() &&
+				int_reg_index + sysv_aggregate->integerRegisterCount() <= max_int_regs &&
+				float_reg_index + sysv_aggregate->sseRegisterCount() <= max_float_regs;
+			if (fits_registers) {
+				emitSysVAggregateToRegisters(arg, *sysv_aggregate, int_reg_index, float_reg_index);
+			}
+			continue;
+		}
 
 			// Determine which register to use based on parameter type
 		if (is_float_arg && float_reg_index < max_float_regs) {
@@ -5262,15 +5326,10 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 				}
 			}
 		} else if (!is_float_arg) {
-				// Integer (non-float) parameter.
-				// SysV AMD64: 9-16 byte by-value structs consume two consecutive registers; verify space up front.
-			bool is_two_reg_sysv = isTwoRegisterStruct(arg, false /* non-variadic */);
-			size_t regs_needed = is_two_reg_sysv ? 2 : 1;
-
-			if (int_reg_index + regs_needed <= max_int_regs) {
+			if (int_reg_index + 1 <= max_int_regs) {
 					// Use integer register(s) for non-floating-point parameters
 				X64Register target_reg = getIntParamReg<TWriterClass>(int_reg_index++);
-				bool should_pass_address = is_reference_param || shouldPassStructByAddress(arg, is_two_reg_sysv);
+				bool should_pass_address = is_reference_param || shouldPassStructByAddress(arg);
 
 				if (should_pass_address && (std::holds_alternative<StringHandle>(paramValue) || std::holds_alternative<TempVar>(paramValue))) {
 					if (!emitLoadAddressLikeArgument(target_reg, arg, source_base_adjustment)) {
@@ -5296,35 +5355,22 @@ void IrToObjConverter<TWriterClass>::handleConstructorCall(const IrInstruction& 
 						// Load from temp variable
 					const TempVar temp_var = std::get<TempVar>(paramValue);
 					int param_offset = getStackOffsetFromTempVar(temp_var);
-					if (is_two_reg_sysv) {
-						emitTwoRegStructToRegs(param_offset, target_reg, int_reg_index, max_int_regs);
-					} else {
-							// For value parameters: source (sized stack slot) -> dest (64-bit register)
-						emitMovFromFrameSized(
-							SizedRegister{target_reg, 64, false},  // dest: 64-bit register
-							SizedStackSlot{param_offset, paramSize, isSignedType(paramType)}	 // source: sized stack slot
-						);
-					}
+					emitMovFromFrameSized(
+						SizedRegister{target_reg, 64, false},
+						SizedStackSlot{param_offset, paramSize, isSignedType(paramType)});
 				} else if (std::holds_alternative<StringHandle>(paramValue)) {
 						// Load from variable
 					StringHandle var_name_handle = std::get<StringHandle>(paramValue);
 					auto it = variable_scopes.back().variables.find(var_name_handle);
 					if (it != variable_scopes.back().variables.end()) {
 						int param_offset = it->second.offset;
-						if (is_two_reg_sysv) {
-							emitTwoRegStructToRegs(param_offset, target_reg, int_reg_index, max_int_regs);
-						} else {
-								// For value parameters: source (sized stack slot) -> dest (64-bit register)
-							emitMovFromFrameSized(
-								SizedRegister{target_reg, 64, false},  // dest: 64-bit register
-								SizedStackSlot{param_offset, paramSize, isSignedType(paramType)}	 // source: sized stack slot
-							);
-						}
+						emitMovFromFrameSized(
+							SizedRegister{target_reg, 64, false},
+							SizedStackSlot{param_offset, paramSize, isSignedType(paramType)});
 					}
 				}
 			} else {
-					// Struct doesn't fit in registers — advance counter to stay in sync with first pass
-				int_reg_index += regs_needed;
+				int_reg_index++;
 			}
 		}
 			// Args that don't fit in registers were already placed on the stack in the first pass above
@@ -7290,7 +7336,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 	std::string_view struct_name = StringTable::getStringView(struct_name_handle);
 
 		// Construct return type
-	TypeSpecifierNode return_type(func_decl.returnType(), TypeQualifier::None, static_cast<unsigned char>(func_decl.return_size_in_bits.value), Token{}, CVQualifier::None);
+	TypeSpecifierNode return_type(func_decl.return_type_index, func_decl.return_size_in_bits,
+		Token{}, CVQualifier::None, ReferenceQualifier::None);
 	for (int i = 0; i < func_decl.return_pointer_depth.value; ++i) {
 		return_type.add_pointer_level();
 	}
@@ -7298,7 +7345,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 		// Extract parameters
 	std::vector<TypeSpecifierNode> parameter_types;
 	for (const auto& param : func_decl.parameters) {
-		TypeSpecifierNode param_type(param.paramType(), TypeQualifier::None, static_cast<unsigned char>(param.size_in_bits.value), Token{}, CVQualifier::None);
+		TypeSpecifierNode param_type(param.type_index, param.size_in_bits,
+			Token{}, param.cv_qualifier, param.ref_qualifier);
 		for (int i = 0; i < param.pointer_depth.value; ++i) {
 			param_type.add_pointer_level();
 		}
@@ -7535,10 +7583,18 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 		// so count them as 2 to ensure enough param_home_space is reserved.
 	size_t param_count = 0;
 	{
-		for (const auto& p : parameter_types) {
-			bool is_two_reg = !is_variadic &&
-							  isTwoRegisterStructRaw(toIrType(p.type()), p.size_in_bits(), p.is_reference(), static_cast<int>(p.pointer_depth()));
-			param_count += is_two_reg ? 2 : 1;
+		for (const auto& p : func_decl.parameters) {
+			if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+				if (!is_variadic && is_struct_type(p.paramType()) && p.size_in_bits.value > 64 &&
+					!p.pointer_depth.is_pointer() && !p.is_reference()) {
+					const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
+						p.type_index, p.size_in_bits,
+						/*pointer_depth=*/0, /*is_reference=*/false);
+					param_count += layout.isMemory() ? 1 : layout.eightbyte_count;
+					continue;
+				}
+			}
+			param_count++;
 		}
 	}
 	if (!struct_name.empty() && !func_decl.is_static_member) {
@@ -7976,6 +8032,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 			// Handle parameters
 	const int coff_eh_param_home_bias = (!std::is_same_v<TWriterClass, ElfFileWriter> && current_function_has_cpp_eh_) ? 1 : 0;
 	struct ParameterInfo {
+		TypeIndex type_index;
 		TypeCategory param_type;
 		int param_size;
 		std::string_view param_name;
@@ -7984,9 +8041,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 		X64Register src_reg;
 		int pointer_depth;
 		bool is_reference;
-				// SysV AMD64: for 9-16 byte by-value struct params, the upper half is in a second register.
-				// X64Register::Count means this is a regular single-register parameter.
-		X64Register second_reg = X64Register::Count;
+		std::optional<SysVAbiValueLayout> sysv_aggregate_layout;
+		std::array<X64Register, 2> aggregate_registers{X64Register::Count, X64Register::Count};
 	};
 	std::vector<ParameterInfo> parameters;
 
@@ -8002,7 +8058,9 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 		variable_scopes.back().variables[StringTable::getOrInternStringHandle("__return_slot")].offset = return_slot_offset;
 
 		X64Register return_slot_reg = getIntParamReg<TWriterClass>(0);  // Always first register
-		parameters.push_back({TypeCategory::Struct, 64, "__return_slot", 0, return_slot_offset, return_slot_reg, 1, false});
+		parameters.push_back({nativeTypeIndex(TypeCategory::Struct), TypeCategory::Struct, 64, "__return_slot", 0,
+			return_slot_offset, return_slot_reg, 1, false, std::nullopt,
+			{X64Register::Count, X64Register::Count}});
 		regAlloc.allocateSpecific(return_slot_reg, return_slot_offset);
 
 		param_offset_adjustment = 1;	 // Shift other parameters (including 'this') by 1
@@ -8028,7 +8086,9 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 
 			// Store 'this' parameter info (register depends on param_offset_adjustment)
 		X64Register this_reg = getIntParamReg<TWriterClass>(param_offset_adjustment);
-		parameters.push_back({TypeCategory::Struct, 64, "this", param_offset_adjustment, this_offset, this_reg, 1, false});
+		parameters.push_back({nativeTypeIndex(TypeCategory::Struct), TypeCategory::Struct, 64, "this", param_offset_adjustment,
+			this_offset, this_reg, 1, false, std::nullopt,
+			{X64Register::Count, X64Register::Count}});
 		regAlloc.allocateSpecific(this_reg, this_offset);
 
 		param_offset_adjustment++;  // Shift regular parameters by 1 more
@@ -8082,8 +8142,12 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				// integer registers and materialized directly in the callee's frame (no pointer indirection).
 				// For variadic callees, the register-save-area prologue handles all register args,
 				// so this path is gated on !is_variadic.
-			bool is_two_reg_struct = !is_variadic &&
-									 isTwoRegisterStructRaw(toIrType(param_type), param_size, is_reference, param_pointer_depth);
+			if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+				if (is_struct_type(param_type) && param_pointer_depth == 0 && !is_reference) {
+					throw InternalError("Legacy FunctionDecl operands lack the TypeIndex required for SysV ABI classification");
+				}
+			}
+			const bool is_two_reg_struct = false;
 
 				// Platform-specific and type-aware offset calculation
 			size_t max_int_regs = getMaxIntParamRegs<TWriterClass>();
@@ -8199,7 +8263,9 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				}
 
 					// Store parameter info for later processing
-				parameters.push_back({param_type, param_size, param_name, paramNumber, offset, src_reg, param_pointer_depth, is_reference, second_reg});
+				parameters.push_back({TypeIndex{0, param_type}, param_type, param_size, param_name, paramNumber,
+					offset, src_reg, param_pointer_depth, is_reference, std::nullopt,
+					{src_reg, second_reg}});
 			}
 
 			paramIndex += FunctionDeclLayout::OPERANDS_PER_PARAM;
@@ -8230,13 +8296,6 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 			const auto& param = func_decl.parameters[i];
 			int paramNumber = static_cast<int>(i) + param_offset_adjustment;
 
-				// SysV AMD64: non-variadic 9-16 byte by-value structs are passed in two consecutive
-				// integer registers and materialized directly in the callee's frame (no pointer indirection).
-				// For variadic callees, the register-save-area prologue handles all register args,
-				// so this path is gated on !is_variadic.
-			bool is_two_reg_struct = !is_variadic &&
-									 isTwoRegisterStructRaw(toIrType(param.paramType()), param.size_in_bits.value, param.is_reference(), param.pointer_depth.value);
-
 				// Platform-specific and type-aware offset calculation
 			size_t max_int_regs = getMaxIntParamRegs<TWriterClass>();
 			size_t max_float_regs = getMaxFloatParamRegs<TWriterClass>();
@@ -8244,9 +8303,24 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				// so they should use integer registers regardless of the underlying type
 			bool is_float_param = isIrFloatingPointType(toIrType(param.paramType())) && !param.pointer_depth.is_pointer() && !param.is_reference();
 
-				// Determine the register count threshold for this parameter type
-			size_t reg_threshold = is_float_param ? max_float_regs : max_int_regs;
-			size_t type_specific_index = is_float_param ? float_param_reg_index : int_param_reg_index;
+			std::optional<SysVAbiValueLayout> sysv_aggregate_layout;
+			if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
+				if (isIrStructType(toIrType(param.paramType())) && param.size_in_bits.value > 64 &&
+					!param.pointer_depth.is_pointer() && !param.is_reference()) {
+					sysv_aggregate_layout = TargetABI::classifySysVValue(
+						param.type_index, param.size_in_bits, param.pointer_depth.value, param.is_reference());
+				}
+			}
+			const bool aggregate_fits_registers = sysv_aggregate_layout.has_value() &&
+				!sysv_aggregate_layout->isMemory() &&
+				int_param_reg_index + sysv_aggregate_layout->integerRegisterCount() <= max_int_regs &&
+				float_param_reg_index + sysv_aggregate_layout->sseRegisterCount() <= max_float_regs;
+			const size_t aggregate_slot_count = sysv_aggregate_layout.has_value()
+				? static_cast<size_t>((param.size_in_bits.value + 63) / 64)
+				: 1;
+			const bool scalar_fits_register = is_float_param
+				? float_param_reg_index < max_float_regs
+				: int_param_reg_index < max_int_regs;
 
 				// Calculate offset based on whether this parameter comes from a register or stack.
 				// For SysV two-register structs: struct base = more-negative slot so field_offset-based
@@ -8260,25 +8334,18 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 					// paramNumber is 0-based, so first param is at +16, second at +24, etc.
 				offset = 16 + (paramNumber - param_offset_adjustment) * 8;
 				param_slot_index++;
-			} else if (type_specific_index + (is_two_reg_struct ? 2 : 1) <= reg_threshold) {
-					// Parameter comes from register - allocate home/shadow space.
-					// Use param_slot_index so two-register struct params don't collide with neighbours.
-					// For two-register structs, both slots must fit; otherwise fall through to stack path.
-				if (is_two_reg_struct) {
-					offset = (param_slot_index + coff_eh_param_home_bias + 2) * -8;	// struct base at more-negative slot
-					param_slot_index += 2;
-				} else {
-					offset = (param_slot_index + coff_eh_param_home_bias + 1) * -8;
-					param_slot_index++;
-				}
+			} else if (aggregate_fits_registers || (!sysv_aggregate_layout.has_value() && scalar_fits_register)) {
+				const size_t home_slot_count = sysv_aggregate_layout.has_value() ? aggregate_slot_count : 1;
+				offset = (param_slot_index + coff_eh_param_home_bias + static_cast<int>(home_slot_count)) * -8;
+				param_slot_index += static_cast<int>(home_slot_count);
 			} else {
 					// Parameter comes from stack - calculate positive offset
 					// Stack params start after: saved rbp [+0], return addr [+8], shadow space (32 on Win64, 0 on SysV)
 					// Use stack_param_index (not type_specific_index - reg_threshold) so that mixed
 					// float and int stack params get consecutive slots matching the caller's layout.
 				offset = 16 + static_cast<int>(getShadowSpaceSize<TWriterClass>()) + static_cast<int>(stack_param_index) * 8;
-				stack_param_index += is_two_reg_struct ? 2 : 1;
-				param_slot_index += is_two_reg_struct ? 2 : 1;
+				stack_param_index += aggregate_slot_count;
+				param_slot_index += static_cast<int>(aggregate_slot_count);
 			}
 
 				// Phase 4: Use helper to get param name for map key
@@ -8290,8 +8357,11 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				// SysV two-register structs, which are materialized directly and need no dereferencing.
 				// NOTE: Pointer parameters (T*) are NOT tracked - they hold pointer VALUES directly.
 				// Explicit dereference (*ptr) is handled by handleDereference which loads from stack directly.
-			bool is_passed_by_reference = param.is_reference() ||
-										  (!is_two_reg_struct && isIrStructType(toIrType(param.paramType())) && param.size_in_bits.value > 64);
+			bool is_passed_by_reference = param.is_reference();
+			if constexpr (!std::is_same_v<TWriterClass, ElfFileWriter>) {
+				is_passed_by_reference = is_passed_by_reference ||
+					(isIrStructType(toIrType(param.paramType())) && param.size_in_bits.value > 64);
+			}
 			if (is_passed_by_reference) {
 				setReferenceInfo(offset, TypeIndex{0, param.paramType()}, param.size_in_bits.value, param.is_rvalue_reference(), TempVar{0});
 			}
@@ -8310,22 +8380,29 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				// Check if parameter fits in a register using separate int/float counters
 			bool use_register = false;
 			X64Register src_reg = X64Register::Count;
-			X64Register second_reg = X64Register::Count;
-			if (is_float_param) {
+			std::array<X64Register, 2> aggregate_registers{X64Register::Count, X64Register::Count};
+			if (aggregate_fits_registers) {
+				use_register = true;
+				size_t integer_index = int_param_reg_index;
+				size_t sse_index = float_param_reg_index;
+				for (size_t eightbyte_index = 0; eightbyte_index < sysv_aggregate_layout->eightbyte_count; ++eightbyte_index) {
+					if (sysv_aggregate_layout->eightbytes[eightbyte_index] == SysVRegisterClass::Integer) {
+						aggregate_registers[eightbyte_index] = getIntParamReg<TWriterClass>(integer_index++);
+					} else if (sysv_aggregate_layout->eightbytes[eightbyte_index] == SysVRegisterClass::Sse) {
+						aggregate_registers[eightbyte_index] = getFloatParamReg<TWriterClass>(sse_index++);
+					}
+				}
+				int_param_reg_index = integer_index;
+				float_param_reg_index = sse_index;
+			} else if (sysv_aggregate_layout.has_value()) {
+				// SysV assigns an aggregate wholly to registers or wholly to the
+				// overflow area. A failed aggregate assignment consumes no register.
+			} else if (is_float_param) {
 				if (float_param_reg_index < max_float_regs) {
 					src_reg = getFloatParamReg<TWriterClass>(float_param_reg_index++);
 					use_register = true;
 				} else {
 					float_param_reg_index++;	 // Still increment counter for stack params
-				}
-			} else if (is_two_reg_struct) {
-					// Two-register struct: consume two consecutive integer registers
-				if (int_param_reg_index + 2 <= max_int_regs) {
-					src_reg = getIntParamReg<TWriterClass>(int_param_reg_index++);
-					second_reg = getIntParamReg<TWriterClass>(int_param_reg_index++);
-					use_register = true;
-				} else {
-					int_param_reg_index += 2;  // Both slots past register file = on stack
 				}
 			} else {
 				if (int_param_reg_index < max_int_regs) {
@@ -8338,14 +8415,13 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 
 			if (use_register) {
 
-				if (!is_float_param && !regAlloc.is_allocated(src_reg)) {
+				if (!sysv_aggregate_layout.has_value() && !is_float_param && !regAlloc.is_allocated(src_reg)) {
 					regAlloc.allocateSpecific(src_reg, offset);
-						// second_reg holds the upper half of the struct's bytes; it is stored to the
-						// frame immediately in the second pass, not tracked as a live register, so
-						// it does not need to be registered in regAlloc.
 				}
 
-				parameters.push_back({param.type_index.category(), param.size_in_bits.value, StringTable::getStringView(param.getName()), paramNumber, offset, src_reg, param.pointer_depth.value, param.is_reference(), second_reg});
+				parameters.push_back({param.type_index, param.type_index.category(), param.size_in_bits.value,
+					StringTable::getStringView(param.getName()), paramNumber, offset, src_reg,
+					param.pointer_depth.value, param.is_reference(), sysv_aggregate_layout, aggregate_registers});
 			}
 		}
 	}
@@ -8370,23 +8446,35 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 				// MSVC-STYLE: Store parameters using RBP-relative addressing
 			bool is_float_param = (param.param_type == TypeCategory::Float || param.param_type == TypeCategory::Double) && !param.pointer_depth && !param.is_reference;
 
-			if (is_float_param) {
+			if (param.sysv_aggregate_layout.has_value()) {
+				for (size_t eightbyte_index = 0;
+					 eightbyte_index < param.sysv_aggregate_layout->eightbyte_count;
+					 ++eightbyte_index) {
+					const X64Register source_reg = param.aggregate_registers[eightbyte_index];
+					const int slot_size_bits = std::min(64, param.param_size - static_cast<int>(eightbyte_index * 64));
+					if (param.sysv_aggregate_layout->eightbytes[eightbyte_index] == SysVRegisterClass::Integer) {
+						emitMovToFrameBySize(source_reg, param.offset + static_cast<int>(eightbyte_index * 8), slot_size_bits);
+					} else if (param.sysv_aggregate_layout->eightbytes[eightbyte_index] == SysVRegisterClass::Sse) {
+						emitFloatMovToFrame(source_reg, param.offset + static_cast<int>(eightbyte_index * 8), slot_size_bits <= 32);
+					} else if (param.sysv_aggregate_layout->eightbytes[eightbyte_index] == SysVRegisterClass::None) {
+						continue;
+					} else {
+						throw InternalError("Unsupported SysV aggregate parameter register class");
+					}
+				}
+			} else if (is_float_param) {
 					// For floating-point parameters, use movss/movsd to store from XMM register
 				bool is_float = (param.param_type == TypeCategory::Float);
 				emitFloatMovToFrame(param.src_reg, param.offset, is_float);
-			} else if (param.second_reg != X64Register::Count) {
-					// SysV AMD64 two-register struct: bytes 0-7 in src_reg → offset (struct base),
-					// bytes 8-15 in second_reg → offset+8 (the less-negative / higher-address slot).
-				emitMovToFrame(param.src_reg, param.offset, 64);
-				emitMovToFrame(param.second_reg, param.offset + 8, 64);
-				regAlloc.release(param.src_reg);
-					// second_reg was never added to regAlloc, so no release needed
 			} else {
 					// For integer parameters, use size-appropriate MOV
 					// References are always passed as 64-bit pointers regardless of the type they refer to
 					// Large struct parameters (> 64 bits) that are NOT two-register structs are passed by pointer
-				bool is_passed_by_pointer = param.is_reference || param.pointer_depth > 0 ||
-											(param.param_type == TypeCategory::Struct && param.param_size > 64);
+				bool is_passed_by_pointer = param.is_reference || param.pointer_depth > 0;
+				if constexpr (!std::is_same_v<TWriterClass, ElfFileWriter>) {
+					is_passed_by_pointer = is_passed_by_pointer ||
+						(param.param_type == TypeCategory::Struct && param.param_size > 64);
+				}
 				int store_size = is_passed_by_pointer ? 64 : param.param_size;
 				emitMovToFrameSized(
 					SizedRegister{param.src_reg, 64, false},	 // source: 64-bit register
@@ -14724,9 +14812,6 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 	auto advanceStackArgCount = [&](size_t slots) {
 		stack_arg_count += slots;
 	};
-	auto intRegSlotsNeeded = [&](const TypedValue& arg) -> size_t {
-		return isTwoRegisterStruct(arg, false) ? 2 : 1;
-	};
 	for (size_t i = 0; i < op.arguments.size(); ++i) {
 		const auto& arg = op.arguments[i];
 		const bool is_reference_arg = arg.is_reference();
@@ -14734,7 +14819,7 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 		const bool promote_vararg_float = op.is_variadic &&
 										 i >= op.fixed_argument_count &&
 										 arg.effectiveIrType() == IrType::Float;
-		const bool is_two_reg_sysv = isTwoRegisterStruct(arg, false);
+		const std::optional<SysVAbiValueLayout> sysv_aggregate = classifySysVAggregate(arg);
 
 		bool goes_on_stack = false;
 		int stack_offset = 0;
@@ -14754,12 +14839,22 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 					stack_offset = static_cast<int>(shadow_space + stack_arg_count * 8);
 				}
 			} else {
-				size_t regs_needed = intRegSlotsNeeded(arg);
-				goes_on_stack = int_reg_index + regs_needed > max_int_regs;
-				int_reg_index += regs_needed;
+				goes_on_stack = int_reg_index + 1 > max_int_regs;
+				int_reg_index++;
 				if (goes_on_stack) {
 					stack_offset = static_cast<int>(shadow_space + stack_arg_count * 8);
 				}
+			}
+		} else if (sysv_aggregate.has_value()) {
+			goes_on_stack = sysv_aggregate->isMemory() ||
+				int_reg_index + sysv_aggregate->integerRegisterCount() > max_int_regs ||
+				float_reg_index + sysv_aggregate->sseRegisterCount() > max_float_regs;
+			if (!goes_on_stack) {
+				int_reg_index += sysv_aggregate->integerRegisterCount();
+				float_reg_index += sysv_aggregate->sseRegisterCount();
+			}
+			if (goes_on_stack) {
+				stack_offset = static_cast<int>(shadow_space + stack_arg_count * 8);
 			}
 		} else if (is_float_arg) {
 			goes_on_stack = float_reg_index >= max_float_regs;
@@ -14768,9 +14863,8 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 				stack_offset = static_cast<int>(shadow_space + stack_arg_count * 8);
 			}
 		} else {
-			size_t regs_needed = intRegSlotsNeeded(arg);
-			goes_on_stack = int_reg_index + regs_needed > max_int_regs;
-			int_reg_index += regs_needed;
+			goes_on_stack = int_reg_index + 1 > max_int_regs;
+			int_reg_index++;
 			if (goes_on_stack) {
 				stack_offset = static_cast<int>(shadow_space + stack_arg_count * 8);
 			}
@@ -14822,7 +14916,7 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 			emitFloatStoreToRSP(textSectionData, temp_xmm, stack_offset, !promote_vararg_float && arg.effectiveIrType() == IrType::Float);
 			regAlloc.release(temp_xmm);
 			advanceStackArgCount(1);
-		} else if (is_reference_arg || shouldPassStructByAddress(arg, is_two_reg_sysv)) {
+		} else if (is_reference_arg || shouldPassStructByAddress(arg)) {
 			X64Register temp_reg = allocateRegisterWithSpilling();
 			if (!emitLoadAddressLikeArgument(temp_reg, arg)) {
 				throw InternalError("Stack indirect-call argument marked pass-by-address is not addressable");
@@ -14830,9 +14924,9 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 			emitStoreToRSP(textSectionData, temp_reg, stack_offset);
 			regAlloc.release(temp_reg);
 			advanceStackArgCount(1);
-		} else if (is_two_reg_sysv) {
-			emitTwoRegStructToStack(arg, stack_offset);
-			advanceStackArgCount(2);
+		} else if (sysv_aggregate.has_value()) {
+			emitAggregateToStack(arg, stack_offset);
+			advanceStackArgCount(static_cast<size_t>((arg.size_in_bits.value + 63) / 64));
 		} else {
 			X64Register temp_reg = loadTypedValueIntoRegister(arg);
 			emitStoreToRSP(textSectionData, temp_reg, stack_offset);
@@ -14853,7 +14947,7 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 		const bool promote_vararg_float = op.is_variadic &&
 										 i >= op.fixed_argument_count &&
 										 arg.effectiveIrType() == IrType::Float;
-		const bool is_two_reg_sysv = isTwoRegisterStruct(arg, false);
+		const std::optional<SysVAbiValueLayout> sysv_aggregate = classifySysVAggregate(arg);
 
 		bool use_register = false;
 		X64Register target_reg = X64Register::RAX;
@@ -14870,21 +14964,23 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 					target_reg = getFloatParamReg<TWriterClass>(float_reg_index++);
 				}
 			} else {
-				size_t regs_needed = intRegSlotsNeeded(arg);
-				if (int_reg_index + regs_needed <= max_int_regs) {
+				if (int_reg_index + 1 <= max_int_regs) {
 					use_register = true;
 					target_reg = getIntParamReg<TWriterClass>(int_reg_index);
 					int_reg_index++;
 				}
 			}
+		} else if (sysv_aggregate.has_value()) {
+			use_register = !sysv_aggregate->isMemory() &&
+				int_reg_index + sysv_aggregate->integerRegisterCount() <= max_int_regs &&
+				float_reg_index + sysv_aggregate->sseRegisterCount() <= max_float_regs;
 		} else if (is_float_arg) {
 			if (float_reg_index < max_float_regs) {
 				use_register = true;
 				target_reg = getFloatParamReg<TWriterClass>(float_reg_index++);
 			}
 		} else {
-			size_t regs_needed = intRegSlotsNeeded(arg);
-			if (int_reg_index + regs_needed <= max_int_regs) {
+			if (int_reg_index + 1 <= max_int_regs) {
 				use_register = true;
 				target_reg = getIntParamReg<TWriterClass>(int_reg_index);
 				int_reg_index++;
@@ -14893,26 +14989,27 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 
 		if (!use_register) {
 			if (!is_coff_format) {
-				if (is_float_arg) {
+				if (sysv_aggregate.has_value()) {
+					// Failed aggregate allocation consumes neither register bank.
+				} else if (is_float_arg) {
 					float_reg_index++;
 				} else {
-					int_reg_index += intRegSlotsNeeded(arg);
+					int_reg_index++;
 				}
 			}
 			continue;
 		}
 
-		if ((is_reference_arg || shouldPassStructByAddress(arg, is_two_reg_sysv)) &&
+		if (sysv_aggregate.has_value()) {
+			emitSysVAggregateToRegisters(arg, *sysv_aggregate, int_reg_index, float_reg_index);
+			continue;
+		}
+
+		if ((is_reference_arg || shouldPassStructByAddress(arg)) &&
 			(std::holds_alternative<StringHandle>(arg.value) || std::holds_alternative<TempVar>(arg.value))) {
 			if (!emitLoadAddressLikeArgument(target_reg, arg)) {
 				throw InternalError("Register indirect-call argument marked pass-by-address is not addressable");
 			}
-			continue;
-		}
-
-		if (is_two_reg_sysv && (std::holds_alternative<StringHandle>(arg.value) || std::holds_alternative<TempVar>(arg.value))) {
-			int src_offset = resolveTypedValueFrameOffset(arg);
-			emitTwoRegStructToRegs(src_offset, target_reg, int_reg_index, max_int_regs);
 			continue;
 		}
 
@@ -14983,17 +15080,7 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
 		if (op.is_variadic) {
-			size_t xmm_count = 0;
-			size_t va_temp_float_idx = 0;
-			for (size_t i = 0; i < op.arguments.size(); ++i) {
-				const auto& arg = op.arguments[i];
-				if (isIrFloatingPointType(arg.effectiveIrType()) && !arg.is_reference()) {
-					if (va_temp_float_idx < max_float_regs) {
-						xmm_count++;
-						va_temp_float_idx++;
-					}
-				}
-			}
+			const size_t xmm_count = std::min(float_reg_index, max_float_regs);
 			textSectionData.push_back(0xB0);
 			textSectionData.push_back(static_cast<uint8_t>(xmm_count));
 		}
@@ -15040,21 +15127,8 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 		if (isFloatingPointType(op.returnType())) {
 			bool is_float = (op.returnType() == TypeCategory::Float);
 			emitFloatMovToFrame(X64Register::XMM0, result_offset, is_float);
-		} else if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-			if (op.returnType() == TypeCategory::Struct && return_size_bits > 64 && return_size_bits <= 128) {
-				const int low_bits = std::min(return_size_bits, 64);
-				const int high_bits = std::max(return_size_bits - 64, 0);
-				emitMovToFrame(X64Register::RAX, result_offset, low_bits);
-				emitMovToFrame(X64Register::RDX, result_offset + 8, high_bits);
-			} else {
-				emitMovToFrameSized(
-					SizedRegister{X64Register::RAX, 64, false},
-					SizedStackSlot{result_offset, return_size_bits, isSignedType(op.returnType())});
-			}
 		} else {
-			emitMovToFrameSized(
-				SizedRegister{X64Register::RAX, 64, false},
-				SizedStackSlot{result_offset, return_size_bits, isSignedType(op.returnType())});
+			emitStoreReturnValue(op.return_type_index, SizeInBits{return_size_bits}, result_offset);
 		}
 	}
 

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -433,24 +433,12 @@ private:
 	// Allocate an XMM register, spilling one to the stack if necessary, excluding a specific register
 	X64Register allocateXMMRegisterWithSpilling(X64Register exclude);
 
-	/// SysV AMD64 ABI: true for 9-16 byte by-value structs that must be passed in two
-	/// consecutive general-purpose registers (INTEGER+INTEGER classification).
-	/// This applies to both variadic and non-variadic calls.
-	/// NOTE: For variadic *callees*, the register-save-area prologue handles these
-	/// implicitly, so callee-side code guards this with !is_variadic separately.
-	static bool isTwoRegisterStructRaw(IrType ir_type, int size_in_bits, bool is_reference, int pointer_depth);
-
-	/// Check if an argument is a two-register struct under System V AMD64 ABI (9-16 bytes, by value).
-	bool isTwoRegisterStruct(const TypedValue& arg, [[maybe_unused]] bool is_variadic_call = false) const;
+	std::optional<SysVAbiValueLayout> classifySysVAggregate(const TypedValue& arg) const;
 
 	/// Determine if a struct argument should be passed by address (pointer) based on ABI.
-	bool shouldPassStructByAddress(const TypedValue& arg, bool is_two_register_struct = false) const;
+	bool shouldPassStructByAddress(const TypedValue& arg) const;
 
-	// ── Two-register struct helpers ──────────────────────────────────────
-	// SysV AMD64 ABI: 9-16 byte by-value structs are passed/received in two
-	// consecutive general-purpose registers.  These helpers centralise the
-	// codegen so that handleFunctionCall and handleConstructorCall don't
-	// duplicate the same emit sequences.
+	// ── Aggregate ABI transfer helpers ───────────────────────────────────
 
 	/// Resolve a TypedValue (StringHandle or TempVar) to its frame offset.
 	int32_t getVariableOffsetOrThrow(StringHandle var_handle, std::string_view context) const;
@@ -459,21 +447,18 @@ private:
 
 	bool emitLoadAddressLikeArgument(X64Register target_reg, const TypedValue& arg, int32_t address_adjustment = 0);
 
-	/// Emit code to store both 8-byte halves of a two-register struct to
-	/// consecutive RSP-relative stack slots (used when the struct overflows
-	/// the register file).
-	void emitTwoRegStructToStack(const TypedValue& arg, int stack_offset);
+	/// Copy an aggregate by value to consecutive RSP-relative overflow slots.
+	void emitAggregateToStack(const TypedValue& arg, int stack_offset);
 
-	/// Emit code to load both 8-byte halves of a two-register struct into
-	/// two consecutive integer parameter registers.  `target_reg` already
-	/// holds the first register; `int_reg_index` is advanced for the second.
-	void emitTwoRegStructToRegs(int src_offset, X64Register target_reg,
-								size_t& int_reg_index, size_t max_int_regs);
+	/// Load each classified eightbyte into its assigned integer or SSE bank.
+	void emitSysVAggregateToRegisters(const TypedValue& arg, const SysVAbiValueLayout& layout,
+									 size_t& int_reg_index, size_t& sse_reg_index);
 
-	/// Materialize a non-floating return value in the target ABI's return registers.
-	/// SysV aggregates spanning two eightbytes use RAX and RDX; other values use RAX.
+	/// Materialize an integer or classified aggregate in the target return registers.
 	void emitIntegerOrAggregateReturnValue(TypeIndex type_index, SizeInBits size_in_bits,
 										 int32_t frame_offset, std::optional<X64Register> live_value_register);
+
+	void emitStoreReturnValue(TypeIndex type_index, SizeInBits size_in_bits, int32_t frame_offset);
 
 	void handleFunctionCall(const IrInstruction& instruction);
 

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -559,17 +559,17 @@ TempVar AstToIr::emitDereference(TypeCategory pointee_type, int pointer_size_bit
 // ============================================================================
 // Return IR helper
 // ============================================================================
-void AstToIr::emitReturn(IrValue return_value, TypeCategory return_type, int return_size, const Token& token) {
+void AstToIr::emitReturn(IrValue return_value, TypeIndex return_type_index, int return_size, const Token& token) {
 	// Normalize ULL immediates to the declared return type width and signedness.
 	// This ensures the ReturnOp carries a consistently-typed value rather than an
 	// overwide carrier (e.g. int(-1) sign-extended to 0xFFFFFFFFFFFFFFFF for a char32_t return).
 	// Doing this at IR generation time keeps the codegen backend free of semantic concerns.
 	if (auto* ull_val = std::get_if<unsigned long long>(&return_value)) {
-		*ull_val = normalizeIntegralImmediateValue(*ull_val, return_type, return_size);
+		*ull_val = normalizeIntegralImmediateValue(*ull_val, return_type_index.category(), return_size);
 	}
 	ReturnOp ret_op;
 	ret_op.return_value = return_value;
-	ret_op.return_type_index = TypeIndex{0, return_type};
+	ret_op.return_type_index = return_type_index;
 	ret_op.return_size = return_size;
 	ir_.addInstruction(IrInstruction(IrOpcode::Return, std::move(ret_op), token));
 }

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -721,7 +721,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 							// Label: diff - return the inner <=> result
 							ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = diff_label}, func_decl.identifier_token()));
 							{
-								emitReturn(IrValue{call_result}, TypeCategory::Int, 32, func_decl.identifier_token());
+								emitReturn(IrValue{call_result}, nativeTypeIndex(TypeCategory::Int), 32, func_decl.identifier_token());
 							}
 
 								// Label: next - continue to next member
@@ -792,13 +792,13 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 					// Label: lt - return -1 (two's complement: 0xFFFFFFFF in 32-bit)
 					ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = lt_label}, func_decl.identifier_token()));
 					{
-						emitReturn(IrValue{0xFFFFFFFFULL}, TypeCategory::Int, 32, func_decl.identifier_token());
+						emitReturn(IrValue{0xFFFFFFFFULL}, nativeTypeIndex(TypeCategory::Int), 32, func_decl.identifier_token());
 					}
 
 					// Label: gt - return 1
 					ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = gt_label}, func_decl.identifier_token()));
 					{
-						emitReturn(IrValue{1ULL}, TypeCategory::Int, 32, func_decl.identifier_token());
+						emitReturn(IrValue{1ULL}, nativeTypeIndex(TypeCategory::Int), 32, func_decl.identifier_token());
 					}
 
 					// Label: next - continue to next member
@@ -806,7 +806,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 				}
 			}
 		// All members equal - return 0
-		emitReturn(IrValue{0ULL}, TypeCategory::Int, 32, func_decl.identifier_token());
+		emitReturn(IrValue{0ULL}, nativeTypeIndex(TypeCategory::Int), 32, func_decl.identifier_token());
 		symbol_table.exit_scope();
 		return;
 	}
@@ -959,7 +959,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 			ir_.addInstruction(IrInstruction(*synthesized_cmp_opcode, std::move(cmp_op), func_decl.identifier_token()));
 
 			// Return the boolean result
-			emitReturn(IrValue{cmp_result}, TypeCategory::Bool, 8, func_decl.identifier_token());
+			emitReturn(IrValue{cmp_result}, nativeTypeIndex(TypeCategory::Bool), 8, func_decl.identifier_token());
 		} else if (function_operator_kind == OverloadableOperator::Equal && compare_struct_info && !compare_struct_info->members.empty()) {
 			static size_t equal_counter = 0;
 			size_t current_equal = equal_counter++;
@@ -1089,12 +1089,12 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 				ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = equal_next_label}, func_decl.identifier_token()));
 			}
 
-			emitReturn(IrValue{1ULL}, TypeCategory::Bool, 8, func_decl.identifier_token());
+			emitReturn(IrValue{1ULL}, nativeTypeIndex(TypeCategory::Bool), 8, func_decl.identifier_token());
 			ir_.addInstruction(IrInstruction(IrOpcode::Label, LabelOp{.label_name = equal_false_label}, func_decl.identifier_token()));
-			emitReturn(IrValue{0ULL}, TypeCategory::Bool, 8, func_decl.identifier_token());
+			emitReturn(IrValue{0ULL}, nativeTypeIndex(TypeCategory::Bool), 8, func_decl.identifier_token());
 		} else {
 			// Fallback: operator<=> not found, return false for synthesized comparison operators
-			emitReturn(IrValue{0ULL}, TypeCategory::Bool, 8, func_decl.identifier_token());
+			emitReturn(IrValue{0ULL}, nativeTypeIndex(TypeCategory::Bool), 8, func_decl.identifier_token());
 		}
 
 		symbol_table.exit_scope();
@@ -1226,7 +1226,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 					ir_.addInstruction(IrInstruction(IrOpcode::Dereference, std::move(deref_op), func_decl.identifier_token()));
 
 						// Return the dereferenced value
-					emitReturn(this_deref, TypeCategory::Struct, struct_info->sizeInBits().value, func_decl.identifier_token());
+					emitReturn(this_deref, currentFunctionReturnTypeIndex(), struct_info->sizeInBits().value, func_decl.identifier_token());
 				}
 			}
 		}
@@ -1269,7 +1269,7 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 		}
 		// Special case: main() implicitly returns 0 if no return statement
 		else if (func_decl.identifier_token().value() == "main") {
-			emitReturn(0ULL, TypeCategory::Int, 32, func_decl.identifier_token());
+			emitReturn(0ULL, nativeTypeIndex(TypeCategory::Int), 32, func_decl.identifier_token());
 		}
 		// For other non-void functions, this is a warning (missing return statement)
 		// A full implementation would require control flow analysis to check all paths,

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -183,7 +183,7 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 			emitDestructorsForNonLocalExit(0);
 
 			// Now return the temporary variable
-			emitReturn(temp_var, return_category, return_size, node.return_token());
+			emitReturn(temp_var, currentFunctionReturnTypeIndex(), return_size, node.return_token());
 			return;
 		}
 
@@ -209,7 +209,7 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 							emitAndClearFullExpressionTempDestructors();
 							emitDestructorsForNonLocalExit(0);
 							emitReturn(StringTable::getOrInternStringHandle("this"),
-									   currentFunctionReturnType(), current_function_return_size_,
+									   currentFunctionReturnTypeIndex(), current_function_return_size_,
 									   node.return_token());
 							return;
 						}
@@ -728,7 +728,7 @@ return_conversion_done:
 			return_value = *d_val;
 		}
 		// Use the function's return type, not the expression type
-		emitReturn(return_value, currentFunctionReturnType(), current_function_return_size_,
+		emitReturn(return_value, currentFunctionReturnTypeIndex(), current_function_return_size_,
 				   node.return_token());
 	} else {
 		// Call any enclosing __finally funclets before returning

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -246,7 +246,8 @@ bool Parser::tryAppendMemberDefaultTemplateArg(
 	InlineVector<TemplateTypeArg, 4>& current_template_args) {
 	// Member templates don't have a separate namespace context - use invalid handle
 	// which causes no namespace scope to be entered during SFINAE reparse.
-	if (tryAppendDefaultTemplateArg(param, template_params, current_template_args, NamespaceHandle{})) {
+	if (outer_binding == nullptr &&
+		tryAppendDefaultTemplateArg(param, template_params, current_template_args, NamespaceHandle{})) {
 		return true;
 	}
 	if (!param.has_default() || !outer_binding) {

--- a/src/TargetABI.h
+++ b/src/TargetABI.h
@@ -111,6 +111,9 @@ inline size_t naturalAlignment(TypeIndex type_index, size_t object_size) {
 	const TypeIndex canonical_type_index = canonicalize_type_alias(type_index).resolvedTypeIndex();
 	if (const TypeInfo* type_info = tryGetTypeInfo(canonical_type_index)) {
 		if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
+			if (!struct_info->layout_is_complete || struct_info->alignment == 0) {
+				throw InternalError("SysV ABI classification requires complete aggregate alignment metadata");
+			}
 			return struct_info->alignment;
 		}
 	}

--- a/src/TargetABI.h
+++ b/src/TargetABI.h
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "AstNodeTypes.h"
+#include "CompileError.h"
+#include "SizeTypes.h"
+
+enum class SysVRegisterClass : uint8_t {
+	None,
+	Integer,
+	Sse,
+	Memory,
+};
+
+struct SysVAbiValueLayout {
+	std::array<SysVRegisterClass, 2> eightbytes{SysVRegisterClass::None, SysVRegisterClass::None};
+	uint8_t eightbyte_count = 0;
+	bool contains_x87 = false;
+
+	bool isMemory() const {
+		return eightbytes[0] == SysVRegisterClass::Memory;
+	}
+
+	size_t integerRegisterCount() const {
+		size_t count = 0;
+		for (size_t i = 0; i < eightbyte_count; ++i) {
+			count += eightbytes[i] == SysVRegisterClass::Integer;
+		}
+		return count;
+	}
+
+	size_t sseRegisterCount() const {
+		size_t count = 0;
+		for (size_t i = 0; i < eightbyte_count; ++i) {
+			count += eightbytes[i] == SysVRegisterClass::Sse;
+		}
+		return count;
+	}
+};
+
+namespace TargetABI {
+namespace Detail {
+
+inline SysVRegisterClass mergeSysVRegisterClasses(SysVRegisterClass lhs, SysVRegisterClass rhs) {
+	if (lhs == rhs || rhs == SysVRegisterClass::None) {
+		return lhs;
+	}
+	if (lhs == SysVRegisterClass::None) {
+		return rhs;
+	}
+	if (lhs == SysVRegisterClass::Memory || rhs == SysVRegisterClass::Memory) {
+		return SysVRegisterClass::Memory;
+	}
+	if (lhs == SysVRegisterClass::Integer || rhs == SysVRegisterClass::Integer) {
+		return SysVRegisterClass::Integer;
+	}
+	return SysVRegisterClass::Sse;
+}
+
+inline bool isSysVIntegerCategory(TypeCategory category) {
+	switch (category) {
+	case TypeCategory::Bool:
+	case TypeCategory::Char:
+	case TypeCategory::UnsignedChar:
+	case TypeCategory::WChar:
+	case TypeCategory::Char8:
+	case TypeCategory::Char16:
+	case TypeCategory::Char32:
+	case TypeCategory::Short:
+	case TypeCategory::UnsignedShort:
+	case TypeCategory::Int:
+	case TypeCategory::UnsignedInt:
+	case TypeCategory::Long:
+	case TypeCategory::UnsignedLong:
+	case TypeCategory::LongLong:
+	case TypeCategory::UnsignedLongLong:
+	case TypeCategory::Enum:
+	case TypeCategory::Nullptr:
+	case TypeCategory::FunctionPointer:
+	case TypeCategory::MemberFunctionPointer:
+	case TypeCategory::MemberObjectPointer:
+		return true;
+	default:
+		return false;
+	}
+}
+
+inline void markSysVEightbytes(SysVAbiValueLayout& layout, size_t offset, size_t size,
+							  SysVRegisterClass register_class) {
+	if (size == 0) {
+		return;
+	}
+	const size_t first_eightbyte = offset / 8;
+	const size_t last_eightbyte = (offset + size - 1) / 8;
+	if (last_eightbyte >= layout.eightbytes.size()) {
+		layout.eightbytes[0] = SysVRegisterClass::Memory;
+		layout.eightbyte_count = 0;
+		return;
+	}
+	for (size_t i = first_eightbyte; i <= last_eightbyte; ++i) {
+		layout.eightbytes[i] = mergeSysVRegisterClasses(layout.eightbytes[i], register_class);
+	}
+}
+
+inline size_t naturalAlignment(TypeIndex type_index, size_t object_size) {
+	const TypeIndex canonical_type_index = canonicalize_type_alias(type_index).resolvedTypeIndex();
+	if (const TypeInfo* type_info = tryGetTypeInfo(canonical_type_index)) {
+		if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
+			return struct_info->alignment;
+		}
+	}
+	return object_size > 8 ? 8 : std::max<size_t>(object_size, 1);
+}
+
+inline bool classifySysVObjectAtOffset(SysVAbiValueLayout& layout, TypeIndex type_index,
+								  size_t object_offset, size_t object_size,
+								  int pointer_depth, bool is_reference);
+
+inline bool classifySysVStructAtOffset(SysVAbiValueLayout& layout, const StructTypeInfo& struct_info,
+								  size_t object_offset) {
+	if (!struct_info.layout_is_complete) {
+		throw InternalError("SysV ABI classification requires complete aggregate layout");
+	}
+	if (toSizeT(struct_info.total_size) > 16) {
+		return false;
+	}
+
+	for (const BaseClassSpecifier& base : struct_info.base_classes) {
+		const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
+		const StructTypeInfo* base_struct_info = base_type_info ? base_type_info->getStructInfo() : nullptr;
+		if (!base_struct_info ||
+			!classifySysVObjectAtOffset(layout, base.type_index, object_offset + base.offset,
+				toSizeT(base_struct_info->total_size),
+				/*pointer_depth=*/0, /*is_reference=*/false)) {
+			return false;
+		}
+	}
+
+	for (const StructMember& member : struct_info.members) {
+		const size_t member_offset = object_offset + member.offset;
+		if (member.bitfield_width.has_value()) {
+			if ((member_offset % naturalAlignment(member.type_index, member.size)) != 0) {
+				return false;
+			}
+			markSysVEightbytes(layout, member_offset, member.size, SysVRegisterClass::Integer);
+			continue;
+		}
+
+		if (member.is_array) {
+			size_t element_count = 1;
+			for (size_t dimension : member.array_dimensions) {
+				element_count *= dimension;
+			}
+			if (element_count == 0 || member.size % element_count != 0) {
+				throw InternalError("SysV ABI classification requires complete array extent metadata");
+			}
+			const size_t element_size = member.size / element_count;
+			for (size_t i = 0; i < element_count; ++i) {
+				if (!classifySysVObjectAtOffset(layout, member.type_index,
+						member_offset + i * element_size, element_size,
+						member.pointer_depth, member.is_reference())) {
+					return false;
+				}
+			}
+			continue;
+		}
+
+		if (!classifySysVObjectAtOffset(layout, member.type_index, member_offset, member.size,
+				member.pointer_depth, member.is_reference())) {
+			return false;
+		}
+	}
+	return true;
+}
+
+inline bool classifySysVObjectAtOffset(SysVAbiValueLayout& layout, TypeIndex type_index,
+								  size_t object_offset, size_t object_size,
+								  int pointer_depth, bool is_reference) {
+	if (pointer_depth > 0 || is_reference) {
+		if ((object_offset % 8) != 0) {
+			return false;
+		}
+		markSysVEightbytes(layout, object_offset, 8, SysVRegisterClass::Integer);
+		return !layout.isMemory();
+	}
+
+	const TypeIndex canonical_type_index = canonicalize_type_alias(type_index).resolvedTypeIndex();
+	TypeCategory category = canonical_type_index.category();
+	if (category == TypeCategory::Invalid) {
+		category = type_index.category();
+	}
+
+	if ((object_offset % naturalAlignment(canonical_type_index, object_size)) != 0) {
+		return false;
+	}
+	if (isSysVIntegerCategory(category)) {
+		markSysVEightbytes(layout, object_offset, object_size, SysVRegisterClass::Integer);
+		return !layout.isMemory();
+	}
+	if (category == TypeCategory::Float || category == TypeCategory::Double) {
+		markSysVEightbytes(layout, object_offset, object_size, SysVRegisterClass::Sse);
+		return !layout.isMemory();
+	}
+	if (category == TypeCategory::LongDouble) {
+		layout.contains_x87 = true;
+		return false;
+	}
+	if (const TypeInfo* type_info = tryGetTypeInfo(canonical_type_index)) {
+		if (const StructTypeInfo* struct_info = type_info->getStructInfo()) {
+			return classifySysVStructAtOffset(layout, *struct_info, object_offset);
+		}
+	}
+	throw InternalError("SysV ABI classification reached a type without canonical runtime metadata (index=" +
+		std::to_string(canonical_type_index.index()) + ", category=" +
+		std::to_string(static_cast<int>(category)) + ", size=" +
+		std::to_string(object_size) + ")");
+}
+
+} // namespace Detail
+
+inline SysVAbiValueLayout classifySysVValue(TypeIndex type_index, SizeInBits size_in_bits,
+									 int pointer_depth, bool is_reference) {
+	SysVAbiValueLayout layout;
+	if (pointer_depth > 0 || is_reference) {
+		layout.eightbytes[0] = SysVRegisterClass::Integer;
+		layout.eightbyte_count = 1;
+		return layout;
+	}
+	if (!size_in_bits.is_set() || size_in_bits.value % 8 != 0) {
+		throw InternalError("SysV ABI classification requires an exact byte-sized type");
+	}
+	const size_t size_in_bytes = static_cast<size_t>(size_in_bits.value / 8);
+	if (size_in_bytes == 0 || size_in_bytes > 16 ||
+		!Detail::classifySysVObjectAtOffset(
+			layout, type_index, 0, size_in_bytes,
+			/*pointer_depth=*/0, /*is_reference=*/false)) {
+		layout.eightbytes = {SysVRegisterClass::Memory, SysVRegisterClass::Memory};
+		layout.eightbyte_count = 0;
+		return layout;
+	}
+	layout.eightbyte_count = static_cast<uint8_t>((size_in_bytes + 7) / 8);
+	return layout;
+}
+
+} // namespace TargetABI

--- a/tests/test_external_abi.cpp
+++ b/tests/test_external_abi.cpp
@@ -19,6 +19,27 @@ struct Big4 {
 	int c;
 	int d;
 };
+struct DoublePair {
+	double a;
+	double b;
+};
+struct IntDouble {
+	int a;
+	double b;
+};
+struct DoubleInt {
+	double a;
+	int b;
+};
+struct alignas(16) TailAlignedDouble {
+	double value;
+};
+#pragma pack(push, 1)
+struct PackedDouble {
+	char tag;
+	double value;
+};
+#pragma pack(pop)
 extern "C" int external_sum_big3(Big3 value);
 extern "C" int external_big3_after_4_ints(int i1, int i2, int i3, int i4, Big3 value);
 extern "C" int external_big3_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big3 value);
@@ -31,6 +52,30 @@ extern "C" int external_call_flashcpp_big3_after_5_ints(int i1, int i2, int i3, 
 extern "C" int external_call_flashcpp_big4(Big4 value);
 extern "C" int external_call_flashcpp_big4_after_4_ints(int i1, int i2, int i3, int i4, Big4 value);
 extern "C" int external_call_flashcpp_big4_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big4 value);
+extern "C" int external_check_double_pair(DoublePair value);
+extern "C" int external_check_int_double(IntDouble value);
+extern "C" int external_check_double_int(DoubleInt value);
+extern "C" int external_call_flashcpp_double_pair(DoublePair value);
+extern "C" int external_call_flashcpp_int_double(IntDouble value);
+extern "C" int external_call_flashcpp_double_int(DoubleInt value);
+extern "C" DoublePair external_make_double_pair(double a, double b);
+extern "C" IntDouble external_make_int_double(int a, double b);
+extern "C" DoubleInt external_make_double_int(double a, int b);
+extern "C" DoublePair external_call_flashcpp_make_double_pair(double a, double b);
+extern "C" IntDouble external_call_flashcpp_make_int_double(int a, double b);
+extern "C" DoubleInt external_call_flashcpp_make_double_int(double a, int b);
+extern "C" int external_check_tail_aligned_double(TailAlignedDouble value);
+extern "C" int external_call_flashcpp_tail_aligned_double(TailAlignedDouble value);
+extern "C" TailAlignedDouble external_make_tail_aligned_double(double value);
+extern "C" TailAlignedDouble external_call_flashcpp_make_tail_aligned_double(double value);
+extern "C" int external_check_packed_double(PackedDouble value);
+extern "C" int external_call_flashcpp_packed_double(PackedDouble value);
+extern "C" int external_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail);
+extern "C" int external_call_flashcpp_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail);
 
 extern "C" int flashcpp_sum_big3(Big3 value) {
 	return value.a + value.b + value.c;
@@ -54,6 +99,49 @@ extern "C" int flashcpp_big4_after_4_ints(int i1, int i2, int i3, int i4, Big4 v
 
 extern "C" int flashcpp_big4_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big4 value) {
 	return i1 + i2 + i3 + i4 + i5 + value.a + value.b + value.c + value.d;
+}
+
+extern "C" int flashcpp_check_double_pair(DoublePair value) {
+	return value.a == 10.5 && value.b == 31.5;
+}
+
+extern "C" int flashcpp_check_int_double(IntDouble value) {
+	return value.a == 10 && value.b == 32.0;
+}
+
+extern "C" int flashcpp_check_double_int(DoubleInt value) {
+	return value.a == 10.5 && value.b == 31;
+}
+
+extern "C" DoublePair flashcpp_make_double_pair(double a, double b) {
+	return DoublePair{a, b};
+}
+
+extern "C" IntDouble flashcpp_make_int_double(int a, double b) {
+	return IntDouble{a, b};
+}
+
+extern "C" DoubleInt flashcpp_make_double_int(double a, int b) {
+	return DoubleInt{a, b};
+}
+
+extern "C" int flashcpp_check_tail_aligned_double(TailAlignedDouble value) {
+	return value.value == 42.5;
+}
+
+extern "C" TailAlignedDouble flashcpp_make_tail_aligned_double(double value) {
+	return TailAlignedDouble{value};
+}
+
+extern "C" int flashcpp_check_packed_double(PackedDouble value) {
+	return value.tag == 10 && value.value == 32.0;
+}
+
+extern "C" int flashcpp_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail) {
+	return static_cast<int>(d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8) + value.a +
+		static_cast<int>(value.b) + tail;
 }
 
 extern "C" int main() {
@@ -159,6 +247,94 @@ extern "C" int main() {
 	Big4 test16 = {100, 200, 300, 400};
 	if (external_call_flashcpp_big4_after_5_ints(1, 2, 3, 4, 5, test16) != 1015) {
 		return 16;
+	}
+
+	// Tests 17-19: FlashCpp caller -> platform compiler callee for all SysV
+	// two-eightbyte register-class combinations.
+	if (!external_check_double_pair(DoublePair{10.5, 31.5})) {
+		return 17;
+	}
+	if (!external_check_int_double(IntDouble{10, 32.0})) {
+		return 18;
+	}
+	if (!external_check_double_int(DoubleInt{10.5, 31})) {
+		return 19;
+	}
+
+	// Tests 20-22: platform compiler caller -> FlashCpp callee.
+	if (!external_call_flashcpp_double_pair(DoublePair{10.5, 31.5})) {
+		return 20;
+	}
+	if (!external_call_flashcpp_int_double(IntDouble{10, 32.0})) {
+		return 21;
+	}
+	if (!external_call_flashcpp_double_int(DoubleInt{10.5, 31})) {
+		return 22;
+	}
+
+	// Tests 23-28: direct aggregate returns in both directions.
+	DoublePair external_double_pair = external_make_double_pair(10.5, 31.5);
+	if (external_double_pair.a != 10.5 || external_double_pair.b != 31.5) {
+		return 23;
+	}
+	IntDouble external_int_double = external_make_int_double(10, 32.0);
+	if (external_int_double.a != 10 || external_int_double.b != 32.0) {
+		return 24;
+	}
+	DoubleInt external_double_int = external_make_double_int(10.5, 31);
+	if (external_double_int.a != 10.5 || external_double_int.b != 31) {
+		return 25;
+	}
+	DoublePair flashcpp_double_pair = external_call_flashcpp_make_double_pair(10.5, 31.5);
+	if (flashcpp_double_pair.a != 10.5 || flashcpp_double_pair.b != 31.5) {
+		return 26;
+	}
+	IntDouble flashcpp_int_double = external_call_flashcpp_make_int_double(10, 32.0);
+	if (flashcpp_int_double.a != 10 || flashcpp_int_double.b != 32.0) {
+		return 27;
+	}
+	DoubleInt flashcpp_double_int = external_call_flashcpp_make_double_int(10.5, 31);
+	if (flashcpp_double_int.a != 10.5 || flashcpp_double_int.b != 31) {
+		return 28;
+	}
+
+	// Tests 29-32: trailing padding remains NO_CLASS, so this 16-byte aggregate
+	// consumes only one SSE register in both argument and return directions.
+	if (!external_check_tail_aligned_double(TailAlignedDouble{42.5})) {
+		return 29;
+	}
+	if (!external_call_flashcpp_tail_aligned_double(TailAlignedDouble{42.5})) {
+		return 30;
+	}
+	TailAlignedDouble external_tail_aligned = external_make_tail_aligned_double(42.5);
+	if (external_tail_aligned.value != 42.5) {
+		return 31;
+	}
+	TailAlignedDouble flashcpp_tail_aligned = external_call_flashcpp_make_tail_aligned_double(42.5);
+	if (flashcpp_tail_aligned.value != 42.5) {
+		return 32;
+	}
+
+	// Tests 33-34: an unaligned aggregate is MEMORY-class even though it is
+	// smaller than 16 bytes, so arguments use the overflow area.
+	if (!external_check_packed_double(PackedDouble{10, 32.0})) {
+		return 33;
+	}
+	if (!external_call_flashcpp_packed_double(PackedDouble{10, 32.0})) {
+		return 34;
+	}
+
+	// Tests 35-36: the mixed aggregate needs one GPR and one SSE register. With
+	// all SSE registers occupied, the whole aggregate spills and the following
+	// integer still uses the unconsumed first GPR.
+	IntDouble exhausted_value{10, 32.0};
+	if (external_int_double_after_8_doubles(
+			1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, exhausted_value, 5) != 83) {
+		return 35;
+	}
+	if (external_call_flashcpp_int_double_after_8_doubles(
+			1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, exhausted_value, 5) != 83) {
+		return 36;
 	}
 
 	return 0; // All tests passed!

--- a/tests/test_external_abi_helper.c
+++ b/tests/test_external_abi_helper.c
@@ -45,12 +45,56 @@ typedef struct Big4 {
 	int d;
 } Big4;
 
+typedef struct DoublePair {
+	double a;
+	double b;
+} DoublePair;
+
+typedef struct IntDouble {
+	int a;
+	double b;
+} IntDouble;
+
+typedef struct DoubleInt {
+	double a;
+	int b;
+} DoubleInt;
+
+#if defined(_MSC_VER)
+typedef __declspec(align(16)) struct TailAlignedDouble {
+	double value;
+} TailAlignedDouble;
+#else
+typedef struct __attribute__((aligned(16))) TailAlignedDouble {
+	double value;
+} TailAlignedDouble;
+#endif
+
+#pragma pack(push, 1)
+typedef struct PackedDouble {
+	char tag;
+	double value;
+} PackedDouble;
+#pragma pack(pop)
+
 int flashcpp_sum_big3(Big3 value);
 int flashcpp_big3_after_4_ints(int i1, int i2, int i3, int i4, Big3 value);
 int flashcpp_big3_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big3 value);
 int flashcpp_sum_big4(Big4 value);
 int flashcpp_big4_after_4_ints(int i1, int i2, int i3, int i4, Big4 value);
 int flashcpp_big4_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big4 value);
+int flashcpp_check_double_pair(DoublePair value);
+int flashcpp_check_int_double(IntDouble value);
+int flashcpp_check_double_int(DoubleInt value);
+DoublePair flashcpp_make_double_pair(double a, double b);
+IntDouble flashcpp_make_int_double(int a, double b);
+DoubleInt flashcpp_make_double_int(double a, int b);
+int flashcpp_check_tail_aligned_double(TailAlignedDouble value);
+TailAlignedDouble flashcpp_make_tail_aligned_double(double value);
+int flashcpp_check_packed_double(PackedDouble value);
+int flashcpp_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail);
 
 int external_sum_big3(Big3 value) {
 	printf("external_sum_big3: %d %d %d\n", value.a, value.b, value.c);
@@ -122,4 +166,93 @@ int external_call_flashcpp_big4_after_5_ints(int i1, int i2, int i3, int i4, int
 	printf("external_call_flashcpp_big4_after_5_ints: %d %d %d %d %d | %d %d %d %d\n",
 		   i1, i2, i3, i4, i5, value.a, value.b, value.c, value.d);
 	return flashcpp_big4_after_5_ints(i1, i2, i3, i4, i5, value);
+}
+
+int external_check_double_pair(DoublePair value) {
+	return value.a == 10.5 && value.b == 31.5;
+}
+
+int external_check_int_double(IntDouble value) {
+	return value.a == 10 && value.b == 32.0;
+}
+
+int external_check_double_int(DoubleInt value) {
+	return value.a == 10.5 && value.b == 31;
+}
+
+int external_call_flashcpp_double_pair(DoublePair value) {
+	return flashcpp_check_double_pair(value);
+}
+
+int external_call_flashcpp_int_double(IntDouble value) {
+	return flashcpp_check_int_double(value);
+}
+
+int external_call_flashcpp_double_int(DoubleInt value) {
+	return flashcpp_check_double_int(value);
+}
+
+DoublePair external_make_double_pair(double a, double b) {
+	DoublePair value = {a, b};
+	return value;
+}
+
+IntDouble external_make_int_double(int a, double b) {
+	IntDouble value = {a, b};
+	return value;
+}
+
+DoubleInt external_make_double_int(double a, int b) {
+	DoubleInt value = {a, b};
+	return value;
+}
+
+DoublePair external_call_flashcpp_make_double_pair(double a, double b) {
+	return flashcpp_make_double_pair(a, b);
+}
+
+IntDouble external_call_flashcpp_make_int_double(int a, double b) {
+	return flashcpp_make_int_double(a, b);
+}
+
+DoubleInt external_call_flashcpp_make_double_int(double a, int b) {
+	return flashcpp_make_double_int(a, b);
+}
+
+int external_check_tail_aligned_double(TailAlignedDouble value) {
+	return value.value == 42.5;
+}
+
+int external_call_flashcpp_tail_aligned_double(TailAlignedDouble value) {
+	return flashcpp_check_tail_aligned_double(value);
+}
+
+TailAlignedDouble external_make_tail_aligned_double(double value) {
+	TailAlignedDouble result = {value};
+	return result;
+}
+
+TailAlignedDouble external_call_flashcpp_make_tail_aligned_double(double value) {
+	return flashcpp_make_tail_aligned_double(value);
+}
+
+int external_check_packed_double(PackedDouble value) {
+	return value.tag == 10 && value.value == 32.0;
+}
+
+int external_call_flashcpp_packed_double(PackedDouble value) {
+	return flashcpp_check_packed_double(value);
+}
+
+int external_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail) {
+	return (int)(d1 + d2 + d3 + d4 + d5 + d6 + d7 + d8) + value.a + (int)value.b + tail;
+}
+
+int external_call_flashcpp_int_double_after_8_doubles(
+	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
+	IntDouble value, int tail) {
+	return flashcpp_int_double_after_8_doubles(
+		d1, d2, d3, d4, d5, d6, d7, d8, value, tail);
 }


### PR DESCRIPTION
## Summary
- preserve canonical return type identity through generated IR and apply outer bindings before accepting member-template defaults
- replace the SysV 9–16-byte size-only rule with recursive INTEGER/SSE/MEMORY classification from canonical layout metadata
- lower mixed aggregate calls and returns consistently across direct, indirect, constructor, callee, overflow, and variadic paths
- add cross-compiler ABI coverage for mixed classes, trailing NO_CLASS padding, unaligned MEMORY parameters, and register-bank exhaustion
- document deferred MEMORY-return, single-eightbyte, and x87 return-planning gaps