### PR TITLE
Resolve unary address-of overloads in sema

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -18,12 +18,6 @@ consistently diagnosed as compile errors yet.
   ambiguous between `void log(int, const char*)` and
   `void log(int, const char*, ...)`.
 
-## Operator overload resolution mismatch (`operator&`)
-The original `tests/test_operator_addressof_overload_baseline_ret99.cpp` behavior
-documented a conformance gap where unary `&` on class type did not reliably
-select overloaded `operator&` as required, effectively collapsing behavior toward
-`__builtin_addressof`.
-
 ## Non-standard layout/constexpr acceptance gaps tracked as compatibility tests
 These tests are intentionally kept in compatibility form so the current FlashCpp
 suite stays green, even though they are not strictly standard-conforming under a

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -14367,6 +14367,13 @@ void IrToObjConverter<TWriterClass>::handleComputeAddress(const IrInstruction& i
 		SizedRegister{X64Register::RAX, 64, false},	// source: 64-bit register
 		SizedStackSlot{result_offset, 64, false}	 // dest: 64-bit for pointer
 	);
+	// ComputeAddress produces a pointer value. Preserve that fact at the backend
+	// boundary so call lowering loads the pointer instead of taking its address.
+	setAddressOnlyInfo(
+		result_offset,
+		op.result_type_index,
+		op.result_size_bits.value,
+		op.result);
 }
 
 template <class TWriterClass>

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -686,77 +686,27 @@ std::optional<ExprResult> AstToIr::decayLambdaStructToFunctionPointer(const Stru
 
 ExprResult AstToIr::generateUnaryOperatorIr(const UnaryOperatorNode& unaryOperatorNode,
 											ExpressionContext context) {
-		// OPERATOR OVERLOAD RESOLUTION
-		// For full standard compliance, operator& should call overloaded operator& if it exists.
-		// __builtin_addressof (marked with is_builtin_addressof flag) always bypasses overloads.
-	if (!unaryOperatorNode.is_builtin_addressof() && unaryOperatorNode.op() == "&" &&
-		unaryOperatorNode.get_operand().is<ExpressionNode>()) {
-		const ExpressionNode& operandExpr = unaryOperatorNode.get_operand().as<ExpressionNode>();
-
-			// For now, only handle simple identifiers
-		if (std::holds_alternative<IdentifierNode>(operandExpr)) {
-			const IdentifierNode& ident = std::get<IdentifierNode>(operandExpr);
-			StringHandle identifier_handle = StringTable::getOrInternStringHandle(ident.name());
-
-			const DeclarationNode* decl = lookupDeclaration(identifier_handle);
-
-			if (decl) {
-				const TypeSpecifierNode* type_node = &decl->type_specifier_node();
-
-				if (type_node->category() == TypeCategory::Struct && type_node->pointer_depth() == 0) {
-						// Check for operator& overload
-					auto overload_result = findUnaryOperatorOverload(type_node->type_index(), OverloadableOperator::BitwiseAnd);
-
-					if (overload_result.has_match) {
-							// Found an overload! Generate a member function call instead of built-in address-of
-						FLASH_LOG_FORMAT(Codegen, Debug, "Resolving operator& overload for type index {}",
-										 type_node->type_index());
-
-						const StructMemberFunction& member_func = *overload_result.member_overload;
-						const FunctionDeclarationNode& func_decl = member_func.function_decl.as<FunctionDeclarationNode>();
-
-							// Get struct name for mangling
-						StringHandle struct_name = getTypeInfo(type_node->type_index()).name();
-
-							// Get the return type from the function declaration
-						const TypeSpecifierNode& return_type = func_decl.decl_node().type_specifier_node();
-
-							// Generate mangled name using the proper mangling infrastructure
-							// This handles both Itanium (Linux) and MSVC (Windows) name mangling
-						std::string_view operator_func_name = "operator&";
-						std::vector<TypeSpecifierNode> empty_params; // No explicit parameters (only implicit 'this')
-						std::vector<std::string_view> empty_namespace;
-						auto mangled_name = NameMangling::generateMangledName(
-							operator_func_name,
-							return_type,
-							empty_params,
-							false, // not variadic
-							struct_name,
-							empty_namespace,
-							Linkage::CPlusPlus,
-							member_func.is_const());
-
-							// Generate the call
-						TempVar ret_var = var_counter.next();
-
-						// Create CallOp — size resolution for struct/primitive types is handled
-						// inside populateCallReturnInfo, so no post-hoc fixup needed.
-						CallOp call_op = createCallOp(ret_var, StringHandle{}, return_type, true, false);
-						call_op.function_name = mangled_name;  // MangledName implicitly converts to StringHandle
-
-							// Add 'this' pointer as first argument
-						call_op.args.push_back(makeTypedValue(type_node->type(), SizeInBits{64}, IrValue(identifier_handle)));
-
-							// Capture return metadata before the move invalidates call_op.
-						SizeInBits ret_size_in_bits = call_op.return_size_in_bits;
-							// Add the function call instruction
-						ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), unaryOperatorNode.get_token()));
-
-							// Return the result
-						return makeExprResult(return_type.type_index(), ret_size_in_bits, IrOperand{ret_var}, PointerDepth{static_cast<int>(return_type.pointer_depth())}, ValueStorage::ContainsData);
-					}
-				}
+	if (!unaryOperatorNode.is_builtin_addressof() && unaryOperatorNode.op() == "&") {
+		sema_.ensureUnaryAddressOfOperatorResolved(unaryOperatorNode);
+		if (const SemanticAnalysis::ResolvedUnaryOperatorCall* resolved_address =
+				sema_.getResolvedUnaryAddressOfOperator(&unaryOperatorNode)) {
+			if (resolved_address->is_member) {
+				ChunkedVector<ASTNode> member_args;
+				CallExprNode member_call = makeResolvedMemberCallExpr(
+					unaryOperatorNode.get_operand(),
+					*resolved_address->function,
+					std::move(member_args),
+					unaryOperatorNode.get_token());
+				return generateMemberFunctionCallIr(member_call, context);
 			}
+
+			ChunkedVector<ASTNode> free_args;
+			free_args.push_back(unaryOperatorNode.get_operand());
+			CallExprNode free_call = makeResolvedCallExpr(
+				*resolved_address->function,
+				std::move(free_args),
+				unaryOperatorNode.get_token());
+			return generateFunctionCallIr(free_call, context, &unaryOperatorNode);
 		}
 	}
 
@@ -2892,25 +2842,11 @@ std::optional<ExprResult> AstToIr::tryApplySemaCallArgReferenceBinding(ExprResul
 			}
 		}
 
-		if (std::holds_alternative<TempVar>(arg_result.value)) {
-			TempVar expr_var = std::get<TempVar>(arg_result.value);
-			bool is_already_address = false;
-			auto& metadata_storage = GlobalTempVarMetadataStorage::instance();
-			if (metadata_storage.hasMetadata(expr_var)) {
-				TempVarMetadata metadata = metadata_storage.getMetadata(expr_var);
-				is_already_address = metadata.category == ValueCategory::LValue ||
-									 metadata.category == ValueCategory::XValue;
-			}
-			if (is_already_address) {
-				return arg_result;
-			}
-
-			TempVar addr_var = emitAddressOf(
-				arg_result.category(),
-				arg_result.size_in_bits.value,
-				IrValue(expr_var),
+		if (arg_expr.is<ExpressionNode>()) {
+			return materializeAddressResult(
+				arg_expr.as<ExpressionNode>(),
+				arg_result,
 				source_token);
-			return makeExprResult(arg_result.type_index, SizeInBits{64}, IrOperand{addr_var}, PointerDepth{}, ValueStorage::ContainsData);
 		}
 
 		return std::nullopt;

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -433,8 +433,10 @@ void AstToIr::applyCallParameterBindingMetadata(TypedValue& value, const TypeSpe
 	value.cv_qualifier = param_type.cv_qualifier();
 	if (param_type.is_rvalue_reference()) {
 		value.ref_qualifier = ReferenceQualifier::RValueReference;
+		value.size_in_bits = SizeInBits{POINTER_SIZE_BITS};
 	} else if (param_type.is_reference()) {
 		value.ref_qualifier = ReferenceQualifier::LValueReference;
+		value.size_in_bits = SizeInBits{POINTER_SIZE_BITS};
 	} else {
 		value.ref_qualifier = ReferenceQualifier::None;
 	}

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -7,6 +7,7 @@
 #include "ChunkedString.h"
 #include "TemplateTypes.h" // For FunctionSignatureKey
 #include "InlineVector.h"
+#include <array>
 #include <vector>
 #include <optional>
 #include <unordered_map>
@@ -1952,7 +1953,7 @@ inline ConversionRank rankBinaryOperatorOperandMatch(const TypeSpecifierNode& ar
 	return conversion.is_valid ? conversion.rank : ConversionRank::NoMatch;
 }
 
-inline ConversionRank rankImplicitObjectToBinaryOperator(
+inline ConversionRank rankImplicitObjectToOperator(
 	const TypeSpecifierNode& object_spec,
 	const StructMemberFunction& member_func,
 	TypeIndex actual_object_type_index,
@@ -1969,6 +1970,10 @@ inline ConversionRank rankImplicitObjectToBinaryOperator(
 	if (uses_base_member) {
 		return ConversionRank::Conversion;
 	}
+	if ((!object_spec.is_const() && member_func.is_const()) ||
+		(!object_spec.is_volatile() && member_func.is_volatile())) {
+		return ConversionRank::QualificationAdjustment;
+	}
 
 	return ConversionRank::ExactMatch;
 }
@@ -1979,6 +1984,46 @@ enum class BinaryOperatorCandidateComparison {
 	Equivalent,
 	Incomparable,
 };
+
+inline std::vector<ASTNode> collectFreeOperatorCandidates(
+	std::string_view operator_name,
+	std::span<const TypeSpecifierNode> operand_types,
+	const SymbolTable& symbol_table) {
+	auto overloads = symbol_table.lookup_all(operator_name);
+	std::vector<TypeSpecifierNode> adl_arg_types(operand_types.begin(), operand_types.end());
+	auto adl_candidates = symbol_table.lookup_adl(operator_name, adl_arg_types);
+
+	std::unordered_set<std::string_view> existing_mangled;
+	std::unordered_set<const FunctionDeclarationNode*> existing_ptrs;
+	existing_mangled.reserve(overloads.size());
+	existing_ptrs.reserve(overloads.size());
+	for (const ASTNode& node : overloads) {
+		if (!node.is<FunctionDeclarationNode>()) {
+			continue;
+		}
+		const auto& function = node.as<FunctionDeclarationNode>();
+		if (function.has_mangled_name()) {
+			existing_mangled.insert(function.mangled_name());
+		} else {
+			existing_ptrs.insert(&function);
+		}
+	}
+
+	for (ASTNode& candidate : adl_candidates) {
+		if (!candidate.is<FunctionDeclarationNode>()) {
+			overloads.push_back(std::move(candidate));
+			continue;
+		}
+		const auto& function = candidate.as<FunctionDeclarationNode>();
+		const bool is_duplicate = function.has_mangled_name()
+			? !existing_mangled.insert(function.mangled_name()).second
+			: !existing_ptrs.insert(&function).second;
+		if (!is_duplicate) {
+			overloads.push_back(std::move(candidate));
+		}
+	}
+	return overloads;
+}
 
 inline BinaryOperatorCandidateComparison compareBinaryOperatorCandidateRanks(
 	ConversionRank lhs_lhs_rank,
@@ -2042,6 +2087,114 @@ inline OperatorOverloadResult findUnaryOperatorOverload(TypeIndex operand_type_i
 	return OperatorOverloadResult::no_overload();
 }
 
+// C++20 [over.match.oper]: member and non-member unary operator candidates form
+// one overload set. The operand expression supplies the implicit-object
+// conversion for members and the first-parameter conversion for non-members.
+inline OperatorOverloadResult findUnaryOperatorOverloadWithFreeFunction(
+	const TypeSpecifierNode& operand_type_spec,
+	OverloadableOperator operator_kind,
+	const SymbolTable& symbol_table) {
+	if (operator_kind == OverloadableOperator::None) {
+		return OperatorOverloadResult::no_overload();
+	}
+
+	struct UnaryOperatorCandidate {
+		ConversionRank rank = ConversionRank::NoMatch;
+		const StructMemberFunction* member_function = nullptr;
+		const FunctionDeclarationNode* free_function = nullptr;
+	};
+	std::vector<UnaryOperatorCandidate> candidates;
+
+	const TypeIndex operand_type_index = operand_type_spec.type_index();
+	const size_t type_info_count = getTypeInfoCount();
+	auto gatherMemberCandidates = [&](auto& self, TypeIndex owner_type_index) -> void {
+		if (!owner_type_index.is_valid() || owner_type_index.index() >= type_info_count) {
+			return;
+		}
+		const StructTypeInfo* struct_info = getTypeInfo(owner_type_index).getStructInfo();
+		if (struct_info == nullptr) {
+			return;
+		}
+
+		for (const StructMemberFunction& member_function : struct_info->member_functions) {
+			if (member_function.operator_kind != operator_kind ||
+				!member_function.function_decl.is<FunctionDeclarationNode>()) {
+				continue;
+			}
+			const auto& function = member_function.function_decl.as<FunctionDeclarationNode>();
+			if (!function.parameter_nodes().empty()) {
+				continue;
+			}
+			const ConversionRank rank = rankImplicitObjectToOperator(
+				operand_type_spec,
+				member_function,
+				operand_type_index,
+				owner_type_index);
+			if (rank != ConversionRank::NoMatch) {
+				candidates.push_back({rank, &member_function, nullptr});
+			}
+		}
+
+		for (const BaseClassSpecifier& base : struct_info->base_classes) {
+			self(self, base.type_index);
+		}
+	};
+	gatherMemberCandidates(gatherMemberCandidates, operand_type_index);
+
+	StringBuilder operator_name_builder;
+	operator_name_builder.append("operator").append(overloadableOperatorToString(operator_kind));
+	const std::array<TypeSpecifierNode, 1> operand_types{operand_type_spec};
+	const std::vector<ASTNode> free_candidates = collectFreeOperatorCandidates(
+		operator_name_builder.commit(),
+		operand_types,
+		symbol_table);
+	for (const ASTNode& candidate : free_candidates) {
+		if (!candidate.is<FunctionDeclarationNode>()) {
+			continue;
+		}
+		const auto& function = candidate.as<FunctionDeclarationNode>();
+		const auto& parameters = function.parameter_nodes();
+		if (parameters.size() != 1 || !parameters[0].is<DeclarationNode>()) {
+			continue;
+		}
+		const ASTNode& parameter_type_node = parameters[0].as<DeclarationNode>().type_node();
+		if (!parameter_type_node.is<TypeSpecifierNode>()) {
+			continue;
+		}
+		const ConversionRank rank = rankBinaryOperatorOperandMatch(
+			operand_type_spec,
+			parameter_type_node.as<TypeSpecifierNode>(),
+			operand_type_index);
+		if (rank != ConversionRank::NoMatch) {
+			candidates.push_back({rank, nullptr, &function});
+		}
+	}
+
+	if (candidates.empty()) {
+		return OperatorOverloadResult::no_overload();
+	}
+	const ConversionRank best_rank = std::ranges::min(
+		candidates,
+		{},
+		&UnaryOperatorCandidate::rank).rank;
+	const UnaryOperatorCandidate* best_candidate = nullptr;
+	for (const UnaryOperatorCandidate& candidate : candidates) {
+		if (candidate.rank != best_rank) {
+			continue;
+		}
+		if (best_candidate != nullptr) {
+			return OperatorOverloadResult::ambiguous();
+		}
+		best_candidate = &candidate;
+	}
+	if (best_candidate == nullptr) {
+		return OperatorOverloadResult::no_overload();
+	}
+	return best_candidate->free_function != nullptr
+		? OperatorOverloadResult(best_candidate->free_function)
+		: OperatorOverloadResult(best_candidate->member_function);
+}
+
 // Find binary operator overload in a struct type (member function form)
 // For binary operators like operator+, operator-, etc.
 // Returns the member function that overloads the given operator, or nullptr if not found
@@ -2095,7 +2248,7 @@ inline OperatorOverloadResult findBinaryOperatorOverload(
 			if (!param_type_node.is<TypeSpecifierNode>())
 				continue;
 
-			ConversionRank lhs_rank = rankImplicitObjectToBinaryOperator(
+			ConversionRank lhs_rank = rankImplicitObjectToOperator(
 				left_type_spec,
 				member_func,
 				left_type_index,
@@ -2232,7 +2385,7 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 			if (!param_type_node.is<TypeSpecifierNode>())
 				continue;
 
-			ConversionRank lhs_rank = rankImplicitObjectToBinaryOperator(
+			ConversionRank lhs_rank = rankImplicitObjectToOperator(
 				left_type_spec,
 				member_func,
 				left_type_index,
@@ -2260,61 +2413,11 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 
 	StringBuilder op_name_sb;
 	op_name_sb.append("operator").append(overloadableOperatorToString(operator_kind));
-	std::string_view op_func_name = op_name_sb.commit();
-	auto overloads = symbol_table.lookup_all(op_func_name);
-
-	// Also search associated namespaces via full ADL (hidden friends + regular
-	// namespace-scoped operators).  Per C++20 [over.match.oper]/2, ADL is
-	// performed for operator overload resolution when at least one operand has
-	// class/enum type.  We use lookup_adl() (not lookup_adl_only()) so that
-	// regular free-function operators in associated namespaces are found — not
-	// only hidden friends.  Deduplicate against the lookup_all() results above
-	// to avoid double-counting operators that are both in the current scope
-	// chain and in an associated namespace.
-	// Use mangled names for stable, semantically-correct identity comparison.
-	{
-		std::vector<TypeSpecifierNode> adl_arg_types;
-		adl_arg_types.push_back(left_type_spec);
-		adl_arg_types.push_back(right_type_spec);
-		auto adl_candidates = symbol_table.lookup_adl(op_func_name, adl_arg_types);
-
-		// Build a set of existing mangled names for O(1) dedup.
-		// Using std::string_view is safe: mangled names are interned in
-		// stable ChunkedStringAllocator storage (they never move).
-		// ASTNode stores a typed pointer handle, so &fd is stable across
-		// copies and vector reallocations — pointer dedup is a safe fallback
-		// for functions that do not yet have a mangled name.
-		std::unordered_set<std::string_view> existing_mangled;
-		std::unordered_set<const FunctionDeclarationNode*> existing_ptrs;
-		existing_mangled.reserve(overloads.size());
-		existing_ptrs.reserve(overloads.size());
-		for (const auto& node : overloads) {
-			if (node.is<FunctionDeclarationNode>()) {
-				const auto& fd = node.as<FunctionDeclarationNode>();
-				if (fd.has_mangled_name()) {
-					existing_mangled.insert(fd.mangled_name());
-				} else {
-					existing_ptrs.insert(&fd);
-				}
-			}
-		}
-		for (auto& cand : adl_candidates) {
-			if (cand.is<FunctionDeclarationNode>()) {
-				const auto& fd = cand.as<FunctionDeclarationNode>();
-				bool is_duplicate;
-				if (fd.has_mangled_name()) {
-					is_duplicate = !existing_mangled.insert(fd.mangled_name()).second;
-				} else {
-					is_duplicate = !existing_ptrs.insert(&fd).second;
-				}
-				if (!is_duplicate) {
-					overloads.push_back(std::move(cand));
-				}
-			} else {
-				overloads.push_back(std::move(cand));
-			}
-		}
-	}
+	const std::array<TypeSpecifierNode, 2> operand_types{left_type_spec, right_type_spec};
+	const std::vector<ASTNode> overloads = collectFreeOperatorCandidates(
+		op_name_sb.commit(),
+		operand_types,
+		symbol_table);
 
 	for (const auto& overload : overloads) {
 		if (!overload.is<FunctionDeclarationNode>())

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -1212,39 +1212,8 @@ ParseResult Parser::parse_unary_expression(ExpressionContext context) {
 	// Check for '__builtin_addressof' intrinsic
 	// Returns the actual address of an object, bypassing any overloaded operator&
 	// Syntax: __builtin_addressof(obj)
-	//
-	// Implementation note: We create a UnaryOperatorNode with the & operator.
-	// In FlashCpp's current implementation, unary & operators are not subject to
-	// overload resolution (overloaded operators would require a separate overload
-	// resolution phase). Therefore, this UnaryOperatorNode will always get the
-	// true address, which is the correct behavior for __builtin_addressof.
-	//
-	// LIMITATION & FUTURE WORK:
-	// Currently, FlashCpp does not perform overload resolution on unary operators,
-	// so regular & operator also bypasses overloaded operator&. This means both
-	// __builtin_addressof and & behave identically. For standard compliance:
-	//
-	// Plan for standard-compliant operator overloading:
-	// 1. Add overload resolution phase after AST construction (before IR generation)
-	// 2. For UnaryOperatorNode with &:
-	//    a. Check if the operand type has an overloaded operator& (member or non-member)
-	//    b. If overloaded operator& exists and applies to regular &:
-	//       - Replace UnaryOperatorNode with a CallExprNode for the overloaded operator
-	//    c. If no overload or __builtin_addressof:
-	//       - Keep UnaryOperatorNode for direct address-of operation
-	// 3. Add a flag to UnaryOperatorNode: is_builtin_addressof
-	//    - Set to true only for __builtin_addressof
-	//    - Overload resolution will skip operators marked with this flag
-	// 4. Implement in OverloadResolution.h:
-	//    - resolveUnaryOperator(UnaryOperatorNode&, TypeContext&)
-	//    - findOperatorOverload(operator_name, operand_type, is_member)
-	// 5. Similar approach needed for other overloadable operators (++, --, etc.)
-	//
-	// Benefits of this approach:
-	// - Standard-compliant: & calls overloaded operator&, __builtin_addressof doesn't
-	// - Minimal AST changes: Just add is_builtin_addressof flag
-	// - Enables other operator overloading (arithmetic, comparison, etc.)
-	// - IR generation remains unchanged (operates on resolved nodes)
+	// Sema recognizes the marker on the resulting UnaryOperatorNode and excludes
+	// this intrinsic from the ordinary member/non-member operator candidate set.
 	if (current_token_.type() == Token::Type::Identifier && current_token_.value() == "__builtin_addressof"sv) {
 		Token builtin_token = current_token_;
 		advance(); // consume '__builtin_addressof'

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -3888,6 +3888,9 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 					tryAnnotateUnaryOperandPromotion(e);
 				}
 				normalizeExpression(e.get_operand(), ctx);
+				if (e.op() == "&" && !e.is_builtin_addressof()) {
+					tryResolveUnaryAddressOfOperator(e);
+				}
 			} else if constexpr (std::is_same_v<T, TernaryOperatorNode>) {
 				// C++20 [expr.cond]/1: the condition is contextually converted to bool.
 				tryAnnotateContextualBool(e.condition());
@@ -4642,6 +4645,16 @@ ValueCategory SemanticAnalysis::inferExpressionValueCategory(const ASTNode& node
 			}
 		} else if constexpr (std::is_same_v<T, UnaryOperatorNode>) {
 			const std::string_view op = inner.op();
+			if (op == "&" && !inner.is_builtin_addressof()) {
+				if (const ResolvedUnaryOperatorCall* resolved_address =
+						getResolvedUnaryAddressOfOperator(&inner)) {
+					if (auto category = getReferenceQualifiedValueCategory(
+							resolved_address->function->decl_node().type_node());
+						category.has_value()) {
+						return *category;
+					}
+				}
+			}
 			if (op == "*" || op == "++" || op == "--") {
 				return ValueCategory::LValue;
 			}
@@ -4753,6 +4766,18 @@ void SemanticAnalysis::ensureCallableOperatorResolved(const CallExprNode& call_n
 const FunctionDeclarationNode* SemanticAnalysis::getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const {
 	auto it = op_unary_deref_table_.find(key);
 	return it != op_unary_deref_table_.end() ? it->second : nullptr;
+}
+
+const SemanticAnalysis::ResolvedUnaryOperatorCall*
+SemanticAnalysis::getResolvedUnaryAddressOfOperator(const UnaryOperatorNode* key) const {
+	auto it = op_unary_address_table_.find(key);
+	return it != op_unary_address_table_.end() ? &it->second : nullptr;
+}
+
+void SemanticAnalysis::ensureUnaryAddressOfOperatorResolved(const UnaryOperatorNode& unary_node) {
+	if (analyzed_op_unary_address_queries_.count(&unary_node) == 0) {
+		tryResolveUnaryAddressOfOperator(unary_node);
+	}
 }
 
 ResolvedFunctionQueryResult SemanticAnalysis::getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const {
@@ -5705,6 +5730,16 @@ CanonicalTypeId SemanticAnalysis::inferExpressionType(const ASTNode& node) {
 					return inferExpressionType(e.get_operand());
 				}
 				if (op == "&") {
+					if (!e.is_builtin_addressof()) {
+						if (const ResolvedUnaryOperatorCall* resolved_address =
+								getResolvedUnaryAddressOfOperator(&e)) {
+							const ASTNode return_type_node = resolved_address->function->decl_node().type_node();
+							if (return_type_node.has_value() && return_type_node.is<TypeSpecifierNode>()) {
+								return canonicalizeType(return_type_node.as<TypeSpecifierNode>());
+							}
+							return {};
+						}
+					}
 					const CanonicalTypeId operand_id = inferExpressionType(e.get_operand());
 					if (!operand_id)
 						return {};
@@ -7740,6 +7775,70 @@ void SemanticAnalysis::tryResolveUnaryDereferenceOperator(const UnaryOperatorNod
 	}
 
 	op_unary_deref_table_[&unary_node] = best_match;
+	stats_.op_calls_resolved++;
+}
+
+void SemanticAnalysis::tryResolveUnaryAddressOfOperator(const UnaryOperatorNode& unary_node) {
+	analyzed_op_unary_address_queries_.insert(&unary_node);
+	op_unary_address_table_.erase(&unary_node);
+	if (unary_node.op() != "&" || unary_node.is_builtin_addressof()) {
+		return;
+	}
+
+	const CanonicalTypeId operand_type_id = inferExpressionType(unary_node.get_operand());
+	if (!operand_type_id) {
+		return;
+	}
+	const CanonicalTypeDesc& operand_desc = type_context_.get(operand_type_id);
+	if ((operand_desc.category() != TypeCategory::Struct &&
+		 operand_desc.category() != TypeCategory::Enum) ||
+		!operand_desc.pointer_levels.empty() ||
+		!operand_desc.array_dimensions.empty()) {
+		return;
+	}
+
+	const std::optional<TypeSpecifierNode> operand_type =
+		getOverloadResolutionArgType(unary_node.get_operand());
+	if (!operand_type.has_value()) {
+		throw InternalError("Unary operator& resolution requires the sema-owned operand type and value category");
+	}
+	const OperatorOverloadResult resolution = findUnaryOperatorOverloadWithFreeFunction(
+		*operand_type,
+		OverloadableOperator::BitwiseAnd,
+		symbols_);
+	if (resolution.is_ambiguous) {
+		throw CompileError("Ambiguous overload for unary operator&");
+	}
+	if (!resolution.has_match) {
+		return;
+	}
+
+	ResolvedUnaryOperatorCall resolved_call;
+	resolved_call.is_member = !resolution.is_free_function;
+	if (resolution.is_free_function) {
+		resolved_call.function = resolution.free_function_overload;
+	} else {
+		if (resolution.member_overload == nullptr ||
+			!resolution.member_overload->function_decl.is<FunctionDeclarationNode>()) {
+			throw InternalError("Resolved unary operator& member is missing its function declaration");
+		}
+		markResolvedOperatorOverloadOdrUsed(*resolution.member_overload);
+		resolved_call.function =
+			&resolution.member_overload->function_decl.as<FunctionDeclarationNode>();
+	}
+	if (resolved_call.function == nullptr) {
+		throw InternalError("Resolved unary operator& is missing its function declaration");
+	}
+	if (!resolved_call.is_member) {
+		ChunkedVector<ASTNode> arguments;
+		arguments.push_back(unary_node.get_operand());
+		annotateResolvedCallArgConversions(
+			&unary_node,
+			arguments,
+			*resolved_call.function,
+			" in unary operator&");
+	}
+	op_unary_address_table_[&unary_node] = resolved_call;
 	stats_.op_calls_resolved++;
 }
 

--- a/src/SemanticAnalysis.h
+++ b/src/SemanticAnalysis.h
@@ -253,6 +253,12 @@ public:
 	void ensureCallableOperatorResolved(const CallExprNode& call_node);
 	ResolvedFunctionQueryResult getResolvedOpSubscriptQuery(const ArraySubscriptNode* key) const;
 	const FunctionDeclarationNode* getResolvedUnaryDereferenceOperator(const UnaryOperatorNode* key) const;
+	struct ResolvedUnaryOperatorCall {
+		const FunctionDeclarationNode* function = nullptr;
+		bool is_member = false;
+	};
+	const ResolvedUnaryOperatorCall* getResolvedUnaryAddressOfOperator(const UnaryOperatorNode* key) const;
+	void ensureUnaryAddressOfOperatorResolved(const UnaryOperatorNode& unary_node);
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const void* key) const;
 	ResolvedFunctionQueryResult getResolvedDirectCallQuery(const CallExprNode* key) const;
 	const FunctionDeclarationNode* getResolvedDirectCall(const void* key) const;
@@ -615,6 +621,7 @@ private:
 	void tryResolveCallableOperator(const CallExprNode& call_node);
 	void tryResolveCallableOperatorImpl(const CallInfo& call_info, const void* call_key);
 	void tryResolveUnaryDereferenceOperator(const UnaryOperatorNode& unary_node);
+	void tryResolveUnaryAddressOfOperator(const UnaryOperatorNode& unary_node);
 
 	// Resolve operator[] for an ArraySubscriptNode whose object is a struct type.
 	// Stores the resolved FunctionDeclarationNode* in op_subscript_table_ so that codegen
@@ -668,6 +675,8 @@ private:
 	// Populated by tryResolveCallableOperator for struct-typed callable objects.
 	std::unordered_map<const void*, const FunctionDeclarationNode*> op_call_table_;
 	std::unordered_map<const UnaryOperatorNode*, const FunctionDeclarationNode*> op_unary_deref_table_;
+	std::unordered_map<const UnaryOperatorNode*, ResolvedUnaryOperatorCall> op_unary_address_table_;
+	std::unordered_set<const UnaryOperatorNode*> analyzed_op_unary_address_queries_;
 	std::unordered_map<const void*, const FunctionDeclarationNode*> resolved_direct_call_table_;
 	std::unordered_set<const void*> analyzed_op_call_queries_;
 	std::unordered_set<const void*> analyzed_direct_call_queries_;

--- a/tests/test_operator_addressof_nonidentifier_adl_ret0.cpp
+++ b/tests/test_operator_addressof_nonidentifier_adl_ret0.cpp
@@ -1,0 +1,62 @@
+// C++20 [over.match.oper]: unary operator overload resolution applies to any
+// class operand expression and includes non-member candidates found by ADL.
+
+namespace sample {
+
+struct MemberAddress {
+	int value;
+
+	int operator&() {
+		return value + 1;
+	}
+};
+
+struct FreeAddress {
+	int value;
+};
+
+int operator&(FreeAddress& value) {
+	value.value += 2;
+	return value.value;
+}
+
+struct ConstAddress {
+	int value;
+
+	int operator&() {
+		return value + 1;
+	}
+
+	int operator&() const {
+		return value + 2;
+	}
+};
+
+} // namespace sample
+
+struct Holder {
+	sample::MemberAddress member;
+	sample::FreeAddress free;
+};
+
+int main() {
+	Holder holder{{40}, {40}};
+	if (&holder.member != 41) {
+		return 1;
+	}
+	if (&holder.free != 42) {
+		return 2;
+	}
+	if (holder.free.value != 42) {
+		return 3;
+	}
+	sample::ConstAddress mutable_address{40};
+	if (&mutable_address != 41) {
+		return 4;
+	}
+	const sample::ConstAddress const_address{40};
+	if (&const_address != 42) {
+		return 5;
+	}
+	return 0;
+}


### PR DESCRIPTION
## Summary

- resolve unary address-of overloads in semantic analysis from canonical operand type and value-category metadata
- combine member candidates with ordinary and argument-dependent non-member lookup, including implicit-object cv ranking
- make codegen consume the resolved target and preserve address-only metadata through reference argument lowering
- retain the intrinsic bypass for `__builtin_addressof`
- add a reduced non-`std` regression covering member access expressions, ADL, original-object reference binding, and const/non-const overload selection
- remove the resolved `operator&` conformance gap from `docs/KNOWN_ISSUES.md`

## Architecture

This removes the old identifier-only codegen lookup and manual mangling path. Semantic analysis now owns candidate selection and call-conversion annotations; codegen receives the exact declaration and only lowers the selected call. No standard-library names, vendor identifiers, reconstructed type names, or fallback sizes are used.