### PR TITLE
Canonicalize function-type and member-function-pointer signatures

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -52,49 +52,6 @@ produce `CompileError`; missing canonical compiler metadata should produce
 `InternalError`; unsupported evaluator coverage must not be accepted as either a
 constant value or an ill-formed program.
 
-## Function types lack one canonical semantic owner
-Complete function-type metadata is currently copied among `TypeSpecifierNode`,
-alias `TypeInfo`, `TemplateTypeArg`, and `FunctionSignature`.
-
-The first canonical-owner slice removed `StructMember` as a signature source,
-deleted the associated member-name scans, made substituted alias metadata take
-precedence, and requires every concrete function-pointer type reaching member
-registration to already have a complete signature. `StructMember` remains a
-consumer copy used by later lowering, but it can no longer repair an incomplete
-template producer.
-
-The second slice removed the remaining registration-time original-type and
-template-argument search. Template substitution now resolves an alias to its
-terminal template-parameter identity, applies the bound `TemplateTypeArg`, and
-attaches the substituted `FunctionSignature` to the produced `TypeSpecifierNode`.
-Registration consumes only that node and treats a concrete callable without a
-signature as an internal producer error. Reading the original pattern and its
-bound argument during substitution is part of the semantic substitution step;
-doing the same lookup later from a member consumer would be recovery.
-
-The third slice made member-function-pointer declarations produce a complete
-callable type instead of a pointer-shaped approximation, substitutes a dependent
-owner from the active semantic template binding, and preserves the canonical
-signature when a qualified member expression is typed. Distinct concrete owner
-classes now remain distinct through `decltype`, type traits, and mangling without
-late owner-name recovery.
-
-The current representation can fail for alias-category function pointers, packs,
-transformed template parameters, dependent `noexcept` expressions, and nested
-callable parameter/return types.
-Missing metadata is often detected only during indirect-call code generation;
-stale metadata can instead affect specialization identity, mangling, or ABI
-lowering without an immediate error.
-
-The remaining intended invariant is that substitution produces one canonical
-callable `TypeSpecifierNode`/`TypeInfo` containing the complete substituted
-function type.
-Member registration, mangling, overload resolution, and code generation should
-consume that object directly. Remaining work should reduce the parallel metadata
-copies and extend structured substitution to the unsupported function-type
-components above; a concrete callable type without complete metadata is already
-treated as an internal producer error.
-
 ## SysV MEMORY-class aggregate returns need deferred ABI planning
 
 SysV aggregate argument and direct register-return lowering classifies concrete

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -72,9 +72,16 @@ signature as an internal producer error. Reading the original pattern and its
 bound argument during substitution is part of the semantic substitution step;
 doing the same lookup later from a member consumer would be recovery.
 
+The third slice made member-function-pointer declarations produce a complete
+callable type instead of a pointer-shaped approximation, substitutes a dependent
+owner from the active semantic template binding, and preserves the canonical
+signature when a qualified member expression is typed. Distinct concrete owner
+classes now remain distinct through `decltype`, type traits, and mangling without
+late owner-name recovery.
+
 The current representation can fail for alias-category function pointers, packs,
-transformed template parameters, dependent member-function-pointer owners,
-dependent `noexcept` expressions, and nested callable parameter/return types.
+transformed template parameters, dependent `noexcept` expressions, and nested
+callable parameter/return types.
 Missing metadata is often detected only during indirect-call code generation;
 stale metadata can instead affect specialization identity, mangling, or ABI
 lowering without an immediate error.

--- a/src/AstNodeTypes_Core.h
+++ b/src/AstNodeTypes_Core.h
@@ -107,3 +107,16 @@ private:
 	void* raw_ptr_ = nullptr;
 	const std::type_info* type_info_ = nullptr;
 };
+
+// Strong handle for syntax that has already crossed an expression-producing
+// parser boundary. Keeping this distinct from ASTNode prevents statement/type
+// nodes from being accepted by semantic APIs that require an expression.
+class ExpressionHandle {
+public:
+	explicit ExpressionHandle(ASTNode expression) : expression_(expression) {}
+
+	const ASTNode& node() const { return expression_; }
+
+private:
+	ASTNode expression_;
+};

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1860,6 +1860,33 @@ public:
 	void set_concept_constraint(std::string_view constraint) { concept_constraint_ = constraint; }
 };
 
+inline FunctionType makeFunctionTypeFromSpecifier(const TypeSpecifierNode& type_spec) {
+	FunctionType type;
+	type.type_index = type_spec.type_index();
+	type.cv_qualifier = type_spec.cv_qualifier();
+	type.reference_qualifier = type_spec.reference_qualifier();
+	type.array_dimensions.assign(
+		type_spec.array_dimensions().begin(), type_spec.array_dimensions().end());
+	type.has_unsized_outer_array_dimension =
+		type_spec.has_unsized_outer_array_dimension();
+	type.is_pack_expansion = type_spec.is_pack_expansion();
+	if (type_spec.has_template_parameter_identity()) {
+		type.template_parameter_name = type_spec.template_parameter_name();
+	}
+	type.pointer_qualifiers.reserve(type_spec.pointer_levels().size());
+	for (const PointerLevel& pointer_level : type_spec.pointer_levels()) {
+		type.pointer_qualifiers.push_back(pointer_level.cv_qualifier);
+	}
+	if (type_spec.has_member_class()) {
+		type.member_class_name = type_spec.member_class_name();
+	}
+	if (type_spec.has_function_signature()) {
+		type.callable_signature =
+			std::make_shared<FunctionSignature>(type_spec.function_signature());
+	}
+	return type;
+}
+
 // Return the structured name carried by a type specifier. Direct template
 // parameters keep their scoped binding on the node; other dependent types use
 // their registered semantic TypeInfo identity.
@@ -2194,7 +2221,87 @@ inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_
 	if (isPlaceholderAutoType(type_spec.type()) && !type_spec.type_index().is_valid()) {
 		return true;
 	}
-	return typeIndexContainsDependentPlaceholder(type_spec.type_index());
+	if (typeIndexContainsDependentPlaceholder(type_spec.type_index())) {
+		return true;
+	}
+	if (type_spec.is_pack_expansion()) {
+		return true;
+	}
+	if (!type_spec.has_function_signature()) {
+		return false;
+	}
+
+	auto function_type_is_dependent = [&](
+		const FunctionType& root_type,
+		auto&& self,
+		size_t depth_limit) -> bool {
+		if (depth_limit == 0) {
+			return true;
+		}
+		if (root_type.template_parameter_name.isValid() ||
+			root_type.is_pack_expansion ||
+			typeIndexContainsDependentPlaceholder(
+				root_type.type_index, depth_limit)) {
+			return true;
+		}
+		if (!root_type.callable_signature) {
+			return false;
+		}
+		const FunctionSignature& nested_signature = *root_type.callable_signature;
+		if (nested_signature.noexcept_expression.has_value()) {
+			return true;
+		}
+		if (nested_signature.hasStructuredTypes() &&
+			self(nested_signature.return_type, self, depth_limit - 1)) {
+			return true;
+		}
+		for (const FunctionType& parameter_type :
+			 nested_signature.parameter_types) {
+			if (self(parameter_type, self, depth_limit - 1)) {
+				return true;
+			}
+		}
+		if (typeIndexContainsDependentPlaceholder(
+				nested_signature.return_type_index, depth_limit - 1)) {
+			return true;
+		}
+		for (TypeIndex parameter_type_index :
+			 nested_signature.parameter_type_indices) {
+			if (typeIndexContainsDependentPlaceholder(
+					parameter_type_index, depth_limit - 1)) {
+				return true;
+			}
+		}
+		return false;
+	};
+
+	const FunctionSignature& signature = type_spec.function_signature();
+	if (signature.noexcept_expression.has_value()) {
+		return true;
+	}
+	const size_t depth_limit = getDependentPlaceholderTraversalBudget();
+	if (signature.hasStructuredTypes() &&
+		function_type_is_dependent(
+			signature.return_type, function_type_is_dependent, depth_limit)) {
+		return true;
+	}
+	for (const FunctionType& parameter_type : signature.parameter_types) {
+		if (function_type_is_dependent(
+				parameter_type, function_type_is_dependent, depth_limit)) {
+			return true;
+		}
+	}
+	if (typeIndexContainsDependentPlaceholder(
+			signature.return_type_index, depth_limit)) {
+		return true;
+	}
+	for (TypeIndex parameter_type_index : signature.parameter_type_indices) {
+		if (typeIndexContainsDependentPlaceholder(
+				parameter_type_index, depth_limit)) {
+			return true;
+		}
+	}
+	return false;
 }
 
 inline TypeIndex getCanonicalConversionTargetType(const TypeSpecifierNode& type_spec) {
@@ -2905,8 +3012,9 @@ public:
 	// noexcept support
 	void set_noexcept(bool is_noexcept) { is_noexcept_ = is_noexcept; }
 	bool is_noexcept() const { return is_noexcept_; }
-	void set_noexcept_expression(ASTNode expr) { noexcept_expression_ = expr; }
-	const std::optional<ASTNode>& noexcept_expression() const { return noexcept_expression_; }
+	void set_noexcept_expression(ExpressionHandle expr) { noexcept_expression_ = expr; }
+	void clear_noexcept_expression() { noexcept_expression_.reset(); }
+	const std::optional<ExpressionHandle>& noexcept_expression() const { return noexcept_expression_; }
 	bool has_noexcept_expression() const { return noexcept_expression_.has_value(); }
 
 	// Static member function support
@@ -3017,7 +3125,7 @@ private:
 	bool is_const_member_function_ = false;	// True if this function is a const member function (K qualifier)
 	bool is_volatile_member_function_ = false;  // True if this function is a volatile member function (V qualifier)
 	bool inline_always_ = false;	 // True if function should always be inlined (e.g., template pure expressions)
-	std::optional<ASTNode> noexcept_expression_;	 // Optional noexcept(expr) expression
+	std::optional<ExpressionHandle> noexcept_expression_; // Optional noexcept(expr) expression
 	std::string_view mangled_name_;	// Pre-computed mangled name (points to ChunkedStringAllocator storage)
 	std::vector<int64_t> non_type_template_args_;  // Non-type template arguments (e.g., 0 for get<0>)
 	InlineVector<StringHandle, 4> outer_template_param_names_;
@@ -3260,6 +3368,9 @@ private:
 // Used by instantiation and codegen paths to decide whether a function node
 // is safe to register for code generation.
 inline bool functionHasUnresolvedPlaceholderSignature(const FunctionDeclarationNode& func) {
+	if (func.has_noexcept_expression()) {
+		return true;
+	}
 	if (typeSpecStillUsesDependentPlaceholder(func.decl_node().type_specifier_node())) {
 		return true;
 	}

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2252,11 +2252,11 @@ inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_
 			return true;
 		}
 		if (nested_signature.hasStructuredTypes() &&
-			self(nested_signature.return_type, self, depth_limit - 1)) {
+			self(nested_signature.return_type(), self, depth_limit - 1)) {
 			return true;
 		}
 		for (const FunctionType& parameter_type :
-			 nested_signature.parameter_types) {
+			 nested_signature.parameter_types()) {
 			if (self(parameter_type, self, depth_limit - 1)) {
 				return true;
 			}
@@ -2282,10 +2282,10 @@ inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_
 	const size_t depth_limit = getDependentPlaceholderTraversalBudget();
 	if (signature.hasStructuredTypes() &&
 		function_type_is_dependent(
-			signature.return_type, function_type_is_dependent, depth_limit)) {
+			signature.return_type(), function_type_is_dependent, depth_limit)) {
 		return true;
 	}
-	for (const FunctionType& parameter_type : signature.parameter_types) {
+	for (const FunctionType& parameter_type : signature.parameter_types()) {
 		if (function_type_is_dependent(
 				parameter_type, function_type_is_dependent, depth_limit)) {
 			return true;

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -817,8 +817,8 @@ public:
 	// isStructNothrowDestructible() instead of reading is_noexcept() directly.
 	void set_noexcept(bool is_noexcept) { is_noexcept_ = is_noexcept; }
 	bool is_noexcept() const { return is_noexcept_; }
-	void set_noexcept_expression(ASTNode expr) { noexcept_expression_ = expr; }
-	const std::optional<ASTNode>& noexcept_expression() const { return noexcept_expression_; }
+	void set_noexcept_expression(ExpressionHandle expr) { noexcept_expression_ = expr; }
+	const std::optional<ExpressionHandle>& noexcept_expression() const { return noexcept_expression_; }
 	bool has_noexcept_expression() const { return noexcept_expression_.has_value(); }
 	void set_has_noexcept_specifier(bool v) { has_noexcept_specifier_ = v; }
 	bool has_noexcept_specifier() const { return has_noexcept_specifier_; }
@@ -868,7 +868,7 @@ private:
 	bool is_noexcept_ = true;  // C++11+: destructors are implicitly noexcept(true)
 	bool has_noexcept_specifier_ = false;  // True iff an explicit noexcept / noexcept(expr) was written
 	bool is_constexpr_ = false;  // True iff the destructor was declared with 'constexpr'
-	std::optional<ASTNode> noexcept_expression_;	 // For explicit noexcept(expr)
+	std::optional<ExpressionHandle> noexcept_expression_; // For explicit noexcept(expr)
 	const TemplateEnvironmentSnapshotNode* outer_template_environment_snapshot_node_{};
 	InlineVector<StringHandle, 4> outer_template_param_names_;
 	InlineVector<TypeInfo::TemplateArgInfo, 4> outer_template_args_;

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -1121,12 +1121,15 @@ struct FunctionType {
 	std::shared_ptr<FunctionSignature> callable_signature;
 };
 
-// Heap-backed structured callable components. Kept off FunctionSignature's
+// Arena-backed structured callable components. Kept off FunctionSignature's
 // inline footprint so TemplateTypeArg / TypeSpecifierNode stack frames stay
 // small enough for deep class-template recursion on Linux's ~8-16MB stack.
+// Immutable after publication: writers allocate a fresh gChunkedAnyStorage
+// entry and swing the pointer, so FunctionSignature can share by raw pointer
+// with no refcount.
 struct FunctionCallableTypes {
 	FunctionType return_type{};
-	std::vector<FunctionType> parameter_types;
+	InlineVector<FunctionType, 4> parameter_types;
 };
 
 // Function signature for function pointers
@@ -1136,7 +1139,7 @@ struct FunctionSignature {
 	TypeIndex return_type_index{};
 	int return_pointer_depth = 0;
 	ReferenceQualifier return_reference_qualifier = ReferenceQualifier::None;
-	std::vector<TypeIndex> parameter_type_indices;
+	InlineVector<TypeIndex, 4> parameter_type_indices;
 	Linkage linkage = Linkage::None;			 // C vs C++ linkage
 	StringHandle class_name;	   // For member function pointers
 	CallingConvention calling_convention = CallingConvention::Default;
@@ -1146,7 +1149,7 @@ struct FunctionSignature {
 	ReferenceQualifier function_reference_qualifier = ReferenceQualifier::None;
 	bool is_noexcept = false;
 	std::optional<ExpressionHandle> noexcept_expression; // Retained until dependent noexcept(expr) is substituted.
-	std::shared_ptr<FunctionCallableTypes> callable_types;
+	FunctionCallableTypes* callable_types = nullptr;
 
 	// Accessor helpers
 	TypeCategory returnType() const { return return_type_index.category(); }
@@ -1157,51 +1160,60 @@ struct FunctionSignature {
 			callable_types->return_type.type_index.category() != TypeCategory::Invalid;
 	}
 
-	FunctionType& return_type() {
-		ensureCallableTypes();
-		return callable_types->return_type;
-	}
 	const FunctionType& return_type() const {
 		static const FunctionType empty{};
-		return callable_types ? callable_types->return_type : empty;
+		return callable_types != nullptr ? callable_types->return_type : empty;
 	}
 
-	std::vector<FunctionType>& parameter_types() {
-		ensureCallableTypes();
+	std::span<const FunctionType> parameter_types() const {
+		if (callable_types == nullptr) {
+			return {};
+		}
 		return callable_types->parameter_types;
-	}
-	const std::vector<FunctionType>& parameter_types() const {
-		static const std::vector<FunctionType> empty{};
-		return callable_types ? callable_types->parameter_types : empty;
 	}
 
 	void setReturnType(FunctionType type) {
 		return_type_index = type.type_index;
 		return_pointer_depth = static_cast<int>(type.pointer_qualifiers.size());
 		return_reference_qualifier = type.reference_qualifier;
-		ensureCallableTypes();
-		callable_types->return_type = std::move(type);
+		FunctionCallableTypes& storage =
+			gChunkedAnyStorage.emplace_back<FunctionCallableTypes>();
+		if (callable_types != nullptr) {
+			storage.parameter_types = callable_types->parameter_types;
+		}
+		storage.return_type = std::move(type);
+		callable_types = &storage;
 	}
 
-	void setParameterTypes(std::vector<FunctionType> types) {
+	void setParameterTypes(InlineVector<FunctionType, 4> types) {
 		parameter_type_indices.clear();
 		parameter_type_indices.reserve(types.size());
 		for (const FunctionType& type : types) {
 			parameter_type_indices.push_back(type.type_index);
 		}
-		ensureCallableTypes();
-		callable_types->parameter_types = std::move(types);
+		FunctionCallableTypes& storage =
+			gChunkedAnyStorage.emplace_back<FunctionCallableTypes>();
+		if (callable_types != nullptr) {
+			storage.return_type = callable_types->return_type;
+		}
+		storage.parameter_types = std::move(types);
+		callable_types = &storage;
 	}
 
-private:
-	void ensureCallableTypes() {
-		if (!callable_types) {
-			callable_types = std::make_shared<FunctionCallableTypes>();
-			return;
-		}
-		if (callable_types.use_count() > 1) {
-			callable_types = std::make_shared<FunctionCallableTypes>(*callable_types);
-		}
+	// Copy-mutate-publish helper for immutable arena storage.
+	template <typename Mutator>
+	void updateReturnType(Mutator&& mutator) {
+		FunctionType type = return_type();
+		mutator(type);
+		setReturnType(std::move(type));
+	}
+
+	template <typename Mutator>
+	void updateParameterTypes(Mutator&& mutator) {
+		InlineVector<FunctionType, 4> types;
+		types = parameter_types();
+		mutator(types);
+		setParameterTypes(std::move(types));
 	}
 };
 

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -1121,13 +1121,18 @@ struct FunctionType {
 	std::shared_ptr<FunctionSignature> callable_signature;
 };
 
+// Heap-backed structured callable components. Kept off FunctionSignature's
+// inline footprint so TemplateTypeArg / TypeSpecifierNode stack frames stay
+// small enough for deep class-template recursion on Linux's ~8-16MB stack.
+struct FunctionCallableTypes {
+	FunctionType return_type{};
+	std::vector<FunctionType> parameter_types;
+};
+
 // Function signature for function pointers
 struct FunctionSignature {
-	FunctionType return_type;
-	std::vector<FunctionType> parameter_types;
-
 	// Lowering-facing projections. Semantic identity and substitution use the
-	// structured components above when present.
+	// structured components below when present.
 	TypeIndex return_type_index{};
 	int return_pointer_depth = 0;
 	ReferenceQualifier return_reference_qualifier = ReferenceQualifier::None;
@@ -1141,20 +1146,41 @@ struct FunctionSignature {
 	ReferenceQualifier function_reference_qualifier = ReferenceQualifier::None;
 	bool is_noexcept = false;
 	std::optional<ExpressionHandle> noexcept_expression; // Retained until dependent noexcept(expr) is substituted.
+	std::shared_ptr<FunctionCallableTypes> callable_types;
 
 	// Accessor helpers
 	TypeCategory returnType() const { return return_type_index.category(); }
 	bool returns_reference() const { return return_reference_qualifier != ReferenceQualifier::None; }
 	bool returns_rvalue_reference() const { return return_reference_qualifier == ReferenceQualifier::RValueReference; }
 	bool hasStructuredTypes() const {
-		return return_type.type_index.category() != TypeCategory::Invalid;
+		return callable_types != nullptr &&
+			callable_types->return_type.type_index.category() != TypeCategory::Invalid;
+	}
+
+	FunctionType& return_type() {
+		ensureCallableTypes();
+		return callable_types->return_type;
+	}
+	const FunctionType& return_type() const {
+		static const FunctionType empty{};
+		return callable_types ? callable_types->return_type : empty;
+	}
+
+	std::vector<FunctionType>& parameter_types() {
+		ensureCallableTypes();
+		return callable_types->parameter_types;
+	}
+	const std::vector<FunctionType>& parameter_types() const {
+		static const std::vector<FunctionType> empty{};
+		return callable_types ? callable_types->parameter_types : empty;
 	}
 
 	void setReturnType(FunctionType type) {
 		return_type_index = type.type_index;
 		return_pointer_depth = static_cast<int>(type.pointer_qualifiers.size());
 		return_reference_qualifier = type.reference_qualifier;
-		return_type = std::move(type);
+		ensureCallableTypes();
+		callable_types->return_type = std::move(type);
 	}
 
 	void setParameterTypes(std::vector<FunctionType> types) {
@@ -1163,7 +1189,19 @@ struct FunctionSignature {
 		for (const FunctionType& type : types) {
 			parameter_type_indices.push_back(type.type_index);
 		}
-		parameter_types = std::move(types);
+		ensureCallableTypes();
+		callable_types->parameter_types = std::move(types);
+	}
+
+private:
+	void ensureCallableTypes() {
+		if (!callable_types) {
+			callable_types = std::make_shared<FunctionCallableTypes>();
+			return;
+		}
+		if (callable_types.use_count() > 1) {
+			callable_types = std::make_shared<FunctionCallableTypes>(*callable_types);
+		}
 	}
 };
 

--- a/src/AstNodeTypes_TypeSystem.h
+++ b/src/AstNodeTypes_TypeSystem.h
@@ -1104,8 +1104,30 @@ struct DeferredTemplateBaseClassSpecifier {
 	SaveHandle replayPosition() const { return *replay_position; }
 };
 
+struct FunctionSignature;
+
+// Complete type-id used by a function signature component. Function parameter
+// adjustment is performed by the parser before this value is created.
+struct FunctionType {
+	TypeIndex type_index{};
+	CVQualifier cv_qualifier = CVQualifier::None;
+	std::vector<CVQualifier> pointer_qualifiers;
+	ReferenceQualifier reference_qualifier = ReferenceQualifier::None;
+	std::vector<size_t> array_dimensions;
+	bool has_unsized_outer_array_dimension = false;
+	bool is_pack_expansion = false;
+	StringHandle template_parameter_name;
+	StringHandle member_class_name;
+	std::shared_ptr<FunctionSignature> callable_signature;
+};
+
 // Function signature for function pointers
 struct FunctionSignature {
+	FunctionType return_type;
+	std::vector<FunctionType> parameter_types;
+
+	// Lowering-facing projections. Semantic identity and substitution use the
+	// structured components above when present.
 	TypeIndex return_type_index{};
 	int return_pointer_depth = 0;
 	ReferenceQualifier return_reference_qualifier = ReferenceQualifier::None;
@@ -1118,11 +1140,31 @@ struct FunctionSignature {
 	bool is_volatile = false;				  // For volatile member functions
 	ReferenceQualifier function_reference_qualifier = ReferenceQualifier::None;
 	bool is_noexcept = false;
+	std::optional<ExpressionHandle> noexcept_expression; // Retained until dependent noexcept(expr) is substituted.
 
 	// Accessor helpers
 	TypeCategory returnType() const { return return_type_index.category(); }
 	bool returns_reference() const { return return_reference_qualifier != ReferenceQualifier::None; }
 	bool returns_rvalue_reference() const { return return_reference_qualifier == ReferenceQualifier::RValueReference; }
+	bool hasStructuredTypes() const {
+		return return_type.type_index.category() != TypeCategory::Invalid;
+	}
+
+	void setReturnType(FunctionType type) {
+		return_type_index = type.type_index;
+		return_pointer_depth = static_cast<int>(type.pointer_qualifiers.size());
+		return_reference_qualifier = type.reference_qualifier;
+		return_type = std::move(type);
+	}
+
+	void setParameterTypes(std::vector<FunctionType> types) {
+		parameter_type_indices.clear();
+		parameter_type_indices.reserve(types.size());
+		for (const FunctionType& type : types) {
+			parameter_type_indices.push_back(type.type_index);
+		}
+		parameter_types = std::move(types);
+	}
 };
 
 // Deferred static_assert information - stored during template definition, evaluated during instantiation

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1113,16 +1113,20 @@ private:
 
 		FunctionSignature signature;
 		const TypeSpecifierNode& return_type = function_decl->decl_node().type_specifier_node();
-		signature.return_type_index = return_type.type_index();
-		signature.return_pointer_depth = static_cast<int>(return_type.pointer_depth());
-		signature.return_reference_qualifier = return_type.reference_qualifier();
+		signature.setReturnType(makeFunctionTypeFromSpecifier(return_type));
+		std::vector<FunctionType> parameter_types;
 		for (const auto& param_node : function_decl->parameter_nodes()) {
 			if (!param_node.is<DeclarationNode>()) {
 				continue;
 			}
 			const auto& param_type =
 				param_node.as<DeclarationNode>().type_specifier_node();
-			signature.parameter_type_indices.push_back(param_type.type_index());
+			parameter_types.push_back(makeFunctionTypeFromSpecifier(param_type));
+		}
+		signature.setParameterTypes(std::move(parameter_types));
+		signature.is_noexcept = function_decl->is_noexcept();
+		if (function_decl->has_noexcept_expression()) {
+			signature.noexcept_expression = *function_decl->noexcept_expression();
 		}
 
 		TypeSpecifierNode function_pointer_type(

--- a/src/ConstExprEvaluator_Bindings.cpp
+++ b/src/ConstExprEvaluator_Bindings.cpp
@@ -1852,17 +1852,7 @@ Evaluator::ResolvedMemberFunctionCandidate Evaluator::findConstexprOperatorOverl
 		if (lhs.has_function_signature()) {
 			const FunctionSignature& lhs_sig = lhs.function_signature();
 			const FunctionSignature& rhs_sig = rhs.function_signature();
-			if (lhs_sig.return_type_index != rhs_sig.return_type_index ||
-				lhs_sig.return_pointer_depth != rhs_sig.return_pointer_depth ||
-				lhs_sig.return_reference_qualifier != rhs_sig.return_reference_qualifier ||
-				lhs_sig.parameter_type_indices != rhs_sig.parameter_type_indices ||
-				lhs_sig.linkage != rhs_sig.linkage ||
-				lhs_sig.class_name != rhs_sig.class_name ||
-				lhs_sig.calling_convention != rhs_sig.calling_convention ||
-				lhs_sig.is_const != rhs_sig.is_const ||
-				lhs_sig.is_volatile != rhs_sig.is_volatile ||
-				lhs_sig.function_reference_qualifier != rhs_sig.function_reference_qualifier ||
-				lhs_sig.is_noexcept != rhs_sig.is_noexcept) {
+			if (!FlashCpp::equalFunctionSignatureIdentity(lhs_sig, rhs_sig)) {
 				return false;
 			}
 		}

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -2191,7 +2191,7 @@ bool Evaluator::is_function_decl_noexcept(const FunctionDeclarationNode& func_de
 		return func_decl.is_noexcept();
 	}
 
-	auto eval_result = evaluate(*func_decl.noexcept_expression(), context);
+	auto eval_result = evaluate(func_decl.noexcept_expression()->node(), context);
 	if (!eval_result.success()) {
 		return func_decl.is_noexcept();
 	}
@@ -2592,7 +2592,7 @@ bool Evaluator::is_expression_noexcept(const ExpressionNode& expr, EvaluationCon
 				return std::nullopt;
 			}
 			ASTNode substituted_noexcept = context.parser->substituteTemplateParameters(
-				*func_decl.noexcept_expression(),
+				func_decl.noexcept_expression()->node(),
 				template_params,
 				std::span<const TemplateTypeArg>(deduced_args.data(), deduced_args.size()));
 			auto eval_result = evaluate(substituted_noexcept, context);
@@ -2856,26 +2856,8 @@ bool Evaluator::typesMatchIgnoringCvAndRef(const TypeSpecifierNode& lhs, const T
 	if (lhs.has_function_signature()) {
 		const FunctionSignature& lhs_sig = lhs.function_signature();
 		const FunctionSignature& rhs_sig = rhs.function_signature();
-		if (lhs_sig.returnType() != rhs_sig.returnType() ||
-			lhs_sig.return_type_index != rhs_sig.return_type_index ||
-			lhs_sig.return_pointer_depth != rhs_sig.return_pointer_depth ||
-			lhs_sig.return_reference_qualifier != rhs_sig.return_reference_qualifier ||
-			lhs_sig.parameter_type_indices.size() != rhs_sig.parameter_type_indices.size() ||
-			lhs_sig.linkage != rhs_sig.linkage ||
-			lhs_sig.class_name != rhs_sig.class_name ||
-			lhs_sig.calling_convention != rhs_sig.calling_convention ||
-			lhs_sig.is_variadic != rhs_sig.is_variadic ||
-			lhs_sig.is_const != rhs_sig.is_const ||
-			lhs_sig.is_volatile != rhs_sig.is_volatile ||
-			lhs_sig.function_reference_qualifier != rhs_sig.function_reference_qualifier ||
-			lhs_sig.is_noexcept != rhs_sig.is_noexcept) {
+		if (!FlashCpp::equalFunctionSignatureIdentity(lhs_sig, rhs_sig)) {
 			return false;
-		}
-		for (size_t i = 0; i < lhs_sig.parameter_type_indices.size(); ++i) {
-			if (lhs_sig.parameter_type_indices[i].category() != rhs_sig.parameter_type_indices[i].category() ||
-				lhs_sig.parameter_type_indices[i] != rhs_sig.parameter_type_indices[i]) {
-				return false;
-			}
 		}
 	}
 

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -524,10 +524,16 @@ int main_impl(int argc, char* argv[]) {
 	bool has_compile_errors = false;
 	{
 		PhaseTimer ir_timer("IR Conversion", false, &ir_conversion_time);
-		// Re-evaluate ast.size() each iteration so template/member instantiations appended
-		// during IR conversion are also visited in the same pass.
-		for (size_t node_index = 0; node_index < ast.size(); ++node_index) {
+		// Re-evaluate ast.size() each iteration so appended template/member
+		// instantiations are visited in the same pass. Constexpr materialization can
+		// also insert a dependency at the front; after each visit, advance to the
+		// node after the one we just processed by identity so a front insertion
+		// cannot shift the cursor onto the same node again. Front-inserted
+		// compile-time-only roots are intentionally not back-scanned: visiting
+		// them can recursively materialize more roots and grow the worklist.
+		for (size_t node_index = 0; node_index < ast.size(); ) {
 			ASTNode node_handle = ast[node_index];
+			const void* visited_node_key = node_handle.raw_pointer();
 			if (show_debug && node_handle.is<FunctionDeclarationNode>()) {
 				const auto& func = node_handle.as<FunctionDeclarationNode>();
 				bool has_def = func.is_materialized();
@@ -599,6 +605,20 @@ int main_impl(int argc, char* argv[]) {
 				FLASH_LOG(General, Error, "IR conversion failed for node '", node_desc, "': ", e.what());
 				++ir_conversion_error_count;
 			}
+
+			// Advance past the node we just visited. Front inserts shift it right;
+			// locate it by identity so we neither revisit it nor fall onto a
+			// newly inserted compile-time-only root behind the cursor.
+			size_t next_index = node_index + 1;
+			if (visited_node_key != nullptr) {
+				for (size_t search_index = node_index; search_index < ast.size(); ++search_index) {
+					if (ast[search_index].raw_pointer() == visited_node_key) {
+						next_index = search_index + 1;
+						break;
+					}
+				}
+			}
+			node_index = next_index;
 		}
 	}
 

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -74,6 +74,38 @@ void printTimingSummary(double preprocessing_time, double lexer_setup_time, doub
 // Forward declaration
 int main_impl(int argc, char* argv[]);
 
+#if !defined(_WIN32)
+#include <sys/resource.h>
+#endif
+
+// Linux/Unix default RLIMIT_STACK is often 8MB, which is too small for deep but
+// finite class-template instantiation chains in -O0 debug builds. Raise the soft
+// limit to 16MB when permitted so Nest/Chain depth regressions match Windows'
+// larger reserved stack without requiring callers to set ulimit.
+static void ensureMinimumProcessStackSize() {
+#if !defined(_WIN32)
+	constexpr rlim_t kMinimumStackBytes = static_cast<rlim_t>(16ull * 1024ull * 1024ull);
+	rlimit limit{};
+	if (getrlimit(RLIMIT_STACK, &limit) != 0) {
+		return;
+	}
+	if (limit.rlim_cur == RLIM_INFINITY || limit.rlim_cur >= kMinimumStackBytes) {
+		return;
+	}
+
+	rlim_t new_soft = kMinimumStackBytes;
+	if (limit.rlim_max != RLIM_INFINITY && limit.rlim_max < new_soft) {
+		new_soft = limit.rlim_max;
+	}
+	if (new_soft <= limit.rlim_cur) {
+		return;
+	}
+
+	limit.rlim_cur = new_soft;
+	(void)setrlimit(RLIMIT_STACK, &limit);
+#endif
+}
+
 // Helper function to set mangling style in both CompileContext and NameMangling namespace
 // Also sets the data model to match (MSVC -> LLP64, Itanium -> LP64)
 // This automatic association assumes typical platform conventions:
@@ -97,6 +129,8 @@ static void setManglingStyle(CompileContext& context, CompileContext::ManglingSt
 }
 
 int main(int argc, char* argv[]) {
+	ensureMinimumProcessStackSize();
+
 	// Install crash handler for automatic crash logging with stack traces
 	CrashHandler::install();
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -392,7 +392,8 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 				ctx.global_symbols = global_symbol_table_;
 			}
 
-			auto eval_result = ConstExpr::Evaluator::evaluate(*node.noexcept_expression(), ctx);
+			auto eval_result = ConstExpr::Evaluator::evaluate(
+				node.noexcept_expression()->node(), ctx);
 			is_truly_noexcept = eval_result.success() && eval_result.as_bool();
 		}
 		func_decl_op.is_noexcept = is_truly_noexcept;

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -288,7 +288,7 @@ inline TypeSpecifierNode buildFunctionTypeComponentForMangling(
 inline TypeSpecifierNode buildFunctionSignatureReturnTypeForMangling(
 	const FunctionSignature& sig) {
 	if (sig.hasStructuredTypes()) {
-		return buildFunctionTypeComponentForMangling(sig.return_type);
+		return buildFunctionTypeComponentForMangling(sig.return_type());
 	}
 	TypeSpecifierNode return_type(
 		resolveTypeAliasIndex(sig.return_type_index),
@@ -308,10 +308,10 @@ inline void appendMsvcFunctionSignatureTypeCode(
 	output += 'A';
 	appendTypeCode(output, buildFunctionSignatureReturnTypeForMangling(sig));
 	if (sig.hasStructuredTypes()) {
-		if (sig.parameter_types.empty()) {
+		if (sig.parameter_types().empty()) {
 			output += 'X';
 		} else {
-			for (const FunctionType& parameter_type : sig.parameter_types) {
+			for (const FunctionType& parameter_type : sig.parameter_types()) {
 				appendTypeCode(
 					output,
 					buildFunctionTypeComponentForMangling(parameter_type)
@@ -1194,10 +1194,10 @@ inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& t
 		appendItaniumTypeCode(
 			output, buildFunctionSignatureReturnTypeForMangling(sig), false);
 		if (sig.hasStructuredTypes()) {
-			if (sig.parameter_types.empty()) {
+			if (sig.parameter_types().empty()) {
 				output += 'v';
 			} else {
-				for (const FunctionType& parameter_type : sig.parameter_types) {
+				for (const FunctionType& parameter_type : sig.parameter_types()) {
 					appendItaniumTypeCode(
 						output,
 						buildFunctionTypeComponentForMangling(parameter_type)

--- a/src/NameMangling.h
+++ b/src/NameMangling.h
@@ -192,6 +192,9 @@ inline std::string generateItaniumEncodedTypeName(std::string_view qualified_nam
 template <typename OutputType>
 inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& type_node, bool is_function_parameter);
 
+template <typename OutputType>
+void appendTypeCode(OutputType& output, const TypeSpecifierNode& type_node);
+
 // Helper to append CV-qualifier code (A/B/C/D) to output
 inline void appendCVQualifier(auto& output, CVQualifier cv) {
 	if (cv == CVQualifier::None) {
@@ -244,8 +247,49 @@ inline std::string_view getMsvcMemberPointerClassName(
 
 inline TypeIndex resolveTypeAliasIndex(TypeIndex idx);
 
+inline TypeSpecifierNode buildFunctionTypeComponentForMangling(
+	const FunctionType& type) {
+	if (type.template_parameter_name.isValid() || type.is_pack_expansion) {
+		StringBuilder message;
+		message.append("Dependent function type component");
+		if (type.template_parameter_name.isValid()) {
+			message
+				.append(" '")
+				.append(type.template_parameter_name.view())
+				.append("'");
+		}
+		message.append(" reached name mangling");
+		throw InternalError(std::string(message.commit()));
+	}
+	TypeSpecifierNode type_spec(
+		resolveTypeAliasIndex(type.type_index),
+		TypeQualifier::None,
+		0,
+		Token{},
+		type.cv_qualifier);
+	for (CVQualifier pointer_qualifier : type.pointer_qualifiers) {
+		type_spec.add_pointer_level(pointer_qualifier);
+	}
+	type_spec.set_reference_qualifier(type.reference_qualifier);
+	if (!type.array_dimensions.empty()) {
+		type_spec.set_array_dimensions(type.array_dimensions);
+	} else if (type.has_unsized_outer_array_dimension) {
+		type_spec.set_unsized_outer_array_dimension(true);
+	}
+	if (type.member_class_name.isValid()) {
+		type_spec.set_member_class_name(type.member_class_name);
+	}
+	if (type.callable_signature) {
+		type_spec.set_function_signature(*type.callable_signature);
+	}
+	return type_spec;
+}
+
 inline TypeSpecifierNode buildFunctionSignatureReturnTypeForMangling(
 	const FunctionSignature& sig) {
+	if (sig.hasStructuredTypes()) {
+		return buildFunctionTypeComponentForMangling(sig.return_type);
+	}
 	TypeSpecifierNode return_type(
 		resolveTypeAliasIndex(sig.return_type_index),
 		TypeQualifier::None,
@@ -255,6 +299,42 @@ inline TypeSpecifierNode buildFunctionSignatureReturnTypeForMangling(
 	return_type.set_reference_qualifier(sig.return_reference_qualifier);
 	return_type.add_pointer_levels(sig.return_pointer_depth);
 	return return_type;
+}
+
+template <typename OutputType>
+inline void appendMsvcFunctionSignatureTypeCode(
+	OutputType& output,
+	const FunctionSignature& sig) {
+	output += 'A';
+	appendTypeCode(output, buildFunctionSignatureReturnTypeForMangling(sig));
+	if (sig.hasStructuredTypes()) {
+		if (sig.parameter_types.empty()) {
+			output += 'X';
+		} else {
+			for (const FunctionType& parameter_type : sig.parameter_types) {
+				appendTypeCode(
+					output,
+					buildFunctionTypeComponentForMangling(parameter_type)
+						.adjusted_function_parameter_type());
+			}
+			output += '@';
+		}
+	} else if (sig.parameter_type_indices.empty()) {
+		output += 'X';
+	} else {
+		for (const TypeIndex parameter_type : sig.parameter_type_indices) {
+			TypeSpecifierNode parameter_spec(
+				resolveTypeAliasIndex(parameter_type),
+				TypeQualifier::None,
+				0,
+				Token{},
+				CVQualifier::None);
+			appendTypeCode(
+				output, parameter_spec.adjusted_function_parameter_type());
+		}
+		output += '@';
+	}
+	output += sig.is_noexcept ? "_E" : "Z";
 }
 
 template <typename OutputType>
@@ -504,10 +584,12 @@ void appendTypeCode(OutputType& output, const TypeSpecifierNode& type_node) {
 
 	// Handle references - MSVC uses different prefixes for lvalue vs rvalue references
 	// Format: [AE|$$QE][A|B|C|D] where A/B/C/D are CV-qualifiers on the REFERENCED type
-	if (normalized.is_lvalue_reference()) {
+	if (normalized.category() != TypeCategory::Function &&
+		normalized.is_lvalue_reference()) {
 		output += "AE";
 		appendCVQualifier(output, normalized.cv_qualifier());
-	} else if (normalized.is_rvalue_reference()) {
+	} else if (normalized.category() != TypeCategory::Function &&
+			   normalized.is_rvalue_reference()) {
 		output += "$$QE";
 		appendCVQualifier(output, normalized.cv_qualifier());
 	}
@@ -649,25 +731,30 @@ void appendTypeCode(OutputType& output, const TypeSpecifierNode& type_node) {
 		output += "@@";
 		break;
 	}
-	case TypeCategory::FunctionPointer: {
-			// MSVC function pointer: P6A<return><params>@Z
-		output += "P6A";
-		if (normalized.has_function_signature()) {
-			const auto& sig = normalized.function_signature();
-			TypeSpecifierNode ret_spec = buildFunctionSignatureReturnTypeForMangling(sig);
-			appendTypeCode(output, ret_spec);
-			if (sig.parameter_type_indices.empty()) {
-				output += 'X';  // void parameter list
-			} else {
-				for (const TypeIndex& pt : sig.parameter_type_indices) {
-					TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);	 // explicit ctor: see above
-					appendTypeCode(output, param_spec.adjusted_function_parameter_type());
-				}
-			}
+	case TypeCategory::Function: {
+		if (!normalized.has_function_signature()) {
+			throw InternalError(
+				"MSVC name mangling: Function type missing function signature");
+		}
+		if (normalized.is_lvalue_reference()) {
+			output += 'A';
+		} else if (normalized.is_rvalue_reference()) {
+			output += "$$Q";
 		} else {
+			output += "$$A";
+		}
+		output += '6';
+		appendMsvcFunctionSignatureTypeCode(
+			output, normalized.function_signature());
+		break;
+	}
+	case TypeCategory::FunctionPointer: {
+		output += "P6";
+		if (!normalized.has_function_signature()) {
 			throw InternalError("MSVC name mangling: FunctionPointer type missing function signature — cannot generate valid symbol");
 		}
-		output += "@Z";
+		appendMsvcFunctionSignatureTypeCode(
+			output, normalized.function_signature());
 		break;
 	}
 	case TypeCategory::MemberFunctionPointer: {
@@ -1082,27 +1169,59 @@ inline void appendItaniumTypeCode(OutputType& output, const TypeSpecifierNode& t
 		}
 		break;
 	}
+	case TypeCategory::Function:
 	case TypeCategory::FunctionPointer: {
-			// Itanium ABI: function pointer is encoded as PF<return-type><param-types>E
-		output += "PF";
-		if (normalized.has_function_signature()) {
-			const auto& sig = normalized.function_signature();
-				// Use explicit constructor (not default + set_type) to prevent uninitialized
-				// cv_qualifier_ and other fields from emitting garbage into the mangled name.
-				// Resolve TypeAlias TypeIndex values to their underlying concrete type first.
-			TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-			appendItaniumTypeCode(output, ret_spec, false);
-				// Encode parameter types
-			if (sig.parameter_type_indices.empty()) {
-				output += 'v';  // void parameter list
+		if (!normalized.has_function_signature()) {
+			throw InternalError(
+				normalized.category() == TypeCategory::Function
+					? "Itanium name mangling: Function type missing function signature"
+					: "Itanium name mangling: FunctionPointer type missing function signature");
+		}
+		const FunctionSignature& sig = normalized.function_signature();
+		if (normalized.category() == TypeCategory::FunctionPointer) {
+			output += 'P';
+		}
+		if (sig.is_const) {
+			output += 'K';
+		}
+		if (sig.is_volatile) {
+			output += 'V';
+		}
+		if (sig.is_noexcept) {
+			output += "Do";
+		}
+		output += 'F';
+		appendItaniumTypeCode(
+			output, buildFunctionSignatureReturnTypeForMangling(sig), false);
+		if (sig.hasStructuredTypes()) {
+			if (sig.parameter_types.empty()) {
+				output += 'v';
 			} else {
-				for (const TypeIndex& pt : sig.parameter_type_indices) {
-					TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);	 // explicit ctor: see above
-					appendItaniumTypeCode(output, param_spec, false);
+				for (const FunctionType& parameter_type : sig.parameter_types) {
+					appendItaniumTypeCode(
+						output,
+						buildFunctionTypeComponentForMangling(parameter_type)
+							.adjusted_function_parameter_type(),
+						false);
 				}
 			}
+		} else if (sig.parameter_type_indices.empty()) {
+			output += 'v';
 		} else {
-			throw InternalError("Itanium name mangling: FunctionPointer type missing function signature — cannot generate valid symbol");
+			for (const TypeIndex parameter_type : sig.parameter_type_indices) {
+				TypeSpecifierNode parameter_spec(
+					resolveTypeAliasIndex(parameter_type),
+					TypeQualifier::None,
+					0,
+					Token{},
+					CVQualifier::None);
+				appendItaniumTypeCode(output, parameter_spec, false);
+			}
+		}
+		if (sig.function_reference_qualifier == ReferenceQualifier::LValueReference) {
+			output += 'R';
+		} else if (sig.function_reference_qualifier == ReferenceQualifier::RValueReference) {
+			output += 'O';
 		}
 		output += 'E';
 		break;
@@ -1499,25 +1618,24 @@ inline void appendItaniumTypeTemplateArgs(
 				output += struct_name;
 				break;
 			}
+			case TypeCategory::Function:
 			case TypeCategory::FunctionPointer: {
-					// Itanium ABI: function pointer is PF<return-type><param-types>E
-				output += "PF";
-				if (arg.function_signature.has_value()) {
-					const auto& sig = *arg.function_signature;
-					TypeSpecifierNode ret_spec(resolveTypeAliasIndex(sig.return_type_index), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-					appendItaniumTypeCode(output, ret_spec, false);
-					if (sig.parameter_type_indices.empty()) {
-						output += 'v';
-					} else {
-						for (const TypeIndex& pt : sig.parameter_type_indices) {
-							TypeSpecifierNode param_spec(resolveTypeAliasIndex(pt), TypeQualifier::None, 0, Token{}, CVQualifier::None);
-							appendItaniumTypeCode(output, param_spec, false);
-						}
-					}
-				} else {
-					throw InternalError("Itanium name mangling: FunctionPointer template arg missing function signature");
+				if (!arg.function_signature.has_value()) {
+					throw InternalError(
+						"Itanium name mangling: callable template argument missing function signature");
 				}
-				output += 'E';
+				TypeSpecifierNode function_type(
+					arg.type_index,
+					TypeQualifier::None,
+					0,
+					Token{},
+					arg.cv_qualifier);
+				function_type.set_reference_qualifier(arg.ref_qualifier);
+				for (CVQualifier pointer_qualifier : arg.pointer_cv_qualifiers) {
+					function_type.add_pointer_level(pointer_qualifier);
+				}
+				function_type.set_function_signature(*arg.function_signature);
+				appendItaniumTypeCode(output, function_type, false);
 				break;
 			}
 			case TypeCategory::MemberFunctionPointer: {

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -121,25 +121,8 @@ inline bool isSameTypeIgnoringTopLevelCvAndRef(
 	if (lhs.has_function_signature()) {
 		const FunctionSignature& lhs_sig = lhs.function_signature();
 		const FunctionSignature& rhs_sig = rhs.function_signature();
-		if (lhs_sig.returnType() != rhs_sig.returnType() ||
-			lhs_sig.return_type_index != rhs_sig.return_type_index ||
-			lhs_sig.return_pointer_depth != rhs_sig.return_pointer_depth ||
-			lhs_sig.return_reference_qualifier != rhs_sig.return_reference_qualifier ||
-			lhs_sig.parameter_type_indices.size() != rhs_sig.parameter_type_indices.size() ||
-			lhs_sig.linkage != rhs_sig.linkage ||
-			lhs_sig.class_name != rhs_sig.class_name ||
-			lhs_sig.calling_convention != rhs_sig.calling_convention ||
-			lhs_sig.is_variadic != rhs_sig.is_variadic ||
-			lhs_sig.is_const != rhs_sig.is_const ||
-			lhs_sig.is_volatile != rhs_sig.is_volatile ||
-			lhs_sig.function_reference_qualifier != rhs_sig.function_reference_qualifier ||
-			lhs_sig.is_noexcept != rhs_sig.is_noexcept) {
+		if (!FlashCpp::equalFunctionSignatureIdentity(lhs_sig, rhs_sig)) {
 			return false;
-		}
-		for (size_t i = 0; i < lhs_sig.parameter_type_indices.size(); ++i) {
-			if (lhs_sig.parameter_type_indices[i] != rhs_sig.parameter_type_indices[i]) {
-				return false;
-			}
 		}
 	}
 

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -149,6 +149,14 @@ struct SubstitutedMemberFunctionShell {
 	StringHandle effective_name;
 };
 
+namespace ParserExpressionDependency {
+
+bool nodeHasDeferredTemplateDependency(
+	const ASTNode& node,
+	const InlineVector<StringHandle, 4>& current_template_param_names);
+
+} // namespace ParserExpressionDependency
+
 static std::string_view get_parser_error_string(ParserError e) {
 	switch (e) {
 	case ParserError::None:
@@ -1561,7 +1569,8 @@ private:
 	// Parse the parameter-type-list inside a function pointer declarator.
 	// Used for both standalone function pointer declarators and function declarations
 	// whose return type is itself a function pointer.
-	ParseResult parse_function_pointer_parameter_types(std::vector<TypeIndex>& out_param_types, bool& out_is_variadic);
+	ParseResult parse_function_pointer_parameter_types(std::vector<FunctionType>& out_param_types, bool& out_is_variadic);
+	ParseResult parse_nested_function_pointer_type(TypeSpecifierNode& type_spec);
 	bool parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::string_view log_context);
 	void bindLocalTypeAlias(
 		const Token& alias_token,
@@ -1632,6 +1641,11 @@ private:
 	CppAttributeInfo consume_cpp_attribute_blocks();	 // Consume consecutive [[...]] blocks and return detected flags
 	ParseResult parse_function_trailing_specifiers(FlashCpp::MemberQualifiers& out_quals, FlashCpp::FunctionSpecifiers& out_specs);	// Phase 2: Unified trailing specifiers
 	ParseResult parse_function_trailing_specifiers(FlashCpp::MemberQualifiers& out_quals, FlashCpp::FunctionSpecifiers& out_specs, std::span<const ASTNode> params);
+	ParseResult parse_function_type_qualifiers(FlashCpp::MemberQualifiers& out_quals, FlashCpp::FunctionSpecifiers& out_specs);
+	ParseResult parse_function_type_qualifiers(FlashCpp::MemberQualifiers& out_quals, FlashCpp::FunctionSpecifiers& out_specs, std::span<const ASTNode> params);
+	void apply_parsed_function_type_qualifiers(FunctionSignature& signature, const FlashCpp::MemberQualifiers& qualifiers, const FlashCpp::FunctionSpecifiers& specifiers);
+	void apply_parsed_function_noexcept(FunctionDeclarationNode& function, const FlashCpp::FunctionSpecifiers& specifiers);
+	FunctionType makeFunctionType(const TypeSpecifierNode& type_spec) const;
 	ParseResult parse_function_header(const FlashCpp::FunctionParsingContext& ctx, FlashCpp::ParsedFunctionHeader& out_header);	// Phase 4: Unified function header parsing
 	ParseResult create_function_from_header(const FlashCpp::ParsedFunctionHeader& header, const FlashCpp::FunctionParsingContext& ctx);	// Phase 4: Create FunctionDeclarationNode from header
 	void setup_member_function_context(StructDeclarationNode* struct_node, StringHandle struct_name, TypeIndex struct_type_index, bool inject_this);  // Phase 5: Helper for member function scope setup
@@ -3156,6 +3170,10 @@ public:	// Public methods for template instantiation
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
 		const TemplateInstantiationContext& context);
+	FunctionSignature substituteTemplateFunctionSignature(
+		FunctionSignature signature,
+		std::span<const TemplateParameterNode> template_params,
+		std::span<const TemplateTypeArg> template_args);
 
 	// Helper to substitute template parameters in lazy member function/constructor/destructor bodies
 	// Uses the stored outer template environment snapshot from lazy_info
@@ -3562,7 +3580,6 @@ private:	 // Resume private methods
 	bool skip_asm_suffix(std::optional<std::string_view>* asm_symbol_name = nullptr); // Skip declaration-suffix __asm("...") / __asm__("...")
 	void parse_variable_declarator_suffixes(DeclarationNode& decl);
 	void skip_noexcept_specifier();				// Skip noexcept or noexcept(expr) specifier
-	bool parse_noexcept_value();				// Parse noexcept or noexcept(expr), returning evaluated bool
 	void skip_function_trailing_specifiers(FlashCpp::MemberQualifiers& out_quals);	   // Skip all trailing specifiers after function parameters (stops before 'requires')
 	void skip_trailing_requires_clause();		  // Parse and discard trailing requires clause (if present)
 	std::optional<ASTNode> parse_trailing_requires_clause();	 // Parse trailing requires clause, return RequiresClauseNode
@@ -4236,7 +4253,7 @@ private:	 // Resume private methods
 		// Parses types separated by commas, handling pack expansion (...), C-style varargs,
 		// and pointer/reference modifiers. Used for bare function types and function pointer types.
 		// Returns true if parsing succeeded and ')' was NOT consumed (caller must consume it).
-	bool parse_function_type_parameter_list(std::vector<TypeIndex>& out_param_types);
+	bool parse_function_type_parameter_list(std::vector<FunctionType>& out_param_types);
 
 		// Helper to update angle bracket depth for template parsing
 		// Handles both '>' (decrement by 1) and '>>' (decrement by 2) for nested templates

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -82,6 +82,9 @@ inline void normalizeSubstitutedTypeSpec(TypeSpecifierNode& type_spec) {
 	if (!type_spec.has_function_signature() && resolved_alias.function_signature.has_value()) {
 		type_spec.set_function_signature(*resolved_alias.function_signature);
 	}
+	if (!type_spec.has_member_class() && resolved_alias.member_class_name.has_value()) {
+		type_spec.set_member_class_name(*resolved_alias.member_class_name);
+	}
 	if (!resolved_alias.array_dimensions.empty()) {
 		const std::span<const size_t> type_dimensions = type_spec.array_dimensions();
 		InlineVector<size_t, 4> array_dimensions;
@@ -193,6 +196,45 @@ inline FunctionSignature substituteTemplateFunctionSignature(
 }
 
 template <typename ParamContainer, typename ArgContainer>
+inline StringHandle substituteTemplateMemberFunctionOwner(
+	StringHandle original_owner,
+	const ParamContainer& template_params,
+	const ArgContainer& template_args) {
+	StringHandle substituted_owner = original_owner;
+	// The declarator stores the scoped template-parameter handle as its owner.
+	// Resolve that exact binding here while both the declaration and argument are
+	// available; consumers must not rediscover an owner through symbol/name scans.
+	forEachNonPackTemplateParamArgBinding(
+		template_params,
+		template_args,
+		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
+			if (param.kind() != TemplateParameterKind::Type ||
+				param.nameHandle() != original_owner ||
+				templateArgIsStructurallyDependent(arg)) {
+				return;
+			}
+			if (!arg.isTypeArgument()) {
+				throw InternalError(
+					"Member-function-pointer owner was bound to a non-type template argument");
+			}
+
+			const TypeIndex owner_type_index =
+				FlashCpp::canonicalizeTemplateIdentityTypeIndex(arg.type_index);
+			const TypeInfo* owner_type_info = tryGetTypeInfo(owner_type_index);
+			if (owner_type_info == nullptr) {
+				throw InternalError(
+					"Concrete member-function-pointer owner is missing canonical class type metadata");
+			}
+			if (!owner_type_info->isStruct()) {
+				throw CompileError(
+					"Member-function-pointer owner must be a class or union type");
+			}
+			substituted_owner = owner_type_info->name();
+		});
+	return substituted_owner;
+}
+
+template <typename ParamContainer, typename ArgContainer>
 inline void materializeSubstitutedFunctionTypeMetadata(
 	TypeSpecifierNode& substituted_type,
 	const TypeSpecifierNode& original_type,
@@ -235,8 +277,22 @@ inline void materializeSubstitutedFunctionTypeMetadata(
 		throw InternalError(
 			"Concrete function pointer type is missing canonical FunctionSignature metadata");
 	}
-	substituted_type.set_function_signature(substituteTemplateFunctionSignature(
-		*signature, template_params, template_args));
+	FunctionSignature substituted_signature = substituteTemplateFunctionSignature(
+		*signature, template_params, template_args);
+	if (substituted_category == TypeCategory::MemberFunctionPointer) {
+		StringHandle original_owner = substituted_type.has_member_class()
+			? substituted_type.member_class_name()
+			: substituted_signature.class_name;
+		if (!original_owner.isValid()) {
+			throw InternalError(
+				"Concrete member function pointer is missing canonical owner metadata");
+		}
+		const StringHandle substituted_owner = substituteTemplateMemberFunctionOwner(
+			original_owner, template_params, template_args);
+		substituted_type.set_member_class_name(substituted_owner);
+		substituted_signature.class_name = substituted_owner;
+	}
+	substituted_type.set_function_signature(substituted_signature);
 }
 
 inline std::optional<FunctionSignature> getCanonicalFunctionPointerSignature(

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -260,12 +260,12 @@ inline FunctionSignature substituteTemplateFunctionSignatureTypes(
 		}
 	};
 	if (signature.hasStructuredTypes()) {
-		substitute_function_type(signature.return_type);
-		signature.return_type_index = signature.return_type.type_index;
+		substitute_function_type(signature.return_type());
+		signature.return_type_index = signature.return_type().type_index;
 	}
-	if (!signature.parameter_types.empty()) {
+	if (!signature.parameter_types().empty()) {
 		std::vector<FunctionType> substituted_parameter_types;
-		for (FunctionType& parameter_type : signature.parameter_types) {
+		for (FunctionType& parameter_type : signature.parameter_types()) {
 			bool expanded_pack = false;
 			if (parameter_type.is_pack_expansion &&
 				parameter_type.template_parameter_name.isValid()) {
@@ -313,10 +313,10 @@ inline FunctionSignature substituteTemplateFunctionSignatureTypes(
 				substituted_parameter_types.push_back(std::move(parameter_type));
 			}
 		}
-		signature.parameter_types = std::move(substituted_parameter_types);
+		signature.parameter_types() = std::move(substituted_parameter_types);
 		signature.parameter_type_indices.clear();
-		signature.parameter_type_indices.reserve(signature.parameter_types.size());
-		for (const FunctionType& parameter_type : signature.parameter_types) {
+		signature.parameter_type_indices.reserve(signature.parameter_types().size());
+		for (const FunctionType& parameter_type : signature.parameter_types()) {
 			signature.parameter_type_indices.push_back(parameter_type.type_index);
 		}
 	}

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -260,65 +260,62 @@ inline FunctionSignature substituteTemplateFunctionSignatureTypes(
 		}
 	};
 	if (signature.hasStructuredTypes()) {
-		substitute_function_type(signature.return_type());
-		signature.return_type_index = signature.return_type().type_index;
+		signature.updateReturnType(substitute_function_type);
 	}
 	if (!signature.parameter_types().empty()) {
-		std::vector<FunctionType> substituted_parameter_types;
-		for (FunctionType& parameter_type : signature.parameter_types()) {
-			bool expanded_pack = false;
-			if (parameter_type.is_pack_expansion &&
-				parameter_type.template_parameter_name.isValid()) {
-				size_t arg_index = 0;
-				for (size_t param_index = 0;
-					 param_index < template_params.size();
-					 ++param_index) {
-					const TemplateParameterNode* template_param =
-						tryGetTemplateParameterNode(template_params[param_index]);
-					if (template_param == nullptr) {
-						continue;
-					}
-					if (!template_param->is_variadic()) {
-						++arg_index;
-						continue;
-					}
-					const size_t remaining_args = arg_index < template_args.size()
-						? template_args.size() - arg_index
-						: 0;
-					const size_t required_after =
-						countRequiredTemplateArgsAfter<ParamContainer, ArgContainer>(
-							template_params, param_index + 1);
-					const size_t pack_size = remaining_args > required_after
-						? remaining_args - required_after
-						: 0;
-					if (template_param->nameHandle() ==
-						parameter_type.template_parameter_name) {
-						for (size_t pack_index = 0; pack_index < pack_size; ++pack_index) {
-							FunctionType expanded_type = parameter_type;
-							expanded_type.is_pack_expansion = false;
-							apply_template_argument(
-								expanded_type,
-								template_args[arg_index + pack_index]);
-							substituted_parameter_types.push_back(
-								std::move(expanded_type));
+		signature.updateParameterTypes([&](InlineVector<FunctionType, 4>& parameter_types) {
+			InlineVector<FunctionType, 4> substituted_parameter_types;
+			substituted_parameter_types.reserve(parameter_types.size());
+			for (FunctionType& parameter_type : parameter_types) {
+				bool expanded_pack = false;
+				if (parameter_type.is_pack_expansion &&
+					parameter_type.template_parameter_name.isValid()) {
+					size_t arg_index = 0;
+					for (size_t param_index = 0;
+						 param_index < template_params.size();
+						 ++param_index) {
+						const TemplateParameterNode* template_param =
+							tryGetTemplateParameterNode(template_params[param_index]);
+						if (template_param == nullptr) {
+							continue;
 						}
-						expanded_pack = true;
-						break;
+						if (!template_param->is_variadic()) {
+							++arg_index;
+							continue;
+						}
+						const size_t remaining_args = arg_index < template_args.size()
+							? template_args.size() - arg_index
+							: 0;
+						const size_t required_after =
+							countRequiredTemplateArgsAfter<ParamContainer, ArgContainer>(
+								template_params, param_index + 1);
+						const size_t pack_size = remaining_args > required_after
+							? remaining_args - required_after
+							: 0;
+						if (template_param->nameHandle() ==
+							parameter_type.template_parameter_name) {
+							for (size_t pack_index = 0; pack_index < pack_size; ++pack_index) {
+								FunctionType expanded_type = parameter_type;
+								expanded_type.is_pack_expansion = false;
+								apply_template_argument(
+									expanded_type,
+									template_args[arg_index + pack_index]);
+								substituted_parameter_types.push_back(
+									std::move(expanded_type));
+							}
+							expanded_pack = true;
+							break;
+						}
+						arg_index += pack_size;
 					}
-					arg_index += pack_size;
+				}
+				if (!expanded_pack) {
+					substitute_function_type(parameter_type);
+					substituted_parameter_types.push_back(std::move(parameter_type));
 				}
 			}
-			if (!expanded_pack) {
-				substitute_function_type(parameter_type);
-				substituted_parameter_types.push_back(std::move(parameter_type));
-			}
-		}
-		signature.parameter_types() = std::move(substituted_parameter_types);
-		signature.parameter_type_indices.clear();
-		signature.parameter_type_indices.reserve(signature.parameter_types().size());
-		for (const FunctionType& parameter_type : signature.parameter_types()) {
-			signature.parameter_type_indices.push_back(parameter_type.type_index);
-		}
+			parameter_types = std::move(substituted_parameter_types);
+		});
 	}
 	signature.return_type_index = substituteTemplateParameterTypeIndex(
 		signature.return_type_index,

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -44,6 +44,17 @@ inline bool anyTemplateArgIsStructurallyDependent(std::span<const TemplateTypeAr
 	return false;
 }
 
+inline TypeIndex canonicalizeConcreteTemplateArgumentTypeIndex(
+	const TemplateTypeArg& arg) {
+	if (templateArgIsStructurallyDependent(arg)) {
+		return arg.type_index;
+	}
+	if (is_builtin_type(arg.category())) {
+		return nativeTypeIndex(arg.category());
+	}
+	return FlashCpp::canonicalizeTemplateIdentityTypeIndex(arg.type_index);
+}
+
 namespace ParserExpressionDependency {
 
 bool argsHaveDeferredTemplateDependency(
@@ -143,14 +154,12 @@ inline TypeIndex substituteTemplateParameterTypeIndex(
 			if (substituted ||
 				param.kind() != TemplateParameterKind::Type ||
 				!arg.isTypeArgument() ||
-				!FlashCpp::equalTypeIndexIdentity(
-					original_type_index,
-					param.registered_type_index()) ||
+				original_type_index != param.registered_type_index() ||
 				!FlashCpp::hasConcreteTemplateIdentity(arg.type_index)) {
 				return;
 			}
 			substituted_type_index =
-				FlashCpp::canonicalizeTemplateIdentityTypeIndex(arg.type_index);
+				canonicalizeConcreteTemplateArgumentTypeIndex(arg);
 			substituted = true;
 		});
 	return substituted_type_index;
@@ -168,9 +177,7 @@ inline const TemplateTypeArg* findTemplateArgByRegisteredTypeIndex(
 		[&](const TemplateParameterNode& param, const TemplateTypeArg& arg, size_t) {
 			if (matched_arg == nullptr &&
 				param.kind() == TemplateParameterKind::Type &&
-				FlashCpp::equalTypeIndexIdentity(
-					type_index,
-					param.registered_type_index())) {
+				type_index == param.registered_type_index()) {
 				matched_arg = &arg;
 			}
 		});
@@ -178,10 +185,141 @@ inline const TemplateTypeArg* findTemplateArgByRegisteredTypeIndex(
 }
 
 template <typename ParamContainer, typename ArgContainer>
-inline FunctionSignature substituteTemplateFunctionSignature(
+inline FunctionSignature substituteTemplateFunctionSignatureTypes(
 	FunctionSignature signature,
 	const ParamContainer& template_params,
 	const ArgContainer& template_args) {
+	auto apply_template_argument = [](
+		FunctionType& type,
+		const TemplateTypeArg& arg) {
+		type.type_index = canonicalizeConcreteTemplateArgumentTypeIndex(arg);
+		type.cv_qualifier |= arg.cv_qualifier;
+		std::vector<CVQualifier> combined_pointer_qualifiers;
+		combined_pointer_qualifiers.reserve(
+			arg.pointer_cv_qualifiers.size() + type.pointer_qualifiers.size());
+		combined_pointer_qualifiers.insert(
+			combined_pointer_qualifiers.end(),
+			arg.pointer_cv_qualifiers.begin(),
+			arg.pointer_cv_qualifiers.end());
+		combined_pointer_qualifiers.insert(
+			combined_pointer_qualifiers.end(),
+			type.pointer_qualifiers.begin(),
+			type.pointer_qualifiers.end());
+		type.pointer_qualifiers = std::move(combined_pointer_qualifiers);
+		if (arg.ref_qualifier == ReferenceQualifier::LValueReference ||
+			type.reference_qualifier == ReferenceQualifier::LValueReference) {
+			type.reference_qualifier = ReferenceQualifier::LValueReference;
+		} else if (arg.ref_qualifier == ReferenceQualifier::RValueReference) {
+			type.reference_qualifier = ReferenceQualifier::RValueReference;
+		}
+		if (arg.is_array) {
+			type.array_dimensions.insert(
+				type.array_dimensions.begin(),
+				arg.array_dimensions.begin(),
+				arg.array_dimensions.end());
+		}
+		if (arg.member_class_name.isValid()) {
+			type.member_class_name = arg.member_class_name;
+		}
+		if (arg.function_signature.has_value()) {
+			type.callable_signature =
+				std::make_shared<FunctionSignature>(*arg.function_signature);
+		}
+		type.template_parameter_name = {};
+	};
+	auto substitute_function_type = [&](FunctionType& type) {
+		if (type.template_parameter_name.isValid()) {
+			bool substituted = false;
+			forEachNonPackTemplateParamArgBinding(
+				template_params,
+				template_args,
+				[&](const TemplateParameterNode& param,
+					const TemplateTypeArg& arg,
+					size_t) {
+					if (substituted ||
+						param.nameHandle() != type.template_parameter_name) {
+						return;
+					}
+					if (!arg.isTypeArgument()) {
+						throw InternalError(
+							"Function type component was bound to a non-type template argument");
+					}
+					apply_template_argument(type, arg);
+					substituted = true;
+				});
+			if (!substituted) {
+				return;
+			}
+		} else {
+			type.type_index = substituteTemplateParameterTypeIndex(
+				type.type_index, template_params, template_args);
+		}
+		if (type.callable_signature) {
+			*type.callable_signature = substituteTemplateFunctionSignatureTypes(
+				*type.callable_signature, template_params, template_args);
+		}
+	};
+	if (signature.hasStructuredTypes()) {
+		substitute_function_type(signature.return_type);
+		signature.return_type_index = signature.return_type.type_index;
+	}
+	if (!signature.parameter_types.empty()) {
+		std::vector<FunctionType> substituted_parameter_types;
+		for (FunctionType& parameter_type : signature.parameter_types) {
+			bool expanded_pack = false;
+			if (parameter_type.is_pack_expansion &&
+				parameter_type.template_parameter_name.isValid()) {
+				size_t arg_index = 0;
+				for (size_t param_index = 0;
+					 param_index < template_params.size();
+					 ++param_index) {
+					const TemplateParameterNode* template_param =
+						tryGetTemplateParameterNode(template_params[param_index]);
+					if (template_param == nullptr) {
+						continue;
+					}
+					if (!template_param->is_variadic()) {
+						++arg_index;
+						continue;
+					}
+					const size_t remaining_args = arg_index < template_args.size()
+						? template_args.size() - arg_index
+						: 0;
+					const size_t required_after =
+						countRequiredTemplateArgsAfter<ParamContainer, ArgContainer>(
+							template_params, param_index + 1);
+					const size_t pack_size = remaining_args > required_after
+						? remaining_args - required_after
+						: 0;
+					if (template_param->nameHandle() ==
+						parameter_type.template_parameter_name) {
+						for (size_t pack_index = 0; pack_index < pack_size; ++pack_index) {
+							FunctionType expanded_type = parameter_type;
+							expanded_type.is_pack_expansion = false;
+							apply_template_argument(
+								expanded_type,
+								template_args[arg_index + pack_index]);
+							substituted_parameter_types.push_back(
+								std::move(expanded_type));
+						}
+						expanded_pack = true;
+						break;
+					}
+					arg_index += pack_size;
+				}
+			}
+			if (!expanded_pack) {
+				substitute_function_type(parameter_type);
+				substituted_parameter_types.push_back(std::move(parameter_type));
+			}
+		}
+		signature.parameter_types = std::move(substituted_parameter_types);
+		signature.parameter_type_indices.clear();
+		signature.parameter_type_indices.reserve(signature.parameter_types.size());
+		for (const FunctionType& parameter_type : signature.parameter_types) {
+			signature.parameter_type_indices.push_back(parameter_type.type_index);
+		}
+	}
 	signature.return_type_index = substituteTemplateParameterTypeIndex(
 		signature.return_type_index,
 		template_params,
@@ -236,6 +374,7 @@ inline StringHandle substituteTemplateMemberFunctionOwner(
 
 template <typename ParamContainer, typename ArgContainer>
 inline void materializeSubstitutedFunctionTypeMetadata(
+	Parser& parser,
 	TypeSpecifierNode& substituted_type,
 	const TypeSpecifierNode& original_type,
 	const ParamContainer& template_params,
@@ -277,8 +416,20 @@ inline void materializeSubstitutedFunctionTypeMetadata(
 		throw InternalError(
 			"Concrete function pointer type is missing canonical FunctionSignature metadata");
 	}
-	FunctionSignature substituted_signature = substituteTemplateFunctionSignature(
-		*signature, template_params, template_args);
+	InlineVector<TemplateParameterNode, 4> semantic_template_params;
+	semantic_template_params.reserve(template_params.size());
+	for (const auto& template_param_node : template_params) {
+		const TemplateParameterNode* template_param =
+			tryGetTemplateParameterNode(template_param_node);
+		if (template_param != nullptr) {
+			semantic_template_params.push_back(*template_param);
+		}
+	}
+	FunctionSignature substituted_signature = parser.substituteTemplateFunctionSignature(
+		*signature,
+		std::span<const TemplateParameterNode>(
+			semantic_template_params.data(), semantic_template_params.size()),
+		std::span<const TemplateTypeArg>(template_args.data(), template_args.size()));
 	if (substituted_category == TypeCategory::MemberFunctionPointer) {
 		StringHandle original_owner = substituted_type.has_member_class()
 			? substituted_type.member_class_name()
@@ -1194,6 +1345,7 @@ template <
 	typename SubstituteAstFn,
 	typename SubstituteTypeIndexFn>
 TypeSpecifierNode buildSubstitutedTypeSpecifier(
+	Parser& parser,
 	const TypeSpecifierNode& original_type_spec,
 	const ASTNode& original_type_node,
 	const Token& fallback_token,
@@ -1263,6 +1415,7 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 			template_args);
 	}
 	materializeSubstitutedFunctionTypeMetadata(
+		parser,
 		substituted_type,
 		original_type_spec,
 		template_params,

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -3250,6 +3250,7 @@ SubstitutedMemberFunctionShell Parser::createSubstitutedMemberFunctionShell(
 	const DeclarationNode& original_decl = original_func.decl_node();
 	const TypeSpecifierNode& original_return_type = original_decl.type_specifier_node();
 	TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
+		*this,
 		original_return_type,
 		original_return_type_node,
 		fallback_return_token,
@@ -3450,6 +3451,7 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			typeSpecifierPreservesDependentMemberTemplateSignatureIdentity(
 				param_type_spec);
 		TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
+			*this,
 			param_type_spec,
 			param_decl.type_node(),
 			param_decl.identifier_token(),

--- a/src/ParserTypes.h
+++ b/src/ParserTypes.h
@@ -106,7 +106,7 @@ struct FunctionSpecifiers {
 	bool is_final = false;
 	DefinitionSpecifier definition = DefinitionSpecifier::None;
 	bool is_noexcept = false;
-	std::optional<ASTNode> noexcept_expr;  // For noexcept(expr)
+	std::optional<ExpressionHandle> noexcept_expr;  // For noexcept(expr)
 	bool is_implicit = false;	  // Compiler-generated (implicit copy ctor, operator=, etc.)
 	std::optional<std::string_view> asm_symbol_name;	 // GNU asm label suffix: __asm("symbol")
 

--- a/src/Parser_Decl_DeclaratorCore.cpp
+++ b/src/Parser_Decl_DeclaratorCore.cpp
@@ -247,7 +247,7 @@ ParseResult Parser::parse_type_and_name() {
 				else if (peek() == "("_tok) {
 					advance(); // consume '('
 
-					std::vector<TypeIndex> param_types;
+					std::vector<FunctionType> param_types;
 					bool is_variadic = false;
 					auto param_result =
 						parse_function_pointer_parameter_types(param_types, is_variadic);
@@ -256,23 +256,27 @@ ParseResult Parser::parse_type_and_name() {
 					} else if (!consume(")"_tok)) {
 						restore_token_position(saved_pos);
 					} else {
-						bool is_noexcept = false;
-						if (peek() == "noexcept"_tok) {
-							advance(); // consume 'noexcept'
-							is_noexcept = parse_noexcept_value();
+						FlashCpp::MemberQualifiers qualifiers;
+						FlashCpp::FunctionSpecifiers specifiers;
+						ParseResult qualifier_result =
+							parse_function_type_qualifiers(qualifiers, specifiers);
+						if (qualifier_result.is_error()) {
+							return qualifier_result;
 						}
 
 						FunctionSignature signature;
+						signature.setReturnType(makeFunctionType(type_spec));
 						signature.return_type_index = type_spec.type_index();
 						signature.return_pointer_depth =
 							static_cast<int>(type_spec.pointer_depth());
 						signature.return_reference_qualifier =
 							type_spec.reference_qualifier();
-						signature.parameter_type_indices = std::move(param_types);
+						signature.setParameterTypes(std::move(param_types));
 						signature.linkage = Linkage::None;
 						signature.calling_convention = last_calling_convention_;
 						signature.is_variadic = is_variadic;
-						signature.is_noexcept = is_noexcept;
+						apply_parsed_function_type_qualifiers(
+							signature, qualifiers, specifiers);
 
 						type_spec.set_function_signature(signature);
 						type_spec.set_reference_qualifier(
@@ -345,7 +349,7 @@ ParseResult Parser::parse_type_and_name() {
 										 type_spec.token().value(), class_name_token.value(), identifier_token.value());
 
 							advance(); // consume '('
-							std::vector<TypeIndex> parameter_types;
+							std::vector<FunctionType> parameter_types;
 							bool is_variadic = false;
 							ParseResult parameter_result = parse_function_pointer_parameter_types(
 								parameter_types, is_variadic);
@@ -358,43 +362,24 @@ ParseResult Parser::parse_type_and_name() {
 									current_token_);
 							}
 
-							bool is_const = false;
-							bool is_volatile = false;
-							ReferenceQualifier function_ref_qualifier = ReferenceQualifier::None;
-							bool is_noexcept = false;
-							while (!peek().is_eof()) {
-								std::string_view tok = peek_info().value();
-								if (tok == "const") {
-									is_const = true;
-									advance();
-								} else if (tok == "volatile") {
-									is_volatile = true;
-									advance();
-								} else if (tok == "&") {
-									function_ref_qualifier = ReferenceQualifier::LValueReference;
-									advance();
-								} else if (tok == "&&") {
-									function_ref_qualifier = ReferenceQualifier::RValueReference;
-									advance();
-								} else if (tok == "noexcept") {
-									advance();
-									is_noexcept = parse_noexcept_value();
-								} else {
-									break;
-								}
+							FlashCpp::MemberQualifiers qualifiers;
+							FlashCpp::FunctionSpecifiers specifiers;
+							ParseResult qualifier_result =
+								parse_function_type_qualifiers(qualifiers, specifiers);
+							if (qualifier_result.is_error()) {
+								return qualifier_result;
 							}
 
 							FunctionSignature signature;
+							signature.setReturnType(makeFunctionType(type_spec));
 							signature.return_type_index = type_spec.type_index();
 							signature.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
 							signature.return_reference_qualifier = type_spec.reference_qualifier();
-							signature.parameter_type_indices = std::move(parameter_types);
+							signature.setParameterTypes(std::move(parameter_types));
 							signature.calling_convention = last_calling_convention_;
 							signature.is_variadic = is_variadic;
-							signature.is_const = is_const;
-							signature.is_volatile = is_volatile;
-							signature.function_reference_qualifier = function_ref_qualifier;
-							signature.is_noexcept = is_noexcept;
+							apply_parsed_function_type_qualifiers(
+								signature, qualifiers, specifiers);
 
 							type_spec.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
 							type_spec.set_size_in_bits(64);
@@ -996,7 +981,7 @@ ParseResult Parser::parse_declarator(TypeSpecifierNode& base_type, Linkage linka
 			if (peek() == "("_tok) {
 				advance(); // consume '('
 
-				std::vector<TypeIndex> return_param_types;
+				std::vector<FunctionType> return_param_types;
 				bool is_return_variadic = false;
 				auto return_params_result = parse_function_pointer_parameter_types(return_param_types, is_return_variadic);
 				if (return_params_result.is_error()) {
@@ -1007,17 +992,28 @@ ParseResult Parser::parse_declarator(TypeSpecifierNode& base_type, Linkage linka
 					return ParseResult::error("Expected ')' after function pointer return type parameters", current_token_);
 				}
 
-				skip_noexcept_specifier();
+				FlashCpp::MemberQualifiers return_function_qualifiers;
+				FlashCpp::FunctionSpecifiers return_function_specifiers;
+				ParseResult return_qualifier_result = parse_function_type_qualifiers(
+					return_function_qualifiers, return_function_specifiers);
+				if (return_qualifier_result.is_error()) {
+					return return_qualifier_result;
+				}
 
 				TypeSpecifierNode function_ptr_type(TypeCategory::FunctionPointer, TypeQualifier::None, kFunctionPointerSizeBits, Token{}, CVQualifier::None);
 				FunctionSignature signature;
+				signature.setReturnType(makeFunctionType(base_type));
 				signature.return_type_index = base_type.type_index();
 				signature.return_pointer_depth = static_cast<int>(base_type.pointer_depth());
 				signature.return_reference_qualifier = base_type.reference_qualifier();
-				signature.parameter_type_indices = return_param_types;
+				signature.setParameterTypes(std::move(return_param_types));
 				signature.linkage = linkage;
 				signature.calling_convention = calling_conv;
 				signature.is_variadic = is_return_variadic;
+				apply_parsed_function_type_qualifiers(
+					signature,
+					return_function_qualifiers,
+					return_function_specifiers);
 				function_ptr_type.set_function_signature(signature);
 				base_type = function_ptr_type;
 
@@ -1151,7 +1147,7 @@ ParseResult Parser::parse_postfix_declarator(TypeSpecifierNode& base_type,
 		advance(); // consume '('
 
 		// Parse parameter list
-		std::vector<TypeIndex> param_types;
+		std::vector<FunctionType> param_types;
 		bool is_variadic = false;
 		auto param_result = parse_function_pointer_parameter_types(param_types, is_variadic);
 		if (param_result.is_error()) {
@@ -1163,9 +1159,13 @@ ParseResult Parser::parse_postfix_declarator(TypeSpecifierNode& base_type,
 									  current_token_);
 		}
 
-		// Check for noexcept specifier on function pointer type
-		// Pattern: void (*)(Args...) noexcept or void (*)(Args...) noexcept(expr)
-		skip_noexcept_specifier();
+		FlashCpp::MemberQualifiers qualifiers;
+		FlashCpp::FunctionSpecifiers specifiers;
+		ParseResult qualifier_result =
+			parse_function_type_qualifiers(qualifiers, specifiers);
+		if (qualifier_result.is_error()) {
+			return qualifier_result;
+		}
 		skip_asm_suffix(&asm_symbol_name);
 
 		// This is a function pointer!
@@ -1179,12 +1179,14 @@ ParseResult Parser::parse_postfix_declarator(TypeSpecifierNode& base_type,
 		TypeSpecifierNode fp_type(TypeCategory::FunctionPointer, TypeQualifier::None, kFunctionPointerSizeBits, Token{}, CVQualifier::None);
 
 		FunctionSignature sig;
+		sig.setReturnType(makeFunctionType(base_type));
 		sig.return_type_index = return_type_index;
 		sig.return_pointer_depth = static_cast<int>(base_type.pointer_depth());
 		sig.return_reference_qualifier = base_type.reference_qualifier();
-		sig.parameter_type_indices = param_types;
+		sig.setParameterTypes(std::move(param_types));
 		sig.linkage = linkage;
 		sig.is_variadic = is_variadic;
+		apply_parsed_function_type_qualifiers(sig, qualifiers, specifiers);
 		fp_type.set_function_signature(sig);
 
 		// Replace base_type with the function pointer type
@@ -1246,7 +1248,7 @@ ParseResult Parser::parse_postfix_declarator(TypeSpecifierNode& base_type,
 // Parse the parameter-type-list that appears inside a function pointer declarator.
 // This shared helper covers both standalone function pointers and function
 // declarations whose return type is itself a function pointer.
-ParseResult Parser::parse_function_pointer_parameter_types(std::vector<TypeIndex>& out_param_types, bool& out_is_variadic) {
+ParseResult Parser::parse_function_pointer_parameter_types(std::vector<FunctionType>& out_param_types, bool& out_is_variadic) {
 	out_is_variadic = false;
 	if (peek() == ")"_tok) {
 		return ParseResult::success();
@@ -1266,10 +1268,13 @@ ParseResult Parser::parse_function_pointer_parameter_types(std::vector<TypeIndex
 		}
 
 		TypeSpecifierNode& param_type = param_type_result.node()->as<TypeSpecifierNode>();
+		ParseResult nested_function_result =
+			parse_nested_function_pointer_type(param_type);
+		if (nested_function_result.is_error()) {
+			return nested_function_result;
+		}
 		skip_noop_gnu_qualifiers();
 		consume_pointer_ref_modifiers(param_type);
-		out_param_types.push_back(param_type.type_index());
-
 		if (peek() == "..."_tok) {
 			advance();
 			param_type.set_pack_expansion(true);
@@ -1281,6 +1286,7 @@ ParseResult Parser::parse_function_pointer_parameter_types(std::vector<TypeIndex
 		if (peek().is_identifier()) {
 			advance();
 		}
+		out_param_types.push_back(makeFunctionType(param_type));
 
 		if (peek() == ","_tok) {
 			advance();
@@ -1289,6 +1295,57 @@ ParseResult Parser::parse_function_pointer_parameter_types(std::vector<TypeIndex
 		}
 	}
 
+	return ParseResult::success();
+}
+
+ParseResult Parser::parse_nested_function_pointer_type(
+	TypeSpecifierNode& type_spec) {
+	if (peek() != "("_tok || peek(1) != "*"_tok) {
+		return ParseResult::success();
+	}
+	advance(); // consume '('
+	advance(); // consume '*'
+	if (peek().is_identifier()) {
+		advance();
+	}
+	if (!consume(")"_tok) || !consume("("_tok)) {
+		return ParseResult::error(
+			"Expected nested function pointer declarator",
+			current_token_);
+	}
+
+	std::vector<FunctionType> parameter_types;
+	bool is_variadic = false;
+	ParseResult parameter_result = parse_function_pointer_parameter_types(
+		parameter_types, is_variadic);
+	if (parameter_result.is_error()) {
+		return parameter_result;
+	}
+	if (!consume(")"_tok)) {
+		return ParseResult::error(
+			"Expected ')' after nested function pointer parameter list",
+			current_token_);
+	}
+
+	FlashCpp::MemberQualifiers qualifiers;
+	FlashCpp::FunctionSpecifiers specifiers;
+	ParseResult qualifier_result =
+		parse_function_type_qualifiers(qualifiers, specifiers);
+	if (qualifier_result.is_error()) {
+		return qualifier_result;
+	}
+
+	FunctionSignature signature;
+	signature.setReturnType(makeFunctionType(type_spec));
+	signature.setParameterTypes(std::move(parameter_types));
+	signature.calling_convention = last_calling_convention_;
+	signature.is_variadic = is_variadic;
+	apply_parsed_function_type_qualifiers(signature, qualifiers, specifiers);
+	type_spec.set_type_index(nativeTypeIndex(TypeCategory::FunctionPointer));
+	type_spec.set_size_in_bits(kFunctionPointerSizeBits);
+	type_spec.limit_pointer_depth(0);
+	type_spec.set_reference_qualifier(ReferenceQualifier::None);
+	type_spec.set_function_signature(signature);
 	return ParseResult::success();
 }
 
@@ -1636,4 +1693,23 @@ ParseResult Parser::parse_declaration(FlashCpp::DeclarationContext context) {
 	default:
 		return ParseResult::error("Unknown declaration context", current_token_);
 	}
+}
+FunctionType Parser::makeFunctionType(const TypeSpecifierNode& type_spec) const {
+	FunctionType type = makeFunctionTypeFromSpecifier(type_spec);
+	if (!type.template_parameter_name.isValid() &&
+		typeIndexContainsDependentPlaceholder(type_spec.type_index())) {
+		const std::optional<TemplateParameterKind> parameter_kind =
+			currentTemplateParamKind(type_spec.token().handle());
+		if (parameter_kind == TemplateParameterKind::Type ||
+			parameter_kind == TemplateParameterKind::Template) {
+			type.template_parameter_name = type_spec.token().handle();
+		} else if (std::ranges::find(
+				   currentTemplateParamNames(), type_spec.token().handle()) !=
+			   currentTemplateParamNames().end()) {
+			type.template_parameter_name = type_spec.token().handle();
+		} else {
+			type.template_parameter_name = getStructuredTypeName(type_spec);
+		}
+	}
+	return type;
 }

--- a/src/Parser_Decl_DeclaratorCore.cpp
+++ b/src/Parser_Decl_DeclaratorCore.cpp
@@ -342,34 +342,65 @@ ParseResult Parser::parse_type_and_name() {
 						if (peek() == "("_tok) {
 							// This is a pointer-to-member-function declaration!
 							FLASH_LOG_FORMAT(Parser, Debug, "parse_type_and_name: Detected pointer-to-member-function: {} ({}::*{})()",
-											 type_spec.token().value(), class_name_token.value(), identifier_token.value());
+										 type_spec.token().value(), class_name_token.value(), identifier_token.value());
 
-							// Skip the function parameter list by counting parentheses
 							advance(); // consume '('
-							int paren_depth = 1;
-							while (paren_depth > 0 && !peek().is_eof()) {
-								if (peek() == "("_tok) {
-									paren_depth++;
-								} else if (peek() == ")"_tok) {
-									paren_depth--;
-								}
-								advance();
+							std::vector<TypeIndex> parameter_types;
+							bool is_variadic = false;
+							ParseResult parameter_result = parse_function_pointer_parameter_types(
+								parameter_types, is_variadic);
+							if (parameter_result.is_error()) {
+								return parameter_result;
+							}
+							if (!consume(")"_tok)) {
+								return ParseResult::error(
+									"Expected ')' after member function pointer parameter list",
+									current_token_);
 							}
 
-							// Skip any cv-qualifiers after the function parameters
-							// e.g., _Ret (_Tp::*__pf)() const
+							bool is_const = false;
+							bool is_volatile = false;
+							ReferenceQualifier function_ref_qualifier = ReferenceQualifier::None;
+							bool is_noexcept = false;
 							while (!peek().is_eof()) {
 								std::string_view tok = peek_info().value();
-								if (tok == "const" || tok == "volatile" || tok == "noexcept") {
+								if (tok == "const") {
+									is_const = true;
 									advance();
+								} else if (tok == "volatile") {
+									is_volatile = true;
+									advance();
+								} else if (tok == "&") {
+									function_ref_qualifier = ReferenceQualifier::LValueReference;
+									advance();
+								} else if (tok == "&&") {
+									function_ref_qualifier = ReferenceQualifier::RValueReference;
+									advance();
+								} else if (tok == "noexcept") {
+									advance();
+									is_noexcept = parse_noexcept_value();
 								} else {
 									break;
 								}
 							}
 
-							// Set up the type as a pointer-to-member-function
+							FunctionSignature signature;
+							signature.return_type_index = type_spec.type_index();
+							signature.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
+							signature.return_reference_qualifier = type_spec.reference_qualifier();
+							signature.parameter_type_indices = std::move(parameter_types);
+							signature.calling_convention = last_calling_convention_;
+							signature.is_variadic = is_variadic;
+							signature.is_const = is_const;
+							signature.is_volatile = is_volatile;
+							signature.function_reference_qualifier = function_ref_qualifier;
+							signature.is_noexcept = is_noexcept;
+
+							type_spec.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
+							type_spec.set_size_in_bits(64);
+							type_spec.limit_pointer_depth(0);
 							type_spec.set_member_class_name(class_name_token.handle());
-							type_spec.add_pointer_level(CVQualifier::None);
+							type_spec.set_function_signature(signature);
 
 							// Create declaration node
 							auto decl_node = emplace_node<DeclarationNode>(

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -704,14 +704,9 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		}
 
 		// Apply noexcept specifier to free functions
-		if (func_specs.is_noexcept) {
-			if (auto func_node_ptr = function_definition_result.node()) {
-				FunctionDeclarationNode& func_node = func_node_ptr->as<FunctionDeclarationNode>();
-				func_node.set_noexcept(true);
-				if (func_specs.noexcept_expr.has_value()) {
-					func_node.set_noexcept_expression(*func_specs.noexcept_expr);
-				}
-			}
+		if (auto func_node_ptr = function_definition_result.node()) {
+			apply_parsed_function_noexcept(
+				func_node_ptr->as<FunctionDeclarationNode>(), func_specs);
 		}
 		if (func_specs.asm_symbol_name.has_value()) {
 			if (auto func_node_ptr = function_definition_result.node()) {

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -2333,7 +2333,8 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				if (dtor_func_specs.noexcept_expr.has_value()) {
 					dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 					ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
-					auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
+					auto eval = ConstExpr::Evaluator::evaluate(
+						dtor_func_specs.noexcept_expr->node(), ctx);
 					if (eval.success())
 						dtor_ref.set_noexcept(eval.as_bool());
 				}

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -66,7 +66,7 @@ bool Parser::parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::s
 		}
 		advance();
 
-		std::vector<TypeIndex> param_types;
+		std::vector<FunctionType> param_types;
 		bool is_variadic = false;
 		auto param_result = parse_function_pointer_parameter_types(param_types, is_variadic);
 		if (param_result.is_error()) {
@@ -80,21 +80,32 @@ bool Parser::parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::s
 		}
 		advance();
 
-		bool is_noexcept = peek() == "noexcept"_tok;
-		skip_noexcept_specifier();
+		FlashCpp::MemberQualifiers qualifiers;
+		FlashCpp::FunctionSpecifiers specifiers;
+		ParseResult qualifier_result =
+			parse_function_type_qualifiers(qualifiers, specifiers);
+		if (qualifier_result.is_error()) {
+			restore_token_position(func_type_saved_pos);
+			return false;
+		}
 
 		FunctionSignature func_sig;
+		func_sig.setReturnType(makeFunctionType(type_spec));
 		func_sig.return_type_index = type_spec.type_index();
 		func_sig.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
 		func_sig.return_reference_qualifier = type_spec.reference_qualifier();
-		func_sig.parameter_type_indices = std::move(param_types);
+		func_sig.setParameterTypes(std::move(param_types));
 		func_sig.calling_convention = calling_conv;
 		func_sig.is_variadic = is_variadic;
-		func_sig.is_noexcept = is_noexcept;
+		apply_parsed_function_type_qualifiers(func_sig, qualifiers, specifiers);
 
-		if (is_function_ptr) {
-			type_spec.add_pointer_level(CVQualifier::None);
-		}
+		type_spec.set_type_index(nativeTypeIndex(
+			is_function_ptr
+				? TypeCategory::FunctionPointer
+				: TypeCategory::Function));
+		type_spec.set_size_in_bits(
+			is_function_ptr ? SizeInBits{64} : SizeInBits{});
+		type_spec.limit_pointer_depth(0);
 		type_spec.set_function_signature(func_sig);
 
 		if (is_function_ref) {
@@ -115,7 +126,7 @@ bool Parser::parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::s
 		return true;
 	}
 
-	std::vector<TypeIndex> param_types;
+	std::vector<FunctionType> param_types;
 	bool is_variadic = false;
 	auto param_result = parse_function_pointer_parameter_types(param_types, is_variadic);
 	if (param_result.is_error()) {
@@ -129,17 +140,27 @@ bool Parser::parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::s
 	}
 	advance();
 
-	bool is_noexcept = peek() == "noexcept"_tok;
-	skip_noexcept_specifier();
+	FlashCpp::MemberQualifiers qualifiers;
+	FlashCpp::FunctionSpecifiers specifiers;
+	ParseResult qualifier_result =
+		parse_function_type_qualifiers(qualifiers, specifiers);
+	if (qualifier_result.is_error()) {
+		restore_token_position(func_type_saved_pos);
+		return false;
+	}
 
 	FunctionSignature func_sig;
+	func_sig.setReturnType(makeFunctionType(type_spec));
 	func_sig.return_type_index = type_spec.type_index();
 	func_sig.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
 	func_sig.return_reference_qualifier = type_spec.reference_qualifier();
-	func_sig.parameter_type_indices = std::move(param_types);
+	func_sig.setParameterTypes(std::move(param_types));
 	func_sig.calling_convention = calling_conv;
 	func_sig.is_variadic = is_variadic;
-	func_sig.is_noexcept = is_noexcept;
+	apply_parsed_function_type_qualifiers(func_sig, qualifiers, specifiers);
+	type_spec.set_type_index(nativeTypeIndex(TypeCategory::Function));
+	type_spec.set_size_in_bits(SizeInBits{});
+	type_spec.limit_pointer_depth(0);
 	type_spec.set_function_signature(func_sig);
 
 	FLASH_LOG_FORMAT(Parser, Debug, "Parsed bare function type in type alias{}", log_context);
@@ -1953,6 +1974,10 @@ ParseResult Parser::parse_typedef_declaration() {
 	// Pattern: '(' '*' identifier ')' '(' params ')'
 	bool is_function_pointer_typedef = false;
 	std::string_view function_pointer_alias_name;
+	std::vector<FunctionType> function_pointer_parameter_types;
+	bool function_pointer_is_variadic = false;
+	FlashCpp::MemberQualifiers function_pointer_qualifiers;
+	FlashCpp::FunctionSpecifiers function_pointer_specifiers;
 	if (peek() == "("_tok) {
 		// Peek ahead to check if this is a function pointer pattern
 		SaveHandle paren_saved = save_token_position();
@@ -1980,22 +2005,25 @@ ParseResult Parser::parse_typedef_declaration() {
 						is_function_pointer_typedef = true;
 						discard_saved_token(paren_saved);
 
-						// Parse the parameter list
+						// Parse the parameter-type-list and its exception specification.
 						advance(); // consume '('
-
-						// Skip the parameter list by counting parentheses
-						int paren_depth = 1;
-						while (paren_depth > 0 && !peek().is_eof()) {
-							auto token = peek_info();
-							if (token.value() == "(") {
-								paren_depth++;
-							} else if (token.value() == ")") {
-								paren_depth--;
-							}
-							advance();
+						ParseResult parameter_result = parse_function_pointer_parameter_types(
+							function_pointer_parameter_types,
+							function_pointer_is_variadic);
+						if (parameter_result.is_error()) {
+							return parameter_result;
 						}
-
-						// We've consumed through the closing ')' of the parameter list
+						if (!consume(")"_tok)) {
+							return ParseResult::error(
+								"Expected ')' after function pointer typedef parameters",
+								current_token_);
+						}
+						ParseResult qualifier_result = parse_function_type_qualifiers(
+							function_pointer_qualifiers,
+							function_pointer_specifiers);
+						if (qualifier_result.is_error()) {
+							return qualifier_result;
+						}
 					}
 				}
 			}
@@ -2016,21 +2044,19 @@ ParseResult Parser::parse_typedef_declaration() {
 		alias_token = Token(Token::Type::Identifier, function_pointer_alias_name, 0, 0, 0);
 
 		// For function pointer typedefs, create a proper FunctionPointer type
-		// The return type is in type_spec, create a function pointer type with it
-		TypeIndex return_type_index = type_spec.type_index();
-
 		// Create a new TypeSpecifierNode for the function pointer (64-bit pointer)
 		TypeSpecifierNode fp_type(TypeCategory::FunctionPointer, TypeQualifier::None, 64, Token{}, CVQualifier::None);
 
-		// Create a basic function signature with the return type
-		// Note: We don't have full parameter info here since we just skipped the param list
-		// This is a simplified implementation that handles the common case
 		FunctionSignature sig;
-		sig.return_type_index = return_type_index;
-		sig.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
-		sig.return_reference_qualifier = type_spec.reference_qualifier();
+		sig.setReturnType(makeFunctionType(type_spec));
+		sig.setParameterTypes(std::move(function_pointer_parameter_types));
 		sig.linkage = Linkage::None;
 		sig.calling_convention = last_calling_convention_;
+		sig.is_variadic = function_pointer_is_variadic;
+		apply_parsed_function_type_qualifiers(
+			sig,
+			function_pointer_qualifiers,
+			function_pointer_specifiers);
 		fp_type.set_function_signature(sig);
 
 		// Replace type_spec with the function pointer type

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1627,7 +1627,7 @@ void Parser::consume_conversion_operator_target_modifiers(TypeSpecifierNode& tar
 // Parses types separated by commas, handling pack expansion (...), C-style varargs,
 // and pointer/reference modifiers. Stops before ')' — caller must consume it.
 // Returns true if at least one type was parsed or the list is empty (valid).
-bool Parser::parse_function_type_parameter_list(std::vector<TypeIndex>& out_param_types) {
+bool Parser::parse_function_type_parameter_list(std::vector<FunctionType>& out_param_types) {
 	while (peek() != ")"_tok && !peek().is_eof()) {
 		// Handle C-style varargs: just '...' (without type before it)
 		if (peek() == "..."_tok) {
@@ -1638,15 +1638,21 @@ bool Parser::parse_function_type_parameter_list(std::vector<TypeIndex>& out_para
 		auto param_type_result = parse_type_specifier();
 		if (!param_type_result.is_error() && param_type_result.node().has_value()) {
 			TypeSpecifierNode& param_type = param_type_result.node()->as<TypeSpecifierNode>();
+			ParseResult nested_function_result =
+				parse_nested_function_pointer_type(param_type);
+			if (nested_function_result.is_error()) {
+				return false;
+			}
 
 			// Handle pack expansion (...) after a parameter type
 			if (peek() == "..."_tok) {
 				advance(); // consume '...'
+				param_type.set_pack_expansion(true);
 			}
 
 			// Apply pointer/reference modifiers to the parameter type
 			consume_pointer_ref_modifiers(param_type);
-			out_param_types.push_back(param_type.type_index());
+			out_param_types.push_back(makeFunctionType(param_type));
 		} else {
 			return false; // Parsing failed
 		}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1720,6 +1720,25 @@ bool expressionHasDeferredTemplateDependency(
 				return identifierExpressionHasDeferredTemplateDependency(
 					inner,
 					current_template_param_names);
+			} else if constexpr (std::is_same_v<T, QualifiedIdentifierNode>) {
+				if (astNodesHaveDeferredTemplateDependency(
+						inner.template_arguments(), current_template_param_names)) {
+					return true;
+				}
+				const std::string_view owner_name =
+					gNamespaceRegistry.getQualifiedName(inner.namespace_handle());
+				const StringHandle owner_handle =
+					StringTable::getOrInternStringHandle(owner_name);
+				if (identifierRefersToCurrentTemplateParam(
+						owner_handle, current_template_param_names)) {
+					return true;
+				}
+				const auto owner = getTypesByNameMap().find(owner_handle);
+				if (owner != getTypesByNameMap().end() && owner->second != nullptr) {
+					return owner->second->isDependentPlaceholder() ||
+						owner->second->is_incomplete_instantiation_;
+				}
+				return inner.hasDependentQualifiedName();
 			} else if constexpr (std::is_same_v<T, BinaryOperatorNode>) {
 				return astNodeHasDeferredTemplateDependency(inner.get_lhs(), current_template_param_names) ||
 					   astNodeHasDeferredTemplateDependency(inner.get_rhs(), current_template_param_names);
@@ -2068,6 +2087,13 @@ bool ParserExpressionDependency::argTypesAreDeferredTemplateDependent(
 	std::span<const TypeSpecifierNode> arg_types,
 	const InlineVector<StringHandle, 4>& current_template_param_names) {
 	return ::argTypesAreDeferredTemplateDependent(arg_types, current_template_param_names);
+}
+
+bool ParserExpressionDependency::nodeHasDeferredTemplateDependency(
+	const ASTNode& node,
+	const InlineVector<StringHandle, 4>& current_template_param_names) {
+	return ::astNodeHasDeferredTemplateDependency(
+		node, current_template_param_names);
 }
 
 std::optional<ASTNode> Parser::try_synthesize_atomic_builtin_overload(

--- a/src/Parser_Expr_PrimaryUnary.cpp
+++ b/src/Parser_Expr_PrimaryUnary.cpp
@@ -236,44 +236,25 @@ ParseResult Parser::parse_cpp_cast_expression(CppCastKind kind, std::string_view
 						advance(); // consume ')'
 						if (peek() == "("_tok) {
 							advance(); // consume '('
-							std::vector<TypeIndex> mfp_params;
+							std::vector<FunctionType> mfp_params;
 							bool param_ok = parse_function_type_parameter_list(mfp_params);
 							if (param_ok && peek() == ")"_tok) {
 								advance(); // consume ')'
-								// Parse optional cv/ref/noexcept qualifiers
-								bool mfp_is_const = false;
-								bool mfp_is_volatile = false;
-								ReferenceQualifier mfp_ref = ReferenceQualifier::None;
-								bool mfp_is_noexcept = false;
-								while (!peek().is_eof()) {
-									if (peek() == "const"_tok) {
-										mfp_is_const = true;
-										advance();
-									} else if (peek() == "volatile"_tok) {
-										mfp_is_volatile = true;
-										advance();
-									} else if (peek() == "&"_tok) {
-										mfp_ref = ReferenceQualifier::LValueReference;
-										advance();
-									} else if (peek() == "&&"_tok) {
-										mfp_ref = ReferenceQualifier::RValueReference;
-										advance();
-									} else if (peek() == "noexcept"_tok) {
-										advance();
-										mfp_is_noexcept = parse_noexcept_value();
-									} else {
-										break;
-									}
+								FlashCpp::MemberQualifiers qualifiers;
+								FlashCpp::FunctionSpecifiers specifiers;
+								ParseResult qualifier_result =
+									parse_function_type_qualifiers(qualifiers, specifiers);
+								if (qualifier_result.is_error()) {
+									return qualifier_result;
 								}
 								FunctionSignature mfp_sig;
+								mfp_sig.setReturnType(makeFunctionType(type_spec));
 								mfp_sig.return_type_index = type_spec.type_index();
 								mfp_sig.return_pointer_depth = static_cast<int>(type_spec.pointer_depth());
 								mfp_sig.return_reference_qualifier = type_spec.reference_qualifier();
-								mfp_sig.parameter_type_indices = std::move(mfp_params);
-								mfp_sig.is_const = mfp_is_const;
-								mfp_sig.is_volatile = mfp_is_volatile;
-								mfp_sig.function_reference_qualifier = mfp_ref;
-								mfp_sig.is_noexcept = mfp_is_noexcept;
+								mfp_sig.setParameterTypes(std::move(mfp_params));
+								apply_parsed_function_type_qualifiers(
+									mfp_sig, qualifiers, specifiers);
 								type_spec.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
 								type_spec.set_size_in_bits(64);
 								type_spec.limit_pointer_depth(0);

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -3502,6 +3502,18 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 						if (member_result.member->reference_qualifier != ReferenceQualifier::None) {
 							member_type.set_reference_qualifier(member_result.member->reference_qualifier);
 						}
+						if (member_result.member->function_signature.has_value()) {
+							const FunctionSignature& signature =
+								*member_result.member->function_signature;
+							if (member_type.is_member_function_pointer()) {
+								if (!signature.class_name.isValid()) {
+									throw InternalError(
+										"Canonical member function pointer is missing owner metadata");
+								}
+								member_type.set_member_class_name(signature.class_name);
+							}
+							member_type.set_function_signature(signature);
+						}
 						return member_type;
 					}
 				}

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2567,21 +2567,28 @@ std::optional<TypeSpecifierNode> Parser::build_function_pointer_type_from_lambda
 
 	FunctionSignature sig;
 	if (auto deduced_return = deduce_lambda_return_type(lambda)) {
-		sig.return_type_index = deduced_return->type_index();
-		sig.return_pointer_depth = static_cast<int>(deduced_return->pointer_depth());
-		sig.return_reference_qualifier = deduced_return->reference_qualifier();
+		sig.setReturnType(makeFunctionType(*deduced_return));
 	} else {
 		// No return statements found => void return type per C++20 §7.5.5.1
-		sig.return_type_index = nativeTypeIndex(TypeCategory::Void);
+		TypeSpecifierNode void_type(
+			TypeCategory::Void,
+			TypeQualifier::None,
+			0,
+			lambda.lambda_token(),
+			CVQualifier::None);
+		sig.setReturnType(makeFunctionType(void_type));
 	}
 
+	std::vector<FunctionType> parameter_types;
 	for (const auto& param : lambda.parameters()) {
 		if (param.is<DeclarationNode>()) {
 			const auto& param_decl = param.as<DeclarationNode>();
 			const auto& param_type = param_decl.type_specifier_node();
-			sig.parameter_type_indices.push_back(param_type.type_index());
+			parameter_types.push_back(makeFunctionType(param_type));
 		}
 	}
+	sig.setParameterTypes(std::move(parameter_types));
+	sig.is_noexcept = lambda.is_noexcept();
 
 	TypeSpecifierNode fp_type(TypeCategory::FunctionPointer, TypeQualifier::None, 64, lambda.lambda_token(), CVQualifier::None);
 	fp_type.set_function_signature(sig);
@@ -2595,12 +2602,12 @@ std::optional<TypeSpecifierNode> Parser::build_function_pointer_type_from_struct
 	}
 
 	FunctionSignature sig;
-	sig.return_type_index = sig_opt->return_type.type_index();
-	sig.return_pointer_depth = static_cast<int>(sig_opt->return_type.pointer_depth());
-	sig.return_reference_qualifier = sig_opt->return_type.reference_qualifier();
+	sig.setReturnType(makeFunctionType(sig_opt->return_type));
+	std::vector<FunctionType> parameter_types;
 	for (const auto& param_type : sig_opt->param_types) {
-		sig.parameter_type_indices.push_back(param_type.type_index());
+		parameter_types.push_back(makeFunctionType(param_type));
 	}
+	sig.setParameterTypes(std::move(parameter_types));
 
 	TypeSpecifierNode fp_type(TypeCategory::FunctionPointer, TypeQualifier::None, 64, source_token, CVQualifier::None);
 	fp_type.set_function_signature(sig);

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -615,67 +615,60 @@ ParseResult Parser::parse_function_trailing_specifiers(
 	return parse_function_trailing_specifiers(out_quals, out_specs, no_params);
 }
 
-ParseResult Parser::parse_function_trailing_specifiers(
+ParseResult Parser::parse_function_type_qualifiers(
+	FlashCpp::MemberQualifiers& out_quals,
+	FlashCpp::FunctionSpecifiers& out_specs) {
+	static const std::vector<ASTNode> no_params;
+	return parse_function_type_qualifiers(out_quals, out_specs, no_params);
+}
+
+ParseResult Parser::parse_function_type_qualifiers(
 	FlashCpp::MemberQualifiers& out_quals,
 	FlashCpp::FunctionSpecifiers& out_specs,
 	std::span<const ASTNode> params) {
-	// Initialize output structures
 	out_quals = FlashCpp::MemberQualifiers{};
 	out_specs = FlashCpp::FunctionSpecifiers{};
 
 	while (!peek().is_eof()) {
-		const Token& token = peek_info();
-
-		CVQualifier cv = parse_cv_qualifiers();
+		const Token token = peek_info();
+		const CVQualifier cv = parse_cv_qualifiers();
 		if (cv != CVQualifier::None) {
 			out_quals.cv_qualifier |= cv;
 			continue;
 		}
 
-		ReferenceQualifier ref = parse_reference_qualifier();
+		const ReferenceQualifier ref = parse_reference_qualifier();
 		if (ref != ReferenceQualifier::None) {
 			out_quals.ref_qualifier = ref;
 			continue;
 		}
 
-		// Parse noexcept specifier
 		if (token.kind() == "noexcept"_tok) {
 			advance(); // consume 'noexcept'
 			out_specs.is_noexcept = true;
-
-			// Check for noexcept(expr) form
 			if (peek() == "("_tok) {
-				SaveHandle noexcept_expr_pos = save_token_position();
 				advance(); // consume '('
-
-				// Parse the constant expression.
-				// The expression parser already handles the noexcept operator
-				// (noexcept(expr) as a unary expression), so nested forms like
-				// noexcept(noexcept(may_throw())) are parsed correctly without
-				// special-casing here.
 				FlashCpp::SymbolTableScope noexcept_scope(ScopeType::Function);
 				register_parameters_in_scope(params);
-				auto expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-				if (!expr_result.is_error() && expr_result.node().has_value() && peek() == ")"_tok) {
-					out_specs.noexcept_expr = *expr_result.node();
-					advance(); // consume ')'
-					discard_saved_token(noexcept_expr_pos);
-				} else {
-					// Header-only standard library code frequently uses heavyweight
-					// noexcept expressions that the front-end does not need to model
-					// precisely. Recover by syntactically skipping the expression so
-					// the declaration still parses. Default to potentially-throwing
-					// (noexcept(false)) because the standard rule when we cannot use the
-					// expression is that the function may throw.
-					out_specs.is_noexcept = false;
-					restore_token_position(noexcept_expr_pos);
-					skip_balanced_parens();
+				ParseResult expression_result =
+					parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
+				if (expression_result.is_error()) {
+					return expression_result;
+				}
+				if (!expression_result.node().has_value()) {
+					throw InternalError(
+						"Parsed noexcept specification is missing its expression node");
+				}
+				out_specs.noexcept_expr = ExpressionHandle(*expression_result.node());
+				if (!consume(")"_tok)) {
+					return ParseResult::error(
+						"Expected ')' after noexcept expression",
+						current_token_);
 				}
 			}
 			continue;
 		}
 
-		// Parse throw() (old-style exception specification) - just skip it
 		if (token.kind() == "throw"_tok) {
 			advance(); // consume 'throw'
 			if (peek() == "("_tok) {
@@ -683,6 +676,87 @@ ParseResult Parser::parse_function_trailing_specifiers(
 			}
 			continue;
 		}
+
+		break;
+	}
+
+	return ParseResult::success();
+}
+
+void Parser::apply_parsed_function_type_qualifiers(
+	FunctionSignature& signature,
+	const FlashCpp::MemberQualifiers& qualifiers,
+	const FlashCpp::FunctionSpecifiers& specifiers) {
+	signature.is_const = qualifiers.is_const();
+	signature.is_volatile = qualifiers.is_volatile();
+	signature.function_reference_qualifier = qualifiers.ref_qualifier;
+	signature.is_noexcept = specifiers.is_noexcept;
+	signature.noexcept_expression = specifiers.noexcept_expr;
+	if (!signature.noexcept_expression.has_value()) {
+		return;
+	}
+	const bool dependent_noexcept_expression =
+		ParserExpressionDependency::nodeHasDeferredTemplateDependency(
+			signature.noexcept_expression->node(), currentTemplateParamNames());
+	if (dependent_noexcept_expression) {
+		signature.is_noexcept = false;
+		return;
+	}
+
+	const auto evaluated = try_evaluate_constant_expression(
+		signature.noexcept_expression->node());
+	if (evaluated.has_value()) {
+		signature.is_noexcept = evaluated->value != 0;
+		signature.noexcept_expression.reset();
+		return;
+	}
+	if (!isDependentTemplateContext()) {
+		throw CompileError("noexcept specification is not a constant expression");
+	}
+	signature.is_noexcept = false;
+}
+
+void Parser::apply_parsed_function_noexcept(
+	FunctionDeclarationNode& function,
+	const FlashCpp::FunctionSpecifiers& specifiers) {
+	if (!specifiers.is_noexcept) {
+		return;
+	}
+	function.set_noexcept(true);
+	if (!specifiers.noexcept_expr.has_value()) {
+		return;
+	}
+
+	const ExpressionHandle expression = *specifiers.noexcept_expr;
+	const bool is_dependent =
+		ParserExpressionDependency::nodeHasDeferredTemplateDependency(
+			expression.node(), currentTemplateParamNames());
+	if (is_dependent) {
+		function.set_noexcept(false);
+		function.set_noexcept_expression(expression);
+		return;
+	}
+
+	const auto evaluated = try_evaluate_constant_expression(expression.node());
+	if (!evaluated.has_value()) {
+		throw CompileError("noexcept specification is not a constant expression");
+	}
+	function.set_noexcept(evaluated->value != 0);
+	function.clear_noexcept_expression();
+}
+
+ParseResult Parser::parse_function_trailing_specifiers(
+	FlashCpp::MemberQualifiers& out_quals,
+	FlashCpp::FunctionSpecifiers& out_specs,
+	std::span<const ASTNode> params) {
+	ParseResult qualifier_result =
+		parse_function_type_qualifiers(out_quals, out_specs, params);
+	if (qualifier_result.is_error()) {
+		return qualifier_result;
+	}
+
+	while (!peek().is_eof()) {
+		const Token& token = peek_info();
 
 		// Parse requires clause - skip the constraint expression
 		// Pattern: func() noexcept requires constraint { }
@@ -1060,12 +1134,7 @@ ParseResult Parser::create_function_from_header(
 	func_ref.set_is_variadic(header.params.is_variadic);
 
 	// Set noexcept if specified
-	if (header.specifiers.is_noexcept) {
-		func_ref.set_noexcept(true);
-		if (header.specifiers.noexcept_expr.has_value()) {
-			func_ref.set_noexcept_expression(*header.specifiers.noexcept_expr);
-		}
-	}
+	apply_parsed_function_noexcept(func_ref, header.specifiers);
 
 	if (header.specifiers.asm_symbol_name.has_value()) {
 		func_ref.set_mangled_name(*header.specifiers.asm_symbol_name);

--- a/src/Parser_FunctionTypeHelpers.h
+++ b/src/Parser_FunctionTypeHelpers.h
@@ -38,15 +38,19 @@ inline const FunctionDeclarationNode* findFunctionDeclarationForSymbol(const AST
 inline TypeSpecifierNode buildFunctionPointerTypeFromFunctionDeclaration(const FunctionDeclarationNode& func_decl) {
 	FunctionSignature sig;
 	const TypeSpecifierNode& return_type = func_decl.decl_node().type_specifier_node();
-	sig.return_type_index = return_type.type_index();
-	sig.return_pointer_depth = static_cast<int>(return_type.pointer_depth());
-	sig.return_reference_qualifier = return_type.reference_qualifier();
+	sig.setReturnType(makeFunctionTypeFromSpecifier(return_type));
+	std::vector<FunctionType> parameter_types;
 	for (const auto& param_node : func_decl.parameter_nodes()) {
 		if (!param_node.is<DeclarationNode>()) {
 			continue;
 		}
 		const auto& param_type = param_node.as<DeclarationNode>().type_specifier_node();
-		sig.parameter_type_indices.push_back(param_type.type_index());
+		parameter_types.push_back(makeFunctionTypeFromSpecifier(param_type));
+	}
+	sig.setParameterTypes(std::move(parameter_types));
+	sig.is_noexcept = func_decl.is_noexcept();
+	if (func_decl.has_noexcept_expression()) {
+		sig.noexcept_expression = *func_decl.noexcept_expression();
 	}
 
 	TypeSpecifierNode fp_type(TypeCategory::FunctionPointer, TypeQualifier::None, 64, func_decl.decl_node().identifier_token(), CVQualifier::None);
@@ -57,19 +61,22 @@ inline TypeSpecifierNode buildFunctionPointerTypeFromFunctionDeclaration(const F
 inline TypeSpecifierNode buildMemberFunctionPointerTypeFromFunctionDeclaration(const FunctionDeclarationNode& func_decl) {
 	FunctionSignature sig;
 	const TypeSpecifierNode& return_type = func_decl.decl_node().type_specifier_node();
-	sig.return_type_index = return_type.type_index();
-	sig.return_pointer_depth = static_cast<int>(return_type.pointer_depth());
-	sig.return_reference_qualifier = return_type.reference_qualifier();
+	sig.setReturnType(makeFunctionTypeFromSpecifier(return_type));
 	sig.is_const = func_decl.is_const_member_function();
 	sig.is_volatile = func_decl.is_volatile_member_function();
 	sig.is_noexcept = func_decl.is_noexcept();
+	if (func_decl.has_noexcept_expression()) {
+		sig.noexcept_expression = *func_decl.noexcept_expression();
+	}
+	std::vector<FunctionType> parameter_types;
 	for (const auto& param_node : func_decl.parameter_nodes()) {
 		if (!param_node.is<DeclarationNode>()) {
 			continue;
 		}
 		const auto& param_type = param_node.as<DeclarationNode>().type_specifier_node();
-		sig.parameter_type_indices.push_back(param_type.type_index());
+		parameter_types.push_back(makeFunctionTypeFromSpecifier(param_type));
 	}
+	sig.setParameterTypes(std::move(parameter_types));
 
 	TypeSpecifierNode mfp_type(
 		TypeCategory::MemberFunctionPointer,

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2127,7 +2127,8 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 							if (dtor_func_specs.noexcept_expr.has_value()) {
 								dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 								ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
-								auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
+								auto eval = ConstExpr::Evaluator::evaluate(
+									dtor_func_specs.noexcept_expr->node(), ctx);
 								if (eval.success())
 									dtor_ref.set_noexcept(eval.as_bool());
 							}
@@ -3605,7 +3606,8 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						if (dtor_func_specs.noexcept_expr.has_value()) {
 							dtor_ref.set_noexcept_expression(*dtor_func_specs.noexcept_expr);
 							ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
-							auto eval = ConstExpr::Evaluator::evaluate(*dtor_func_specs.noexcept_expr, ctx);
+								auto eval = ConstExpr::Evaluator::evaluate(
+									dtor_func_specs.noexcept_expr->node(), ctx);
 							if (eval.success())
 								dtor_ref.set_noexcept(eval.as_bool());
 						}

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -138,49 +138,13 @@ ParseResult Parser::parse_template_function_declaration_body(
 	// We need to skip cv-qualifiers, ref-qualifier, and noexcept BEFORE checking for trailing return type
 	// Example: template<typename T> auto func(T x) const noexcept -> decltype(x + 1)
 	FlashCpp::MemberQualifiers member_quals;
-	member_quals = FlashCpp::MemberQualifiers{};
-	while (!peek().is_eof()) {
-		CVQualifier cv = parse_cv_qualifiers();
-		if (cv != CVQualifier::None) {
-			member_quals.cv_qualifier |= cv;
-			continue;
-		}
-
-		ReferenceQualifier ref = parse_reference_qualifier();
-		if (ref != ReferenceQualifier::None) {
-			member_quals.ref_qualifier = ref;
-			continue;
-		}
-
-		if (peek() == "noexcept"_tok) {
-			advance();
-			func_decl.set_noexcept(true);
-			if (peek() == "("_tok) {
-				SaveHandle noexcept_expr_pos = save_token_position();
-				advance();
-				FlashCpp::SymbolTableScope noexcept_scope(ScopeType::Function);
-				register_parameters_in_scope(func_decl.parameter_nodes());
-				ParseResult expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-				if (!expr_result.is_error() && expr_result.node().has_value() && peek() == ")"_tok) {
-					func_decl.set_noexcept_expression(*expr_result.node());
-					advance();
-					discard_saved_token(noexcept_expr_pos);
-				} else {
-					restore_token_position(noexcept_expr_pos);
-					skip_balanced_parens();
-				}
-			}
-			continue;
-		}
-		if (peek() == "throw"_tok) {
-			advance();
-			if (peek() == "("_tok) {
-				skip_balanced_parens();
-			}
-			continue;
-		}
-		break;
+	FlashCpp::FunctionSpecifiers function_specifiers;
+	ParseResult qualifier_result = parse_function_type_qualifiers(
+		member_quals, function_specifiers, func_decl.parameter_nodes());
+	if (qualifier_result.is_error()) {
+		return qualifier_result;
 	}
+	apply_parsed_function_noexcept(func_decl, function_specifiers);
 	func_decl.set_is_const_member_function(member_quals.is_const());
 	func_decl.set_is_volatile_member_function(member_quals.is_volatile());
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -24,6 +24,45 @@ static thread_local int g_template_inst_iteration_count = 0;
 static thread_local bool g_template_inst_iteration_limit_tripped = false;
 static constexpr int g_template_inst_max_iterations = 10000;
 
+FunctionSignature Parser::substituteTemplateFunctionSignature(
+	FunctionSignature signature,
+	std::span<const TemplateParameterNode> template_params,
+	std::span<const TemplateTypeArg> template_args) {
+	signature = substituteTemplateFunctionSignatureTypes(
+		std::move(signature), template_params, template_args);
+	if (!signature.noexcept_expression.has_value()) {
+		return signature;
+	}
+
+	ASTNode substituted_expression = substituteTemplateParameters(
+		signature.noexcept_expression->node(), template_params, template_args);
+	signature.noexcept_expression = ExpressionHandle(substituted_expression);
+	ConstExpr::EvaluationContext evaluation_context(gSymbolTable, *this);
+	evaluation_context.template_args = template_args;
+	for (const TemplateParameterNode& template_param : template_params) {
+		evaluation_context.template_param_names.push_back(template_param.name());
+	}
+	const ConstExpr::EvalResult value = ConstExpr::Evaluator::evaluate(
+		substituted_expression, evaluation_context);
+	if (value.success()) {
+		signature.is_noexcept = value.as_bool();
+		signature.noexcept_expression.reset();
+		return signature;
+	}
+	if (const auto parser_value =
+			try_evaluate_constant_expression(substituted_expression);
+		parser_value.has_value()) {
+		signature.is_noexcept = parser_value->value != 0;
+		signature.noexcept_expression.reset();
+		return signature;
+	}
+	if (!anyTemplateArgIsStructurallyDependent(template_args)) {
+		throw CompileError(
+			"Instantiated noexcept specification is not a constant expression");
+	}
+	return signature;
+}
+
 void resetTemplateInstantiationCounters() {
 	g_template_inst_iteration_count = 0;
 	g_template_inst_iteration_limit_tripped = false;
@@ -1113,12 +1152,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			substituted_type_index = substituted_type_spec.type_index();
 			substituted_type = substituted_type_spec.type();
 		}
+		if (!substituted_type_spec.has_function_signature() &&
+			resolved_alias_target.function_signature.has_value()) {
+			substituted_type_spec.set_function_signature(
+				*resolved_alias_target.function_signature);
+		}
 		if (substituted_type_spec.has_function_signature()) {
 			substituted_type_spec.set_function_signature(
 				substituteTemplateFunctionSignature(
 					substituted_type_spec.function_signature(),
-					params,
-					args));
+					std::span<const TemplateParameterNode>(params),
+					std::span<const TemplateTypeArg>(args)));
 		}
 
 		FLASH_LOG(Templates, Debug, "buildSubstitutedTypeAliasSpecifier: alias_name=", StringTable::getStringView(type_alias.alias_name),
@@ -2157,6 +2201,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				TypeSpecifierNode substituted_member_type_spec = *effective_type_spec;
 				substituted_member_type_spec.set_type_index(member_type_index);
 				materializeSubstitutedFunctionTypeMetadata(
+					*this,
 					substituted_member_type_spec,
 					*effective_type_spec,
 					template_params,
@@ -3673,6 +3718,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							}
 						}
 						normalizeSubstitutedTypeSpec(new_return_spec);
+						materializeSubstitutedFunctionTypeMetadata(
+							*this,
+							new_return_spec,
+							return_type_spec,
+							template_params,
+							template_args_for_pattern);
 
 						auto [new_decl_node, new_decl_ref] = emplace_node_ref<DeclarationNode>(
 							new_return_type, decl_node.identifier_token());
@@ -6954,6 +7005,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		substituted_type_spec.set_size_in_bits(
 			get_type_size_bits(member_type_index.category()));
 		materializeSubstitutedFunctionTypeMetadata(
+			*this,
 			substituted_type_spec,
 			type_spec,
 			effective_template_params,
@@ -7944,6 +7996,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				substituted_type_spec.set_size_in_bits(
 					get_type_size_bits(substituted_type_index.category()));
 				materializeSubstitutedFunctionTypeMetadata(
+					*this,
 					substituted_type_spec,
 					type_spec,
 					template_params,
@@ -9316,6 +9369,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	for (const auto& member_decl : class_decl.members()) {
 		ASTNode substituted_member_decl = substituteTemplateParameters(
 			member_decl.declaration, effective_template_params, effective_template_args);
+		if (substituted_member_decl.is<DeclarationNode>() &&
+			member_decl.declaration.is<DeclarationNode>()) {
+			materializeSubstitutedFunctionTypeMetadata(
+				*this,
+				substituted_member_decl.as<DeclarationNode>().type_specifier_node(),
+				member_decl.declaration.as<DeclarationNode>().type_specifier_node(),
+				effective_template_params,
+				effective_template_args);
+		}
 		std::optional<ASTNode> substituted_default_initializer = substitute_default_initializer(
 			member_decl.default_initializer, effective_template_args, effective_template_params);
 		std::optional<ASTNode> substituted_bitfield_width_expr;
@@ -10105,10 +10167,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_dtor_ref.set_has_noexcept_specifier(dtor_decl.has_noexcept_specifier());
 					if (dtor_decl.has_noexcept_expression()) {
 						ASTNode substituted_noexcept = substituteTemplateParameters(
-							*dtor_decl.noexcept_expression(),
+							dtor_decl.noexcept_expression()->node(),
 							template_params,
 							template_args_to_use);
-						new_dtor_ref.set_noexcept_expression(substituted_noexcept);
+						new_dtor_ref.set_noexcept_expression(
+							ExpressionHandle(substituted_noexcept));
 						ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
 						ctx.struct_info = struct_info_ptr;
 						ctx.struct_type_index =
@@ -10262,6 +10325,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 				}
 				normalizeSubstitutedTypeSpec(new_return_spec);
+				materializeSubstitutedFunctionTypeMetadata(
+					*this,
+					new_return_spec,
+					return_type_spec,
+					template_params,
+					template_args_to_use);
 
 				auto buildMergedOuterTemplateBinding = [&](OuterTemplateBinding& out_binding) {
 					if (func_decl.has_outer_template_bindings()) {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -524,17 +524,7 @@ static bool sameTypeSpecifierShape(const TypeSpecifierNode& lhs, const TypeSpeci
 	if (lhs.has_function_signature()) {
 		const FunctionSignature& lhs_sig = lhs.function_signature();
 		const FunctionSignature& rhs_sig = rhs.function_signature();
-		if (lhs_sig.return_type_index != rhs_sig.return_type_index ||
-			lhs_sig.return_pointer_depth != rhs_sig.return_pointer_depth ||
-			lhs_sig.return_reference_qualifier != rhs_sig.return_reference_qualifier ||
-			lhs_sig.parameter_type_indices != rhs_sig.parameter_type_indices ||
-			lhs_sig.linkage != rhs_sig.linkage ||
-			lhs_sig.class_name != rhs_sig.class_name ||
-			lhs_sig.calling_convention != rhs_sig.calling_convention ||
-			lhs_sig.is_const != rhs_sig.is_const ||
-			lhs_sig.is_volatile != rhs_sig.is_volatile ||
-			lhs_sig.function_reference_qualifier != rhs_sig.function_reference_qualifier ||
-			lhs_sig.is_noexcept != rhs_sig.is_noexcept) {
+		if (!FlashCpp::equalFunctionSignatureIdentity(lhs_sig, rhs_sig)) {
 			return false;
 		}
 	}
@@ -2249,6 +2239,7 @@ bool Parser::materializeTemplateFunctionParameters(
 				}
 
 				TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
+					*this,
 					original_param_type,
 					original_param_decl.type_node(),
 					original_param_decl.identifier_token(),
@@ -2438,6 +2429,7 @@ bool Parser::materializeTemplateFunctionParameters(
 								 recursion_depth, override_type_index);
 			}
 			TypeSpecifierNode substituted_param_type = buildSubstitutedTypeSpecifier(
+				*this,
 				orig_param_type,
 				param_decl.type_node(),
 				param_decl.identifier_token(),
@@ -2537,6 +2529,22 @@ std::optional<ASTNode> Parser::finalizeInstantiatedFunction(
 	const bool skip_body_materialization =
 		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::SkipBodyMaterialization);
 	copy_function_properties(new_func_ref, func_decl);
+	if (func_decl.has_noexcept_expression()) {
+		FunctionSignature exception_specification;
+		exception_specification.is_noexcept = func_decl.is_noexcept();
+		exception_specification.noexcept_expression = *func_decl.noexcept_expression();
+		exception_specification = substituteTemplateFunctionSignature(
+			std::move(exception_specification),
+			instantiation_context.template_params,
+			instantiation_context.template_args);
+		new_func_ref.set_noexcept(exception_specification.is_noexcept);
+		if (exception_specification.noexcept_expression.has_value()) {
+			new_func_ref.set_noexcept_expression(
+				*exception_specification.noexcept_expression);
+		} else {
+			new_func_ref.clear_noexcept_expression();
+		}
+	}
 
 	if (run_inline_heuristic) {
 		const auto& func_definition = new_func_ref.get_definition();
@@ -2809,6 +2817,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			const TypeSpecifierNode& parsed_return_type =
 				resolved_return_type.as<TypeSpecifierNode>();
 			TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
+				*this,
 				parsed_return_type,
 				resolved_return_type,
 				parsed_return_type.token(),
@@ -2901,6 +2910,19 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
 				auto& rt = return_type_result.node()->as<TypeSpecifierNode>();
 				consume_pointer_ref_modifiers(rt);
+				if (orig_return_type.has_function_signature()) {
+					rt.set_type_index(orig_return_type.type_index());
+					rt.set_size_in_bits(orig_return_type.sizeBits());
+					if (orig_return_type.has_member_class()) {
+						rt.set_member_class_name(orig_return_type.member_class_name());
+					}
+					materializeSubstitutedFunctionTypeMetadata(
+						*this,
+						rt,
+						orig_return_type,
+						template_params,
+						template_args);
+				}
 			}
 			restore_lexer_position_only(current_pos);
 			if (return_type_result.is_error()) {
@@ -2919,6 +2941,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			return_type = *return_type_result.node();
 		} else {
 			TypeSpecifierNode substituted_return_type = buildSubstitutedTypeSpecifier(
+				*this,
 				orig_return_type,
 				orig_decl.type_node(),
 				orig_decl.identifier_token(),
@@ -3032,6 +3055,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			new_return_type.set_type_index(return_type_index);
 			new_return_type.set_reference_qualifier(orig_return_type.reference_qualifier());
 			materializeSubstitutedFunctionTypeMetadata(
+				*this,
 				new_return_type,
 				orig_return_type,
 				template_params,

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1976,6 +1976,7 @@ ASTNode Parser::buildMaterializedParamType(
 		param_type_ref.add_pointer_level(ptr_level.cv_qualifier);
 	}
 	materializeSubstitutedFunctionTypeMetadata(
+		*this,
 		param_type_ref,
 		original_param_type,
 		materialized_template_params,
@@ -2785,6 +2786,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 						: nullptr;
 				if (normalized_param_type_info != nullptr) {
 					TypeSpecifierNode rebuilt_param_type_spec = buildSubstitutedTypeSpecifier(
+						*this,
 						param_type_spec,
 						param_decl.type_node(),
 						param_decl.identifier_token(),
@@ -2877,7 +2879,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	copy_function_properties(new_func_ref, func_decl);
 	if (func_decl.has_noexcept_expression()) {
 		ASTNode substituted_noexcept = substituteTemplateParameters(
-			*func_decl.noexcept_expression(),
+			func_decl.noexcept_expression()->node(),
 			template_params,
 			inline_template_args,
 			current_owner_type_name);
@@ -2927,11 +2929,15 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				outer_args,
 				current_owner_type_name);
 		}
-		new_func_ref.set_noexcept_expression(substituted_noexcept);
+		new_func_ref.set_noexcept_expression(ExpressionHandle(substituted_noexcept));
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
 		auto eval = ConstExpr::Evaluator::evaluate(substituted_noexcept, eval_ctx);
 		if (eval.success()) {
 			new_func_ref.set_noexcept(eval.as_bool());
+			new_func_ref.clear_noexcept_expression();
+		} else if (!anyTemplateArgIsStructurallyDependent(inline_template_args)) {
+			throw CompileError(
+				"Instantiated noexcept specification is not a constant expression");
 		}
 	}
 

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -574,11 +574,12 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 
 		if (dtor_decl.has_noexcept_expression()) {
 			ASTNode substituted_noexcept = substituteTemplateParameters(
-				*dtor_decl.noexcept_expression(),
+				dtor_decl.noexcept_expression()->node(),
 				lazy_info.template_params,
 				converted_template_args,
 				lazy_info.identity.instantiated_owner_name);
-			new_dtor_ref.set_noexcept_expression(substituted_noexcept);
+			new_dtor_ref.set_noexcept_expression(
+				ExpressionHandle(substituted_noexcept));
 			ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
 			std::optional<TemplateEnvironment> outer_environment;
 			ctx.template_environment = buildLazySubstitutionEnvironment(
@@ -1666,6 +1667,7 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 		TypeSpecifierNode substituted_type_spec = type_spec;
 		substituted_type_spec.set_type_index(substituted_type_index);
 		materializeSubstitutedFunctionTypeMetadata(
+			*this,
 			substituted_type_spec,
 			type_spec,
 			lazy_info->parent_template_params,

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -14,33 +14,6 @@ bool isBoolResultOperator(std::string_view op) {
 }
 }
 
-// Parse noexcept or noexcept(expr) specifier and return the evaluated boolean value.
-// Assumes the 'noexcept' token has already been consumed by the caller.
-// - Bare 'noexcept' (no parens) → returns true.
-// - 'noexcept(expr)' → tries to parse and evaluate expr as a constant expression.
-//   If expr evaluates to 0/false, returns false. Otherwise (including dependent
-//   expressions that cannot be evaluated), returns true conservatively.
-bool Parser::parse_noexcept_value() {
-	if (peek() != "("_tok) {
-		// bare noexcept (no parens) is noexcept(true)
-		return true;
-	}
-	// noexcept(expr) — try to evaluate; default to true for dependent exprs
-	SaveHandle noexcept_expr_pos = save_token_position();
-	advance(); // consume '('
-	auto noexcept_expr_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-	if (!noexcept_expr_result.is_error() && noexcept_expr_result.node().has_value() && peek() == ")"_tok) {
-		advance(); // consume ')'
-		discard_saved_token(noexcept_expr_pos);
-		auto eval = try_evaluate_constant_expression(*noexcept_expr_result.node());
-		return !eval.has_value() || eval->value != 0;
-	}
-	// Expression parsing failed — fall back to skipping balanced parens
-	restore_token_position(noexcept_expr_pos);
-	skip_balanced_parens();
-	return true; // dependent — assume true
-}
-
 ParseResult Parser::parse_template_parameter_list(InlineVector<TemplateParameterNode, 4>& out_params) {
 	// Save and restore the current template parameter state that existed before
 	// parsing this list so names added here do not persist after the parse.
@@ -550,28 +523,31 @@ ParseResult Parser::parse_template_parameter() {
 				if (peek() == "("_tok) {
 					advance(); // consume '('
 
-					std::vector<TypeIndex> fp_param_types;
+					std::vector<FunctionType> fp_param_types;
 					bool param_parse_ok = parse_function_type_parameter_list(fp_param_types);
 
 					if (param_parse_ok && peek() == ")"_tok) {
 						advance(); // consume ')'
 
-						// Parse optional noexcept specifier after parameter list
-						bool sig_is_noexcept = false;
-						if (peek() == "noexcept"_tok) {
-							advance(); // consume 'noexcept'
-							sig_is_noexcept = parse_noexcept_value();
+						FlashCpp::MemberQualifiers qualifiers;
+						FlashCpp::FunctionSpecifiers specifiers;
+						ParseResult qualifier_result =
+							parse_function_type_qualifiers(qualifiers, specifiers);
+						if (qualifier_result.is_error()) {
+							return qualifier_result;
 						}
 
 						// Build the function signature: the return type is nttp_type as currently
 						// parsed (e.g. 'int' for int (*F)()).
 						FunctionSignature func_sig;
+						func_sig.setReturnType(makeFunctionType(nttp_type));
 						func_sig.return_type_index = nttp_type.type_index();
 						func_sig.return_pointer_depth = static_cast<int>(nttp_type.pointer_depth());
 						func_sig.return_reference_qualifier = nttp_type.reference_qualifier();
-						func_sig.parameter_type_indices = std::move(fp_param_types);
+						func_sig.setParameterTypes(std::move(fp_param_types));
 						func_sig.calling_convention = fp_calling_convention;
-						func_sig.is_noexcept = sig_is_noexcept;
+						apply_parsed_function_type_qualifiers(
+							func_sig, qualifiers, specifiers);
 
 						// Rewrite nttp_type to TypeCategory::FunctionPointer.
 						// FunctionPointer is intrinsically pointer-sized; the "pointer-ness" is
@@ -632,50 +608,30 @@ ParseResult Parser::parse_template_parameter() {
 						if (peek() == "("_tok) {
 							advance(); // consume '('
 
-							std::vector<TypeIndex> mfp_param_types;
+							std::vector<FunctionType> mfp_param_types;
 							bool mfp_param_ok = parse_function_type_parameter_list(mfp_param_types);
 
 							if (mfp_param_ok && peek() == ")"_tok) {
 								advance(); // consume ')'
 
-								// Parse optional cv-qualifiers, ref-qualifier, noexcept
-								// e.g., template <int (S::* F)() const noexcept>
-								bool mfp_is_const = false;
-								bool mfp_is_volatile = false;
-								ReferenceQualifier mfp_ref_qual = ReferenceQualifier::None;
-								bool mfp_is_noexcept = false;
-								while (!peek().is_eof()) {
-									if (peek() == "const"_tok) {
-										mfp_is_const = true;
-										advance();
-									} else if (peek() == "volatile"_tok) {
-										mfp_is_volatile = true;
-										advance();
-									} else if (peek() == "&"_tok) {
-										mfp_ref_qual = ReferenceQualifier::LValueReference;
-										advance();
-									} else if (peek() == "&&"_tok) {
-										mfp_ref_qual = ReferenceQualifier::RValueReference;
-										advance();
-									} else if (peek() == "noexcept"_tok) {
-										advance();
-										mfp_is_noexcept = parse_noexcept_value();
-									} else {
-										break;
-									}
+								FlashCpp::MemberQualifiers qualifiers;
+								FlashCpp::FunctionSpecifiers specifiers;
+								ParseResult qualifier_result =
+									parse_function_type_qualifiers(qualifiers, specifiers);
+								if (qualifier_result.is_error()) {
+									return qualifier_result;
 								}
 
 								// Build function signature for the member function pointer
 								FunctionSignature mfp_sig;
+								mfp_sig.setReturnType(makeFunctionType(nttp_type));
 								mfp_sig.return_type_index = nttp_type.type_index();
 								mfp_sig.return_pointer_depth = static_cast<int>(nttp_type.pointer_depth());
 								mfp_sig.return_reference_qualifier = nttp_type.reference_qualifier();
-								mfp_sig.parameter_type_indices = std::move(mfp_param_types);
+								mfp_sig.setParameterTypes(std::move(mfp_param_types));
 								mfp_sig.calling_convention = fp_calling_convention;
-								mfp_sig.is_const = mfp_is_const;
-								mfp_sig.is_volatile = mfp_is_volatile;
-								mfp_sig.function_reference_qualifier = mfp_ref_qual;
-								mfp_sig.is_noexcept = mfp_is_noexcept;
+								apply_parsed_function_type_qualifiers(
+									mfp_sig, qualifiers, specifiers);
 
 								// Rewrite nttp_type as MemberFunctionPointer
 								nttp_type.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
@@ -2730,7 +2686,7 @@ try_type_template_argument_parse:
 					advance(); // consume '('
 
 					// Parse parameter list using shared helper
-					std::vector<TypeIndex> param_types;
+					std::vector<FunctionType> param_types;
 					bool param_parse_ok = parse_function_type_parameter_list(param_types);
 
 					if (!param_parse_ok) {
@@ -2745,44 +2701,31 @@ try_type_template_argument_parse:
 						// For member function pointers: _Res (_Class::*)(_ArgTypes...) const & noexcept
 						// For function pointers: _Res(*)(_ArgTypes...) noexcept(_NE)
 						// For function references: _Res(&)(_ArgTypes...) noexcept
-						bool sig_is_const = false;
-						bool sig_is_volatile = false;
-						ReferenceQualifier sig_function_ref_qualifier = ReferenceQualifier::None;
-						bool sig_is_noexcept = false;
-						while (!peek().is_eof()) {
-							if ((is_member_ptr) && peek() == "const"_tok) {
-								sig_is_const = true;
-								advance();
-							} else if ((is_member_ptr) && peek() == "volatile"_tok) {
-								sig_is_volatile = true;
-								advance();
-							} else if (is_member_ptr && peek() == "&"_tok) {
-								sig_function_ref_qualifier = ReferenceQualifier::LValueReference;
-								advance();
-							} else if (is_member_ptr && peek() == "&&"_tok) {
-								sig_function_ref_qualifier = ReferenceQualifier::RValueReference;
-								advance();
-							} else if (peek() == "noexcept"_tok) {
-								advance(); // consume 'noexcept'
-								sig_is_noexcept = parse_noexcept_value();
-							} else {
-								break;
-							}
+						FlashCpp::MemberQualifiers qualifiers;
+						FlashCpp::FunctionSpecifiers specifiers;
+						ParseResult qualifier_result =
+							parse_function_type_qualifiers(qualifiers, specifiers);
+						if (qualifier_result.is_error()) {
+							return std::nullopt;
+						}
+						if (!is_member_ptr &&
+							(qualifiers.cv_qualifier != CVQualifier::None ||
+							 qualifiers.ref_qualifier != ReferenceQualifier::None)) {
+							return std::nullopt;
 						}
 
 						// Successfully parsed function reference/pointer type!
 						// Capture the return type BEFORE rewriting type_node (mirrors
 						// Parser_Decl_DeclaratorCore.cpp which creates a fresh FunctionPointer node).
 						FunctionSignature func_sig;
+						func_sig.setReturnType(makeFunctionType(type_node));
 						func_sig.return_type_index = type_node.type_index();
 						func_sig.return_pointer_depth = static_cast<int>(type_node.pointer_depth());
 						func_sig.return_reference_qualifier = type_node.reference_qualifier();
-						func_sig.parameter_type_indices = std::move(param_types);
+						func_sig.setParameterTypes(std::move(param_types));
 						func_sig.calling_convention = paren_calling_convention;
-						func_sig.is_const = sig_is_const;
-						func_sig.is_volatile = sig_is_volatile;
-						func_sig.function_reference_qualifier = sig_function_ref_qualifier;
-						func_sig.is_noexcept = sig_is_noexcept;
+						apply_parsed_function_type_qualifiers(
+							func_sig, qualifiers, specifiers);
 
 						if (is_member_ptr) {
 							type_node.set_type_index(nativeTypeIndex(TypeCategory::MemberFunctionPointer));
@@ -2828,7 +2771,7 @@ try_type_template_argument_parse:
 				// Save position within the parens
 				SaveHandle func_type_saved_pos = save_token_position();
 				bool is_bare_func_type = false;
-				std::vector<TypeIndex> func_param_types;
+				std::vector<FunctionType> func_param_types;
 
 				// Try to parse as function parameter list using shared helper
 				bool param_parse_ok = parse_function_type_parameter_list(func_param_types);
@@ -2839,32 +2782,21 @@ try_type_template_argument_parse:
 
 					// Successfully parsed bare function type
 					FunctionSignature func_sig;
+					func_sig.setReturnType(makeFunctionType(type_node));
 					func_sig.return_type_index = type_node.type_index();
 					func_sig.return_pointer_depth = static_cast<int>(type_node.pointer_depth());
 					func_sig.return_reference_qualifier = type_node.reference_qualifier();
-					func_sig.parameter_type_indices = std::move(func_param_types);
+					func_sig.setParameterTypes(std::move(func_param_types));
 					func_sig.calling_convention = direct_function_calling_convention;
-					while (!peek().is_eof()) {
-						if (peek() == "const"_tok) {
-							func_sig.is_const = true;
-							advance();
-						} else if (peek() == "volatile"_tok) {
-							func_sig.is_volatile = true;
-							advance();
-						} else if (peek() == "&"_tok) {
-							func_sig.function_reference_qualifier = ReferenceQualifier::LValueReference;
-							advance();
-						} else if (peek() == "&&"_tok) {
-							func_sig.function_reference_qualifier = ReferenceQualifier::RValueReference;
-							advance();
-						} else {
-							break;
-						}
+					FlashCpp::MemberQualifiers qualifiers;
+					FlashCpp::FunctionSpecifiers specifiers;
+					ParseResult qualifier_result =
+						parse_function_type_qualifiers(qualifiers, specifiers);
+					if (qualifier_result.is_error()) {
+						return std::nullopt;
 					}
-					if (peek() == "noexcept"_tok) {
-						advance(); // consume 'noexcept'
-						func_sig.is_noexcept = parse_noexcept_value();
-					}
+					apply_parsed_function_type_qualifiers(
+						func_sig, qualifiers, specifiers);
 					type_node.set_function_signature(func_sig);
 
 					discard_saved_token(func_type_saved_pos);

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -1347,6 +1347,11 @@ ASTNode Parser::substituteTemplateParameters(
 			return result;
 		} else if (std::holds_alternative<InitializerListConstructionNode>(expr)) {
 			return substituteWithExpressionSubstitutor(node);
+		} else if (const auto* noexcept_expr = std::get_if<NoexceptExprNode>(&expr)) {
+			ASTNode substituted_operand = substitute_nested(noexcept_expr->expr());
+			return emplace_node<ExpressionNode>(NoexceptExprNode(
+				substituted_operand,
+				noexcept_expr->noexcept_token()));
 		} else if (const auto* static_cast_node = std::get_if<StaticCastNode>(&expr)) {
 			// static_cast<Type>(expr) - recursively substitute in both target type and expression
 			const StaticCastNode& cast_node = *static_cast_node;

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -3630,7 +3630,12 @@ ParseResult Parser::parse_type_specifier() {
 				if (it == getTypesByNameMap().end())
 					return nullptr;
 				const TypeInfo* info = it->second;
-				if (info->is_incomplete_instantiation_)
+				const bool is_active_dependent_alias =
+					info->isTypeAlias() &&
+					info->aliasTypeSpecifier() != nullptr &&
+					(parsing_template_depth_ > 0 || hasActiveTemplateParameters());
+				if (info->is_incomplete_instantiation_ &&
+					!is_active_dependent_alias)
 					return nullptr;
 				return info;
 			};

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -16,6 +16,7 @@
 #include "ParserInternal.h"
 #include "NameMangling.h"
 #include "MemberFunctionLookupShared.h"
+#include "TemplateTypes.h"
 #include <algorithm>
 #include <limits>
 
@@ -890,33 +891,7 @@ bool CanonicalTypeDesc::operator==(const CanonicalTypeDesc& other) const {
 	if (function_signature.has_value()) {
 		const auto& a = *function_signature;
 		const auto& b = *other.function_signature;
-		if (a.returnType() != b.returnType() ||
-			a.return_type_index != b.return_type_index ||
-			a.return_pointer_depth != b.return_pointer_depth ||
-			a.return_reference_qualifier != b.return_reference_qualifier)
-			return false;
-		if (a.parameter_type_indices.size() != b.parameter_type_indices.size())
-			return false;
-		for (size_t i = 0; i < a.parameter_type_indices.size(); ++i) {
-			if (a.parameter_type_indices[i].category() != b.parameter_type_indices[i].category() ||
-				a.parameter_type_indices[i] != b.parameter_type_indices[i])
-				return false;
-		}
-		if (a.linkage != b.linkage)
-			return false;
-		if (a.calling_convention != b.calling_convention)
-			return false;
-		if (a.is_variadic != b.is_variadic)
-			return false;
-		if (a.is_const != b.is_const)
-			return false;
-		if (a.is_volatile != b.is_volatile)
-			return false;
-		if (a.function_reference_qualifier != b.function_reference_qualifier)
-			return false;
-		if (a.is_noexcept != b.is_noexcept)
-			return false;
-		if (a.class_name != b.class_name)
+		if (!FlashCpp::equalFunctionSignatureIdentity(a, b))
 			return false;
 	}
 	return true;

--- a/src/SemanticTypes.h
+++ b/src/SemanticTypes.h
@@ -2,6 +2,7 @@
 #include "AstNodeTypes_TypeSystem.h"
 #include "IRTypes_Registers.h"
 #include "InlineVector.h"
+#include "TemplateTypes.h"
 #include <functional>
 #include <unordered_map>
 
@@ -148,25 +149,9 @@ struct hash<CanonicalTypeDesc> {
 			h = combine(h, dim);
 		h = combine(h, static_cast<size_t>(d.flags));
 		if (d.function_signature) {
-			const auto& fs = *d.function_signature;
-			h = combine(h, static_cast<size_t>(fs.return_type_index.category()));
-			h = combine(h, fs.return_type_index.index());
-			h = combine(h, static_cast<size_t>(fs.return_pointer_depth));
-			h = combine(h, static_cast<size_t>(fs.return_reference_qualifier));
-			h = combine(h, fs.parameter_type_indices.size());
-			for (const TypeIndex& pt : fs.parameter_type_indices) {
-				h = combine(h, static_cast<size_t>(pt.category()));
-				h = combine(h, pt.index());
-			}
-			h = combine(h, static_cast<size_t>(fs.linkage));
-			h = combine(h, fs.is_variadic ? 1u : 0u);
-			h = combine(h, static_cast<size_t>(fs.calling_convention));
-			h = combine(h, fs.is_const ? 1u : 0u);
-			h = combine(h, fs.is_volatile ? 1u : 0u);
-			h = combine(h, static_cast<size_t>(fs.function_reference_qualifier));
-			h = combine(h, fs.is_noexcept ? 1u : 0u);
-			if (fs.class_name.isValid())
-				h = combine(h, fs.class_name.hash());
+			h = combine(
+				h,
+				FlashCpp::hashFunctionSignatureIdentity(*d.function_signature));
 		}
 		return h;
 	}

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -153,15 +153,15 @@ inline bool equalFunctionSignatureIdentity(const FunctionSignature& lhs, const F
 		return false;
 	}
 	if (lhs_is_structured) {
-		if (!equalFunctionTypeIdentity(lhs.return_type, rhs.return_type)) {
+		if (!equalFunctionTypeIdentity(lhs.return_type(), rhs.return_type())) {
 			return false;
 		}
-		if (lhs.parameter_types.size() != rhs.parameter_types.size()) {
+		if (lhs.parameter_types().size() != rhs.parameter_types().size()) {
 			return false;
 		}
-		for (size_t i = 0; i < lhs.parameter_types.size(); ++i) {
+		for (size_t i = 0; i < lhs.parameter_types().size(); ++i) {
 			if (!equalFunctionTypeIdentity(
-					lhs.parameter_types[i], rhs.parameter_types[i])) {
+					lhs.parameter_types()[i], rhs.parameter_types()[i])) {
 				return false;
 			}
 		}
@@ -191,8 +191,8 @@ inline bool equalFunctionSignatureIdentity(const FunctionSignature& lhs, const F
 inline size_t hashFunctionSignatureIdentity(const FunctionSignature& sig) {
 	size_t h = 0;
 	if (sig.hasStructuredTypes()) {
-		combineFunctionTypeIdentityHash(h, hashFunctionTypeIdentity(sig.return_type));
-		for (const FunctionType& parameter_type : sig.parameter_types) {
+		combineFunctionTypeIdentityHash(h, hashFunctionTypeIdentity(sig.return_type()));
+		for (const FunctionType& parameter_type : sig.parameter_types()) {
 			combineFunctionTypeIdentityHash(
 				h, hashFunctionTypeIdentity(parameter_type));
 		}

--- a/src/TemplateTypes.h
+++ b/src/TemplateTypes.h
@@ -51,48 +51,162 @@ bool equalDependentExpressionIdentity(const ASTNode& lhs, const ASTNode& rhs);
 size_t hashDependentExpressionIdentity(const ASTNode& node);
 
 inline bool equalTypeIndexIdentity(TypeIndex lhs, TypeIndex rhs) {
-	// TypeIndex::operator== compares only the index slot; category must be checked separately
-	// so primitive/default TypeIndex values don't collapse incorrectly.
+	if (is_builtin_type(lhs.category()) && is_builtin_type(rhs.category())) {
+		return lhs.category() == rhs.category();
+	}
+	// TypeIndex::operator== compares only the index slot; category must be checked
+	// separately for non-builtin semantic types.
 	return lhs == rhs && lhs.category() == rhs.category();
 }
 
 inline size_t hashTypeIndexIdentity(TypeIndex idx) {
+	if (is_builtin_type(idx.category())) {
+		return std::hash<int>{}(static_cast<int>(idx.category()));
+	}
 	size_t h = std::hash<TypeIndex>{}(idx);
 	h ^= std::hash<int>{}(static_cast<int>(idx.category())) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	return h;
 }
 
+inline bool equalFunctionSignatureIdentity(
+	const FunctionSignature& lhs,
+	const FunctionSignature& rhs);
+inline size_t hashFunctionSignatureIdentity(const FunctionSignature& sig);
+
+inline bool equalFunctionTypeIdentity(const FunctionType& lhs, const FunctionType& rhs) {
+	const bool type_identity_matches =
+		lhs.callable_signature && rhs.callable_signature
+			? lhs.type_index.category() == rhs.type_index.category()
+			: equalTypeIndexIdentity(lhs.type_index, rhs.type_index);
+	if (!type_identity_matches ||
+		lhs.cv_qualifier != rhs.cv_qualifier ||
+		lhs.pointer_qualifiers != rhs.pointer_qualifiers ||
+		lhs.reference_qualifier != rhs.reference_qualifier ||
+		lhs.array_dimensions != rhs.array_dimensions ||
+		lhs.has_unsized_outer_array_dimension != rhs.has_unsized_outer_array_dimension ||
+		lhs.is_pack_expansion != rhs.is_pack_expansion ||
+		lhs.template_parameter_name != rhs.template_parameter_name ||
+		lhs.member_class_name != rhs.member_class_name ||
+		static_cast<bool>(lhs.callable_signature) !=
+		static_cast<bool>(rhs.callable_signature)) {
+		return false;
+	}
+	return !lhs.callable_signature ||
+		equalFunctionSignatureIdentity(
+			*lhs.callable_signature, *rhs.callable_signature);
+}
+
+inline void combineFunctionTypeIdentityHash(size_t& seed, size_t value) {
+	seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+inline size_t hashFunctionTypeIdentity(const FunctionType& type) {
+	size_t hash = type.callable_signature
+		? std::hash<int>{}(static_cast<int>(type.type_index.category()))
+		: hashTypeIndexIdentity(type.type_index);
+	combineFunctionTypeIdentityHash(
+		hash, std::hash<uint8_t>{}(static_cast<uint8_t>(type.cv_qualifier)));
+	for (CVQualifier qualifier : type.pointer_qualifiers) {
+		combineFunctionTypeIdentityHash(
+			hash, std::hash<uint8_t>{}(static_cast<uint8_t>(qualifier)));
+	}
+	combineFunctionTypeIdentityHash(
+		hash, std::hash<uint8_t>{}(static_cast<uint8_t>(type.reference_qualifier)));
+	for (size_t dimension : type.array_dimensions) {
+		combineFunctionTypeIdentityHash(hash, std::hash<size_t>{}(dimension));
+	}
+	combineFunctionTypeIdentityHash(
+		hash, std::hash<bool>{}(type.has_unsized_outer_array_dimension));
+	combineFunctionTypeIdentityHash(hash, std::hash<bool>{}(type.is_pack_expansion));
+	combineFunctionTypeIdentityHash(
+		hash, std::hash<bool>{}(type.template_parameter_name.isValid()));
+	if (type.template_parameter_name.isValid()) {
+		combineFunctionTypeIdentityHash(hash, type.template_parameter_name.hash());
+	}
+	combineFunctionTypeIdentityHash(
+		hash, std::hash<bool>{}(type.member_class_name.isValid()));
+	if (type.member_class_name.isValid()) {
+		combineFunctionTypeIdentityHash(hash, type.member_class_name.hash());
+	}
+	if (type.callable_signature) {
+		combineFunctionTypeIdentityHash(
+			hash, hashFunctionSignatureIdentity(*type.callable_signature));
+	}
+	return hash;
+}
+
 inline bool equalFunctionSignatureIdentity(const FunctionSignature& lhs, const FunctionSignature& rhs) {
-	// Compare every field that contributes to function type identity in the AST signature model:
-	// return type, parameter types, linkage, member class name, and cv-qualification.
-	if (!equalTypeIndexIdentity(lhs.return_type_index, rhs.return_type_index) ||
-		lhs.return_pointer_depth != rhs.return_pointer_depth ||
-		lhs.return_reference_qualifier != rhs.return_reference_qualifier ||
-		lhs.parameter_type_indices.size() != rhs.parameter_type_indices.size() ||
-		lhs.linkage != rhs.linkage ||
+	if (lhs.linkage != rhs.linkage ||
 		lhs.class_name != rhs.class_name ||
 		lhs.calling_convention != rhs.calling_convention ||
 		lhs.is_variadic != rhs.is_variadic ||
 		lhs.is_const != rhs.is_const ||
 		lhs.is_volatile != rhs.is_volatile ||
 		lhs.function_reference_qualifier != rhs.function_reference_qualifier ||
-		lhs.is_noexcept != rhs.is_noexcept) {
+		lhs.is_noexcept != rhs.is_noexcept ||
+		lhs.noexcept_expression.has_value() != rhs.noexcept_expression.has_value()) {
 		return false;
 	}
-	for (size_t i = 0; i < lhs.parameter_type_indices.size(); ++i) {
-		if (!equalTypeIndexIdentity(lhs.parameter_type_indices[i], rhs.parameter_type_indices[i])) {
+	const bool lhs_is_structured = lhs.hasStructuredTypes();
+	const bool rhs_is_structured = rhs.hasStructuredTypes();
+	if (lhs_is_structured != rhs_is_structured) {
+		return false;
+	}
+	if (lhs_is_structured) {
+		if (!equalFunctionTypeIdentity(lhs.return_type, rhs.return_type)) {
 			return false;
 		}
+		if (lhs.parameter_types.size() != rhs.parameter_types.size()) {
+			return false;
+		}
+		for (size_t i = 0; i < lhs.parameter_types.size(); ++i) {
+			if (!equalFunctionTypeIdentity(
+					lhs.parameter_types[i], rhs.parameter_types[i])) {
+				return false;
+			}
+		}
+	} else {
+		if (!equalTypeIndexIdentity(lhs.return_type_index, rhs.return_type_index) ||
+			lhs.return_pointer_depth != rhs.return_pointer_depth ||
+			lhs.return_reference_qualifier != rhs.return_reference_qualifier ||
+			lhs.parameter_type_indices.size() != rhs.parameter_type_indices.size()) {
+			return false;
+		}
+		for (size_t i = 0; i < lhs.parameter_type_indices.size(); ++i) {
+			if (!equalTypeIndexIdentity(
+					lhs.parameter_type_indices[i], rhs.parameter_type_indices[i])) {
+				return false;
+			}
+		}
+	}
+	if (lhs.noexcept_expression.has_value() &&
+		!equalDependentExpressionIdentity(
+			lhs.noexcept_expression->node(),
+			rhs.noexcept_expression->node())) {
+		return false;
 	}
 	return true;
 }
 
 inline size_t hashFunctionSignatureIdentity(const FunctionSignature& sig) {
-	size_t h = hashTypeIndexIdentity(sig.return_type_index);
-	h ^= std::hash<int>{}(sig.return_pointer_depth) + 0x9e3779b9 + (h << 6) + (h >> 2);
-	h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(sig.return_reference_qualifier)) + 0x9e3779b9 + (h << 6) + (h >> 2);
-	for (const auto& pt : sig.parameter_type_indices) {
-		h ^= hashTypeIndexIdentity(pt) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	size_t h = 0;
+	if (sig.hasStructuredTypes()) {
+		combineFunctionTypeIdentityHash(h, hashFunctionTypeIdentity(sig.return_type));
+		for (const FunctionType& parameter_type : sig.parameter_types) {
+			combineFunctionTypeIdentityHash(
+				h, hashFunctionTypeIdentity(parameter_type));
+		}
+	} else {
+		combineFunctionTypeIdentityHash(h, hashTypeIndexIdentity(sig.return_type_index));
+		combineFunctionTypeIdentityHash(h, std::hash<int>{}(sig.return_pointer_depth));
+		combineFunctionTypeIdentityHash(
+			h,
+			std::hash<uint8_t>{}(
+				static_cast<uint8_t>(sig.return_reference_qualifier)));
+		for (const TypeIndex parameter_type : sig.parameter_type_indices) {
+			combineFunctionTypeIdentityHash(
+				h, hashTypeIndexIdentity(parameter_type));
+		}
 	}
 	h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(sig.linkage)) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	h ^= std::hash<bool>{}(sig.class_name.isValid()) + 0x9e3779b9 + (h << 6) + (h >> 2);
@@ -105,6 +219,9 @@ inline size_t hashFunctionSignatureIdentity(const FunctionSignature& sig) {
 	h ^= std::hash<bool>{}(sig.is_volatile) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	h ^= std::hash<uint8_t>{}(static_cast<uint8_t>(sig.function_reference_qualifier)) + 0x9e3779b9 + (h << 6) + (h >> 2);
 	h ^= std::hash<bool>{}(sig.is_noexcept) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	if (sig.noexcept_expression.has_value()) {
+		h ^= hashDependentExpressionIdentity(sig.noexcept_expression->node()) + 0x9e3779b9 + (h << 6) + (h >> 2);
+	}
 	return h;
 }
 

--- a/src/TypeTraitEvaluator.cpp
+++ b/src/TypeTraitEvaluator.cpp
@@ -147,29 +147,7 @@ TypeSpecifierNode normalizeTypeTraitOperand(const TypeSpecifierNode& type_spec) 
 bool functionSignaturesMatch(
 	const FunctionSignature& lhs,
 	const FunctionSignature& rhs) {
-	if (lhs.returnType() != rhs.returnType() ||
-		canonicalize_type_alias(lhs.return_type_index).resolvedTypeIndex() !=
-			canonicalize_type_alias(rhs.return_type_index).resolvedTypeIndex() ||
-		lhs.return_pointer_depth != rhs.return_pointer_depth ||
-		lhs.return_reference_qualifier != rhs.return_reference_qualifier ||
-		lhs.parameter_type_indices.size() != rhs.parameter_type_indices.size() ||
-		lhs.linkage != rhs.linkage ||
-		lhs.class_name != rhs.class_name ||
-		lhs.calling_convention != rhs.calling_convention ||
-		lhs.is_variadic != rhs.is_variadic ||
-		lhs.is_const != rhs.is_const ||
-		lhs.is_volatile != rhs.is_volatile ||
-		lhs.function_reference_qualifier != rhs.function_reference_qualifier ||
-		lhs.is_noexcept != rhs.is_noexcept) {
-		return false;
-	}
-	for (size_t i = 0; i < lhs.parameter_type_indices.size(); ++i) {
-		if (canonicalize_type_alias(lhs.parameter_type_indices[i]).resolvedTypeIndex() !=
-			canonicalize_type_alias(rhs.parameter_type_indices[i]).resolvedTypeIndex()) {
-			return false;
-		}
-	}
-	return true;
+	return FlashCpp::equalFunctionSignatureIdentity(lhs, rhs);
 }
 
 bool areSameTypeTraitOperands(
@@ -178,7 +156,9 @@ bool areSameTypeTraitOperands(
 	const TypeSpecifierNode normalized_lhs = normalizeTypeTraitOperand(lhs);
 	const TypeSpecifierNode normalized_rhs = normalizeTypeTraitOperand(rhs);
 	if (normalized_lhs.type() != normalized_rhs.type() ||
-		normalized_lhs.type_index() != normalized_rhs.type_index() ||
+		(!normalized_lhs.has_function_signature() &&
+		 !normalized_rhs.has_function_signature() &&
+		 normalized_lhs.type_index() != normalized_rhs.type_index()) ||
 		normalized_lhs.cv_qualifier() != normalized_rhs.cv_qualifier() ||
 		normalized_lhs.reference_qualifier() != normalized_rhs.reference_qualifier() ||
 		normalized_lhs.pointer_levels().size() != normalized_rhs.pointer_levels().size() ||

--- a/tests/run_all_tests.sh
+++ b/tests/run_all_tests.sh
@@ -7,6 +7,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
+# Match FlashCpp's Linux startup policy: deep template instantiation needs a
+# 16MB soft stack. Raise it for the test runner process tree when permitted.
+if ulimit -s >/dev/null 2>&1; then
+	current_stack_kb="$(ulimit -s)"
+	if [ "$current_stack_kb" != "unlimited" ] && [ "$current_stack_kb" -lt 16384 ]; then
+		ulimit -s 16384 2>/dev/null || true
+	fi
+fi
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/tests/test_template_dependent_member_function_pointer_owner_ret0.cpp
+++ b/tests/test_template_dependent_member_function_pointer_owner_ret0.cpp
@@ -1,0 +1,39 @@
+struct LeftOwner {};
+struct RightOwner {};
+
+struct LeftFunctionHolder {
+	long long (LeftOwner::*member)(short, long) const & noexcept;
+};
+
+struct RightFunctionHolder {
+	long long (RightOwner::*member)(short, long) const & noexcept;
+};
+
+template <typename Owner>
+struct MemberFunctionHolder {
+	long long (Owner::*member)(short, long) const & noexcept;
+};
+
+static_assert(__is_same(
+	decltype(MemberFunctionHolder<LeftOwner>::member),
+	decltype(LeftFunctionHolder::member)));
+static_assert(__is_same(
+	decltype(MemberFunctionHolder<RightOwner>::member),
+	decltype(RightFunctionHolder::member)));
+static_assert(!__is_same(
+	decltype(MemberFunctionHolder<LeftOwner>::member),
+	decltype(MemberFunctionHolder<RightOwner>::member)));
+
+int main() {
+	return __is_same(
+			   decltype(MemberFunctionHolder<LeftOwner>::member),
+			   decltype(LeftFunctionHolder::member)) &&
+			   __is_same(
+				   decltype(MemberFunctionHolder<RightOwner>::member),
+				   decltype(RightFunctionHolder::member)) &&
+			   !__is_same(
+				   decltype(MemberFunctionHolder<LeftOwner>::member),
+				   decltype(MemberFunctionHolder<RightOwner>::member))
+		? 0
+		: 1;
+}

--- a/tests/test_template_function_pointer_alias_category_ret0.cpp
+++ b/tests/test_template_function_pointer_alias_category_ret0.cpp
@@ -1,0 +1,57 @@
+template <typename Value>
+struct AliasHolder {
+	using CallbackAlias = Value (*)();
+	CallbackAlias function;
+};
+
+struct ConcreteHolder {
+	int (*function)();
+};
+
+struct DifferentHolder {
+	long long (*function)();
+};
+
+template <bool IsNoexcept>
+struct NoexceptAliasHolder {
+	using CallbackAlias = int (*)() noexcept(IsNoexcept);
+	CallbackAlias function;
+};
+
+struct NoexceptHolder {
+	int (*function)() noexcept;
+};
+
+struct ThrowingHolder {
+	int (*function)();
+};
+
+static_assert(__is_same(
+	decltype(AliasHolder<int>::function),
+	decltype(ConcreteHolder::function)));
+static_assert(!__is_same(
+	decltype(AliasHolder<int>::function),
+	decltype(DifferentHolder::function)));
+static_assert(__is_same(
+	decltype(NoexceptAliasHolder<true>::function),
+	decltype(NoexceptHolder::function)));
+static_assert(__is_same(
+	decltype(NoexceptAliasHolder<false>::function),
+	decltype(ThrowingHolder::function)));
+
+int main() {
+	return __is_same(
+			   decltype(AliasHolder<int>::function),
+			   decltype(ConcreteHolder::function)) &&
+		   !__is_same(
+			   decltype(AliasHolder<int>::function),
+			   decltype(DifferentHolder::function)) &&
+		   __is_same(
+			   decltype(NoexceptAliasHolder<true>::function),
+			   decltype(NoexceptHolder::function)) &&
+		   __is_same(
+			   decltype(NoexceptAliasHolder<false>::function),
+			   decltype(ThrowingHolder::function))
+		? 0
+		: 1;
+}

--- a/tests/test_template_function_pointer_dependent_noexcept_ret0.cpp
+++ b/tests/test_template_function_pointer_dependent_noexcept_ret0.cpp
@@ -1,0 +1,36 @@
+template <bool IsNoexcept>
+struct Callback {
+	int (*function)() noexcept(IsNoexcept);
+};
+
+struct NoexceptFunctionHolder {
+	int (*function)() noexcept;
+};
+
+struct ThrowingFunctionHolder {
+	int (*function)();
+};
+
+static_assert(__is_same(
+	decltype(Callback<true>::function),
+	decltype(NoexceptFunctionHolder::function)));
+static_assert(__is_same(
+	decltype(Callback<false>::function),
+	decltype(ThrowingFunctionHolder::function)));
+static_assert(!__is_same(
+	decltype(Callback<true>::function),
+	decltype(Callback<false>::function)));
+
+int main() {
+	return __is_same(
+			   decltype(Callback<true>::function),
+			   decltype(NoexceptFunctionHolder::function)) &&
+			   __is_same(
+				   decltype(Callback<false>::function),
+				   decltype(ThrowingFunctionHolder::function)) &&
+			   !__is_same(
+				   decltype(Callback<true>::function),
+				   decltype(Callback<false>::function))
+		? 0
+		: 1;
+}

--- a/tests/test_template_function_pointer_pack_signature_ret0.cpp
+++ b/tests/test_template_function_pointer_pack_signature_ret0.cpp
@@ -1,0 +1,40 @@
+long long combine(short first, int second, long long third) {
+	return first + second + third;
+}
+
+template <typename Result, typename... Arguments>
+struct PackedCallback {
+	Result (*callback)(Arguments...);
+};
+
+struct ConcreteCallback {
+	long long (*callback)(short, int, long long);
+};
+
+struct DifferentCallback {
+	long long (*callback)(short, long long);
+};
+
+static_assert(__is_same(
+	decltype(PackedCallback<long long, short, int, long long>::callback),
+	decltype(ConcreteCallback::callback)));
+static_assert(!__is_same(
+	decltype(PackedCallback<long long, short, int, long long>::callback),
+	decltype(DifferentCallback::callback)));
+
+int main() {
+	PackedCallback<long long, short, int, long long> value{combine};
+	if (value.callback(10, 12, 20) != 42) {
+		return 1;
+	}
+	if (!__is_same(
+			decltype(PackedCallback<long long, short, int, long long>::callback),
+			decltype(ConcreteCallback::callback))) {
+		return 2;
+	}
+	return __is_same(
+			   decltype(PackedCallback<long long, short, int, long long>::callback),
+			   decltype(DifferentCallback::callback))
+		? 3
+		: 0;
+}

--- a/tests/test_template_function_pointer_transformed_signature_ret0.cpp
+++ b/tests/test_template_function_pointer_transformed_signature_ret0.cpp
@@ -1,0 +1,30 @@
+template <typename Value>
+struct TransformedCallback {
+	Value* (*function)(const Value&, Value&&);
+};
+
+struct ConcreteCallback {
+	int* (*function)(const int&, int&&);
+};
+
+struct DifferentCallback {
+	int* (*function)(int&, const int&&);
+};
+
+static_assert(__is_same(
+	decltype(TransformedCallback<int>::function),
+	decltype(ConcreteCallback::function)));
+static_assert(!__is_same(
+	decltype(TransformedCallback<int>::function),
+	decltype(DifferentCallback::function)));
+
+int main() {
+	return __is_same(
+			   decltype(TransformedCallback<int>::function),
+			   decltype(ConcreteCallback::function)) &&
+			   !__is_same(
+				   decltype(TransformedCallback<int>::function),
+				   decltype(DifferentCallback::function))
+		? 0
+		: 1;
+}

--- a/tests/test_template_nested_callable_signature_ret0.cpp
+++ b/tests/test_template_nested_callable_signature_ret0.cpp
@@ -1,0 +1,48 @@
+template <typename Value>
+struct NestedCallback {
+	Value (*function)(Value (*)(const Value&));
+};
+
+struct ConcreteCallback {
+	int (*function)(int (*)(const int&));
+};
+
+struct DifferentCallback {
+	int (*function)(int (*)(int&));
+};
+
+template <typename Value>
+Value (*nestedReturnCallback())(const Value&);
+
+int (*concreteReturnCallback())(const int&);
+int (*differentReturnCallback())(int&);
+
+static_assert(__is_same(
+	decltype(NestedCallback<int>::function),
+	decltype(ConcreteCallback::function)));
+static_assert(!__is_same(
+	decltype(NestedCallback<int>::function),
+	decltype(DifferentCallback::function)));
+static_assert(__is_same(
+	decltype(nestedReturnCallback<int>),
+	decltype(concreteReturnCallback)));
+static_assert(!__is_same(
+	decltype(nestedReturnCallback<int>),
+	decltype(differentReturnCallback)));
+
+int main() {
+	return __is_same(
+			   decltype(NestedCallback<int>::function),
+			   decltype(ConcreteCallback::function)) &&
+		   !__is_same(
+			   decltype(NestedCallback<int>::function),
+			   decltype(DifferentCallback::function)) &&
+		   __is_same(
+			   decltype(nestedReturnCallback<int>),
+			   decltype(concreteReturnCallback)) &&
+		   !__is_same(
+			   decltype(nestedReturnCallback<int>),
+			   decltype(differentReturnCallback))
+		? 0
+		: 1;
+}


### PR DESCRIPTION
## Summary
- parse function and member-function-pointer declarators into complete callable metadata, including parameters, cv/ref, packs, variadic, and noexcept state
- keep that metadata as first-class `FunctionType` / signature identity through template substitution, mangling, and constexpr noexcept evaluation
- substitute dependent owner classes from the active template binding and canonical TypeIndex during materialization
- advance the IR AST worklist by node identity so late front-inserted constexpr dependencies neither double-emit nor recursively grow compile-time-only roots
- remove the resolved callable-signature limitation from KNOWN_ISSUES.md

## Test plan
- [x] `test_template_dependent_member_function_pointer_owner_ret0.cpp`
- [x] `test_template_function_pointer_alias_category_ret0.cpp`
- [x] `test_template_function_pointer_dependent_noexcept_ret0.cpp`
- [x] `test_template_function_pointer_pack_signature_ret0.cpp`
- [x] `test_template_function_pointer_transformed_signature_ret0.cpp`
- [x] `test_template_nested_callable_signature_ret0.cpp`
- [x] `test_mock_std_byte_noexcept_probe_ret0.cpp`
- [x] full suite: 2775/2775 + 240 `_fail` as expected