### PR TITLE
Shrink TypeInfo with ChunkedVector cold arenas

### DIFF
--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -304,6 +304,10 @@ size_t getTypeInfoTemplateArgsCount() {
 	return gTypeInfoTemplateArgLists.size();
 }
 
+const InlineVector<TypeInfo::TemplateArgInfo, 4>& TypeInfo::InstantiationContext::param_args() const {
+	return getTypeInfoTemplateArgs(param_args_index);
+}
+
 const InlineVector<TypeInfo::TemplateArgInfo, 4>& TypeInfo::templateArgs() const {
 	return getTypeInfoTemplateArgs(template_args_index_);
 }
@@ -570,7 +574,7 @@ void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& se
 		instantiation_context != nullptr) {
 		alias_type_info.setInstantiationContext(
 			instantiation_context->param_names,
-			instantiation_context->param_args,
+			InlineVector<TypeInfo::TemplateArgInfo, 4>(instantiation_context->param_args()),
 			instantiation_context->parent);
 	} else {
 		alias_type_info.instantiation_context_.reset();
@@ -1472,17 +1476,18 @@ void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names
 	instantiation_context_ = std::make_unique<InstantiationContext>();
 	instantiation_context_->parent = parent;
 	instantiation_context_->param_names = param_names;
-	instantiation_context_->param_args = param_args;
+	instantiation_context_->param_args_index = storeTypeInfoTemplateArgs(std::move(param_args));
+	const auto& stored_param_args = getTypeInfoTemplateArgs(instantiation_context_->param_args_index);
 
 	// Phase 5: Populate binding-based storage alongside legacy fields.
 	// param_args may be a flattened pack list and can therefore be longer than
 	// param_names in legacy callers.
-	if (param_args.size() < param_names.size()) {
+	if (stored_param_args.size() < param_names.size()) {
 		StringBuilder error_builder;
 		error_builder.append("TypeInfo::setInstantiationContext invalid size mismatch: param_names=");
 		error_builder.append(param_names.size());
 		error_builder.append(", param_args=");
-		error_builder.append(param_args.size());
+		error_builder.append(stored_param_args.size());
 		throw InternalError(std::string(error_builder.commit()));
 	}
 	const size_t estimated_binding_count = param_names.size();
@@ -1493,15 +1498,15 @@ void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names
 	while (name_index < param_names.size()) {
 		InlineVector<TemplateArgInfo, 1> binding_args;
 		const StringHandle binding_name = param_names[name_index];
-		if (arg_index < param_args.size()) {
-			binding_args.push_back(param_args[arg_index]);
+		if (arg_index < stored_param_args.size()) {
+			binding_args.push_back(stored_param_args[arg_index]);
 			++arg_index;
 		}
 		++name_index;
 		while (name_index < param_names.size() &&
 			   param_names[name_index] == binding_name &&
-			   arg_index < param_args.size()) {
-			binding_args.push_back(param_args[arg_index]);
+			   arg_index < stored_param_args.size()) {
+			binding_args.push_back(stored_param_args[arg_index]);
 			++arg_index;
 			++name_index;
 		}
@@ -1510,8 +1515,8 @@ void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names
 		// element. Preserve those elements by attaching the remaining args to the
 		// final binding.
 		if (name_index == param_names.size()) {
-			while (arg_index < param_args.size()) {
-				binding_args.push_back(param_args[arg_index]);
+			while (arg_index < stored_param_args.size()) {
+				binding_args.push_back(stored_param_args[arg_index]);
 				++arg_index;
 			}
 		}

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -246,6 +246,7 @@ std::unordered_map<TypeCategory, const TypeInfo*> gNativeTypes;
 
 // Explicit chunk size: default ChunkSize=sizeof(T)*4 would reserve ~25k *huge* elements.
 ChunkedVector<TypeInfo::DependentQualifiedNameRecord, 4> gDependentQualifiedNameRecords;
+ChunkedVector<InlineVector<TypeInfo::TemplateArgInfo, 4>, 8> gTypeInfoTemplateArgLists;
 
 uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record) {
 	const uint32_t index = static_cast<uint32_t>(gDependentQualifiedNameRecords.size());
@@ -279,6 +280,42 @@ void TypeInfo::clearDependentQualifiedName() {
 
 void TypeInfo::setDependentQualifiedName(DependentQualifiedNameRecord record) {
 	dependent_qualified_name_index_ = storeDependentQualifiedNameRecord(std::move(record));
+}
+
+uint32_t storeTypeInfoTemplateArgs(InlineVector<TypeInfo::TemplateArgInfo, 4> args) {
+	if (args.empty()) {
+		return TypeInfo::kNoTemplateArgs;
+	}
+	const uint32_t index = static_cast<uint32_t>(gTypeInfoTemplateArgLists.size());
+	gTypeInfoTemplateArgLists.push_back(std::move(args));
+	return index;
+}
+
+const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32_t index) {
+	static const InlineVector<TypeInfo::TemplateArgInfo, 4> empty_args;
+	if (index == TypeInfo::kNoTemplateArgs) {
+		return empty_args;
+	}
+	assert(index < gTypeInfoTemplateArgLists.size());
+	return gTypeInfoTemplateArgLists[index];
+}
+
+size_t getTypeInfoTemplateArgsCount() {
+	return gTypeInfoTemplateArgLists.size();
+}
+
+const InlineVector<TypeInfo::TemplateArgInfo, 4>& TypeInfo::templateArgs() const {
+	return getTypeInfoTemplateArgs(template_args_index_);
+}
+
+void TypeInfo::clearTemplateArgs() {
+	template_args_index_ = kNoTemplateArgs;
+}
+
+void TypeInfo::setTemplateInstantiationInfo(QualifiedIdentifier base_template,
+											InlineVector<TemplateArgInfo, 4> args) {
+	base_template_ = base_template;
+	template_args_index_ = storeTypeInfoTemplateArgs(std::move(args));
 }
 
 template <typename... Args>
@@ -508,7 +545,7 @@ void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 	alias_type_info.clearDependentQualifiedName();
 	alias_type_info.clearDeferredDecltypeExpression();
 	alias_type_info.base_template_ = QualifiedIdentifier{};
-	alias_type_info.template_args_.clear();
+	alias_type_info.clearTemplateArgs();
 	alias_type_info.instantiation_context_.reset();
 	alias_type_info.is_incomplete_instantiation_ = false;
 }
@@ -525,7 +562,8 @@ void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& se
 		alias_type_info.clearDeferredDecltypeExpression();
 	}
 	alias_type_info.base_template_ = semantic_source_type_info.base_template_;
-	alias_type_info.template_args_ = semantic_source_type_info.template_args_;
+	// Share the cold-arena index; arg lists are immutable after store.
+	alias_type_info.template_args_index_ = semantic_source_type_info.template_args_index_;
 	alias_type_info.is_incomplete_instantiation_ = semantic_source_type_info.is_incomplete_instantiation_;
 	if (const TypeInfo::InstantiationContext* instantiation_context =
 			semantic_source_type_info.instantiationContext();
@@ -667,6 +705,7 @@ void printTypeTableStats() {
 	FLASH_LOG(General, Info, "  TypeInfo layout breakdown (bytes): ",
 			  "TemplateArgInfo=", sizeof(TypeInfo::TemplateArgInfo),
 			  ", InlineVector<TemplateArgInfo,4>=", sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
+			  ", template_args_index_=", sizeof(uint32_t),
 			  ", DependentQualifiedNameRecord=", sizeof(TypeInfo::DependentQualifiedNameRecord),
 			  ", dependent_qualified_name_index_=", sizeof(uint32_t),
 			  ", InstantiationContext=", sizeof(TypeInfo::InstantiationContext),
@@ -707,6 +746,12 @@ void printTypeTableStats() {
 			  ", record_bytes=", sizeof(TypeInfo::DependentQualifiedNameRecord),
 			  ", estimated cold storage=",
 			  getDependentQualifiedNameRecordCount() * sizeof(TypeInfo::DependentQualifiedNameRecord),
+			  " bytes");
+	FLASH_LOG(General, Info, "  gTypeInfoTemplateArgLists: entries=",
+			  getTypeInfoTemplateArgsCount(),
+			  ", list_bytes=", sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
+			  ", estimated cold storage=",
+			  getTypeInfoTemplateArgsCount() * sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
 			  " bytes");
 
 	// Break down entries by category

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -247,6 +247,7 @@ std::unordered_map<TypeCategory, const TypeInfo*> gNativeTypes;
 // Explicit chunk size: default ChunkSize=sizeof(T)*4 would reserve ~25k *huge* elements.
 ChunkedVector<TypeInfo::DependentQualifiedNameRecord, 4> gDependentQualifiedNameRecords;
 ChunkedVector<InlineVector<TypeInfo::TemplateArgInfo, 4>, 8> gTypeInfoTemplateArgLists;
+ChunkedVector<TypeInfo::InstantiationContext, 8> gInstantiationContexts;
 
 uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record) {
 	const uint32_t index = static_cast<uint32_t>(gDependentQualifiedNameRecords.size());
@@ -302,6 +303,36 @@ const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32
 
 size_t getTypeInfoTemplateArgsCount() {
 	return gTypeInfoTemplateArgLists.size();
+}
+
+uint32_t storeInstantiationContext(TypeInfo::InstantiationContext ctx) {
+	const uint32_t index = static_cast<uint32_t>(gInstantiationContexts.size());
+	gInstantiationContexts.push_back(std::move(ctx));
+	return index;
+}
+
+const TypeInfo::InstantiationContext* getInstantiationContext(uint32_t index) {
+	if (index == TypeInfo::kNoInstantiationContext) {
+		return nullptr;
+	}
+	assert(index < gInstantiationContexts.size());
+	return &gInstantiationContexts[index];
+}
+
+TypeInfo::InstantiationContext* getInstantiationContextMut(uint32_t index) {
+	if (index == TypeInfo::kNoInstantiationContext) {
+		return nullptr;
+	}
+	assert(index < gInstantiationContexts.size());
+	return &gInstantiationContexts[index];
+}
+
+size_t getInstantiationContextCount() {
+	return gInstantiationContexts.size();
+}
+
+const TypeInfo::InstantiationContext* TypeInfo::instantiationContext() const {
+	return getInstantiationContext(instantiation_context_index_);
 }
 
 const InlineVector<TypeInfo::TemplateArgInfo, 4>& TypeInfo::InstantiationContext::param_args() const {
@@ -550,7 +581,7 @@ void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 	alias_type_info.clearDeferredDecltypeExpression();
 	alias_type_info.base_template_ = QualifiedIdentifier{};
 	alias_type_info.clearTemplateArgs();
-	alias_type_info.instantiation_context_.reset();
+	alias_type_info.clearInstantiationContext();
 	alias_type_info.is_incomplete_instantiation_ = false;
 }
 
@@ -569,16 +600,9 @@ void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& se
 	// Share the cold-arena index; arg lists are immutable after store.
 	alias_type_info.template_args_index_ = semantic_source_type_info.template_args_index_;
 	alias_type_info.is_incomplete_instantiation_ = semantic_source_type_info.is_incomplete_instantiation_;
-	if (const TypeInfo::InstantiationContext* instantiation_context =
-			semantic_source_type_info.instantiationContext();
-		instantiation_context != nullptr) {
-		alias_type_info.setInstantiationContext(
-			instantiation_context->param_names,
-			InlineVector<TypeInfo::TemplateArgInfo, 4>(instantiation_context->param_args()),
-			instantiation_context->parent);
-	} else {
-		alias_type_info.instantiation_context_.reset();
-	}
+	// Share the cold-arena index; contexts are immutable after store.
+	alias_type_info.instantiation_context_index_ =
+		semantic_source_type_info.instantiation_context_index_;
 }
 
 } // namespace
@@ -713,6 +737,7 @@ void printTypeTableStats() {
 			  ", DependentQualifiedNameRecord=", sizeof(TypeInfo::DependentQualifiedNameRecord),
 			  ", dependent_qualified_name_index_=", sizeof(uint32_t),
 			  ", InstantiationContext=", sizeof(TypeInfo::InstantiationContext),
+			  ", instantiation_context_index_=", sizeof(uint32_t),
 			  ", FunctionSignature=", sizeof(FunctionSignature),
 			  ", optional<FunctionSignature>=", sizeof(std::optional<FunctionSignature>),
 			  ", optional<ASTNode>=", sizeof(std::optional<ASTNode>));
@@ -756,6 +781,12 @@ void printTypeTableStats() {
 			  ", list_bytes=", sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
 			  ", estimated cold storage=",
 			  getTypeInfoTemplateArgsCount() * sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
+			  " bytes");
+	FLASH_LOG(General, Info, "  gInstantiationContexts: entries=",
+			  getInstantiationContextCount(),
+			  ", context_bytes=", sizeof(TypeInfo::InstantiationContext),
+			  ", estimated cold storage=",
+			  getInstantiationContextCount() * sizeof(TypeInfo::InstantiationContext),
 			  " bytes");
 
 	// Break down entries by category
@@ -1473,11 +1504,11 @@ void TypeInfo::setStructInfo(std::unique_ptr<StructTypeInfo> info) {
 void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names,
 									   InlineVector<TemplateArgInfo, 4> param_args,
 									   const InstantiationContext* parent) {
-	instantiation_context_ = std::make_unique<InstantiationContext>();
-	instantiation_context_->parent = parent;
-	instantiation_context_->param_names = param_names;
-	instantiation_context_->param_args_index = storeTypeInfoTemplateArgs(std::move(param_args));
-	const auto& stored_param_args = getTypeInfoTemplateArgs(instantiation_context_->param_args_index);
+	InstantiationContext ctx;
+	ctx.parent = parent;
+	ctx.param_names = param_names;
+	ctx.param_args_index = storeTypeInfoTemplateArgs(std::move(param_args));
+	const auto& stored_param_args = getTypeInfoTemplateArgs(ctx.param_args_index);
 
 	// Phase 5: Populate binding-based storage alongside legacy fields.
 	// param_args may be a flattened pack list and can therefore be longer than
@@ -1491,7 +1522,7 @@ void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names
 		throw InternalError(std::string(error_builder.commit()));
 	}
 	const size_t estimated_binding_count = param_names.size();
-	instantiation_context_->bindings.reserve(estimated_binding_count);
+	ctx.bindings.reserve(estimated_binding_count);
 
 	size_t arg_index = 0;
 	size_t name_index = 0;
@@ -1535,8 +1566,9 @@ void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names
 		}
 		binding.kind = static_cast<uint8_t>(binding_kind);
 		binding.is_pack = (binding.args.size() > 1);
-		instantiation_context_->bindings.push_back(std::move(binding));
+		ctx.bindings.push_back(std::move(binding));
 	}
+	instantiation_context_index_ = storeInstantiationContext(std::move(ctx));
 }
 
 bool StructTypeInfo::isOwnTypeIndex(TypeIndex param_type_index) const {

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -244,6 +244,43 @@ std::deque<TypeInfo, TypeInfoTrackingAllocator<TypeInfo>> gTypeInfo;
 std::unordered_map<StringHandle, TypeInfo*, StringHash, StringEqual> gTypesByName;
 std::unordered_map<TypeCategory, const TypeInfo*> gNativeTypes;
 
+// Explicit chunk size: default ChunkSize=sizeof(T)*4 would reserve ~25k *huge* elements.
+ChunkedVector<TypeInfo::DependentQualifiedNameRecord, 4> gDependentQualifiedNameRecords;
+
+uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record) {
+	const uint32_t index = static_cast<uint32_t>(gDependentQualifiedNameRecords.size());
+	gDependentQualifiedNameRecords.push_back(std::move(record));
+	return index;
+}
+
+const TypeInfo::DependentQualifiedNameRecord* getDependentQualifiedNameRecord(uint32_t index) {
+	if (index == TypeInfo::kNoDependentQualifiedName) {
+		return nullptr;
+	}
+	assert(index < gDependentQualifiedNameRecords.size());
+	return &gDependentQualifiedNameRecords[index];
+}
+
+size_t getDependentQualifiedNameRecordCount() {
+	return gDependentQualifiedNameRecords.size();
+}
+
+bool TypeInfo::hasDependentQualifiedName() const {
+	return dependent_qualified_name_index_ != kNoDependentQualifiedName;
+}
+
+const TypeInfo::DependentQualifiedNameRecord* TypeInfo::dependentQualifiedName() const {
+	return getDependentQualifiedNameRecord(dependent_qualified_name_index_);
+}
+
+void TypeInfo::clearDependentQualifiedName() {
+	dependent_qualified_name_index_ = kNoDependentQualifiedName;
+}
+
+void TypeInfo::setDependentQualifiedName(DependentQualifiedNameRecord record) {
+	dependent_qualified_name_index_ = storeDependentQualifiedNameRecord(std::move(record));
+}
+
 template <typename... Args>
 TypeInfo& emplaceTypeInfoTracked(const char* reason, Args&&... args) {
 	if (!gTypeTableStatsEnabled) {
@@ -468,7 +505,7 @@ namespace {
 
 void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 	alias_type_info.placeholder_kind_ = DependentPlaceholderKind::None;
-	alias_type_info.dependent_qualified_name_.reset();
+	alias_type_info.clearDependentQualifiedName();
 	alias_type_info.clearDeferredDecltypeExpression();
 	alias_type_info.base_template_ = QualifiedIdentifier{};
 	alias_type_info.template_args_.clear();
@@ -478,7 +515,9 @@ void resetTypeAliasSemanticMetadata(TypeInfo& alias_type_info) {
 
 void copyTypeAliasSemanticMetadata(TypeInfo& alias_type_info, const TypeInfo& semantic_source_type_info) {
 	alias_type_info.placeholder_kind_ = semantic_source_type_info.placeholder_kind_;
-	alias_type_info.dependent_qualified_name_ = semantic_source_type_info.dependent_qualified_name_;
+	// Share the cold-arena index; records are immutable after store.
+	alias_type_info.dependent_qualified_name_index_ =
+		semantic_source_type_info.dependent_qualified_name_index_;
 	if (const ASTNode* deferred_decltype_expr = semantic_source_type_info.deferredDecltypeExpression();
 		deferred_decltype_expr != nullptr) {
 		alias_type_info.setDeferredDecltypeExpression(*deferred_decltype_expr);
@@ -625,6 +664,50 @@ void printTypeTableStats() {
 			  ", sizeof(TypeInfo)=", sizeof(TypeInfo),
 			  ", estimated storage=", type_info_bytes, " bytes (",
 			  type_info_bytes / 1024, " KiB)");
+	FLASH_LOG(General, Info, "  TypeInfo layout breakdown (bytes): ",
+			  "TemplateArgInfo=", sizeof(TypeInfo::TemplateArgInfo),
+			  ", InlineVector<TemplateArgInfo,4>=", sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
+			  ", DependentQualifiedNameRecord=", sizeof(TypeInfo::DependentQualifiedNameRecord),
+			  ", dependent_qualified_name_index_=", sizeof(uint32_t),
+			  ", InstantiationContext=", sizeof(TypeInfo::InstantiationContext),
+			  ", FunctionSignature=", sizeof(FunctionSignature),
+			  ", optional<FunctionSignature>=", sizeof(std::optional<FunctionSignature>),
+			  ", optional<ASTNode>=", sizeof(std::optional<ASTNode>));
+
+	size_t types_with_template_args = 0;
+	size_t types_with_dependent_qualified_name = 0;
+	size_t types_with_instantiation_context = 0;
+	size_t types_with_struct_info = 0;
+	size_t types_with_alias_spec = 0;
+	for (size_t i = 0; i < type_info_count; ++i) {
+		const TypeInfo& info = gTypeInfo[i];
+		if (!info.templateArgs().empty()) {
+			++types_with_template_args;
+		}
+		if (info.hasDependentQualifiedName()) {
+			++types_with_dependent_qualified_name;
+		}
+		if (info.hasInstantiationContext()) {
+			++types_with_instantiation_context;
+		}
+		if (info.getStructInfo() != nullptr) {
+			++types_with_struct_info;
+		}
+		if (info.aliasTypeSpecifier() != nullptr) {
+			++types_with_alias_spec;
+		}
+	}
+	FLASH_LOG(General, Info, "  TypeInfo payload usage: with_template_args=", types_with_template_args,
+			  ", with_dependent_qualified_name=", types_with_dependent_qualified_name,
+			  ", with_instantiation_context=", types_with_instantiation_context,
+			  ", with_struct_info=", types_with_struct_info,
+			  ", with_alias_spec=", types_with_alias_spec);
+	FLASH_LOG(General, Info, "  gDependentQualifiedNameRecords: entries=",
+			  getDependentQualifiedNameRecordCount(),
+			  ", record_bytes=", sizeof(TypeInfo::DependentQualifiedNameRecord),
+			  ", estimated cold storage=",
+			  getDependentQualifiedNameRecordCount() * sizeof(TypeInfo::DependentQualifiedNameRecord),
+			  " bytes");
 
 	// Break down entries by category
 	size_t cat_struct = 0, cat_enum = 0, cat_alias = 0, cat_native = 0, cat_other = 0;

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1262,7 +1262,10 @@ struct TypeInfo {
 
 	InlineVector<TemplateArgInfo, 4> template_args_;
 
-	std::optional<DependentQualifiedNameRecord> dependent_qualified_name_;
+	// Index into gDependentQualifiedNameRecords. UINT32_MAX = none.
+	// Keeps the fat DependentQualifiedNameRecord (~6KB) out of every TypeInfo row.
+	static constexpr uint32_t kNoDependentQualifiedName = UINT32_MAX;
+	uint32_t dependent_qualified_name_index_ = kNoDependentQualifiedName;
 
  // Type-owned instantiation context (non-null for template instantiations
  // and for types nested inside a template instantiation).
@@ -1281,8 +1284,10 @@ struct TypeInfo {
 	StringHandle baseTemplateName() const { return base_template_.identifier_handle; }
 	NamespaceHandle sourceNamespace() const { return base_template_.namespace_handle; }
 	const InlineVector<TemplateArgInfo, 4>& templateArgs() const { return template_args_; }
-	bool hasDependentQualifiedName() const { return dependent_qualified_name_.has_value(); }
-	const DependentQualifiedNameRecord* dependentQualifiedName() const { return dependent_qualified_name_ ? &*dependent_qualified_name_ : nullptr; }
+	bool hasDependentQualifiedName() const;
+	const DependentQualifiedNameRecord* dependentQualifiedName() const;
+	void clearDependentQualifiedName();
+	void setDependentQualifiedName(DependentQualifiedNameRecord record);
 
 	// Access the type-owned instantiation context (may be null).
 	const InstantiationContext* instantiationContext() const { return instantiation_context_.get(); }
@@ -1316,9 +1321,6 @@ struct TypeInfo {
 	void setAliasTypeSpecifier(const TypeSpecifierNode& type_spec);
 	void clearDeferredDecltypeExpression();
 	void setDeferredDecltypeExpression(const ASTNode& expr);
-	void setDependentQualifiedName(DependentQualifiedNameRecord record) {
-		dependent_qualified_name_ = std::move(record);
-	}
 
 	// Set the type-owned instantiation context for template instantiations.
 	void setInstantiationContext(InlineVector<StringHandle, 4> param_names,
@@ -1389,6 +1391,12 @@ struct TypeInfo {
 	bool isDependentMemberType() const { return placeholder_kind_ == DependentPlaceholderKind::DependentMemberType; }
 	bool isDependentPlaceholder() const { return placeholder_kind_ != DependentPlaceholderKind::None; }
 };
+
+// Cold arena for DependentQualifiedNameRecord. Indices are stable; chunks stay packed
+// for linear/scattered reads without a unique_ptr malloc per record.
+uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record);
+const TypeInfo::DependentQualifiedNameRecord* getDependentQualifiedNameRecord(uint32_t index);
+size_t getDependentQualifiedNameRecordCount();
 
 // Returned by add_user_type / add_function_type / add_struct_type / add_enum_type /
 // register_type_alias so callers can capture both the TypeInfo reference AND the
@@ -2434,12 +2442,14 @@ public:
 	std::string_view name() const { return identifier_.value(); }
 	StringHandle nameHandle() const { return identifier_.handle(); }
 	const Token& identifier_token() const { return identifier_; }
-	bool hasDependentQualifiedName() const { return dependent_qualified_name_.has_value(); }
+	bool hasDependentQualifiedName() const {
+		return dependent_qualified_name_index_ != TypeInfo::kNoDependentQualifiedName;
+	}
 	const TypeInfo::DependentQualifiedNameRecord* dependentQualifiedName() const {
-		return dependent_qualified_name_ ? &*dependent_qualified_name_ : nullptr;
+		return getDependentQualifiedNameRecord(dependent_qualified_name_index_);
 	}
 	void setDependentQualifiedName(TypeInfo::DependentQualifiedNameRecord record) {
-		dependent_qualified_name_ = std::move(record);
+		dependent_qualified_name_index_ = storeDependentQualifiedNameRecord(std::move(record));
 	}
 	void set_template_arguments(std::vector<ASTNode>&& template_args) {
 		template_arguments_ = std::move(template_args);
@@ -2467,7 +2477,7 @@ public:
 private:
 	NamespaceHandle namespace_handle_;  // Handle to namespace, e.g., handle for "std" in std::print
 	Token identifier_;				   // The final identifier (e.g., "print", "func")
-	std::optional<TypeInfo::DependentQualifiedNameRecord> dependent_qualified_name_;
+	uint32_t dependent_qualified_name_index_ = TypeInfo::kNoDependentQualifiedName;
 	std::vector<ASTNode> template_arguments_;
 };
 
@@ -3203,13 +3213,14 @@ public:
 	}
 	void set_dependent_qualified_lookup_record(
 		const TypeInfo::DependentQualifiedNameRecord& record) {
-		dependent_qualified_lookup_record_ = record;
+		dependent_qualified_lookup_record_index_ =
+			storeDependentQualifiedNameRecord(record);
 	}
-	const std::optional<TypeInfo::DependentQualifiedNameRecord>& dependent_qualified_lookup_record() const {
-		return dependent_qualified_lookup_record_;
+	const TypeInfo::DependentQualifiedNameRecord* dependent_qualified_lookup_record() const {
+		return getDependentQualifiedNameRecord(dependent_qualified_lookup_record_index_);
 	}
 	bool has_dependent_qualified_lookup_record() const {
-		return dependent_qualified_lookup_record_.has_value();
+		return dependent_qualified_lookup_record_index_ != TypeInfo::kNoDependentQualifiedName;
 	}
 
 private:
@@ -3223,7 +3234,7 @@ private:
 	std::optional<TypeSpecifierNode> parser_return_type_hint_;
 	std::optional<FunctionCallDefinitionLookupRecord> definition_lookup_record_;
 	std::optional<DependentUnqualifiedCallLookupRecord> dependent_unqualified_lookup_record_;
-	std::optional<TypeInfo::DependentQualifiedNameRecord> dependent_qualified_lookup_record_;
+	uint32_t dependent_qualified_lookup_record_index_ = TypeInfo::kNoDependentQualifiedName;
 };
 
 // Constructor call node - represents constructor calls like T(args)

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1272,9 +1272,10 @@ struct TypeInfo {
 	static constexpr uint32_t kNoDependentQualifiedName = UINT32_MAX;
 	uint32_t dependent_qualified_name_index_ = kNoDependentQualifiedName;
 
- // Type-owned instantiation context (non-null for template instantiations
- // and for types nested inside a template instantiation).
-	std::unique_ptr<InstantiationContext> instantiation_context_;
+	// Index into gInstantiationContexts. UINT32_MAX = none.
+	// Keeps InstantiationContext out of every TypeInfo row.
+	static constexpr uint32_t kNoInstantiationContext = UINT32_MAX;
+	uint32_t instantiation_context_index_ = kNoInstantiationContext;
 
 	StringHandle name() const {
 		return name_;
@@ -1296,10 +1297,11 @@ struct TypeInfo {
 	void setDependentQualifiedName(DependentQualifiedNameRecord record);
 
 	// Access the type-owned instantiation context (may be null).
-	const InstantiationContext* instantiationContext() const { return instantiation_context_.get(); }
-	bool hasInstantiationContext() const { return instantiation_context_ != nullptr; }
+	const InstantiationContext* instantiationContext() const;
+	bool hasInstantiationContext() const { return instantiation_context_index_ != kNoInstantiationContext; }
+	void clearInstantiationContext() { instantiation_context_index_ = kNoInstantiationContext; }
 	const TemplateArgInfo* findLegacyInstantiationArgByName(std::string_view param_name) const {
-		for (const auto* inst_ctx = instantiation_context_.get(); inst_ctx; inst_ctx = inst_ctx->parent) {
+		for (const auto* inst_ctx = instantiationContext(); inst_ctx; inst_ctx = inst_ctx->parent) {
 			const auto& args = inst_ctx->param_args();
 			size_t param_count = inst_ctx->param_names.size();
 			if (args.size() < param_count) {
@@ -1406,6 +1408,12 @@ size_t getDependentQualifiedNameRecordCount();
 uint32_t storeTypeInfoTemplateArgs(InlineVector<TypeInfo::TemplateArgInfo, 4> args);
 const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32_t index);
 size_t getTypeInfoTemplateArgsCount();
+
+// Cold arena for TypeInfo::InstantiationContext.
+uint32_t storeInstantiationContext(TypeInfo::InstantiationContext ctx);
+const TypeInfo::InstantiationContext* getInstantiationContext(uint32_t index);
+TypeInfo::InstantiationContext* getInstantiationContextMut(uint32_t index);
+size_t getInstantiationContextCount();
 
 // Returned by add_user_type / add_function_type / add_struct_type / add_enum_type /
 // register_type_alias so callers can capture both the TypeInfo reference AND the

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1240,6 +1240,8 @@ struct TypeInfo {
  // (codegen, constexpr evaluation) can resolve template bindings without
  // registry-name reconstruction.  For nested types inside a template
  // instantiation, `parent` points to the enclosing type's context.
+	static constexpr uint32_t kNoTemplateArgs = UINT32_MAX;
+
 	struct InstantiationContext {
 		struct Binding {
 			StringHandle name;
@@ -1253,16 +1255,16 @@ struct TypeInfo {
 
 		// Legacy fields for compatibility (populated in parallel during transition)
 		InlineVector<StringHandle, 4> param_names; // Template parameter names (e.g., "T", "U")
-		InlineVector<TemplateArgInfo, 4> param_args; // Concrete template arguments
+		uint32_t param_args_index = kNoTemplateArgs;
+
+		const InlineVector<TemplateArgInfo, 4>& param_args() const;
 
 		// Phase 5 accessors
 		bool hasInstantiationContextBindings() const { return !bindings.empty(); }
 		size_t getInstantiationContextBindingsCount() const { return bindings.size(); }
 	};
 
-	// Index into gTypeInfoTemplateArgLists. UINT32_MAX = none/empty.
 	// Keeps InlineVector<TemplateArgInfo,4> (~1.2KB) out of every TypeInfo row.
-	static constexpr uint32_t kNoTemplateArgs = UINT32_MAX;
 	uint32_t template_args_index_ = kNoTemplateArgs;
 
 	// Index into gDependentQualifiedNameRecords. UINT32_MAX = none.
@@ -1298,13 +1300,14 @@ struct TypeInfo {
 	bool hasInstantiationContext() const { return instantiation_context_ != nullptr; }
 	const TemplateArgInfo* findLegacyInstantiationArgByName(std::string_view param_name) const {
 		for (const auto* inst_ctx = instantiation_context_.get(); inst_ctx; inst_ctx = inst_ctx->parent) {
+			const auto& args = inst_ctx->param_args();
 			size_t param_count = inst_ctx->param_names.size();
-			if (inst_ctx->param_args.size() < param_count) {
-				param_count = inst_ctx->param_args.size();
+			if (args.size() < param_count) {
+				param_count = args.size();
 			}
 			for (size_t param_index = 0; param_index < param_count; ++param_index) {
 				if (StringTable::getStringView(inst_ctx->param_names[param_index]) == param_name) {
-					return &inst_ctx->param_args[param_index];
+					return &args[param_index];
 				}
 			}
 		}

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1260,7 +1260,10 @@ struct TypeInfo {
 		size_t getInstantiationContextBindingsCount() const { return bindings.size(); }
 	};
 
-	InlineVector<TemplateArgInfo, 4> template_args_;
+	// Index into gTypeInfoTemplateArgLists. UINT32_MAX = none/empty.
+	// Keeps InlineVector<TemplateArgInfo,4> (~1.2KB) out of every TypeInfo row.
+	static constexpr uint32_t kNoTemplateArgs = UINT32_MAX;
+	uint32_t template_args_index_ = kNoTemplateArgs;
 
 	// Index into gDependentQualifiedNameRecords. UINT32_MAX = none.
 	// Keeps the fat DependentQualifiedNameRecord (~6KB) out of every TypeInfo row.
@@ -1283,7 +1286,8 @@ struct TypeInfo {
 	bool isTemplateInstantiation() const { return base_template_.valid(); }
 	StringHandle baseTemplateName() const { return base_template_.identifier_handle; }
 	NamespaceHandle sourceNamespace() const { return base_template_.namespace_handle; }
-	const InlineVector<TemplateArgInfo, 4>& templateArgs() const { return template_args_; }
+	const InlineVector<TemplateArgInfo, 4>& templateArgs() const;
+	void clearTemplateArgs();
 	bool hasDependentQualifiedName() const;
 	const DependentQualifiedNameRecord* dependentQualifiedName() const;
 	void clearDependentQualifiedName();
@@ -1312,10 +1316,7 @@ struct TypeInfo {
 		return deferred_decltype_expression_.has_value() ? &*deferred_decltype_expression_ : nullptr;
 	}
 
-	void setTemplateInstantiationInfo(QualifiedIdentifier base_template, InlineVector<TemplateArgInfo, 4> args) {
-		base_template_ = base_template;
-		template_args_ = std::move(args);
-	}
+	void setTemplateInstantiationInfo(QualifiedIdentifier base_template, InlineVector<TemplateArgInfo, 4> args);
 
 	void clearAliasTypeSpecifier();
 	void setAliasTypeSpecifier(const TypeSpecifierNode& type_spec);
@@ -1397,6 +1398,11 @@ struct TypeInfo {
 uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record);
 const TypeInfo::DependentQualifiedNameRecord* getDependentQualifiedNameRecord(uint32_t index);
 size_t getDependentQualifiedNameRecordCount();
+
+// Cold arena for TypeInfo template-argument lists (InlineVector<TemplateArgInfo,4>).
+uint32_t storeTypeInfoTemplateArgs(InlineVector<TypeInfo::TemplateArgInfo, 4> args);
+const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32_t index);
+size_t getTypeInfoTemplateArgsCount();
 
 // Returned by add_user_type / add_function_type / add_struct_type / add_enum_type /
 // register_type_alias so callers can capture both the TypeInfo reference AND the

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1231,7 +1231,7 @@ private:
 		}
 
 		for (const auto* inst_ctx = type_info->instantiationContext(); inst_ctx; inst_ctx = inst_ctx->parent) {
-			if (!inst_ctx->param_names.empty() || !inst_ctx->param_args.empty()) {
+			if (!inst_ctx->param_names.empty() || !inst_ctx->param_args().empty()) {
 				return true;
 			}
 		}

--- a/src/CallNodeHelpers.h
+++ b/src/CallNodeHelpers.h
@@ -158,7 +158,7 @@ struct CallInfo {
 	const std::optional<TypeSpecifierNode>* parser_return_type_hint;
 	const std::optional<FunctionCallDefinitionLookupRecord>* definition_lookup_record;
 	const std::optional<DependentUnqualifiedCallLookupRecord>* dependent_unqualified_lookup_record;
-	const std::optional<TypeInfo::DependentQualifiedNameRecord>* dependent_qualified_lookup_record;
+	const TypeInfo::DependentQualifiedNameRecord* dependent_qualified_lookup_record;
 	bool is_indirect;
 
 	// --- Factory helpers ---------------------------------------------------
@@ -179,7 +179,7 @@ struct CallInfo {
 		info.dependent_unqualified_lookup_record =
 			&node.dependent_unqualified_lookup_record();
 		info.dependent_qualified_lookup_record =
-			&node.dependent_qualified_lookup_record();
+			node.dependent_qualified_lookup_record();
 		info.is_indirect           = node.callee().is_indirect();
 		return info;
 	}
@@ -241,10 +241,9 @@ inline void copyCallMetadataFromInfo(
 			**source.dependent_unqualified_lookup_record);
 	}
 	if (options.copy_dependent_qualified_lookup_record &&
-		source.dependent_qualified_lookup_record != nullptr &&
-		source.dependent_qualified_lookup_record->has_value()) {
+		source.dependent_qualified_lookup_record != nullptr) {
 		target.set_dependent_qualified_lookup_record(
-			**source.dependent_qualified_lookup_record);
+			*source.dependent_qualified_lookup_record);
 	}
 }
 

--- a/src/ConstExprEvalHelpers.cpp
+++ b/src/ConstExprEvalHelpers.cpp
@@ -508,8 +508,8 @@ std::optional<TemplateTypeArg> trySubstituteDependentTemplateArgForLookup(
 			", owner_has_inst_ctx=", (owner_type_info != nullptr && owner_type_info->hasInstantiationContext()));
 		if (owner_type_info != nullptr && owner_type_info->hasInstantiationContext()) {
 			const auto* inst_ctx = owner_type_info->instantiationContext();
-			for (size_t i = 0; i < inst_ctx->param_names.size() && i < inst_ctx->param_args.size(); ++i) {
-				const TemplateTypeArg arg = toTemplateTypeArg(inst_ctx->param_args[i]);
+			for (size_t i = 0; i < inst_ctx->param_names.size() && i < inst_ctx->param_args().size(); ++i) {
+				const TemplateTypeArg arg = toTemplateTypeArg(inst_ctx->param_args()[i]);
 				FLASH_LOG(ConstExpr, Debug, "  owner inst_ctx[", i, "] name=",
 					StringTable::getStringView(inst_ctx->param_names[i]),
 					", is_value=", arg.is_value,

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -5461,11 +5461,11 @@ void Evaluator::load_template_bindings_from_type(const TypeInfo* source_type, Ev
 		context.template_param_names.clear();
 		context.template_args.clear();
 		context.template_param_names.reserve(inst_ctx->param_names.size());
-		context.template_args.reserve(inst_ctx->param_args.size());
+		context.template_args.reserve(inst_ctx->param_args().size());
 		for (StringHandle h : inst_ctx->param_names) {
 			context.template_param_names.push_back(StringTable::getStringView(h));
 		}
-		for (const auto& arg_info : inst_ctx->param_args) {
+		for (const auto& arg_info : inst_ctx->param_args()) {
 			context.template_args.push_back(toTemplateTypeArg(arg_info));
 		}
 		return;

--- a/src/ConstExprEvaluator_MemberAccess.cpp
+++ b/src/ConstExprEvaluator_MemberAccess.cpp
@@ -812,9 +812,9 @@ EvalResult Evaluator::evaluate_qualified_identifier(const QualifiedIdentifierNod
 				if (IS_FLASH_LOG_ENABLED(ConstExpr, Debug)) {
 					FLASH_LOG(ConstExpr, Debug, "Static lookup in struct '", StringTable::getStringView(struct_handle), "', bases=", struct_info->base_classes.size());
 					if (resolved_type_info) {
-						FLASH_LOG(ConstExpr, Debug, "Resolved type base template='", StringTable::getStringView(resolved_type_info->baseTemplateName()), "', template args=", resolved_type_info->template_args_.size());
-						for (size_t i = 0; i < resolved_type_info->template_args_.size(); ++i) {
-							const auto& arg = resolved_type_info->template_args_[i];
+						FLASH_LOG(ConstExpr, Debug, "Resolved type base template='", StringTable::getStringView(resolved_type_info->baseTemplateName()), "', template args=", resolved_type_info->templateArgs().size());
+						for (size_t i = 0; i < resolved_type_info->templateArgs().size(); ++i) {
+							const auto& arg = resolved_type_info->templateArgs()[i];
 							FLASH_LOG(ConstExpr, Debug, "  resolved arg[", i, "] is_value=", arg.is_value, ", category=", static_cast<int>(arg.category()), ", type_index=", arg.type_index, ", value(int)=", arg.intValue());
 						}
 					}

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -23,11 +23,11 @@ ConstExpr::EvaluationContext AstToIr::makeEvalContext(const SymbolTable& symbols
 				if (const auto* inst_ctx = struct_type_info->instantiationContext()) {
 					ctx.template_environment = buildTemplateEnvironment(*inst_ctx);
 					ctx.template_param_names.reserve(inst_ctx->param_names.size());
-					ctx.template_args.reserve(inst_ctx->param_args.size());
+					ctx.template_args.reserve(inst_ctx->param_args().size());
 					for (StringHandle param_name : inst_ctx->param_names) {
 						ctx.template_param_names.push_back(StringTable::getStringView(param_name));
 					}
-					for (const auto& arg_info : inst_ctx->param_args) {
+					for (const auto& arg_info : inst_ctx->param_args()) {
 						ctx.template_args.push_back(toTemplateTypeArg(arg_info));
 					}
 				}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -1039,7 +1039,7 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveCurr
 	} else if (current_type_info != nullptr &&
 			   current_type_info->hasInstantiationContext()) {
 		current_param_names = &current_type_info->instantiationContext()->param_names;
-		current_concrete_args = &current_type_info->instantiationContext()->param_args;
+		current_concrete_args = &current_type_info->instantiationContext()->param_args();
 	}
 
 	if (current_param_names != nullptr && !current_param_names->empty()) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -1079,31 +1079,31 @@ std::optional<OuterTemplateBinding> Parser::buildOuterBindingForOwner(StringHand
 
 	const size_t pair_count = std::min(
 		owner_context->param_names.size(),
-		owner_context->param_args.size());
+		owner_context->param_args().size());
 	if (pair_count == 0) {
 		return std::nullopt;
 	}
-	if (owner_context->param_names.size() != owner_context->param_args.size()) {
+	if (owner_context->param_names.size() != owner_context->param_args().size()) {
 		FLASH_LOG_FORMAT(
 			Templates,
 			Warning,
 			"Outer binding size mismatch for '{}': names={}, args={}",
 			StringTable::getStringView(owner_name),
 			owner_context->param_names.size(),
-			owner_context->param_args.size());
+			owner_context->param_args().size());
 	}
 
 	OuterTemplateBinding binding;
 	binding.param_names.reserve(pair_count);
 	binding.param_args.reserve(pair_count);
-	binding.all_args.reserve(owner_context->param_args.size());
+	binding.all_args.reserve(owner_context->param_args().size());
 	for (size_t i = 0; i < pair_count; ++i) {
 		binding.param_names.push_back(owner_context->param_names[i]);
-		TemplateTypeArg arg = toTemplateTypeArg(owner_context->param_args[i]);
-		arg.setCategory(owner_context->param_args[i].category());
+		TemplateTypeArg arg = toTemplateTypeArg(owner_context->param_args()[i]);
+		arg.setCategory(owner_context->param_args()[i].category());
 		binding.param_args.push_back(arg);
 	}
-	for (const TypeInfo::TemplateArgInfo& owner_arg : owner_context->param_args) {
+	for (const TypeInfo::TemplateArgInfo& owner_arg : owner_context->param_args()) {
 		TemplateTypeArg arg = toTemplateTypeArg(owner_arg);
 		arg.setCategory(owner_arg.category());
 		binding.all_args.push_back(arg);

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -127,7 +127,7 @@ static void appendInstantiationContextBindingsToSubstitutionMap(
 	}
 	for (size_t i = 0;
 		 i < context->param_names.size() &&
-		 i < context->param_args.size();
+		 i < context->param_args().size();
 		 ++i) {
 		if (!context->param_names[i].isValid()) {
 			continue;
@@ -141,7 +141,7 @@ static void appendInstantiationContextBindingsToSubstitutionMap(
 			sub_map.param_order.end()) {
 			sub_map.param_order.push_back(binding_name);
 			sub_map.param_map[binding_name] =
-				toTemplateTypeArg(context->param_args[i]);
+				toTemplateTypeArg(context->param_args()[i]);
 		}
 	}
 }

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2297,16 +2297,16 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			}
 			self(self, current_ctx->parent);
 			size_t binding_count = current_ctx->param_names.size();
-			if (current_ctx->param_args.size() < binding_count) {
-				binding_count = current_ctx->param_args.size();
+			if (current_ctx->param_args().size() < binding_count) {
+				binding_count = current_ctx->param_args().size();
 			}
 			for (size_t binding_index = 0; binding_index < binding_count; ++binding_index) {
 				ctx_params.push_back(
 					rebuildOuterTemplateParameter(
 						current_ctx->param_names[binding_index],
-						current_ctx->param_args[binding_index]));
+						current_ctx->param_args()[binding_index]));
 				ctx_args.push_back(
-					toTemplateTypeArg(current_ctx->param_args[binding_index]));
+					toTemplateTypeArg(current_ctx->param_args()[binding_index]));
 			}
 		};
 		append_instantiation_context(append_instantiation_context, inst_ctx);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -2617,7 +2617,7 @@ Parser::AliasTemplateMaterializationResult Parser::materializeCanonicalOwnerType
 	if (canonical_owner_type_info->hasInstantiationContext() &&
 		canonical_owner_type_info->instantiationContext() != nullptr &&
 		try_materialize_exact_owner(
-			canonical_owner_type_info->instantiationContext()->param_args)) {
+			canonical_owner_type_info->instantiationContext()->param_args())) {
 		return result;
 	}
 
@@ -2776,11 +2776,11 @@ OuterTemplateBinding Parser::buildAccumulatedOuterTemplateBinding(
 		for (size_t i = 0;
 			 instantiation_context != nullptr &&
 			 i < instantiation_context->param_names.size() &&
-			 i < instantiation_context->param_args.size();
+			 i < instantiation_context->param_args().size();
 			 ++i) {
 			overlay_binding(
 				instantiation_context->param_names[i],
-				toTemplateTypeArg(instantiation_context->param_args[i]));
+				toTemplateTypeArg(instantiation_context->param_args()[i]));
 		}
 	}
 
@@ -5466,7 +5466,7 @@ std::optional<TemplateTypeArg> Parser::evaluateDependentNTTPExpression(
 			}
 			const TypeInfo::InstantiationContext* inst_ctx =
 				type_info->instantiationContext();
-			for (const TypeInfo::TemplateArgInfo& arg_info : inst_ctx->param_args) {
+			for (const TypeInfo::TemplateArgInfo& arg_info : inst_ctx->param_args()) {
 				TemplateTypeArg arg = toTemplateTypeArg(arg_info);
 				if (arg.is_dependent || arg.dependent_name.isValid()) {
 					continue;

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1379,7 +1379,7 @@ ParseResult Parser::parse_type_specifier() {
 							const TypeInfo::InstantiationContext* target_context = alias_target_info->instantiationContext();
 							placeholder_type.setInstantiationContext(
 								target_context->param_names,
-								target_context->param_args,
+								InlineVector<TypeInfo::TemplateArgInfo, 4>(target_context->param_args()),
 								target_context->parent);
 						}
 						getTypesByNameMap()[target_member_handle] = &placeholder_type;
@@ -1492,7 +1492,7 @@ ParseResult Parser::parse_type_specifier() {
 							owner_type_info->instantiationContext();
 						placeholder_type.setInstantiationContext(
 							owner_context->param_names,
-							owner_context->param_args,
+							InlineVector<TypeInfo::TemplateArgInfo, 4>(owner_context->param_args()),
 							owner_context->parent);
 					}
 					getTypesByNameMap()[type_handle] = &placeholder_type;
@@ -1512,7 +1512,7 @@ ParseResult Parser::parse_type_specifier() {
 							owner_type_info->instantiationContext();
 						type_it->second->setInstantiationContext(
 							owner_context->param_names,
-							owner_context->param_args,
+							InlineVector<TypeInfo::TemplateArgInfo, 4>(owner_context->param_args()),
 							owner_context->parent);
 					}
 					type_idx = type_it->second->type_index_;
@@ -1708,7 +1708,7 @@ ParseResult Parser::parse_type_specifier() {
 							} else if (base_context != nullptr) {
 								member_type_info.setInstantiationContext(
 									base_context->param_names,
-									base_context->param_args,
+									InlineVector<TypeInfo::TemplateArgInfo, 4>(base_context->param_args()),
 									base_context->parent);
 							}
 						};
@@ -2782,7 +2782,7 @@ ParseResult Parser::parse_type_specifier() {
 								const auto* base_ctx = base_type_it->second->instantiationContext();
 								type_info.setInstantiationContext(
 									base_ctx->param_names,
-									base_ctx->param_args,
+									InlineVector<TypeInfo::TemplateArgInfo, 4>(base_ctx->param_args()),
 									base_ctx->parent);
 							}
 						}
@@ -3226,7 +3226,7 @@ ParseResult Parser::parse_type_specifier() {
 										const TypeInfo::InstantiationContext* existing_context =
 											instantiated_type_info->instantiationContext();
 										merged_param_names = existing_context->param_names;
-										merged_param_args = existing_context->param_args;
+										merged_param_args = existing_context->param_args();
 									}
 									const auto alias_arg_infos =
 										convertToTemplateArgInfo(*member_template_args);

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8352,8 +8352,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		resolveDefinitionLookupRecordTarget();
 	const bool has_deferred_qualified_template_metadata =
 		!call_info.template_arguments.empty() ||
-		(call_info.dependent_qualified_lookup_record != nullptr &&
-		 call_info.dependent_qualified_lookup_record->has_value());
+		call_info.dependent_qualified_lookup_record != nullptr;
 	struct QualifiedLookupTarget {
 		NamespaceHandle namespace_handle;
 		std::string_view identifier;
@@ -8415,10 +8414,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 	};
 	auto resolveQualifiedOwnerTypeForCall = [&](std::string_view owner_name) -> const TypeInfo* {
-		if (call_info.dependent_qualified_lookup_record != nullptr &&
-			call_info.dependent_qualified_lookup_record->has_value()) {
+		if (call_info.dependent_qualified_lookup_record != nullptr) {
 			const TypeInfo::DependentQualifiedNameRecord& dependent_record =
-				**call_info.dependent_qualified_lookup_record;
+				*call_info.dependent_qualified_lookup_record;
 			if (dependent_record.owner_type.is_valid()) {
 				if (const TypeInfo* owner_from_record = tryGetTypeInfo(dependent_record.owner_type)) {
 					return tryResolveStructOwnerTypeInfo(owner_from_record);

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -219,11 +219,11 @@ void appendContextBindings(
 		return;
 	}
 
-	const size_t binding_count = std::min(context->param_names.size(), context->param_args.size());
+	const size_t binding_count = std::min(context->param_names.size(), context->param_args().size());
 	for (size_t i = 0; i < binding_count;) {
 		TemplateBinding binding;
 		binding.name = context->param_names[i];
-		TemplateTypeArg arg = toTemplateTypeArg(context->param_args[i]);
+		TemplateTypeArg arg = toTemplateTypeArg(context->param_args()[i]);
 		binding.kind = inferBindingKind(arg);
 		binding.is_pack = arg.is_pack;
 		binding.args.push_back(std::move(arg));
@@ -231,7 +231,7 @@ void appendContextBindings(
 		size_t next_index = i + 1;
 		while (next_index < binding_count && context->param_names[next_index] == binding.name) {
 			binding.is_pack = true;
-			binding.args.push_back(toTemplateTypeArg(context->param_args[next_index]));
+			binding.args.push_back(toTemplateTypeArg(context->param_args()[next_index]));
 			++next_index;
 		}
 		out_bindings.push_back(std::move(binding));

--- a/src/TypeSizeQuery.h
+++ b/src/TypeSizeQuery.h
@@ -86,9 +86,9 @@ inline int queryInstantiationContextBindingSizeBits(
 				}
 			}
 		}
-		for (size_t i = 0; i < current->param_names.size() && i < current->param_args.size(); ++i) {
+		for (size_t i = 0; i < current->param_names.size() && i < current->param_args().size(); ++i) {
 			if (current->param_names[i] == name) {
-				const int binding_size_bits = queryTemplateArgInfoObjectSizeBits(current->param_args[i]);
+				const int binding_size_bits = queryTemplateArgInfoObjectSizeBits(current->param_args()[i]);
 				if (binding_size_bits > 0) {
 					return binding_size_bits;
 				}


### PR DESCRIPTION
## Summary
- Move rare/fat `TypeInfo` payloads (`DependentQualifiedNameRecord`, `template_args`, `InstantiationContext`) into shared `ChunkedVector` cold arenas, leaving a slim hot row (`sizeof(TypeInfo)` 7800 → 192).
- Share arena indices on alias metadata copy to avoid duplicating cold records.
- Same API surface for callers (`templateArgs()`, `param_args()`, pointer accessors); QualId/CallExpr dependent-qualified records use the DQN arena too.

## Performance (warm median, 5 runs, branch vs main)
- `type_traits`: TOTAL **−28%**, peak WS **137 → 108 MB**
- `concepts`: TOTAL **−29%**
- `iterator` / `limits` (still erroring): wall **~−36%**, peak WS **471 → 257 MB** / **314 → 192 MB**

## Test plan
- [x] `./tests/run_all_tests.ps1` — 2769 regular + 240 `_fail`, all green
- [x] Warm-median `-time` compare vs main on `type_traits`, `concepts`, `limits`, `iterator`
- [ ] CI

Made with [Cursor](https://cursor.com)