### PR TITLE
Parse noexcept PMF and move .* / ->* to pm-expression layer

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3484,10 +3484,11 @@ private:	 // Resume private methods
 	ParseResult parse_primary_expression(ExpressionContext context);
 	ParseResult parse_postfix_expression(ExpressionContext context);	 // Phase 3: New postfix operator layer
 	ParseResult apply_postfix_operators(ASTNode& result);  // Apply postfix operators (., ->, [], (), ++, --) to existing result
-	ParseResult applyPointerToMemberPostfixAfterDotOrArrow(
-		std::optional<ASTNode>& result,
-		Token operator_token,
-		bool is_arrow);
+	// C++ [expr.mptr.oper]: pm-expression sits between cast/unary and multiplicative.
+	// Applies left-associative .* / ->* with cast-expression RHS (parse_unary_expression).
+	ParseResult apply_pointer_to_member_operators(ASTNode start_result, ExpressionContext context);
+	// True when peek is '.' or '->' immediately followed by '*' (.* / ->*).
+	bool peek_is_pointer_to_member_operator();
 	std::optional<ASTNode> try_synthesize_atomic_builtin_overload(std::string_view builtin_name, std::span<const TypeSpecifierNode> arg_types, const Token& call_token);
 	void finalizePostfixCallExpression(
 		std::optional<ASTNode>& result,

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3484,6 +3484,10 @@ private:	 // Resume private methods
 	ParseResult parse_primary_expression(ExpressionContext context);
 	ParseResult parse_postfix_expression(ExpressionContext context);	 // Phase 3: New postfix operator layer
 	ParseResult apply_postfix_operators(ASTNode& result);  // Apply postfix operators (., ->, [], (), ++, --) to existing result
+	ParseResult applyPointerToMemberPostfixAfterDotOrArrow(
+		std::optional<ASTNode>& result,
+		Token operator_token,
+		bool is_arrow);
 	std::optional<ASTNode> try_synthesize_atomic_builtin_overload(std::string_view builtin_name, std::span<const TypeSpecifierNode> arg_types, const Token& call_token);
 	void finalizePostfixCallExpression(
 		std::optional<ASTNode>& result,
@@ -3549,6 +3553,9 @@ private:	 // Resume private methods
 		std::span<const TemplateTypeArg> template_args,
 		std::string_view template_name,
 		const Token& identifier_token);
+	ParseResult tryParseExplicitTemplateBraceInitialization(
+		const Token& identifier_token,
+		const InlineVector<TemplateTypeArg, 4>& explicit_template_args);
 
 	// Helper to parse member template function calls: Template<T>::member<U>()
 	// Returns:

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -398,6 +398,16 @@ ParseResult Parser::parse_expression(int precedence, ExpressionContext context) 
 		return result;
 	}
 
+	// Pointer-to-member (.* / ->*) binds weaker than unary/cast and stronger than
+	// multiplicative operators. Apply it here so every Pratt entry (including
+	// high min-precedence RHS parses) still forms pm-expressions correctly.
+	if (result.node().has_value()) {
+		result = apply_pointer_to_member_operators(*result.node(), context);
+		if (result.is_error()) {
+			return result;
+		}
+	}
+
 	auto isParserAtSameToken = [](const Token& lhs, const Token& rhs) {
 		return lhs.type() == rhs.type() &&
 			   lhs.value() == rhs.value() &&
@@ -1184,6 +1194,11 @@ int Parser::get_operator_precedence(const std::string_view& op) {
 	// C++ operator precedence (higher number = higher precedence)
 	// Standard precedence order: Shift > Three-Way (<=>)  > Relational
 	static const std::unordered_map<std::string_view, int> precedence_map = {
+			// Pointer-to-member (precedence 18) — above multiplicative.
+			// Lexer emits '.'/'->' + '*' separately; handled in apply_pointer_to_member_operators.
+			// Entries kept for documentation / fold-operator completeness if fused later.
+		{".*", 18},
+		{"->*", 18},
 			// Multiplicative (precedence 17)
 		{"*", 17},
 		{"/", 17},

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1493,6 +1493,30 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 	return ParseResult::success(*result);
 }
 
+ParseResult Parser::applyPointerToMemberPostfixAfterDotOrArrow(
+	std::optional<ASTNode>& result,
+	Token operator_token,
+	bool is_arrow) {
+	if (peek() != "*"_tok) {
+		return ParseResult();
+	}
+	advance(); // consume '*'
+
+	ParseResult member_ptr_result = parse_expression(17, ExpressionContext::Normal);
+	if (member_ptr_result.is_error()) {
+		return member_ptr_result;
+	}
+	if (!member_ptr_result.node().has_value()) {
+		return ParseResult::error(
+			is_arrow ? "Expected expression after '->*' operator" : "Expected expression after '.*' operator",
+			current_token_);
+	}
+
+	result = emplace_node<ExpressionNode>(
+		PointerToMemberAccessNode(*result, *member_ptr_result.node(), operator_token, is_arrow));
+	return ParseResult::success(*result);
+}
+
 // Apply postfix operators (., ->, [], (), ++, --) to an existing expression result
 // This allows cast expressions (static_cast, dynamic_cast, etc.) to be followed by member access
 // e.g., static_cast<T&&>(t).operator<=>(u)
@@ -1521,10 +1545,20 @@ ParseResult Parser::apply_postfix_operators(ASTNode& start_result) {
 			}
 		}
 
-		// Check for member access (. or ->)
+		// Check for member access (. or ->), including pointer-to-member (.* or ->*)
 		if ((peek().is_punctuator() && peek() == "."_tok) || peek() == "->"_tok) {
 			Token member_operator_token = peek_info();
+			const bool is_arrow = member_operator_token.value() == "->";
 			advance(); // consume '.' or '->'
+
+			ParseResult pointer_to_member_result =
+				applyPointerToMemberPostfixAfterDotOrArrow(result, member_operator_token, is_arrow);
+			if (pointer_to_member_result.is_error()) {
+				return pointer_to_member_result;
+			}
+			if (pointer_to_member_result.has_value()) {
+				continue;
+			}
 
 			ParseResult member_result = parse_member_postfix(result, member_operator_token);
 			if (member_result.is_error()) {
@@ -2939,50 +2973,25 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			operator_start_token = peek_info();
 			advance(); // consume '.'
 
-			// Check for pointer-to-member operator .*
-			if (peek() == "*"_tok) {
-				advance(); // consume '*'
-
-				// Parse the RHS expression (pointer to member)
-				// Pointer-to-member operators have precedence similar to multiplicative operators (17)
-				// But we need to stop at lower precedence operators, so use precedence 17
-				ParseResult member_ptr_result = parse_expression(17, ExpressionContext::Normal);
-
-				if (member_ptr_result.is_error()) {
-					return member_ptr_result;
-				}
-				if (!member_ptr_result.node().has_value()) {
-					return ParseResult::error("Expected expression after '.*' operator", current_token_);
-				}
-
-				// Create PointerToMemberAccessNode
-				result = emplace_node<ExpressionNode>(
-					PointerToMemberAccessNode(*result, *member_ptr_result.node(), operator_start_token, false));
-				continue;  // Check for more postfix operators
+			ParseResult pointer_to_member_result =
+				applyPointerToMemberPostfixAfterDotOrArrow(result, operator_start_token, false);
+			if (pointer_to_member_result.is_error()) {
+				return pointer_to_member_result;
+			}
+			if (pointer_to_member_result.has_value()) {
+				continue;
 			}
 		} else if (peek() == "->"_tok) {
 			operator_start_token = peek_info();
 			advance(); // consume '->'
 
-			// Check for pointer-to-member operator ->*
-			if (peek() == "*"_tok) {
-				advance(); // consume '*'
-
-				// Parse the RHS expression (pointer to member)
-				// Pointer-to-member operators have precedence similar to multiplicative operators (17)
-				// But we need to stop at lower precedence operators, so use precedence 17
-				ParseResult member_ptr_result = parse_expression(17, ExpressionContext::Normal);
-				if (member_ptr_result.is_error()) {
-					return member_ptr_result;
-				}
-				if (!member_ptr_result.node().has_value()) {
-					return ParseResult::error("Expected expression after '->*' operator", current_token_);
-				}
-
-				// Create PointerToMemberAccessNode
-				result = emplace_node<ExpressionNode>(
-					PointerToMemberAccessNode(*result, *member_ptr_result.node(), operator_start_token, true));
-				continue;  // Check for more postfix operators
+			ParseResult pointer_to_member_result =
+				applyPointerToMemberPostfixAfterDotOrArrow(result, operator_start_token, true);
+			if (pointer_to_member_result.is_error()) {
+				return pointer_to_member_result;
+			}
+			if (pointer_to_member_result.has_value()) {
+				continue;
 			}
 
 			// Note: We don't transform ptr->member to (*ptr).member here anymore.

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -1493,33 +1493,69 @@ ParseResult Parser::parse_member_postfix(std::optional<ASTNode>& result, const T
 	return ParseResult::success(*result);
 }
 
-ParseResult Parser::applyPointerToMemberPostfixAfterDotOrArrow(
-	std::optional<ASTNode>& result,
-	Token operator_token,
-	bool is_arrow) {
-	if (peek() != "*"_tok) {
-		return ParseResult();
+// True when peek is '.' or '->' immediately followed by '*' (.* / ->*).
+// Does not consume tokens.
+bool Parser::peek_is_pointer_to_member_operator() {
+	const bool is_dot = peek().is_punctuator() && peek() == "."_tok;
+	const bool is_arrow = peek() == "->"_tok;
+	if (!is_dot && !is_arrow) {
+		return false;
 	}
-	advance(); // consume '*'
+	SaveHandle saved = save_token_position();
+	advance(); // tentatively consume '.' or '->'
+	const bool is_pm = peek() == "*"_tok;
+	restore_token_position(saved);
+	return is_pm;
+}
 
-	ParseResult member_ptr_result = parse_expression(17, ExpressionContext::Normal);
-	if (member_ptr_result.is_error()) {
-		return member_ptr_result;
-	}
-	if (!member_ptr_result.node().has_value()) {
-		return ParseResult::error(
-			is_arrow ? "Expected expression after '->*' operator" : "Expected expression after '.*' operator",
-			current_token_);
+// Apply pointer-to-member operators (.* / ->*) per C++ [expr.mptr.oper].
+// Not a postfix operator: binds weaker than unary/cast, stronger than multiplicative.
+// RHS is a cast-expression (parse_unary_expression), left-associative.
+ParseResult Parser::apply_pointer_to_member_operators(ASTNode start_result, ExpressionContext context) {
+	std::optional<ASTNode> result = start_result;
+
+	constexpr int MAX_PM_ITERATIONS = 100;
+	int pm_iteration = 0;
+	while (result.has_value() && !peek().is_eof() && pm_iteration < MAX_PM_ITERATIONS) {
+		++pm_iteration;
+
+		if (!peek_is_pointer_to_member_operator()) {
+			break;
+		}
+
+		const bool is_arrow = peek() == "->"_tok;
+		Token operator_token = peek_info();
+		advance(); // consume '.' or '->'
+		advance(); // consume '*'
+
+		ParseResult member_ptr_result = parse_unary_expression(context);
+		if (member_ptr_result.is_error()) {
+			return member_ptr_result;
+		}
+		if (!member_ptr_result.node().has_value()) {
+			return ParseResult::error(
+				is_arrow ? "Expected expression after '->*' operator" : "Expected expression after '.*' operator",
+				current_token_);
+		}
+
+		result = emplace_node<ExpressionNode>(
+			PointerToMemberAccessNode(*result, *member_ptr_result.node(), operator_token, is_arrow));
 	}
 
-	result = emplace_node<ExpressionNode>(
-		PointerToMemberAccessNode(*result, *member_ptr_result.node(), operator_token, is_arrow));
-	return ParseResult::success(*result);
+	if (pm_iteration >= MAX_PM_ITERATIONS) {
+		return ParseResult::error("Parser error: too many pointer-to-member operator iterations", current_token_);
+	}
+
+	if (result.has_value()) {
+		return ParseResult::success(*result);
+	}
+	return ParseResult();
 }
 
 // Apply postfix operators (., ->, [], (), ++, --) to an existing expression result
 // This allows cast expressions (static_cast, dynamic_cast, etc.) to be followed by member access
 // e.g., static_cast<T&&>(t).operator<=>(u)
+// Note: .* / ->* are NOT postfix — see apply_pointer_to_member_operators.
 ParseResult Parser::apply_postfix_operators(ASTNode& start_result) {
 	std::optional<ASTNode> result = start_result;
 
@@ -1545,20 +1581,16 @@ ParseResult Parser::apply_postfix_operators(ASTNode& start_result) {
 			}
 		}
 
-		// Check for member access (. or ->), including pointer-to-member (.* or ->*)
+		// Check for member access (. or ->). Pointer-to-member (.* / ->*) is handled
+		// by apply_pointer_to_member_operators after unary/cast, not here.
 		if ((peek().is_punctuator() && peek() == "."_tok) || peek() == "->"_tok) {
-			Token member_operator_token = peek_info();
-			const bool is_arrow = member_operator_token.value() == "->";
-			advance(); // consume '.' or '->'
+			// Leave '.'/'->' + '*' for the pm-expression layer.
+			if (peek_is_pointer_to_member_operator()) {
+				break;
+			}
 
-			ParseResult pointer_to_member_result =
-				applyPointerToMemberPostfixAfterDotOrArrow(result, member_operator_token, is_arrow);
-			if (pointer_to_member_result.is_error()) {
-				return pointer_to_member_result;
-			}
-			if (pointer_to_member_result.has_value()) {
-				continue;
-			}
+			Token member_operator_token = peek_info();
+			advance(); // consume '.' or '->'
 
 			ParseResult member_result = parse_member_postfix(result, member_operator_token);
 			if (member_result.is_error()) {
@@ -2966,33 +2998,19 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 			}
 		}
 
-		// Check for member access operator . or -> (or pointer-to-member .* or ->*)
+		// Check for member access operator . or ->.
+		// Pointer-to-member (.* / ->*) is handled by apply_pointer_to_member_operators
+		// after unary/cast (C++ [expr.mptr.oper]), not as postfix.
 		Token operator_start_token;	// Track the operator token for error reporting
 
-		if (peek() == "."_tok) {
-			operator_start_token = peek_info();
-			advance(); // consume '.'
+		if (peek() == "."_tok || peek() == "->"_tok) {
+			// Leave '.'/'->' + '*' for the pm-expression layer.
+			if (peek_is_pointer_to_member_operator()) {
+				break;
+			}
 
-			ParseResult pointer_to_member_result =
-				applyPointerToMemberPostfixAfterDotOrArrow(result, operator_start_token, false);
-			if (pointer_to_member_result.is_error()) {
-				return pointer_to_member_result;
-			}
-			if (pointer_to_member_result.has_value()) {
-				continue;
-			}
-		} else if (peek() == "->"_tok) {
 			operator_start_token = peek_info();
-			advance(); // consume '->'
-
-			ParseResult pointer_to_member_result =
-				applyPointerToMemberPostfixAfterDotOrArrow(result, operator_start_token, true);
-			if (pointer_to_member_result.is_error()) {
-				return pointer_to_member_result;
-			}
-			if (pointer_to_member_result.has_value()) {
-				continue;
-			}
+			advance(); // consume '.' or '->'
 
 			// Note: We don't transform ptr->member to (*ptr).member here anymore.
 			// Instead, we pass the is_arrow flag to MemberAccessNode, and CodeGen will

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2855,6 +2855,131 @@ bool Parser::trySubstituteValueTemplateParameterExpression(
 	return false;
 }
 
+ParseResult Parser::tryParseExplicitTemplateBraceInitialization(
+	const Token& identifier_token,
+	const InlineVector<TemplateTypeArg, 4>& explicit_template_args) {
+	if (peek() != "{"_tok) {
+		return ParseResult();
+	}
+
+	bool is_template_brace_initialization =
+		gTemplateRegistry.lookupTemplate(identifier_token.value()).has_value() ||
+		gTemplateRegistry.lookup_alias_template(identifier_token.value()).has_value() ||
+		tryResolveCurrentInstantiationTemplateOwner(
+			identifier_token.value(),
+			explicit_template_args).has_value();
+	if (!is_template_brace_initialization) {
+		NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
+		if (!current_namespace.isGlobal()) {
+			StringHandle qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(
+				current_namespace,
+				identifier_token.handle());
+			std::string_view qualified_name = StringTable::getStringView(qualified_handle);
+			is_template_brace_initialization =
+				gTemplateRegistry.lookupTemplate(qualified_name).has_value() ||
+				gTemplateRegistry.lookup_alias_template(qualified_name).has_value();
+		}
+	}
+	if (!is_template_brace_initialization && !struct_parsing_context_stack_.empty()) {
+		const StructParsingContext& struct_context = struct_parsing_context_stack_.back();
+		if (struct_context.struct_name == identifier_token.value()) {
+			is_template_brace_initialization = true;
+		}
+	}
+	if (!is_template_brace_initialization) {
+		return ParseResult();
+	}
+
+	bool has_dependent_args = false;
+	for (const TemplateTypeArg& arg : explicit_template_args) {
+		if (arg.is_dependent || arg.is_pack) {
+			has_dependent_args = true;
+			break;
+		}
+	}
+
+	FLASH_LOG(Parser, Debug, "Template brace initialization detected for '", identifier_token.value(), "', has_dependent_args=", has_dependent_args);
+
+	if (has_dependent_args) {
+		advance(); // consume '{'
+		ChunkedVector<ASTNode> args;
+		while (!peek().is_eof() && peek() != "}"_tok) {
+			ParseResult arg_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
+			if (arg_result.is_error()) {
+				return arg_result;
+			}
+			if (auto node = arg_result.node()) {
+				args.push_back(*node);
+			}
+
+			if (peek() == ","_tok) {
+				advance(); // consume ','
+			} else if (peek() != "}"_tok) {
+				return ParseResult::error("Expected ',' or '}' in brace initializer", current_token_);
+			}
+		}
+
+		if (!consume("}"_tok)) {
+			return ParseResult::error("Expected '}' after brace initializer", current_token_);
+		}
+
+		InlineVector<TypeInfo::TemplateArgInfo, 4> dependent_template_args =
+			toTemplateArgInfoList(explicit_template_args);
+		StringBuilder dependent_type_builder;
+		dependent_type_builder.append(identifier_token.value());
+		dependent_type_builder.append("<");
+		for (size_t i = 0; i < dependent_template_args.size(); ++i) {
+			if (i != 0) {
+				dependent_type_builder.append(", ");
+			}
+			appendDependentTemplateArgSpelling(
+				dependent_type_builder,
+				dependent_template_args[i]);
+		}
+		dependent_type_builder.append(">");
+		StringHandle dependent_type_handle =
+			StringTable::getOrInternStringHandle(dependent_type_builder.commit());
+		TypeInfo* dependent_type_info = nullptr;
+		auto dependent_type_it = getTypesByNameMap().find(dependent_type_handle);
+		if (dependent_type_it != getTypesByNameMap().end()) {
+			dependent_type_info = dependent_type_it->second;
+		}
+		if (dependent_type_info == nullptr) {
+			dependent_type_info = &add_template_param_type(
+				dependent_type_handle,
+				TypeCategory::Template,
+				0);
+		}
+		QualifiedIdentifier base_template_name =
+			QualifiedIdentifier::fromQualifiedName(
+				identifier_token.value(),
+				gSymbolTable.get_current_namespace_handle());
+		dependent_type_info->setTemplateInstantiationInfo(
+			base_template_name,
+			dependent_template_args);
+		dependent_type_info->setInstantiationContext(
+			{},
+			dependent_template_args,
+			nullptr);
+		auto dependent_type_node = emplace_node<TypeSpecifierNode>(
+			dependent_type_info->registeredTypeIndex().withCategory(TypeCategory::Template),
+			0,
+			identifier_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		return ParseResult::success(emplace_node<ExpressionNode>(
+			ConstructorCallNode(
+				dependent_type_node,
+				std::move(args),
+				identifier_token)));
+	}
+
+	return parse_template_brace_initialization(
+		explicit_template_args,
+		identifier_token.value(),
+		identifier_token);
+}
+
 ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 #if WITH_PARSER_RUNTIME_STATS
 	FLASHCPP_PARSER_RUNTIME_PHASE(PrimaryExpression);
@@ -8017,126 +8142,16 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						}
 
 						// Template arguments parsed but NOT followed by ::
-						// Check for template class brace initialization: Template<T>{}
-						// This creates a temporary object using value-initialization or aggregate-initialization
-						if (!identifierType && peek() == "{"_tok) {
-							bool is_template_brace_initialization =
-								gTemplateRegistry.lookupTemplate(identifier_token.value()).has_value() ||
-								gTemplateRegistry.lookup_alias_template(identifier_token.value()).has_value();
-							if (!is_template_brace_initialization) {
-								NamespaceHandle current_namespace = gSymbolTable.get_current_namespace_handle();
-								if (!current_namespace.isGlobal()) {
-									StringHandle qualified_handle = gNamespaceRegistry.buildQualifiedIdentifier(
-										current_namespace,
-										identifier_token.handle());
-									std::string_view qualified_name =
-										StringTable::getStringView(qualified_handle);
-									is_template_brace_initialization =
-										gTemplateRegistry.lookupTemplate(qualified_name).has_value() ||
-										gTemplateRegistry.lookup_alias_template(qualified_name).has_value();
-								}
+						if (!identifierType) {
+							ParseResult brace_init_result =
+								tryParseExplicitTemplateBraceInitialization(
+									identifier_token,
+									*explicit_template_args);
+							if (brace_init_result.is_error()) {
+								return brace_init_result;
 							}
-							if (is_template_brace_initialization) {
-								// This is template class brace initialization (e.g., type_identity<int>{})
-								// Check if any template arguments are dependent
-								bool has_dependent_args = false;
-								for (const auto& arg : *explicit_template_args) {
-									if (arg.is_dependent || arg.is_pack) {
-										has_dependent_args = true;
-										break;
-									}
-								}
-
-								FLASH_LOG(Parser, Debug, "Template brace initialization detected for '", identifier_token.value(), "', has_dependent_args=", has_dependent_args);
-
-								if (has_dependent_args) {
-									advance(); // consume '{'
-									ChunkedVector<ASTNode> args;
-									while (!peek().is_eof() && peek() != "}"_tok) {
-										auto argResult = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::Normal);
-										if (argResult.is_error()) {
-											return argResult;
-										}
-										if (auto node = argResult.node()) {
-											args.push_back(*node);
-										}
-
-										if (peek() == ","_tok) {
-											advance(); // consume ','
-										} else if (peek() != "}"_tok) {
-											return ParseResult::error("Expected ',' or '}' in brace initializer", current_token_);
-										}
-									}
-
-									if (!consume("}"_tok)) {
-										return ParseResult::error("Expected '}' after brace initializer", current_token_);
-									}
-
-									InlineVector<TypeInfo::TemplateArgInfo, 4> dependent_template_args =
-										toTemplateArgInfoList(*explicit_template_args);
-									StringBuilder dependent_type_builder;
-									dependent_type_builder.append(identifier_token.value());
-									dependent_type_builder.append("<");
-									for (size_t i = 0;
-										 i < dependent_template_args.size();
-										 ++i) {
-										if (i != 0) {
-											dependent_type_builder.append(", ");
-										}
-										appendDependentTemplateArgSpelling(
-											dependent_type_builder,
-											dependent_template_args[i]);
-									}
-									dependent_type_builder.append(">");
-									StringHandle dependent_type_handle =
-										StringTable::getOrInternStringHandle(
-											dependent_type_builder.commit());
-									TypeInfo* dependent_type_info = nullptr;
-									auto dependent_type_it = getTypesByNameMap().find(dependent_type_handle);
-									if (dependent_type_it != getTypesByNameMap().end()) {
-										dependent_type_info = dependent_type_it->second;
-									}
-									if (dependent_type_info == nullptr) {
-										dependent_type_info = &add_template_param_type(
-											dependent_type_handle,
-											TypeCategory::Template,
-											0);
-									}
-									QualifiedIdentifier base_template_name =
-										QualifiedIdentifier::fromQualifiedName(
-											identifier_token.value(),
-											gSymbolTable.get_current_namespace_handle());
-									dependent_type_info->setTemplateInstantiationInfo(
-										base_template_name,
-										dependent_template_args);
-									dependent_type_info->setInstantiationContext(
-										{},
-										dependent_template_args,
-										nullptr);
-									auto dependent_type_node = emplace_node<TypeSpecifierNode>(
-										dependent_type_info->registeredTypeIndex().withCategory(TypeCategory::Template),
-										0,
-										identifier_token,
-										CVQualifier::None,
-										ReferenceQualifier::None);
-									result = emplace_node<ExpressionNode>(
-										ConstructorCallNode(
-											dependent_type_node,
-											std::move(args),
-											identifier_token));
-									return ParseResult::success(*result);
-								}
-
-								ParseResult brace_init_result = parse_template_brace_initialization(
-									*explicit_template_args,
-									identifier_token.value(),
-									identifier_token);
-								if (brace_init_result.is_error()) {
-									return brace_init_result;
-								}
-								if (brace_init_result.node().has_value()) {
-									return ParseResult::success(*brace_init_result.node());
-								}
+							if (brace_init_result.has_value()) {
+								return brace_init_result;
 							}
 						}
 
@@ -8793,6 +8808,19 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				};
 				explicit_template_args = parse_contextual_template_args();
 				// If parsing failed, it might be a less-than operator, so continue normally
+
+				if (explicit_template_args.has_value()) {
+					ParseResult brace_init_result =
+						tryParseExplicitTemplateBraceInitialization(
+							identifier_token,
+							*explicit_template_args);
+					if (brace_init_result.is_error()) {
+						return brace_init_result;
+					}
+					if (brace_init_result.has_value()) {
+						return brace_init_result;
+					}
+				}
 
 				// After template arguments, check for :: to handle Template<T>::member syntax
 				if (explicit_template_args.has_value() && peek() == "::"_tok) {
@@ -10657,8 +10685,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 		advance();
 	} else if (current_token_.type() == Token::Type::Keyword && current_token_.value() == "this"sv) {
 		// Handle 'this' keyword - represents a pointer to the current object
-		// Only valid inside member functions
-		if (member_function_context_stack_.empty()) {
+		// Only valid inside member functions. During member declaration parsing the
+		// member-function context stack is not pushed yet, but the struct context is.
+		if (member_function_context_stack_.empty() && struct_parsing_context_stack_.empty()) {
 			return ParseResult::error("'this' can only be used inside a member function", current_token_);
 		}
 

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -738,11 +738,16 @@ void Parser::apply_parsed_function_noexcept(
 	}
 
 	const auto evaluated = try_evaluate_constant_expression(expression.node());
-	if (!evaluated.has_value()) {
+	if (evaluated.has_value()) {
+		function.set_noexcept(evaluated->value != 0);
+		function.clear_noexcept_expression();
+		return;
+	}
+	if (!isDependentTemplateContext()) {
 		throw CompileError("noexcept specification is not a constant expression");
 	}
-	function.set_noexcept(evaluated->value != 0);
-	function.clear_noexcept_expression();
+	function.set_noexcept(false);
+	function.set_noexcept_expression(expression);
 }
 
 ParseResult Parser::parse_function_trailing_specifiers(

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -36,7 +36,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<functional>` | `test_std_functional.cpp` | ❌ Compile Error | ~4.76s (`TOTAL`) / ~5.13s wall (retested 2026-05-27, Linux/libstdc++-14). `__make_move_if_noexcept_iterator` still emits non-fatal overload noise, but the current first hard error remains depth-guarded `rebind`. |
 | `<map>` | `test_std_map.cpp` | ❌ Compile Error | ~2498ms (retested 2026-04-30, Linux/libstdc++-14). No longer stops at `Missing TypeInfo while computing template argument size`; it now reaches `Unregistered dependent placeholder type reached template argument classification`. |
 | `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2350ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
-| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile/Codegen Error | >40s in focused retest (2026-07-23, Windows/MSVC STL 14.44). Moved past `__msvc_ranges_to.hpp:429` noexcept/`this` parse stop; now progresses into deep template/codegen. |
+| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~1534s compile-only / >25 min (retested 2026-07-23, Windows/MSVC STL 14.44). Parse/noexcept stops fixed; full compile now exhausts template depth on variadic `invoke` / `operator()` recursion. |
 | `<iostream>` | `test_std_iostream.cpp` | 💥 Crash | ~4559ms (retested 2026-04-11). |
 | `<sstream>` | `test_std_sstream.cpp` | 💥 Crash | ~4565ms (retested 2026-04-11). |
 | `<fstream>` | `test_std_fstream.cpp` | 💥 Crash | ~4642ms (retested 2026-04-11). |
@@ -105,7 +105,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 Fixes landed (parser / early semantic layer):
 
-- **`apply_postfix_operators` now handles `.*` / `->*` after cast expressions.** `static_cast<T>(obj).*pmf` inside function bodies and noexcept operands no longer stops with `Expected member name after '.'`. Shared helper: `applyPointerToMemberPostfixAfterDotOrArrow`.
+- **Pointer-to-member (`.*` / `->*`) is a pm-expression layer after unary/cast**, not postfix. `apply_pointer_to_member_operators` applies left-associative `.*`/`->*` with cast-expression RHS so `static_cast<T>(obj).*pmf`, `*p.*pm`, and `a.*pm * n` follow C++ [expr.mptr.oper].
 - **`tryParseExplicitTemplateBraceInitialization` centralizes `Template<Args>{...}` brace-init parsing** for dependent and concrete template-ids, including injected-class-name cases inside class templates. Both the early qualified/unqualified template-id paths and the general explicit-template-argument path call it.
 - **Dependent `noexcept(expr)` on member functions defers instead of hard-erroring** when constexpr evaluation fails but the surrounding template context is still dependent (`apply_parsed_function_noexcept` now mirrors `apply_parsed_function_type_qualifiers`).
 - **`this` is accepted while parsing member declarations inside a struct context**, so noexcept operands like `noexcept(_Call(std::move(*this), ...))` parse before the member-function context stack is pushed.
@@ -124,7 +124,7 @@ Validation snapshot (`x64/Sharded/FlashCppMSVC.exe`, Windows/MSVC STL 14.44; run
 | `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~4.6s | Was failing at `type_traits:1586` (`.*` after `static_cast` in `_Invoker_pmf_object` noexcept); now compiles/links/returns 0. |
 | `<concepts>` (`test_std_concepts.cpp`) | ✅ Pass | ~4.3s | Control retest still passes. |
 | `<iterator>` (`test_std_iterator.cpp`) | ❌ Codegen error | ~15.8s | Parse/noexcept regressions fixed. Current stops: `ranges::empty` overload viability (non-fatal template noise) and `view_interface` codegen: `Runtime aggregate value requires complete canonical layout metadata`. |
-| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile/codegen (in progress) | >40s in focused retest | No longer stops at `__msvc_ranges_to.hpp:429` `Expected ')' after noexcept expression`; retest reaches deep template/codegen (deferred `_Conjunction` base warnings, then later phases). Full runner retest still pending. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile/codegen (in progress) | ~1534s compile-only (`FlashCppMSVC.exe --timing`, 2026-07-23) | No longer stops at `__msvc_ranges_to.hpp:429` `Expected ')' after noexcept expression`. Full retest runs ~25.5 min and then hits repeated `Failed to instantiate template function: invoke` plus `try_instantiate_template recursion depth exceeded 64` for `operator()`. |
 | `<utility>` (`test_std_utility.cpp`) | ❌ Codegen error | ~3.7s | Reaches deferred `std::swap` / `three_way_comparable_with` / `pair` category-31 codegen after parsing `<type_traits>`. |
 
 Net movement: `<type_traits>` regressed to a hard parse failure on current branch before this work and is green again; `<iterator>` moved from parse/noexcept into codegen; `<ranges>` moved past the shared `type_traits` / `__msvc_ranges_to.hpp` noexcept parse stop.

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -9,7 +9,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | Header | Test File | Status | Notes |
 |--------|-----------|--------|-------|
 | `<limits>` | `test_std_limits.cpp` | ✅ Compiled | ~5795ms (retested 2026-05-25, Linux/libstdc++-14); ternary common-type fix (wchar_t/int branch type correction in constexpr folding). |
-| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~1124ms (`TOTAL`) / ~1.29s wall (retested 2026-05-28, Linux/libstdc++-14). |
+| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~4.6s wall (retested 2026-07-23, Windows/MSVC STL 14.44). Restored after parser fixes for cast/postfix `.*` and template brace-init/noexcept parsing. |
 | `<compare>` | `test_std_compare_ret42.cpp` | ✅ Compiled | ~0.06s (retested 2026-05-23, Linux/libstdc++-14). |
 | `<version>` | `test_std_version.cpp` | ✅ Compiled | ~41ms |
 | `<source_location>` | `test_std_source_location.cpp` | ✅ Compiled | ~41ms |
@@ -36,7 +36,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<functional>` | `test_std_functional.cpp` | ❌ Compile Error | ~4.76s (`TOTAL`) / ~5.13s wall (retested 2026-05-27, Linux/libstdc++-14). `__make_move_if_noexcept_iterator` still emits non-fatal overload noise, but the current first hard error remains depth-guarded `rebind`. |
 | `<map>` | `test_std_map.cpp` | ❌ Compile Error | ~2498ms (retested 2026-04-30, Linux/libstdc++-14). No longer stops at `Missing TypeInfo while computing template argument size`; it now reaches `Unregistered dependent placeholder type reached template argument classification`. |
 | `<set>` | `test_std_set.cpp` | ❌ Compile Error | ~2350ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
-| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile Error | ~2906ms (retested 2026-04-12). The earlier variable-template/type-traits arity blocker is gone. Current first error is later in the Windows UCRT headers: "No matching function for call to '__stdio_common_vfwprintf'". |
+| `<ranges>` | `test_std_ranges.cpp` | ❌ Compile/Codegen Error | >40s in focused retest (2026-07-23, Windows/MSVC STL 14.44). Moved past `__msvc_ranges_to.hpp:429` noexcept/`this` parse stop; now progresses into deep template/codegen. |
 | `<iostream>` | `test_std_iostream.cpp` | 💥 Crash | ~4559ms (retested 2026-04-11). |
 | `<sstream>` | `test_std_sstream.cpp` | 💥 Crash | ~4565ms (retested 2026-04-11). |
 | `<fstream>` | `test_std_fstream.cpp` | 💥 Crash | ~4642ms (retested 2026-04-11). |
@@ -48,7 +48,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeinfo>` | `test_std_typeinfo_ret0.cpp` | ✅ Compiled | ~46ms (retested 2026-04-30, Linux/libstdc++-14). Sema now models pointer arithmetic (`T* + integral`, `T* - integral`, `T* - T*`) so the ternary in `type_info::name()` (`__name[0] == '*' ? __name + 1 : __name`) gets a sema-owned exact result type and codegen no longer throws. Regression: `tests/test_ternary_pointer_arithmetic_branches_ret0.cpp`. |
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ✅ Compiled | ~7529ms (retested 2026-05-25, Linux/libstdc++-14). **NOW WORKS**: ternary common-type fix resolved `numeric_limits` member constexpr folding. Builtin `__builtin_huge_val`/`__builtin_nan` families now handled in constexpr evaluator. |
-| `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~13.49s (`TOTAL`) / ~16.5s wall (retested 2026-06-21, Windows/MSVC STL 14.44). Progressed past the old `swap`-adjacent parser stops; current first hard error is `Could not evaluate non-type template default for parameter 2 of 'subrange'`. |
+| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~15.8s wall (retested 2026-07-23, Windows/MSVC STL 14.44). Parse/noexcept stops fixed; current first hard stops are `ranges::empty` overload viability and `view_interface` aggregate layout metadata in codegen. |
 | `<variant>` | `test_std_variant.cpp` | ✅ Compiled | ~736ms (retested 2026-04-24, Linux/libstdc++). **NEW: Now compiles successfully on Linux!** The `_Variadic_union` arithmetic non-type template argument (`_Np-1`) inside a member initializer is now resolved. |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
@@ -100,6 +100,34 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<generator>` | N/A | ❌ Compile Error | ~2593ms (retested 2026-04-11). Call to deleted function 'swap' — previously was a parse error, now parses successfully. (C++23) |
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
+
+### 2026-07-23 Windows/MSVC parser/noexcept follow-up
+
+Fixes landed (parser / early semantic layer):
+
+- **`apply_postfix_operators` now handles `.*` / `->*` after cast expressions.** `static_cast<T>(obj).*pmf` inside function bodies and noexcept operands no longer stops with `Expected member name after '.'`. Shared helper: `applyPointerToMemberPostfixAfterDotOrArrow`.
+- **`tryParseExplicitTemplateBraceInitialization` centralizes `Template<Args>{...}` brace-init parsing** for dependent and concrete template-ids, including injected-class-name cases inside class templates. Both the early qualified/unqualified template-id paths and the general explicit-template-argument path call it.
+- **Dependent `noexcept(expr)` on member functions defers instead of hard-erroring** when constexpr evaluation fails but the surrounding template context is still dependent (`apply_parsed_function_noexcept` now mirrors `apply_parsed_function_type_qualifiers`).
+- **`this` is accepted while parsing member declarations inside a struct context**, so noexcept operands like `noexcept(_Call(std::move(*this), ...))` parse before the member-function context stack is pushed.
+
+Regression coverage:
+
+- `tests/test_noexcept_pmf_call_ret0.cpp`
+- `tests/test_noexcept_braced_init_ctor_ret0.cpp`
+- `tests/test_noexcept_call_empty_brace_pack_ret0.cpp`
+- `tests/test_noexcept_rvalue_call_empty_brace_ret0.cpp`
+
+Validation snapshot (`x64/Sharded/FlashCppMSVC.exe`, Windows/MSVC STL 14.44; runner wall time includes compile/link/run):
+
+| Header/Test | Status | Runner wall time | First-order stop / note |
+|-------------|--------|------------------|-------------------------|
+| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~4.6s | Was failing at `type_traits:1586` (`.*` after `static_cast` in `_Invoker_pmf_object` noexcept); now compiles/links/returns 0. |
+| `<concepts>` (`test_std_concepts.cpp`) | ✅ Pass | ~4.3s | Control retest still passes. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Codegen error | ~15.8s | Parse/noexcept regressions fixed. Current stops: `ranges::empty` overload viability (non-fatal template noise) and `view_interface` codegen: `Runtime aggregate value requires complete canonical layout metadata`. |
+| `<ranges>` (`test_std_ranges.cpp`) | ❌ Compile/codegen (in progress) | >40s in focused retest | No longer stops at `__msvc_ranges_to.hpp:429` `Expected ')' after noexcept expression`; retest reaches deep template/codegen (deferred `_Conjunction` base warnings, then later phases). Full runner retest still pending. |
+| `<utility>` (`test_std_utility.cpp`) | ❌ Codegen error | ~3.7s | Reaches deferred `std::swap` / `three_way_comparable_with` / `pair` category-31 codegen after parsing `<type_traits>`. |
+
+Net movement: `<type_traits>` regressed to a hard parse failure on current branch before this work and is green again; `<iterator>` moved from parse/noexcept into codegen; `<ranges>` moved past the shared `type_traits` / `__msvc_ranges_to.hpp` noexcept parse stop.
 
 ### Current Windows/MSVC snapshot (2026-07-13)
 

--- a/tests/test_noexcept_braced_init_ctor_ret0.cpp
+++ b/tests/test_noexcept_braced_init_ctor_ret0.cpp
@@ -1,0 +1,19 @@
+// Regression: braced-init constructor call inside noexcept(...) operand.
+
+template <class T>
+struct Wrap {
+	T value;
+	int length;
+
+	constexpr Wrap(T val, int len) : value(val), length(len) {}
+
+	constexpr bool unwrapped() const noexcept(
+		noexcept(Wrap<T>{value, length})) {
+		return true;
+	}
+};
+
+int main() {
+	Wrap<int> w{7, 3};
+	return w.unwrapped() ? 0 : 1;
+}

--- a/tests/test_noexcept_call_empty_brace_pack_ret0.cpp
+++ b/tests/test_noexcept_call_empty_brace_pack_ret0.cpp
@@ -1,0 +1,12 @@
+// Regression: noexcept operand with Type{} empty braced init as call argument.
+
+constexpr bool helper(int) { return true; }
+
+template <class Indices>
+constexpr bool probe() noexcept(noexcept(helper(Indices{}))) {
+	return helper(Indices{});
+}
+
+int main() {
+	return probe<int>() ? 0 : 1;
+}

--- a/tests/test_noexcept_pmf_call_ret0.cpp
+++ b/tests/test_noexcept_pmf_call_ret0.cpp
@@ -1,0 +1,15 @@
+// Regression: static_cast followed by pointer-to-member access (.* / ->*)
+// MSVC type_traits _Invoker_pmf_object uses:
+//   (static_cast<_Ty1&&>(_Arg1).*_Pmf)(...)
+// apply_postfix_operators must handle .* after cast expressions.
+
+template <class Decayed, class Ty1, class... Types2>
+struct Invoker {
+	static constexpr auto call(Decayed pmf, Ty1&& arg1, Types2&&... args2)
+		noexcept(noexcept((static_cast<Ty1&&>(arg1).*pmf)(static_cast<Types2&&>(args2)...)))
+		-> decltype((static_cast<Ty1&&>(arg1).*pmf)(static_cast<Types2&&>(args2)...)) {
+		return (static_cast<Ty1&&>(arg1).*pmf)(static_cast<Types2&&>(args2)...);
+	}
+};
+
+int main() { return 0; }

--- a/tests/test_noexcept_pmf_call_ret0.cpp
+++ b/tests/test_noexcept_pmf_call_ret0.cpp
@@ -1,7 +1,8 @@
 // Regression: static_cast followed by pointer-to-member access (.* / ->*)
 // MSVC type_traits _Invoker_pmf_object uses:
 //   (static_cast<_Ty1&&>(_Arg1).*_Pmf)(...)
-// apply_postfix_operators must handle .* after cast expressions.
+// .* / ->* are pm-expressions ([expr.mptr.oper]), applied after unary/cast
+// by apply_pointer_to_member_operators — not postfix.
 
 template <class Decayed, class Ty1, class... Types2>
 struct Invoker {

--- a/tests/test_noexcept_rvalue_call_empty_brace_ret0.cpp
+++ b/tests/test_noexcept_rvalue_call_empty_brace_ret0.cpp
@@ -1,0 +1,34 @@
+// Regression: noexcept on rvalue call operator with move/forward and Type{} arg.
+// MSVC __msvc_ranges_to.hpp pattern.
+
+template <class T>
+constexpr T&& move(T& value) noexcept {
+	return static_cast<T&&>(value);
+}
+
+template <class T>
+constexpr T&& forward(T&& value) noexcept {
+	return static_cast<T&&>(value);
+}
+
+template <class... Types>
+struct Closure {
+	template <class Ty>
+	static constexpr bool call(Closure&& self, Ty&& arg, int) {
+		(void)self;
+		(void)arg;
+		return true;
+	}
+
+	using Indices = int;
+
+	template <class Ty>
+	constexpr bool operator()(Ty&& arg) && noexcept(
+		noexcept(call(move(*this), forward<Ty>(arg), Indices{}))) {
+		return call(move(*this), forward<Ty>(arg), Indices{});
+	}
+};
+
+int main() {
+	return Closure<>{}(1) ? 0 : 1;
+}

--- a/tests/test_pm_cast_then_member_pointer_ret0.cpp
+++ b/tests/test_pm_cast_then_member_pointer_ret0.cpp
@@ -1,0 +1,12 @@
+// Regression: cast-expression then .* is a pm-expression (not postfix).
+// static_cast<T>(x).*pm must parse without requiring .* inside apply_postfix_operators.
+
+struct S {
+	int v;
+};
+
+int main() {
+	S s{11};
+	int S::* pm = &S::v;
+	return static_cast<S&>(s).*pm - 11;
+}

--- a/tests/test_pm_multiplicative_binds_looser_ret0.cpp
+++ b/tests/test_pm_multiplicative_binds_looser_ret0.cpp
@@ -1,0 +1,12 @@
+// Regression: pointer-to-member .* binds tighter than multiplicative *
+// C++: a.*pm * 2 means (a.*pm)*2, not a.*(pm*2).
+
+struct S {
+	int v;
+};
+
+int main() {
+	S a{3};
+	int S::* pm = &S::v;
+	return a.*pm * 2 - 6;
+}

--- a/tests/test_pm_unary_binds_tighter_ret0.cpp
+++ b/tests/test_pm_unary_binds_tighter_ret0.cpp
@@ -1,0 +1,13 @@
+// Regression: unary * binds tighter than pointer-to-member .*
+// C++ [expr.mptr.oper] / [expr.unary.op]: *p.*pm means (*p).*pm, not *(p.*pm).
+
+struct S {
+	int v;
+};
+
+int main() {
+	S s{7};
+	S* p = &s;
+	int S::* pm = &S::v;
+	return *p.*pm - 7;
+}


### PR DESCRIPTION
## Summary
- Parse `static_cast<T>(x).*pmf` and related MSVC `_Invoker_pmf_object` / noexcept patterns used by `<type_traits>` / `<concepts>`.
- Move `.*` / `->*` out of postfix into a dedicated pm-expression layer after unary/cast (`apply_pointer_to_member_operators`), with cast-expression RHS per [expr.mptr.oper].
- Defer dependent `noexcept(expr)` when constexpr evaluation fails in template context; allow `this` in member-declaration noexcept; consolidate `Template<Args>{}` brace-init parsing.
- Unblocks Windows/MSVC `<type_traits>` and `<concepts>`; updates `README_STANDARD_HEADERS.md`.

## Test plan
- [x] Full `./tests/run_all_tests.ps1` — 2782 pass, 240 `_fail` as expected, 0 crashes/mismatches
- [x] `test_pm_unary_binds_tighter_ret0.cpp` (`*p.*pm` → `(*p).*pm`)
- [x] `test_pm_multiplicative_binds_looser_ret0.cpp` (`a.*pm * n`)
- [x] `test_pm_cast_then_member_pointer_ret0.cpp`
- [x] `test_noexcept_pmf_call_ret0.cpp` and related noexcept brace-init regressions
- [x] `tests/std/test_std_type_traits.cpp`