### PR TITLE
Remove TypeInfo::reference_qualifier_; use alias_type_spec_ only

### DIFF
--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1053,9 +1053,6 @@ struct TypeInfo {
 	// Struct layout remains authoritative in StructTypeInfo::total_size.
 	int fallback_size_bits_ = 0;	// Changed from unsigned char to int for large types
 
-	// For typedef of reference types, store the reference qualifier
-	ReferenceQualifier reference_qualifier_ = ReferenceQualifier::None;
-
 	// For aliases, preserve the original aliased type specifier so consumers can
 	// recover array/pointer/reference metadata by following the alias chain.
 	std::unique_ptr<TypeSpecifierNode> alias_type_spec_;

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -2026,9 +2026,8 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		const ChunkedVector<ASTNode>& arguments,
 		std::span<const TypeSpecifierNode> arg_types);
 	// Shared helper: re-parse a template function body with concrete argument substitution.
-	// Called from both try_instantiate_template_explicit (preserve_ref_qualifier=true) and
-	// try_instantiate_single_template (preserve_ref_qualifier=false, default) after cycle
-	// detection has already passed.  Sets new_func_ref's definition.
+	// Called from both try_instantiate_template_explicit and try_instantiate_single_template
+	// after cycle detection has already passed.  Sets new_func_ref's definition.
 	// Pack-parameter state (pack_param_info_, has_parameter_packs_) and cycle detection
 	// remain entirely in the callers.  The callers must set pack_param_info_ to the
 	// already-expanded pack info before the call and restore it afterwards.
@@ -2039,8 +2038,7 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		FunctionDeclarationNode& new_func_ref,
 		const FunctionDeclarationNode& func_decl,
 		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
-		bool preserve_ref_qualifier);
+		std::span<const TemplateTypeArg> template_args);
 	struct FunctionTemplateInstantiationContext {
 		std::string_view template_name;
 		const TemplateFunctionDeclarationNode& template_func;
@@ -2060,14 +2058,13 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 	};
 	enum class FunctionTemplateInstantiationFlags : uint16_t {
 		None = 0,
-		PreserveRefQualifier = 1u << 0,
-		ExplicitMaterialization = 1u << 1,
-		CacheableInstantiation = 1u << 2,
-		CommitInstantiation = 1u << 3,
-		RegisterInstantiation = 1u << 4,
-		MemoizeBodyReparseFailure = 1u << 5,
-		RunInlineHeuristic = 1u << 6,
-		SkipBodyMaterialization = 1u << 7
+		ExplicitMaterialization = 1u << 0,
+		CacheableInstantiation = 1u << 1,
+		CommitInstantiation = 1u << 2,
+		RegisterInstantiation = 1u << 3,
+		MemoizeBodyReparseFailure = 1u << 4,
+		RunInlineHeuristic = 1u << 5,
+		SkipBodyMaterialization = 1u << 6
 	};
 	static constexpr FunctionTemplateInstantiationFlags mergeInstantiationFlags(
 		FunctionTemplateInstantiationFlags lhs,

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -53,8 +53,7 @@ void findLocalVariableDeclarations(const ASTNode& node, std::unordered_set<Strin
 void registerTypeParamsInScope(
 	const InlineVector<StringHandle, 4>& param_names,
 	const InlineVector<TemplateTypeArg, 4>& type_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier);
+	FlashCpp::TemplateParameterScope& scope);
 
 TypeInfo& registerTemplateTypeBinding(
 	StringHandle param_name,
@@ -63,14 +62,12 @@ TypeInfo& registerTemplateTypeBinding(
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier);
+	FlashCpp::TemplateParameterScope& scope);
 
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier);
+	FlashCpp::TemplateParameterScope& scope);
 
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
@@ -81,8 +78,7 @@ void registerTypeParamsInScope(
 void registerTypeParamsInScope(
 	std::span<const TemplateParameterNode> template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier);
+	FlashCpp::TemplateParameterScope& scope);
 
 void registerTypeParamsInScope(
 	std::span<const TemplateParameterNode> template_param_nodes,
@@ -92,8 +88,7 @@ void registerTypeParamsInScope(
 
 void registerTypeParamsInScope(
 	const TemplateEnvironment& environment,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier);
+	FlashCpp::TemplateParameterScope& scope);
 
 void registerTypeParamsInScope(
 	const TemplateEnvironment& environment,

--- a/src/ParserInternal.h
+++ b/src/ParserInternal.h
@@ -56,6 +56,10 @@ void registerTypeParamsInScope(
 	FlashCpp::TemplateParameterScope& scope,
 	bool preserve_ref_qualifier);
 
+TypeInfo& registerTemplateTypeBinding(
+	StringHandle param_name,
+	const TemplateTypeArg& arg);
+
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -9747,7 +9747,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 
-					registerTypeParamsInScope(param_names, effective_template_args, template_scope, true);
+					registerTypeParamsInScope(param_names, effective_template_args, template_scope);
 
 					// Save current position and parsing context
 					SaveHandle current_pos = save_token_position();

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -3958,10 +3958,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						// instantiation arguments.
 						FlashCpp::TemplateParameterScope template_scope;
 						for (const auto& [param_name, deduced_arg] : deduced_args) {
-							TypeCategory concrete_type = deduced_arg.typeEnum();
-							auto& type_info = add_template_param_type(StringTable::getOrInternStringHandle(param_name), concrete_type, get_type_size_bits(concrete_type));
-							type_info.reference_qualifier_ = deduced_arg.is_rvalue_reference() ? ReferenceQualifier::RValueReference
-																							   : (deduced_arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
+							auto& type_info = registerTemplateTypeBinding(
+								StringTable::getOrInternStringHandle(param_name),
+								deduced_arg);
 							template_scope.addParameter(&type_info);
 						}
 

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -192,26 +192,7 @@ bool Parser::isTemplateFunctionParameterPack(
 	return false;
 }
 
-static void applyRegisteredTypeBindingMetadata(
-	TypeInfo& type_info,
-	const TemplateTypeArg& arg,
-	bool preserve_ref_qualifier) {
-	if (is_builtin_type(arg.typeEnum())) {
-		type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
-	} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
-		type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
-	} else {
-		type_info.fallback_size_bits_ = 0;
-	}
-
-	if (preserve_ref_qualifier) {
-		type_info.reference_qualifier_ = arg.is_rvalue_reference()
-											 ? ReferenceQualifier::RValueReference
-											 : (arg.is_lvalue_reference() ? ReferenceQualifier::LValueReference : ReferenceQualifier::None);
-	}
-}
-
-static TypeInfo& registerTemplateTypeBinding(
+TypeInfo& registerTemplateTypeBinding(
 	StringHandle param_name,
 	const TemplateTypeArg& arg) {
 	TypeIndex registered_type_index = arg.type_index;
@@ -225,11 +206,19 @@ static TypeInfo& registerTemplateTypeBinding(
 	}
 	TypeSpecifierNode alias_spec = makeTypeSpecifierFromTemplateTypeArg(arg, Token());
 	alias_spec.set_type_index(registered_type_index.withCategory(arg.typeEnum()));
-	return add_type_alias_copy(
+	TypeInfo& type_info = add_type_alias_copy(
 		param_name,
 		registered_type_index.withCategory(arg.typeEnum()),
 		getTypeSizeFromTemplateArgument(arg),
 		alias_spec);
+	if (is_builtin_type(arg.typeEnum())) {
+		type_info.fallback_size_bits_ = get_type_size_bits(arg.category());
+	} else if (const TypeInfo* arg_type_info = tryGetTypeInfo(arg.type_index)) {
+		type_info.fallback_size_bits_ = arg_type_info->sizeInBits().value;
+	} else {
+		type_info.fallback_size_bits_ = 0;
+	}
+	return type_info;
 }
 
 static void resetTypeIndirection(TypeSpecifierNode& type_spec) {
@@ -971,10 +960,8 @@ bool Parser::tryAppendDefaultTemplateArg(
 // "N" to getTypesByNameMap() and confuse subsequent type lookups.
 // Template-template parameters are also skipped for the same reason.
 //
-// preserve_ref_qualifier: pass true for paths where the TemplateTypeArg ref_qualifier was
-//   set from user-written explicit args or class-template instantiation args (e.g., T
-//   bound to int& from a class<int&> instantiation).  Pass false for deduction paths
-//   where lvalue-ness of the call-site argument must NOT propagate to the TypeInfo entry.
+// preserve_ref_qualifier is retained on registerTypeParamsInScope for API compatibility.
+// Reference metadata for template bindings lives on alias_type_spec_ via registerTemplateTypeBinding.
 void registerTypeParamsInScope(
 	const InlineVector<StringHandle, 4>& param_names,
 	const InlineVector<TemplateTypeArg, 4>& type_args,
@@ -987,7 +974,6 @@ void registerTypeParamsInScope(
 		if (arg.is_template_template_arg)
 			continue;  // Template-template params don't represent concrete types
 		auto& type_info = registerTemplateTypeBinding(param_names[i], arg);
-		applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 		scope.addParameter(&type_info);
 	}
 }
@@ -1023,7 +1009,6 @@ void registerTypeParamsInScope(
 				return;
 			}
 			auto& type_info = registerTemplateTypeBinding(binding.name, arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -1043,7 +1028,6 @@ void registerTypeParamsInScope(
 				return;
 			}
 			auto& type_info = registerTemplateTypeBinding(binding.name, arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, true);
 			scope.addParameter(&type_info);
 			if (sfinae_map) {
 				(*sfinae_map)[type_info.name()] = arg.type_index;
@@ -1071,7 +1055,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -1088,7 +1071,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -1105,7 +1087,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, true);
 			scope.addParameter(&type_info);
 			if (sfinae_map)
 				(*sfinae_map)[type_info.name()] = arg.type_index;
@@ -1124,7 +1105,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, true);
 			scope.addParameter(&type_info);
 			if (sfinae_map)
 				(*sfinae_map)[type_info.name()] = arg.type_index;
@@ -1143,7 +1123,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, preserve_ref_qualifier);
 			scope.addParameter(&type_info);
 		});
 }
@@ -1160,7 +1139,6 @@ void registerTypeParamsInScope(
 			if (arg.is_value || arg.is_template_template_arg)
 				return;
 			auto& type_info = registerTemplateTypeBinding(param.nameHandle(), arg);
-			applyRegisteredTypeBindingMetadata(type_info, arg, true);
 			scope.addParameter(&type_info);
 			if (sfinae_map)
 				(*sfinae_map)[type_info.name()] = arg.type_index;
@@ -1312,7 +1290,7 @@ void Parser::reparse_template_function_body(
 		param_names.push_back(template_param.nameHandle());
 	}
 	// preserve_ref_qualifier=true for the explicit path (user-written T=int& must be
-	// reflected in TypeInfo); false for the deduced path.
+	// reflected in alias_type_spec_); false for the deduced path.
 	InlineVector<TemplateParameterNode, 4> template_param_nodes;
 	template_param_nodes.reserve(template_params.size());
 	for (const TemplateParameterNode& template_param_node : template_params) {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -960,13 +960,11 @@ bool Parser::tryAppendDefaultTemplateArg(
 // "N" to getTypesByNameMap() and confuse subsequent type lookups.
 // Template-template parameters are also skipped for the same reason.
 //
-// preserve_ref_qualifier is retained on registerTypeParamsInScope for API compatibility.
 // Reference metadata for template bindings lives on alias_type_spec_ via registerTemplateTypeBinding.
 void registerTypeParamsInScope(
 	const InlineVector<StringHandle, 4>& param_names,
 	const InlineVector<TemplateTypeArg, 4>& type_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier) {
+	FlashCpp::TemplateParameterScope& scope) {
 	for (size_t i = 0; i < param_names.size() && i < type_args.size(); ++i) {
 		const TemplateTypeArg& arg = type_args[i];
 		if (arg.is_value)
@@ -996,8 +994,7 @@ void forEachEnvironmentBinding(
 
 void registerTypeParamsInScope(
 	const TemplateEnvironment& environment,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier) {
+	FlashCpp::TemplateParameterScope& scope) {
 	forEachEnvironmentBinding(
 		environment,
 		[&](const TemplateBinding& binding) {
@@ -1046,8 +1043,7 @@ void registerTypeParamsInScope(
 void registerTypeParamsInScope(
 	const InlineVector<TemplateParameterNode, 4>& template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier) {
+	FlashCpp::TemplateParameterScope& scope) {
 	forEachNonPackTemplateParamArgBinding(
 		template_param_nodes,
 		template_args,
@@ -1062,8 +1058,7 @@ void registerTypeParamsInScope(
 void registerTypeParamsInScope(
 	const InlineVector<ASTNode, 4>& template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier) {
+	FlashCpp::TemplateParameterScope& scope) {
 	forEachNonPackTemplateParamArgBinding(
 		template_param_nodes,
 		template_args,
@@ -1114,8 +1109,7 @@ void registerTypeParamsInScope(
 void registerTypeParamsInScope(
 	std::span<const TemplateParameterNode> template_param_nodes,
 	std::span<const TemplateTypeArg> template_args,
-	FlashCpp::TemplateParameterScope& scope,
-	bool preserve_ref_qualifier) {
+	FlashCpp::TemplateParameterScope& scope) {
 	forEachNonPackTemplateParamArgBinding(
 		template_param_nodes,
 		template_args,
@@ -1238,17 +1232,15 @@ void Parser::populateTemplateParamSubstitutions(
 // Shared helper: re-parse a template function body with concrete argument
 // substitution and set the result as new_func_ref's definition.
 //
-// Called by both try_instantiate_template_explicit (preserve_ref_qualifier=true)
-// and try_instantiate_single_template (preserve_ref_qualifier=false) *after*
-// cycle detection has passed.  Pack-parameter state management and cycle
+// Called by both try_instantiate_template_explicit and try_instantiate_single_template
+// after cycle detection has passed.  Pack-parameter state management and cycle
 // detection remain the responsibility of the callers because they differ
 // between the two paths.
 void Parser::reparse_template_function_body(
 	FunctionDeclarationNode& new_func_ref,
 	const FunctionDeclarationNode& func_decl,
 	std::span<const TemplateParameterNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	bool preserve_ref_qualifier) {
+	std::span<const TemplateTypeArg> template_args) {
 	// Depth guard: function-template body replay can recursively re-enter via
 	// expressions inside the body that instantiate further templates.  libstdc++
 	// headers like <string_view>, <vector>, and <iterator> reach dozens of nested
@@ -1289,14 +1281,7 @@ void Parser::reparse_template_function_body(
 	for (const TemplateParameterNode& template_param : template_params) {
 		param_names.push_back(template_param.nameHandle());
 	}
-	// preserve_ref_qualifier=true for the explicit path (user-written T=int& must be
-	// reflected in alias_type_spec_); false for the deduced path.
-	InlineVector<TemplateParameterNode, 4> template_param_nodes;
-	template_param_nodes.reserve(template_params.size());
-	for (const TemplateParameterNode& template_param_node : template_params) {
-		template_param_nodes.push_back(template_param_node);
-	}
-	registerTypeParamsInScope(template_param_nodes, template_args, template_scope, preserve_ref_qualifier);
+	registerTypeParamsInScope(template_params, template_args, template_scope);
 
 	// Save lexer position and function context.
 	SaveHandle current_pos = save_token_position();
@@ -2627,8 +2612,6 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 	const std::span<const size_t>* template_param_arg_counts = binding_data.template_param_arg_counts;
 	const std::optional<CallArgDeductionInfo>* deduction_info = binding_data.deduction_info;
 	const std::optional<TypeSpecifierNode>* reparsed_trailing_return_type = binding_data.reparsed_trailing_return_type;
-	const bool preserve_ref_qualifier =
-		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::PreserveRefQualifier);
 	const bool use_explicit_materialization =
 		hasInstantiationFlag(instantiation_flags, FunctionTemplateInstantiationFlags::ExplicitMaterialization);
 	const bool cacheable_instantiation =
@@ -2760,8 +2743,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 		FlashCpp::TemplateParameterScope template_scope;
 		registerTypeParamsInScope(
 			substitution_environment,
-			template_scope,
-			preserve_ref_qualifier);
+			template_scope);
 		const int entered_namespace_count = enterSourceNamespaceIfNeeded();
 		auto exit_source_namespace = ScopeGuard([&]() {
 			exitSourceNamespaceIfNeeded(entered_namespace_count);
@@ -2879,7 +2861,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				pushCurrentTemplateParamName(template_param.nameHandle());
 			}
 			FlashCpp::TemplateParameterScope template_scope;
-			registerTypeParamsInScope(substitution_environment, template_scope, preserve_ref_qualifier);
+			registerTypeParamsInScope(substitution_environment, template_scope);
 			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
 			auto exit_source_namespace = ScopeGuard([&]() {
 				exitSourceNamespaceIfNeeded(entered_namespace_count);
@@ -2982,7 +2964,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 				pushCurrentTemplateParamName(template_param.nameHandle());
 			}
 			FlashCpp::TemplateParameterScope template_scope;
-			registerTypeParamsInScope(substitution_environment, template_scope, false);
+			registerTypeParamsInScope(substitution_environment, template_scope);
 			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
 			auto exit_return_type_namespace = ScopeGuard([&]() {
 				exitSourceNamespaceIfNeeded(entered_namespace_count);
@@ -3009,7 +2991,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			return_type = *return_type_result.node();
 			restore_lexer_position_only(func_decl.template_declaration_position());
 			FlashCpp::TemplateParameterScope template_scope2;
-			registerTypeParamsInScope(substitution_environment, template_scope2, false);
+			registerTypeParamsInScope(substitution_environment, template_scope2);
 			const int entered_name_parse_namespace_count = enterSourceNamespaceIfNeeded();
 			auto exit_name_parse_namespace = ScopeGuard([&]() {
 				exitSourceNamespaceIfNeeded(entered_name_parse_namespace_count);
@@ -3152,7 +3134,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			if (!pack_param_info_.empty()) {
 				has_parameter_packs_ = true;
 			}
-			reparse_template_function_body(new_func_ref, func_decl, template_params, template_args, preserve_ref_qualifier);
+			reparse_template_function_body(new_func_ref, func_decl, template_params, template_args);
 		} else {
 			static thread_local std::unordered_set<std::string_view> body_reparse_in_progress;
 			std::string_view cycle_key = mangled_name;
@@ -3174,11 +3156,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			}
 			if (template_instantiation_mode_ == TemplateInstantiationMode::HardUseCandidateProbe) {
 				ScopedParserInstantiationContext body_instantiation_mode(*this, TemplateInstantiationMode::HardUse, StringHandle{});
-				reparse_template_function_body(new_func_ref, func_decl, template_params, template_args,
-											   preserve_ref_qualifier);
+				reparse_template_function_body(new_func_ref, func_decl, template_params, template_args);
 			} else {
-				reparse_template_function_body(new_func_ref, func_decl, template_params, template_args,
-											   preserve_ref_qualifier);
+				reparse_template_function_body(new_func_ref, func_decl, template_params, template_args);
 			}
 			if (!new_func_ref.is_materialized()) {
 				StringBuilder reason_builder;
@@ -3948,9 +3928,8 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 			&template_param_arg_counts_view,
 			&helper_deduction_info,
 			&reparsed_trailing_return_type};
-		FunctionTemplateInstantiationFlags instantiation_flags = mergeInstantiationFlags(
-			FunctionTemplateInstantiationFlags::PreserveRefQualifier,
-			FunctionTemplateInstantiationFlags::ExplicitMaterialization);
+		FunctionTemplateInstantiationFlags instantiation_flags =
+			FunctionTemplateInstantiationFlags::ExplicitMaterialization;
 		instantiation_flags = mergeInstantiationFlags(
 			instantiation_flags,
 			FunctionTemplateInstantiationFlags::CommitInstantiation);
@@ -4020,9 +3999,8 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(std::string_vie
 				&template_param_arg_counts_view,
 				&helper_deduction_info,
 				&reparsed_trailing_return_type};
-			FunctionTemplateInstantiationFlags shape_flags = mergeInstantiationFlags(
-				FunctionTemplateInstantiationFlags::SkipBodyMaterialization,
-				FunctionTemplateInstantiationFlags::PreserveRefQualifier);
+			FunctionTemplateInstantiationFlags shape_flags =
+				FunctionTemplateInstantiationFlags::SkipBodyMaterialization;
 			shape_flags = mergeInstantiationFlags(
 				shape_flags,
 				FunctionTemplateInstantiationFlags::ExplicitMaterialization);

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -3020,7 +3020,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 
 	// Kind::Value and Kind::Template entries are intentionally skipped by registerTypeParamsInScope:
 	// registering them would poison getTypesByNameMap() with Invalid/garbage TypeInfo entries.
-	registerTypeParamsInScope(template_params, template_args, template_scope, false);
+	registerTypeParamsInScope(template_params, template_args, template_scope);
 
 	// Also add outer template parameter bindings (e.g., T→int from class template)
 	if (func_decl.has_outer_template_bindings()) {
@@ -3031,7 +3031,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		for (const auto& outer_arg : outer_arg_infos) {
 			outer_args.push_back(toTemplateTypeArg(outer_arg));
 		}
-		registerTypeParamsInScope(outer_param_names, outer_args, template_scope, true);
+		registerTypeParamsInScope(outer_param_names, outer_args, template_scope);
 		for (StringHandle outer_name : outer_param_names) {
 			param_names.push_back(outer_name);
 		}

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -54,7 +54,7 @@ ASTNode Parser::substituteLazyMemberBody(
 		template_args,
 		outer_environment);
 	FlashCpp::TemplateParameterScope template_scope;
-	registerTypeParamsInScope(substitution_environment, template_scope, true);
+	registerTypeParamsInScope(substitution_environment, template_scope);
 	FlashCpp::ScopedState guard_subs(template_param_substitutions_);
 	populateTemplateParamSubstitutions(template_param_substitutions_, substitution_environment);
 	return substituteTemplateParameters(
@@ -388,7 +388,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
 				outer_environment);
 			FlashCpp::TemplateParameterScope template_scope;
-			registerTypeParamsInScope(substitution_environment, template_scope, true);
+			registerTypeParamsInScope(substitution_environment, template_scope);
 			ScopedDefinitionLookupContext definition_ctx_scope(
 				current_template_definition_lookup_context_,
 				lazy_info.definition_lookup_context.is_valid()
@@ -767,7 +767,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
 			outer_environment);
 		FlashCpp::TemplateParameterScope template_scope;
-		registerTypeParamsInScope(substitution_environment, template_scope, true);
+		registerTypeParamsInScope(substitution_environment, template_scope);
 
 		// Save current position and parsing context
 		SaveHandle current_pos = save_token_position();
@@ -1118,7 +1118,7 @@ bool Parser::instantiateLazyStaticMember(StringHandle instantiated_class_name, S
 			std::span<const TemplateTypeArg>(lazy_info.template_args.data(), lazy_info.template_args.size()),
 			outer_environment);
 		FlashCpp::TemplateParameterScope template_scope;
-		registerTypeParamsInScope(substitution_environment, template_scope, true);
+		registerTypeParamsInScope(substitution_environment, template_scope);
 
 		SaveHandle current_pos = save_token_position();
 		ScopedLexerPositionRestore lexer_restore(*this, current_pos);

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -3788,12 +3788,6 @@ ParseResult Parser::parse_type_specifier() {
 			if (!is_typedef && has_alias_type_shape) {
 				is_typedef = true;
 			}
-			// Keep non-alias synthetic type entries (e.g. template parameter placeholders) working.
-			// This is critical for std::move's ReturnType which is typename remove_reference<T>::type&&
-			if (!is_typedef &&
-				type_info_ctx->reference_qualifier_ != ReferenceQualifier::None) {
-				is_typedef = true;
-			}
 			if (is_typedef) {
 				resolved_type = resolved_alias.typeEnum();
 				type_size = static_cast<unsigned char>(type_info_ctx->sizeInBits().value);


### PR DESCRIPTION
## Summary
- Remove dead `TypeInfo::reference_qualifier_`; template binding reference metadata now lives solely on `alias_type_spec_` via `registerTemplateTypeBinding`.`n- Route the class-template deferred body re-parse path through the same helper instead of `add_template_param_type` plus a top-level ref field.`n- Drop the now-no-op `preserve_ref_qualifier` parameter from `registerTypeParamsInScope` / `reparse_template_function_body`, and remove `FunctionTemplateInstantiationFlags::PreserveRefQualifier`.`n`nPart of the TypeInfo cleanup series tracked in #631.`n`n## Test plan`n- [x] `pwsh tests/run_all_tests.ps1` — 2775/2775 pass, 240/240 `_fail` tests pass as expected`n- [x] Targeted regressions: `test_sfinae_trailing_return_ref_arg_ret0.cpp`, `test_function_template_fixed_param_before_pack_ret0.cpp`

Made with [Cursor](https://cursor.com)