### PR TITLE
Store StructTypeInfo/EnumTypeInfo in ChunkedVector arenas

### DIFF
--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -248,6 +248,9 @@ std::unordered_map<TypeCategory, const TypeInfo*> gNativeTypes;
 ChunkedVector<TypeInfo::DependentQualifiedNameRecord, 4> gDependentQualifiedNameRecords;
 ChunkedVector<InlineVector<TypeInfo::TemplateArgInfo, 4>, 8> gTypeInfoTemplateArgLists;
 ChunkedVector<TypeInfo::InstantiationContext, 8> gInstantiationContexts;
+// StructTypeInfo is large; keep chunks small to avoid huge reserved slabs.
+ChunkedVector<StructTypeInfo, 4> gStructTypeInfos;
+ChunkedVector<EnumTypeInfo, 16> gEnumTypeInfos;
 
 uint32_t storeDependentQualifiedNameRecord(TypeInfo::DependentQualifiedNameRecord record) {
 	const uint32_t index = static_cast<uint32_t>(gDependentQualifiedNameRecords.size());
@@ -329,6 +332,14 @@ TypeInfo::InstantiationContext* getInstantiationContextMut(uint32_t index) {
 
 size_t getInstantiationContextCount() {
 	return gInstantiationContexts.size();
+}
+
+size_t getStructTypeInfoCount() {
+	return gStructTypeInfos.size();
+}
+
+size_t getEnumTypeInfoCount() {
+	return gEnumTypeInfos.size();
 }
 
 const TypeInfo::InstantiationContext* TypeInfo::instantiationContext() const {
@@ -482,7 +493,7 @@ TypeCreationResult register_type_alias(StringHandle name, const TypeSpecifierNod
 		tryGetTypeInfo(type_spec.type_index()));
 	if (type_spec.category() == TypeCategory::Enum && type_spec.type_index().index() < gTypeInfo.size()) {
 		if (const EnumTypeInfo* enum_info = gTypeInfo[type_spec.type_index().index()].getEnumInfo()) {
-			info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
+			info.setEnumInfo(EnumTypeInfo(*enum_info));
 		}
 	}
 	emplaceTypeNameTracked("register_type_alias", info.name(), &info);
@@ -618,7 +629,7 @@ void update_type_alias_copy(
 	alias_type_info.registered_type_index_ = TypeIndex{alias_slot, TypeCategory::TypeAlias};
 	alias_type_info.fallback_size_bits_ = size_bits;
 	alias_type_info.is_type_alias_ = true;
-	alias_type_info.setEnumInfo(nullptr);
+	alias_type_info.clearEnumInfo();
 	const TypeInfo* enum_source_type_info = semantic_source_type_info;
 	if (enum_source_type_info == nullptr &&
 		alias_type_spec != nullptr &&
@@ -627,7 +638,7 @@ void update_type_alias_copy(
 	}
 	if (enum_source_type_info != nullptr) {
 		if (const EnumTypeInfo* enum_info = enum_source_type_info->getEnumInfo()) {
-			alias_type_info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
+			alias_type_info.setEnumInfo(EnumTypeInfo(*enum_info));
 		}
 	}
 	resetTypeAliasSemanticMetadata(alias_type_info);
@@ -787,6 +798,18 @@ void printTypeTableStats() {
 			  ", context_bytes=", sizeof(TypeInfo::InstantiationContext),
 			  ", estimated cold storage=",
 			  getInstantiationContextCount() * sizeof(TypeInfo::InstantiationContext),
+			  " bytes");
+	FLASH_LOG(General, Info, "  gStructTypeInfos: entries=",
+			  getStructTypeInfoCount(),
+			  ", struct_bytes=", sizeof(StructTypeInfo),
+			  ", estimated cold storage=",
+			  getStructTypeInfoCount() * sizeof(StructTypeInfo),
+			  " bytes");
+	FLASH_LOG(General, Info, "  gEnumTypeInfos: entries=",
+			  getEnumTypeInfoCount(),
+			  ", enum_bytes=", sizeof(EnumTypeInfo),
+			  ", estimated cold storage=",
+			  getEnumTypeInfoCount() * sizeof(EnumTypeInfo),
 			  " bytes");
 
 	// Break down entries by category
@@ -1483,22 +1506,58 @@ void StructTypeInfo::addConstructor(ASTNode constructor_decl, AccessSpecifier ac
 	propagateAstProperties(ctor);
 }
 
-void TypeInfo::setStructInfo(std::unique_ptr<StructTypeInfo> info) {
-	if (struct_info_) {
+StructTypeInfo& TypeInfo::createStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
+										   NamespaceHandle ns) {
+	if (struct_info_ != nullptr) {
 		FlashCpp::gLazyMemberResolver.invalidateEntriesOwnedBy(type_index_);
 	}
-	if (info) {
-		info->own_type_index_ = type_index_;
-		for (auto& member_func : info->member_functions) {
-			if (member_func.is_constructor) {
-				if (!member_func.function_decl.is<ConstructorDeclarationNode>()) {
-					throw InternalError("Constructor member metadata does not contain a ConstructorDeclarationNode");
-				}
-				member_func.function_decl.as<ConstructorDeclarationNode>().set_owning_type_index(type_index_);
+	StructTypeInfo& info = gStructTypeInfos.emplace_back(n, default_acc, union_type, ns);
+	info.own_type_index_ = type_index_;
+	struct_info_ = &info;
+	return info;
+}
+
+void TypeInfo::bindStructInfoOwnership() {
+	if (struct_info_ == nullptr) {
+		return;
+	}
+	struct_info_->own_type_index_ = type_index_;
+	for (auto& member_func : struct_info_->member_functions) {
+		if (member_func.is_constructor) {
+			if (!member_func.function_decl.is<ConstructorDeclarationNode>()) {
+				throw InternalError("Constructor member metadata does not contain a ConstructorDeclarationNode");
 			}
+			member_func.function_decl.as<ConstructorDeclarationNode>().set_owning_type_index(type_index_);
 		}
 	}
-	struct_info_ = std::move(info);
+}
+
+void TypeInfo::setStructInfo(StructTypeInfo info) {
+	if (struct_info_ != nullptr) {
+		FlashCpp::gLazyMemberResolver.invalidateEntriesOwnedBy(type_index_);
+	}
+	info.own_type_index_ = type_index_;
+	for (auto& member_func : info.member_functions) {
+		if (member_func.is_constructor) {
+			if (!member_func.function_decl.is<ConstructorDeclarationNode>()) {
+				throw InternalError("Constructor member metadata does not contain a ConstructorDeclarationNode");
+			}
+			member_func.function_decl.as<ConstructorDeclarationNode>().set_owning_type_index(type_index_);
+		}
+	}
+	struct_info_ = &gStructTypeInfos.push_back(std::move(info));
+}
+
+EnumTypeInfo& TypeInfo::createEnumInfo(StringHandle n, bool scoped) {
+	EnumTypeInfo& info = gEnumTypeInfos.emplace_back(n, scoped);
+	fallback_size_bits_ = info.underlying_size.value;
+	enum_info_ = &info;
+	return info;
+}
+
+void TypeInfo::setEnumInfo(EnumTypeInfo info) {
+	fallback_size_bits_ = info.underlying_size.value;
+	enum_info_ = &gEnumTypeInfos.push_back(std::move(info));
 }
 
 void TypeInfo::setInstantiationContext(InlineVector<StringHandle, 4> param_names,

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -1506,14 +1506,25 @@ void StructTypeInfo::addConstructor(ASTNode constructor_decl, AccessSpecifier ac
 	propagateAstProperties(ctor);
 }
 
-StructTypeInfo& TypeInfo::createStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
-										   NamespaceHandle ns) {
-	if (struct_info_ != nullptr) {
-		FlashCpp::gLazyMemberResolver.invalidateEntriesOwnedBy(type_index_);
-	}
+StructTypeInfo& TypeInfo::emplaceStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
+											NamespaceHandle ns) {
 	StructTypeInfo& info = gStructTypeInfos.emplace_back(n, default_acc, union_type, ns);
 	info.own_type_index_ = type_index_;
+	return info;
+}
+
+void TypeInfo::attachStructInfo(StructTypeInfo& info) {
+	if (struct_info_ != nullptr && struct_info_ != &info) {
+		FlashCpp::gLazyMemberResolver.invalidateEntriesOwnedBy(type_index_);
+	}
+	info.own_type_index_ = type_index_;
 	struct_info_ = &info;
+}
+
+StructTypeInfo& TypeInfo::createStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
+										   NamespaceHandle ns) {
+	StructTypeInfo& info = emplaceStructInfo(n, default_acc, union_type, ns);
+	attachStructInfo(info);
 	return info;
 }
 

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -84,8 +84,8 @@ struct StructTypeInfo {
 	// Error tracking for semantic errors detected during finalization
 	std::string finalization_error_;	 // Non-empty if semantic error occurred during finalization
 
-	// Cached type_index from the owning TypeInfo, set by TypeInfo::setStructInfo().
-	// Avoids fragile gTypesByName lookups in isOwnTypeIndex().
+	// Cached type_index from the owning TypeInfo, set by TypeInfo::createStructInfo() /
+	// TypeInfo::setStructInfo(). Avoids fragile gTypesByName lookups in isOwnTypeIndex().
 	std::optional<TypeIndex> own_type_index_;
 
 	StructTypeInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
@@ -1043,11 +1043,10 @@ struct TypeInfo {
 	// True if this TypeInfo entry was registered via register_type_alias (typedef / using alias)
 	bool is_type_alias_ = false;
 
-	// For struct types, store additional information
-	std::unique_ptr<StructTypeInfo> struct_info_;
-
-	// For enum types, store additional information
-	std::unique_ptr<EnumTypeInfo> enum_info_;
+	// Pointers into gStructTypeInfos / gEnumTypeInfos cold arenas (nullptr = none).
+	// Keeps StructTypeInfo / EnumTypeInfo payloads out of every TypeInfo row.
+	StructTypeInfo* struct_info_ = nullptr;
+	EnumTypeInfo* enum_info_ = nullptr;
 
 	// Generic fallback size in bits for aliases, incomplete types, and forward declarations.
 	// Struct layout remains authoritative in StructTypeInfo::total_size.
@@ -1331,36 +1330,48 @@ struct TypeInfo {
 
 	// Helper methods for struct types
 	bool isStruct() const { return category() == TypeCategory::Struct; }
-	const StructTypeInfo* getStructInfo() const { return struct_info_.get(); }
-	StructTypeInfo* getStructInfo() { return struct_info_.get(); }
+	bool hasStructInfo() const { return struct_info_ != nullptr; }
+	const StructTypeInfo* getStructInfo() const { return struct_info_; }
+	StructTypeInfo* getStructInfo() { return struct_info_; }
 
-	void setStructInfo(std::unique_ptr<StructTypeInfo> info);
+	// Pre-allocate StructTypeInfo in gStructTypeInfos and attach it. Prefer this when
+	// the payload is mutated over a long parse/instantiation — the returned reference is
+	// stable for the process lifetime (append-only arena).
+	StructTypeInfo& createStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
+									 NamespaceHandle ns);
+	// Move a stack-built or copied StructTypeInfo into the arena and attach it.
+	void setStructInfo(StructTypeInfo info);
+	// Re-bind owning TypeIndex onto constructors (safe to call after createStructInfo once
+	// all constructors have been added; redundant with addConstructor when own_type_index_
+	// was already set at create time).
+	void bindStructInfoOwnership();
+	void clearStructInfo() { struct_info_ = nullptr; }
 
 	// Helper methods for enum types
 	bool isEnum() const { return category() == TypeCategory::Enum; }
-	const EnumTypeInfo* getEnumInfo() const { return enum_info_.get(); }
-	EnumTypeInfo* getEnumInfo() { return enum_info_.get(); }
+	bool hasEnumInfo() const { return enum_info_ != nullptr; }
+	const EnumTypeInfo* getEnumInfo() const { return enum_info_; }
+	EnumTypeInfo* getEnumInfo() { return enum_info_; }
 
-	void setEnumInfo(std::unique_ptr<EnumTypeInfo> info) {
-		if (info) {
-			fallback_size_bits_ = info->underlying_size.value;
-		}
-		enum_info_ = std::move(info);
-	}
+	// Pre-allocate EnumTypeInfo in gEnumTypeInfos and attach it.
+	EnumTypeInfo& createEnumInfo(StringHandle n, bool scoped);
+	// Move a stack-built or copied EnumTypeInfo into the arena and attach it.
+	void setEnumInfo(EnumTypeInfo info);
+	void clearEnumInfo() { enum_info_ = nullptr; }
 
 	SizeInBits sizeInBits() const {
-		if (struct_info_) {
-			return struct_info_->sizeInBits();
+		if (const StructTypeInfo* struct_info = getStructInfo()) {
+			return struct_info->sizeInBits();
 		}
-		if (enum_info_) {
-			return enum_info_->sizeInBits();
+		if (const EnumTypeInfo* enum_info = getEnumInfo()) {
+			return enum_info->sizeInBits();
 		}
 		return SizeInBits{fallback_size_bits_};
 	}
 
 	SizeInBytes sizeInBytes() const {
-		if (struct_info_) {
-			return struct_info_->sizeInBytes();
+		if (const StructTypeInfo* struct_info = getStructInfo()) {
+			return struct_info->sizeInBytes();
 		}
 		SizeInBits bits = sizeInBits();
 		return bits.is_set() ? toBytesCeil(bits) : SizeInBytes{};
@@ -1405,6 +1416,10 @@ uint32_t storeInstantiationContext(TypeInfo::InstantiationContext ctx);
 const TypeInfo::InstantiationContext* getInstantiationContext(uint32_t index);
 TypeInfo::InstantiationContext* getInstantiationContextMut(uint32_t index);
 size_t getInstantiationContextCount();
+
+// Cold arenas for StructTypeInfo / EnumTypeInfo payloads.
+size_t getStructTypeInfoCount();
+size_t getEnumTypeInfoCount();
 
 // Returned by add_user_type / add_function_type / add_struct_type / add_enum_type /
 // register_type_alias so callers can capture both the TypeInfo reference AND the

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1334,16 +1334,23 @@ struct TypeInfo {
 	const StructTypeInfo* getStructInfo() const { return struct_info_; }
 	StructTypeInfo* getStructInfo() { return struct_info_; }
 
-	// Pre-allocate StructTypeInfo in gStructTypeInfos and attach it. Prefer this when
-	// the payload is mutated over a long parse/instantiation — the returned reference is
-	// stable for the process lifetime (append-only arena).
+	// Pre-allocate StructTypeInfo in gStructTypeInfos. Does NOT publish via
+	// struct_info_ — call attachStructInfo() once the payload is complete so
+	// incomplete types stay invisible to lookup (e.g. member typedefs during
+	// template instantiation).
+	StructTypeInfo& emplaceStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
+									  NamespaceHandle ns);
+	// Publish an arena-allocated StructTypeInfo on this TypeInfo.
+	void attachStructInfo(StructTypeInfo& info);
+	// emplaceStructInfo + attachStructInfo — use when the payload is immediately
+	// ready for lookup (or will be mutated while already published).
 	StructTypeInfo& createStructInfo(StringHandle n, AccessSpecifier default_acc, bool union_type,
 									 NamespaceHandle ns);
 	// Move a stack-built or copied StructTypeInfo into the arena and attach it.
 	void setStructInfo(StructTypeInfo info);
-	// Re-bind owning TypeIndex onto constructors (safe to call after createStructInfo once
-	// all constructors have been added; redundant with addConstructor when own_type_index_
-	// was already set at create time).
+	// Re-bind owning TypeIndex onto constructors (safe to call after attach once
+	// all constructors have been added; redundant with addConstructor when
+	// own_type_index_ was already set at emplace time).
 	void bindStructInfoOwnership();
 	void clearStructInfo() { struct_info_ = nullptr; }
 

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -5164,11 +5164,11 @@ EvalResult Evaluator::evaluate_function_call(const CallExprNode& call_expr, Eval
 
 		for (size_t i = 1; i < getTypeInfoCount(); ++i) {
 			const TypeInfo& type_info = getTypeInfo(TypeIndex{i});
-			if (!type_info.struct_info_)
+			if (!type_info.getStructInfo())
 				continue;
 
 			// Search member functions in this struct
-			for (const auto& member_func : type_info.struct_info_->member_functions) {
+			for (const auto& member_func : type_info.getStructInfo()->member_functions) {
 				if (member_func.name == StringTable::getOrInternStringHandle(func_name)) {
 					// Found a matching member function
 					const ASTNode& func_node = member_func.function_decl;

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -3023,8 +3023,8 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 			}
 
 			if (ordering_type) {
-				const int ordering_size = static_cast<int>(ordering_type->struct_info_
-															   ? ordering_type->struct_info_->sizeInBits().value
+				const int ordering_size = static_cast<int>(ordering_type->getStructInfo()
+															   ? ordering_type->getStructInfo()->sizeInBits().value
 															   : 8);
 
 				// Compute three-way result: (a > b) - (a < b) -> -1, 0, or 1.
@@ -4129,7 +4129,7 @@ std::string_view AstToIr::generateMangledNameForCall(const FunctionDeclarationNo
 			// Check return type for self-referential struct
 			if (return_type.category() == TypeCategory::Struct && return_type.type_index().is_valid()) {
 				const TypeInfo* rti = tryGetTypeInfo(return_type.type_index());
-				if (!rti || !rti->struct_info_ || !rti->struct_info_->sizeInBytes().is_set()) {
+				if (!rti || !rti->getStructInfo() || !rti->getStructInfo()->sizeInBytes().is_set()) {
 					needs_resolution = true;
 				}
 			}
@@ -4139,7 +4139,7 @@ std::string_view AstToIr::generateMangledNameForCall(const FunctionDeclarationNo
 						const auto& pt = param.as<DeclarationNode>().type_specifier_node();
 						if (pt.category() == TypeCategory::Struct && pt.type_index().is_valid()) {
 							const TypeInfo* ti = tryGetTypeInfo(pt.type_index());
-							if (!ti || !ti->struct_info_ || !ti->struct_info_->sizeInBytes().is_set()) {
+							if (!ti || !ti->getStructInfo() || !ti->getStructInfo()->sizeInBytes().is_set()) {
 								needs_resolution = true;
 								break;
 							}

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -217,8 +217,8 @@ ExprResult AstToIr::generateNewExpressionIr(const NewExpressionNode& newExpr) {
 				if (type_cat == TypeCategory::Struct) {
 					TypeIndex type_index = type_spec.type_index();
 					if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-						if (type_info->struct_info_) {
-							const StructTypeInfo* struct_info = type_info->struct_info_.get();
+						if (type_info->getStructInfo()) {
+							const StructTypeInfo* struct_info = type_info->getStructInfo();
 							size_t element_size = toSizeT(struct_info->sizeInBytes());
 
 								// Generate initialization for each element
@@ -315,10 +315,10 @@ ExprResult AstToIr::generateNewExpressionIr(const NewExpressionNode& newExpr) {
 			if (type_cat == TypeCategory::Struct) {
 				TypeIndex type_index = type_spec.type_index();
 				if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-					if (type_info->struct_info_ && type_info->struct_info_->hasAnyConstructor()) {
-						array_struct_info = type_info->struct_info_.get();
+					if (type_info->getStructInfo() && type_info->getStructInfo()->hasAnyConstructor()) {
+						array_struct_info = type_info->getStructInfo();
 						needs_ctor_loop = true;
-						op.needs_cookie = type_info->struct_info_->hasDestructor();
+						op.needs_cookie = type_info->getStructInfo()->hasDestructor();
 					}
 				}
 			}
@@ -332,8 +332,8 @@ ExprResult AstToIr::generateNewExpressionIr(const NewExpressionNode& newExpr) {
 				if (type_cat == TypeCategory::Struct) {
 					TypeIndex type_index = type_spec.type_index();
 					if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-						if (type_info->struct_info_) {
-							const StructTypeInfo* struct_info = type_info->struct_info_.get();
+						if (type_info->getStructInfo()) {
+							const StructTypeInfo* struct_info = type_info->getStructInfo();
 							size_t element_size = toSizeT(struct_info->sizeInBytes());
 
 							for (size_t i = 0; i < array_inits.size(); ++i) {
@@ -490,14 +490,14 @@ ExprResult AstToIr::generateNewExpressionIr(const NewExpressionNode& newExpr) {
 		if (type_cat == TypeCategory::Struct) {
 			TypeIndex type_index = type_spec.type_index();
 			if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-					if (type_info->struct_info_) {
+					if (type_info->getStructInfo()) {
 						// Check if this is an abstract class
-					if (type_info->struct_info_->is_abstract) {
+					if (type_info->getStructInfo()->is_abstract) {
 						std::cerr << "Error: Cannot instantiate abstract class '" << type_info->name() << "'\n";
 						throw CompileError("Cannot instantiate abstract class");
 					}
 
-					emit_struct_new_initializer(result_var, *type_info->struct_info_);
+					emit_struct_new_initializer(result_var, *type_info->getStructInfo());
 				}
 			}
 		}
@@ -517,14 +517,14 @@ ExprResult AstToIr::generateNewExpressionIr(const NewExpressionNode& newExpr) {
 		if (type_cat == TypeCategory::Struct) {
 			TypeIndex type_index = type_spec.type_index();
 			if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-				if (type_info->struct_info_) {
+				if (type_info->getStructInfo()) {
 						// Check if this is an abstract class
-					if (type_info->struct_info_->is_abstract) {
+					if (type_info->getStructInfo()->is_abstract) {
 						std::cerr << "Error: Cannot instantiate abstract class '" << type_info->name() << "'\n";
 						throw CompileError("Cannot instantiate abstract class");
 					}
 
-					emit_struct_new_initializer(result_var, *type_info->struct_info_);
+					emit_struct_new_initializer(result_var, *type_info->getStructInfo());
 				}
 			}
 		}
@@ -1074,9 +1074,9 @@ ExprResult AstToIr::generateStaticCastIr(const StaticCastNode& staticCastNode) {
 	// identity instead of treating every struct cast as a raw reinterpretation.
 	if (target_type == TypeCategory::Struct && isExactComparisonCategoryType(target_type_node.type_index())) {
 		const TypeInfo* target_type_info = tryGetTypeInfo(target_type_node.type_index());
-		if (target_type_info && target_type_info->struct_info_) {
+		if (target_type_info && target_type_info->getStructInfo()) {
 			return makeExprResult(target_type_node.type_index(),
-								  SizeInBits{static_cast<int>(target_type_info->struct_info_->sizeInBits().value)},
+								  SizeInBits{static_cast<int>(target_type_info->getStructInfo()->sizeInBits().value)},
 								  expr_operands.value, PointerDepth{}, ValueStorage::ContainsData);
 		}
 	}
@@ -1162,9 +1162,9 @@ ExprResult AstToIr::generateTypeidIr(const TypeidNode& typeidNode) {
 						if (type_node.category() == TypeCategory::UserDefined) {
 							StringHandle type_name_handle = StringTable::getOrInternStringHandle(type_node.token().value());
 							auto it = getTypesByNameMap().find(type_name_handle);
-							if (it != getTypesByNameMap().end() && it->second && it->second->struct_info_ &&
-								it->second->struct_info_->own_type_index_.has_value()) {
-								return *it->second->struct_info_->own_type_index_;
+							if (it != getTypesByNameMap().end() && it->second && it->second->getStructInfo() &&
+								it->second->getStructInfo()->own_type_index_.has_value()) {
+								return *it->second->getStructInfo()->own_type_index_;
 							}
 						}
 						return {};

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -356,7 +356,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 		deferred_member_functions_.push_back(std::move(deferred_info));
 	};
 	auto register_destructor_if_needed = [this](const DeclarationNode& inner_decl, const TypeInfo* type_info) {
-		if (!type_info || !type_info->struct_info_ || !type_info->struct_info_->hasDestructor()) {
+		if (!type_info || !type_info->getStructInfo() || !type_info->getStructInfo()->hasDestructor()) {
 			return;
 		}
 		registerVariableWithDestructor(
@@ -1488,8 +1488,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 				if (type_node.category() == TypeCategory::Struct) {
 					TypeIndex type_index = type_node.type_index();
 					if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-						if (type_info->struct_info_) {
-							const StructTypeInfo& struct_info = *type_info->struct_info_;
+						if (type_info->getStructInfo()) {
+							const StructTypeInfo& struct_info = *type_info->getStructInfo();
 
 								// Check if this is an abstract class (only for non-pointer types)
 							if (struct_info.is_abstract && type_node.pointer_levels().empty()) {
@@ -1566,8 +1566,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								const bool require_sema_resolved_ctor =
 									sema_normalized_current_function_ &&
 									type_info &&
-									type_info->struct_info_ &&
-									type_info->struct_info_->hasUserDeclaredConstructor();
+									type_info->getStructInfo() &&
+									type_info->getStructInfo()->hasUserDeclaredConstructor();
 
 								// SECOND: If no copy constructor matched, prefer the sema annotation.
 								// Only fall back to local type-based/arity-based resolution when sema
@@ -1873,9 +1873,9 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 											if (const TypeInfo* nested_member_type_info = tryGetTypeInfo(nested_member_type_index)) {
 
 												// If this is a struct type, use the recursive helper
-												if (nested_member_type_info->struct_info_ && !nested_member_type_info->struct_info_->members.empty()) {
+												if (nested_member_type_info->getStructInfo() && !nested_member_type_info->getStructInfo()->members.empty()) {
 													generateNestedMemberStores(
-														*nested_member_type_info->struct_info_,
+														*nested_member_type_info->getStructInfo(),
 														nested_init_list,
 														decl.identifier_token().handle(),
 														static_cast<int>(member.offset),
@@ -2020,7 +2020,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 				!type_node.is_reference() &&
 				!type_node.is_rvalue_reference()) {
 				const TypeInfo* type_info = tryGetTypeInfo(type_node.type_index());
-				if (type_info && type_info->struct_info_ && type_info->struct_info_->hasAnyConstructor()) {
+				if (type_info && type_info->getStructInfo() && type_info->getStructInfo()->hasAnyConstructor()) {
 					is_struct_with_constructor = true;
 				}
 			}
@@ -2390,7 +2390,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 			const StructTypeInfo* struct_info_ptr = nullptr;
 			if (type_node.category() == TypeCategory::Struct) {
 				if (const TypeInfo* type_info = tryGetTypeInfo(type_node.type_index())) {
-					struct_info_ptr = type_info->struct_info_.get();
+					struct_info_ptr = type_info->getStructInfo();
 				}
 			}
 			if (!struct_info_ptr && type_node.array_dimension_count() > 1) {
@@ -2471,9 +2471,9 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 				return;
 			}
 
-			if (type_info->struct_info_) {
+			if (type_info->getStructInfo()) {
 					// Check if this is an abstract class (only for non-pointer types)
-				if (type_info->struct_info_->is_abstract && type_node.pointer_levels().empty()) {
+				if (type_info->getStructInfo()->is_abstract && type_node.pointer_levels().empty()) {
 					FLASH_LOG(General, Error, "Cannot instantiate abstract class '", type_info->name(), "'");
 					throw CompileError("Cannot instantiate abstract class");
 				}
@@ -2482,7 +2482,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 				// synthesized by generateTrivialDefaultConstructors() for template-
 				// instantiated structs that have member default initializers but no
 				// explicit user-declared constructors.
-				if (type_info->struct_info_->hasAnyConstructor() || type_info->struct_info_->needs_default_constructor) {
+				if (type_info->getStructInfo()->hasAnyConstructor() || type_info->getStructInfo()->needs_default_constructor) {
 					FLASH_LOG(Codegen, Debug, "Struct ", type_info->name(), " has constructor or needs default constructor");
 						// Check if we have a copy/move initializer like "Tiny t2 = t;"
 						// Skip if the variable was already initialized with an rvalue (function return)
@@ -2524,8 +2524,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 						const bool require_sema_resolved_ctor =
 							sema_normalized_current_function_ &&
 							ctor_constructs_target_type &&
-							type_info->struct_info_ &&
-							type_info->struct_info_->hasUserDeclaredConstructor();
+							type_info->getStructInfo() &&
+							type_info->getStructInfo()->hasUserDeclaredConstructor();
 						if (const ConstructorDeclarationNode* resolved_ctor = direct_ctor->resolved_constructor()) {
 							if (resolvedConstructorMatchesTargetType(*resolved_ctor, type_node.type_index())) {
 								matching_ctor = resolved_ctor;
@@ -2538,7 +2538,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 						size_t num_args = 0;
 						direct_ctor->arguments().visit([&](ASTNode) { num_args++; });
 
-						if (type_info->struct_info_) {
+						if (type_info->getStructInfo()) {
 							if (require_sema_resolved_ctor && matching_ctor) {
 								FLASH_LOG_FORMAT(Codegen, Debug, "Using sema-resolved constructor for {}", StringTable::getStringView(type_info->name()));
 							}
@@ -2581,9 +2581,9 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 
 									// Only select same-type special members if argument is of the same struct type
 									if (arg_is_same_struct_type) {
-										diagnoseDeletedSameTypeConstructorUsage(*type_info->struct_info_, prefer_move_ctor);
+										diagnoseDeletedSameTypeConstructorUsage(*type_info->getStructInfo(), prefer_move_ctor);
 										const StructMemberFunction* same_type_ctor_func =
-											type_info->struct_info_->findPreferredSameTypeConstructor(prefer_move_ctor, true);
+											type_info->getStructInfo()->findPreferredSameTypeConstructor(prefer_move_ctor, true);
 										if (same_type_ctor_func && same_type_ctor_func->function_decl.is<ConstructorDeclarationNode>()) {
 											matching_ctor = &same_type_ctor_func->function_decl.as<ConstructorDeclarationNode>();
 											FLASH_LOG(Codegen, Debug, "Matched ", prefer_move_ctor ? "move" : "copy", " constructor for ", type_info->name());
@@ -2605,14 +2605,14 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 									});
 
 									if (arg_types.size() == num_args) {
-										auto resolution = resolve_constructor_overload(*type_info->struct_info_, arg_types, false);
+										auto resolution = resolve_constructor_overload(*type_info->getStructInfo(), arg_types, false);
 										if (resolution.is_ambiguous) {
 											throw CompileError("Ambiguous constructor call");
 										}
 										bool template_ctor_ambiguous = false;
 										matching_ctor = parser_.materializeMatchingConstructorTemplate(
 											type_info->name(),
-											*type_info->struct_info_,
+											*type_info->getStructInfo(),
 											arg_types,
 											resolution.selected_overload,
 											template_ctor_ambiguous);
@@ -2626,7 +2626,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 
 									if (!matching_ctor && !sema_normalized_current_function_) {
 										FLASH_LOG_FORMAT(Codegen, Debug, "Falling back to arity-based constructor resolution for {}", StringTable::getStringView(type_info->name()));
-										auto arity_resolution = resolve_constructor_overload_arity(*type_info->struct_info_, num_args, true);
+										auto arity_resolution = resolve_constructor_overload_arity(*type_info->getStructInfo(), num_args, true);
 										matching_ctor = arity_resolution.selected_overload;
 									}
 								}
@@ -2637,9 +2637,9 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							// If no matching constructor was found and the struct is an aggregate
 							// (no user-defined constructors), generate direct member stores.
 						bool used_aggregate_paren_init = false;
-						if (!matching_ctor && type_info->struct_info_ && num_args > 0 && !type_info->struct_info_->members.empty()) {
+						if (!matching_ctor && type_info->getStructInfo() && num_args > 0 && !type_info->getStructInfo()->members.empty()) {
 							bool is_aggregate = true;
-							for (const auto& func : type_info->struct_info_->member_functions) {
+							for (const auto& func : type_info->getStructInfo()->member_functions) {
 								if (func.is_constructor && func.function_decl.is<ConstructorDeclarationNode>()) {
 									if (!func.function_decl.as<ConstructorDeclarationNode>().is_implicit()) {
 										is_aggregate = false;
@@ -2648,24 +2648,24 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								}
 							}
 
-							if (is_aggregate && num_args <= type_info->struct_info_->members.size()) {
+							if (is_aggregate && num_args <= type_info->getStructInfo()->members.size()) {
 								FLASH_LOG(Codegen, Debug, "Using aggregate parenthesized init for ", type_info->name());
 								used_aggregate_paren_init = true;
 								// Emit default constructor call first (zero-initializes the object)
 								ConstructorCallOp default_ctor_op;
 								default_ctor_op.object = decl.identifier_token().handle();
-								fillInDefaultConstructorArguments(default_ctor_op, *type_info->struct_info_);
-								finalizeConstructorCallOp(default_ctor_op, *type_info->struct_info_, decl.identifier_token());
+								fillInDefaultConstructorArguments(default_ctor_op, *type_info->getStructInfo());
+								finalizeConstructorCallOp(default_ctor_op, *type_info->getStructInfo(), decl.identifier_token());
 								ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(default_ctor_op), decl.identifier_token()));
 
 									// Then emit member stores for each argument
 								size_t member_idx = 0;
 								direct_ctor->arguments().visit([&](ASTNode argument) {
-									if (member_idx >= type_info->struct_info_->members.size()) {
+									if (member_idx >= type_info->getStructInfo()->members.size()) {
 										member_idx++;
 										return;
 									}
-									const StructMember& member = type_info->struct_info_->members[member_idx];
+									const StructMember& member = type_info->getStructInfo()->members[member_idx];
 									ExprResult arg_operands = visitExpressionNode(argument.as<ExpressionNode>());
 									MemberStoreOp store_op;
 									store_op.object = decl.identifier_token().handle();
@@ -2680,7 +2680,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								});
 
 									// Register for destructor if needed
-								if (type_info->struct_info_->hasDestructor()) {
+								if (type_info->getStructInfo()->hasDestructor()) {
 									registerVariableWithDestructor(
 										std::string(decl.identifier_token().value()),
 										std::string(StringTable::getStringView(type_info->name())));
@@ -2692,10 +2692,10 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							const bool allowImplicitDefault =
 								!matching_ctor &&
 								num_args == 0 &&
-								type_info->struct_info_->findDefaultConstructor() == nullptr &&
-								!type_info->struct_info_->hasAnyConstructor() &&
-								type_info->struct_info_->needs_default_constructor &&
-								!type_info->struct_info_->isDefaultConstructorDeleted();
+								type_info->getStructInfo()->findDefaultConstructor() == nullptr &&
+								!type_info->getStructInfo()->hasAnyConstructor() &&
+								type_info->getStructInfo()->needs_default_constructor &&
+								!type_info->getStructInfo()->isDefaultConstructorDeleted();
 							if (!matching_ctor && !allowImplicitDefault) {
 								reportNoMatchingConstructor(type_info->name(), "direct initialization", decl.identifier_token());
 							}
@@ -2735,7 +2735,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							if (matching_ctor) {
 								fillInConstructorDefaultArguments(ctor_op, *matching_ctor, ctor_op.arguments.size());
 							}
-							finalizeConstructorCallOp(ctor_op, *type_info->struct_info_, decl.identifier_token());
+							finalizeConstructorCallOp(ctor_op, *type_info->getStructInfo(), decl.identifier_token());
 
 							ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), decl.identifier_token()));
 
@@ -2815,12 +2815,12 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							}
 
 								// For converting constructors in copy initialization, check if constructor is explicit
-							if (!sema_selected_converting_ctor && type_info->struct_info_) {
+							if (!sema_selected_converting_ctor && type_info->getStructInfo()) {
 									// Find converting constructors that take the initializer type as single parameter.
 									// Scan all candidates: only error when every match is explicit.
 								bool found_matching_ctor = false;
 								bool found_non_explicit_ctor = false;
-								for (const auto& func : type_info->struct_info_->member_functions) {
+								for (const auto& func : type_info->getStructInfo()->member_functions) {
 									if (func.is_constructor && func.function_decl.is<ConstructorDeclarationNode>()) {
 										const auto& ctor_node = func.function_decl.as<ConstructorDeclarationNode>();
 										const auto& params = ctor_node.parameter_nodes();
@@ -2876,8 +2876,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								if (found_matching_ctor && !found_non_explicit_ctor) {
 									const std::string_view target_name = StringTable::getStringView(type_info->name());
 									const bool suppress_explicit_ctor_error =
-										is_integer_type(init_type) && type_info->struct_info_ &&
-										toSizeT(type_info->struct_info_->sizeInBytes()) == 1 &&
+										is_integer_type(init_type) && type_info->getStructInfo() &&
+										toSizeT(type_info->getStructInfo()->sizeInBytes()) == 1 &&
 										isExactComparisonCategoryType(type_info->type_index_);
 									if (!suppress_explicit_ctor_error) {
 										FLASH_LOG(General, Error, "Cannot use copy initialization with explicit constructor for type '",
@@ -2889,10 +2889,10 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								}
 							}
 
-							if (!sema_selected_converting_ctor && type_info->struct_info_) {
+							if (!sema_selected_converting_ctor && type_info->getStructInfo()) {
 								ConversionRank best_rank = ConversionRank::NoMatch;
 								bool best_is_ambiguous = false;
-								for (const auto& func : type_info->struct_info_->member_functions) {
+								for (const auto& func : type_info->getStructInfo()->member_functions) {
 									if (!func.is_constructor || !func.function_decl.is<ConstructorDeclarationNode>()) {
 										continue;
 									}
@@ -2950,11 +2950,11 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								}
 							}
 
-							if (is_converting_ctor && !sema_selected_converting_ctor && type_info->struct_info_) {
+							if (is_converting_ctor && !sema_selected_converting_ctor && type_info->getStructInfo()) {
 								if (auto init_arg_type_opt = tryBuildCodegenOverloadResolutionArgType(init_node)) {
 									std::vector<TypeSpecifierNode> arg_types;
 									arg_types.push_back(*init_arg_type_opt);
-									auto resolution = resolve_constructor_overload(*type_info->struct_info_, arg_types, true);
+									auto resolution = resolve_constructor_overload(*type_info->getStructInfo(), arg_types, true);
 									// Keep going when overload resolution is ambiguous here: copy-init fallback
 									// still gets a second chance via arity-based selection below, which mirrors
 									// existing behavior for template-heavy library constructors.
@@ -2965,7 +2965,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 									}
 								}
 								if (!sema_selected_converting_ctor) {
-									auto arity_resolution = resolve_constructor_overload_arity(*type_info->struct_info_, 1, true);
+									auto arity_resolution = resolve_constructor_overload_arity(*type_info->getStructInfo(), 1, true);
 									if (!arity_resolution.is_ambiguous &&
 										arity_resolution.selected_overload &&
 										!arity_resolution.selected_overload->is_explicit()) {
@@ -3088,20 +3088,20 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								fillInConstructorDefaultArguments(
 									ctor_op, *sema_selected_converting_ctor, ctor_op.arguments.size());
 							}
-						} else if (type_info->struct_info_ &&
+						} else if (type_info->getStructInfo() &&
 								   (!is_converting_ctor ||
 									(is_converting_ctor &&
 									 init_category_for_copy_init == TypeCategory::Struct &&
 									 !sema_selected_converting_ctor &&
-									 !type_info->struct_info_->hasUserDeclaredConstructor()))) {
+									 !type_info->getStructInfo()->hasUserDeclaredConstructor()))) {
 							const bool prefer_move_ctor =
 								isSameTypeXValueSource(init_node, init_operands, type_node);
 							const bool is_prvalue_same_type_source = isExprResultPRValue(init_operands);
 							if (!is_prvalue_same_type_source) {
-								diagnoseDeletedSameTypeConstructorUsage(*type_info->struct_info_, prefer_move_ctor);
+								diagnoseDeletedSameTypeConstructorUsage(*type_info->getStructInfo(), prefer_move_ctor);
 							}
 							const StructMemberFunction* same_type_ctor =
-								type_info->struct_info_->findPreferredSameTypeConstructor(prefer_move_ctor, true);
+								type_info->getStructInfo()->findPreferredSameTypeConstructor(prefer_move_ctor, true);
 							if (same_type_ctor && same_type_ctor->function_decl.is<ConstructorDeclarationNode>()) {
 								const auto& matched_ctor = same_type_ctor->function_decl.as<ConstructorDeclarationNode>();
 								selected_ctor = &matched_ctor;
@@ -3135,7 +3135,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 						if (is_converting_ctor && !selected_ctor) {
 							reportNoMatchingConstructor(type_info->name(), "copy initialization", decl.identifier_token());
 						}
-						finalizeConstructorCallOp(ctor_op, *type_info->struct_info_, decl.identifier_token());
+						finalizeConstructorCallOp(ctor_op, *type_info->getStructInfo(), decl.identifier_token());
 
 						ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), decl.identifier_token()));
 
@@ -3147,7 +3147,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							// 2. The struct has default member initializers (implicit ctor needs to init them), OR
 							// 3. The struct has a vtable (implicit ctor needs to init the vptr), OR
 							// 4. The struct has base classes with constructors (implicit ctor needs to call base ctors)
-						const StructMemberFunction* default_ctor = type_info->struct_info_->findDefaultConstructor();
+						const StructMemberFunction* default_ctor = type_info->getStructInfo()->findDefaultConstructor();
 						bool is_implicit_default_ctor = false;
 						if (default_ctor && default_ctor->function_decl.is<ConstructorDeclarationNode>()) {
 							const auto& ctor_node = default_ctor->function_decl.as<ConstructorDeclarationNode>();
@@ -3156,7 +3156,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 
 							// Check if any base class has constructors that need to be called
 						bool has_base_with_constructors = false;
-						for (const auto& base : type_info->struct_info_->base_classes) {
+						for (const auto& base : type_info->getStructInfo()->base_classes) {
 							if (const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index)) {
 								const StructTypeInfo* base_struct_info = base_type_info->getStructInfo();
 								if (base_struct_info && base_struct_info->hasAnyConstructor()) {
@@ -3167,8 +3167,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 						}
 
 						bool needs_default_ctor_call = !is_implicit_default_ctor ||
-													   type_info->struct_info_->hasDefaultMemberInitializers() ||
-													   type_info->struct_info_->has_vtable ||
+													   type_info->getStructInfo()->hasDefaultMemberInitializers() ||
+													   type_info->getStructInfo()->has_vtable ||
 													   has_base_with_constructors;
 
 						if (needs_default_ctor_call) {
@@ -3198,7 +3198,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 										const auto& ctor_node = default_ctor->function_decl.as<ConstructorDeclarationNode>();
 										fillInConstructorDefaultArguments(ctor_op, ctor_node, 0);
 									}
-									finalizeConstructorCallOp(ctor_op, *type_info->struct_info_, decl.identifier_token());
+									finalizeConstructorCallOp(ctor_op, *type_info->getStructInfo(), decl.identifier_token());
 
 									ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), decl.identifier_token()));
 								}
@@ -3211,7 +3211,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 									const auto& ctor_node = default_ctor->function_decl.as<ConstructorDeclarationNode>();
 									fillInConstructorDefaultArguments(ctor_op, ctor_node, 0);
 								}
-								finalizeConstructorCallOp(ctor_op, *type_info->struct_info_, decl.identifier_token());
+								finalizeConstructorCallOp(ctor_op, *type_info->getStructInfo(), decl.identifier_token());
 
 								ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), decl.identifier_token()));
 							}
@@ -3221,7 +3221,7 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 			}
 
 				// If this struct has a destructor, register it for automatic cleanup
-			if (type_info->struct_info_ && type_info->struct_info_->hasDestructor()) {
+			if (type_info->getStructInfo() && type_info->getStructInfo()->hasDestructor()) {
 				registerVariableWithDestructor(
 					std::string(decl.identifier_token().value()),
 					std::string(StringTable::getStringView(type_info->name())));

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -2095,7 +2095,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 						TypedValue other_arg;
 						other_arg.type_index = virtual_base.type_index;
 						other_arg.setType(TypeCategory::Struct);
-						other_arg.size_in_bits = SizeInBits{static_cast<int>(base_type_info->struct_info_ ? base_type_info->struct_info_->sizeInBits().value : enclosing_struct_info->sizeInBits().value)};
+						other_arg.size_in_bits = SizeInBits{static_cast<int>(base_type_info->getStructInfo() ? base_type_info->getStructInfo()->sizeInBits().value : enclosing_struct_info->sizeInBits().value)};
 						other_arg.value = StringTable::getOrInternStringHandle("other");
 						other_arg.ref_qualifier = is_implicit_copy_constructor ? ReferenceQualifier::LValueReference : ReferenceQualifier::RValueReference;
 						other_arg.cv_qualifier = is_implicit_copy_constructor ? CVQualifier::Const : CVQualifier::None;
@@ -2361,7 +2361,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 						TypedValue other_arg;
 						other_arg.setType(TypeCategory::Struct);	 // Parameter type (struct reference)
 						other_arg.ir_type = IrType::Struct;
-						other_arg.size_in_bits = SizeInBits{static_cast<int>(base_type_info->struct_info_ ? base_type_info->struct_info_->sizeInBits().value : struct_info->sizeInBits().value)};
+						other_arg.size_in_bits = SizeInBits{static_cast<int>(base_type_info->getStructInfo() ? base_type_info->getStructInfo()->sizeInBits().value : struct_info->sizeInBits().value)};
 						other_arg.value = StringTable::getOrInternStringHandle("other");	 // Parameter value ('other' object)
 						other_arg.type_index = base.type_index;	// Use BASE class type index for proper mangling
 						if (is_implicit_copy_constructor) {
@@ -2465,9 +2465,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 						}
 						if (member.type_index.category() == TypeCategory::Struct) {
 							const TypeInfo* mti = tryGetTypeInfo(member.type_index);
-							if (mti && mti->struct_info_ &&
-								mti->struct_info_->hasUserDefinedConstructor() &&
-								!mti->struct_info_->hasConstructor()) {
+							if (mti && mti->getStructInfo() &&
+								mti->getStructInfo()->hasUserDefinedConstructor() &&
+								!mti->getStructInfo()->hasConstructor()) {
 								is_implicitly_deleted = true;
 								break;
 							}
@@ -2601,7 +2601,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 									if (const TypeInfo* member_type_info = tryGetTypeInfo(member_type_index)) {
 
 										// If this is a struct type, we need to initialize its members
-										if (member_type_info->struct_info_ && !member_type_info->struct_info_->members.empty()) {
+										if (member_type_info->getStructInfo() && !member_type_info->getStructInfo()->members.empty()) {
 											// Build a map of member names to initializer expressions
 											std::unordered_map<StringHandle, const ASTNode*> member_values;
 											size_t positional_index = 0;
@@ -2613,8 +2613,8 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 													member_values[member_name] = &initializers[i];
 												} else {
 														// Positional initializer - map to member by index
-													if (positional_index < member_type_info->struct_info_->members.size()) {
-														StringHandle member_name = member_type_info->struct_info_->members[positional_index].getName();
+													if (positional_index < member_type_info->getStructInfo()->members.size()) {
+														StringHandle member_name = member_type_info->getStructInfo()->members[positional_index].getName();
 														member_values[member_name] = &initializers[i];
 														positional_index++;
 													}
@@ -2622,7 +2622,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 											}
 
 											// Generate nested member stores for each member of the nested struct
-											for (const StructMember& nested_member : member_type_info->struct_info_->members) {
+											for (const StructMember& nested_member : member_type_info->getStructInfo()->members) {
 												// Determine initial value for nested member
 												std::optional<IrValue> nested_member_value;
 												StringHandle nested_member_name_handle = nested_member.getName();
@@ -2640,9 +2640,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 														if (const TypeInfo* nested_member_type_info = tryGetTypeInfo(nested_member_type_index)) {
 
 															// If this is a struct type, use the recursive helper
-															if (nested_member_type_info->struct_info_ && !nested_member_type_info->struct_info_->members.empty()) {
+															if (nested_member_type_info->getStructInfo() && !nested_member_type_info->getStructInfo()->members.empty()) {
 																generateNestedMemberStores(
-																	*nested_member_type_info->struct_info_,
+																	*nested_member_type_info->getStructInfo(),
 																	nested_init_list,
 																	StringTable::getOrInternStringHandle("this"),
 																	static_cast<int>(member.offset + nested_member.offset),
@@ -2738,7 +2738,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 								bool is_struct_with_constructor = false;
 								if (member.type_index.category() == TypeCategory::Struct) {
 									const TypeInfo* member_type_info = tryGetTypeInfo(member.type_index);
-									if (member_type_info && member_type_info->struct_info_ && member_type_info->struct_info_->hasAnyConstructor()) {
+									if (member_type_info && member_type_info->getStructInfo() && member_type_info->getStructInfo()->hasAnyConstructor()) {
 										is_struct_with_constructor = true;
 									}
 								}
@@ -2752,9 +2752,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 									// Use base_class_offset to specify the member's offset within the parent struct
 									assert(member.offset <= static_cast<size_t>(std::numeric_limits<int>::max()) && "Member offset exceeds int range");
 									ctor_op.base_class_offset = static_cast<int>(member.offset);
-									if (member_type_info.struct_info_) {
-										fillInDefaultConstructorArguments(ctor_op, *member_type_info.struct_info_);
-										finalizeConstructorCallOp(ctor_op, *member_type_info.struct_info_, node.name_token());
+									if (member_type_info.getStructInfo()) {
+										fillInDefaultConstructorArguments(ctor_op, *member_type_info.getStructInfo());
+										finalizeConstructorCallOp(ctor_op, *member_type_info.getStructInfo(), node.name_token());
 									}
 									ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), node.name_token()));
 									continue;  // Skip the MemberStore since constructor handles initialization
@@ -3015,7 +3015,7 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 						bool is_struct_with_constructor = false;
 						if (member.type_index.category() == TypeCategory::Struct) {
 							const TypeInfo* member_type_info = tryGetTypeInfo(member.type_index);
-							if (member_type_info && member_type_info->struct_info_ && member_type_info->struct_info_->hasAnyConstructor()) {
+							if (member_type_info && member_type_info->getStructInfo() && member_type_info->getStructInfo()->hasAnyConstructor()) {
 								is_struct_with_constructor = true;
 							}
 						}
@@ -3029,9 +3029,9 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 							// Use base_class_offset to specify the member's offset within the parent struct
 							assert(member.offset <= static_cast<size_t>(std::numeric_limits<int>::max()) && "Member offset exceeds int range");
 							ctor_op.base_class_offset = static_cast<int>(member.offset);
-							if (member_type_info.struct_info_) {
-								fillInDefaultConstructorArguments(ctor_op, *member_type_info.struct_info_);
-								finalizeConstructorCallOp(ctor_op, *member_type_info.struct_info_, node.name_token());
+							if (member_type_info.getStructInfo()) {
+								fillInDefaultConstructorArguments(ctor_op, *member_type_info.getStructInfo());
+								finalizeConstructorCallOp(ctor_op, *member_type_info.getStructInfo(), node.name_token());
 							}
 							ir_.addInstruction(IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), node.name_token()));
 							continue;  // Skip the MemberStore since constructor handles initialization
@@ -3484,23 +3484,23 @@ ExprResult AstToIr::generateConstructorCallIr(const ConstructorCallNode& constru
 	const StructTypeInfo* struct_info = nullptr;
 	if (constructor_type_category == TypeCategory::Struct) {
 		const TypeInfo* type_info = tryGetTypeInfo(normalized_type_spec.type_index());
-		if (type_info && type_info->struct_info_) {
-			actual_size_bits = static_cast<int>(type_info->struct_info_->sizeInBits().value);
-			struct_info = type_info->struct_info_.get();
+		if (type_info && type_info->getStructInfo()) {
+			actual_size_bits = static_cast<int>(type_info->getStructInfo()->sizeInBits().value);
+			struct_info = type_info->getStructInfo();
 		}
 	} else {
 		// Fallback: look up by name
 		auto type_it = getTypesByNameMap().find(constructor_name);
-		if (type_it != getTypesByNameMap().end() && type_it->second->struct_info_) {
-			actual_size_bits = static_cast<int>(type_it->second->struct_info_->sizeInBits().value);
-			struct_info = type_it->second->struct_info_.get();
+		if (type_it != getTypesByNameMap().end() && type_it->second->getStructInfo()) {
+			actual_size_bits = static_cast<int>(type_it->second->getStructInfo()->sizeInBits().value);
+			struct_info = type_it->second->getStructInfo();
 		}
 	}
 	if (current_instantiation_type_index.is_valid()) {
 		if (const TypeInfo* current_instantiation_type_info =
 				tryGetTypeInfo(current_instantiation_type_index);
-			current_instantiation_type_info && current_instantiation_type_info->struct_info_) {
-			struct_info = current_instantiation_type_info->struct_info_.get();
+			current_instantiation_type_info && current_instantiation_type_info->getStructInfo()) {
+			struct_info = current_instantiation_type_info->getStructInfo();
 			actual_size_bits = static_cast<int>(struct_info->sizeInBits().value);
 		}
 	}

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -120,9 +120,9 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 
 			// Look up the struct by return type index or name
 			for (size_t i = 0; i < getTypeInfoCount(); ++i) {
-				if (getTypeInfo(TypeIndex{i}).struct_info_ &&
-					static_cast<int>(getTypeInfo(TypeIndex{i}).struct_info_->sizeInBits().value) == return_size) {
-					struct_info = getTypeInfo(TypeIndex{i}).struct_info_.get();
+				if (getTypeInfo(TypeIndex{i}).getStructInfo() &&
+					static_cast<int>(getTypeInfo(TypeIndex{i}).getStructInfo()->sizeInBits().value) == return_size) {
+					struct_info = getTypeInfo(TypeIndex{i}).getStructInfo();
 					break;
 				}
 			}

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2385,7 +2385,7 @@ void AstToIr::resolveSelfReferentialType(TypeSpecifierNode& type, TypeIndex encl
 		const TypeInfo* ti = tryGetTypeInfo(type.type_index());
 		if (!ti)
 			return;
-		if (!ti->struct_info_ || !ti->struct_info_->sizeInBytes().is_set()) {
+		if (!ti->getStructInfo() || !ti->getStructInfo()->sizeInBytes().is_set()) {
 			if (const TypeInfo* enc_ti = tryGetTypeInfo(enclosing_type_index)) {
 				// Verify this is actually a self-reference by checking that the unfinalized
 				// type's name matches the base name of the enclosing struct.

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1838,7 +1838,7 @@ inline TypeIndex resolveSelfRefParamIndex(TypeIndex param_idx, TypeIndex left_ty
 	if (!param_idx.is_valid() || param_idx.index() >= type_info_size || left_type_index.index() >= type_info_size)
 		return param_idx;
 	const auto& param_ti = getTypeInfo(param_idx);
-	if (!param_ti.struct_info_)
+	if (!param_ti.getStructInfo())
 		return param_idx;
 	auto param_name = StringTable::getStringView(param_ti.name());
 	auto param_base_name = simpleBaseName(param_name);

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1470,6 +1470,11 @@ inline ConstructorOverloadResolutionResult resolve_constructor_overload_arity(
 		if (skip_implicit && is_implicit_copy_or_move) {
 			continue;
 		}
+		if (ctor_decl.has_template_parameters()) {
+			// Constructor templates require deduction; arity-only fallback must not
+			// treat them as competing non-template overloads (C++ [temp.deduct]).
+			continue;
+		}
 		const auto& parameters = ctor_decl.parameter_nodes();
 		size_t min_required = countMinRequiredArgs(ctor_decl);
 		if (num_args < min_required || num_args > parameters.size()) {

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -99,15 +99,17 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 	attr_info.linkage = specs.linkage;
 	attr_info.calling_convention = specs.calling_convention;
 
-	// Check for inline/constexpr struct/class definition pattern:
-	// inline constexpr struct Name { ... } variable = {};
-	// This is a struct definition combined with a variable declaration
+	// Check for inline/constexpr struct/class/union *definition* pattern:
+	//   inline constexpr struct Name { ... } variable = {};
+	// Do NOT take this path for elaborated-type variable declarations:
+	//   struct Point p1 = { 10, 20 };
+	// Those must go through parse_type_and_name() so an existing StructTypeInfo
+	// is not replaced by createStructInfo() mid-declaration.
 	if (peek().is_keyword() &&
-		(peek() == "struct"_tok || peek() == "class"_tok)) {
+		(peek() == "struct"_tok || peek() == "class"_tok || peek() == "union"_tok) &&
+		!looks_like_elaborated_type_variable_declaration()) {
 		// Delegate to struct parsing which will handle the full definition
-		// and any trailing variable declarations
-		// TODO is now resolved: specs are passed to parse_struct_declaration_with_specs()
-		// so they can be applied to trailing variable declarations after the struct body.
+		// and any trailing variable declarations.
 		auto result = parse_struct_declaration_with_specs(is_constexpr, is_inline);
 		if (!result.is_error()) {
 			// Successfully parsed struct, propagate the result

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -552,11 +552,11 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 	} else {
 		struct_info_name = struct_name;
 	}
-	auto struct_info = std::make_unique<StructTypeInfo>(struct_info_name, struct_ref.default_access(), is_union, current_namespace_handle);
+	StructTypeInfo* struct_info = &struct_type_info.createStructInfo(struct_info_name, struct_ref.default_access(), is_union, current_namespace_handle);
 
 	// Update the struct parsing context with the local_struct_info for static member lookup
 	if (!struct_parsing_context_stack_.empty()) {
-		struct_parsing_context_stack_.back().local_struct_info = struct_info.get();
+		struct_parsing_context_stack_.back().local_struct_info = struct_info;
 	}
 
 	// Apply pack alignment from #pragma pack BEFORE adding members
@@ -638,7 +638,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 					FLASH_LOG(Templates, Debug, "Resolved decltype base class immediately: ", resolved_base_class_name);
 
 					// Check if base class is final
-					if (base_type_info->struct_info_ && base_type_info->struct_info_->is_final) {
+					if (base_type_info->getStructInfo() && base_type_info->getStructInfo()->is_final) {
 						return ParseResult::error("Cannot inherit from final class '" + std::string(resolved_base_class_name) + "'", base_name_token);
 					}
 
@@ -1039,7 +1039,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			}
 
 			// Validate and add the base class
-			ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info.get(), base_access, is_virtual_base, base_name_token);
+			ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info, base_access, is_virtual_base, base_name_token);
 			if (result.is_error()) {
 				return result;
 			}
@@ -1112,7 +1112,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				// Register template friend classes (e.g., template<typename T> friend struct Foo;)
 				if (auto result_node = template_result.node()) {
 					if (result_node->is<FriendDeclarationNode>()) {
-						registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info.get());
+						registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info);
 					}
 				}
 				continue;
@@ -1251,9 +1251,8 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 						// Create the anonymous struct/union type
 						TypeInfo& anon_type_info = add_struct_type(anon_type_name_handle, gSymbolTable.get_current_namespace_handle());
 
-						// Create StructTypeInfo
-						auto anon_struct_info_ptr = std::make_unique<StructTypeInfo>(anon_type_name_handle, AccessSpecifier::Public, is_union_keyword, gSymbolTable.get_current_namespace_handle());
-						StructTypeInfo* anon_struct_info = anon_struct_info_ptr.get();
+						// Create StructTypeInfo in the cold arena
+						StructTypeInfo* anon_struct_info = &anon_type_info.createStructInfo(anon_type_name_handle, AccessSpecifier::Public, is_union_keyword, gSymbolTable.get_current_namespace_handle());
 
 						// Parse all members of the anonymous struct/union and add them to the anonymous type
 						while (!peek().is_eof() && peek() != "}"_tok) {
@@ -1361,8 +1360,8 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 							anon_struct_info->finalizeLayoutSize(offset, offset, max_alignment);
 						}
 
-						// Set the StructTypeInfo for the anonymous type
-						anon_type_info.setStructInfo(std::move(anon_struct_info_ptr));
+						// StructTypeInfo already lives in the arena via createStructInfo
+						anon_type_info.bindStructInfoOwnership();
 
 						// Now parse the member declarators (one or more identifiers separated by commas)
 						do {
@@ -1764,7 +1763,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			// Add friend declaration to struct
 			if (auto friend_node = friend_result.node()) {
 				struct_ref.add_friend(*friend_node);
-				registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info.get());
+				registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info);
 			}
 
 			continue; // Skip to next member
@@ -1806,7 +1805,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 					is_static_constexpr,
 					qualified_struct_name,
 					struct_ref,
-					struct_info.get(),
+					struct_info,
 					current_access,
 					currentTemplateParamNames(),
 					/*add_to_struct_info=*/false,
@@ -1855,7 +1854,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				if (type_it != getTypesByNameMap().end()) {
 					struct_type_index = type_it->second->type_index_;
 				}
-				member_function_context_stack_.push_back({qualified_struct_name, struct_type_index, &struct_ref, struct_info.get()});
+				member_function_context_stack_.push_back({qualified_struct_name, struct_type_index, &struct_ref, struct_info});
 				ScopedDefinitionLookupContext ctx_scope(
 					current_template_definition_lookup_context_,
 					initializer_definition_lookup_context);
@@ -1883,7 +1882,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				if (type_it != getTypesByNameMap().end()) {
 					struct_type_index = type_it->second->type_index_;
 				}
-				member_function_context_stack_.push_back({qualified_struct_name, struct_type_index, &struct_ref, struct_info.get()});
+				member_function_context_stack_.push_back({qualified_struct_name, struct_type_index, &struct_ref, struct_info});
 				ScopedDefinitionLookupContext ctx_scope(
 					current_template_definition_lookup_context_,
 					initializer_definition_lookup_context);
@@ -1946,7 +1945,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 				// covers both primary templates and partial specialisations.
 				if (!isDependentTemplateContext()) {
 					ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
-					eval_ctx.struct_info = struct_info.get();
+					eval_ctx.struct_info = struct_info;
 					eval_ctx.storage_duration = ConstExpr::StorageDuration::Automatic;
 					auto validation = ConstExpr::Evaluator::evaluate(*init_expr_opt, eval_ctx);
 					if (!validation.success() &&
@@ -3893,8 +3892,8 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 		has_static_members = !struct_info->static_members.empty();
 	}
 
-	// Store struct info in type info
-	struct_type_info.setStructInfo(std::move(struct_info));
+	// StructTypeInfo already lives in the arena via createStructInfo
+	struct_type_info.bindStructInfoOwnership();
 	// Update fallback_size_bits_ from the finalized struct's total size
 	if (struct_type_info.getStructInfo()) {
 		struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
@@ -4168,8 +4167,8 @@ ParseResult Parser::parse_enum_declaration() {
 		return ParseResult::error("Expected '{' after enum name", peek_info());
 	}
 
-	// Create enum type info
-	auto enum_info = std::make_unique<EnumTypeInfo>(enum_name, is_scoped);
+	// Create enum type info in the cold arena (live during enumerator parsing)
+	EnumTypeInfo& enum_info = enum_type_info.createEnumInfo(enum_name, is_scoped);
 
 	// Determine underlying type (default is int)
 	TypeCategory underlying_type = TypeCategory::Int;
@@ -4179,12 +4178,11 @@ ParseResult Parser::parse_enum_declaration() {
 		underlying_type = type_spec.type();
 		underlying_size = type_spec.size_in_bits();
 	}
-	enum_info->underlying_type = underlying_type;
-	enum_info->underlying_size = SizeInBits{underlying_size};
+	enum_info.underlying_type = underlying_type;
+	enum_info.underlying_size = SizeInBits{underlying_size};
+	enum_type_info.fallback_size_bits_ = underlying_size;
 
-	// Store enum info early so ConstExprEvaluator can look up values during parsing
-	enum_type_info.setEnumInfo(std::move(enum_info));
-	auto* live_enum_info = enum_type_info.getEnumInfo();
+	auto* live_enum_info = &enum_info;
 
 	// Parse enumerators
 	long long next_value = 0;
@@ -4407,9 +4405,8 @@ ParseResult Parser::parse_anonymous_struct_union_members(StructTypeInfo* out_str
 				// Create the nested anonymous struct/union type
 				TypeInfo& nested_anon_type_info = add_struct_type(nested_anon_type_name_handle, gSymbolTable.get_current_namespace_handle());
 
-				// Create StructTypeInfo
-				auto nested_anon_struct_info_ptr = std::make_unique<StructTypeInfo>(nested_anon_type_name_handle, AccessSpecifier::Public, nested_is_union, gSymbolTable.get_current_namespace_handle());
-				StructTypeInfo* nested_anon_struct_info = nested_anon_struct_info_ptr.get();
+				// Create StructTypeInfo in the cold arena
+				StructTypeInfo* nested_anon_struct_info = &nested_anon_type_info.createStructInfo(nested_anon_type_name_handle, AccessSpecifier::Public, nested_is_union, gSymbolTable.get_current_namespace_handle());
 
 				// Recursively parse members of the nested anonymous struct/union
 				ParseResult nested_result = parse_anonymous_struct_union_members(nested_anon_struct_info, nested_anon_type_name);
@@ -4460,7 +4457,7 @@ ParseResult Parser::parse_anonymous_struct_union_members(StructTypeInfo* out_str
 				}
 
 				// Set the struct info on the type info
-				nested_anon_type_info.setStructInfo(std::move(nested_anon_struct_info_ptr));
+				nested_anon_type_info.bindStructInfoOwnership();
 
 				// Now parse the member name for the enclosing anonymous struct/union
 				auto outer_member_name_token = peek_info();

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -524,8 +524,8 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 			// Create struct declaration node
 			auto [struct_node, struct_ref_inner] = emplace_node_ref<StructDeclarationNode>(struct_name, is_class);
 
-			// Create StructTypeInfo
-			auto struct_info = std::make_unique<StructTypeInfo>(struct_name, is_class ? AccessSpecifier::Private : AccessSpecifier::Public, false, gSymbolTable.get_current_namespace_handle());
+			// Create StructTypeInfo in the cold arena
+			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(struct_name, is_class ? AccessSpecifier::Private : AccessSpecifier::Public, false, gSymbolTable.get_current_namespace_handle());
 
 			// Expect opening brace
 			if (!consume("{"_tok)) {
@@ -665,8 +665,8 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 				return ParseResult::error(struct_info->getFinalizationError(), Token());
 			}
 
-			// Store struct info
-			struct_type_info.setStructInfo(std::move(struct_info));
+			// StructTypeInfo already lives in the arena via createStructInfo
+			struct_type_info.bindStructInfoOwnership();
 			// Update fallback_size_bits_ from the finalized struct's total size
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
@@ -750,8 +750,8 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 				return ParseResult::error("Expected '{' in enum definition", peek_info());
 			}
 
-			// Create enum type info
-			auto enum_info = std::make_unique<EnumTypeInfo>(enum_name, is_scoped);
+			// Create enum type info in the cold arena (live during enumerator parsing)
+			EnumTypeInfo& enum_info = enum_type_info.createEnumInfo(enum_name, is_scoped);
 
 			// Determine underlying type
 			int underlying_size = 32;
@@ -765,9 +765,7 @@ ParseResult Parser::parse_member_type_alias(std::string_view keyword, StructDecl
 			size_t enumerator_count = 0;
 			const size_t MAX_ENUMERATORS = 10000; // Safety limit
 
-			// Store enum info early so ConstExprEvaluator can look up values during parsing
-			enum_type_info.setEnumInfo(std::move(enum_info));
-			auto* live_enum_info = enum_type_info.getEnumInfo();
+			auto* live_enum_info = &enum_info;
 
 			// For scoped enums, push a temporary scope so that enumerator names
 			// are visible to subsequent value expressions (C++ §9.7.1/2)
@@ -1224,8 +1222,9 @@ ParseResult Parser::parse_typedef_declaration() {
 			return ParseResult::error("Expected '{' in enum definition", peek_info());
 		}
 
-		// Create enum type info
-		auto enum_info = std::make_unique<EnumTypeInfo>(enum_name_for_typedef, is_scoped);
+		// Create enum type info in the cold arena (live during enumerator parsing)
+		auto& enum_type_info_ref = getTypeInfoMut(enum_type_index);
+		EnumTypeInfo& enum_info = enum_type_info_ref.createEnumInfo(enum_name_for_typedef, is_scoped);
 
 		// Determine underlying type (default is int)
 		int underlying_size = 32;
@@ -1234,10 +1233,7 @@ ParseResult Parser::parse_typedef_declaration() {
 			underlying_size = type_spec_node.size_in_bits();
 		}
 
-		// Store enum info early so ConstExprEvaluator can look up values during parsing
-		auto& enum_type_info_ref = getTypeInfoMut(enum_type_index);
-		enum_type_info_ref.setEnumInfo(std::move(enum_info));
-		auto* live_enum_info = enum_type_info_ref.getEnumInfo();
+		auto* live_enum_info = &enum_info;
 
 		// Parse enumerators
 		int64_t next_value = 0;
@@ -1369,12 +1365,12 @@ ParseResult Parser::parse_typedef_declaration() {
 												 gSymbolTable.get_current_namespace_handle(),
 												 {}});
 
-		// Create StructTypeInfo
-		auto struct_info = std::make_unique<StructTypeInfo>(struct_name_for_typedef, AccessSpecifier::Public, is_inline_union, gSymbolTable.get_current_namespace_handle());
+		// Create StructTypeInfo in the cold arena
+		StructTypeInfo* struct_info = &struct_type_info.createStructInfo(struct_name_for_typedef, AccessSpecifier::Public, is_inline_union, gSymbolTable.get_current_namespace_handle());
 
 		// Update the struct parsing context with the local_struct_info for static member lookup
 		if (!struct_parsing_context_stack_.empty()) {
-			struct_parsing_context_stack_.back().local_struct_info = struct_info.get();
+			struct_parsing_context_stack_.back().local_struct_info = struct_info;
 		}
 
 		// Apply pack alignment from #pragma pack
@@ -1433,8 +1429,7 @@ ParseResult Parser::parse_typedef_declaration() {
 						TypeInfo& anon_type_info = add_struct_type(anon_type_name_handle, gSymbolTable.get_current_namespace_handle());
 
 						// Create StructTypeInfo
-						auto anon_struct_info_ptr = std::make_unique<StructTypeInfo>(anon_type_name_handle, AccessSpecifier::Public, is_union, gSymbolTable.get_current_namespace_handle());
-						StructTypeInfo* anon_struct_info = anon_struct_info_ptr.get();
+						StructTypeInfo* anon_struct_info = &anon_type_info.createStructInfo(anon_type_name_handle, AccessSpecifier::Public, is_union, gSymbolTable.get_current_namespace_handle());
 
 						// Parse all members using the recursive helper
 						ParseResult members_result = parse_anonymous_struct_union_members(anon_struct_info, anon_type_name);
@@ -1484,8 +1479,8 @@ ParseResult Parser::parse_typedef_declaration() {
 							anon_struct_info->finalizeLayoutSize(current_offset, current_offset, max_alignment);
 						}
 
-						// Set the struct info on the type info
-						anon_type_info.setStructInfo(std::move(anon_struct_info_ptr));
+						// StructTypeInfo already lives in the arena via createStructInfo
+						anon_type_info.bindStructInfoOwnership();
 
 						// Now parse the member name(s) - handle comma-separated declarators
 						do {
@@ -1906,15 +1901,15 @@ ParseResult Parser::parse_typedef_declaration() {
 			return ParseResult::error(struct_info->getFinalizationError(), Token());
 		}
 
-		// Store struct info
-		struct_type_info.setStructInfo(std::move(struct_info));
+		// StructTypeInfo already lives in the arena via createStructInfo
+		struct_type_info.bindStructInfoOwnership();
 		// Update fallback_size_bits_ from the finalized struct's total size
 		if (struct_type_info.getStructInfo()) {
 			struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 		}
 
 		// Create type specifier for the struct
-		// Note: Use struct_type_info.getStructInfo() since struct_info was moved above
+		// Note: Use struct_type_info.getStructInfo() — payload already attached via createStructInfo
 		type_spec = TypeSpecifierNode(
 			struct_type_index.withCategory(TypeCategory::Struct),
 			static_cast<int>(struct_type_info.getStructInfo()->sizeInBits().value),

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -1182,7 +1182,7 @@ ParseResult Parser::parse_lambda_expression() {
 	const auto& lambda_captures = lambda.captures();
 
 	TypeInfo& closure_type = add_struct_type(closure_name, gSymbolTable.get_current_namespace_handle());
-	auto closure_struct_info = std::make_unique<StructTypeInfo>(closure_name, AccessSpecifier::Public, false, gSymbolTable.get_current_namespace_handle());
+	StructTypeInfo* closure_struct_info = &closure_type.createStructInfo(closure_name, AccessSpecifier::Public, false, gSymbolTable.get_current_namespace_handle());
 
 	// For non-capturing lambdas, create a 1-byte struct (like Clang does)
 	if (lambda_captures.empty()) {
@@ -1441,7 +1441,7 @@ ParseResult Parser::parse_lambda_expression() {
 
 	closure_struct_info->member_functions.push_back(operator_call_member);
 
-	closure_type.struct_info_ = std::move(closure_struct_info);
+	closure_type.bindStructInfoOwnership();
 
 	// Wrap the lambda in an ExpressionNode before returning
 	ExpressionNode expr_node = lambda_node.as<LambdaExpressionNode>();

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -2748,8 +2748,8 @@ ParseResult Parser::parseMaterializedTemplateFunctionalCast(
 	if (instantiated_type_info != nullptr && instantiated_type_info->isStruct()) {
 		TypeIndex inst_type_index = instantiated_type_info->type_index_;
 		SizeInBits inst_type_size{};
-		if (instantiated_type_info->struct_info_) {
-			inst_type_size = instantiated_type_info->struct_info_->sizeInBits();
+		if (instantiated_type_info->getStructInfo()) {
+			inst_type_size = instantiated_type_info->getStructInfo()->sizeInBits();
 		}
 		type_spec_node = emplace_node<TypeSpecifierNode>(
 			inst_type_index.withCategory(TypeCategory::Struct),
@@ -3428,11 +3428,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			// Look up the operator function in the current struct type
 			const auto& member_ctx = member_function_context_stack_.back();
 			if (TypeInfo* type_info = tryGetTypeInfoMut(member_ctx.struct_type_index)) {
-				if (type_info->struct_info_) {
+				if (type_info->getStructInfo()) {
 					const StringHandle operator_name_handle = StringTable::getOrInternStringHandle(operator_name);
 					const OverloadableOperator desired_operator_kind = overloadableOperatorFromFunctionName(operator_name);
 					// Search for the operator member function
-					for (auto& member_func : type_info->struct_info_->member_functions) {
+					for (auto& member_func : type_info->getStructInfo()->member_functions) {
 						// Overloadable operators have canonical operator_kind metadata.
 						// Conversion operators and other non-overloadable forms still fall back
 						// to name-based lookup because they are not represented by operator_kind.
@@ -6049,8 +6049,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							const TypeInfo& type_info = *instantiated_type_info;
 							TypeIndex type_index = type_info.type_index_;
 							SizeInBits type_size{};
-							if (type_info.struct_info_) {
-								type_size = type_info.struct_info_->sizeInBits();
+							if (type_info.getStructInfo()) {
+								type_size = type_info.getStructInfo()->sizeInBits();
 							}
 							auto type_spec_node = emplace_node<TypeSpecifierNode>(type_index.withCategory(type_info.category()), type_size, final_identifier, CVQualifier::None, ReferenceQualifier::None);
 
@@ -6302,8 +6302,8 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				const TypeInfo& type_info = *type_it->second;
 				TypeIndex type_index = type_info.type_index_;
 				SizeInBits type_size = type_info.sizeInBits();
-				if (type_info.struct_info_) {
-					type_size = type_info.struct_info_->sizeInBits();
+				if (type_info.getStructInfo()) {
+					type_size = type_info.getStructInfo()->sizeInBits();
 				}
 				auto type_spec_node = emplace_node<TypeSpecifierNode>(type_index.withCategory(type_info.category()), type_size, identifier_token, CVQualifier::None, ReferenceQualifier::None);
 
@@ -6954,9 +6954,9 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							FLASH_LOG_FORMAT(Parser, Debug, "Checking if '{}' is lambda variable: type_idx={}, getTypeInfoCount()={}",
 											 identifier_token.value(), type_idx, getTypeInfoCount());
 							if (const TypeInfo* type_info = tryGetTypeInfo(type_idx)) {
-								if (type_info->struct_info_) {
+								if (type_info->getStructInfo()) {
 									// Check if the struct name starts with "__lambda_"
-									std::string_view type_name = StringTable::getStringView(type_info->struct_info_->name);
+									std::string_view type_name = StringTable::getStringView(type_info->getStructInfo()->name);
 									FLASH_LOG_FORMAT(Parser, Debug, "Type name for '{}': '{}', starts_with __lambda_: {}",
 													 identifier_token.value(), type_name, type_name.starts_with("__lambda_"));
 									if (type_name.starts_with("__lambda_")) {
@@ -9507,11 +9507,11 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						TypeIndex type_index = type_node.type_index();
 						FLASH_LOG_FORMAT(Parser, Debug, "Checking identifier '{}' for operator(): type_index={}", identifier_token.value(), type_index);
 						if (const TypeInfo* type_info = tryGetTypeInfo(type_index)) {
-							if (type_info->struct_info_) {
+							if (type_info->getStructInfo()) {
 								FLASH_LOG_FORMAT(Parser, Debug, "Struct '{}' has {} member functions",
-												 StringTable::getStringView(type_info->struct_info_->name), type_info->struct_info_->member_functions.size());
+												 StringTable::getStringView(type_info->getStructInfo()->name), type_info->getStructInfo()->member_functions.size());
 								// Check if struct has operator()
-								for (const auto& member_func : type_info->struct_info_->member_functions) {
+								for (const auto& member_func : type_info->getStructInfo()->member_functions) {
 									FLASH_LOG_FORMAT(Parser, Debug, "Member function: is_operator={}, symbol='{}'",
 													 member_func.operator_kind != OverloadableOperator::None,
 													 overloadableOperatorToString(member_func.operator_kind));

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -143,8 +143,8 @@ ParseResult Parser::parse_template_brace_initialization(
 	const TypeInfo& type_info = *materialized_type.resolved_type_info;
 	TypeIndex type_index = type_info.type_index_;
 	SizeInBits type_size{};
-	if (type_info.struct_info_) {
-		type_size = type_info.struct_info_->sizeInBits();
+	if (type_info.getStructInfo()) {
+		type_size = type_info.getStructInfo()->sizeInBits();
 	}
 	Token type_token(Token::Type::Identifier, materialized_type.instantiated_name,
 					 identifier_token.line(), identifier_token.column(), identifier_token.file_index());
@@ -691,7 +691,7 @@ static const TypeInfo* tryResolveDeferredBaseToConcreteStruct(
 			base_class.name);
 		return nullptr;
 	}
-	if (deferred_type->struct_info_) {
+	if (deferred_type->getStructInfo()) {
 		FLASH_LOG_FORMAT(Templates, Debug,
 			"Deferred base '{}' has valid type_index, resolved to concrete struct '{}', recursing",
 			base_class.name, StringTable::getStringView(deferred_type->name()));
@@ -700,7 +700,7 @@ static const TypeInfo* tryResolveDeferredBaseToConcreteStruct(
 	// Underlying type is itself an alias — follow one more level.
 	if (deferred_type->type_index_.is_valid()) {
 		const TypeInfo* chained_type = tryGetTypeInfo(deferred_type->type_index_);
-		if (chained_type != nullptr && chained_type->struct_info_) {
+		if (chained_type != nullptr && chained_type->getStructInfo()) {
 			FLASH_LOG_FORMAT(Templates, Debug,
 				"Deferred base '{}' resolved via alias chain to '{}', recursing",
 				base_class.name, StringTable::getStringView(chained_type->name()));
@@ -784,7 +784,7 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 	const TypeInfo* struct_type_info = struct_it->second;
 
 	// If this is a type alias (no struct_info_), resolve the underlying type
-	if (!struct_type_info->struct_info_) {
+	if (!struct_type_info->getStructInfo()) {
 		if (struct_type_info->isTemplateInstantiation()) {
 			AliasTemplateMaterializationResult canonical_owner =
 				materializeCanonicalOwnerTypeForLookup(*struct_type_info, {});
@@ -862,7 +862,7 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
 			// Check if this is actually an alias (points to a different TypeInfo)
 			// by comparing the pointer addresses
-			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
+			if (underlying_type != struct_type_info && underlying_type->getStructInfo()) {
 				StringHandle underlying_name = underlying_type->name();
 				FLASH_LOG_FORMAT(Templates, Debug, "Type '{}' is an alias for '{}', following alias",
 								 StringTable::getStringView(struct_name), StringTable::getStringView(underlying_name));
@@ -874,7 +874,7 @@ const TypeInfo* Parser::lookup_inherited_type_alias(StringHandle struct_name, St
 	}
 
 	// Search base classes recursively
-	const StructTypeInfo* struct_info = struct_type_info->struct_info_.get();
+	const StructTypeInfo* struct_info = struct_type_info->getStructInfo();
 	FLASH_LOG_FORMAT(Templates, Debug, "Struct '{}' has {} base classes", StringTable::getStringView(struct_name), struct_info->base_classes.size());
 	for (const auto& base_class : struct_info->base_classes) {
 		if (base_class.is_deferred) {
@@ -942,14 +942,14 @@ const std::vector<ASTNode>* Parser::lookup_inherited_template(StringHandle struc
 	const TypeInfo* struct_type_info = struct_it->second;
 
 	// If this is a type alias (no struct_info_), resolve the underlying type
-	if (!struct_type_info->struct_info_) {
+	if (!struct_type_info->getStructInfo()) {
 		// This might be a type alias - try to find the actual struct type
 		// Type aliases have a type_index that points to the underlying type
 		// Check if type_index_ is valid and points to a different TypeInfo entry
 		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
 			// Check if this is actually an alias (points to a different TypeInfo)
 			// by comparing the pointer addresses
-			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
+			if (underlying_type != struct_type_info && underlying_type->getStructInfo()) {
 				StringHandle underlying_name = underlying_type->name();
 				FLASH_LOG_FORMAT(Templates, Debug, "Type '{}' is an alias for '{}', following alias",
 								 StringTable::getStringView(struct_name), StringTable::getStringView(underlying_name));
@@ -961,7 +961,7 @@ const std::vector<ASTNode>* Parser::lookup_inherited_template(StringHandle struc
 	}
 
 	// Search base classes recursively
-	const StructTypeInfo* struct_info = struct_type_info->struct_info_.get();
+	const StructTypeInfo* struct_info = struct_type_info->getStructInfo();
 	FLASH_LOG_FORMAT(Templates, Debug, "Struct '{}' has {} base classes", StringTable::getStringView(struct_name), struct_info->base_classes.size());
 	for (const auto& base_class : struct_info->base_classes) {
 		if (base_class.is_deferred) {
@@ -1210,9 +1210,9 @@ std::string_view Parser::lookup_inherited_member_variable_template_name(
 		return {};
 	}
 
-	if (!struct_type_info->struct_info_) {
+	if (!struct_type_info->getStructInfo()) {
 		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
-			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
+			if (underlying_type != struct_type_info && underlying_type->getStructInfo()) {
 				return lookup_inherited_member_variable_template_name(
 					underlying_type->name(),
 					member_name,
@@ -1222,7 +1222,7 @@ std::string_view Parser::lookup_inherited_member_variable_template_name(
 		return {};
 	}
 
-	const StructTypeInfo* struct_info = struct_type_info->struct_info_.get();
+	const StructTypeInfo* struct_info = struct_type_info->getStructInfo();
 	for (const auto& base_class : struct_info->base_classes) {
 		if (base_class.is_deferred) {
 			const TypeInfo* resolved = tryResolveDeferredBaseToConcreteStruct(base_class);
@@ -1286,7 +1286,7 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		return {};
 	}
 
-	if (!struct_type_info->struct_info_) {
+	if (!struct_type_info->getStructInfo()) {
 		if (struct_type_info->isTemplateInstantiation()) {
 			StringHandle alias_template_name = gNamespaceRegistry.buildQualifiedIdentifier(
 				struct_type_info->sourceNamespace(),
@@ -1332,7 +1332,7 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		}
 
 		if (const TypeInfo* underlying_type = tryGetTypeInfo(struct_type_info->type_index_)) {
-			if (underlying_type != struct_type_info && underlying_type->struct_info_) {
+			if (underlying_type != struct_type_info && underlying_type->getStructInfo()) {
 				return lookup_inherited_member_template_name(
 					underlying_type->name(),
 					member_name,
@@ -1342,7 +1342,7 @@ std::string_view Parser::lookup_inherited_member_template_name(
 		return {};
 	}
 
-	const StructTypeInfo* struct_info = struct_type_info->struct_info_.get();
+	const StructTypeInfo* struct_info = struct_type_info->getStructInfo();
 	for (const auto& base_class : struct_info->base_classes) {
 		if (base_class.is_deferred) {
 			const TypeInfo* resolved = tryResolveDeferredBaseToConcreteStruct(base_class);
@@ -1725,7 +1725,7 @@ ParseResult Parser::validate_and_add_base_class(
 	// For template parameters, dependent placeholders, or dependent type aliases, skip 'final' check
 	if (!is_template_param && !is_dependent_placeholder && !is_dependent_type_alias) {
 		// Check if base class is final
-		if (base_type_info->struct_info_ && base_type_info->struct_info_->is_final) {
+		if (base_type_info->getStructInfo() && base_type_info->getStructInfo()->is_final) {
 			return ParseResult::error("Cannot inherit from final class '" + std::string(base_class_name) + "'", error_token);
 		}
 	}

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -2276,6 +2276,14 @@ ParseResult Parser::parse_brace_initializer(const TypeSpecifierNode& type_specif
 			return make_constructor_call(elements);
 		}
 
+		// No user-declared constructors: empty braces are value/aggregate initialization
+		// (C++20 [dcl.init.general]/[dcl.init.aggr]). Do not require an already-
+		// synthesized implicit default constructor entry — e.g. trailing variables
+		// after `struct S { } s{}` are parsed before implicit special members exist.
+		if (elements.empty()) {
+			return make_constructor_call(elements);
+		}
+
 		// Check if there's a constructor that matches the argument count and types
 		bool found_matching_ctor = false;
 		auto ctor_candidates = struct_info.getConstructorsByParameterCount(elements.size(), false);

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -1258,8 +1258,8 @@ ParseResult Parser::parse_variable_declaration() {
 		const auto& init_list = first_init_expr->as<InitializerListNode>();
 		if (init_list.initializers().empty()) {
 			TypeIndex type_idx = type_specifier.type_index();
-			if (const TypeInfo* type_info = tryGetTypeInfo(type_idx); type_info && type_info->struct_info_) {
-				const StructTypeInfo& struct_info = *type_info->struct_info_;
+			if (const TypeInfo* type_info = tryGetTypeInfo(type_idx); type_info && type_info->getStructInfo()) {
+				const StructTypeInfo& struct_info = *type_info->getStructInfo();
 				if (struct_info.isDefaultConstructorDeleted()) {
 					return ParseResult::error("Call to deleted constructor of '" + std::string(StringTable::getStringView(type_info->name())) + "'", first_decl.identifier_token());
 				}
@@ -2022,7 +2022,7 @@ ParseResult Parser::parse_brace_initializer(const TypeSpecifierNode& type_specif
 	const bool is_user_defined_category = (type_specifier.category() == TypeCategory::UserDefined || type_specifier.category() == TypeCategory::TypeAlias || type_specifier.category() == TypeCategory::Template);
 	if (!is_struct_like_type && is_user_defined_category) {
 		TypeIndex type_index = type_specifier.type_index();
-		if (const TypeInfo* type_info = tryGetTypeInfo(type_index); type_info && type_info->struct_info_) {
+		if (const TypeInfo* type_info = tryGetTypeInfo(type_index); type_info && type_info->getStructInfo()) {
 			is_struct_like_type = true;
 		} else {
 			StringHandle type_name_handle = type_specifier.token().handle();
@@ -2086,7 +2086,7 @@ ParseResult Parser::parse_brace_initializer(const TypeSpecifierNode& type_specif
 
 	TypeIndex type_index = type_specifier.type_index();
 	const TypeInfo* type_info = tryGetTypeInfo(type_index);
-	if (!type_info || !type_info->struct_info_) {
+	if (!type_info || !type_info->getStructInfo()) {
 		const bool invalid_struct_type_index = !type_info;
 		if (!(parsing_template_depth_ > 0) && struct_parsing_context_stack_.empty()) {
 			return ParseResult::error(
@@ -2110,7 +2110,7 @@ ParseResult Parser::parse_brace_initializer(const TypeSpecifierNode& type_specif
 		return ParseResult::success(init_list_node);
 	}
 
-	const StructTypeInfo& struct_info = *type_info->struct_info_;
+	const StructTypeInfo& struct_info = *type_info->getStructInfo();
 
 	auto init_list_type_result = is_initializer_list_type(type_specifier);
 	if (init_list_type_result.has_value()) {

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -1428,7 +1428,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			struct_type_info.setInstantiationContext({}, template_args_info, nullptr);
 
 			// Create struct info in the cold arena - required before parsing static members
-			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
+			StructTypeInfo* struct_info = &struct_type_info.emplaceStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
 
 			// Parse base class list (if present): : public Base1, private Base2
 			if (peek() == ":"_tok) {
@@ -2485,6 +2485,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			}
 
 			// struct_type_info and struct_info were already created above in the cold arena
+			struct_type_info.attachStructInfo(*struct_info);
 			struct_type_info.bindStructInfoOwnership();
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
@@ -2894,7 +2895,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			struct_type_info.setInstantiationContext({}, {}, nullptr);
 
 			// Create StructTypeInfo for this specialization in the cold arena
-			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
+			StructTypeInfo* struct_info = &struct_type_info.emplaceStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
 
 			// Parse base class list (if present): : public Base1, private Base2
 			if (peek() == ":"_tok) {
@@ -4070,6 +4071,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			}
 
 			// StructTypeInfo already lives in the arena via createStructInfo
+			struct_type_info.attachStructInfo(*struct_info);
 			struct_type_info.bindStructInfoOwnership();
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -1427,8 +1427,8 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				template_args_info);
 			struct_type_info.setInstantiationContext({}, template_args_info, nullptr);
 
-			// Create struct info for tracking members - required before parsing static members
-			auto struct_info = std::make_unique<StructTypeInfo>(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
+			// Create struct info in the cold arena - required before parsing static members
+			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
 
 			// Parse base class list (if present): : public Base1, private Base2
 			if (peek() == ":"_tok) {
@@ -1566,7 +1566,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 					}
 
 					// Validate and add the base class
-					ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info.get(), base_access, is_virtual_base, base_name_token);
+					ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info, base_access, is_virtual_base, base_name_token);
 					if (result.is_error()) {
 						return result;
 					}
@@ -1605,7 +1605,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			// RAII guard ensures the stack entry is always popped, even on early returns.
 			struct_parsing_context_stack_.push_back({StringTable::getStringView(instantiated_name),
 													 &struct_ref,
-													 struct_info.get(),
+													 struct_info,
 													 gSymbolTable.get_current_namespace_handle(),
 													 {}});
 			auto pop_struct_ctx_guard = [this](void*) {
@@ -1659,7 +1659,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 							return enum_result;
 						}
 						if (auto enum_node = enum_result.node(); enum_node.has_value() && enum_node->is<EnumDeclarationNode>()) {
-							addUnscopedEnumEnumeratorsAsStaticMembers(struct_ref, struct_info.get(), enum_node->as<EnumDeclarationNode>(), current_access);
+							addUnscopedEnumEnumeratorsAsStaticMembers(struct_ref, struct_info, enum_node->as<EnumDeclarationNode>(), current_access);
 						}
 						continue;
 					} else if (peek() == "using"_tok) {
@@ -1685,7 +1685,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						// Register template friend classes (e.g., template<typename T> friend struct Foo;)
 						if (auto result_node = template_result.node()) {
 							if (result_node->is<FriendDeclarationNode>()) {
-								registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info.get());
+								registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info);
 							}
 						}
 						continue;
@@ -1696,7 +1696,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						auto static_result = parse_static_member_block(
 							instantiated_name,
 							struct_ref,
-							struct_info.get(),
+							struct_info,
 							current_access,
 							currentTemplateParamNames(),
 							/*use_struct_type_info=*/false,
@@ -1755,7 +1755,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						// Register friend in AST and StructTypeInfo
 						if (auto friend_node = friend_result.node()) {
 							struct_ref.add_friend(*friend_node);
-							registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info.get());
+							registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info);
 						}
 						continue;
 					}
@@ -2484,15 +2484,10 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				return ParseResult::error("Expected ';' after class declaration", peek_info());
 			}
 
-			// struct_type_info and struct_info were already created above
-			// Attach struct_info to type info if not already done
-			if (!struct_type_info.getStructInfo()) {
-				// Attach here (after member parsing) so static member helpers above can use
-				// the original struct_info pointer without hitting moved-from state.
-				struct_type_info.setStructInfo(std::move(struct_info));
-				if (struct_type_info.getStructInfo()) {
-					struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
-				}
+			// struct_type_info and struct_info were already created above in the cold arena
+			struct_type_info.bindStructInfoOwnership();
+			if (struct_type_info.getStructInfo()) {
+				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 			}
 
 			// Get pointer to the struct info to add member information
@@ -2898,8 +2893,8 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				QualifiedIdentifier::fromQualifiedName(template_name, gSymbolTable.get_current_namespace_handle()), {});
 			struct_type_info.setInstantiationContext({}, {}, nullptr);
 
-			// Create StructTypeInfo for this specialization
-			auto struct_info = std::make_unique<StructTypeInfo>(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
+			// Create StructTypeInfo for this specialization in the cold arena
+			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, struct_ref.default_access(), is_union, gSymbolTable.get_current_namespace_handle());
 
 			// Parse base class list (if present): : public Base1, private Base2
 			if (peek() == ":"_tok) {
@@ -3006,7 +3001,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 					}
 
 					// Validate and add the base class
-					ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info.get(), base_access, is_virtual_base, base_name_token);
+					ParseResult result = validate_and_add_base_class(base_class_name, struct_ref, struct_info, base_access, is_virtual_base, base_name_token);
 					if (result.is_error()) {
 						return result;
 					}
@@ -3127,7 +3122,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			// when used as template arguments in typedef declarations within the same struct body
 			struct_parsing_context_stack_.push_back({StringTable::getStringView(instantiated_name),
 													 &struct_ref,
-													 struct_info.get(),
+													 struct_info,
 													 gSymbolTable.get_current_namespace_handle(),
 													 {}});
 
@@ -3171,7 +3166,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 							return enum_result;
 						}
 						if (auto enum_node = enum_result.node(); enum_node.has_value() && enum_node->is<EnumDeclarationNode>()) {
-							addUnscopedEnumEnumeratorsAsStaticMembers(struct_ref, struct_info.get(), enum_node->as<EnumDeclarationNode>(), current_access);
+							addUnscopedEnumEnumeratorsAsStaticMembers(struct_ref, struct_info, enum_node->as<EnumDeclarationNode>(), current_access);
 						}
 						continue;
 					} else if (peek() == "struct"_tok || peek() == "class"_tok) {
@@ -3223,7 +3218,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						auto static_result = parse_static_member_block(
 							instantiated_name,
 							struct_ref,
-							struct_info.get(),
+							struct_info,
 							current_access,
 							currentTemplateParamNames(),
 							/*use_struct_type_info=*/false,
@@ -3256,7 +3251,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						// Register friend in AST and StructTypeInfo
 						if (auto friend_node = friend_result.node()) {
 							struct_ref.add_friend(*friend_node);
-							registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info.get());
+							registerFriendInStructInfo(friend_node->as<FriendDeclarationNode>(), struct_info);
 						}
 						continue;
 					} else if (peek() == "template"_tok) {
@@ -3268,7 +3263,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 						// Register template friend classes (e.g., template<typename T> friend struct Foo;)
 						if (auto result_node = template_result.node()) {
 							if (result_node->is<FriendDeclarationNode>()) {
-								registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info.get());
+								registerFriendInStructInfo(result_node->as<FriendDeclarationNode>(), struct_info);
 							}
 						}
 						continue;
@@ -4074,8 +4069,8 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 				return ParseResult::error(struct_info->getFinalizationError(), Token());
 			}
 
-			// Store struct info
-			struct_type_info.setStructInfo(std::move(struct_info));
+			// StructTypeInfo already lives in the arena via createStructInfo
+			struct_type_info.bindStructInfoOwnership();
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 			}

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -8132,10 +8132,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				[&](const StructMemberFunctionDecl& source_member) -> ASTNode {
 					const ConstructorDeclarationNode& original_ctor =
 						source_member.function_declaration.as<ConstructorDeclarationNode>();
-					if (!original_ctor.is_materialized()) {
-						return source_member.function_declaration;
-					}
 
+					// Always materialize a nested constructor stub owned by the
+					// instantiated nested class. Constructor templates in particular
+					// must carry the enclosing class's concrete outer bindings
+					// (e.g. Outer<int>::Inner::Inner(T*, U) with T=int) so later
+					// deduction/overload ranking compares int* vs long*, not a
+					// dependent T* placeholder.
 					auto [substituted_ctor_node, substituted_ctor] =
 						emplace_node_ref<ConstructorDeclarationNode>(
 							qualified_name,
@@ -8144,8 +8147,18 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						substituted_ctor,
 						template_params,
 						template_args_to_use);
-					substituted_ctor.set_template_parameters(
-						original_ctor.template_parameters());
+					if (!original_ctor.is_materialized() || original_ctor.has_template_body_position()) {
+						substituted_ctor.set_template_parameters(
+							original_ctor.template_parameters());
+					}
+					if (original_ctor.has_template_body_position()) {
+						substituted_ctor.set_template_body_position(
+							original_ctor.template_body_position());
+						if (original_ctor.has_template_initializer_list_position()) {
+							substituted_ctor.set_template_initializer_list_position(
+								original_ctor.template_initializer_list_position());
+						}
+					}
 
 					const size_t saved_pack_info = pack_param_info_.size();
 					substituteAndCopyParams(
@@ -8165,11 +8178,13 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const PackParamInfo>(
 							ctor_pack_param_info.data(),
 							ctor_pack_param_info.size()));
-					substituted_ctor.set_definition(substituteTemplateParameters(
-						*original_ctor.get_definition(),
-						template_params,
-						template_args_to_use,
-						qualified_name));
+					if (original_ctor.is_materialized()) {
+						substituted_ctor.set_definition(substituteTemplateParameters(
+							*original_ctor.get_definition(),
+							template_params,
+							template_args_to_use,
+							qualified_name));
+					}
 					pack_param_info_.resize(saved_pack_info);
 
 					substituted_ctor.set_is_implicit(original_ctor.is_implicit());
@@ -8188,9 +8203,20 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					instantiated_nested_struct_ref.add_constructor(
 						substituted_ctor_node,
 						source_member.access);
+					registerSourceMemberStubIdentity(
+						nested_source_member_identity_maps,
+						source_member.function_declaration,
+						substituted_ctor_node);
 					return substituted_ctor_node;
 				});
+			// Identity for non-constructor members (and any constructor that did
+			// not produce a distinct stub) still maps source→source as a fallback.
 			for (const StructMemberFunctionDecl& source_member : nested_source_member_functions) {
+				if (findSourceMemberStubByIdentity(
+						nested_source_member_identity_maps,
+						source_member.function_declaration) != nullptr) {
+					continue;
+				}
 				registerSourceMemberStubIdentity(
 					nested_source_member_identity_maps,
 					source_member.function_declaration,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1775,7 +1775,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				class_template_pack_registry_[instantiated_name] = class_template_pack_stack_.back();
 			}
 
-			auto struct_info = std::make_unique<StructTypeInfo>(instantiated_name, pattern_struct.default_access(), pattern_struct.is_union(), spec_decl_ns);
+			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, pattern_struct.default_access(), pattern_struct.is_union(), spec_decl_ns);
 
 			// Handle base classes from the pattern
 			// Base classes need to be instantiated with concrete template arguments
@@ -2400,7 +2400,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						if (orig_func.is_static()) {
 							substituted_body = rebindStaticMemberInitializerFunctionCalls(
 								substituted_body,
-								struct_info.get(),
+								struct_info,
 								true);
 						}
 						new_func_ref.set_definition(substituted_body);
@@ -3144,7 +3144,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				FLASH_LOG(Parser, Error, struct_info->getFinalizationError());
 				return std::nullopt;
 			}
-			struct_type_info.setStructInfo(std::move(struct_info));
+			struct_type_info.bindStructInfoOwnership();
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 			}
@@ -3153,7 +3153,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// across member copying, aliases, and semantic substitution.
 			std::span<const TemplateTypeArg> template_args_for_pattern =
 				template_args_for_member_copy;
-			StructTypeInfo* instantiated_struct_info_mut = struct_info.get();
+			StructTypeInfo* instantiated_struct_info_mut = struct_info;
 			const StructTypeInfo* instantiated_struct_info = instantiated_struct_info_mut;
 			auto [effective_pattern_template_params, effective_pattern_template_args_storage] =
 				build_effective_partial_spec_template_bindings(
@@ -5702,8 +5702,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		}
 	}
 
-	// Create StructTypeInfo
-	auto struct_info = std::make_unique<StructTypeInfo>(instantiated_name, AccessSpecifier::Public, class_decl.is_union(), decl_ns);
+	// Create StructTypeInfo in the cold arena
+	StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, AccessSpecifier::Public, class_decl.is_union(), decl_ns);
 
 	// Handle base classes from the primary template
 	// Base classes need to be instantiated with concrete template arguments
@@ -5754,7 +5754,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 					return false;
 				}
-				if (concrete_type->struct_info_ && concrete_type->struct_info_->is_final) {
+				if (concrete_type->getStructInfo() && concrete_type->getStructInfo()->is_final) {
 					FLASH_LOG(Templates, Error, "Cannot inherit from final class '", concrete_type->name_, "'");
 					return false;
 				}
@@ -7203,7 +7203,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			non_type_categories);
 
 		auto member_ctx_scope =
-			push_replay_member_context(owning_instantiated_name, struct_info.get());
+			push_replay_member_context(owning_instantiated_name, struct_info);
 
 		restore_lexer_position_only(*static_member.initializer_position);
 
@@ -7604,7 +7604,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					substituted_initializer,
 					gSymbolTable,
 					*this,
-					struct_info.get(),
+					struct_info,
 					effective_template_params,
 					effective_template_args_vector,
 					substituted_type_index,
@@ -7697,17 +7697,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			// Register the nested semantic owner before producing members and signatures.
 			// Constructor current-instantiation substitution requires both the pattern
 			// and instantiated owner TypeIndex values to be canonical at this point.
-			auto nested_struct_info_owner = std::make_unique<StructTypeInfo>(
-				qualified_name,
-				nested_struct.default_access(),
-				nested_struct.is_union(),
-				decl_ns);
 			auto& nested_type_info = add_instantiated_type(
 				qualified_name,
 				TypeCategory::Struct,
 				0); // Layout is finalized after member production.
-			nested_type_info.setStructInfo(std::move(nested_struct_info_owner));
-			StructTypeInfo* nested_struct_info = nested_type_info.getStructInfo();
+			StructTypeInfo* nested_struct_info = &nested_type_info.createStructInfo(
+				qualified_name,
+				nested_struct.default_access(),
+				nested_struct.is_union(),
+				decl_ns);
 			if (nested_struct_info == nullptr || !nested_struct_info->own_type_index_.has_value()) {
 				throw InternalError("Nested class registration did not establish a canonical semantic owner");
 			}
@@ -8662,7 +8660,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 		struct_parsing_context_stack_.push_back({StringTable::getStringView(instantiated_name),
 												 nullptr, // struct_node — not needed; parse_struct_declaration() creates its own
-												 struct_info.get(),
+												 struct_info,
 												 decl_ns,
 												 {}});
 
@@ -8777,7 +8775,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// so members of type "Wrapper::Nested" (with size 0) remain unresolved.
 	// Now that nested classes are registered as "Wrapper$hash::Nested", update those members.
 	{
-		StructTypeInfo* si = struct_info.get();
+		StructTypeInfo* si = struct_info;
 		if (si) {
 			bool had_fixup = false;
 			for (auto& member : si->members) {
@@ -9078,7 +9076,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		if (substituted_type == TypeCategory::Enum && substituted_type_index.is_valid()) {
 			if (const TypeInfo* enum_alias_ti = tryGetTypeInfo(substituted_type_index)) {
 				if (const EnumTypeInfo* enum_info = enum_alias_ti->getEnumInfo()) {
-					alias_type_info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
+					alias_type_info.setEnumInfo(EnumTypeInfo(*enum_info));
 				}
 			}
 		}
@@ -9152,7 +9150,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						retry_initializer,
 						gSymbolTable,
 						*this,
-						struct_info.get(),
+						struct_info,
 						effective_template_params,
 						effective_template_args_vector,
 						instantiated_static_member->type_index,
@@ -9281,8 +9279,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		return std::nullopt;
 	}
 
-	// Store struct info in type info
-	struct_type_info.setStructInfo(std::move(struct_info));
+	// StructTypeInfo already lives in the arena via createStructInfo
+	struct_type_info.bindStructInfoOwnership();
 
 	// Update fallback_size_bits_ from the finalized struct's total size
 	if (struct_type_info.getStructInfo()) {
@@ -11526,9 +11524,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							bool is_base_init = false;
 							StringHandle matched_base_name;
 							StringHandle init_name_handle = StringTable::getOrInternStringHandle(init_name);
-							if (struct_type_info.struct_info_) {
+							if (struct_type_info.getStructInfo()) {
 								// Check if this is a base class by looking at the struct's base classes
-								for (const auto& base : struct_type_info.struct_info_->base_classes) {
+								for (const auto& base : struct_type_info.getStructInfo()->base_classes) {
 									std::string_view base_name = base.name;
 									bool base_names_match =
 										(base_name == init_name || extractBaseTemplateName(base_name) == init_name);
@@ -11550,8 +11548,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									}
 								}
 
-								if (!is_base_init && struct_type_info.struct_info_->has_deferred_base_classes) {
-									for (const auto& deferred_base_entry : struct_type_info.struct_info_->deferred_template_bases) {
+								if (!is_base_init && struct_type_info.getStructInfo()->has_deferred_base_classes) {
+									for (const auto& deferred_base_entry : struct_type_info.getStructInfo()->deferred_template_bases) {
 										if (deferred_base_entry.base_template_name == init_name_handle) {
 											is_base_init = true;
 											matched_base_name = deferred_base_entry.base_template_name;
@@ -11614,10 +11612,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_args_to_use);
 					ctor.set_definition(substituted_body);
 					// Also update the StructTypeInfo's copy (used by codegen)
-					if (struct_type_info.struct_info_) {
+					if (struct_type_info.getStructInfo()) {
 						OutOfLineConstructorStubResolution info_ctor_resolution =
 							findReplayedOutOfLineConstructorInStructInfo(
-								struct_type_info.struct_info_.get(),
+								struct_type_info.getStructInfo(),
 								struct_info_member_identity_maps,
 								ctor_resolution.source_member,
 								ctor,

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -1775,7 +1775,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				class_template_pack_registry_[instantiated_name] = class_template_pack_stack_.back();
 			}
 
-			StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, pattern_struct.default_access(), pattern_struct.is_union(), spec_decl_ns);
+			StructTypeInfo* struct_info = &struct_type_info.emplaceStructInfo(instantiated_name, pattern_struct.default_access(), pattern_struct.is_union(), spec_decl_ns);
 
 			// Handle base classes from the pattern
 			// Base classes need to be instantiated with concrete template arguments
@@ -3144,10 +3144,6 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				FLASH_LOG(Parser, Error, struct_info->getFinalizationError());
 				return std::nullopt;
 			}
-			struct_type_info.bindStructInfoOwnership();
-			if (struct_type_info.getStructInfo()) {
-				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
-			}
 
 			// Reuse the matcher-produced, specialization-parameter-aligned bindings
 			// across member copying, aliases, and semantic substitution.
@@ -3409,6 +3405,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				FLASH_LOG(Templates, Debug, "Registered type alias from pattern: ", qualified_alias_name,
 						  " -> type=", static_cast<int>(substituted_type),
 						  ", type_index=", substituted_type_index);
+			}
+
+			// Publish StructTypeInfo only after aliases are registered so mid-
+			// instantiation lookup does not see an incomplete payload.
+			struct_type_info.attachStructInfo(*struct_info);
+			struct_type_info.bindStructInfoOwnership();
+			if (struct_type_info.getStructInfo()) {
+				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 			}
 
 			// Create an AST node for the instantiated struct so member functions can be code-generated
@@ -5703,7 +5707,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	// Create StructTypeInfo in the cold arena
-	StructTypeInfo* struct_info = &struct_type_info.createStructInfo(instantiated_name, AccessSpecifier::Public, class_decl.is_union(), decl_ns);
+	StructTypeInfo* struct_info = &struct_type_info.emplaceStructInfo(instantiated_name, AccessSpecifier::Public, class_decl.is_union(), decl_ns);
 
 	// Handle base classes from the primary template
 	// Base classes need to be instantiated with concrete template arguments
@@ -9279,7 +9283,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		return std::nullopt;
 	}
 
-	// StructTypeInfo already lives in the arena via createStructInfo
+	// Publish arena payload now that members/aliases/ctors are complete.
+	struct_type_info.attachStructInfo(*struct_info);
 	struct_type_info.bindStructInfoOwnership();
 
 	// Update fallback_size_bits_ from the finalized struct's total size

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -28,7 +28,7 @@ std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_n
 	}
 
 	const TypeInfo* type_info = type_it->second;
-	if (!type_info->struct_info_) {
+	if (!type_info->getStructInfo()) {
 		if (type_info->isTemplateInstantiation()) {
 			return type_info->baseTemplateName();
 		}
@@ -62,7 +62,7 @@ std::optional<StringHandle> getTemplateLookupOwnerName(std::string_view struct_n
 		has_owner_component = true;
 	};
 
-	append_lookup_owner(append_lookup_owner, type_info->struct_info_.get());
+	append_lookup_owner(append_lookup_owner, type_info->getStructInfo());
 	if (!has_owner_component) {
 		return std::nullopt;
 	}
@@ -467,35 +467,35 @@ InlineVector<TemplateNameLookupCandidate, 4> Parser::lookupMemberFunctionTemplat
 			}
 
 			const TypeInfo* struct_type_info = struct_it->second;
-			if (!struct_type_info->struct_info_) {
+			if (!struct_type_info->getStructInfo()) {
 				if (const TypeInfo* underlying_type =
 						tryGetTypeInfo(struct_type_info->type_index_);
 					underlying_type != nullptr &&
 					underlying_type != struct_type_info &&
-					underlying_type->struct_info_) {
+					underlying_type->getStructInfo()) {
 					return self(self, underlying_type->name(), depth + 1);
 				}
 				return {};
 			}
 
 			const StructTypeInfo* struct_info =
-				struct_type_info->struct_info_.get();
+				struct_type_info->getStructInfo();
 			for (const auto& base_class : struct_info->base_classes) {
 				if (base_class.is_deferred) {
 					const TypeInfo* resolved = nullptr;
 					if (base_class.type_index.is_valid()) {
 						resolved = tryGetTypeInfo(base_class.type_index);
-						if (resolved != nullptr && !resolved->struct_info_ &&
+						if (resolved != nullptr && !resolved->getStructInfo() &&
 							resolved->type_index_.is_valid()) {
 							const TypeInfo* chained_type =
 								tryGetTypeInfo(resolved->type_index_);
 							if (chained_type != nullptr &&
-								chained_type->struct_info_) {
+								chained_type->getStructInfo()) {
 								resolved = chained_type;
 							}
 						}
 					}
-					if (resolved != nullptr && resolved->struct_info_) {
+					if (resolved != nullptr && resolved->getStructInfo()) {
 						InheritedOwnerMatch inherited_owner =
 							self(self, resolved->name(), depth + 1);
 						if (inherited_owner.owner_name.isValid()) {

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1385,9 +1385,17 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 			if (!instantiated.has_value() || !instantiated->is<ConstructorDeclarationNode>()) {
 				return;
 			}
+			const ConstructorDeclarationNode& concrete_ctor_ref =
+				instantiated->as<ConstructorDeclarationNode>();
+			// Only publish specializations that actually match the call. Failed
+			// probes must not enter the overload set (they would poison arity
+			// fallback and displace later, better specializations).
+			if (!matches_call_arguments(concrete_ctor_ref)) {
+				return;
+			}
 			const ConstructorDeclarationNode* concrete_ctor =
 				attachInstantiatedCtor(template_ctor, *instantiated);
-			if (concrete_ctor && matches_call_arguments(*concrete_ctor)) {
+			if (concrete_ctor != nullptr) {
 				concrete_matches.push_back(concrete_ctor);
 			}
 		};

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -1432,17 +1432,24 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 
 	if (preferred_ctor != nullptr) {
 		if (!preferred_ctor->has_template_parameters()) {
-			return preferred_ctor;
-		}
-		if (const ConstructorDeclarationNode* concrete_ctor =
+			// A previously materialized non-template specialization must still
+			// convert from the current arguments. Otherwise a stale specialization
+			// (e.g. Inner(T*,U) kept with dependent T*) can suppress probing the
+			// correct constructor template overload.
+			if (matches_call_arguments(*preferred_ctor)) {
+				return preferred_ctor;
+			}
+			preferred_ctor = nullptr;
+		} else if (const ConstructorDeclarationNode* concrete_ctor =
 				materialize_template_ctor_candidates(preferred_ctor);
 			concrete_ctor != nullptr) {
 			return concrete_ctor;
+		} else {
+			// Instantiation failed or the instantiated ctor doesn't match call arguments.
+			// Return nullptr so callers fall back to arity-based resolution instead of
+			// forwarding an uninstantiated template constructor.
+			return nullptr;
 		}
-		// Instantiation failed or the instantiated ctor doesn't match call arguments.
-		// Return nullptr so callers fall back to arity-based resolution instead of
-		// forwarding an uninstantiated template constructor.
-		return nullptr;
 	}
 
 	return materialize_template_ctor_candidates(nullptr);

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -5154,7 +5154,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 		template_args_info);
 	struct_type_info.setInstantiationContext({}, template_args_info, nullptr);
 
-	StructTypeInfo* struct_info = &struct_type_info.createStructInfo(StringTable::getOrInternStringHandle(instantiated_name), spec_struct.default_access(), spec_struct.is_union(), decl_ns);
+	StructTypeInfo* struct_info = &struct_type_info.emplaceStructInfo(StringTable::getOrInternStringHandle(instantiated_name), spec_struct.default_access(), spec_struct.is_union(), decl_ns);
 
 	// Copy members from the specialization
 	for (const auto& member_decl : spec_struct.members()) {
@@ -5359,6 +5359,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 	struct_info->needs_default_constructor = !has_constructor;
 	FLASH_LOG(Templates, Debug, "Full spec has constructor: ", has_constructor ? "yes" : "no, needs default");
 
+	struct_type_info.attachStructInfo(*struct_info);
 	struct_type_info.bindStructInfoOwnership();
 	if (struct_type_info.getStructInfo()) {
 		struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;

--- a/src/Parser_Templates_Inst_Substitution.cpp
+++ b/src/Parser_Templates_Inst_Substitution.cpp
@@ -4999,7 +4999,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 				if (const TypeInfo* source_alias_type_info = tryGetTypeInfo(alias_target_index);
 					source_alias_type_info && source_alias_type_info->getEnumInfo()) {
 					const EnumTypeInfo* enum_info = source_alias_type_info->getEnumInfo();
-					alias_type_info.setEnumInfo(std::make_unique<EnumTypeInfo>(*enum_info));
+					alias_type_info.setEnumInfo(EnumTypeInfo(*enum_info));
 				}
 			}
 			getTypesByNameMap().insert_or_assign(qualified_alias_name, &alias_type_info);
@@ -5154,7 +5154,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 		template_args_info);
 	struct_type_info.setInstantiationContext({}, template_args_info, nullptr);
 
-	auto struct_info = std::make_unique<StructTypeInfo>(StringTable::getOrInternStringHandle(instantiated_name), spec_struct.default_access(), spec_struct.is_union(), decl_ns);
+	StructTypeInfo* struct_info = &struct_type_info.createStructInfo(StringTable::getOrInternStringHandle(instantiated_name), spec_struct.default_access(), spec_struct.is_union(), decl_ns);
 
 	// Copy members from the specialization
 	for (const auto& member_decl : spec_struct.members()) {
@@ -5359,7 +5359,7 @@ std::optional<ASTNode> Parser::instantiate_full_specialization(
 	struct_info->needs_default_constructor = !has_constructor;
 	FLASH_LOG(Templates, Debug, "Full spec has constructor: ", has_constructor ? "yes" : "no, needs default");
 
-	struct_type_info.setStructInfo(std::move(struct_info));
+	struct_type_info.bindStructInfoOwnership();
 	if (struct_type_info.getStructInfo()) {
 		struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 	}

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -1651,8 +1651,8 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 	TypeInfo& nested_type_info = add_struct_type(lazy_info->qualified_name, decl_ns);
 	TypeIndex type_index = nested_type_info.type_index_;
 
-	// Create StructTypeInfo for the nested type
-	auto nested_struct_info = std::make_unique<StructTypeInfo>(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
+	// Create StructTypeInfo for the nested type in the cold arena
+	StructTypeInfo* nested_struct_info = &nested_type_info.createStructInfo(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
 
 	// Process members with template parameter substitution
 	const InlineVector<TemplateParameterNode, 4>& parent_template_params_inline =
@@ -1722,8 +1722,8 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 											 : nullptr,
 										 shouldCommitTemplateInstantiationArtifacts());
 
-	// Set the struct info on the type
-	nested_type_info.struct_info_ = std::move(nested_struct_info);
+	// StructTypeInfo already lives in the arena via createStructInfo
+	nested_type_info.bindStructInfoOwnership();
 
 	// Mark as instantiated (removes from lazy registry)
 	registry.markInstantiated(parent_class_name, nested_type_name);

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -453,6 +453,23 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			new_ctor_ref, {}, NameMangling::ConstructorVariant::Complete).view());
 		pack_param_info_.resize(saved_ctor_pack_info);
 
+		// Constructor templates must remain in the overload set; each concrete
+		// instantiation is a distinct specialization. Replacing the template stub
+		// would permanently drop other specializations (e.g. TupleImpl(U, const T&)
+		// for different U). Non-template lazy OOL ctor stubs are still replaced in
+		// place once their body is materialized.
+		//
+		// Constructor-template specializations are also NOT registered here. Callers
+		// such as materializeMatchingConstructorTemplate attach them only after the
+		// concrete signature is confirmed to match the call arguments, so failed
+		// deduction probes do not pollute the overload set.
+		const bool source_is_constructor_template = ctor_decl.has_template_parameters();
+		if (source_is_constructor_template) {
+			registerLateMaterializedOwningStructRoot(lazy_info.identity.instantiated_owner_name);
+			normalizePendingSemanticRoots();
+			return new_ctor_node;
+		}
+
 		auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
 		if (struct_it != getTypesByNameMap().end()) {
 			if (StructTypeInfo* struct_info = struct_it->second->getStructInfo()) {
@@ -1652,7 +1669,7 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 	TypeIndex type_index = nested_type_info.type_index_;
 
 	// Create StructTypeInfo for the nested type in the cold arena
-	StructTypeInfo* nested_struct_info = &nested_type_info.createStructInfo(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
+	StructTypeInfo* nested_struct_info = &nested_type_info.emplaceStructInfo(lazy_info->qualified_name, nested_struct.default_access(), nested_struct.is_union(), decl_ns);
 
 	// Process members with template parameter substitution
 	const InlineVector<TemplateParameterNode, 4>& parent_template_params_inline =
@@ -1722,7 +1739,7 @@ std::optional<TypeIndex> Parser::instantiateLazyNestedType(
 											 : nullptr,
 										 shouldCommitTemplateInstantiationArtifacts());
 
-	// StructTypeInfo already lives in the arena via createStructInfo
+	nested_type_info.attachStructInfo(*nested_struct_info);
 	nested_type_info.bindStructInfoOwnership();
 
 	// Mark as instantiated (removes from lazy registry)

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -2099,7 +2099,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 								// Check if it's a concrete struct (has struct_info_)
 								// OR if it's a type alias that resolves to a concrete type
 								// Type aliases have type_index pointing to the underlying type
-								if (type_info->struct_info_ != nullptr) {
+								if (type_info->getStructInfo() != nullptr) {
 									is_concrete_type = true;
 									FLASH_LOG(Templates, Debug, "Identifier '", id.name(), "' is a concrete struct type, falling through to type parsing");
 								} else if (const TypeInfo* underlying = tryGetTypeInfo(type_info->type_index_)) {
@@ -2110,7 +2110,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 									// 2. It's not Type::UserDefined (i.e., it's a built-in type like int, bool, float)
 									// Template parameters are stored as Type::UserDefined without struct_info_,
 									// so this check correctly excludes them while accepting concrete types.
-									if (underlying->struct_info_ != nullptr ||
+									if (underlying->getStructInfo() != nullptr ||
 										underlying->resolvedType() != TypeCategory::UserDefined) {
 									// It's a type alias to a concrete type (struct or built-in)
 										is_concrete_type = true;
@@ -2140,7 +2140,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 							if (!variable_template_expression &&
 								type_it != getTypesByNameMap().end()) {
 								const TypeInfo* type_info = type_it->second;
-								if (type_info->struct_info_ != nullptr) {
+								if (type_info->getStructInfo() != nullptr) {
 									is_concrete_type = true;
 									FLASH_LOG(Templates, Debug, "QualifiedIdentifierNode '", qualified_name, "' is a concrete type, falling through to type parsing");
 								}

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -485,7 +485,7 @@ ParseResult Parser::parse_type_specifier() {
 			// Look up the enum type to get its underlying type
 			const TypeInfo& enum_type_info = getTypeInfo(arg_type.type_index());
 			if (enum_type_info.enum_info_) {
-				const EnumTypeInfo* enum_info = enum_type_info.enum_info_.get();
+				const EnumTypeInfo* enum_info = enum_type_info.getEnumInfo();
 				TypeCategory underlying = enum_info->underlying_type;
 				int underlying_size = enum_info->sizeInBits().value;
 				FLASH_LOG(Parser, Debug, "parse_type_specifier: __underlying_type resolved to ", static_cast<int>(underlying));
@@ -497,7 +497,7 @@ ParseResult Parser::parse_type_specifier() {
 		// If we have a type index, try to look up if it's an enum
 		const TypeInfo& type_info = getTypeInfo(arg_type.type_index());
 		if (type_info.enum_info_) {
-			const EnumTypeInfo* enum_info = type_info.enum_info_.get();
+			const EnumTypeInfo* enum_info = type_info.getEnumInfo();
 			TypeCategory underlying = enum_info->underlying_type;
 			int underlying_size = enum_info->sizeInBits().value;
 			FLASH_LOG(Parser, Debug, "parse_type_specifier: __underlying_type resolved to ", static_cast<int>(underlying));


### PR DESCRIPTION
## Summary
- Move `StructTypeInfo` / `EnumTypeInfo` payloads out of per-`TypeInfo` `unique_ptr` heap allocations into append-only `gStructTypeInfos` / `gEnumTypeInfos` arenas.
- `TypeInfo` holds stable arena pointers; callers use `createStructInfo` / `createEnumInfo` (or by-value `set*` for copies) instead of `make_unique` + move.
- Migrate accessor call sites to `getStructInfo()` / `getEnumInfo()` and keep constructor ownership binding via `bindStructInfoOwnership()`.

Note: issue #1816 proposed `uint32_t` indices for an extra ~8 bytes/row saving. This PR uses cached arena pointers instead — same allocation win, less API churn, same 16-byte row cost as `unique_ptr`.

Fixes #1816

## Test plan
- [x] `.\build_flashcpp.bat`
- [x] Focused: `test_lazy_member_cache_reparse_type_trait_ret42.cpp`, struct/enum/lambda smoke tests
- [x] Full `./tests/run_all_tests.ps1` (some lazy-instantiation crashes also reproduce on `main`)