### PR TITLE
Plan SysV aggregate returns from layout classification

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -52,32 +52,25 @@ produce `CompileError`; missing canonical compiler metadata should produce
 `InternalError`; unsupported evaluator coverage must not be accepted as either a
 constant value or an ill-formed program.
 
-## SysV MEMORY-class aggregate returns need deferred ABI planning
+## SysV single-eightbyte and x87 aggregate return gaps
 
-SysV aggregate argument and direct register-return lowering classifies concrete
-types from canonical layout metadata. Unaligned aggregates and other MEMORY-class
-values are also classified correctly for parameter passing. Return-slot selection,
-however, is still decided while IR is generated from a size threshold. Replacing
-that threshold directly with strict layout classification exposes function
-templates and deferred lambda signatures whose return types are not concrete at
-that phase.
+Concrete SysV aggregate returns now plan `direct` vs `indirect` from canonical
+layout classification during IR generation. Aggregates larger than two
+eightbytes, and ≤16-byte MEMORY-class values such as unaligned packed
+aggregates, select a hidden return slot. Incomplete or placeholder return types
+are `dependent` and must not be treated as direct; concrete function/call IR
+requires a resolved plan and surfaces missing canonical metadata as
+`InternalError`.
 
-The remaining C++20-compliant fix is to represent return ABI disposition as
-`direct`, `indirect`, or `dependent`, defer the last case until substitution has
-produced a complete canonical return type, and require concrete call/function IR
-to carry the resulting ABI plan. Treating an unresolved type as direct, guessing
-from its category or size, or reconstructing it during code generation would hide
-the producer defect. Until that planning boundary exists, a small unaligned
-aggregate return can still use the wrong direct-return convention on SysV.
+Remaining gaps:
 
-The first shared-classifier lowering slice is deliberately limited to concrete
-two-eightbyte aggregates (9–16 bytes). Single-eightbyte aggregate lowering still
-uses the legacy scalar path, which is correct for INTEGER-class values but does
-not yet select an SSE register for aggregates containing only `float`/`double`.
-Enabling strict classification for that path currently exposes several IR
-producers that omit canonical type identity for small class values. Those
-producers must be closed before the scalar path is replaced; accepting an absent
-`TypeIndex` as INTEGER would only preserve the same non-standard guess.
+Single-eightbyte aggregate lowering still uses the legacy scalar path, which is
+correct for INTEGER-class values but does not yet select an SSE register for
+aggregates containing only `float`/`double`. Enabling strict classification for
+that path currently exposes several IR producers that omit canonical type
+identity for small class values. Those producers must be closed before the
+scalar path is replaced; accepting an absent `TypeIndex` as INTEGER would only
+preserve the same non-standard guess.
 
 Aggregate returns containing `long double` also remain on the legacy path. Their
 SysV result classification uses the X87/X87UP classes, which the current backend

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -52,27 +52,18 @@ produce `CompileError`; missing canonical compiler metadata should produce
 `InternalError`; unsupported evaluator coverage must not be accepted as either a
 constant value or an ill-formed program.
 
-## SysV single-eightbyte and x87 aggregate return gaps
+## SysV x87 aggregate return gap
 
-Concrete SysV aggregate returns now plan `direct` vs `indirect` from canonical
-layout classification during IR generation. Aggregates larger than two
-eightbytes, and ≤16-byte MEMORY-class values such as unaligned packed
-aggregates, select a hidden return slot. Incomplete or placeholder return types
-are `dependent` and must not be treated as direct; concrete function/call IR
-requires a resolved plan and surfaces missing canonical metadata as
-`InternalError`.
+Concrete SysV aggregate returns plan `direct` vs `indirect` from canonical layout
+classification during IR generation, including single-eightbyte SSE-only values
+such as `struct { float; }` / `struct { double; }` that must use XMM0 rather than
+the legacy integer return path. Aggregates larger than two eightbytes, and ≤16-byte
+MEMORY-class values such as unaligned packed aggregates, select a hidden return
+slot. Incomplete or placeholder return types are `dependent` and must not be
+treated as direct; concrete function/call IR requires a resolved plan and surfaces
+missing canonical metadata as `InternalError`.
 
-Remaining gaps:
-
-Single-eightbyte aggregate lowering still uses the legacy scalar path, which is
-correct for INTEGER-class values but does not yet select an SSE register for
-aggregates containing only `float`/`double`. Enabling strict classification for
-that path currently exposes several IR producers that omit canonical type
-identity for small class values. Those producers must be closed before the
-scalar path is replaced; accepting an absent `TypeIndex` as INTEGER would only
-preserve the same non-standard guess.
-
-Aggregate returns containing `long double` also remain on the legacy path. Their
-SysV result classification uses the X87/X87UP classes, which the current backend
+Aggregate returns containing `long double` remain on the legacy path. Their SysV
+result classification uses the X87/X87UP classes, which the current backend
 return-register abstraction cannot represent yet. Aggregate parameters containing
 `long double` are still classified as MEMORY as required.

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -64,6 +64,14 @@ treated as direct; concrete function/call IR requires a resolved plan and surfac
 missing canonical metadata as `InternalError`.
 
 Aggregate returns containing `long double` remain on the legacy path. Their SysV
-result classification uses the X87/X87UP classes, which the current backend
-return-register abstraction cannot represent yet. Aggregate parameters containing
-`long double` are still classified as MEMORY as required.
+result classification uses the X87/X87UP classes (`%st0` / paired X87UP), which the
+current backend return-register abstraction cannot represent yet. Aggregate
+parameters containing `long double` are still classified as MEMORY as required.
+
+This gap is specific to `long double` (not `float`/`double` SSE aggregates). Closing
+it is blocked on broader `long double` codegen support: FlashCpp currently has type
+identity, some constexpr/overload/builtin coverage, and inconsistent sizing (80-bit
+x87 extended in places, Windows-style 8-byte `double` alias elsewhere), but no real
+x87 load/store/`%st0` emission path. Constexpr evaluation often collapses
+`long double` to `double`. Do not paper over return ABI with size guesses or INTEGER
+fallbacks; wait until `long double` lowering can emit the SysV x87 convention.

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1385,6 +1385,8 @@ private:
 	CVReferenceQualifier callParameterRefQualifier(const TypeSpecifierNode* param_type) const;
 	void applyTypeNodeMetadata(TypedValue& value, const TypeSpecifierNode& type_node);
 	void applyCallParameterBindingMetadata(TypedValue& value, const TypeSpecifierNode& param_type);
+	// ABI: member 'this' is always a pointer to the class object, never a by-value aggregate.
+	TypedValue makeMemberThisCallArgument(TypeIndex object_type_index, IrValue this_ptr_value);
 	std::optional<TypedValue> tryBuildSemaBoundCallArgument(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode& param_type, const CallArgReferenceBindingInfo* sema_ref_binding, const Token& token);
 	ExprResult applyCallArgumentConversions(ExprResult argument_result, const ASTNode& argument, const TypeSpecifierNode* param_type, const Token& token);
 	TypedValue buildOrdinaryCallArgument(const ASTNode& argument, const TypeSpecifierNode* param_type, const std::optional<ExprResult>& evaluated_arg, const Token& token);

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -625,12 +625,14 @@ int main_impl(int argc, char* argv[]) {
 					has_dependent_signature = functionHasUnresolvedPlaceholderSignature(node_handle.as<FunctionDeclarationNode>());
 				}
 				if (has_dependent_signature) {
+					// Match the CompileError placeholder path: these are SFINAE/decltype
+					// probes, not concrete functions that should fail the TU.
 					FLASH_LOG(Codegen, Warning, "IR error for function '", node_desc,
 							  "' with unsubstituted dependent signature types: ", e.what());
 				} else {
 					FLASH_LOG(General, Error, "IR conversion failed for node '", node_desc, "': ", e.what());
+					++ir_conversion_error_count;
 				}
-				++ir_conversion_error_count;
 			} catch (const std::runtime_error& e) {
 				std::string node_desc = node_handle.type_name();
 				if (node_handle.is<FunctionDeclarationNode>()) {

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -4097,6 +4097,27 @@ template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitIntegerOrAggregateReturnValue(
 	TypeIndex type_index, SizeInBits size_in_bits,
 	int32_t frame_offset, std::optional<X64Register> live_value_register) {
+	if (current_function_returns_reference_ || current_function_returns_pointer_) {
+		// A reference (T& / T&&) or pointer (T*) return is an address, never a
+		// by-value aggregate. It occupies a single 64-bit pointer in RAX, so bypass
+		// SysV/struct classification entirely (classifying the pointee struct — e.g.
+		// a covariant Derived* / Derived& — would otherwise misfire as MEMORY-class
+		// and abort the whole function body).
+		if (live_value_register.has_value()) {
+			if (*live_value_register != X64Register::RAX) {
+				spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
+				auto move_to_rax = regAlloc.get_reg_reg_move_op_code(
+					X64Register::RAX, *live_value_register, 8);
+				logAsmEmit("emitIntegerOrAggregateReturnValue", move_to_rax.op_codes.data(), move_to_rax.size_in_bytes);
+				textSectionData.insert(textSectionData.end(), move_to_rax.op_codes.begin(),
+								   move_to_rax.op_codes.begin() + move_to_rax.size_in_bytes);
+			}
+			return;
+		}
+		spillAndInvalidateRegisterForManualOverwrite(X64Register::RAX);
+		emitMovFromFrameBySize(X64Register::RAX, frame_offset, 64);
+		return;
+	}
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
 		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 0) {
 			const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
@@ -4258,7 +4279,53 @@ bool IrToObjConverter<TWriterClass>::emitLoadAddressLikeArgument(X64Register tar
 }
 
 template <class TWriterClass>
+bool IrToObjConverter<TWriterClass>::isImmediateAggregateValue(const TypedValue& arg) const {
+	// A by-value aggregate whose whole payload was constant-folded to a scalar (e.g.
+	// Source(38) collapsed to its single INTEGER member) has no addressable frame slot.
+	return !std::holds_alternative<StringHandle>(arg.value) &&
+		!std::holds_alternative<TempVar>(arg.value);
+}
+
+template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::materializeImmediateAggregateEightbyteInGpr(
+	const TypedValue& arg, X64Register target_reg) {
+	if (const auto* imm = std::get_if<unsigned long long>(&arg.value)) {
+		if (arg.size_in_bits == SizeInBits{32}) {
+			emitMovImm32(target_reg, static_cast<uint32_t>(*imm));
+		} else {
+			emitMovImm64(target_reg, *imm);
+		}
+		return;
+	}
+	if (const auto* dbl = std::get_if<double>(&arg.value)) {
+		uint64_t bits;
+		if (arg.effectiveIrType() == IrType::Float) {
+			float float_val = static_cast<float>(*dbl);
+			uint32_t float_bits;
+			std::memcpy(&float_bits, &float_val, sizeof(float_bits));
+			bits = float_bits;
+		} else {
+			std::memcpy(&bits, dbl, sizeof(bits));
+		}
+		emitMovImm64(target_reg, bits);
+		return;
+	}
+	throw InternalError("Unsupported immediate value kind for by-value aggregate argument");
+}
+
+template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitAggregateToStack(const TypedValue& arg, int stack_offset) {
+	if (isImmediateAggregateValue(arg)) {
+		// Single-eightbyte constant aggregate: materialize the scalar and store it.
+		if (arg.size_in_bits.value > 64) {
+			throw InternalError("Constant aggregate wider than one eightbyte lacks addressable storage");
+		}
+		X64Register temp_reg = allocateRegisterWithSpilling();
+		materializeImmediateAggregateEightbyteInGpr(arg, temp_reg);
+		emitStoreToRSP(textSectionData, temp_reg, stack_offset);
+		regAlloc.release(temp_reg);
+		return;
+	}
 	int src_offset = resolveTypedValueFrameOffset(arg);
 	const size_t slot_count = static_cast<size_t>((arg.size_in_bits.value + 63) / 64);
 	for (size_t slot_index = 0; slot_index < slot_count; ++slot_index) {
@@ -4274,6 +4341,26 @@ template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitSysVAggregateToRegisters(
 	const TypedValue& arg, const SysVAbiValueLayout& layout,
 	size_t& int_reg_index, size_t& sse_reg_index) {
+	if (isImmediateAggregateValue(arg)) {
+		// Constant-folded single-eightbyte aggregate: place the scalar directly in
+		// its ABI register rather than loading from a nonexistent frame slot.
+		if (layout.eightbyte_count != 1) {
+			throw InternalError("Constant aggregate spanning multiple eightbytes lacks addressable storage");
+		}
+		if (layout.eightbytes[0] == SysVRegisterClass::Integer) {
+			X64Register target_reg = getIntParamReg<TWriterClass>(int_reg_index++);
+			materializeImmediateAggregateEightbyteInGpr(arg, target_reg);
+		} else if (layout.eightbytes[0] == SysVRegisterClass::Sse) {
+			X64Register temp_gpr = allocateRegisterWithSpilling();
+			materializeImmediateAggregateEightbyteInGpr(arg, temp_gpr);
+			X64Register target_reg = getFloatParamReg<TWriterClass>(sse_reg_index++);
+			emitMovqGprToXmm(temp_gpr, target_reg);
+			regAlloc.release(temp_gpr);
+		} else {
+			throw InternalError("Unsupported SysV constant aggregate argument register class");
+		}
+		return;
+	}
 	const int src_offset = resolveTypedValueFrameOffset(arg);
 	for (size_t eightbyte_index = 0; eightbyte_index < layout.eightbyte_count; ++eightbyte_index) {
 		const int slot_size_bits = std::min(64, arg.size_in_bits.value - static_cast<int>(eightbyte_index * 64));
@@ -4839,7 +4926,13 @@ void IrToObjConverter<TWriterClass>::handleFunctionCall(const IrInstruction& ins
 			// Store return value - RAX for integers, XMM0 for floats
 			// For struct returns using return slot, the struct is already in place - no copy needed
 		if (call_op.return_type_index.category() != TypeCategory::Void && !call_op.usesReturnSlot()) {
-			if (isFloatingPointType(call_op.return_type_index.category())) {
+			if (call_op.returns_reference) {
+					// A reference result is a 64-bit pointer in RAX, never a by-value
+					// aggregate. Store it directly; running SysV struct classification
+					// on the referent (e.g. a polymorphic Base) would misclassify it
+					// and emit no store, leaving the result slot uninitialized.
+				emitMovToFrameBySize(X64Register::RAX, result_offset, 64);
+			} else if (isFloatingPointType(call_op.return_type_index.category())) {
 					// Float return value is in XMM0
 				bool is_float = (call_op.return_type_index.category() == TypeCategory::Float);
 				emitFloatMovToFrame(X64Register::XMM0, result_offset, is_float);
@@ -7661,6 +7754,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 	current_function_return_size_in_bits_ = func_decl.return_size_in_bits.value;
 	current_function_has_hidden_return_param_ = func_decl.has_hidden_return_param;  // Track for return statement handling
 	current_function_returns_reference_ = func_decl.returns_reference;  // Track if function returns a reference
+	current_function_returns_pointer_ = func_decl.return_pointer_depth.value > 0;  // Track if function returns a pointer
 	current_function_this_offset_ = 0;
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
 		current_function_is_noexcept_ = func_decl.is_noexcept;

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -4066,8 +4066,14 @@ X64Register IrToObjConverter<TWriterClass>::allocateXMMRegisterWithSpilling(X64R
 template <class TWriterClass>
 std::optional<SysVAbiValueLayout> IrToObjConverter<TWriterClass>::classifySysVAggregate(const TypedValue& arg) const {
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-		if (isIrStructType(arg.effectiveIrType()) && arg.size_in_bits.value > 64 &&
+		// Classify every by-value aggregate from canonical layout, including single-eightbyte
+		// SSE-only values that must use XMM registers rather than the legacy GPR path.
+		if (isIrStructType(arg.effectiveIrType()) && arg.size_in_bits.value > 0 &&
 			!arg.pointer_depth.is_pointer() && !arg.is_reference()) {
+			if (!arg.type_index.is_valid()) {
+				throw InternalError(
+					"SysV ABI classification requires canonical type identity for by-value aggregates");
+			}
 			return TargetABI::classifySysVValue(
 				arg.type_index, arg.size_in_bits, arg.pointer_depth.value, arg.is_reference());
 		}
@@ -4092,7 +4098,7 @@ void IrToObjConverter<TWriterClass>::emitIntegerOrAggregateReturnValue(
 	TypeIndex type_index, SizeInBits size_in_bits,
 	int32_t frame_offset, std::optional<X64Register> live_value_register) {
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 64) {
+		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 0) {
 			const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
 				type_index, size_in_bits, /*pointer_depth=*/0, /*is_reference=*/false);
 			// x87 aggregate returns stay on the legacy direct-return path until the
@@ -4146,7 +4152,7 @@ template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitStoreReturnValue(
 	TypeIndex type_index, SizeInBits size_in_bits, int32_t frame_offset) {
 	if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 64) {
+		if (isIrStructType(toIrType(type_index.category())) && size_in_bits.value > 0) {
 			const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
 				type_index, size_in_bits, /*pointer_depth=*/0, /*is_reference=*/false);
 			// Keep caller result materialization paired with the callee x87 path above.
@@ -7585,7 +7591,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 	{
 		for (const auto& p : func_decl.parameters) {
 			if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-				if (!is_variadic && is_struct_type(p.paramType()) && p.size_in_bits.value > 64 &&
+				if (!is_variadic && is_struct_type(p.paramType()) && p.size_in_bits.value > 0 &&
 					!p.pointer_depth.is_pointer() && !p.is_reference()) {
 					const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
 						p.type_index, p.size_in_bits,
@@ -8305,7 +8311,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 
 			std::optional<SysVAbiValueLayout> sysv_aggregate_layout;
 			if constexpr (std::is_same_v<TWriterClass, ElfFileWriter>) {
-				if (isIrStructType(toIrType(param.paramType())) && param.size_in_bits.value > 64 &&
+				if (isIrStructType(toIrType(param.paramType())) && param.size_in_bits.value > 0 &&
 					!param.pointer_depth.is_pointer() && !param.is_reference()) {
 					sysv_aggregate_layout = TargetABI::classifySysVValue(
 						param.type_index, param.size_in_bits, param.pointer_depth.value, param.is_reference());

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -15231,7 +15231,13 @@ void IrToObjConverter<TWriterClass>::handleIndirectCall(const IrInstruction& ins
 	textSectionData.push_back(0xD0); // ModR/M: RAX
 
 	if (op.returnType() != TypeCategory::Void && !op.usesReturnSlot()) {
-		if (isFloatingPointType(op.returnType())) {
+		if (op.returns_reference || op.return_pointer_depth.is_pointer()) {
+				// A reference (T& / T&&) or pointer (T*) result is a 64-bit address in
+				// RAX, never a by-value aggregate. Store it directly; running SysV struct
+				// classification on the referent (e.g. a MEMORY-class Big) would abort the
+				// whole function body instead of storing the pointer.
+			emitMovToFrameBySize(X64Register::RAX, result_offset, 64);
+		} else if (isFloatingPointType(op.returnType())) {
 			bool is_float = (op.returnType() == TypeCategory::Float);
 			emitFloatMovToFrame(X64Register::XMM0, result_offset, is_float);
 		} else {

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -445,6 +445,13 @@ private:
 
 	int resolveTypedValueFrameOffset(const TypedValue& arg);
 
+	/// True when a by-value aggregate argument was constant-folded to a scalar and
+	/// therefore has no addressable frame slot to load from.
+	bool isImmediateAggregateValue(const TypedValue& arg) const;
+
+	/// Materialize a constant-folded single-eightbyte aggregate scalar into a GPR.
+	void materializeImmediateAggregateEightbyteInGpr(const TypedValue& arg, X64Register target_reg);
+
 	bool emitLoadAddressLikeArgument(X64Register target_reg, const TypedValue& arg, int32_t address_adjustment = 0);
 
 	/// Copy an aggregate by value to consecutive RSP-relative overflow slots.
@@ -989,6 +996,7 @@ private:
 	int current_function_return_size_in_bits_ = 0;
 	bool current_function_has_hidden_return_param_ = false;	// True if function uses hidden return parameter (RVO)
 	bool current_function_returns_reference_ = false;  // True if function returns a reference (lvalue or rvalue)
+	bool current_function_returns_pointer_ = false;  // True if function returns a pointer (any pointer depth)
 	int32_t current_function_this_offset_ = 0;  // Stack home offset of the implicit this parameter in member functions
 	int32_t current_function_varargs_reg_save_offset_ = 0;  // Offset of varargs register save area (Linux only)
 	bool skip_previous_function_finalization_ = false;  // Set when a function is skipped due to codegen error

--- a/src/IROperandHelpers.h
+++ b/src/IROperandHelpers.h
@@ -180,6 +180,24 @@ inline TypedValue makeTypedValue(TypeIndex type_index, SizeInBits size_in_bits, 
 	return tv;
 }
 
+/// Build the TypedValue for an ordinary (non-this) indirect-call argument. By-value
+/// aggregates must carry their canonical TypeIndex so the SysV backend can classify
+/// the eightbytes; primitives keep their native type identity. Reference/pointer
+/// storage flows through unchanged so the backend loads the address rather than the
+/// aggregate contents.
+inline TypedValue makeIndirectCallArgument(const ExprResult& argument_result) {
+	const TypeCategory arg_type = argument_result.typeEnum();
+	IrValue arg_value = toIrValue(argument_result.value);
+	TypedValue arg_tv =
+		(isIrStructType(toIrType(arg_type)) && argument_result.type_index.is_valid())
+			? makeTypedValue(argument_result.type_index.withCategory(arg_type),
+							 argument_result.size_in_bits, std::move(arg_value))
+			: makeTypedValue(arg_type, argument_result.size_in_bits, std::move(arg_value));
+	arg_tv.pointer_depth = argument_result.pointer_depth;
+	arg_tv.storage = argument_result.storage;
+	return arg_tv;
+}
+
 inline TypedValue toTypedValue(std::span<const IrOperand> operands) {
 	assert(operands.size() >= 3 && "Expected operand order [type][size_in_bits][value][metadata]");
 	assert(std::holds_alternative<TypeCategory>(operands[0]) && "Expected operand order [type][size_in_bits][value][metadata]");

--- a/src/IrGenerator.h
+++ b/src/IrGenerator.h
@@ -196,16 +196,110 @@ inline int getStructReturnThreshold(bool is_llp64) {
 	return is_llp64 ? WIN64_STRUCT_RETURN_THRESHOLD : SYSV_STRUCT_RETURN_THRESHOLD;
 }
 
+/// Aggregate return ABI disposition for a function or call result.
+/// Dependent means the return type is not yet concrete enough to classify; concrete
+/// function/call IR must never treat Dependent as Direct.
+enum class ReturnAbiDisposition : uint8_t {
+	Direct,
+	Indirect,
+	Dependent,
+};
+
 /// Check if a struct return type requires a hidden return parameter (for RVO)
 /// Windows x64 ABI: structs of 1, 2, 4, or 8 bytes return in RAX, larger use hidden param
-/// SystemV AMD64 ABI: structs up to 16 bytes can return in RAX/RDX, larger use hidden param
+/// SystemV AMD64 ABI: classify from canonical layout; MEMORY-class and >16-byte returns
+/// use a hidden parameter. Incomplete/placeholder returns are Dependent.
 inline bool returnsStructByValue(TypeCategory type, int pointer_depth, bool is_reference) {
 	return is_struct_type(type) && pointer_depth == 0 && !is_reference;
 }
 
-inline bool needsHiddenReturnParam(TypeCategory type, int pointer_depth, bool is_reference, int size_in_bits, bool is_llp64) {
-	return returnsStructByValue(type, pointer_depth, is_reference) &&
-		   (size_in_bits > getStructReturnThreshold(is_llp64));
+inline bool returnsStructByValue(const TypeSpecifierNode& return_type) {
+	return returnsStructByValue(
+		return_type.type(), return_type.pointer_depth(), return_type.is_reference());
+}
+
+inline ReturnAbiDisposition planAggregateReturnDisposition(
+	TypeIndex type_index,
+	TypeCategory type,
+	int pointer_depth,
+	bool is_reference,
+	int size_in_bits,
+	bool is_llp64) {
+	if (!returnsStructByValue(type, pointer_depth, is_reference)) {
+		return ReturnAbiDisposition::Direct;
+	}
+
+	if (is_llp64) {
+		return size_in_bits > WIN64_STRUCT_RETURN_THRESHOLD
+			? ReturnAbiDisposition::Indirect
+			: ReturnAbiDisposition::Direct;
+	}
+
+	// SysV: any aggregate larger than two eightbytes is MEMORY regardless of layout.
+	if (size_in_bits > SYSV_STRUCT_RETURN_THRESHOLD) {
+		return ReturnAbiDisposition::Indirect;
+	}
+
+	if (!type_index.is_valid()) {
+		return ReturnAbiDisposition::Dependent;
+	}
+
+	const TypeInfo* type_info = tryGetTypeInfo(type_index);
+	const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
+	if (!struct_info || !struct_info->hasCompleteObjectLayout()) {
+		return ReturnAbiDisposition::Dependent;
+	}
+
+	const SysVAbiValueLayout layout = TargetABI::classifySysVValue(
+		type_index, SizeInBits{size_in_bits}, pointer_depth, is_reference);
+	// x87 aggregate returns stay on the legacy direct path until X87/X87UP
+	// return registers are modeled in the backend.
+	if (layout.contains_x87) {
+		return ReturnAbiDisposition::Direct;
+	}
+	return layout.isMemory() ? ReturnAbiDisposition::Indirect : ReturnAbiDisposition::Direct;
+}
+
+inline ReturnAbiDisposition planAggregateReturnDisposition(
+	const TypeSpecifierNode& return_type, bool is_llp64) {
+	return planAggregateReturnDisposition(
+		return_type.type_index(),
+		return_type.type(),
+		return_type.pointer_depth(),
+		return_type.is_reference(),
+		getTypeSpecSizeBits(return_type),
+		is_llp64);
+}
+
+inline bool needsHiddenReturnParam(
+	TypeIndex type_index,
+	TypeCategory type,
+	int pointer_depth,
+	bool is_reference,
+	int size_in_bits,
+	bool is_llp64) {
+	const ReturnAbiDisposition disposition = planAggregateReturnDisposition(
+		type_index, type, pointer_depth, is_reference, size_in_bits, is_llp64);
+	switch (disposition) {
+	case ReturnAbiDisposition::Direct:
+		return false;
+	case ReturnAbiDisposition::Indirect:
+		return true;
+	case ReturnAbiDisposition::Dependent:
+		throw InternalError(
+			"Concrete function/call IR requires a resolved aggregate return ABI plan");
+	}
+	throw InternalError("Unhandled aggregate return ABI disposition");
+}
+
+inline bool needsHiddenReturnParam(const TypeSpecifierNode& return_type, bool is_llp64) {
+	return needsHiddenReturnParam(
+		return_type.type_index(),
+		return_type.type(),
+		return_type.pointer_depth(),
+		return_type.is_reference(),
+		getTypeSpecSizeBits(return_type),
+		is_llp64);
 }
 
 // Resolve a runtime namespace component stack back into a declaration NamespaceHandle.

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -662,20 +662,7 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 			std::vector<TypedValue> arguments;
 			callExprNode.arguments().visit([&](ASTNode argument) {
 				ExprResult argumentIrOperands = visitExpressionNode(argument.as<ExpressionNode>());
-				// Extract type, size, and value from the expression result
-				TypeCategory arg_type = argumentIrOperands.typeEnum();
-				int arg_size = argumentIrOperands.size_in_bits.value;
-				IrValue arg_value = std::visit([](auto&& arg) -> IrValue {
-					using T = std::decay_t<decltype(arg)>;
-					if constexpr (std::is_same_v<T, TempVar> || std::is_same_v<T, StringHandle> ||
-								  std::is_same_v<T, unsigned long long> || std::is_same_v<T, double>) {
-						return arg;
-					} else {
-						return 0ULL;
-					}
-				},
-											   argumentIrOperands.value);
-				arguments.push_back(makeTypedValue(arg_type, SizeInBits{arg_size}, arg_value));
+				arguments.push_back(makeIndirectCallArgument(argumentIrOperands));
 			});
 
 			// Add the indirect call instruction

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -761,18 +761,25 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 					false,
 					false);
 
-				// Add the object (self) as the first argument (this pointer)
-				call_op.args.push_back(makeTypedValue(TypeCategory::Struct, SizeInBits{64}, IrValue(func_name)));
-
-				// Generate IR for the remaining arguments and collect types for mangling
-				std::vector<TypeSpecifierNode> arg_types;
-
 				// Look up the closure type to get the proper type_index
 				TypeIndex closure_type_index{};
 				auto it = getTypesByNameMap().find(current_lambda_context_.closure_type);
 				if (it != getTypesByNameMap().end()) {
 					closure_type_index = it->second->type_index_;
 				}
+				if (!closure_type_index.is_valid()) {
+					throw InternalError("Recursive lambda call missing canonical closure type identity");
+				}
+
+				// Add the object (self) as the first argument (this pointer)
+				call_op.args.push_back(makeTypedValue(
+					closure_type_index.withCategory(TypeCategory::Struct),
+					SizeInBits{64},
+					IrValue(func_name),
+					PointerDepth{1}));
+
+				// Generate IR for the remaining arguments and collect types for mangling
+				std::vector<TypeSpecifierNode> arg_types;
 
 				callExprNode.arguments().visit([&](ASTNode argument) {
 					// Check if this argument is the same as the callee (recursive lambda pattern)
@@ -788,7 +795,11 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 					if (is_self_arg) {
 						// For the self argument in recursive lambda calls, pass the reference directly
 						// Don't call visitExpressionNode which would dereference it
-						call_op.args.push_back(makeTypedValue(TypeCategory::Struct, SizeInBits{64}, IrValue(func_name)));
+						call_op.args.push_back(makeTypedValue(
+							closure_type_index.withCategory(TypeCategory::Struct),
+							SizeInBits{64},
+							IrValue(func_name),
+							ReferenceQualifier::LValueReference));
 
 						// Type for mangling is lvalue reference to closure type
 						TypeSpecifierNode self_type(closure_type_index.withCategory(TypeCategory::Struct), 8, Token(), CVQualifier::None, ReferenceQualifier::None);

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1719,7 +1719,17 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 					this_type_index = parent_it->second->type_index_;
 				}
 			}
-			call_op.args.push_back(makeTypedValue(this_type_index.withCategory(this_type), SizeInBits{64}, IrValue(StringTable::getOrInternStringHandle("this"))));
+			// The implicit 'this' argument is a pointer, not a by-value aggregate.
+			// It must carry PointerDepth/ContainsAddress ABI metadata so the SysV
+			// classifier passes it in an integer register instead of misclassifying
+			// the pointee struct as a by-value aggregate argument.
+			TypedValue this_arg = makeTypedValue(
+				this_type_index.withCategory(this_type),
+				SizeInBits{POINTER_SIZE_BITS},
+				IrValue(StringTable::getOrInternStringHandle("this")),
+				PointerDepth{1});
+			this_arg.storage = ValueStorage::ContainsAddress;
+			call_op.args.push_back(std::move(this_arg));
 		}
 	}
 

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -107,12 +107,7 @@ void AstToIr::populateIndirectCallReturnInfo(IndirectCallOp& call_op, const Func
 	call_op.referenced_value_size_in_bits = call_op.returns_reference
 												? SizeInBits{requireConcreteAliasResolvedTypeSizeBits(return_type, "indirect call reference return")}
 												: call_op.return_size_in_bits;
-	call_op.use_return_slot = needsHiddenReturnParam(
-		call_op.returnType(),
-		signature.return_pointer_depth,
-		signature.returns_reference(),
-		call_op.return_size_in_bits.value,
-		context_->isLLP64());
+	call_op.use_return_slot = needsHiddenReturnParam(return_type, context_->isLLP64());
 }
 
 static TypeIndex getCallReturnTypeIndex(const TypeSpecifierNode& return_type) {
@@ -1719,8 +1714,8 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 
 	// Detect if calling a function that returns struct by value (needs hidden return parameter for RVO)
 	// Exclude references - they return a pointer, not a struct by value
-	bool returns_struct = returnsStructByValue(effective_return_type.type(), effective_return_type.pointer_depth(), effective_return_type.is_reference());
-	bool needs_hidden_ret = needsHiddenReturnParam(effective_return_type.type(), effective_return_type.pointer_depth(), effective_return_type.is_reference(), effective_return_type.size_in_bits(), context_->isLLP64());
+	bool returns_struct = returnsStructByValue(effective_return_type);
+	bool needs_hidden_ret = needsHiddenReturnParam(effective_return_type, context_->isLLP64());
 	if (needs_hidden_ret) {
 		call_op.return_slot = ret_var;  // The result temp var serves as the return slot
 

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -379,18 +379,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 				if (needs_placeholder_return_deduction) {
 					argument_results.push_back(argument_result);
 				}
-				TypeCategory arg_type = argument_result.typeEnum();
-				int arg_size = argument_result.size_in_bits.value;
-				IrValue arg_value = std::visit([](auto&& arg) -> IrValue {
-					using T = std::decay_t<decltype(arg)>;
-					if constexpr (std::is_same_v<T, TempVar> || std::is_same_v<T, StringHandle> ||
-								  std::is_same_v<T, unsigned long long> || std::is_same_v<T, double>) {
-						return arg;
-					}
-					return 0ULL;
-				},
-											   argument_result.value);
-				arguments.push_back(makeTypedValue(arg_type, SizeInBits{arg_size}, arg_value));
+				arguments.push_back(makeIndirectCallArgument(argument_result));
 			});
 
 			IndirectCallOp op{
@@ -784,7 +773,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 				std::vector<TypedValue> arguments;
 				callExprNode.arguments().visit([&](ASTNode argument) {
 					ExprResult argument_result = visitExpressionNode(argument.as<ExpressionNode>());
-					arguments.push_back(makeTypedValue(argument_result.typeEnum(), argument_result.size_in_bits, toIrValue(argument_result.value)));
+					arguments.push_back(makeIndirectCallArgument(argument_result));
 				});
 
 				IndirectCallOp op{
@@ -839,7 +828,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 								std::vector<TypedValue> arguments;
 								callExprNode.arguments().visit([&](ASTNode argument) {
 									ExprResult argument_result = visitExpressionNode(argument.as<ExpressionNode>());
-									arguments.push_back(makeTypedValue(argument_result.typeEnum(), argument_result.size_in_bits, toIrValue(argument_result.value)));
+									arguments.push_back(makeIndirectCallArgument(argument_result));
 								});
 
 								IndirectCallOp op{
@@ -1304,7 +1293,7 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 					std::vector<TypedValue> arguments;
 					callExprNode.arguments().visit([&](ASTNode argument) {
 						ExprResult argument_result = visitExpressionNode(argument.as<ExpressionNode>());
-						arguments.push_back(makeTypedValue(argument_result.typeEnum(), argument_result.size_in_bits, toIrValue(argument_result.value)));
+						arguments.push_back(makeIndirectCallArgument(argument_result));
 					});
 
 					IndirectCallOp op{

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -2187,12 +2187,13 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 			this_arg_storage = ValueStorage::ContainsAddress;
 		}
 		// 'this' is always passed as a pointer in the ABI, never as a by-value aggregate.
-		TypedValue this_arg = makeTypedValue(object_type.type(), SizeInBits{64}, this_arg_value);
-		if (object_type.type_index().is_valid()) {
-			this_arg.type_index = object_type.type_index().withCategory(object_type.type());
+		if (!object_type.type_index().is_valid()) {
+			throw InternalError("Member function 'this' argument requires canonical class type identity");
 		}
+		TypedValue this_arg = makeMemberThisCallArgument(
+			object_type.type_index().withCategory(object_type.type()),
+			this_arg_value);
 		this_arg.storage = this_arg_storage;
-		this_arg.pointer_depth = PointerDepth{1};
 		call_op.args.push_back(std::move(this_arg));
 
 		// Generate IR for function arguments and add to CallOp

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1971,8 +1971,8 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		call_op.is_variadic = actual_func_decl_for_variadic->is_variadic();
 
 		// Detect if calling a member function that returns struct by value (needs hidden return parameter for RVO)
-		bool returns_struct_by_value = returnsStructByValue(return_type.type(), return_type.pointer_depth(), return_type.is_reference());
-		bool needs_hidden_return_param = needsHiddenReturnParam(return_type.type(), return_type.pointer_depth(), return_type.is_reference(), return_type.size_in_bits(), context_->isLLP64());
+		bool returns_struct_by_value = returnsStructByValue(return_type);
+		bool needs_hidden_return_param = needsHiddenReturnParam(return_type, context_->isLLP64());
 
 		FLASH_LOG_FORMAT(Codegen, Debug,
 						 "Member function call check: returns_struct={}, size={}, threshold={}, needs_hidden={}",

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -2137,6 +2137,8 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 				addr_op.operand.value = obj_temp;
 				ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), callExprNode.called_from()));
 				this_arg_value = IrValue(this_addr);
+				this_arg_is_pointer_value = true;
+				this_arg_storage = ValueStorage::ContainsAddress;
 			}
 		} else if (object_is_pointer_like) {
 			bool requires_loaded_pointer_value = false;
@@ -2181,12 +2183,16 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 			addr_op.operand.value = StringTable::getOrInternStringHandle(object_name);
 			ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), callExprNode.called_from()));
 			this_arg_value = IrValue(this_addr);
+			this_arg_is_pointer_value = true;
+			this_arg_storage = ValueStorage::ContainsAddress;
 		}
+		// 'this' is always passed as a pointer in the ABI, never as a by-value aggregate.
 		TypedValue this_arg = makeTypedValue(object_type.type(), SizeInBits{64}, this_arg_value);
-		this_arg.storage = this_arg_storage;
-		if (this_arg_is_pointer_value) {
-			this_arg.pointer_depth = PointerDepth{1};
+		if (object_type.type_index().is_valid()) {
+			this_arg.type_index = object_type.type_index().withCategory(object_type.type());
 		}
+		this_arg.storage = this_arg_storage;
+		this_arg.pointer_depth = PointerDepth{1};
 		call_op.args.push_back(std::move(this_arg));
 
 		// Generate IR for function arguments and add to CallOp

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -2193,7 +2193,14 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		TypedValue this_arg = makeMemberThisCallArgument(
 			object_type.type_index().withCategory(object_type.type()),
 			this_arg_value);
-		this_arg.storage = this_arg_storage;
+		// Preserve producer intent: AddressOf / loaded pointer temps are
+		// ContainsAddress; local pointer/ref names may still need frame LEA/MOV
+		// via the StringHandle address path when storage stays ContainsData.
+		if (this_arg_is_pointer_value && this_arg_storage == ValueStorage::ContainsAddress) {
+			this_arg.storage = ValueStorage::ContainsAddress;
+		} else if (!this_arg_is_pointer_value) {
+			this_arg.storage = ValueStorage::ContainsData;
+		}
 		call_op.args.push_back(std::move(this_arg));
 
 		// Generate IR for function arguments and add to CallOp

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -1510,9 +1510,7 @@ ExprResult AstToIr::generateUnaryOperatorIr(const UnaryOperatorNode& unaryOperat
 
 				TempVar ret_var = var_counter.next();
 				CallOp call_op = createCallOp(ret_var, mangled_name, return_type, true, false);
-				if (needsHiddenReturnParam(return_type.type(), return_type.pointer_depth(),
-										   return_type.is_reference(), call_op.return_size_in_bits.value,
-										   context_->isLLP64())) {
+				if (needsHiddenReturnParam(return_type, context_->isLLP64())) {
 					call_op.return_slot = ret_var;
 				}
 
@@ -1953,8 +1951,8 @@ std::optional<ExprResult> AstToIr::generateUnaryIncDecOverloadCall(
 	CallOp call_op = createCallOp(ret_var, mangled_name, return_type, true, false);
 
 	// Detect if returning struct by value (needs hidden return parameter for RVO).
-	// Small structs (≤ ABI threshold) return in registers and need no return_slot.
-	if (needsHiddenReturnParam(return_type.type(), return_type.pointer_depth(), return_type.is_reference(), call_op.return_size_in_bits.value, context_->isLLP64())) {
+	// SysV MEMORY-class and oversized aggregates use a return_slot; register-class returns do not.
+	if (needsHiddenReturnParam(return_type, context_->isLLP64())) {
 		call_op.return_slot = ret_var;
 	}
 

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -1521,14 +1521,10 @@ ExprResult AstToIr::generateUnaryOperatorIr(const UnaryOperatorNode& unaryOperat
 				addr_op.operand.pointer_depth = PointerDepth{};
 				ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), unaryOperatorNode.get_token()));
 
-				TypedValue this_arg;
-				this_arg.setType(operandType);
-				this_arg.ir_type = toIrType(operandType);
-				this_arg.size_in_bits = SizeInBits{get_type_size_bits(TypeCategory::FunctionPointer)};
-				this_arg.pointer_depth = PointerDepth{1};
-				this_arg.type_index = operand_type_index.withCategory(operandType);
-				this_arg.value = this_addr;
-				call_op.args.push_back(this_arg);
+				TypedValue this_arg = makeMemberThisCallArgument(
+					operand_type_index.withCategory(operandType),
+					IrValue(this_addr));
+				call_op.args.push_back(std::move(this_arg));
 
 				const int result_size = call_op.return_size_in_bits.value;
 				const TypeIndex result_type_index = call_op.return_type_index;
@@ -1964,11 +1960,10 @@ std::optional<ExprResult> AstToIr::generateUnaryIncDecOverloadCall(
 	addr_op.operand.pointer_depth = PointerDepth{};
 	ir_.addInstruction(IrInstruction(IrOpcode::AddressOf, std::move(addr_op), Token()));
 
-	TypedValue this_arg;
-	this_arg.setType(operandType);
-	this_arg.size_in_bits = SizeInBits{64};
-	this_arg.value = this_addr;
-	call_op.args.push_back(this_arg);
+	TypedValue this_arg = makeMemberThisCallArgument(
+		operand_type_index.withCategory(operandType),
+		IrValue(this_addr));
+	call_op.args.push_back(std::move(this_arg));
 
 	// For postfix operators, pass dummy int argument (value 0)
 	// Use the matched function's actual parameter count (not the call form) to decide,

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -442,6 +442,19 @@ void AstToIr::applyCallParameterBindingMetadata(TypedValue& value, const TypeSpe
 	}
 }
 
+TypedValue AstToIr::makeMemberThisCallArgument(TypeIndex object_type_index, IrValue this_ptr_value) {
+	if (!object_type_index.is_valid()) {
+		throw InternalError("Member function 'this' argument requires canonical class type identity");
+	}
+	TypedValue this_arg = makeTypedValue(
+		object_type_index,
+		SizeInBits{POINTER_SIZE_BITS},
+		std::move(this_ptr_value),
+		PointerDepth{1});
+	this_arg.storage = ValueStorage::ContainsAddress;
+	return this_arg;
+}
+
 CVReferenceQualifier AstToIr::callParameterRefQualifier(const TypeSpecifierNode* param_type) const {
 	if (!param_type) {
 		return CVReferenceQualifier::None;
@@ -1989,21 +2002,41 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 		return isIrStructType(toIrType(resolved)) && type_index.is_valid();
 	};
 
-	auto makeReferenceArgument = [&](const ExprResult& operand_result, TypeCategory operand_type, int operand_size) -> std::optional<TypedValue> {
-		TypedValue arg;
-		arg.setType(operand_type);
-		arg.size_in_bits = SizeInBits{64};
+	auto makeReferenceArgument = [&](const ExprResult& operand_result, TypeCategory operand_type, int operand_size, const TypeSpecifierNode* param_type) -> std::optional<TypedValue> {
+		TypeIndex arg_type_index = operand_result.type_index.is_valid()
+			? operand_result.type_index.withCategory(operand_type)
+			: (param_type && param_type->type_index().is_valid()
+				   ? param_type->type_index().withCategory(operand_type)
+				   : nativeTypeIndex(operand_type).withCategory(operand_type));
+		ReferenceQualifier ref_qual = ReferenceQualifier::LValueReference;
+		if (param_type) {
+			if (param_type->is_rvalue_reference()) {
+				ref_qual = ReferenceQualifier::RValueReference;
+			} else if (param_type->is_reference()) {
+				ref_qual = ReferenceQualifier::LValueReference;
+			}
+		}
+
+		auto finishReferenceArg = [&](IrValue address_value) {
+			TypedValue arg = makeTypedValue(
+				arg_type_index,
+				SizeInBits{POINTER_SIZE_BITS},
+				std::move(address_value),
+				ref_qual);
+			if (param_type) {
+				arg.cv_qualifier = param_type->cv_qualifier();
+			}
+			return arg;
+		};
 
 		if (const auto* string = std::get_if<StringHandle>(&operand_result.value)) {
-			arg.value = emitAddressOf(operand_type, operand_size, IrValue(*string));
-			return arg;
+			return finishReferenceArg(emitAddressOf(operand_type, operand_size, IrValue(*string)));
 		}
 
 		if (std::holds_alternative<TempVar>(operand_result.value)) {
 			TempVar temp_var = std::get<TempVar>(operand_result.value);
 			if (auto global_name = tryGetGlobalLValueName(operand_result); global_name.has_value()) {
-				arg.value = emitAddressOf(operand_type, operand_size, IrValue(*global_name));
-				return arg;
+				return finishReferenceArg(emitAddressOf(operand_type, operand_size, IrValue(*global_name)));
 			}
 			bool is_already_address = false;
 
@@ -2019,10 +2052,10 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 				is_already_address = true;
 			}
 
-			arg.value = is_already_address
-							? IrValue(temp_var)
-							: emitAddressOf(operand_type, operand_size, IrValue(temp_var));
-			return arg;
+			return finishReferenceArg(
+				is_already_address
+					? IrValue(temp_var)
+					: emitAddressOf(operand_type, operand_size, IrValue(temp_var)));
 		}
 
 		bool is_literal = std::holds_alternative<unsigned long long>(operand_result.value) || std::holds_alternative<double>(operand_result.value);
@@ -2044,8 +2077,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 		assign_op.rhs = makeTypedValue(operand_type, SizeInBits{static_cast<int>(operand_size)}, rhs_value);
 		ir_.addInstruction(IrInstruction(IrOpcode::Assignment, std::move(assign_op), Token()));
 
-		arg.value = emitAddressOf(operand_type, operand_size, IrValue(temp_var));
-		return arg;
+		return finishReferenceArg(emitAddressOf(operand_type, operand_size, IrValue(temp_var)));
 	};
 
 	// Special handling for struct assignment with user-defined operator=(non-struct)
@@ -2171,12 +2203,9 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 							false);
 
 						// Pass 'this' pointer as first argument
-						TypedValue this_arg;
-						this_arg.setType(lhsCat);
-						this_arg.ir_type = toIrType(lhsCat);
-						this_arg.size_in_bits = SizeInBits{64}; // 'this' is always a pointer (64-bit)
-						this_arg.value = lhs_addr;
-						call_op.args.push_back(this_arg);
+						call_op.args.push_back(makeMemberThisCallArgument(
+							lhs_type_index.withCategory(lhsCat),
+							IrValue(lhs_addr)));
 
 						// Pass RHS value as second argument
 						call_op.args.push_back(toTypedValue(rhsExprResult));
@@ -2560,8 +2589,8 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 			}
 
 			// Helper: take address of operand for reference parameters
-			auto passOperandArg = [&](const ExprResult& operand_result, TypeCategory opType, int opSize, std::string_view role, CallOp& cop) -> bool {
-				if (auto ref_arg = makeReferenceArgument(operand_result, opType, opSize); ref_arg.has_value()) {
+			auto passOperandArg = [&](const ExprResult& operand_result, TypeCategory opType, int opSize, std::string_view role, CallOp& cop, const TypeSpecifierNode* param_type) -> bool {
+				if (auto ref_arg = makeReferenceArgument(operand_result, opType, opSize, param_type); ref_arg.has_value()) {
 					cop.args.push_back(*ref_arg);
 					return true;
 				}
@@ -2571,7 +2600,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 
 			// Pass LHS as first argument
 			if (!param_types.empty() && param_types[0].is_reference()) {
-				if (!passOperandArg(lhsExprResult, lhsCat, lhsSize, "LHS", call_op))
+				if (!passOperandArg(lhsExprResult, lhsCat, lhsSize, "LHS", call_op, &param_types[0]))
 					return ExprResult{};
 			} else {
 				TypedValue lhs_arg = toTypedValue(lhsExprResult);
@@ -2596,7 +2625,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 
 			// Pass RHS as second argument
 			if (param_types.size() >= 2 && param_types[1].is_reference()) {
-				if (!passOperandArg(rhsExprResult, rhsCat, rhsSize, "RHS", call_op))
+				if (!passOperandArg(rhsExprResult, rhsCat, rhsSize, "RHS", call_op, &param_types[1]))
 					return ExprResult{};
 			} else {
 				TypedValue rhs_arg = toTypedValue(rhsExprResult);
@@ -2766,17 +2795,14 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 			}
 
 			// Add 'this' pointer as first argument
-			TypedValue this_arg;
-			this_arg.setType(lhsCat);
-			this_arg.ir_type = toIrType(lhsCat);
-			this_arg.size_in_bits = SizeInBits{64}; // 'this' is always a pointer (64-bit)
-			this_arg.value = lhs_addr;
-			call_op.args.push_back(this_arg);
+			call_op.args.push_back(makeMemberThisCallArgument(
+				lhs_type_index.withCategory(lhsCat),
+				IrValue(lhs_addr)));
 
 			// Add RHS as the second argument
 			// Check if the parameter is a reference - if so, we need to pass the address
 			if (!param_types.empty() && param_types[0].is_reference()) {
-				if (auto rhs_arg = makeReferenceArgument(rhsExprResult, rhsCat, rhsSize); rhs_arg.has_value()) {
+				if (auto rhs_arg = makeReferenceArgument(rhsExprResult, rhsCat, rhsSize, &param_types[0]); rhs_arg.has_value()) {
 					call_op.args.push_back(*rhs_arg);
 				} else {
 					FLASH_LOG(Codegen, Error, "Cannot materialize binary operator RHS reference argument");

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -2554,7 +2554,7 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 				false,
 				false);
 
-			bool needs_hidden_return = needsHiddenReturnParam(return_type.type(), return_type.pointer_depth(), return_type.is_reference(), call_op.return_size_in_bits.value, context_->isLLP64());
+			bool needs_hidden_return = needsHiddenReturnParam(return_type, context_->isLLP64());
 			if (needs_hidden_return) {
 				call_op.return_slot = result_var;
 			}
@@ -2748,8 +2748,9 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 			int actual_return_size = call_op.return_size_in_bits.value;
 
 			// Detect if returning struct by value (needs hidden return parameter for RVO)
-			bool returns_struct_by_value = returnsStructByValue(return_type.type(), return_type.pointer_depth(), return_type.is_reference());
-			bool needs_hidden_return_param = needsHiddenReturnParam(return_type.type(), return_type.pointer_depth(), return_type.is_reference(), actual_return_size, context_->isLLP64());
+			bool returns_struct_by_value = returnsStructByValue(resolved_return_type_spec);
+			bool needs_hidden_return_param = needsHiddenReturnParam(
+				resolved_return_type_spec, context_->isLLP64());
 
 			if (needs_hidden_return_param) {
 				call_op.return_slot = result_var;
@@ -2934,8 +2935,9 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 						func_decl.is_variadic());
 
 					// Determine if return slot is needed (same logic as generateFunctionCallIr)
-					bool returns_struct_by_value = returnsStructByValue(return_type, return_type_node.pointer_depth(), return_type_node.is_reference());
-					bool needs_hidden_return_param = needsHiddenReturnParam(return_type, return_type_node.pointer_depth(), return_type_node.is_reference(), return_size.value, context_->isLLP64());
+					bool returns_struct_by_value = returnsStructByValue(return_type_node);
+					bool needs_hidden_return_param = needsHiddenReturnParam(
+						return_type_node, context_->isLLP64());
 
 					FLASH_LOG_FORMAT(Codegen, Debug,
 									 "Spaceship operator call: return_size={}, threshold={}, returns_struct={}, needs_hidden={}",

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -2976,19 +2976,34 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 						FLASH_LOG(Codegen, Debug, "No return slot for spaceship operator (small struct return in RAX)");
 					}
 
-					// Add the LHS object as the first argument (this pointer)
-					// For member functions, the this pointer is passed by name or temp var
-					TypedValue lhs_arg;
-					lhs_arg.setType(lhsCat);
-					lhs_arg.ir_type = toIrType(lhsCat);
-					lhs_arg.size_in_bits = SizeInBits{lhsSize};
-					// Convert lhs_value (which can be string_view or TempVar) to IrValue
+					// Add the LHS object as the first argument (this pointer).
+					// Member 'this' is always a pointer — never a by-value aggregate.
+					IrValue this_ptr_value;
 					if (const auto* string = std::get_if<StringHandle>(&lhs_value)) {
-						lhs_arg.value = IrValue(*string);
+						this_ptr_value = IrValue(emitAddressOf(
+							lhsCat,
+							lhsSize,
+							IrValue(*string),
+							binaryOperatorNode.get_token()));
 					} else {
-						lhs_arg.value = IrValue(std::get<TempVar>(lhs_value));
+						TempVar lhs_temp = std::get<TempVar>(lhs_value);
+						const bool temp_already_holds_address =
+							std::holds_alternative<TempVar>(lhsExprResult.value) &&
+							std::get<TempVar>(lhsExprResult.value).var_number == lhs_temp.var_number &&
+							lhsExprResult.storage == ValueStorage::ContainsAddress;
+						if (temp_already_holds_address) {
+							this_ptr_value = IrValue(lhs_temp);
+						} else {
+							this_ptr_value = IrValue(emitAddressOf(
+								lhsCat,
+								lhsSize,
+								IrValue(lhs_temp),
+								binaryOperatorNode.get_token()));
+						}
 					}
-					call_op.args.push_back(lhs_arg);
+					call_op.args.push_back(makeMemberThisCallArgument(
+						spaceship_lhs_type_index.withCategory(lhsCat),
+						this_ptr_value));
 
 					// Add the RHS as the second argument
 					// Check if parameter expects a reference
@@ -2998,8 +3013,15 @@ ExprResult AstToIr::generateBinaryOperatorIr(const BinaryOperatorNode& binaryOpe
 						const TypeSpecifierNode& param_type = param_types[0];
 						if (param_type.is_rvalue_reference()) {
 							rhs_arg.ref_qualifier = ReferenceQualifier::RValueReference;
+							rhs_arg.size_in_bits = SizeInBits{POINTER_SIZE_BITS};
 						} else if (param_type.is_reference()) {
 							rhs_arg.ref_qualifier = ReferenceQualifier::LValueReference;
+							rhs_arg.size_in_bits = SizeInBits{POINTER_SIZE_BITS};
+						}
+						if (param_type.type_index().is_valid()) {
+							rhs_arg.type_index = param_type.type_index().withCategory(param_type.type());
+						} else if (rhsExprResult.type_index.is_valid()) {
+							rhs_arg.type_index = rhsExprResult.type_index.withCategory(rhsCat);
 						}
 					}
 					call_op.args.push_back(rhs_arg);

--- a/src/IrGenerator_Lambdas.cpp
+++ b/src/IrGenerator_Lambdas.cpp
@@ -706,10 +706,13 @@ void AstToIr::generateLambdaOperatorCallFunction(LambdaInfo& lambda_info) {
 	func_decl_op.returns_reference = lambda_info.return_ref_qualifier != ReferenceQualifier::None;
 	func_decl_op.returns_rvalue_reference = lambda_info.return_ref_qualifier == ReferenceQualifier::RValueReference;
 
+	// Build TypeSpecifierNode for return type (with proper type_index if struct)
+	TypeSpecifierNode return_type_node(lambda_info.return_type_index.withCategory(lambda_info.returnType()), lambda_info.return_size, lambda_info.lambda_token, CVQualifier::None, lambda_info.return_ref_qualifier);
+
 	// Detect if lambda returns struct by value (needs hidden return parameter for RVO/NRVO)
 	// Only non-pointer, non-reference struct returns need this
-	bool returns_struct_by_value = returnsStructByValue(lambda_info.returnType(), 0, lambda_info.returnsReference());
-	bool needs_hidden_return_param = needsHiddenReturnParam(lambda_info.returnType(), 0, lambda_info.returnsReference(), lambda_info.return_size, context_->isLLP64());
+	bool returns_struct_by_value = returnsStructByValue(return_type_node);
+	bool needs_hidden_return_param = needsHiddenReturnParam(return_type_node, context_->isLLP64());
 	func_decl_op.has_hidden_return_param = needs_hidden_return_param;
 
 	// Track hidden return parameter flag for current function context
@@ -726,9 +729,6 @@ void AstToIr::generateLambdaOperatorCallFunction(LambdaInfo& lambda_info) {
 							 lambda_info.closure_type_name, lambda_info.return_size);
 		}
 	}
-
-	// Build TypeSpecifierNode for return type (with proper type_index if struct)
-	TypeSpecifierNode return_type_node(lambda_info.return_type_index.withCategory(lambda_info.returnType()), lambda_info.return_size, lambda_info.lambda_token, CVQualifier::None, lambda_info.return_ref_qualifier);
 
 	// Build TypeSpecifierNodes for parameters using parameter_nodes to preserve type_index
 	std::vector<TypeSpecifierNode> param_types;
@@ -870,16 +870,14 @@ void AstToIr::generateLambdaInvokeFunction(LambdaInfo& lambda_info) {
 	func_decl_op.returns_reference = lambda_info.return_ref_qualifier != ReferenceQualifier::None;
 	func_decl_op.returns_rvalue_reference = lambda_info.return_ref_qualifier == ReferenceQualifier::RValueReference;
 
-		// Detect if lambda returns struct by value (needs hidden return parameter for RVO/NRVO)
-		// Detect if lambda returns struct by value (needs hidden return parameter for RVO/NRVO)
-	bool needs_hidden_return_param = needsHiddenReturnParam(lambda_info.returnType(), 0, lambda_info.returnsReference(), lambda_info.return_size, context_->isLLP64());
+	// Build TypeSpecifierNode for return type (with proper type_index if struct)
+	TypeSpecifierNode return_type_node(lambda_info.return_type_index.withCategory(lambda_info.returnType()), lambda_info.return_size, lambda_info.lambda_token, CVQualifier::None, lambda_info.return_ref_qualifier);
+
+	bool needs_hidden_return_param = needsHiddenReturnParam(return_type_node, context_->isLLP64());
 	func_decl_op.has_hidden_return_param = needs_hidden_return_param;
 
-		// Track hidden return parameter flag for current function context
+	// Track hidden return parameter flag for current function context
 	current_function_has_hidden_return_param_ = needs_hidden_return_param;
-
-		// Build TypeSpecifierNode for return type (with proper type_index if struct)
-	TypeSpecifierNode return_type_node(lambda_info.return_type_index.withCategory(lambda_info.returnType()), lambda_info.return_size, lambda_info.lambda_token, CVQualifier::None, lambda_info.return_ref_qualifier);
 
 		// Build TypeSpecifierNodes for parameters using parameter_nodes to preserve type_index
 	std::vector<TypeSpecifierNode> param_types;

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -1391,12 +1391,19 @@ ExprResult AstToIr::generateMemberAccessIr(const MemberAccessNode& memberAccessN
 					lvalue_info.is_pointer_to_member = true;
 					setTempVarMetadata(member_object_temp, TempVarMetadata::makeLValue(lvalue_info, TypeCategory::Invalid, 0));
 
-					call_op.args.push_back(makeTypedValue(
+					// MemberAccess left an lvalue address in the temp; pass it as 'this'.
+					call_op.args.push_back(makeMemberThisCallArgument(
 						member_object->type_index,
-						SizeInBits{static_cast<int>(member_object->size * 8)},
 						IrValue(member_object_temp)));
 				} else {
-					call_op.args.push_back(makeTypedValue(type_node->type_index(), SizeInBits{64}, IrValue(identifier_handle)));
+					TempVar this_ptr = emitAddressOf(
+						type_node->category(),
+						getStructObjectSizeBits(type_node->type_index()),
+						IrValue(identifier_handle),
+						memberAccessNode.member_token());
+					call_op.args.push_back(makeMemberThisCallArgument(
+						type_node->type_index(),
+						IrValue(this_ptr)));
 				}
 
 				// Add the function call instruction
@@ -3776,22 +3783,12 @@ std::optional<ExprResult> AstToIr::emitConversionOperatorCall(
 		TempVar this_ptr = emitAddressOf(source.category(), source.size_in_bits.value,
 										 IrValue(std::get<StringHandle>(source_value)), token);
 
-		TypedValue this_arg;
-		this_arg.setType(source.category());
-		this_arg.ir_type = toIrType(source.typeEnum());
-		this_arg.size_in_bits = SizeInBits{64}; // pointer size
-		this_arg.value = this_ptr;
-		this_arg.type_index = source.type_index;
-		call_op.args.push_back(std::move(this_arg));
+		call_op.args.push_back(makeMemberThisCallArgument(source.type_index, IrValue(this_ptr)));
 	} else if (std::holds_alternative<TempVar>(source_value)) {
 		// Already a TempVar — for struct types this holds the object address
-		TypedValue this_arg;
-		this_arg.setType(source.category());
-		this_arg.ir_type = toIrType(source.typeEnum());
-		this_arg.size_in_bits = SizeInBits{64}; // pointer size
-		this_arg.value = std::get<TempVar>(source_value);
-		this_arg.type_index = source.type_index;
-		call_op.args.push_back(std::move(this_arg));
+		call_op.args.push_back(makeMemberThisCallArgument(
+			source.type_index,
+			IrValue(std::get<TempVar>(source_value))));
 	} else {
 		throw InternalError("emitConversionOperatorCall: source value is neither StringHandle nor TempVar");
 	}

--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -3785,10 +3785,28 @@ std::optional<ExprResult> AstToIr::emitConversionOperatorCall(
 
 		call_op.args.push_back(makeMemberThisCallArgument(source.type_index, IrValue(this_ptr)));
 	} else if (std::holds_alternative<TempVar>(source_value)) {
-		// Already a TempVar — for struct types this holds the object address
-		call_op.args.push_back(makeMemberThisCallArgument(
-			source.type_index,
-			IrValue(std::get<TempVar>(source_value))));
+		TempVar object_temp = std::get<TempVar>(source_value);
+		// Only treat the temp as an already-materialized 'this' pointer when the
+		// ExprResult storage says so. Dereference / Load results are ContainsData
+		// object storage and must be AddressOf'd (LEA), not MOV'd as a fake pointer.
+		const bool temp_already_holds_address =
+			std::holds_alternative<TempVar>(source.value) &&
+			std::get<TempVar>(source.value).var_number == object_temp.var_number &&
+			source.storage == ValueStorage::ContainsAddress;
+		if (temp_already_holds_address) {
+			call_op.args.push_back(makeMemberThisCallArgument(
+				source.type_index,
+				IrValue(object_temp)));
+		} else {
+			TempVar this_ptr = emitAddressOf(
+				source.category(),
+				source.size_in_bits.value,
+				IrValue(object_temp),
+				token);
+			call_op.args.push_back(makeMemberThisCallArgument(
+				source.type_index,
+				IrValue(this_ptr)));
+		}
 	} else {
 		throw InternalError("emitConversionOperatorCall: source value is neither StringHandle nor TempVar");
 	}

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1193,24 +1193,15 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 						ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(member_store), func_decl.identifier_token()));
 					}
 
-					// Return *this (the return value is the 'this' pointer dereferenced)
-					// Generate: %temp = dereference [Type][Size] %this
-					//           return [Type][Size] %temp
-					TempVar this_deref = var_counter.next();
-					std::vector<IrOperand> deref_operands;
-					deref_operands.emplace_back(this_deref);	 // result variable
-					DereferenceOp deref_op;
-					deref_op.result = this_deref;
-					deref_op.pointer.setType(TypeCategory::Struct);
-					deref_op.pointer.type_index = nativeTypeIndex(TypeCategory::Struct);
-					deref_op.pointer.ir_type = IrType::Struct;
-					deref_op.pointer.size_in_bits = SizeInBits{64};	// Pointer is always 64 bits
-					deref_op.pointer.value = StringTable::getOrInternStringHandle("this");
-
-					ir_.addInstruction(IrInstruction(IrOpcode::Dereference, std::move(deref_op), func_decl.identifier_token()));
-
-						// Return the dereferenced value
-					emitReturn(this_deref, currentFunctionReturnTypeIndex(), struct_info->sizeInBits().value, func_decl.identifier_token());
+					// operator= returns 'Type&', so 'return *this' yields a reference
+					// whose value is the 'this' pointer itself. Returning the object by
+					// value (dereferencing into a full-size struct return) would wrongly
+					// trigger an sret copy — and for >128-bit types that copy re-enters
+					// the copy constructor and crashes. Return the pointer directly, the
+					// same way the visitReturnStatementNode reference fast path does.
+					emitReturn(StringTable::getOrInternStringHandle("this"),
+						currentFunctionReturnTypeIndex(), current_function_return_size_,
+						func_decl.identifier_token());
 				}
 			}
 		}

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -686,21 +686,16 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 								true,
 								false);
 
-							TypedValue lhs_arg;
-							lhs_arg.setType(TypeCategory::Struct);
-							lhs_arg.ir_type = IrType::Struct;
-							lhs_arg.size_in_bits = SizeInBits{64};
-							lhs_arg.value = lhs_val;
-							lhs_arg.pointer_depth = PointerDepth{1};
+							TypedValue lhs_arg = makeMemberThisCallArgument(
+								member.type_index.withCategory(TypeCategory::Struct),
+								IrValue(lhs_val));
 							call_op.args.push_back(std::move(lhs_arg));
 
-							TypedValue rhs_arg;
-							rhs_arg.setType(TypeCategory::Struct);
-							rhs_arg.ir_type = IrType::Struct;
-							rhs_arg.size_in_bits = SizeInBits{64};
-							rhs_arg.value = rhs_val;
-							rhs_arg.ref_qualifier = ReferenceQualifier::LValueReference;
-							call_op.args.push_back(std::move(rhs_arg));
+							call_op.args.push_back(makeTypedValue(
+								member.type_index.withCategory(TypeCategory::Struct),
+								SizeInBits{POINTER_SIZE_BITS},
+								IrValue(rhs_val),
+								ReferenceQualifier::LValueReference));
 
 							ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), func_decl.identifier_token()));
 
@@ -920,15 +915,10 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 				true,
 				false);
 
-				// Pass 'this' as first arg
-			StringHandle this_handle = StringTable::getOrInternStringHandle("this");
-			TypedValue this_arg;
-			this_arg.setType(TypeCategory::Struct);
-			this_arg.ir_type = IrType::Struct;
-			this_arg.size_in_bits = SizeInBits{64};
-			this_arg.value = this_handle;
-			this_arg.pointer_depth = PointerDepth{1};
-			call_op.args.push_back(std::move(this_arg));
+			TypeIndex owner_type_index = type_it->second->type_index_.withCategory(TypeCategory::Struct);
+			call_op.args.push_back(makeMemberThisCallArgument(
+				owner_type_index,
+				IrValue(StringTable::getOrInternStringHandle("this"))));
 
 			// Pass 'other' as second arg (reference = pointer)
 			StringHandle other_handle;
@@ -941,13 +931,11 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 			if (!other_handle.isValid()) {
 				other_handle = StringTable::getOrInternStringHandle("other");
 			}
-			TypedValue other_arg;
-			other_arg.setType(TypeCategory::Struct);
-			other_arg.ir_type = IrType::Struct;
-			other_arg.size_in_bits = SizeInBits{64};
-			other_arg.value = other_handle;
-			other_arg.ref_qualifier = ReferenceQualifier::LValueReference;
-			call_op.args.push_back(std::move(other_arg));
+			call_op.args.push_back(makeTypedValue(
+				owner_type_index,
+				SizeInBits{POINTER_SIZE_BITS},
+				IrValue(other_handle),
+				ReferenceQualifier::LValueReference));
 
 			ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), func_decl.identifier_token()));
 
@@ -1019,21 +1007,16 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 							true,
 							false);
 
-						TypedValue lhs_arg;
-						lhs_arg.setType(TypeCategory::Struct);
-						lhs_arg.ir_type = IrType::Struct;
-						lhs_arg.size_in_bits = SizeInBits{64};
-						lhs_arg.value = lhs_val;
-						lhs_arg.pointer_depth = PointerDepth{1};
+						TypedValue lhs_arg = makeMemberThisCallArgument(
+							member.type_index.withCategory(TypeCategory::Struct),
+							IrValue(lhs_val));
 						call_op.args.push_back(std::move(lhs_arg));
 
-						TypedValue rhs_arg;
-						rhs_arg.setType(TypeCategory::Struct);
-						rhs_arg.ir_type = IrType::Struct;
-						rhs_arg.size_in_bits = SizeInBits{64};
-						rhs_arg.value = rhs_val;
-						rhs_arg.ref_qualifier = ReferenceQualifier::LValueReference;
-						call_op.args.push_back(std::move(rhs_arg));
+						call_op.args.push_back(makeTypedValue(
+							member.type_index.withCategory(TypeCategory::Struct),
+							SizeInBits{POINTER_SIZE_BITS},
+							IrValue(rhs_val),
+							ReferenceQualifier::LValueReference));
 
 						ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), func_decl.identifier_token()));
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -686,16 +686,29 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 								true,
 								false);
 
-							TypedValue lhs_arg = makeMemberThisCallArgument(
+							// MemberAccess materializes the member object in a temp.
+							// 'this' for the nested <=> must be the address of that object.
+							TempVar lhs_addr = emitAddressOf(
+								member.type_index.category(),
+								member_bits,
+								IrValue(lhs_val),
+								func_decl.identifier_token());
+							call_op.args.push_back(makeMemberThisCallArgument(
 								member.type_index.withCategory(TypeCategory::Struct),
-								IrValue(lhs_val));
-							call_op.args.push_back(std::move(lhs_arg));
+								IrValue(lhs_addr)));
 
-							call_op.args.push_back(makeTypedValue(
+							TempVar rhs_addr = emitAddressOf(
+								member.type_index.category(),
+								member_bits,
+								IrValue(rhs_val),
+								func_decl.identifier_token());
+							TypedValue rhs_arg = makeTypedValue(
 								member.type_index.withCategory(TypeCategory::Struct),
 								SizeInBits{POINTER_SIZE_BITS},
-								IrValue(rhs_val),
-								ReferenceQualifier::LValueReference));
+								IrValue(rhs_addr),
+								ReferenceQualifier::LValueReference);
+							rhs_arg.storage = ValueStorage::ContainsAddress;
+							call_op.args.push_back(std::move(rhs_arg));
 
 							ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), func_decl.identifier_token()));
 
@@ -1007,16 +1020,27 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 							true,
 							false);
 
-						TypedValue lhs_arg = makeMemberThisCallArgument(
+						TempVar lhs_addr = emitAddressOf(
+							member.type_index.category(),
+							member_bits,
+							IrValue(lhs_val),
+							func_decl.identifier_token());
+						call_op.args.push_back(makeMemberThisCallArgument(
 							member.type_index.withCategory(TypeCategory::Struct),
-							IrValue(lhs_val));
-						call_op.args.push_back(std::move(lhs_arg));
+							IrValue(lhs_addr)));
 
-						call_op.args.push_back(makeTypedValue(
+						TempVar rhs_addr = emitAddressOf(
+							member.type_index.category(),
+							member_bits,
+							IrValue(rhs_val),
+							func_decl.identifier_token());
+						TypedValue rhs_arg = makeTypedValue(
 							member.type_index.withCategory(TypeCategory::Struct),
 							SizeInBits{POINTER_SIZE_BITS},
-							IrValue(rhs_val),
-							ReferenceQualifier::LValueReference));
+							IrValue(rhs_addr),
+							ReferenceQualifier::LValueReference);
+						rhs_arg.storage = ValueStorage::ContainsAddress;
+						call_op.args.push_back(std::move(rhs_arg));
 
 						ir_.addInstruction(IrInstruction(IrOpcode::FunctionCall, std::move(call_op), func_decl.identifier_token()));
 

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -336,8 +336,8 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 
 	// Detect if function returns struct by value (needs hidden return parameter for RVO/NRVO)
 	// Only non-pointer, non-reference struct returns need this (pointer/reference returns are in RAX like regular pointers)
-	bool returns_struct_by_value = returnsStructByValue(ret_type.type(), ret_type.pointer_depth(), ret_type.is_reference());
-	bool needs_hidden_return_param = needsHiddenReturnParam(ret_type.type(), ret_type.pointer_depth(), ret_type.is_reference(), actual_return_size, context_->isLLP64());
+	bool returns_struct_by_value = returnsStructByValue(ret_type);
+	bool needs_hidden_return_param = needsHiddenReturnParam(ret_type, context_->isLLP64());
 	func_decl_op.has_hidden_return_param = needs_hidden_return_param;
 
 	// Track return type index and hidden parameter flag for current function context

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -1387,10 +1387,17 @@ ParseResult Parser::parse_lambda_expression() {
 				false);
 		}
 
-		// addMember() already updates total_size and alignment, but ensure minimum size of 1
-		if (!closure_struct_info->total_size.is_set()) {
-			closure_struct_info->finalizeLayoutSize(1, 1, closure_struct_info->alignment);
+		// Capturing closures must publish a complete object layout. addMember updates
+		// sizes but leaves layout_is_complete false; SysV return/argument classification
+		// requires a finalized layout and must not treat these as Dependent forever.
+		const size_t final_alignment = std::max(closure_struct_info->alignment, size_t(1));
+		size_t object_size = toSizeT(closure_struct_info->total_size);
+		size_t layout_size = toSizeT(closure_struct_info->layout_data_size);
+		if (object_size == 0) {
+			object_size = 1;
+			layout_size = std::max(layout_size, size_t(1));
 		}
+		closure_struct_info->finalizeLayoutSize(layout_size, object_size, final_alignment);
 	}
 
 	// Generate operator() member function for the lambda

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2652,8 +2652,7 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 			return TypeSpecifierNode(closure_type->type_index_.withCategory(TypeCategory::Struct), closure_size_bits, lambda.lambda_token(), CVQualifier::None, ReferenceQualifier::None);
 		}
 
-		// Fallback: return a placeholder struct type
-			return TypeSpecifierNode(TypeIndex{}.withCategory(TypeCategory::Struct), SizeInBits{64}, lambda.lambda_token(), CVQualifier::None, ReferenceQualifier::None);
+		throw InternalError("Lambda expression type lookup reached an unregistered closure type");
 	}
 
 	if (!expr_node.is<ExpressionNode>()) {
@@ -3214,8 +3213,7 @@ std::optional<TypeSpecifierNode> Parser::get_expression_type(const ASTNode& expr
 			return TypeSpecifierNode(closure_type->type_index_.withCategory(TypeCategory::Struct), closure_size_bits, lambda.lambda_token(), CVQualifier::None, ReferenceQualifier::None);
 		}
 
-		// Fallback: return a placeholder struct type
-		return TypeSpecifierNode(TypeIndex{}.withCategory(TypeCategory::Struct), 64, lambda.lambda_token(), CVQualifier::None, ReferenceQualifier::None);
+		throw InternalError("Lambda expression type lookup reached an unregistered closure type");
 	} else if (std::holds_alternative<ConstructorCallNode>(expr)) {
 		// For constructor calls like Widget(42), return the type being constructed
 		const auto& ctor_call = std::get<ConstructorCallNode>(expr);

--- a/tests/test_external_abi.cpp
+++ b/tests/test_external_abi.cpp
@@ -31,6 +31,12 @@ struct DoubleInt {
 	double a;
 	int b;
 };
+struct FloatOnly {
+	float value;
+};
+struct DoubleOnly {
+	double value;
+};
 struct alignas(16) TailAlignedDouble {
 	double value;
 };
@@ -72,6 +78,14 @@ extern "C" int external_check_packed_double(PackedDouble value);
 extern "C" int external_call_flashcpp_packed_double(PackedDouble value);
 extern "C" PackedDouble external_make_packed_double(char tag, double value);
 extern "C" PackedDouble external_call_flashcpp_make_packed_double(char tag, double value);
+extern "C" int external_check_float_only(FloatOnly value);
+extern "C" int external_call_flashcpp_float_only(FloatOnly value);
+extern "C" FloatOnly external_make_float_only(float value);
+extern "C" FloatOnly external_call_flashcpp_make_float_only(float value);
+extern "C" int external_check_double_only(DoubleOnly value);
+extern "C" int external_call_flashcpp_double_only(DoubleOnly value);
+extern "C" DoubleOnly external_make_double_only(double value);
+extern "C" DoubleOnly external_call_flashcpp_make_double_only(double value);
 extern "C" int external_int_double_after_8_doubles(
 	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
 	IntDouble value, int tail);
@@ -141,6 +155,22 @@ extern "C" int flashcpp_check_packed_double(PackedDouble value) {
 
 extern "C" PackedDouble flashcpp_make_packed_double(char tag, double value) {
 	return PackedDouble{tag, value};
+}
+
+extern "C" int flashcpp_check_float_only(FloatOnly value) {
+	return value.value == 1.5f;
+}
+
+extern "C" FloatOnly flashcpp_make_float_only(float value) {
+	return FloatOnly{value};
+}
+
+extern "C" int flashcpp_check_double_only(DoubleOnly value) {
+	return value.value == 4.5;
+}
+
+extern "C" DoubleOnly flashcpp_make_double_only(double value) {
+	return DoubleOnly{value};
 }
 
 extern "C" int flashcpp_int_double_after_8_doubles(
@@ -352,6 +382,38 @@ extern "C" int main() {
 	if (external_call_flashcpp_int_double_after_8_doubles(
 			1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, exhausted_value, 5) != 83) {
 		return 38;
+	}
+
+	// Tests 39-42: single-eightbyte SSE-only aggregates must use XMM0, not RAX.
+	if (!external_check_float_only(FloatOnly{1.5f})) {
+		return 39;
+	}
+	if (!external_call_flashcpp_float_only(FloatOnly{1.5f})) {
+		return 40;
+	}
+	FloatOnly external_float_only = external_make_float_only(1.5f);
+	if (external_float_only.value != 1.5f) {
+		return 41;
+	}
+	FloatOnly flashcpp_float_only = external_call_flashcpp_make_float_only(1.5f);
+	if (flashcpp_float_only.value != 1.5f) {
+		return 42;
+	}
+
+	// Tests 43-46: same for an 8-byte double-only aggregate.
+	if (!external_check_double_only(DoubleOnly{4.5})) {
+		return 43;
+	}
+	if (!external_call_flashcpp_double_only(DoubleOnly{4.5})) {
+		return 44;
+	}
+	DoubleOnly external_double_only = external_make_double_only(4.5);
+	if (external_double_only.value != 4.5) {
+		return 45;
+	}
+	DoubleOnly flashcpp_double_only = external_call_flashcpp_make_double_only(4.5);
+	if (flashcpp_double_only.value != 4.5) {
+		return 46;
 	}
 
 	return 0; // All tests passed!

--- a/tests/test_external_abi.cpp
+++ b/tests/test_external_abi.cpp
@@ -70,6 +70,8 @@ extern "C" TailAlignedDouble external_make_tail_aligned_double(double value);
 extern "C" TailAlignedDouble external_call_flashcpp_make_tail_aligned_double(double value);
 extern "C" int external_check_packed_double(PackedDouble value);
 extern "C" int external_call_flashcpp_packed_double(PackedDouble value);
+extern "C" PackedDouble external_make_packed_double(char tag, double value);
+extern "C" PackedDouble external_call_flashcpp_make_packed_double(char tag, double value);
 extern "C" int external_int_double_after_8_doubles(
 	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
 	IntDouble value, int tail);
@@ -135,6 +137,10 @@ extern "C" TailAlignedDouble flashcpp_make_tail_aligned_double(double value) {
 
 extern "C" int flashcpp_check_packed_double(PackedDouble value) {
 	return value.tag == 10 && value.value == 32.0;
+}
+
+extern "C" PackedDouble flashcpp_make_packed_double(char tag, double value) {
+	return PackedDouble{tag, value};
 }
 
 extern "C" int flashcpp_int_double_after_8_doubles(
@@ -324,17 +330,28 @@ extern "C" int main() {
 		return 34;
 	}
 
-	// Tests 35-36: the mixed aggregate needs one GPR and one SSE register. With
+	// Tests 35-36: MEMORY-class returns also use a hidden return slot, not
+	// the direct two-register convention implied by size alone.
+	PackedDouble external_packed = external_make_packed_double(10, 32.0);
+	if (external_packed.tag != 10 || external_packed.value != 32.0) {
+		return 35;
+	}
+	PackedDouble flashcpp_packed = external_call_flashcpp_make_packed_double(10, 32.0);
+	if (flashcpp_packed.tag != 10 || flashcpp_packed.value != 32.0) {
+		return 36;
+	}
+
+	// Tests 37-38: the mixed aggregate needs one GPR and one SSE register. With
 	// all SSE registers occupied, the whole aggregate spills and the following
 	// integer still uses the unconsumed first GPR.
 	IntDouble exhausted_value{10, 32.0};
 	if (external_int_double_after_8_doubles(
 			1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, exhausted_value, 5) != 83) {
-		return 35;
+		return 37;
 	}
 	if (external_call_flashcpp_int_double_after_8_doubles(
 			1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, exhausted_value, 5) != 83) {
-		return 36;
+		return 38;
 	}
 
 	return 0; // All tests passed!

--- a/tests/test_external_abi_helper.c
+++ b/tests/test_external_abi_helper.c
@@ -92,6 +92,7 @@ DoubleInt flashcpp_make_double_int(double a, int b);
 int flashcpp_check_tail_aligned_double(TailAlignedDouble value);
 TailAlignedDouble flashcpp_make_tail_aligned_double(double value);
 int flashcpp_check_packed_double(PackedDouble value);
+PackedDouble flashcpp_make_packed_double(char tag, double value);
 int flashcpp_int_double_after_8_doubles(
 	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
 	IntDouble value, int tail);
@@ -242,6 +243,17 @@ int external_check_packed_double(PackedDouble value) {
 
 int external_call_flashcpp_packed_double(PackedDouble value) {
 	return flashcpp_check_packed_double(value);
+}
+
+PackedDouble external_make_packed_double(char tag, double value) {
+	PackedDouble result;
+	result.tag = tag;
+	result.value = value;
+	return result;
+}
+
+PackedDouble external_call_flashcpp_make_packed_double(char tag, double value) {
+	return flashcpp_make_packed_double(tag, value);
 }
 
 int external_int_double_after_8_doubles(

--- a/tests/test_external_abi_helper.c
+++ b/tests/test_external_abi_helper.c
@@ -77,6 +77,14 @@ typedef struct PackedDouble {
 } PackedDouble;
 #pragma pack(pop)
 
+typedef struct FloatOnly {
+	float value;
+} FloatOnly;
+
+typedef struct DoubleOnly {
+	double value;
+} DoubleOnly;
+
 int flashcpp_sum_big3(Big3 value);
 int flashcpp_big3_after_4_ints(int i1, int i2, int i3, int i4, Big3 value);
 int flashcpp_big3_after_5_ints(int i1, int i2, int i3, int i4, int i5, Big3 value);
@@ -93,6 +101,10 @@ int flashcpp_check_tail_aligned_double(TailAlignedDouble value);
 TailAlignedDouble flashcpp_make_tail_aligned_double(double value);
 int flashcpp_check_packed_double(PackedDouble value);
 PackedDouble flashcpp_make_packed_double(char tag, double value);
+int flashcpp_check_float_only(FloatOnly value);
+FloatOnly flashcpp_make_float_only(float value);
+int flashcpp_check_double_only(DoubleOnly value);
+DoubleOnly flashcpp_make_double_only(double value);
 int flashcpp_int_double_after_8_doubles(
 	double d1, double d2, double d3, double d4, double d5, double d6, double d7, double d8,
 	IntDouble value, int tail);
@@ -254,6 +266,42 @@ PackedDouble external_make_packed_double(char tag, double value) {
 
 PackedDouble external_call_flashcpp_make_packed_double(char tag, double value) {
 	return flashcpp_make_packed_double(tag, value);
+}
+
+int external_check_float_only(FloatOnly value) {
+	return value.value == 1.5f;
+}
+
+int external_call_flashcpp_float_only(FloatOnly value) {
+	return flashcpp_check_float_only(value);
+}
+
+FloatOnly external_make_float_only(float value) {
+	FloatOnly result;
+	result.value = value;
+	return result;
+}
+
+FloatOnly external_call_flashcpp_make_float_only(float value) {
+	return flashcpp_make_float_only(value);
+}
+
+int external_check_double_only(DoubleOnly value) {
+	return value.value == 4.5;
+}
+
+int external_call_flashcpp_double_only(DoubleOnly value) {
+	return flashcpp_check_double_only(value);
+}
+
+DoubleOnly external_make_double_only(double value) {
+	DoubleOnly result;
+	result.value = value;
+	return result;
+}
+
+DoubleOnly external_call_flashcpp_make_double_only(double value) {
+	return flashcpp_make_double_only(value);
 }
 
 int external_int_double_after_8_doubles(

--- a/tests/test_sysv_single_eightbyte_sse_return_ret0.cpp
+++ b/tests/test_sysv_single_eightbyte_sse_return_ret0.cpp
@@ -1,0 +1,78 @@
+// SysV single-eightbyte aggregates that contain only float/double must return
+// in XMM0, not the legacy integer RAX path used for INTEGER-class small structs.
+
+struct FloatOnly {
+	float value;
+};
+
+struct DoubleOnly {
+	double value;
+};
+
+struct TwoFloats {
+	float a;
+	float b;
+};
+
+FloatOnly make_float_only(float value) {
+	return FloatOnly{value};
+}
+
+DoubleOnly make_double_only(double value) {
+	return DoubleOnly{value};
+}
+
+TwoFloats make_two_floats(float a, float b) {
+	return TwoFloats{a, b};
+}
+
+float consume_float_only(FloatOnly value) {
+	return value.value;
+}
+
+double consume_double_only(DoubleOnly value) {
+	return value.value;
+}
+
+float consume_two_floats(TwoFloats value) {
+	return value.a + value.b;
+}
+
+template <typename T>
+T identity_template(T value) {
+	return value;
+}
+
+int main() {
+	FloatOnly made_float = make_float_only(1.5f);
+	if (made_float.value != 1.5f) {
+		return 1;
+	}
+	if (consume_float_only(FloatOnly{2.5f}) != 2.5f) {
+		return 2;
+	}
+	if (identity_template(FloatOnly{3.5f}).value != 3.5f) {
+		return 3;
+	}
+
+	DoubleOnly made_double = make_double_only(4.5);
+	if (made_double.value != 4.5) {
+		return 4;
+	}
+	if (consume_double_only(DoubleOnly{5.5}) != 5.5) {
+		return 5;
+	}
+	if (identity_template(DoubleOnly{6.5}).value != 6.5) {
+		return 6;
+	}
+
+	TwoFloats made_pair = make_two_floats(1.0f, 2.5f);
+	if (made_pair.a != 1.0f || made_pair.b != 2.5f) {
+		return 7;
+	}
+	if (consume_two_floats(TwoFloats{3.0f, 4.0f}) != 7.0f) {
+		return 8;
+	}
+
+	return 0;
+}

--- a/tests/test_sysv_unaligned_aggregate_return_ret0.cpp
+++ b/tests/test_sysv_unaligned_aggregate_return_ret0.cpp
@@ -1,0 +1,85 @@
+// 8-byte unaligned aggregate: Win64 returns in RAX; SysV classifies MEMORY and
+// must use a hidden return slot rather than the size-based direct convention.
+#pragma pack(push, 1)
+struct PackedMisaligned {
+	char tag;
+	int value;
+	char pad[3];
+};
+#pragma pack(pop)
+
+static_assert(sizeof(PackedMisaligned) == 8);
+
+PackedMisaligned make_packed(char tag, int value) {
+	PackedMisaligned result;
+	result.tag = tag;
+	result.value = value;
+	result.pad[0] = 1;
+	result.pad[1] = 2;
+	result.pad[2] = 3;
+	return result;
+}
+
+template <typename T>
+T make_templated(char tag, int value) {
+	T result;
+	result.tag = tag;
+	result.value = value;
+	result.pad[0] = 1;
+	result.pad[1] = 2;
+	result.pad[2] = 3;
+	return result;
+}
+
+struct Holder {
+	PackedMisaligned make(char tag, int value) {
+		return make_packed(tag, value);
+	}
+};
+
+int main() {
+	if (sizeof(PackedMisaligned) != 8) {
+		return 100 + (int)sizeof(PackedMisaligned);
+	}
+
+	PackedMisaligned made = make_packed(10, 32);
+	if (made.tag != 10) {
+		return 1;
+	}
+	if (made.value != 32) {
+		return 2;
+	}
+	if (made.pad[0] != 1 || made.pad[1] != 2 || made.pad[2] != 3) {
+		return 3;
+	}
+
+	PackedMisaligned templated = make_templated<PackedMisaligned>(7, 11);
+	if (templated.tag != 7) {
+		return 4;
+	}
+	if (templated.value != 11) {
+		return 5;
+	}
+
+	Holder holder;
+	PackedMisaligned member = holder.make(3, 9);
+	if (member.tag != 3) {
+		return 6;
+	}
+	if (member.value != 9) {
+		return 7;
+	}
+
+	auto lambda_make = [](char tag, int value) -> PackedMisaligned {
+		return make_packed(tag, value);
+	};
+	PackedMisaligned from_lambda = lambda_make(5, 42);
+	if (from_lambda.tag != 5) {
+		return 8;
+	}
+	if (from_lambda.value != 42) {
+		return 9;
+	}
+
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Plan SysV aggregate returns as direct/indirect/dependent from canonical layout instead of a size-only threshold, so MEMORY-class values such as packed unaligned aggregates use a hidden return slot.
- Widen single-eightbyte classification so float/double-only aggregates return in XMM0, and close related IR producers (capturing lambda layout finalization, this/recursive-lambda TypeIndex and pointer depth).
- Document that the remaining X87/X87UP return gap is long-double-specific and blocked on real long double / x87 codegen, not another ABI planner fallback.

## Test plan
- [x] `tests/test_sysv_unaligned_aggregate_return_ret0.cpp`
- [x] `tests/test_sysv_single_eightbyte_sse_return_ret0.cpp`
- [x] `tests/test_external_abi.cpp` (Linux SysV interop, including PackedDouble / FloatOnly / DoubleOnly returns)
- [x] Focused Linux + Windows regression cluster (`test_lambda_cpp20_comprehensive_ret135`, RVO / param-shift / two-reg overflow)
