### PR TITLE
Slim TemplateArgInfo with ChunkedVector cold payloads

### DIFF
--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -248,6 +248,7 @@ std::unordered_map<TypeCategory, const TypeInfo*> gNativeTypes;
 ChunkedVector<TypeInfo::DependentQualifiedNameRecord, 4> gDependentQualifiedNameRecords;
 ChunkedVector<InlineVector<TypeInfo::TemplateArgInfo, 4>, 8> gTypeInfoTemplateArgLists;
 ChunkedVector<TypeInfo::InstantiationContext, 8> gInstantiationContexts;
+ChunkedVector<TypeInfo::TemplateArgInfoColdPayload, 16> gTemplateArgInfoColdPayloads;
 // StructTypeInfo is large; keep chunks small to avoid huge reserved slabs.
 ChunkedVector<StructTypeInfo, 4> gStructTypeInfos;
 ChunkedVector<EnumTypeInfo, 16> gEnumTypeInfos;
@@ -306,6 +307,186 @@ const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32
 
 size_t getTypeInfoTemplateArgsCount() {
 	return gTypeInfoTemplateArgLists.size();
+}
+
+uint32_t storeTemplateArgInfoColdPayload(TypeInfo::TemplateArgInfoColdPayload payload) {
+	if (!payload.function_signature.has_value() && !payload.dependent_expr.has_value()) {
+		return TypeInfo::TemplateArgInfo::kNoColdPayload;
+	}
+	const uint32_t index = static_cast<uint32_t>(gTemplateArgInfoColdPayloads.size());
+	gTemplateArgInfoColdPayloads.push_back(std::move(payload));
+	return index;
+}
+
+const TypeInfo::TemplateArgInfoColdPayload* getTemplateArgInfoColdPayload(uint32_t index) {
+	if (index == TypeInfo::TemplateArgInfo::kNoColdPayload) {
+		return nullptr;
+	}
+	assert(index < gTemplateArgInfoColdPayloads.size());
+	return &gTemplateArgInfoColdPayloads[index];
+}
+
+TypeInfo::TemplateArgInfoColdPayload* getTemplateArgInfoColdPayloadMut(uint32_t index) {
+	if (index == TypeInfo::TemplateArgInfo::kNoColdPayload) {
+		return nullptr;
+	}
+	assert(index < gTemplateArgInfoColdPayloads.size());
+	return &gTemplateArgInfoColdPayloads[index];
+}
+
+uint32_t cloneTemplateArgInfoColdPayload(uint32_t index) {
+	if (index == TypeInfo::TemplateArgInfo::kNoColdPayload) {
+		return TypeInfo::TemplateArgInfo::kNoColdPayload;
+	}
+	return storeTemplateArgInfoColdPayload(*getTemplateArgInfoColdPayload(index));
+}
+
+size_t getTemplateArgInfoColdPayloadCount() {
+	return gTemplateArgInfoColdPayloads.size();
+}
+
+namespace {
+
+const std::optional<FunctionSignature> kEmptyFunctionSignature;
+const std::optional<ASTNode> kEmptyDependentExpr;
+
+TypeInfo::TemplateArgInfoColdPayload& ensureTemplateArgInfoColdPayload(uint32_t& index) {
+	if (index == TypeInfo::TemplateArgInfo::kNoColdPayload) {
+		index = static_cast<uint32_t>(gTemplateArgInfoColdPayloads.size());
+		gTemplateArgInfoColdPayloads.push_back({});
+	}
+	return *getTemplateArgInfoColdPayloadMut(index);
+}
+
+void copyTemplateArgInfoScalarFields(TypeInfo::TemplateArgInfo& dst, const TypeInfo::TemplateArgInfo& src) {
+	dst.type_index = src.type_index;
+	dst.pointer_cv_qualifiers = src.pointer_cv_qualifiers;
+	dst.pointer_depth = src.pointer_depth;
+	dst.cv_qualifier = src.cv_qualifier;
+	dst.ref_qualifier = src.ref_qualifier;
+	dst.value = src.value;
+	dst.is_value = src.is_value;
+	dst.is_pack = src.is_pack;
+	dst.is_array = src.is_array;
+	dst.array_dimensions = src.array_dimensions;
+	dst.array_dimension_parameter_names = src.array_dimension_parameter_names;
+	dst.dependent_name = src.dependent_name;
+	dst.is_template_template_arg = src.is_template_template_arg;
+	dst.template_name = src.template_name;
+	dst.member_pointer_kind = src.member_pointer_kind;
+	dst.member_class_name = src.member_class_name;
+	dst.nttp_kind = src.nttp_kind;
+	dst.nttp_entity_name = src.nttp_entity_name;
+	dst.nttp_member_name = src.nttp_member_name;
+	dst.nttp_pointer_offset = src.nttp_pointer_offset;
+}
+
+} // namespace
+
+TypeInfo::TemplateArgInfo::TemplateArgInfo()
+	: type_index(),
+	  pointer_depth(0),
+	  cv_qualifier(CVQualifier::None),
+	  ref_qualifier(ReferenceQualifier::None),
+	  value(int64_t{0}),
+	  is_value(false),
+	  is_pack(false),
+	  is_array(false),
+	  is_template_template_arg(false),
+	  member_pointer_kind(MemberPointerKind::None),
+	  member_class_name(),
+	  nttp_kind(FlashCpp::NonTypeValueIdentityKind::Integral),
+	  nttp_pointer_offset(0) {}
+
+TypeInfo::TemplateArgInfo::TemplateArgInfo(const TemplateArgInfo& other)
+	: type_index(other.type_index),
+	  pointer_cv_qualifiers(other.pointer_cv_qualifiers),
+	  pointer_depth(other.pointer_depth),
+	  cv_qualifier(other.cv_qualifier),
+	  ref_qualifier(other.ref_qualifier),
+	  value(other.value),
+	  is_value(other.is_value),
+	  is_pack(other.is_pack),
+	  is_array(other.is_array),
+	  array_dimensions(other.array_dimensions),
+	  array_dimension_parameter_names(other.array_dimension_parameter_names),
+	  dependent_name(other.dependent_name),
+	  is_template_template_arg(other.is_template_template_arg),
+	  template_name(other.template_name),
+	  member_pointer_kind(other.member_pointer_kind),
+	  member_class_name(other.member_class_name),
+	  nttp_kind(other.nttp_kind),
+	  nttp_entity_name(other.nttp_entity_name),
+	  nttp_member_name(other.nttp_member_name),
+	  nttp_pointer_offset(other.nttp_pointer_offset),
+	  cold_payload_index_(cloneTemplateArgInfoColdPayload(other.cold_payload_index_)) {}
+
+TypeInfo::TemplateArgInfo::TemplateArgInfo(TemplateArgInfo&& other) noexcept
+	: type_index(other.type_index),
+	  pointer_cv_qualifiers(std::move(other.pointer_cv_qualifiers)),
+	  pointer_depth(other.pointer_depth),
+	  cv_qualifier(other.cv_qualifier),
+	  ref_qualifier(other.ref_qualifier),
+	  value(std::move(other.value)),
+	  is_value(other.is_value),
+	  is_pack(other.is_pack),
+	  is_array(other.is_array),
+	  array_dimensions(std::move(other.array_dimensions)),
+	  array_dimension_parameter_names(std::move(other.array_dimension_parameter_names)),
+	  dependent_name(other.dependent_name),
+	  is_template_template_arg(other.is_template_template_arg),
+	  template_name(other.template_name),
+	  member_pointer_kind(other.member_pointer_kind),
+	  member_class_name(other.member_class_name),
+	  nttp_kind(other.nttp_kind),
+	  nttp_entity_name(other.nttp_entity_name),
+	  nttp_member_name(other.nttp_member_name),
+	  nttp_pointer_offset(other.nttp_pointer_offset),
+	  cold_payload_index_(other.cold_payload_index_) {
+	other.cold_payload_index_ = kNoColdPayload;
+}
+
+TypeInfo::TemplateArgInfo& TypeInfo::TemplateArgInfo::operator=(const TemplateArgInfo& other) {
+	if (this != &other) {
+		copyTemplateArgInfoScalarFields(*this, other);
+		cold_payload_index_ = cloneTemplateArgInfoColdPayload(other.cold_payload_index_);
+	}
+	return *this;
+}
+
+TypeInfo::TemplateArgInfo& TypeInfo::TemplateArgInfo::operator=(TemplateArgInfo&& other) noexcept {
+	if (this != &other) {
+		copyTemplateArgInfoScalarFields(*this, other);
+		cold_payload_index_ = other.cold_payload_index_;
+		other.cold_payload_index_ = kNoColdPayload;
+	}
+	return *this;
+}
+
+const std::optional<FunctionSignature>& TypeInfo::TemplateArgInfo::function_signature() const {
+	if (const TypeInfo::TemplateArgInfoColdPayload* payload = getTemplateArgInfoColdPayload(cold_payload_index_)) {
+		return payload->function_signature;
+	}
+	return kEmptyFunctionSignature;
+}
+
+std::optional<FunctionSignature>& TypeInfo::TemplateArgInfo::function_signature() {
+	return ensureTemplateArgInfoColdPayload(cold_payload_index_).function_signature;
+}
+
+const std::optional<ASTNode>& TypeInfo::TemplateArgInfo::dependent_expr() const {
+	if (const TypeInfo::TemplateArgInfoColdPayload* payload = getTemplateArgInfoColdPayload(cold_payload_index_)) {
+		return payload->dependent_expr;
+	}
+	return kEmptyDependentExpr;
+}
+
+std::optional<ASTNode>& TypeInfo::TemplateArgInfo::dependent_expr() {
+	return ensureTemplateArgInfoColdPayload(cold_payload_index_).dependent_expr;
+}
+
+void TypeInfo::TemplateArgInfo::resetColdPayload() {
+	cold_payload_index_ = kNoColdPayload;
 }
 
 uint32_t storeInstantiationContext(TypeInfo::InstantiationContext ctx) {
@@ -792,6 +973,12 @@ void printTypeTableStats() {
 			  ", list_bytes=", sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
 			  ", estimated cold storage=",
 			  getTypeInfoTemplateArgsCount() * sizeof(InlineVector<TypeInfo::TemplateArgInfo, 4>),
+			  " bytes");
+	FLASH_LOG(General, Info, "  gTemplateArgInfoColdPayloads: entries=",
+			  getTemplateArgInfoColdPayloadCount(),
+			  ", payload_bytes=", sizeof(TypeInfo::TemplateArgInfoColdPayload),
+			  ", estimated cold storage=",
+			  getTemplateArgInfoColdPayloadCount() * sizeof(TypeInfo::TemplateArgInfoColdPayload),
 			  " bytes");
 	FLASH_LOG(General, Info, "  gInstantiationContexts: entries=",
 			  getInstantiationContextCount(),

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1067,7 +1067,14 @@ struct TypeInfo {
 	// Lightweight storage for template argument type indices (avoids TemplateTypeArg dependency)
 	// For type arguments: stores TypeIndex (index into gTypeInfo)
 	// For non-type arguments: stores the value directly (supports int64_t, double, StringHandle)
+	struct TemplateArgInfoColdPayload {
+		std::optional<FunctionSignature> function_signature;
+		std::optional<ASTNode> dependent_expr;
+	};
+
 	struct TemplateArgInfo {
+		static constexpr uint32_t kNoColdPayload = UINT32_MAX;
+
 		TypeIndex type_index;		// Carries both gTypeInfo slot and TypeCategory
 		InlineVector<CVQualifier, 4> pointer_cv_qualifiers;
 		size_t pointer_depth;		  // Pointer indirection level
@@ -1080,8 +1087,6 @@ struct TypeInfo {
 		InlineVector<size_t, 2> array_dimensions;  // All dimension sizes (e.g., {3, 4} for T[3][4])
 		InlineVector<StringHandle, 2> array_dimension_parameter_names; // Direct dependent bound for each dimension, if any
 		StringHandle dependent_name;	 // Name of the dependent template parameter (for inner deduction)
-		std::optional<FunctionSignature> function_signature; // For function pointer template arguments
-		std::optional<ASTNode> dependent_expr;  // Original AST for dependent NTTP expressions (e.g., sizeof(T))
 		bool is_template_template_arg;  // true if this is a template template argument
 		StringHandle template_name;  // Name of the template for template-template arguments
 		MemberPointerKind member_pointer_kind;  // Distinguish member function vs data pointers
@@ -1094,76 +1099,21 @@ struct TypeInfo {
 		StringHandle nttp_member_name;                 // Member name for member-pointer NTTPs
 		int64_t nttp_pointer_offset;                   // Object-pointer element offset or member-pointer value offset
 
-		TemplateArgInfo()
-			: type_index(),
-			  pointer_depth(0),
-			  cv_qualifier(CVQualifier::None),
-			  ref_qualifier(ReferenceQualifier::None),
-			  value(int64_t{0}),
-			  is_value(false),
-			  is_pack(false),
-			  is_array(false),
-			  is_template_template_arg(false),
-			  member_pointer_kind(MemberPointerKind::None),
-			  member_class_name(),
-			  nttp_kind(FlashCpp::NonTypeValueIdentityKind::Integral),
-			  nttp_pointer_offset(0) {}
+		// Index into gTemplateArgInfoColdPayloads for rare fat fields (~function sig / dependent expr).
+		uint32_t cold_payload_index_ = kNoColdPayload;
 
-		TemplateArgInfo(const TemplateArgInfo& other)
-			: type_index(other.type_index),
-			  pointer_cv_qualifiers(other.pointer_cv_qualifiers),
-			  pointer_depth(other.pointer_depth),
-			  cv_qualifier(other.cv_qualifier),
-			  ref_qualifier(other.ref_qualifier),
-			  value(other.value),
-			  is_value(other.is_value),
-			  is_pack(other.is_pack),
-			  is_array(other.is_array),
-			  array_dimensions(other.array_dimensions),
-			  array_dimension_parameter_names(other.array_dimension_parameter_names),
-			  dependent_name(other.dependent_name),
-			  function_signature(other.function_signature),
-			  dependent_expr(other.dependent_expr),
-			  is_template_template_arg(other.is_template_template_arg),
-			  template_name(other.template_name),
-			  member_pointer_kind(other.member_pointer_kind),
-			  member_class_name(other.member_class_name),
-			  nttp_kind(other.nttp_kind),
-			  nttp_entity_name(other.nttp_entity_name),
-			  nttp_member_name(other.nttp_member_name),
-			  nttp_pointer_offset(other.nttp_pointer_offset) {}
+		TemplateArgInfo();
+		TemplateArgInfo(const TemplateArgInfo& other);
+		TemplateArgInfo(TemplateArgInfo&& other) noexcept;
+		TemplateArgInfo& operator=(const TemplateArgInfo& other);
+		TemplateArgInfo& operator=(TemplateArgInfo&& other) noexcept;
+		~TemplateArgInfo() = default;
 
-		TemplateArgInfo(TemplateArgInfo&&) noexcept = default;
-
-		TemplateArgInfo& operator=(const TemplateArgInfo& other) {
-			if (this != &other) {
-				type_index = other.type_index;
-				pointer_cv_qualifiers = other.pointer_cv_qualifiers;
-				pointer_depth = other.pointer_depth;
-				cv_qualifier = other.cv_qualifier;
-				ref_qualifier = other.ref_qualifier;
-				value = other.value;
-				is_value = other.is_value;
-				is_pack = other.is_pack;
-				is_array = other.is_array;
-				array_dimensions = other.array_dimensions;
-				array_dimension_parameter_names = other.array_dimension_parameter_names;
-				dependent_name = other.dependent_name;
-				function_signature = other.function_signature;
-				dependent_expr = other.dependent_expr;
-				is_template_template_arg = other.is_template_template_arg;
-				template_name = other.template_name;
-				member_pointer_kind = other.member_pointer_kind;
-				member_class_name = other.member_class_name;
-				nttp_kind = other.nttp_kind;
-				nttp_entity_name = other.nttp_entity_name;
-				nttp_member_name = other.nttp_member_name;
-				nttp_pointer_offset = other.nttp_pointer_offset;
-			}
-			return *this;
-		}
-
-		TemplateArgInfo& operator=(TemplateArgInfo&&) noexcept = default;
+		const std::optional<FunctionSignature>& function_signature() const;
+		std::optional<FunctionSignature>& function_signature();
+		const std::optional<ASTNode>& dependent_expr() const;
+		std::optional<ASTNode>& dependent_expr();
+		void resetColdPayload();
 
 		// Backward-compatible accessor: returns the first (outermost) array dimension if the type
 		// is a 1-D or multi-dimensional array, or nullopt if it is not an array.
@@ -1417,6 +1367,13 @@ size_t getDependentQualifiedNameRecordCount();
 uint32_t storeTypeInfoTemplateArgs(InlineVector<TypeInfo::TemplateArgInfo, 4> args);
 const InlineVector<TypeInfo::TemplateArgInfo, 4>& getTypeInfoTemplateArgs(uint32_t index);
 size_t getTypeInfoTemplateArgsCount();
+
+// Cold arena for rare TemplateArgInfo payloads (function signature / dependent expr).
+uint32_t storeTemplateArgInfoColdPayload(TypeInfo::TemplateArgInfoColdPayload payload);
+const TypeInfo::TemplateArgInfoColdPayload* getTemplateArgInfoColdPayload(uint32_t index);
+TypeInfo::TemplateArgInfoColdPayload* getTemplateArgInfoColdPayloadMut(uint32_t index);
+uint32_t cloneTemplateArgInfoColdPayload(uint32_t index);
+size_t getTemplateArgInfoColdPayloadCount();
 
 // Cold arena for TypeInfo::InstantiationContext.
 uint32_t storeInstantiationContext(TypeInfo::InstantiationContext ctx);
@@ -2241,7 +2198,7 @@ inline bool templateArgInfoContainsDependentPlaceholderImpl(const TypeInfo::Temp
 	if (depth_limit == 0) {
 		return true;
 	}
-	if (arg_info.dependent_name.isValid() || arg_info.dependent_expr.has_value()) {
+	if (arg_info.dependent_name.isValid() || arg_info.dependent_expr().has_value()) {
 		return true;
 	}
 	return typeIndexContainsDependentPlaceholder(arg_info.type_index, depth_limit);

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -2048,25 +2048,25 @@ inline bool dependentQualifiedTemplateArgMatchesForSignature(
 		return false;
 	}
 
-	if (instantiated_arg.function_signature.has_value() !=
-		out_of_line_arg.function_signature.has_value()) {
+	if (instantiated_arg.function_signature().has_value() !=
+		out_of_line_arg.function_signature().has_value()) {
 		return false;
 	}
-	if (instantiated_arg.function_signature.has_value() &&
+	if (instantiated_arg.function_signature().has_value() &&
 		!FlashCpp::equalFunctionSignatureIdentity(
-			*instantiated_arg.function_signature,
-			*out_of_line_arg.function_signature)) {
+			*instantiated_arg.function_signature(),
+			*out_of_line_arg.function_signature())) {
 		return false;
 	}
 
-	if (instantiated_arg.dependent_expr.has_value() !=
-		out_of_line_arg.dependent_expr.has_value()) {
+	if (instantiated_arg.dependent_expr().has_value() !=
+		out_of_line_arg.dependent_expr().has_value()) {
 		return false;
 	}
-	if (instantiated_arg.dependent_expr.has_value() &&
+	if (instantiated_arg.dependent_expr().has_value() &&
 		!FlashCpp::equalDependentExpressionIdentity(
-			*instantiated_arg.dependent_expr,
-			*out_of_line_arg.dependent_expr)) {
+			*instantiated_arg.dependent_expr(),
+			*out_of_line_arg.dependent_expr())) {
 		return false;
 	}
 

--- a/src/Parser_Expr_ControlFlowStmt.cpp
+++ b/src/Parser_Expr_ControlFlowStmt.cpp
@@ -1158,7 +1158,7 @@ ParseResult Parser::parse_lambda_expression() {
 					info.is_array = subst.substituted_type.is_array;
 					info.array_dimensions = subst.substituted_type.array_dimensions;
 					info.dependent_name = subst.substituted_type.dependent_name;
-					info.function_signature = subst.substituted_type.function_signature;
+					info.function_signature() = subst.substituted_type.function_signature;
 				} else {
 					continue;
 				}

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -972,13 +972,13 @@ bool Parser::templateArgMatchesCurrentInstantiationSlot(
 		type_index_match = parsed_arg.type_index == concrete_arg->type_index;
 	}
 
-	if (parsed_arg.function_signature.has_value() != concrete_arg->function_signature.has_value()) {
+	if (parsed_arg.function_signature.has_value() != concrete_arg->function_signature().has_value()) {
 		return false;
 	}
 	if (parsed_arg.function_signature.has_value() &&
 		!FlashCpp::equalFunctionSignatureIdentity(
 			*parsed_arg.function_signature,
-			*concrete_arg->function_signature)) {
+			*concrete_arg->function_signature())) {
 		return false;
 	}
 

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -1217,7 +1217,7 @@ std::optional<Parser::ConstantValue> Parser::try_evaluate_constant_expression(co
 			arg.array_dimensions.assign(arg_info.array_dimensions.begin(), arg_info.array_dimensions.end());
 			arg.pointer_cv_qualifiers = arg_info.pointer_cv_qualifiers;
 			arg.dependent_name = arg_info.dependent_name;
-			arg.function_signature = arg_info.function_signature;
+			arg.function_signature = arg_info.function_signature();
 			arg.is_dependent = arg_info.dependent_name.isValid();
 			if (arg.is_value) {
 				arg.value = arg_info.intValue();

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -42,8 +42,8 @@ TypeInfo::TemplateArgInfo toTemplateArgInfo(const TemplateTypeArg& arg) {
 	info.is_value = arg.is_value;
 	info.is_pack = arg.is_pack;
 	info.dependent_name = arg.dependent_name;
-	info.function_signature = arg.function_signature;
-	info.dependent_expr = arg.dependent_expr;
+	info.function_signature() = arg.function_signature;
+	info.dependent_expr() = arg.dependent_expr;
 	info.is_template_template_arg = arg.is_template_template_arg;
 	info.template_name = arg.template_name_handle;
 	info.member_pointer_kind = arg.member_pointer_kind;
@@ -86,9 +86,9 @@ TemplateTypeArg toTemplateTypeArg(const TypeInfo::TemplateArgInfo& arg) {
 		arg.array_dimension_parameter_names.end());
 	ta.pointer_cv_qualifiers = arg.pointer_cv_qualifiers;
 	ta.dependent_name = arg.dependent_name;
-	ta.dependent_expr = arg.dependent_expr;
-	ta.function_signature = arg.function_signature;
-	ta.is_dependent = arg.dependent_name.isValid() || arg.dependent_expr.has_value();
+	ta.dependent_expr = arg.dependent_expr();
+	ta.function_signature = arg.function_signature();
+	ta.is_dependent = arg.dependent_name.isValid() || arg.dependent_expr().has_value();
 	ta.is_template_template_arg = arg.is_template_template_arg;
 	ta.template_name_handle = arg.template_name;
 	ta.member_pointer_kind = arg.member_pointer_kind;

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -132,7 +132,7 @@ struct TemplatePattern {
 			deduced.array_dimensions.assign(
 				c.array_dimensions.begin(),
 				c.array_dimensions.end());
-			deduced.function_signature = c.function_signature;
+			deduced.function_signature = c.function_signature();
 		}
 		return deduced;
 	}

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -1159,7 +1159,7 @@ inline std::optional<TypeSpecifierNode> makeTypeSpecifierFromTemplateArgInfo(
 	materialized.cv_qualifier = arg_info.cv_qualifier;
 	materialized.is_array = arg_info.is_array;
 	materialized.array_dimensions.assign(arg_info.array_dimensions.begin(), arg_info.array_dimensions.end());
-	materialized.function_signature = arg_info.function_signature;
+	materialized.function_signature = arg_info.function_signature();
 
 	TypeSpecifierNode substituted_spec(
 		arg_info.type_index.withCategory(arg_info.typeEnum()),
@@ -1183,8 +1183,8 @@ inline std::optional<TypeSpecifierNode> makeTypeSpecifierFromTemplateArgInfo(
 	if (arg_info.member_class_name.isValid()) {
 		substituted_spec.set_member_class_name(arg_info.member_class_name);
 	}
-	if (arg_info.function_signature.has_value()) {
-		substituted_spec.set_function_signature(*arg_info.function_signature);
+	if (arg_info.function_signature().has_value()) {
+		substituted_spec.set_function_signature(*arg_info.function_signature());
 	}
 	return substituted_spec;
 }
@@ -1246,7 +1246,7 @@ inline TemplateTypeArg rebindDependentTemplateTypeArg(
 		dependent_pattern.array_dimension_parameter_names.begin(),
 		dependent_pattern.array_dimension_parameter_names.end());
 	pattern_arg.is_array = dependent_pattern.is_array;
-	pattern_arg.function_signature = dependent_pattern.function_signature;
+	pattern_arg.function_signature = dependent_pattern.function_signature();
 	pattern_arg.dependent_name = dependent_pattern.dependent_name;
 	pattern_arg.is_dependent = dependent_pattern.dependent_name.isValid();
 	return rebindDependentTemplateTypeArg(substituted_arg, pattern_arg);
@@ -1356,7 +1356,7 @@ inline TemplateTypeArg materializeTemplateArg(
 				if (!arg_info.is_value && !substituted_arg.is_value) {
 					concrete_arg = rebindDependentTemplateTypeArg(substituted_arg, arg_info);
 					substituted_dependent_name = true;
-				} else if (arg_info.is_value && arg_info.dependent_expr.has_value() && !substituted_arg.is_value) {
+				} else if (arg_info.is_value && arg_info.dependent_expr().has_value() && !substituted_arg.is_value) {
 					// NTTP arg (e.g. bool) has a TypeTraitExpr stored in dependent_expr but the
 					// matched template parameter was a type (e.g. Head → Empty).  Copying the
 					// type arg verbatim into the value slot is incorrect.  Instead we leave
@@ -1397,7 +1397,7 @@ inline TemplateTypeArg materializeTemplateArg(
 			}
 		}
 	}
-	if (!substituted_dependent_name && arg_info.dependent_expr.has_value() && arg_info.is_value) {
+	if (!substituted_dependent_name && arg_info.dependent_expr().has_value() && arg_info.is_value) {
 		// For dependent NTTP expressions (e.g., sizeof(T)), evaluate with concrete args.
 		// Only attempted when a non-null evaluator callback is provided.
 		if constexpr (!std::is_null_pointer_v<std::decay_t<EvalFn>>) {
@@ -1405,7 +1405,7 @@ inline TemplateTypeArg materializeTemplateArg(
 				std::remove_cvref_t<decltype(*std::begin(template_params))>;
 			if constexpr (std::is_same_v<TemplateParamNodeType, ASTNode>) {
 				if (auto evaluated = eval_dependent_expr(
-						*arg_info.dependent_expr,
+						*arg_info.dependent_expr(),
 						std::span<const ASTNode>(std::data(template_params), std::size(template_params)),
 						std::span<const TemplateTypeArg>(std::data(template_args), std::size(template_args)))) {
 					concrete_arg = *evaluated;
@@ -1424,7 +1424,7 @@ inline TemplateTypeArg materializeTemplateArg(
 					}
 				}
 				if (auto evaluated = eval_dependent_expr(
-						*arg_info.dependent_expr,
+						*arg_info.dependent_expr(),
 						std::span<const ASTNode>(ast_template_params.data(), ast_template_params.size()),
 						std::span<const TemplateTypeArg>(std::data(template_args), std::size(template_args)))) {
 					concrete_arg = *evaluated;

--- a/src/TypeSizeQuery.h
+++ b/src/TypeSizeQuery.h
@@ -38,7 +38,7 @@ inline int queryTemplateArgInfoObjectSizeBits(const TypeInfo::TemplateArgInfo& a
 	}
 	if (arg_info.pointer_depth > 0 ||
 		arg_info.ref_qualifier != ReferenceQualifier::None ||
-		arg_info.function_signature.has_value()) {
+		arg_info.function_signature().has_value()) {
 		return 64;
 	}
 	if (arg_info.is_array) {


### PR DESCRIPTION
## Summary
- Move rare `TemplateArgInfo` fields (`function_signature`, `dependent_expr`) into `gTemplateArgInfoColdPayloads`, keeping a slim hot row with accessor methods.
- Shrink `sizeof(TemplateArgInfo)` from 376 to 216 bytes and `InlineVector<TemplateArgInfo,4>` from 1536 to 896 bytes.
- `TemplateTypeArg` parsing fields are unchanged; only stored `TypeInfo::TemplateArgInfo` uses the cold arena.

## Performance (warm median, 5 runs vs main)
- `type_traits`: TOTAL **-12%**, Parsing **-12%**
- `concepts`: TOTAL **-8%**, Parsing **-18%**
- `iterator`: TOTAL **-17%**, Parsing **-19%**
- `limits` (still errors): wall **-16%**

## Test plan
- [x] `./tests/run_all_tests.ps1` — 2782 regular + 240 `_fail`, all green
- [x] Warm-median `-time` compare vs main on `type_traits`, `concepts`, `limits`, `iterator`
- [x] CI

Made with [Cursor](https://cursor.com)