### PR TITLE
Fix SoftProbe operator() deferral and floating builtins for std headers

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3487,7 +3487,10 @@ private:	 // Resume private methods
 	// True when peek is '.' or '->' immediately followed by '*' (.* / ->*).
 	bool peek_is_pointer_to_member_operator();
 	std::optional<ASTNode> try_synthesize_atomic_builtin_overload(std::string_view builtin_name, std::span<const TypeSpecifierNode> arg_types, const Token& call_token);
-	void finalizePostfixCallExpression(
+	// Finalize `expr(args)` after parentheses are parsed. In SoftProbe/SFINAE contexts,
+	// a concrete no-match / ambiguous operator() must not hard-error: requires-expressions
+	// need a deferred placeholder so constraint checking can re-resolve after substitution.
+	ParseResult finalizePostfixCallExpression(
 		std::optional<ASTNode>& result,
 		const Token& paren_token,
 		ChunkedVector<ASTNode>&& args,
@@ -3512,6 +3515,12 @@ private:	 // Resume private methods
 		std::span<const TypeSpecifierNode> arg_types,
 		size_t argument_count,
 		bool all_arg_types_known);
+	// SoftProbe/ShapeOnly must not hard-fail on concrete operator() miss/ambiguity;
+	// clear *function and return nullopt so callers can emit a deferred placeholder.
+	// HardUse returns a diagnostic message that callers should surface as an error.
+	std::optional<std::string_view> consumeConcreteCallOperatorFailure(
+		ConcreteCallOperatorResolution::State state,
+		const FunctionDeclarationNode*& function);
 	const FunctionDeclarationNode* tryResolveQualifiedCallableObjectTemplateOperator(
 		const QualifiedIdentifierNode& receiver,
 		std::span<const TypeSpecifierNode> arg_types);

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -1763,6 +1763,15 @@ void Parser::register_builtin_functions() {
 	register_builtin("__builtin_fabsf", TypeCategory::Float, TypeCategory::Float);
 	register_builtin("__builtin_fabsl", TypeCategory::LongDouble, TypeCategory::LongDouble);
 
+	// Floating infinity / NaN builtins used by <limits> (MSVC numeric_limits specializations).
+	// GCC also accepts the double-underscore spellings.
+	register_no_param_builtin("__builtin_huge_valf", TypeCategory::Float);
+	register_no_param_builtin("__builtin_huge_valf__", TypeCategory::Float);
+	register_no_param_builtin("__builtin_huge_val", TypeCategory::Double);
+	register_no_param_builtin("__builtin_huge_val__", TypeCategory::Double);
+	register_no_param_builtin("__builtin_huge_vall", TypeCategory::LongDouble);
+	register_no_param_builtin("__builtin_huge_vall__", TypeCategory::LongDouble);
+
 	// Register optimization hint intrinsics
 	// __builtin_unreachable() - marks unreachable code paths
 	register_no_param_builtin("__builtin_unreachable", TypeCategory::Void);
@@ -1812,6 +1821,23 @@ void Parser::register_builtin_functions() {
 	const ASTNode float_type = make_builtin_type(TypeCategory::Float, CVQualifier::None, 0);
 	const ASTNode double_type = make_builtin_type(TypeCategory::Double, CVQualifier::None, 0);
 	const ASTNode long_double_type = make_builtin_type(TypeCategory::LongDouble, CVQualifier::None, 0);
+	const ASTNode const_char_ptr = make_builtin_type(TypeCategory::Char, CVQualifier::Const, 1);
+	// __builtin_nan* / __builtin_nans* take a const char* tag payload (used by <limits>).
+	auto register_nan_builtin = [&](std::string_view name, const ASTNode& return_type) {
+		register_extern_c_builtin(name, return_type, {const_char_ptr});
+	};
+	register_nan_builtin("__builtin_nanf", float_type);
+	register_nan_builtin("__builtin_nanf__", float_type);
+	register_nan_builtin("__builtin_nan", double_type);
+	register_nan_builtin("__builtin_nan__", double_type);
+	register_nan_builtin("__builtin_nanl", long_double_type);
+	register_nan_builtin("__builtin_nanl__", long_double_type);
+	register_nan_builtin("__builtin_nansf", float_type);
+	register_nan_builtin("__builtin_nansf__", float_type);
+	register_nan_builtin("__builtin_nans", double_type);
+	register_nan_builtin("__builtin_nans__", double_type);
+	register_nan_builtin("__builtin_nansl", long_double_type);
+	register_nan_builtin("__builtin_nansl__", long_double_type);
 	const ASTNode unsigned_short_type = make_builtin_type(TypeCategory::UnsignedShort, CVQualifier::None, 0);
 	const ASTNode unsigned_int_type = make_builtin_type(TypeCategory::UnsignedInt, CVQualifier::None, 0);
 	const ASTNode unsigned_long_long_type = make_builtin_type(TypeCategory::UnsignedLongLong, CVQualifier::None, 0);

--- a/src/Parser_Expr_PostfixCalls.cpp
+++ b/src/Parser_Expr_PostfixCalls.cpp
@@ -494,6 +494,29 @@ Parser::ConcreteCallOperatorResolution Parser::tryResolveConcreteCallOperator(
 	return {ConcreteCallOperatorResolution::State::NoViableMatch, nullptr};
 }
 
+std::optional<std::string_view> Parser::consumeConcreteCallOperatorFailure(
+	ConcreteCallOperatorResolution::State state,
+	const FunctionDeclarationNode*& function) {
+	if (state == ConcreteCallOperatorResolution::State::Ambiguous) {
+		if (isHardUseLikeInstantiationMode()) {
+			return "call to overloaded operator() is ambiguous"sv;
+		}
+		function = nullptr;
+		return std::nullopt;
+	}
+	if (state == ConcreteCallOperatorResolution::State::NoViableMatch) {
+		if (isHardUseLikeInstantiationMode()) {
+			return "callable object has no matching operator()"sv;
+		}
+		// SoftProbe / ShapeOnly: keep a deferred placeholder so requires-expressions
+		// can re-resolve after template argument substitution instead of hard-failing
+		// while the callable's other operator() overloads are still being declared.
+		function = nullptr;
+		return std::nullopt;
+	}
+	return std::nullopt;
+}
+
 const FunctionDeclarationNode*
 Parser::tryResolveQualifiedCallableObjectTemplateOperator(
 	const QualifiedIdentifierNode& receiver,
@@ -542,7 +565,7 @@ Parser::tryResolveQualifiedCallableObjectTemplateOperator(
 	return &instantiated_operator->as<FunctionDeclarationNode>();
 }
 
-void Parser::finalizePostfixCallExpression(
+ParseResult Parser::finalizePostfixCallExpression(
 	std::optional<ASTNode>& result,
 	const Token& paren_token,
 	ChunkedVector<ASTNode>&& args,
@@ -598,7 +621,7 @@ void Parser::finalizePostfixCallExpression(
 						result->as<ExpressionNode>(),
 						*function_pointer_return_type_hint);
 				}
-				return;
+				return ParseResult::success(*result);
 			}
 		}
 
@@ -643,7 +666,7 @@ void Parser::finalizePostfixCallExpression(
 							result->as<ExpressionNode>(),
 							*member_function_return_type_hint);
 					}
-					return;
+					return ParseResult::success(*result);
 				}
 			}
 		}
@@ -671,7 +694,7 @@ void Parser::finalizePostfixCallExpression(
 								true,
 								false,
 								std::nullopt);
-							return;
+							return ParseResult::success(*result);
 						}
 					}
 				}
@@ -708,11 +731,10 @@ void Parser::finalizePostfixCallExpression(
 			}
 		}
 	}
-	if (call_operator_resolution.state == ConcreteCallOperatorResolution::State::Ambiguous) {
-		throw CompileError("call to overloaded operator() is ambiguous");
-	}
-	if (call_operator_resolution.state == ConcreteCallOperatorResolution::State::NoViableMatch) {
-		throw CompileError("callable object has no matching operator()");
+	if (const std::optional<std::string_view> hard_failure =
+			consumeConcreteCallOperatorFailure(call_operator_resolution.state, func_ref);
+		hard_failure.has_value()) {
+		return ParseResult::error(std::string(*hard_failure), paren_token);
 	}
 	if (!func_ref) {
 		// Keep the deferred member-call representation for unresolved/dependent
@@ -735,6 +757,7 @@ void Parser::finalizePostfixCallExpression(
 			false,
 			*func_ref);
 	}
+	return ParseResult::success(*result);
 }
 
 std::optional<ASTNode> Parser::tryInstantiateMemberFunctionTemplateCall(
@@ -1618,7 +1641,14 @@ ParseResult Parser::apply_postfix_operators(ASTNode& start_result) {
 				return ParseResult::error("Expected ')' after function call arguments", current_token_);
 			}
 
-			finalizePostfixCallExpression(result, paren_token, std::move(args), std::move(args_result.arg_types));
+			if (ParseResult call_result = finalizePostfixCallExpression(
+					result,
+					paren_token,
+					std::move(args),
+					std::move(args_result.arg_types));
+				call_result.is_error()) {
+				return call_result;
+			}
 			continue;
 		}
 
@@ -2130,7 +2160,14 @@ ParseResult Parser::parse_postfix_expression(ExpressionContext context) {
 				return ParseResult::error("Expected ')' after function call arguments", current_token_);
 			}
 
-			finalizePostfixCallExpression(result, paren_token, std::move(args), std::move(arg_types));
+			if (ParseResult call_result = finalizePostfixCallExpression(
+					result,
+					paren_token,
+					std::move(args),
+					std::move(arg_types));
+				call_result.is_error()) {
+				return call_result;
+			}
 			continue;
 		}
 

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -5075,11 +5075,14 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						QualifiedIdentifierNode(
 							qual_id.namespace_handle(),
 							qual_id.identifier_token()));
-					finalizePostfixCallExpression(
-						result,
-						open_paren_token,
-						std::move(args),
-						std::move(arg_types));
+					if (ParseResult call_result = finalizePostfixCallExpression(
+							result,
+							open_paren_token,
+							std::move(args),
+							std::move(arg_types));
+						call_result.is_error()) {
+						return call_result;
+					}
 					return ParseResult::success(*result);
 				}
 
@@ -9627,16 +9630,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 							all_op_types_known);
 					const FunctionDeclarationNode* operator_call_func =
 						call_operator_resolution.function;
-					if (call_operator_resolution.state ==
-						ConcreteCallOperatorResolution::State::Ambiguous) {
+					if (const std::optional<std::string_view> hard_failure =
+							consumeConcreteCallOperatorFailure(
+								call_operator_resolution.state,
+								operator_call_func);
+						hard_failure.has_value()) {
 						return ParseResult::error(
-							"call to overloaded operator() is ambiguous",
-							identifier_token);
-					}
-					if (call_operator_resolution.state ==
-						ConcreteCallOperatorResolution::State::NoViableMatch) {
-						return ParseResult::error(
-							"operator() not found in struct",
+							std::string(*hard_failure),
 							identifier_token);
 					}
 					if (operator_call_func == nullptr) {

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -8,8 +8,8 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 | Header | Test File | Status | Notes |
 |--------|-----------|--------|-------|
-| `<limits>` | `test_std_limits.cpp` | ❌ Compile Error | ~8.8s wall (retested 2026-07-24, Windows/MSVC STL 14.44). IR conversion: `infinity` / `quiet_NaN` / `signaling_NaN` sema missed return conversion (`double` → `long double`). |
-| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~2000ms (`TOTAL`) / ~7.2s wall (retested 2026-07-24, Windows/MSVC STL 14.44). TypeInfo cold-arena + slim `TemplateArgInfo` + template-arg-list interning. |
+| `<limits>` | `test_std_limits.cpp` | ❌ Compile Error | ~6.2s wall (retested 2026-07-25, Windows/MSVC STL 14.44). Prior `infinity`/`quiet_NaN`/`signaling_NaN` `double`→`long double` return-conversion stop is gone after registering `__builtin_huge_val*` / `__builtin_nan*` / `__builtin_nans*`. Current stop: semantic errors in `wmemchr` / `wmemcmp` (`Operator=` not defined). |
+| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~1221ms (`TOTAL`) / ~1.3s wall (retested 2026-07-25, Windows/MSVC STL 14.44). |
 | `<compare>` | `test_std_compare_ret42.cpp` | ✅ Compiled | ~0.06s (retested 2026-05-23, Linux/libstdc++-14). |
 | `<version>` | `test_std_version.cpp` | ✅ Compiled | ~41ms |
 | `<source_location>` | `test_std_source_location.cpp` | ✅ Compiled | ~41ms |
@@ -19,7 +19,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<optional>` | `test_std_optional.cpp` | 💥 Crash | ~3.30s wall (retested 2026-05-28, Linux/libstdc++-14). Current run now gets past the older `_Optional_payload_base` category-25/codegen stop and instead crashes after a constexpr/static-assert frontier: `Dependent function/variable template call in constant expression: is_same_v`. |
 | `<any>` | `test_std_any.cpp` | ✅ Compiled | ~1052ms (retested 2026-05-25, Linux/libstdc++-14). |
 | `<utility>` | `test_std_utility.cpp` | ✅ Compiled | ~1524ms (retested 2026-05-25, Linux/libstdc++-14). |
-| `<concepts>` | `test_std_concepts.cpp` | ❌ Compile Error | ~1230ms (`TOTAL`) / ~4.3s wall (retested 2026-07-24, Windows/MSVC STL 14.44). Current first hard stop: `callable object has no matching operator()`. |
+| `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~1284ms (`TOTAL`) / ~1.3s wall (retested 2026-07-25, Windows/MSVC STL 14.44). SoftProbe no longer hard-fails `ranges::_Swap::_Cpo` array-overload `requires requires(Cpo fn) { fn(t[0], u[0]); }` while other `operator()` overloads are still being declared. |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~1083ms (retested 2026-05-23, Linux/libstdc++-14). |
 | `<string_view>` | `test_std_string_view.cpp` | ❌ Codegen Error | ~4.58s wall (retested 2026-05-27, Linux/libstdc++-14). First stop remains unresolved direct-call return type (`Type with no runtime size reached codegen in direct call return size`, type category 25) with repeated `to_address` instantiation failures; `_CharT` constructor-call struct-info failures still appear in `char_traits`. |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~6.19s (`TOTAL`) / ~6.68s wall (retested 2026-05-27, Linux/libstdc++-14). Completed class-template cache hits no longer consume template-depth budget; current first hard error is now depth-guarded recursive `basic_string` instantiation. |
@@ -48,7 +48,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeinfo>` | `test_std_typeinfo_ret0.cpp` | ✅ Compiled | ~46ms (retested 2026-04-30, Linux/libstdc++-14). Sema now models pointer arithmetic (`T* + integral`, `T* - integral`, `T* - T*`) so the ternary in `type_info::name()` (`__name[0] == '*' ? __name + 1 : __name`) gets a sema-owned exact result type and codegen no longer throws. Regression: `tests/test_ternary_pointer_arithmetic_branches_ret0.cpp`. |
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ✅ Compiled | ~7529ms (retested 2026-05-25, Linux/libstdc++-14). **NOW WORKS**: ternary common-type fix resolved `numeric_limits` member constexpr folding. Builtin `__builtin_huge_val`/`__builtin_nan` families now handled in constexpr evaluator. |
-| `<iterator>` | `test_std_iterator.cpp` | ❌ Compile Error | ~6750ms (`TOTAL`) / ~9.9s wall (retested 2026-07-24, Windows/MSVC STL 14.44). Now stops earlier with `callable object has no matching operator()` plus `std::swap` overload failures (was codegen error on 2026-07-23). |
+| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~10.7s wall (retested 2026-07-25, Windows/MSVC STL 14.44). Shared SoftProbe `operator()` fix unblocked parse; now reaches IR/codegen (`view_interface` layout/`operator==`, init conversions, late `swap` callable miss). |
 | `<variant>` | `test_std_variant.cpp` | ✅ Compiled | ~736ms (retested 2026-04-24, Linux/libstdc++). **NEW: Now compiles successfully on Linux!** The `_Variadic_union` arithmetic non-type template argument (`_Np-1`) inside a member initializer is now resolved. |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
@@ -100,6 +100,30 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<generator>` | N/A | ❌ Compile Error | ~2593ms (retested 2026-04-11). Call to deleted function 'swap' — previously was a parse error, now parses successfully. (C++23) |
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
+
+### 2026-07-25 Windows/MSVC SoftProbe operator() + floating builtins follow-up
+
+Fixes landed (parser SoftProbe / compiler builtins):
+
+- **`finalizePostfixCallExpression` no longer throws on concrete `operator()` miss/ambiguity in SoftProbe/ShapeOnly.** MSVC `<concepts>` `ranges::_Swap::_Cpo` declares an array overload whose nested `requires requires(_Cpo __fn) { __fn(__t[0], __u[0]); }` must soft-defer while sibling `operator()` templates are still being parsed; hard-failing there blocked the whole header. Shared helper: `consumeConcreteCallOperatorFailure`.
+- **Register `__builtin_huge_val{,f,l}` / `__builtin_nan{,f,l}` / `__builtin_nans{,f,l}`** (and GCC `__` spellings) so `numeric_limits<long double>::infinity` / `quiet_NaN` / `signaling_NaN` resolve as real calls. That removes the prior IR `sema missed return conversion (double -> long double)` stop for those members.
+
+Regression coverage:
+
+- `tests/test_requires_cpo_no_match_soft_fail_ret0.cpp`
+- `tests/test_ranges_swap_cpo_msvc_pattern_ret0.cpp`
+- `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp` (now passes end-to-end)
+- `tests/test_return_double_to_long_double_ret0.cpp`
+- `tests/test_return_builtin_double_to_long_double_ret0.cpp`
+
+Validation snapshot (`x64/Sharded/FlashCppMSVC.exe`, Windows/MSVC STL 14.44; compile-only `TOTAL` from timing table where available; runner wall includes compile/link/run for full tests):
+
+| Header/Test | Status | Compile `TOTAL` | Runner wall | First-order stop / note |
+|-------------|--------|-----------------|-------------|-------------------------|
+| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~1221ms | ~1.3s | Still compiles. |
+| `<concepts>` (`test_std_concepts.cpp`) | ✅ Pass | ~1284ms | ~1.3s / full run OK | Was `callable object has no matching operator()`; now compiles, links, returns 0. |
+| `<limits>` (`test_std_limits.cpp`) | ❌ Semantic error | (fails after parse) | ~6.2s | Infinity/NaN return-conversion stop gone. Current: `wmemchr` / `wmemcmp` `Operator=` not defined. |
+| `<iterator>` (`test_std_iterator.cpp`) | ❌ Codegen/IR | (fails in IR) | ~10.7s | Past shared `operator()` parse stop; IR/`view_interface` / conversion / late `swap` remain. |
 
 ### 2026-07-24 Windows/MSVC TypeInfo memory / template-arg interning follow-up
 

--- a/tests/test_ranges_swap_cpo_msvc_pattern_ret0.cpp
+++ b/tests/test_ranges_swap_cpo_msvc_pattern_ret0.cpp
@@ -1,0 +1,70 @@
+// Closer reproduction of MSVC <concepts> ranges::_Swap::_Cpo
+template <class T, class U>
+constexpr bool is_same_v = false;
+template <class T>
+constexpr bool is_same_v<T, T> = true;
+
+template <class T>
+struct remove_reference { using type = T; };
+template <class T>
+struct remove_reference<T&> { using type = T; };
+template <class T>
+struct remove_reference<T&&> { using type = T; };
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T>
+concept class_or_enum =
+	__is_class(remove_reference_t<T>) || __is_enum(remove_reference_t<T>) || __is_union(remove_reference_t<T>);
+
+template <class T>
+concept move_constructible = true;
+template <class T, class U>
+concept assignable_from = true;
+
+namespace ranges {
+namespace SwapDetail {
+template <class T>
+void swap(T&, T&) = delete;
+
+template <class T1, class T2>
+concept use_adl_swap =
+	(class_or_enum<T1> || class_or_enum<T2>) && requires(T1&& t, T2&& u) {
+		swap(static_cast<T1&&>(t), static_cast<T2&&>(u));
+	};
+
+struct Cpo {
+	template <class T1, class T2>
+		requires use_adl_swap<T1, T2>
+	static constexpr void operator()(T1&& t, T2&& u) {
+		swap(static_cast<T1&&>(t), static_cast<T2&&>(u));
+	}
+
+	template <class T>
+		requires (!use_adl_swap<T&, T&> && move_constructible<T> && assignable_from<T&, T>)
+	static constexpr void operator()(T& x, T& y) {
+		T tmp(static_cast<T&&>(x));
+		x = static_cast<T&&>(y);
+		y = static_cast<T&&>(tmp);
+	}
+
+	template <class T1, class T2, unsigned long long Size>
+	static constexpr void operator()(T1 (&t)[Size], T2 (&u)[Size])
+		requires requires(Cpo fn) { fn(t[0], u[0]); }
+	{
+		for (unsigned long long i = 0; i < Size; ++i) {
+			operator()(t[i], u[i]);
+		}
+	}
+};
+} // namespace SwapDetail
+
+inline constexpr SwapDetail::Cpo swap{};
+} // namespace ranges
+
+int main() {
+	int left = 1;
+	int right = 2;
+	ranges::swap(left, right);
+	return left == 2 && right == 1 ? 0 : 1;
+}

--- a/tests/test_requires_cpo_no_match_soft_fail_ret0.cpp
+++ b/tests/test_requires_cpo_no_match_soft_fail_ret0.cpp
@@ -1,0 +1,14 @@
+// Minimal: nested requires calling CPO with no viable operator() must soft-fail, not hard-error.
+struct Cpo {
+	template <class T>
+	static constexpr void operator()(T (&)[2])
+		requires requires(Cpo fn, T x) { fn(x); }
+	{
+		(void)0;
+	}
+};
+
+int main() {
+	(void)sizeof(Cpo);
+	return 0;
+}

--- a/tests/test_return_builtin_double_to_long_double_ret0.cpp
+++ b/tests/test_return_builtin_double_to_long_double_ret0.cpp
@@ -1,0 +1,40 @@
+// Closer to MSVC numeric_limits<long double>::infinity / quiet_NaN / signaling_NaN
+long double infinity_ld() {
+	return __builtin_huge_val();
+}
+
+long double quiet_nan_ld() {
+	return __builtin_nan("0");
+}
+
+long double signaling_nan_ld() {
+	return __builtin_nans("1");
+}
+
+struct LimitsLike {
+	static long double infinity() noexcept {
+		return __builtin_huge_val();
+	}
+	static long double quiet_NaN() noexcept {
+		return __builtin_nan("0");
+	}
+	static long double signaling_NaN() noexcept {
+		return __builtin_nans("1");
+	}
+};
+
+int main() {
+	volatile long double a = infinity_ld();
+	volatile long double b = quiet_nan_ld();
+	volatile long double c = signaling_nan_ld();
+	volatile long double d = LimitsLike::infinity();
+	volatile long double e = LimitsLike::quiet_NaN();
+	volatile long double f = LimitsLike::signaling_NaN();
+	(void)a;
+	(void)b;
+	(void)c;
+	(void)d;
+	(void)e;
+	(void)f;
+	return 0;
+}

--- a/tests/test_return_double_to_long_double_ret0.cpp
+++ b/tests/test_return_double_to_long_double_ret0.cpp
@@ -1,0 +1,17 @@
+// Regression: returning a double expression from a long-double function
+// must receive a sema-owned return conversion annotation.
+long double from_double_literal() {
+	return 1.0; // double -> long double
+}
+
+long double from_double_var(double value) {
+	return value; // double -> long double
+}
+
+int main() {
+	volatile long double a = from_double_literal();
+	volatile long double b = from_double_var(2.0);
+	(void)a;
+	(void)b;
+	return 0;
+}


### PR DESCRIPTION
## Summary
- Soft-defer concrete operator() miss/ambiguity in SoftProbe/ShapeOnly so MSVC ranges::_Swap::_Cpo nested requires-expressions do not hard-fail while sibling overloads are still being declared.
- Register __builtin_huge_val*, __builtin_nan*, and __builtin_nans* builtins so numeric_limits<long double> infinity/NaN members resolve and return-conversion sema can run.
- Unblocks <concepts> on Windows/MSVC STL; moves <limits> past the prior double->long double return-conversion stop.

## Test plan
- [x] pwsh tests/run_all_tests.ps1 test_requires_cpo_no_match_soft_fail_ret0.cpp
- [x] pwsh tests/run_all_tests.ps1 test_ranges_swap_cpo_msvc_pattern_ret0.cpp
- [x] pwsh tests/run_all_tests.ps1 test_std_concepts_ranges_swap_int_ret0.cpp
- [x] pwsh tests/run_all_tests.ps1 test_return_double_to_long_double_ret0.cpp
- [x] pwsh tests/run_all_tests.ps1 test_return_builtin_double_to_long_double_ret0.cpp
- [x] pwsh tests/run_all_tests.ps1 test_std_concepts.cpp
- [x] Updated tests/std/README_STANDARD_HEADERS.md with retested timings

Made with [Cursor](https://cursor.com)