### PR TITLE
Fix typedef-union assignment for MSVC <limits> path

### DIFF
--- a/src/IrGenerator_MemberAccess.cpp
+++ b/src/IrGenerator_MemberAccess.cpp
@@ -3583,6 +3583,17 @@ bool AstToIr::isExprConstQualified(const ASTNode& expr_node) const {
 		return nullptr;
 	};
 
+	// True when the expression names a const *object* (C++ [dcl.type.cv]).
+	// For pointers, only the outermost *'s cv-qualifiers apply — `const T*` is a
+	// mutable pointer to const T, while `T* const` is a const pointer.
+	auto isObjectConstQualified = [](const TypeSpecifierNode& ts) -> bool {
+		if (ts.pointer_depth() > 0) {
+			const PointerLevel& outer = ts.pointer_levels().back();
+			return (static_cast<uint8_t>(outer.cv_qualifier) & static_cast<uint8_t>(CVQualifier::Const)) != 0;
+		}
+		return ts.is_const();
+	};
+
 	// IdentifierNode — look up in symbol_table, check if the declaration is const
 	if (std::holds_alternative<IdentifierNode>(expr)) {
 		const IdentifierNode& id = std::get<IdentifierNode>(expr);
@@ -3590,7 +3601,7 @@ bool AstToIr::isExprConstQualified(const ASTNode& expr_node) const {
 		if (!sym.has_value())
 			return false;
 		const TypeSpecifierNode* ts = getTypeSpec(*sym);
-		return ts && ts->is_const();
+		return ts && isObjectConstQualified(*ts);
 	}
 
 	// *ptr — dereference of const T* yields const T
@@ -3614,7 +3625,7 @@ bool AstToIr::isExprConstQualified(const ASTNode& expr_node) const {
 	}
 
 	if (auto expr_type = parser_.get_expression_type(expr_node); expr_type.has_value()) {
-		return expr_type->is_const();
+		return isObjectConstQualified(*expr_type);
 	}
 
 	return false;

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -2104,6 +2104,40 @@ inline BinaryOperatorCandidateComparison compareBinaryOperatorCandidateRanks(
 	return BinaryOperatorCandidateComparison::Incomparable;
 }
 
+// Same rank comparison, then C++20 [over.ics.rank]/3.2.3 rvalue→T&& vs const T&
+// preference on the right-hand operand (shared with free-function overload resolution).
+inline BinaryOperatorCandidateComparison compareBinaryOperatorCandidatesWithRefTiebreak(
+	ConversionRank lhs_lhs_rank,
+	ConversionRank lhs_rhs_rank,
+	const TypeSpecifierNode* lhs_rhs_param,
+	ConversionRank rhs_lhs_rank,
+	ConversionRank rhs_rhs_rank,
+	const TypeSpecifierNode* rhs_rhs_param,
+	const TypeSpecifierNode& right_arg_spec) {
+	BinaryOperatorCandidateComparison rank_cmp = compareBinaryOperatorCandidateRanks(
+		lhs_lhs_rank,
+		lhs_rhs_rank,
+		rhs_lhs_rank,
+		rhs_rhs_rank);
+	if (rank_cmp != BinaryOperatorCandidateComparison::Equivalent) {
+		return rank_cmp;
+	}
+	if (lhs_rhs_param == nullptr || rhs_rhs_param == nullptr) {
+		return BinaryOperatorCandidateComparison::Equivalent;
+	}
+
+	ArgumentConversionInfo lhs_info{lhs_rhs_rank, lhs_rhs_param, true};
+	ArgumentConversionInfo rhs_info{rhs_rhs_rank, rhs_rhs_param, true};
+	const int tie = compareArgumentConversionInfo(right_arg_spec, lhs_info, rhs_info);
+	if (tie < 0) {
+		return BinaryOperatorCandidateComparison::Better;
+	}
+	if (tie > 0) {
+		return BinaryOperatorCandidateComparison::Worse;
+	}
+	return BinaryOperatorCandidateComparison::Equivalent;
+}
+
 // Find operator overload in a struct type
 // Returns the member function that overloads the given operator, or nullptr if not found
 inline OperatorOverloadResult findUnaryOperatorOverload(TypeIndex operand_type_index, OverloadableOperator operator_kind) {
@@ -2269,6 +2303,7 @@ inline OperatorOverloadResult findBinaryOperatorOverload(
 		ConversionRank lhs_rank;
 		ConversionRank rhs_rank;
 		const StructMemberFunction* member_func = nullptr;
+		const TypeSpecifierNode* rhs_param_type = nullptr;
 	};
 	std::vector<OperatorCandidate> candidates;
 
@@ -2308,14 +2343,15 @@ inline OperatorOverloadResult findBinaryOperatorOverload(
 			if (lhs_rank == ConversionRank::NoMatch)
 				continue;
 
+			const TypeSpecifierNode& rhs_param_spec = param_type_node.as<TypeSpecifierNode>();
 			ConversionRank rhs_rank = rankBinaryOperatorOperandMatch(
 				right_type_spec,
-				param_type_node.as<TypeSpecifierNode>(),
+				rhs_param_spec,
 				struct_idx);
 			if (rhs_rank == ConversionRank::NoMatch)
 				continue;
 
-			candidates.push_back({lhs_rank, rhs_rank, &member_func});
+			candidates.push_back({lhs_rank, rhs_rank, &member_func, &rhs_param_spec});
 		}
 
 		for (const auto& base_spec : si->base_classes) {
@@ -2340,11 +2376,14 @@ inline OperatorOverloadResult findBinaryOperatorOverload(
 		for (size_t j = 0; j < candidates.size(); ++j) {
 			if (i == j)
 				continue;
-			if (compareBinaryOperatorCandidateRanks(
+			if (compareBinaryOperatorCandidatesWithRefTiebreak(
 					candidates[j].lhs_rank,
 					candidates[j].rhs_rank,
+					candidates[j].rhs_param_type,
 					candidate.lhs_rank,
-					candidate.rhs_rank) == BinaryOperatorCandidateComparison::Better) {
+					candidate.rhs_rank,
+					candidate.rhs_param_type,
+					right_type_spec) == BinaryOperatorCandidateComparison::Better) {
 				is_dominated = true;
 				break;
 			}
@@ -2401,6 +2440,7 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 		const StructMemberFunction* member_func = nullptr;
 		const FunctionDeclarationNode* free_func = nullptr;
 		bool is_free_function = false;
+		const TypeSpecifierNode* rhs_param_type = nullptr;
 	};
 	std::vector<OperatorCandidate> candidates;
 
@@ -2445,12 +2485,13 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 			if (lhs_rank == ConversionRank::NoMatch)
 				continue;
 
+			const TypeSpecifierNode& rhs_param_spec = param_type_node.as<TypeSpecifierNode>();
 			ConversionRank rhs_rank = rankBinaryOperatorOperandMatch(
 				right_type_spec,
-				param_type_node.as<TypeSpecifierNode>(),
+				rhs_param_spec,
 				struct_idx);
 			if (rhs_rank != ConversionRank::NoMatch) {
-				candidates.push_back({lhs_rank, rhs_rank, &member_func, nullptr, false});
+				candidates.push_back({lhs_rank, rhs_rank, &member_func, nullptr, false, &rhs_param_spec});
 			}
 		}
 
@@ -2501,7 +2542,7 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 		if (rhs_rank == ConversionRank::NoMatch)
 			continue;
 
-		candidates.push_back({lhs_rank, rhs_rank, nullptr, &func_decl, true});
+		candidates.push_back({lhs_rank, rhs_rank, nullptr, &func_decl, true, &p1_spec});
 	}
 
 	// --- 3. Rank all candidates per [over.match.best]/2 ---
@@ -2519,11 +2560,14 @@ inline OperatorOverloadResult findBinaryOperatorOverloadWithFreeFunction(
 		for (size_t j = 0; j < candidates.size(); ++j) {
 			if (i == j)
 				continue;
-			if (compareBinaryOperatorCandidateRanks(
+			if (compareBinaryOperatorCandidatesWithRefTiebreak(
 					candidates[j].lhs_rank,
 					candidates[j].rhs_rank,
+					candidates[j].rhs_param_type,
 					candidate.lhs_rank,
-					candidate.rhs_rank) == BinaryOperatorCandidateComparison::Better) {
+					candidate.rhs_rank,
+					candidate.rhs_param_type,
+					right_type_spec) == BinaryOperatorCandidateComparison::Better) {
 				is_dominated = true;
 				break;
 			}

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3127,6 +3127,14 @@ private:
 		StructTypeInfo& struct_info,
 		TypeIndex self_type_index,
 		StringHandle instantiated_name);
+	// Synthesize C++20 implicit special members for a class that has no user-declared
+	// constructors/assignment/destructor yet (e.g. typedef struct/union { ... } Alias).
+	void synthesize_implicit_special_members_for_aggregate(
+		StructTypeInfo& struct_info,
+		StructDeclarationNode& struct_ref,
+		TypeIndex struct_type_index,
+		StringHandle qualified_struct_name,
+		const Token& name_token);
 
 	std::optional<bool> try_parse_out_of_line_template_member(const InlineVector<TemplateParameterNode, 4>& template_params, const InlineVector<StringHandle, 4>& template_param_names, const InlineVector<TemplateParameterNode, 4>& inner_template_params, const InlineVector<StringHandle, 4>& inner_template_param_names);	 // NEW: Parse out-of-line template member function
 	bool try_apply_deduction_guides(TypeSpecifierNode& type_specifier, const InitializerListNode& init_list);

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -5041,6 +5041,143 @@ ParseResult Parser::parse_template_friend_declaration(StructDeclarationNode& str
 	return saved_position.success(friend_node);
 }
 
+void Parser::synthesize_implicit_special_members_for_aggregate(
+	StructTypeInfo& struct_info,
+	StructDeclarationNode& struct_ref,
+	TypeIndex struct_type_index,
+	StringHandle qualified_struct_name,
+	const Token& name_token) {
+	// Typedef inline struct/union bodies do not parse member functions, so there are
+	// never user-declared special members here. Still honor C++20 rules and skip
+	// during class-template pattern parsing (instantiation synthesizes later).
+	if (parsing_template_class_) {
+		return;
+	}
+
+	{
+		auto [default_ctor_node, default_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
+			qualified_struct_name,
+			qualified_struct_name);
+		auto [block_node, block_ref] = create_node_ref(BlockNode());
+		default_ctor_ref.set_definition(block_node);
+		default_ctor_ref.set_is_implicit(true);
+		struct_info.addConstructor(default_ctor_node, AccessSpecifier::Public);
+		struct_ref.add_constructor(default_ctor_node, AccessSpecifier::Public);
+	}
+
+	{
+		auto [copy_ctor_node, copy_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
+			qualified_struct_name,
+			qualified_struct_name);
+		auto param_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::Const,
+			ReferenceQualifier::None);
+		param_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::LValueReference);
+		Token param_token(Token::Type::Identifier, "other"sv, 0, 0, 0);
+		auto param_decl_node = emplace_node<DeclarationNode>(param_type_node, param_token);
+		copy_ctor_ref.add_parameter_node(param_decl_node);
+		auto [copy_block_node, copy_block_ref] = create_node_ref(BlockNode());
+		copy_ctor_ref.set_definition(copy_block_node);
+		copy_ctor_ref.set_is_implicit(true);
+		struct_info.addConstructor(copy_ctor_node, AccessSpecifier::Public);
+		struct_ref.add_constructor(copy_ctor_node, AccessSpecifier::Public);
+	}
+
+	{
+		auto return_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		return_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::LValueReference);
+		Token operator_name_token(Token::Type::Identifier, "operator="sv,
+								  name_token.line(), name_token.column(),
+								  name_token.file_index());
+		auto operator_decl_node = emplace_node<DeclarationNode>(return_type_node, operator_name_token);
+		auto [func_node, func_ref] = emplace_node_ref<FunctionDeclarationNode>(
+			operator_decl_node.as<DeclarationNode>(), qualified_struct_name);
+		auto param_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::Const,
+			ReferenceQualifier::None);
+		param_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::LValueReference);
+		Token param_token(Token::Type::Identifier, "other"sv, 0, 0, 0);
+		auto param_decl_node = emplace_node<DeclarationNode>(param_type_node, param_token);
+		func_ref.add_parameter_node(param_decl_node);
+		auto [op_block_node, op_block_ref] = create_node_ref(BlockNode());
+		func_ref.set_definition(op_block_node);
+		finalize_function_after_definition(func_ref);
+		func_ref.set_is_implicit(true);
+		struct_info.addOperatorOverload(
+			OverloadableOperator::CopyAssign,
+			func_node,
+			AccessSpecifier::Public);
+		struct_ref.add_operator_overload(OverloadableOperator::CopyAssign, func_node, AccessSpecifier::Public);
+	}
+
+	{
+		auto [move_ctor_node, move_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
+			qualified_struct_name,
+			qualified_struct_name);
+		auto param_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		param_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::RValueReference);
+		Token param_token(Token::Type::Identifier, "other"sv, 0, 0, 0);
+		auto param_decl_node = emplace_node<DeclarationNode>(param_type_node, param_token);
+		move_ctor_ref.add_parameter_node(param_decl_node);
+		auto [move_block_node, move_block_ref] = create_node_ref(BlockNode());
+		move_ctor_ref.set_definition(move_block_node);
+		move_ctor_ref.set_is_implicit(true);
+		struct_info.addConstructor(move_ctor_node, AccessSpecifier::Public);
+		struct_ref.add_constructor(move_ctor_node, AccessSpecifier::Public);
+	}
+
+	{
+		auto return_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		return_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::LValueReference);
+		Token move_operator_name_token(Token::Type::Identifier, "operator="sv,
+									   name_token.line(), name_token.column(),
+									   name_token.file_index());
+		auto move_operator_decl_node = emplace_node<DeclarationNode>(return_type_node, move_operator_name_token);
+		auto [move_func_node, move_func_ref] = emplace_node_ref<FunctionDeclarationNode>(
+			move_operator_decl_node.as<DeclarationNode>(), qualified_struct_name);
+		auto move_param_type_node = emplace_node<TypeSpecifierNode>(
+			struct_type_index.withCategory(TypeCategory::Struct),
+			struct_info.sizeInBits().value,
+			name_token,
+			CVQualifier::None,
+			ReferenceQualifier::None);
+		move_param_type_node.as<TypeSpecifierNode>().set_reference_qualifier(ReferenceQualifier::RValueReference);
+		Token move_param_token(Token::Type::Identifier, "other"sv, 0, 0, 0);
+		auto move_param_decl_node = emplace_node<DeclarationNode>(move_param_type_node, move_param_token);
+		move_func_ref.add_parameter_node(move_param_decl_node);
+		auto [move_op_block_node, move_op_block_ref] = create_node_ref(BlockNode());
+		move_func_ref.set_definition(move_op_block_node);
+		finalize_function_after_definition(move_func_ref);
+		move_func_ref.set_is_implicit(true);
+		struct_info.addOperatorOverload(
+			OverloadableOperator::MoveAssign,
+			move_func_node,
+			AccessSpecifier::Public);
+		struct_ref.add_operator_overload(OverloadableOperator::MoveAssign, move_func_node, AccessSpecifier::Public);
+	}
+}
+
 // Helper: register a friend declaration in StructTypeInfo, handling all FriendKinds and
 // adding the namespace-qualified form so access checks against fully-qualified names match.
 // Does NOT add the node to the struct's AST friend list (callers that need that call

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -1908,12 +1908,28 @@ ParseResult Parser::parse_typedef_declaration() {
 			struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
 		}
 
+		// Typedef inline struct/union parsing does not walk member functions, so
+		// synthesize the C++20 implicit special members that normal class parsing
+		// would have emitted (needed for MSVC __m128i / wchar.h wmemchr patterns).
+		Token struct_name_token(
+			Token::Type::Identifier,
+			StringTable::getStringView(struct_name_for_typedef),
+			0,
+			0,
+			0);
+		synthesize_implicit_special_members_for_aggregate(
+			*struct_info,
+			struct_ref,
+			struct_type_index,
+			struct_name_for_typedef,
+			struct_name_token);
+
 		// Create type specifier for the struct
 		// Note: Use struct_type_info.getStructInfo() — payload already attached via createStructInfo
 		type_spec = TypeSpecifierNode(
 			struct_type_index.withCategory(TypeCategory::Struct),
 			static_cast<int>(struct_type_info.getStructInfo()->sizeInBits().value),
-			Token(Token::Type::Identifier, StringTable::getStringView(struct_name_for_typedef), 0, 0, 0),
+			struct_name_token,
 			CVQualifier::None,
 			ReferenceQualifier::None);
 		type_node = emplace_node<TypeSpecifierNode>(type_spec);

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -4,11 +4,11 @@ This directory contains test files for C++ standard library headers to assess Fl
 
 ## Current Status
 
-> **Note (2026-05-05 `__is_complete_or_unbounded` follow-up):** the rows below still include historical timings from earlier hosts and commits.  The authoritative current Linux/libstdc++-14 state for the retested `tests/std/test_std_*.cpp` files is the latest dated section below the table.
+> **Note:** The table **Notes** column is the current stop per header. Dated sections below are brief history, not a full changelog.
 
 | Header | Test File | Status | Notes |
 |--------|-----------|--------|-------|
-| `<limits>` | `test_std_limits.cpp` | ❌ Compile Error | ~6.2s wall (retested 2026-07-25, Windows/MSVC STL 14.44). Prior `infinity`/`quiet_NaN`/`signaling_NaN` `double`→`long double` return-conversion stop is gone after registering `__builtin_huge_val*` / `__builtin_nan*` / `__builtin_nans*`. Current stop: semantic errors in `wmemchr` / `wmemcmp` (`Operator=` not defined). |
+| `<limits>` | `test_std_limits.cpp` | ❌ Link Error | ~6s wall (Windows/MSVC STL 14.44). Compiles; link fails on `_mm_*` / `_mm256_*` / `_BitScanForward*` / `_Avx2WmemEnabled` from UCRT `wmemchr`/`wmemcmp`. |
 | `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~1221ms (`TOTAL`) / ~1.3s wall (retested 2026-07-25, Windows/MSVC STL 14.44). |
 | `<compare>` | `test_std_compare_ret42.cpp` | ✅ Compiled | ~0.06s (retested 2026-05-23, Linux/libstdc++-14). |
 | `<version>` | `test_std_version.cpp` | ✅ Compiled | ~41ms |
@@ -19,7 +19,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<optional>` | `test_std_optional.cpp` | 💥 Crash | ~3.30s wall (retested 2026-05-28, Linux/libstdc++-14). Current run now gets past the older `_Optional_payload_base` category-25/codegen stop and instead crashes after a constexpr/static-assert frontier: `Dependent function/variable template call in constant expression: is_same_v`. |
 | `<any>` | `test_std_any.cpp` | ✅ Compiled | ~1052ms (retested 2026-05-25, Linux/libstdc++-14). |
 | `<utility>` | `test_std_utility.cpp` | ✅ Compiled | ~1524ms (retested 2026-05-25, Linux/libstdc++-14). |
-| `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~1284ms (`TOTAL`) / ~1.3s wall (retested 2026-07-25, Windows/MSVC STL 14.44). SoftProbe no longer hard-fails `ranges::_Swap::_Cpo` array-overload `requires requires(Cpo fn) { fn(t[0], u[0]); }` while other `operator()` overloads are still being declared. |
+| `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~1.3s wall (Windows/MSVC STL 14.44). |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~1083ms (retested 2026-05-23, Linux/libstdc++-14). |
 | `<string_view>` | `test_std_string_view.cpp` | ❌ Codegen Error | ~4.58s wall (retested 2026-05-27, Linux/libstdc++-14). First stop remains unresolved direct-call return type (`Type with no runtime size reached codegen in direct call return size`, type category 25) with repeated `to_address` instantiation failures; `_CharT` constructor-call struct-info failures still appear in `char_traits`. |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~6.19s (`TOTAL`) / ~6.68s wall (retested 2026-05-27, Linux/libstdc++-14). Completed class-template cache hits no longer consume template-depth budget; current first hard error is now depth-guarded recursive `basic_string` instantiation. |
@@ -48,7 +48,7 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<typeinfo>` | `test_std_typeinfo_ret0.cpp` | ✅ Compiled | ~46ms (retested 2026-04-30, Linux/libstdc++-14). Sema now models pointer arithmetic (`T* + integral`, `T* - integral`, `T* - T*`) so the ternary in `type_info::name()` (`__name[0] == '*' ? __name + 1 : __name`) gets a sema-owned exact result type and codegen no longer throws. Regression: `tests/test_ternary_pointer_arithmetic_branches_ret0.cpp`. |
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ✅ Compiled | ~7529ms (retested 2026-05-25, Linux/libstdc++-14). **NOW WORKS**: ternary common-type fix resolved `numeric_limits` member constexpr folding. Builtin `__builtin_huge_val`/`__builtin_nan` families now handled in constexpr evaluator. |
-| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~10.7s wall (retested 2026-07-25, Windows/MSVC STL 14.44). Shared SoftProbe `operator()` fix unblocked parse; now reaches IR/codegen (`view_interface` layout/`operator==`, init conversions, late `swap` callable miss). |
+| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~10.7s wall (Windows/MSVC STL 14.44). IR/codegen: `view_interface` / `operator==`, init conversions, late `swap`. |
 | `<variant>` | `test_std_variant.cpp` | ✅ Compiled | ~736ms (retested 2026-04-24, Linux/libstdc++). **NEW: Now compiles successfully on Linux!** The `_Variadic_union` arithmetic non-type template argument (`_Np-1`) inside a member initializer is now resolved. |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
@@ -100,30 +100,6 @@ This directory contains test files for C++ standard library headers to assess Fl
 | `<generator>` | N/A | ❌ Compile Error | ~2593ms (retested 2026-04-11). Call to deleted function 'swap' — previously was a parse error, now parses successfully. (C++23) |
 
 **Legend:** ✅ Compiled | ❌ Failed/Parse/Include Error | 💥 Crash
-
-### 2026-07-25 Windows/MSVC SoftProbe operator() + floating builtins follow-up
-
-Fixes landed (parser SoftProbe / compiler builtins):
-
-- **`finalizePostfixCallExpression` no longer throws on concrete `operator()` miss/ambiguity in SoftProbe/ShapeOnly.** MSVC `<concepts>` `ranges::_Swap::_Cpo` declares an array overload whose nested `requires requires(_Cpo __fn) { __fn(__t[0], __u[0]); }` must soft-defer while sibling `operator()` templates are still being parsed; hard-failing there blocked the whole header. Shared helper: `consumeConcreteCallOperatorFailure`.
-- **Register `__builtin_huge_val{,f,l}` / `__builtin_nan{,f,l}` / `__builtin_nans{,f,l}`** (and GCC `__` spellings) so `numeric_limits<long double>::infinity` / `quiet_NaN` / `signaling_NaN` resolve as real calls. That removes the prior IR `sema missed return conversion (double -> long double)` stop for those members.
-
-Regression coverage:
-
-- `tests/test_requires_cpo_no_match_soft_fail_ret0.cpp`
-- `tests/test_ranges_swap_cpo_msvc_pattern_ret0.cpp`
-- `tests/std/test_std_concepts_ranges_swap_int_ret0.cpp` (now passes end-to-end)
-- `tests/test_return_double_to_long_double_ret0.cpp`
-- `tests/test_return_builtin_double_to_long_double_ret0.cpp`
-
-Validation snapshot (`x64/Sharded/FlashCppMSVC.exe`, Windows/MSVC STL 14.44; compile-only `TOTAL` from timing table where available; runner wall includes compile/link/run for full tests):
-
-| Header/Test | Status | Compile `TOTAL` | Runner wall | First-order stop / note |
-|-------------|--------|-----------------|-------------|-------------------------|
-| `<type_traits>` (`test_std_type_traits.cpp`) | ✅ Pass | ~1221ms | ~1.3s | Still compiles. |
-| `<concepts>` (`test_std_concepts.cpp`) | ✅ Pass | ~1284ms | ~1.3s / full run OK | Was `callable object has no matching operator()`; now compiles, links, returns 0. |
-| `<limits>` (`test_std_limits.cpp`) | ❌ Semantic error | (fails after parse) | ~6.2s | Infinity/NaN return-conversion stop gone. Current: `wmemchr` / `wmemcmp` `Operator=` not defined. |
-| `<iterator>` (`test_std_iterator.cpp`) | ❌ Codegen/IR | (fails in IR) | ~10.7s | Past shared `operator()` parse stop; IR/`view_interface` / conversion / late `swap` remain. |
 
 ### 2026-07-24 Windows/MSVC TypeInfo memory / template-arg interning follow-up
 

--- a/tests/test_const_object_assign_fail.cpp
+++ b/tests/test_const_object_assign_fail.cpp
@@ -1,0 +1,6 @@
+// Assignment through a const lvalue must still be rejected.
+int main() {
+	const int x = 1;
+	x = 2;
+	return 0;
+}

--- a/tests/test_const_ptr_increment_ret0.cpp
+++ b/tests/test_const_ptr_increment_ret0.cpp
@@ -1,0 +1,8 @@
+// Pointer-to-const is a mutable pointer; compound assignment must be allowed.
+// (UCRT wmemchr: `wchar_t const* __s = _S; __s += 8;`)
+int main() {
+	const int vals[4] = {1, 2, 3, 4};
+	const int* p = vals;
+	p += 1;
+	return *p == 2 ? 0 : 1;
+}

--- a/tests/test_struct_rvalue_assign_ret0.cpp
+++ b/tests/test_struct_rvalue_assign_ret0.cpp
@@ -1,0 +1,15 @@
+// C++20 [over.ics.rank]: prvalue RHS prefers operator=(T&&) over operator=(const T&).
+struct S {
+	int x;
+	int y;
+};
+
+S make_s(int v) {
+	return S{v, 0};
+}
+
+int main() {
+	S a{};
+	a = make_s(42);
+	return a.x == 42 ? 0 : 1;
+}

--- a/tests/test_typedef_m128_like_copy_assign_ret0.cpp
+++ b/tests/test_typedef_m128_like_copy_assign_ret0.cpp
@@ -1,0 +1,16 @@
+// Reduced MSVC emmintrin/wchar.h pattern: typedef union with multiple array
+// members, then copy-assign (as in __m128i __v1 = ...; __v1 = __cmpeq(...);).
+typedef union __declspec(align(16)) M128 {
+	__int8 i8[16];
+	__int16 i16[8];
+	__int32 i32[4];
+	__int64 i64[2];
+} M128;
+
+int main() {
+	M128 a{};
+	M128 b{};
+	a.i32[0] = 42;
+	b = a;
+	return b.i32[0] == 42 ? 0 : 1;
+}

--- a/tests/test_typedef_struct_copy_assign_ret0.cpp
+++ b/tests/test_typedef_struct_copy_assign_ret0.cpp
@@ -1,0 +1,13 @@
+// Regression: typedef struct Name { ... } Name must get implicit copy assignment.
+typedef struct S {
+	int x;
+	char y[4];
+} S;
+
+int main() {
+	S a{};
+	S b{};
+	a.x = 11;
+	b = a;
+	return b.x == 11 ? 0 : 1;
+}

--- a/tests/test_typedef_union_copy_assign_ret0.cpp
+++ b/tests/test_typedef_union_copy_assign_ret0.cpp
@@ -1,0 +1,14 @@
+// Regression: typedef union Name { ... } Name must get implicit copy assignment
+// (MSVC __m128i / wchar.h wmemchr pattern). Plain `union Name` already worked.
+typedef union U {
+	int x;
+	char y[4];
+} U;
+
+int main() {
+	U a{};
+	U b{};
+	a.x = 7;
+	b = a;
+	return b.x == 7 ? 0 : 1;
+}

--- a/tests/test_typedef_union_rvalue_assign_ret0.cpp
+++ b/tests/test_typedef_union_rvalue_assign_ret0.cpp
@@ -1,0 +1,20 @@
+// C++20 [over.ics.rank]: prvalue RHS prefers move assignment for typedef unions
+// (MSVC __m128i / wchar.h wmemchr pattern: __v1 = _mm_cmpeq_epi16(...)).
+typedef union M128 {
+	__int8 i8[16];
+	__int16 i16[8];
+	__int32 i32[4];
+	__int64 i64[2];
+} M128;
+
+M128 make_m128() {
+	M128 v{};
+	v.i32[0] = 7;
+	return v;
+}
+
+int main() {
+	M128 a{};
+	a = make_m128();
+	return a.i32[0] == 7 ? 0 : 1;
+}

--- a/tests/test_union_copy_assign_ret0.cpp
+++ b/tests/test_union_copy_assign_ret0.cpp
@@ -1,0 +1,11 @@
+union U {
+	int x;
+	char y[4];
+};
+
+int main() {
+	U a{};
+	U b{};
+	a = b;
+	return a.x == b.x ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Synthesize C++20 implicit special members for 	ypedef struct/union { ... } Alias inline definitions so MSVC __m128i-style unions get copy/move assignment.
- Apply the [over.ics.rank] rvalue→T&& vs const T& tie-break when ranking binary operator= overloads.
- Fix isExprConstQualified so const T* is a mutable pointer (UCRT wmemchr pointer arithmetic).

<limits> now compiles on Windows/MSVC; next blocker is link-time MSVC SSE/AVX intrinsics from UCRT wmemchr/wmemcmp.

Made with [Cursor](https://cursor.com)