### PR TITLE
Tag allocations by compile phase and add opt-in profiling build flags

### DIFF
--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -550,7 +550,7 @@
       <AdditionalIncludeDirectories>
         %(AdditionalIncludeDirectories)
       </AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS;$(AdditionalPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <LanguageStandard Condition="'$(Configuration)|$(Platform)'=='Release|x64'">stdcpp20</LanguageStandard>
       <Optimization Condition="'$(Configuration)|$(Platform)'=='Test|x64'">Disabled</Optimization>
       <MultiProcessorCompilation Condition="'$(Configuration)|$(Platform)'=='Modular|x64'">true</MultiProcessorCompilation>

--- a/FlashCppMSVC.vcxproj
+++ b/FlashCppMSVC.vcxproj
@@ -192,7 +192,7 @@
       <AdditionalIncludeDirectories>external;src;tests\external\doctest;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PreprocessorDefinitions>WITH_PARSER_RUNTIME_STATS=1;FLASHCPP_TRACK_ALLOCATIONS=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <Optimization>Disabled</Optimization>
       <WarningLevel>Level1</WarningLevel>

--- a/Readme.md
+++ b/Readme.md
@@ -74,9 +74,15 @@ make test && ./x64/test
 | `--alloc-stats` | Track global `operator new/delete` counts (see profiling note below) |
 | `--mem-stats` | Alias for `--alloc-stats` |
 
-### Profiling builds (Windows Sharded)
+### Profiling builds (opt-in)
 
-The default Sharded MSVC build enables parser runtime phase timers (`WITH_PARSER_RUNTIME_STATS=1`) and global allocation hooks (`FLASHCPP_TRACK_ALLOCATIONS=1`). Use the flags separately:
+Parser phase timers and allocation hooks are **off by default**. Enable them in `FlashCppMSVC.vcxproj` under the Sharded `PreprocessorDefinitions` (rebuild required):
+
+- `WITH_PARSER_RUNTIME_STATS=1` — parser subphase timers for `--perf-stats`
+- `FLASHCPP_TRACK_ALLOCATIONS=1` — global `operator new/delete` hooks for `--alloc-stats`
+- `FLASHCPP_TRACK_ALLOCATION_STACKS=1` — per-phase call-site stacks (requires allocations; much slower)
+
+Example:
 
 ```powershell
 .\build_flashcpp.bat
@@ -93,8 +99,6 @@ The default Sharded MSVC build enables parser runtime phase timers (`WITH_PARSER
 # Quick allocation count script
 pwsh tests/bench_allocations.ps1 tests/std/test_std_type_traits.cpp
 ```
-
-Optional call-site stacks (much slower): add `FLASHCPP_TRACK_ALLOCATION_STACKS=1` to Sharded `PreprocessorDefinitions` in `FlashCppMSVC.vcxproj` and rebuild.
 
 ---
 

--- a/Readme.md
+++ b/Readme.md
@@ -76,7 +76,15 @@ make test && ./x64/test
 
 ### Profiling builds (opt-in)
 
-Parser phase timers and allocation hooks are **off by default**. Enable them in `FlashCppMSVC.vcxproj` under the Sharded `PreprocessorDefinitions` (rebuild required):
+Parser phase timers and allocation hooks are **off by default**. Enable them when building:
+
+```powershell
+.\build_flashcpp.bat --alloc-stats              # heap tracking for --alloc-stats
+.\build_flashcpp.bat --perf-stats               # parser subphase timers for --perf-stats
+.\build_flashcpp.bat --profile                  # all profiling defines (incl. stack traces)
+```
+
+Or add these to Sharded `PreprocessorDefinitions` in `FlashCppMSVC.vcxproj`:
 
 - `WITH_PARSER_RUNTIME_STATS=1` — parser subphase timers for `--perf-stats`
 - `FLASHCPP_TRACK_ALLOCATIONS=1` — global `operator new/delete` hooks for `--alloc-stats`

--- a/build_flashcpp.bat
+++ b/build_flashcpp.bat
@@ -1,15 +1,89 @@
 @echo off
+setlocal EnableDelayedExpansion
 cd /d "%~dp0"
 
-set CONFIG=%~1
-if "%CONFIG%"=="" set CONFIG=Sharded
+set "CONFIG=Sharded"
+set "EXTRA_DEFINES="
+set "ENABLE_PERF_STATS=0"
+set "ENABLE_ALLOC_STATS=0"
+set "ENABLE_ALLOC_STACKS=0"
+
+:parse_args
+if "%~1"=="" goto done_parse
+if /i "%~1"=="--perf-stats" (
+	set "ENABLE_PERF_STATS=1"
+	shift
+	goto parse_args
+)
+if /i "%~1"=="--alloc-stats" (
+	set "ENABLE_ALLOC_STATS=1"
+	shift
+	goto parse_args
+)
+if /i "%~1"=="--alloc-stacks" (
+	set "ENABLE_ALLOC_STATS=1"
+	set "ENABLE_ALLOC_STACKS=1"
+	shift
+	goto parse_args
+)
+if /i "%~1"=="--profile" (
+	set "ENABLE_PERF_STATS=1"
+	set "ENABLE_ALLOC_STATS=1"
+	set "ENABLE_ALLOC_STACKS=1"
+	shift
+	goto parse_args
+)
+if /i "%~1"=="--help" (
+	goto show_help
+)
+if "%~1:~0,2%"=="--" (
+	echo Unknown option: %~1
+	goto show_help
+)
+set "CONFIG=%~1"
+shift
+goto parse_args
+
+:done_parse
+if "%ENABLE_PERF_STATS%"=="1" (
+	set "EXTRA_DEFINES=!EXTRA_DEFINES!WITH_PARSER_RUNTIME_STATS=1;"
+)
+if "%ENABLE_ALLOC_STATS%"=="1" (
+	set "EXTRA_DEFINES=!EXTRA_DEFINES!FLASHCPP_TRACK_ALLOCATIONS=1;"
+)
+if "%ENABLE_ALLOC_STACKS%"=="1" (
+	set "EXTRA_DEFINES=!EXTRA_DEFINES!FLASHCPP_TRACK_ALLOCATION_STACKS=1;"
+)
 
 echo Building FlashCpp (%CONFIG%)...
-"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" FlashCppMSVC.vcxproj /t:Rebuild /m /p:Configuration=%CONFIG% /p:Platform=x64
+if not "%EXTRA_DEFINES%"=="" (
+	echo Profiling defines: %EXTRA_DEFINES%
+	"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" FlashCppMSVC.vcxproj /t:Rebuild /m /p:Configuration=%CONFIG% /p:Platform=x64 /p:AdditionalPreprocessorDefinitions="%EXTRA_DEFINES%"
+) else (
+	"C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\MSBuild.exe" FlashCppMSVC.vcxproj /t:Rebuild /m /p:Configuration=%CONFIG% /p:Platform=x64
+)
 
 if %ERRORLEVEL% neq 0 (
-    echo Build failed!
-    exit /b %ERRORLEVEL%
+	echo Build failed!
+	exit /b %ERRORLEVEL%
 )
 
 echo Build successful!
+exit /b 0
+
+:show_help
+echo Usage: build_flashcpp.bat [CONFIG] [options]
+echo.
+echo CONFIG defaults to Sharded.
+echo.
+echo Profiling options (opt-in, can be combined):
+echo   --perf-stats    Enable WITH_PARSER_RUNTIME_STATS for --perf-stats
+echo   --alloc-stats   Enable FLASHCPP_TRACK_ALLOCATIONS for --alloc-stats
+echo   --alloc-stacks  Enable FLASHCPP_TRACK_ALLOCATION_STACKS (implies --alloc-stats)
+echo   --profile       Enable all profiling defines above
+echo.
+echo Examples:
+echo   build_flashcpp.bat
+echo   build_flashcpp.bat Sharded --alloc-stats
+echo   build_flashcpp.bat --profile
+exit /b 1

--- a/src/AllocationTracker.cpp
+++ b/src/AllocationTracker.cpp
@@ -39,11 +39,58 @@ std::atomic<uint64_t> g_bytes_allocated{0};
 std::atomic<uint64_t> g_bytes_deallocated{0};
 std::atomic<uint64_t> g_current_live_bytes{0};
 std::atomic<uint64_t> g_peak_live_bytes{0};
+std::atomic<uint8_t> g_current_allocation_phase{static_cast<uint8_t>(AllocationPhase::Unknown)};
+std::array<std::atomic<uint64_t>, static_cast<size_t>(AllocationPhase::Count)> g_phase_allocation_count{};
+std::array<std::atomic<uint64_t>, static_cast<size_t>(AllocationPhase::Count)> g_phase_bytes_allocated{};
 
 void updatePeakLive(uint64_t live_bytes) {
 	uint64_t peak = g_peak_live_bytes.load(std::memory_order_relaxed);
 	while (live_bytes > peak &&
 		   !g_peak_live_bytes.compare_exchange_weak(peak, live_bytes, std::memory_order_relaxed)) {
+	}
+}
+
+void printPhaseAllocationSummary(const AllocationTracker::Snapshot& stats) {
+	FLASH_LOG(General, Info, "\nAllocation totals by compile phase:");
+	for (size_t i = 0; i < static_cast<size_t>(AllocationPhase::Count); ++i) {
+		const auto phase = static_cast<AllocationPhase>(i);
+		const AllocationTracker::PhaseSnapshot& phase_stats = stats.phases[i];
+		if (phase_stats.allocation_count == 0) {
+			continue;
+		}
+		const double count_pct = stats.allocation_count > 0
+									 ? static_cast<double>(phase_stats.allocation_count) * 100.0 /
+										   static_cast<double>(stats.allocation_count)
+									 : 0.0;
+		const double bytes_pct = stats.bytes_allocated > 0
+									 ? static_cast<double>(phase_stats.bytes_allocated) * 100.0 /
+										   static_cast<double>(stats.bytes_allocated)
+									 : 0.0;
+		const double mean_bytes = phase_stats.allocation_count > 0
+									  ? static_cast<double>(phase_stats.bytes_allocated) /
+											static_cast<double>(phase_stats.allocation_count)
+									  : 0.0;
+		FLASH_LOG(General, Info, "  ", AllocationTracker::phaseName(phase),
+				  ": allocations=", phase_stats.allocation_count, " (", std::fixed, std::setprecision(2),
+				  count_pct, "%), bytes=", phase_stats.bytes_allocated, " (", bytes_pct, "%), mean=",
+				  std::setprecision(1), mean_bytes, " bytes");
+	}
+
+	const size_t parsing_index = static_cast<size_t>(AllocationPhase::Parsing);
+	const size_t preprocessing_index = static_cast<size_t>(AllocationPhase::Preprocessing);
+	const size_t codegen_index = static_cast<size_t>(AllocationPhase::CodeGeneration);
+	const uint64_t parsing_count = stats.phases[parsing_index].allocation_count;
+	const uint64_t non_bottleneck_count = stats.phases[preprocessing_index].allocation_count +
+										  stats.phases[static_cast<size_t>(AllocationPhase::LexerSetup)]
+											  .allocation_count +
+										  stats.phases[codegen_index].allocation_count;
+	if (stats.allocation_count > 0) {
+		FLASH_LOG(General, Info, "  parsing-focused remainder: ", parsing_count, " parsing allocations (",
+				  std::setprecision(2),
+				  static_cast<double>(parsing_count) * 100.0 / static_cast<double>(stats.allocation_count),
+				  "%), preprocessing+lexer+codegen: ", non_bottleneck_count, " (",
+				  static_cast<double>(non_bottleneck_count) * 100.0 / static_cast<double>(stats.allocation_count),
+				  "%)");
 	}
 }
 
@@ -62,7 +109,24 @@ struct StackSite {
 };
 
 std::mutex g_stack_sites_mutex;
-std::unordered_map<uint64_t, StackSite> g_stack_sites;
+struct PhaseStackKey {
+	uint8_t phase = 0;
+	uint64_t stack_hash = 0;
+};
+
+struct PhaseStackKeyHash {
+	size_t operator()(const PhaseStackKey& key) const noexcept {
+		return std::hash<uint64_t>{}((static_cast<uint64_t>(key.phase) << 56) ^ key.stack_hash);
+	}
+};
+
+struct PhaseStackKeyEqual {
+	bool operator()(const PhaseStackKey& left, const PhaseStackKey& right) const noexcept {
+		return left.phase == right.phase && left.stack_hash == right.stack_hash;
+	}
+};
+
+std::unordered_map<PhaseStackKey, StackSite, PhaseStackKeyHash, PhaseStackKeyEqual> g_stack_sites;
 thread_local bool g_recording_allocation_stack = false;
 
 uint64_t hashStackFrames(const void* const* frames, size_t frame_count) {
@@ -106,7 +170,7 @@ void captureAllocationStackFrames(void** frames_out, size_t& frame_count_out) {
 #endif
 }
 
-void recordAllocationStack(std::size_t size) {
+void recordAllocationStack(std::size_t size, AllocationPhase phase) {
 	if (g_recording_allocation_stack) {
 		return;
 	}
@@ -125,10 +189,10 @@ void recordAllocationStack(std::size_t size) {
 	StackSite probe;
 	probe.frame_count = frame_count;
 	std::memcpy(probe.frames.data(), frames, frame_count * sizeof(void*));
-	const uint64_t stack_hash = hashStackFrames(probe.frames.data(), probe.frame_count);
+	const PhaseStackKey key{static_cast<uint8_t>(phase), hashStackFrames(probe.frames.data(), probe.frame_count)};
 
 	std::lock_guard<std::mutex> lock(g_stack_sites_mutex);
-	StackSite& site = g_stack_sites[stack_hash];
+	StackSite& site = g_stack_sites[key];
 	if (site.frame_count == 0) {
 		site = probe;
 	} else if (!stackFramesEqual(site, probe)) {
@@ -237,44 +301,41 @@ void printResolvedStackSite(const StackSite& site, uint64_t total_allocations, u
 	}
 }
 
-void printAllocationStackSites(const AllocationTracker::Snapshot& stats) {
-	struct DisableStackRecording {
-		DisableStackRecording() { g_recording_allocation_stack = true; }
-		~DisableStackRecording() { g_recording_allocation_stack = false; }
-	} disable_stack_recording;
-
-	size_t site_count = 0;
-	{
-		std::lock_guard<std::mutex> lock(g_stack_sites_mutex);
-		site_count = g_stack_sites.size();
+bool shouldPrintDetailedStacksForPhase(AllocationPhase phase) {
+	switch (phase) {
+	case AllocationPhase::Parsing:
+	case AllocationPhase::SemanticAnalysis:
+	case AllocationPhase::IrConversion:
+	case AllocationPhase::DeferredGen:
+		return true;
+	default:
+		return false;
 	}
+}
 
-	std::vector<StackSite> site_copy;
-	site_copy.reserve(site_count);
-	{
-		std::lock_guard<std::mutex> lock(g_stack_sites_mutex);
-		site_copy.reserve(g_stack_sites.size());
-		for (const auto& entry : g_stack_sites) {
-			if (entry.second.allocation_count > 0) {
-				site_copy.push_back(entry.second);
-			}
-		}
+void printAllocationStackSitesForPhase(AllocationPhase phase,
+									   const std::vector<StackSite>& site_copy,
+									   const AllocationTracker::PhaseSnapshot& phase_stats) {
+	if (!shouldPrintDetailedStacksForPhase(phase)) {
+		return;
+	}
+	if (phase_stats.allocation_count == 0) {
+		return;
 	}
 
 	std::vector<const StackSite*> sites;
 	sites.reserve(site_copy.size());
 	for (const StackSite& site : site_copy) {
-		sites.push_back(&site);
+		if (site.allocation_count > 0) {
+			sites.push_back(&site);
+		}
 	}
-
 	if (sites.empty()) {
-		FLASH_LOG(General, Info, "Allocation stack sites: no samples captured");
 		return;
 	}
 
-	FLASH_LOG(General, Info, "\n=== Allocation Stack Sites (operator new/delete) ===");
-	FLASH_LOG(General, Info, "Unique stack patterns: ", sites.size(),
-			  " (skip ", kStackSkipFrames, " allocator frames, capture ", kStackCaptureFrames, ")");
+	FLASH_LOG(General, Info, "\nTop allocation stack sites during ", AllocationTracker::phaseName(phase), " (",
+			  phase_stats.allocation_count, " allocations, ", phase_stats.bytes_allocated, " bytes):");
 
 	std::sort(sites.begin(), sites.end(), [](const StackSite* left, const StackSite* right) {
 		if (left->allocation_count != right->allocation_count) {
@@ -283,31 +344,92 @@ void printAllocationStackSites(const AllocationTracker::Snapshot& stats) {
 		return left->bytes_allocated > right->bytes_allocated;
 	});
 
-	FLASH_LOG(General, Info, "\nTop sites by allocation count:");
 	const size_t count_limit = std::min(kTopSitesByCount, sites.size());
 	for (size_t i = 0; i < count_limit; ++i) {
 		FLASH_LOG(General, Info, "#", i + 1);
-		printResolvedStackSite(*sites[i], stats.allocation_count, stats.bytes_allocated);
+		printResolvedStackSite(*sites[i], phase_stats.allocation_count, phase_stats.bytes_allocated);
+	}
+}
+
+void printAllocationStackSites(const AllocationTracker::Snapshot& stats) {
+	struct DisableStackRecording {
+		DisableStackRecording() { g_recording_allocation_stack = true; }
+		~DisableStackRecording() { g_recording_allocation_stack = false; }
+	} disable_stack_recording;
+
+	std::array<std::vector<StackSite>, static_cast<size_t>(AllocationPhase::Count)> sites_by_phase;
+	{
+		std::lock_guard<std::mutex> lock(g_stack_sites_mutex);
+		for (const auto& entry : g_stack_sites) {
+			if (entry.second.allocation_count == 0) {
+				continue;
+			}
+			const size_t phase_index = entry.first.phase;
+			if (phase_index >= static_cast<size_t>(AllocationPhase::Count)) {
+				continue;
+			}
+			sites_by_phase[phase_index].push_back(entry.second);
+		}
 	}
 
-	std::sort(sites.begin(), sites.end(), [](const StackSite* left, const StackSite* right) {
-		if (left->bytes_allocated != right->bytes_allocated) {
-			return left->bytes_allocated > right->bytes_allocated;
+	bool any_sites = false;
+	for (const auto& phase_sites : sites_by_phase) {
+		if (!phase_sites.empty()) {
+			any_sites = true;
+			break;
 		}
-		return left->allocation_count > right->allocation_count;
-	});
+	}
+	if (!any_sites) {
+		FLASH_LOG(General, Info, "Allocation stack sites: no samples captured");
+		return;
+	}
 
-	FLASH_LOG(General, Info, "\nTop sites by bytes allocated:");
-	const size_t bytes_limit = std::min(kTopSitesByBytes, sites.size());
-	for (size_t i = 0; i < bytes_limit; ++i) {
-		FLASH_LOG(General, Info, "#", i + 1);
-		printResolvedStackSite(*sites[i], stats.allocation_count, stats.bytes_allocated);
+	FLASH_LOG(General, Info, "\n=== Allocation Stack Sites (operator new/delete) ===");
+	FLASH_LOG(General, Info, "Detailed stack traces shown for Parsing/Semantic/IR/Deferred only; see phase summary above for Preprocessing/Lexer Setup/Code Generation");
+
+	for (size_t i = 0; i < static_cast<size_t>(AllocationPhase::Count); ++i) {
+		const auto phase = static_cast<AllocationPhase>(i);
+		printAllocationStackSitesForPhase(phase, sites_by_phase[i], stats.phases[i]);
 	}
 }
 
 #endif // FLASHCPP_TRACK_ALLOCATION_STACKS
 
 } // namespace
+
+void AllocationTracker::setPhase(AllocationPhase phase) {
+	g_current_allocation_phase.store(static_cast<uint8_t>(phase), std::memory_order_relaxed);
+}
+
+AllocationPhase AllocationTracker::currentPhase() {
+	return static_cast<AllocationPhase>(g_current_allocation_phase.load(std::memory_order_relaxed));
+}
+
+const char* AllocationTracker::phaseName(AllocationPhase phase) {
+	switch (phase) {
+	case AllocationPhase::Unknown:
+		return "Unknown";
+	case AllocationPhase::Preprocessing:
+		return "Preprocessing";
+	case AllocationPhase::LexerSetup:
+		return "Lexer Setup";
+	case AllocationPhase::Parsing:
+		return "Parsing";
+	case AllocationPhase::SemanticAnalysis:
+		return "Semantic Analysis";
+	case AllocationPhase::IrConversion:
+		return "IR Conversion";
+	case AllocationPhase::DeferredGen:
+		return "Deferred Gen";
+	case AllocationPhase::CodeGeneration:
+		return "Code Generation";
+	case AllocationPhase::Other:
+		return "Other";
+	case AllocationPhase::Count:
+		break;
+	}
+	return "Invalid";
+}
 
 void AllocationTracker::setEnabled(bool enabled) {
 	g_allocation_tracking_enabled.store(enabled, std::memory_order_relaxed);
@@ -327,8 +449,15 @@ void AllocationTracker::recordAllocation(std::size_t size) {
 		g_current_live_bytes.fetch_add(static_cast<uint64_t>(size), std::memory_order_relaxed) +
 		static_cast<uint64_t>(size);
 	updatePeakLive(live_bytes);
+
+	const AllocationPhase phase = currentPhase();
+	const size_t phase_index = static_cast<size_t>(phase);
+	if (phase_index < static_cast<size_t>(AllocationPhase::Count)) {
+		++g_phase_allocation_count[phase_index];
+		g_phase_bytes_allocated[phase_index].fetch_add(static_cast<uint64_t>(size), std::memory_order_relaxed);
+	}
 #if FLASHCPP_TRACK_ALLOCATION_STACKS
-	recordAllocationStack(size);
+	recordAllocationStack(size, phase);
 #endif
 }
 
@@ -356,6 +485,10 @@ AllocationTracker::Snapshot AllocationTracker::snapshot() {
 	snapshot.bytes_deallocated = g_bytes_deallocated.load(std::memory_order_relaxed);
 	snapshot.current_live_bytes = g_current_live_bytes.load(std::memory_order_relaxed);
 	snapshot.peak_live_bytes = g_peak_live_bytes.load(std::memory_order_relaxed);
+	for (size_t i = 0; i < static_cast<size_t>(AllocationPhase::Count); ++i) {
+		snapshot.phases[i].allocation_count = g_phase_allocation_count[i].load(std::memory_order_relaxed);
+		snapshot.phases[i].bytes_allocated = g_phase_bytes_allocated[i].load(std::memory_order_relaxed);
+	}
 	return snapshot;
 }
 
@@ -373,6 +506,7 @@ void AllocationTracker::printStats() {
 			  ", bytes deallocated=", stats.bytes_deallocated);
 	FLASH_LOG(General, Info, "  current live bytes=", stats.current_live_bytes,
 			  ", peak live bytes=", stats.peak_live_bytes);
+	printPhaseAllocationSummary(stats);
 #if FLASHCPP_TRACK_ALLOCATION_STACKS
 	printAllocationStackSites(stats);
 #else

--- a/src/AllocationTracker.cpp
+++ b/src/AllocationTracker.cpp
@@ -50,6 +50,8 @@ void updatePeakLive(uint64_t live_bytes) {
 	}
 }
 
+#if FLASHCPP_TRACK_ALLOCATIONS
+
 void printPhaseAllocationSummary(const AllocationTracker::Snapshot& stats) {
 	FLASH_LOG(General, Info, "\nAllocation totals by compile phase:");
 	for (size_t i = 0; i < static_cast<size_t>(AllocationPhase::Count); ++i) {
@@ -93,6 +95,8 @@ void printPhaseAllocationSummary(const AllocationTracker::Snapshot& stats) {
 				  "%)");
 	}
 }
+
+#endif // FLASHCPP_TRACK_ALLOCATIONS
 
 #if FLASHCPP_TRACK_ALLOCATION_STACKS
 

--- a/src/AllocationTracker.h
+++ b/src/AllocationTracker.h
@@ -17,15 +17,36 @@
 
 namespace FlashCpp {
 
+enum class AllocationPhase : uint8_t {
+	Unknown,
+	Preprocessing,
+	LexerSetup,
+	Parsing,
+	SemanticAnalysis,
+	IrConversion,
+	DeferredGen,
+	CodeGeneration,
+	Other,
+	Count
+};
+
 class AllocationTracker {
 public:
 	static void setEnabled(bool enabled);
 	static bool isEnabled();
 
+	static void setPhase(AllocationPhase phase);
+	static AllocationPhase currentPhase();
+
 	static void recordAllocation(std::size_t size);
 	static void recordDeallocation(std::size_t size);
 
 	static void printStats();
+
+	struct PhaseSnapshot {
+		uint64_t allocation_count = 0;
+		uint64_t bytes_allocated = 0;
+	};
 
 	struct Snapshot {
 		uint64_t allocation_count = 0;
@@ -34,9 +55,11 @@ public:
 		uint64_t bytes_deallocated = 0;
 		uint64_t current_live_bytes = 0;
 		uint64_t peak_live_bytes = 0;
+		PhaseSnapshot phases[static_cast<size_t>(AllocationPhase::Count)]{};
 	};
 
 	static Snapshot snapshot();
+	static const char* phaseName(AllocationPhase phase);
 };
 
 } // namespace FlashCpp

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -5,10 +5,18 @@ struct PhaseTimer {
 	std::chrono::high_resolution_clock::time_point start;
 	const char* phase_name;
 	bool print_enabled;
-	double* accumulator = nullptr;  // Optional accumulator for phase timing
+	double* accumulator = nullptr;
+	FlashCpp::AllocationPhase allocation_phase = FlashCpp::AllocationPhase::Unknown;
 
-	PhaseTimer(const char* name, bool print_enable, double* accum = nullptr)
-		: start(std::chrono::high_resolution_clock::now()), phase_name(name), print_enabled(print_enable), accumulator(accum) {
+	PhaseTimer(const char* name, bool print_enable, double* accum, FlashCpp::AllocationPhase alloc_phase)
+		: start(std::chrono::high_resolution_clock::now()),
+		  phase_name(name),
+		  print_enabled(print_enable),
+		  accumulator(accum),
+		  allocation_phase(alloc_phase) {
+		if (FlashCpp::AllocationTracker::isEnabled()) {
+			FlashCpp::AllocationTracker::setPhase(allocation_phase);
+		}
 	}
 
 	~PhaseTimer() {
@@ -362,7 +370,7 @@ int main_impl(int argc, char* argv[]) {
 	FileTree file_tree;
 	FileReader file_reader(context, file_tree);
 	{
-		PhaseTimer timer("Preprocessing", false, &preprocessing_time);
+		PhaseTimer timer("Preprocessing", false, &preprocessing_time, FlashCpp::AllocationPhase::Preprocessing);
 		if (!file_reader.readFile(context.getInputFile().value())) {
 			FLASH_LOG(General, Error, "Failed to read input file: ", context.getInputFile().value());
 			std::cerr << "Error: Failed to read input file: " << context.getInputFile().value() << std::endl;
@@ -429,7 +437,7 @@ int main_impl(int argc, char* argv[]) {
 	std::unique_ptr<Parser> parser;
 	setTypeTableStatsEnabled(show_perf_stats);
 	{
-		PhaseTimer timer("Lexer Setup", false, &lexer_setup_time);
+		PhaseTimer timer("Lexer Setup", false, &lexer_setup_time, FlashCpp::AllocationPhase::LexerSetup);
 		lexer_ptr = std::make_unique<Lexer>(preprocessed_source, file_reader.get_line_map(), file_reader.get_file_paths());
 		lexer_ptr->setMsvcSehKeywords(context.isMsvcMode());
 		sema = std::make_unique<SemanticAnalysis>(context, gSymbolTable);
@@ -447,7 +455,7 @@ int main_impl(int argc, char* argv[]) {
 	std::string parse_compile_error_message;
 	std::string parse_compile_error_notes;
 	{
-		PhaseTimer timer("Parsing", false, &parsing_time);
+		PhaseTimer timer("Parsing", false, &parsing_time, FlashCpp::AllocationPhase::Parsing);
 		// Note: Lexing happens lazily during parsing in this implementation
 		// Template instantiation also happens during parsing
 
@@ -499,7 +507,8 @@ int main_impl(int argc, char* argv[]) {
 	// The object is kept alive past AstToIr construction so that AstToIr can
 	// consume the semantic annotations (SemanticSlot side table, cast_info_table_).
 	{
-		PhaseTimer sema_timer("Semantic Analysis", false, &semantic_analysis_time);
+		PhaseTimer sema_timer("Semantic Analysis", false, &semantic_analysis_time,
+							  FlashCpp::AllocationPhase::SemanticAnalysis);
 		try {
 			sema->run();
 		} catch (const CompileError& e) {
@@ -560,7 +569,7 @@ int main_impl(int argc, char* argv[]) {
 	size_t ir_conversion_error_count = 0;
 	bool has_compile_errors = false;
 	{
-		PhaseTimer ir_timer("IR Conversion", false, &ir_conversion_time);
+		PhaseTimer ir_timer("IR Conversion", false, &ir_conversion_time, FlashCpp::AllocationPhase::IrConversion);
 		// Re-evaluate ast.size() each iteration so appended template/member
 		// instantiations are visited in the same pass. Constexpr materialization can
 		// also insert a dependency at the front; after each visit, advance to the
@@ -664,7 +673,7 @@ int main_impl(int argc, char* argv[]) {
 	// Deferred generation (lambdas and local struct member functions)
 	size_t deferred_gen_error_count = 0;
 	{
-		PhaseTimer deferred_timer("Deferred Gen", false, &deferred_gen_time);
+		PhaseTimer deferred_timer("Deferred Gen", false, &deferred_gen_time, FlashCpp::AllocationPhase::DeferredGen);
 		try {
 			// Generate all collected lambdas after visiting all nodes
 			converter.generateCollectedLambdas();
@@ -729,7 +738,7 @@ int main_impl(int argc, char* argv[]) {
 #endif
 
 	try {
-		PhaseTimer timer("Code Generation", false, &codegen_time);
+		PhaseTimer timer("Code Generation", false, &codegen_time, FlashCpp::AllocationPhase::CodeGeneration);
 
 		if (useElfFormat) {
 #if defined(__linux__) || defined(__unix__) || defined(__APPLE__)

--- a/tests/bench_allocations.ps1
+++ b/tests/bench_allocations.ps1
@@ -1,5 +1,6 @@
 # Print global operator new/delete stats from a compile with --alloc-stats.
 # Requires a Sharded build compiled with FLASHCPP_TRACK_ALLOCATIONS=1.
+# Enable with: .\build_flashcpp.bat --alloc-stats
 #
 # Usage:
 #   pwsh tests/bench_allocations.ps1 [test.cpp]

--- a/tests/bench_allocations.ps1
+++ b/tests/bench_allocations.ps1
@@ -34,12 +34,102 @@ if ($LASTEXITCODE -ne 0) {
 	throw "Compile failed with exit code $LASTEXITCODE"
 }
 
-$allocMatch = [regex]::Match($output, "allocations=(\d+)")
-$bytesMatch = [regex]::Match($output, "bytes allocated=(\d+)")
-if (-not $allocMatch.Success -or -not $bytesMatch.Success) {
-	Write-Host $output
-	throw "Could not parse allocation stats (rebuild with FLASHCPP_TRACK_ALLOCATIONS=1 and pass --alloc-stats)"
+$globalMatch = [regex]::Match(
+	$output,
+	"allocations=(\d+), deallocations=(\d+), bytes allocated=(\d+), bytes deallocated=(\d+)"
+)
+if (-not $globalMatch.Success) {
+	$allocMatch = [regex]::Match($output, "allocations=(\d+)")
+	$bytesMatch = [regex]::Match($output, "bytes allocated=(\d+)")
+	if (-not $allocMatch.Success -or -not $bytesMatch.Success) {
+		Write-Host $output
+		throw "Could not parse allocation stats (rebuild with FLASHCPP_TRACK_ALLOCATIONS=1 and pass --alloc-stats)"
+	}
+	$totalAllocations = [uint64]$allocMatch.Groups[1].Value
+	$totalDeallocations = 0
+	$totalBytes = [uint64]$bytesMatch.Groups[1].Value
+	$totalBytesDeallocated = 0
+} else {
+	$totalAllocations = [uint64]$globalMatch.Groups[1].Value
+	$totalDeallocations = [uint64]$globalMatch.Groups[2].Value
+	$totalBytes = [uint64]$globalMatch.Groups[3].Value
+	$totalBytesDeallocated = [uint64]$globalMatch.Groups[4].Value
 }
 
-Write-Host "allocations=$($allocMatch.Groups[1].Value)"
-Write-Host "bytes_allocated=$($bytesMatch.Groups[1].Value)"
+Write-Host ""
+Write-Host "=== Allocation Summary ==="
+Write-Host ("allocations={0}" -f $totalAllocations)
+Write-Host ("bytes_allocated={0}" -f $totalBytes)
+if ($totalDeallocations -gt 0) {
+	Write-Host ("deallocations={0}" -f $totalDeallocations)
+	Write-Host ("bytes_deallocated={0}" -f $totalBytesDeallocated)
+	Write-Host ("live_bytes={0}" -f ($totalBytes - $totalBytesDeallocated))
+}
+
+$phasePattern = '(?m)^\s+(?<phase>[^:]+): allocations=(?<count>\d+) \((?<countpct>[\d.]+)%\), bytes=(?<bytes>\d+) \((?<bytespct>[\d.]+)%\), mean=(?<mean>[\d.]+) bytes'
+$phaseMatches = [regex]::Matches($output, $phasePattern)
+if ($phaseMatches.Count -eq 0) {
+	Write-Host ""
+	Write-Host "Phase breakdown unavailable (rebuild with phase-tagged allocation tracking)."
+	exit 0
+}
+
+$phaseRows = @()
+foreach ($match in $phaseMatches) {
+	$phaseRows += [pscustomobject]@{
+		Phase = $match.Groups["phase"].Value.Trim()
+		Allocations = [uint64]$match.Groups["count"].Value
+		CountPct = [double]$match.Groups["countpct"].Value
+		Bytes = [uint64]$match.Groups["bytes"].Value
+		BytesPct = [double]$match.Groups["bytespct"].Value
+		MeanBytes = [double]$match.Groups["mean"].Value
+	}
+}
+
+Write-Host ""
+Write-Host "=== Allocation Totals By Compile Phase ==="
+$invariant = [System.Globalization.CultureInfo]::InvariantCulture
+Write-Host ("{0,-18} {1,12} {2,8} {3,14} {4,8} {5,8}" -f "Phase", "Allocations", "%Count", "Bytes", "%Bytes", "MeanB")
+Write-Host ("{0,-18} {1,12} {2,8} {3,14} {4,8} {5,8}" -f ("-" * 18), ("-" * 12), ("-" * 8), ("-" * 14), ("-" * 8), ("-" * 8))
+foreach ($row in $phaseRows) {
+	Write-Host ([string]::Format(
+		$invariant,
+		"{0,-18} {1,12:N0} {2,7:N2}% {3,14:N0} {4,7:N2}% {5,8:N1}",
+		$row.Phase,
+		$row.Allocations,
+		$row.CountPct,
+		$row.Bytes,
+		$row.BytesPct,
+		$row.MeanBytes))
+}
+
+$focusedMatch = [regex]::Match(
+	$output,
+	'parsing-focused remainder: (?<parsing>\d+) parsing allocations \((?<parsingpct>[\d.]+)%\), preprocessing\+lexer\+codegen: (?<nonbottleneck>\d+) \((?<nonbottleneckpct>[\d.]+)%\)'
+)
+if ($focusedMatch.Success) {
+	Write-Host ""
+	Write-Host "=== Parsing-Focused View ==="
+	Write-Host ([string]::Format(
+		$invariant,
+		"Parsing allocations:              {0,12:N0} ({1:N2}% of total)",
+		[uint64]$focusedMatch.Groups["parsing"].Value,
+		[double]$focusedMatch.Groups["parsingpct"].Value))
+	Write-Host ([string]::Format(
+		$invariant,
+		"Preprocessing + Lexer + Codegen:  {0,12:N0} ({1:N2}% of total)",
+		[uint64]$focusedMatch.Groups["nonbottleneck"].Value,
+		[double]$focusedMatch.Groups["nonbottleneckpct"].Value))
+
+	$midPhases = @("Parsing", "Semantic Analysis", "IR Conversion", "Deferred Gen")
+	$midAllocations = ($phaseRows | Where-Object { $midPhases -contains $_.Phase } | Measure-Object -Property Allocations -Sum).Sum
+	$midBytes = ($phaseRows | Where-Object { $midPhases -contains $_.Phase } | Measure-Object -Property Bytes -Sum).Sum
+	if ($totalAllocations -gt 0) {
+		$midAllocPct = 100.0 * $midAllocations / $totalAllocations
+		$midBytesPct = 100.0 * $midBytes / $totalBytes
+		Write-Host ([string]::Format(
+			$invariant,
+			"Parsing + Sema + IR + Deferred: {0,12:N0} ({1:N2}% count, {2:N2}% bytes)",
+			$midAllocations, $midAllocPct, $midBytesPct))
+	}
+}


### PR DESCRIPTION
## Summary
- Tag global allocation tracking by compile phase (Preprocessing, Parsing, Semantic Analysis, IR, etc.) so profiling can focus on bottleneck phases.
- Report per-phase allocation totals and top stack sites for Parsing/Sema/IR/Deferred when stack tracing is enabled.
- Keep profiling defines off by default in Sharded builds; add `build_flashcpp.bat` flags (`--perf-stats`, `--alloc-stats`, `--alloc-stacks`, `--profile`) to enable them without editing the vcxproj.
- Extend `bench_allocations.ps1` to print a phase breakdown table and parsing-focused summary.

## Test plan
- [x] `.\build_flashcpp.bat` (default build, no profiling defines)
- [x] `.\build_flashcpp.bat --alloc-stats` (verify `/D FLASHCPP_TRACK_ALLOCATIONS=1` on compile line)
- [ ] `.\build_flashcpp.bat --profile` then `pwsh tests/bench_allocations.ps1 tests/std/test_std_type_traits.cpp`
- [x] `pwsh tests/run_all_tests.ps1` on default (non-profiling) Sharded build

Made with [Cursor](https://cursor.com)