### PR TITLE
Extract shared injected-class-name identity helpers

### DIFF
--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -1005,6 +1005,22 @@ inline std::string_view simpleBaseName(std::string_view name) {
 	return name;
 }
 
+// C++20 [temp.local]: two spellings name the same injected-class-name identity
+// when their simple base names match (ignore namespace qualification and any
+// compiler `$hash` specialization suffix).
+inline bool namesSameInjectedClassIdentity(std::string_view left, std::string_view right) {
+	return simpleBaseName(left) == simpleBaseName(right);
+}
+
+inline bool namesSameInjectedClassIdentity(StringHandle left, StringHandle right) {
+	if (!left.isValid() || !right.isValid()) {
+		return false;
+	}
+	return namesSameInjectedClassIdentity(
+		StringTable::getStringView(left),
+		StringTable::getStringView(right));
+}
+
 // Phase 4: Explicit placeholder kind replaces string-level heuristics (e.g., name.find("::"))
 // for detecting dependent placeholder categories.  Every TypeInfo created as a
 // dependent placeholder stamps one of these values so that SFINAE viability checks,

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -472,8 +472,7 @@ private:
 	// When a template member function references its own class (e.g., const W& in W<T>::operator+=),
 	// the type_index may point to the unfinalized template base. This resolves it to the
 	// enclosing instantiated struct's type_index by mutating `type` in-place.
-	// Important: only resolves when the unfinalized type's name matches the base name of the
-	// enclosing struct — avoids incorrectly resolving outer class references in nested classes.
+	// Delegates to resolveSelfRefParamIndex / namesSameInjectedClassIdentity for [temp.local].
 	static void resolveSelfReferentialType(TypeSpecifierNode& type, TypeIndex enclosing_type_index);
 
 	// Helper: generate a member function call for user-defined operator++/-- overloads on structs.

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -2377,32 +2377,32 @@ void AstToIr::generateTrivialDefaultConstructors() {
 // When a template member function references its own class (e.g., const W& in W<T>::operator+=),
 // the type_index may point to the unfinalized template base. This resolves it to the
 // enclosing instantiated struct's type_index by mutating `type` in-place.
-// Important: only resolves when the unfinalized type's name matches the base name of the
-// enclosing struct — avoids incorrectly resolving outer class references in nested classes.
+// Shares the [temp.local] identity rule with resolveSelfRefParamIndex / namesSameInjectedClassIdentity.
 void AstToIr::resolveSelfReferentialType(TypeSpecifierNode& type, TypeIndex enclosing_type_index) {
-	if (type.category() == TypeCategory::Struct) {
-		const TypeInfo* ti = tryGetTypeInfo(type.type_index());
-		if (!ti)
-			return;
-		if (!ti->getStructInfo() || !ti->getStructInfo()->sizeInBytes().is_set()) {
-			if (const TypeInfo* enc_ti = tryGetTypeInfo(enclosing_type_index)) {
-				// Verify this is actually a self-reference by checking that the unfinalized
-				// type's name matches the base name of the enclosing struct.
-				// For template instantiations: W (unfinalized) matches W$hash (enclosing)
-				// For nested classes: Outer (unfinalized) does NOT match Outer::Inner (enclosing)
-				auto unfinalized_name = StringTable::getStringView(ti->name());
-				auto enclosing_name = StringTable::getStringView(enc_ti->name());
+	if (!type.type_index().is_valid() || !enclosing_type_index.is_valid()) {
+		return;
+	}
 
-				// Extract the base name of the enclosing struct (strip template hash and nested class prefix)
-				// Template hash: "Name$hash" -> "Name"
-				// Nested class: "Outer::Inner" -> "Inner"
-				auto base_name = simpleBaseName(enclosing_name);
+	// Prefer the shared TypeIndex rewrite used by overload resolution and template
+	// parameter copy (incomplete StructInfo, `$hash` skip, nested leaf names).
+	TypeIndex resolved =
+		resolveSelfRefParamIndex(type.type_index(), enclosing_type_index);
+	if (resolved != type.type_index()) {
+		type.set_type_index(resolved);
+		return;
+	}
 
-				if (unfinalized_name == base_name) {
-					type.set_type_index(enclosing_type_index);
-				}
-			}
-		}
+	// Pattern TypeInfos without StructInfo still need name-based rewrite:
+	// W (unfinalized) matches W$hash; Outer does not match Outer::Inner.
+	const TypeInfo* ti = tryGetTypeInfo(type.type_index());
+	const TypeInfo* enc_ti = tryGetTypeInfo(enclosing_type_index);
+	if (ti == nullptr || enc_ti == nullptr || ti->getStructInfo() != nullptr) {
+		return;
+	}
+	if (namesSameInjectedClassIdentity(
+			StringTable::getStringView(ti->name()),
+			StringTable::getStringView(enc_ti->name()))) {
+		type.set_type_index(enclosing_type_index);
 	}
 }
 

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1837,7 +1837,7 @@ struct OperatorOverloadResult {
 // operator+=(const Foo& other) stores the parameter as the uninstantiated Foo
 // (whose struct_info has total_size==0). We resolve it to the concrete instantiated
 // left_type_index so that type matching works correctly.
-// This mirrors the AstToIr::resolveSelfReferentialType logic used in codegen.
+// This is the TypeIndex twin of AstToIr::resolveSelfReferentialType used in codegen.
 inline TypeIndex resolveSelfRefParamIndex(TypeIndex param_idx, TypeIndex left_type_index) {
 	const size_t type_info_size = getTypeInfoCount();
 	if (!param_idx.is_valid() || param_idx.index() >= type_info_size || left_type_index.index() >= type_info_size)

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -1874,6 +1874,76 @@ inline TypeIndex resolveSelfRefParamIndex(TypeIndex param_idx, TypeIndex left_ty
 	return param_idx;
 }
 
+// True when a type token spells the injected-class-name of `owner_decl`
+// (qualified, leaf, or semantic spelling). Used when pattern params never
+// received a TypeIndex and must be rewritten by name under [temp.local].
+inline bool typeTokenNamesOwnerClass(
+	const TypeSpecifierNode& type_spec,
+	const StructDeclarationNode& owner_decl) {
+	StringHandle token = type_spec.token().handle();
+	if (!token.isValid()) {
+		return false;
+	}
+	return namesSameInjectedClassIdentity(token, owner_decl.name()) ||
+		namesSameInjectedClassIdentity(token, owner_decl.semantic_name());
+}
+
+// Look up the TypeInfo for a class being defined/instantiated from its pattern
+// StructDeclarationNode. Member class templates are often registered under the
+// leaf name ("iterator") while pattern_struct.name() is qualified
+// ("outer::iterator"), so try every identity the defining class may use.
+inline TypeIndex resolveDefiningClassTypeIndex(const StructDeclarationNode& owner_decl) {
+	auto try_name = [&](StringHandle name) -> TypeIndex {
+		if (!name.isValid()) {
+			return TypeIndex{};
+		}
+		auto type_it = getTypesByNameMap().find(name);
+		if (type_it == getTypesByNameMap().end() || type_it->second == nullptr) {
+			return TypeIndex{};
+		}
+		TypeIndex index = type_it->second->registeredTypeIndex();
+		if (!index.is_valid()) {
+			index = type_it->second->type_index_;
+		}
+		return index.is_valid()
+			? index.withCategory(TypeCategory::Struct)
+			: TypeIndex{};
+	};
+
+	if (TypeIndex by_name = try_name(owner_decl.name()); by_name.is_valid()) {
+		return by_name;
+	}
+	if (TypeIndex by_semantic = try_name(owner_decl.semantic_name()); by_semantic.is_valid()) {
+		return by_semantic;
+	}
+
+	std::string_view owner_name_view = StringTable::getStringView(owner_decl.name());
+	std::string_view leaf_view = simpleBaseName(owner_name_view);
+	if (!leaf_view.empty() && leaf_view != owner_name_view) {
+		if (TypeIndex by_leaf = try_name(StringTable::getOrInternStringHandle(leaf_view));
+			by_leaf.is_valid()) {
+			return by_leaf;
+		}
+	}
+	return TypeIndex{};
+}
+
+// Explicit self-type rewrite requires a matched from/to pair. When either side
+// is unavailable, disable the pair (callers fall back to name-based rewrite).
+inline void bindSelfTypeRewritePair(
+	TypeIndex from_index,
+	TypeIndex to_index,
+	TypeIndex& self_rewrite_from,
+	TypeIndex& self_rewrite_to) {
+	if (from_index.is_valid() && to_index.is_valid()) {
+		self_rewrite_from = from_index;
+		self_rewrite_to = to_index;
+		return;
+	}
+	self_rewrite_from = TypeIndex{};
+	self_rewrite_to = TypeIndex{};
+}
+
 inline bool binaryOperatorUsesTypeIndexIdentity(TypeCategory cat) {
 	return needs_type_index(cat);
 }

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -3514,43 +3514,15 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 		// current specialization. Prefer TypeIndex identity when available; when
 		// the pattern never registered a TypeInfo (common for member class
 		// templates), fall back to token naming the defining class.
-		auto type_token_names_owner_injected_class =
-			[&](const TypeSpecifierNode& type_spec) -> bool {
-			if (owner_decl == nullptr) {
-				return false;
-			}
-			StringHandle token = type_spec.token().handle();
-			if (!token.isValid()) {
-				return false;
-			}
-			auto leaf_name = [](std::string_view name) -> std::string_view {
-				if (size_t sep = name.rfind("::"); sep != std::string_view::npos) {
-					return name.substr(sep + 2);
-				}
-				return name;
-			};
-			std::string_view token_view = StringTable::getStringView(token);
-			std::string_view token_leaf = leaf_name(token_view);
-			auto matches_owner_name = [&](StringHandle owner_name) {
-				if (!owner_name.isValid()) {
-					return false;
-				}
-				std::string_view owner_view = StringTable::getStringView(owner_name);
-				return token_view == owner_view ||
-					token_leaf == leaf_name(owner_view);
-			};
-			return matches_owner_name(owner_decl->name()) ||
-				matches_owner_name(owner_decl->semantic_name());
-		};
-
 		TypeIndex rewritten_owner_type{};
 		if (self_type_from_index.is_valid() &&
 			self_type_to_index.is_valid() &&
 			substituted_param_type.type_index() == self_type_from_index) {
 			rewritten_owner_type = self_type_to_index;
 		} else if (instantiated_owner_type_index.is_valid() &&
+				   owner_decl != nullptr &&
 				   !substituted_param_type.type_index().is_valid() &&
-				   type_token_names_owner_injected_class(substituted_param_type)) {
+				   typeTokenNamesOwnerClass(substituted_param_type, *owner_decl)) {
 			rewritten_owner_type = instantiated_owner_type_index;
 		}
 		if (rewritten_owner_type.is_valid()) {

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -5241,62 +5241,18 @@ void Parser::materializeHiddenFriendsForClassTemplateInstantiation(
 
 	// Resolve the pattern class TypeInfo used for explicit self-type rewrite of
 	// injected-class-name parameters (e.g. `const iterator&` in a hidden friend).
-	// Member class templates are often stored under a leaf name ("iterator") while
-	// pattern_struct.name() is qualified ("outer::iterator"), so try every identity
-	// the defining class may have been registered under.
-	auto resolve_pattern_owner_type_index = [&]() -> TypeIndex {
-		auto try_name = [&](StringHandle name) -> TypeIndex {
-			if (!name.isValid()) {
-				return TypeIndex{};
-			}
-			auto type_it = getTypesByNameMap().find(name);
-			if (type_it == getTypesByNameMap().end() || type_it->second == nullptr) {
-				return TypeIndex{};
-			}
-			TypeIndex index = type_it->second->registeredTypeIndex();
-			if (!index.is_valid()) {
-				index = type_it->second->type_index_;
-			}
-			return index.is_valid()
-				? index.withCategory(TypeCategory::Struct)
-				: TypeIndex{};
-		};
-
-		if (TypeIndex by_name = try_name(pattern_struct.name()); by_name.is_valid()) {
-			return by_name;
-		}
-		if (TypeIndex by_semantic = try_name(pattern_struct.semantic_name());
-			by_semantic.is_valid()) {
-			return by_semantic;
-		}
-
-		std::string_view pattern_name_view =
-			StringTable::getStringView(pattern_struct.name());
-		if (size_t sep = pattern_name_view.rfind("::"); sep != std::string_view::npos) {
-			StringHandle leaf_name = StringTable::getOrInternStringHandle(
-				pattern_name_view.substr(sep + 2));
-			if (TypeIndex by_leaf = try_name(leaf_name); by_leaf.is_valid()) {
-				return by_leaf;
-			}
-		}
-		return TypeIndex{};
-	};
-
-	const TypeIndex pattern_type_index = resolve_pattern_owner_type_index();
+	const TypeIndex pattern_type_index = resolveDefiningClassTypeIndex(pattern_struct);
 	const TypeIndex concrete_owner_type_index =
 		instantiated_type_index.is_valid()
 			? instantiated_type_index.withCategory(TypeCategory::Struct)
 			: TypeIndex{};
-	// Explicit self rewrite requires a matched from/to pair. When the pattern
-	// TypeInfo is unavailable (common for member class-template patterns before
-	// a standalone registration), disable the pair and rely on owner-decl +
-	// resolveSelfRefParamIndex via instantiated_owner_type_index.
-	const TypeIndex self_rewrite_from =
-		(pattern_type_index.is_valid() && concrete_owner_type_index.is_valid())
-			? pattern_type_index
-			: TypeIndex{};
-	const TypeIndex self_rewrite_to =
-		self_rewrite_from.is_valid() ? concrete_owner_type_index : TypeIndex{};
+	TypeIndex self_rewrite_from{};
+	TypeIndex self_rewrite_to{};
+	bindSelfTypeRewritePair(
+		pattern_type_index,
+		concrete_owner_type_index,
+		self_rewrite_from,
+		self_rewrite_to);
 
 	for (const ASTNode& friend_decl_node : pattern_struct.friend_declarations()) {
 		if (!friend_decl_node.is<FriendDeclarationNode>()) {
@@ -5333,30 +5289,12 @@ void Parser::materializeHiddenFriendsForClassTemplateInstantiation(
 
 		const TypeSpecifierNode& pattern_return_type = pattern_decl.type_specifier_node();
 		TypeIndex return_type_override{};
-		auto return_token_names_pattern = [&]() {
-			StringHandle token = pattern_return_type.token().handle();
-			if (!token.isValid()) {
-				return false;
-			}
-			if (token == pattern_struct.name() || token == pattern_struct.semantic_name()) {
-				return true;
-			}
-			std::string_view token_view = StringTable::getStringView(token);
-			std::string_view pattern_view = StringTable::getStringView(pattern_struct.name());
-			auto leaf = [](std::string_view name) -> std::string_view {
-				if (size_t sep = name.rfind("::"); sep != std::string_view::npos) {
-					return name.substr(sep + 2);
-				}
-				return name;
-			};
-			return leaf(token_view) == leaf(pattern_view);
-		};
 		if (concrete_owner_type_index.is_valid()) {
 			TypeIndex pattern_return_index = pattern_return_type.type_index();
 			if ((pattern_type_index.is_valid() &&
 				 (!pattern_return_index.is_valid() ||
 				  pattern_return_index == pattern_type_index)) ||
-				return_token_names_pattern()) {
+				typeTokenNamesOwnerClass(pattern_return_type, pattern_struct)) {
 				return_type_override = concrete_owner_type_index;
 			}
 		}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -4164,12 +4164,12 @@ CanonicalTypeId SemanticAnalysis::canonicalizeType(const TypeSpecifierNode& type
 					source_namespace == named_type_info->namespaceHandle();
 				bool names_match = false;
 				if (!base_name.empty()) {
-					// Prefer the fully-qualified match, then fall back to the
-					// unqualified spelling for metadata paths that disagree on
-					// whether the template name includes its namespace prefix.
+					// Prefer the fully-qualified match, then fall back to injected-
+					// class-name identity (leaf / `$hash`-stripped) for metadata
+					// paths that disagree on namespace prefix or specialization suffix.
 					names_match = named_name == base_name;
 					if (!names_match) {
-						names_match = unqualifiedTypeName(named_name) == unqualifiedTypeName(base_name);
+						names_match = namesSameInjectedClassIdentity(named_name, base_name);
 					}
 				}
 				if (namespace_matches && names_match) {

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -222,13 +222,6 @@ namespace {
 constexpr std::string_view kTemplatePatternStructSuffix = "$pattern__";
 constexpr std::string_view kAnonymousNamespaceContext = "<anonymous namespace>";
 
-// Return the name after the last scope-resolution operator:
-// `std::ReverseLike` -> `ReverseLike`.
-std::string_view unqualifiedTypeName(std::string_view name) {
-	const size_t pos = name.rfind("::");
-	return pos == std::string_view::npos ? name : name.substr(pos + 2);
-}
-
 // Placeholder return-type finalization requires every return statement in the
 // body to deduce to the same full type identity, including cv/reference and
 // pointer qualifiers. This prevents plain `auto` and `decltype(auto)` from


### PR DESCRIPTION
## Summary
- Centralize C++20 `[temp.local]` injected-class-name matching into shared helpers (`namesSameInjectedClassIdentity`, `typeTokenNamesOwnerClass`, `resolveDefiningClassTypeIndex`, `bindSelfTypeRewritePair`) next to `simpleBaseName` / `resolveSelfRefParamIndex`.
- Replace local lambdas in hidden-friend materialization and member-parameter copy with those helpers.
- Align semantic injected-class-name remapping with the same identity rule.
- Route `AstToIr::resolveSelfReferentialType` through `resolveSelfRefParamIndex` / `namesSameInjectedClassIdentity`, and remove unused `unqualifiedTypeName`.

## Test plan
- [x] `./tests/run_all_tests.ps1 test_member_struct_template_hidden_friend_operator_eq_ret0.cpp`
- [x] `./tests/run_all_tests.ps1 test_class_tmpl_friend_plus_byvalue_ret0.cpp`
- [x] `./tests/run_all_tests.ps1 test_class_tmpl_functional_cast_ctor_ret0.cpp`
- [x] `./tests/run_all_tests.ps1 test_plus_equals_ret5.cpp`