### PR TITLE
Cut parsing allocations from symbol table scope management

### DIFF
--- a/src/ParserScopeGuards.h
+++ b/src/ParserScopeGuards.h
@@ -47,17 +47,15 @@ public:
 
 	// Allow moving
 	TemplateParameterScope(TemplateParameterScope&& other) noexcept
-		: registered_types_(std::move(other.registered_types_)) {
-		other.registered_types_.clear();
+		: registered_parameters_(std::move(other.registered_parameters_)) {
+		other.registered_parameters_.clear();
 	}
 	TemplateParameterScope& operator=(TemplateParameterScope&& other) noexcept {
 		if (this != &other) {
 			// Clean up current registrations first
 			restoreBindings();
-			registered_types_ = std::move(other.registered_types_);
-			previous_bindings_ = std::move(other.previous_bindings_);
-			other.registered_types_.clear();
-			other.previous_bindings_.clear();
+			registered_parameters_ = std::move(other.registered_parameters_);
+			other.registered_parameters_.clear();
 		}
 		return *this;
 	}
@@ -73,23 +71,16 @@ public:
 				previous.type_info = existing->second;
 			}
 			types_by_name.insert_or_assign(type_info->name(), type_info);
-			registered_types_.push_back(type_info);
-			previous_bindings_.push_back(previous);
+			registered_parameters_.push_back(RegisteredParameter{type_info, previous});
 		}
 	}
 
-	// Get the list of registered types (for iteration if needed)
-	std::span<TypeInfo* const> registeredTypes() const {
-		return registered_types_;
-	}
-
 	// Check if any parameters are registered
-	bool empty() const { return registered_types_.empty(); }
+	bool empty() const { return registered_parameters_.empty(); }
 
 	// Dismiss the guard (don't clean up - caller takes responsibility)
 	void dismiss() {
-		registered_types_.clear();
-		previous_bindings_.clear();
+		registered_parameters_.clear();
 	}
 
 private:
@@ -98,10 +89,16 @@ private:
 		TypeInfo* type_info = nullptr;
 	};
 
+	struct RegisteredParameter {
+		TypeInfo* type_info = nullptr;
+		PreviousBinding previous;
+	};
+
 	void restoreBindings() {
 		auto& types_by_name = getTypesByNameMap();
-		for (size_t i = registered_types_.size(); i > 0; --i) {
-			TypeInfo* type_info = registered_types_[i - 1];
+		for (size_t i = registered_parameters_.size(); i > 0; --i) {
+			const RegisteredParameter& entry = registered_parameters_[i - 1];
+			TypeInfo* type_info = entry.type_info;
 			if (!type_info) {
 				continue;
 			}
@@ -109,19 +106,17 @@ private:
 			if (current != types_by_name.end() && current->second != type_info) {
 				continue;
 			}
-			const PreviousBinding& previous = previous_bindings_[i - 1];
+			const PreviousBinding& previous = entry.previous;
 			if (previous.had_binding) {
 				types_by_name.insert_or_assign(type_info->name(), previous.type_info);
 			} else {
 				types_by_name.erase(type_info->name());
 			}
 		}
-		registered_types_.clear();
-		previous_bindings_.clear();
+		registered_parameters_.clear();
 	}
 
-	std::vector<TypeInfo*> registered_types_;
-	std::vector<PreviousBinding> previous_bindings_;
+	InlineVector<RegisteredParameter, 4> registered_parameters_;
 };
 
 // =============================================================================

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -39,6 +39,32 @@ static void logTemplateRequiresClauseFailure(
 	FLASH_LOG(Templates, Debug, "  template arguments: ", args_str);
 }
 
+// Enter all ancestor namespace scopes for a source namespace (outermost first).
+// Returns the number of scopes pushed (to be passed to exitSourceNamespaceScopes).
+static int enterSourceNamespaceScopes(NamespaceHandle source_namespace) {
+	if (!source_namespace.isValid() || source_namespace.isGlobal()) {
+		return 0;
+	}
+	// Collect chain from innermost to outermost (excluding global)
+	InlineVector<NamespaceHandle, 8> chain;
+	NamespaceHandle cur = source_namespace;
+	while (cur.isValid() && !cur.isGlobal()) {
+		chain.push_back(cur);
+		cur = gNamespaceRegistry.getParent(cur);
+	}
+	// Push from outermost to innermost so lookup finds ancestors first
+	for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
+		gSymbolTable.enter_namespace(chain[i]);
+	}
+	return static_cast<int>(chain.size());
+}
+
+static void exitSourceNamespaceScopes(int entered) {
+	for (int i = 0; i < entered; ++i) {
+		gSymbolTable.exit_scope();
+	}
+}
+
 static bool isForwardingReferenceParameter(
 	const TypeSpecifierNode& type,
 	std::span<const TemplateParameterNode> template_params) {
@@ -783,33 +809,6 @@ bool Parser::tryAppendDefaultTemplateArg(
 		return false;
 	};
 
-	// Helper to enter the source namespace for reparsing if provided
-	// Pushes ALL ancestor namespace scopes (outermost first) so that unqualified
-	// lookup correctly walks from the declaration namespace up to global.
-	// Returns the number of scopes pushed (to be passed to exitSourceNamespaceIfNeeded).
-	auto enterSourceNamespaceIfNeeded = [&]() -> int {
-		if (!source_namespace.isValid() || source_namespace.isGlobal()) {
-			return 0;
-		}
-		// Collect chain from innermost to outermost (excluding global)
-		InlineVector<NamespaceHandle, 8> chain;
-		NamespaceHandle cur = source_namespace;
-		while (cur.isValid() && !cur.isGlobal()) {
-			chain.push_back(cur);
-			cur = gNamespaceRegistry.getParent(cur);
-		}
-		// Push from outermost to innermost so lookup finds ancestors first
-		for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
-			gSymbolTable.enter_namespace(chain[i]);
-		}
-		return static_cast<int>(chain.size());
-	};
-	auto exitSourceNamespaceIfNeeded = [&](int entered) {
-		for (int i = 0; i < entered; ++i) {
-			gSymbolTable.exit_scope();
-		}
-	};
-
 	auto tryReparseNonTypeDefaultArg = [&]() -> bool {
 		if (!param.has_default_value_position() || template_args.empty()) {
 			return false;
@@ -832,9 +831,9 @@ bool Parser::tryAppendDefaultTemplateArg(
 		FlashCpp::TemplateParameterScope sfinae_scope;
 		registerTypeParamsInScope(template_params, template_args, sfinae_scope, &sfinae_type_map_);
 
-		int entered_ns = enterSourceNamespaceIfNeeded();
+		int entered_ns = enterSourceNamespaceScopes(source_namespace);
 		auto reparse_result = parse_expression(DEFAULT_PRECEDENCE, ExpressionContext::TemplateTypeArg);
-		exitSourceNamespaceIfNeeded(entered_ns);
+		exitSourceNamespaceScopes(entered_ns);
 		restore_lexer_position_only(sfinae_pos);
 
 		if (reparse_result.is_error() || !reparse_result.node().has_value() ||
@@ -866,14 +865,14 @@ bool Parser::tryAppendDefaultTemplateArg(
 			FlashCpp::TemplateParameterScope sfinae_scope;
 			registerTypeParamsInScope(template_params, template_args, sfinae_scope, &sfinae_type_map_);
 
-			int entered_ns = enterSourceNamespaceIfNeeded();
+			int entered_ns = enterSourceNamespaceScopes(source_namespace);
 			FLASH_LOG_FORMAT(Templates, Debug, "SFINAE reparse: entered_ns={}, current_ns={}",
 				entered_ns,
 				gSymbolTable.get_current_namespace_handle().isValid()
 					? gNamespaceRegistry.getQualifiedName(gSymbolTable.get_current_namespace_handle())
 					: "(global)");
 			auto reparse_result = parse_type_specifier();
-			exitSourceNamespaceIfNeeded(entered_ns);
+			exitSourceNamespaceScopes(entered_ns);
 			restore_lexer_position_only(sfinae_pos);
 
 			if (reparse_result.is_error() || !reparse_result.node().has_value() ||
@@ -1290,30 +1289,9 @@ void Parser::reparse_template_function_body(
 	// Restore lexer to the template body start.
 	restore_lexer_position_only(func_decl.template_body_position());
 
-	auto enterSourceNamespaceIfNeeded = [&]() -> int {
-		NamespaceHandle source_namespace = func_decl.namespace_handle();
-		if (!source_namespace.isValid() || source_namespace.isGlobal()) {
-			return 0;
-		}
-		InlineVector<NamespaceHandle, 8> chain;
-		NamespaceHandle current = source_namespace;
-		while (current.isValid() && !current.isGlobal()) {
-			chain.push_back(current);
-			current = gNamespaceRegistry.getParent(current);
-		}
-		for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
-			gSymbolTable.enter_namespace(chain[i]);
-		}
-		return static_cast<int>(chain.size());
-	};
-	auto exitSourceNamespaceIfNeeded = [&](int entered) {
-		for (int i = 0; i < entered; ++i) {
-			gSymbolTable.exit_scope();
-		}
-	};
-	const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+	const int entered_namespace_count = enterSourceNamespaceScopes(func_decl.namespace_handle());
 	auto exit_source_namespace = ScopeGuard([&]() {
-		exitSourceNamespaceIfNeeded(entered_namespace_count);
+		exitSourceNamespaceScopes(entered_namespace_count);
 	});
 
 	// Enter function scope, set current function, register parameters.
@@ -2660,28 +2638,6 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 		}
 	};
 
-	auto enterSourceNamespaceIfNeeded = [&]() -> int {
-		NamespaceHandle source_namespace = func_decl.namespace_handle();
-		if (!source_namespace.isValid() || source_namespace.isGlobal()) {
-			return 0;
-		}
-		InlineVector<NamespaceHandle, 8> chain;
-		NamespaceHandle current = source_namespace;
-		while (current.isValid() && !current.isGlobal()) {
-			chain.push_back(current);
-			current = gNamespaceRegistry.getParent(current);
-		}
-		for (int i = static_cast<int>(chain.size()) - 1; i >= 0; --i) {
-			gSymbolTable.enter_namespace(chain[i]);
-		}
-		return static_cast<int>(chain.size());
-	};
-	auto exitSourceNamespaceIfNeeded = [&](int entered) {
-		for (int i = 0; i < entered; ++i) {
-			gSymbolTable.exit_scope();
-		}
-	};
-
 	const bool should_reparse_trailing_return_type =
 		func_decl.has_trailing_return_type_position();
 
@@ -2744,9 +2700,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 		registerTypeParamsInScope(
 			substitution_environment,
 			template_scope);
-		const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+		const int entered_namespace_count = enterSourceNamespaceScopes(func_decl.namespace_handle());
 		auto exit_source_namespace = ScopeGuard([&]() {
-			exitSourceNamespaceIfNeeded(entered_namespace_count);
+			exitSourceNamespaceScopes(entered_namespace_count);
 		});
 
 		try {
@@ -2862,9 +2818,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			}
 			FlashCpp::TemplateParameterScope template_scope;
 			registerTypeParamsInScope(substitution_environment, template_scope);
-			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			const int entered_namespace_count = enterSourceNamespaceScopes(func_decl.namespace_handle());
 			auto exit_source_namespace = ScopeGuard([&]() {
-				exitSourceNamespaceIfNeeded(entered_namespace_count);
+				exitSourceNamespaceScopes(entered_namespace_count);
 			});
 			auto return_type_result = parse_type_specifier();
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
@@ -2965,9 +2921,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			}
 			FlashCpp::TemplateParameterScope template_scope;
 			registerTypeParamsInScope(substitution_environment, template_scope);
-			const int entered_namespace_count = enterSourceNamespaceIfNeeded();
+			const int entered_namespace_count = enterSourceNamespaceScopes(func_decl.namespace_handle());
 			auto exit_return_type_namespace = ScopeGuard([&]() {
-				exitSourceNamespaceIfNeeded(entered_namespace_count);
+				exitSourceNamespaceScopes(entered_namespace_count);
 			});
 			auto return_type_result = parse_type_specifier();
 			if (return_type_result.node().has_value() && return_type_result.node()->is<TypeSpecifierNode>()) {
@@ -2992,9 +2948,9 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			restore_lexer_position_only(func_decl.template_declaration_position());
 			FlashCpp::TemplateParameterScope template_scope2;
 			registerTypeParamsInScope(substitution_environment, template_scope2);
-			const int entered_name_parse_namespace_count = enterSourceNamespaceIfNeeded();
+			const int entered_name_parse_namespace_count = enterSourceNamespaceScopes(func_decl.namespace_handle());
 			auto exit_name_parse_namespace = ScopeGuard([&]() {
-				exitSourceNamespaceIfNeeded(entered_name_parse_namespace_count);
+				exitSourceNamespaceScopes(entered_name_parse_namespace_count);
 			});
 			auto type_and_name_result = parse_type_and_name();
 			restore_lexer_position_only(current_pos);

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -40,6 +40,11 @@ struct Scope {
 	Scope(ScopeType scopeType, size_t scope_level, StringHandle ns_name)
 		: scope_type(scopeType), scope_handle{.scope_level = scope_level}, namespace_name(ns_name) {}
 
+	Scope(Scope&&) noexcept = default;
+	Scope& operator=(Scope&&) noexcept = default;
+	Scope(const Scope&) = default;
+	Scope& operator=(const Scope&) = default;
+
 	ScopeType scope_type = ScopeType::Block;
 	// Changed to support function overloading: each name can map to multiple symbols (for overloaded functions)
 	// Use string_view keys with a dedicated ChunkedStringAllocator in SymbolTable to avoid copies

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -191,7 +191,18 @@ public:
 					ns_handle = get_current_namespace_handle();
 					ns_key = StringTable::getOrInternStringHandle(identifier);
 				}
-				namespace_symbols_[ns_handle][ns_key] = std::vector<ASTNode>{node};
+				/* Global scope keys existence off scope.symbols, so namespace_symbols_ can
+				   in principle already hold entries this scope never saw. Append rather than
+				   assign so such entries are never silently dropped. For namespace scopes
+				   existing_ptr came from this very map, so absence here is authoritative and
+				   the append degenerates into a fresh vector. */
+				auto& ns_symbols = namespace_symbols_[ns_handle];
+				auto ns_it = ns_symbols.find(ns_key);
+				if (ns_it == ns_symbols.end()) {
+					ns_symbols[ns_key] = std::vector<ASTNode>{node};
+				} else {
+					ns_it->second.push_back(node);
+				}
 			}
 			return true;
 		}

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -423,11 +423,12 @@ public:
 
 			// If we're in a namespace scope, also check namespace_symbols_ for symbols
 			// from other blocks of the same namespace (e.g., reopened namespace blocks).
-			// Use lookup_qualified() so that inline child namespaces are also searched
-			// (lookup_qualified -> lookup_qualified_all -> forEachInlineChildNamespace).
+			// Use allocation-free first-match lookup; inline child namespaces and
+			// ambiguity diagnostics match lookup_qualified_all.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
-					auto result = lookup_qualified(scope_namespace, identifier);
+					StringHandle key = StringTable::getOrInternStringHandle(identifier);
+					auto result = lookup_qualified_first(scope_namespace, key);
 					if (result.has_value()) {
 						return result;
 					}
@@ -1024,14 +1025,7 @@ public:
 	}
 
 	std::optional<ASTNode> lookup_qualified(NamespaceHandle namespace_handle, StringHandle identifier) const {
-		if (!namespace_handle.isValid()) {
-			return std::nullopt;
-		}
-		auto result = lookup_qualified_all(namespace_handle, identifier);
-		if (result.empty()) {
-			return std::nullopt;
-		}
-		return result[0];
+		return lookup_qualified_first(namespace_handle, identifier);
 	}
 
 	bool has_namespace_symbols(NamespaceHandle namespace_handle) const {
@@ -1263,6 +1257,40 @@ private:
 		std::string_view interned = sb.append(str).commit();
 		interned_strings_.insert(interned);
 		return interned;
+	}
+
+	// First-match qualified lookup without allocating an overload vector.
+	// Mirrors lookup_qualified_all's inline-child walk and ambiguity rule, but
+	// returns only the first node (same as lookup_qualified historically did via [0]).
+	std::optional<ASTNode> lookup_qualified_first(NamespaceHandle namespace_handle, StringHandle identifier) const {
+		if (!namespace_handle.isValid()) {
+			return std::nullopt;
+		}
+		const std::vector<ASTNode>* first_nodes = nullptr;
+		gNamespaceRegistry.forEachInlineChildNamespace(namespace_handle, [&](NamespaceHandle visible_ns) {
+			auto ns_it = namespace_symbols_.find(visible_ns);
+			if (ns_it == namespace_symbols_.end()) {
+				return;
+			}
+			auto symbol_it = ns_it->second.find(identifier);
+			if (symbol_it == ns_it->second.end() || symbol_it->second.empty()) {
+				return;
+			}
+			if (!first_nodes) {
+				first_nodes = &symbol_it->second;
+				return;
+			}
+			if (!is_pure_function_set(*first_nodes) || !is_pure_function_set(symbol_it->second)) {
+				// C++20 [namespace.qual]: same ambiguity rule as lookup_qualified_all.
+				throw CompileError("ambiguous lookup: '" + std::string(StringTable::getStringView(identifier)) + "' found in multiple inline namespaces");
+			}
+			// Pure function sets across inline namespaces merge into one overload set;
+			// the first match's [0] is unchanged, so nothing further is needed here.
+		});
+		if (!first_nodes) {
+			return std::nullopt;
+		}
+		return (*first_nodes)[0];
 	}
 
 	template <typename Map, typename Key, typename Value>

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -153,132 +153,173 @@ public:
 
 	bool insert(std::string_view identifier, ASTNode node) {
 		auto& current_scope = symbol_table_stack_.back();
-		// First, try to find the identifier without interning
-		auto it = current_scope.symbols.find(identifier);
+		const bool ns_scope = current_scope.scope_type == ScopeType::Namespace;
+		const bool global_scope = current_scope.scope_type == ScopeType::Global;
 
-		// If this is a new identifier, intern it and create a new vector
-		if (it == current_scope.symbols.end()) {
+		// For namespace scopes, namespace_symbols_ is the source of truth for
+		// redeclaration / overload detection across reopened blocks. Global and
+		// other scopes still use the local symbols map.
+		std::vector<ASTNode>* existing_ptr = nullptr;
+		NamespaceHandle ns_handle{};
+		StringHandle ns_key{};
+		if (ns_scope) {
+			ns_handle = get_current_namespace_handle();
+			auto& ns_symbols = namespace_symbols_[ns_handle];
+			ns_key = StringTable::getOrInternStringHandle(identifier);
+			auto ns_it = ns_symbols.find(ns_key);
+			if (ns_it != ns_symbols.end()) {
+				existing_ptr = &ns_it->second;
+			}
+		} else {
+			auto it = current_scope.symbols.find(identifier);
+			if (it != current_scope.symbols.end()) {
+				existing_ptr = &it->second;
+			}
+		}
+
+		auto sync_namespace_scope_symbols = [&](const std::vector<ASTNode>& nodes) {
+			std::string_view key = intern_string(identifier);
+			current_scope.symbols[key] = nodes;
+		};
+
+		// If this is a new identifier, create a new vector
+		if (!existing_ptr) {
 			std::string_view key = intern_string(identifier);
 			current_scope.symbols[key] = std::vector<ASTNode>{node};
-		} else {
-			// Identifier exists - check if we can add this as an overload
-			auto& existing_nodes = it->second;
-
-			// For non-function symbols (variables, etc.), don't allow duplicates in the same scope
-			// This includes DeclarationNode and VariableDeclarationNode
-			// Use helper function to check for both FunctionDeclarationNode and TemplateFunctionDeclarationNode
-			if (!is_function_or_template_function(node)) {
-				// Check if any existing symbol has a different type
-				if (!existing_nodes.empty() && existing_nodes[0].type_name() != node.type_name()) {
-					return false;
+			if (ns_scope || global_scope) {
+				if (!ns_scope) {
+					ns_handle = get_current_namespace_handle();
+					ns_key = StringTable::getOrInternStringHandle(identifier);
 				}
-				// Don't allow duplicate non-function symbols in the same scope
+				namespace_symbols_[ns_handle][ns_key] = std::vector<ASTNode>{node};
+			}
+			return true;
+		}
+
+		// Identifier exists - check if we can add this as an overload
+		auto& existing_nodes = *existing_ptr;
+
+		// For non-function symbols (variables, etc.), don't allow duplicates in the same scope
+		// This includes DeclarationNode and VariableDeclarationNode
+		// Use helper function to check for both FunctionDeclarationNode and TemplateFunctionDeclarationNode
+		if (!is_function_or_template_function(node)) {
+			// Check if any existing symbol has a different type
+			if (!existing_nodes.empty() && existing_nodes[0].type_name() != node.type_name()) {
 				return false;
 			}
+			// Don't allow duplicate non-function symbols in the same scope
+			return false;
+		}
 
-			// For function declarations (including template functions), allow overloading
+		// For function declarations (including template functions), allow overloading
+		// Check if a function with the same signature already exists
+		const FunctionDeclarationNode* new_func = get_function_decl_node(node);
+		if (new_func) {
+			const auto& new_params = new_func->parameter_nodes();
+
 			// Check if a function with the same signature already exists
-			const FunctionDeclarationNode* new_func = get_function_decl_node(node);
-			if (new_func) {
-				const auto& new_params = new_func->parameter_nodes();
+			for (size_t i = 0; i < existing_nodes.size(); ++i) {
+				const FunctionDeclarationNode* existing_func = get_function_decl_node(existing_nodes[i]);
+				if (existing_func) {
+					const auto& existing_params = existing_func->parameter_nodes();
 
-				// Check if a function with the same signature already exists
-				for (size_t i = 0; i < existing_nodes.size(); ++i) {
-					const FunctionDeclarationNode* existing_func = get_function_decl_node(existing_nodes[i]);
-					if (existing_func) {
-						const auto& existing_params = existing_func->parameter_nodes();
+					// Check if parameter counts match
+					if (new_params.size() == existing_params.size() &&
+						new_func->is_variadic() == existing_func->is_variadic()) {
+						// Check if all parameter types match
+						bool all_match = true;
+						for (size_t j = 0; j < new_params.size(); ++j) {
+							const auto& new_param_type = new_params[j].as<DeclarationNode>().type_specifier_node();
+							const auto& existing_param_type = existing_params[j].as<DeclarationNode>().type_specifier_node();
 
-						// Check if parameter counts match
-						if (new_params.size() == existing_params.size() &&
-							new_func->is_variadic() == existing_func->is_variadic()) {
-							// Check if all parameter types match
-							bool all_match = true;
-							for (size_t j = 0; j < new_params.size(); ++j) {
-								const auto& new_param_type = new_params[j].as<DeclarationNode>().type_specifier_node();
-								const auto& existing_param_type = existing_params[j].as<DeclarationNode>().type_specifier_node();
-
-								if (!new_param_type.matches_signature(existing_param_type)) {
-									all_match = false;
-									break;
-								}
+							if (!new_param_type.matches_signature(existing_param_type)) {
+								all_match = false;
+								break;
 							}
+						}
 
-							// Also check return types for template specializations
-							// (e.g., get<0> returns int, get<1> returns double - different specializations)
-							if (all_match) {
-								const auto& new_return_type = new_func->decl_node().type_specifier_node();
-								const auto& existing_return_type = existing_func->decl_node().type_specifier_node();
-								if (!new_return_type.matches_signature(existing_return_type)) {
-									all_match = false;  // Different return types = different specializations
-								}
+						// Also check return types for template specializations
+						// (e.g., get<0> returns int, get<1> returns double - different specializations)
+						if (all_match) {
+							const auto& new_return_type = new_func->decl_node().type_specifier_node();
+							const auto& existing_return_type = existing_func->decl_node().type_specifier_node();
+							if (!new_return_type.matches_signature(existing_return_type)) {
+								all_match = false;  // Different return types = different specializations
 							}
+						}
 
-							if (all_match) {
-								const bool new_is_template =
-									node.is<TemplateFunctionDeclarationNode>();
-								const bool existing_is_template =
-									existing_nodes[i].is<TemplateFunctionDeclarationNode>();
-								if (new_is_template != existing_is_template) {
-									continue;
-								}
-								// Same signature found - replace forward declaration with definition if needed
-								// If the new one has a definition and the existing one doesn't, replace it
-								if (new_func->is_materialized() && !existing_func->is_materialized()) {
-									existing_nodes[i] = node;
+						if (all_match) {
+							const bool new_is_template =
+								node.is<TemplateFunctionDeclarationNode>();
+							const bool existing_is_template =
+								existing_nodes[i].is<TemplateFunctionDeclarationNode>();
+							if (new_is_template != existing_is_template) {
+								continue;
+							}
+							// Same signature found - replace forward declaration with definition if needed
+							// If the new one has a definition and the existing one doesn't, replace it
+							if (new_func->is_materialized() && !existing_func->is_materialized()) {
+								existing_nodes[i] = node;
 
-									// Also update the namespace_symbols_ map if we're in a namespace or global scope
-									if (current_scope.scope_type == ScopeType::Namespace || current_scope.scope_type == ScopeType::Global) {
-										NamespaceHandle ns_handle = get_current_namespace_handle();
-										auto& ns_symbols = namespace_symbols_[ns_handle];
-										StringHandle key = StringTable::getOrInternStringHandle(identifier);
+								if (ns_scope) {
+									// existing_nodes is already namespace_symbols_; keep the local map in sync
+									sync_namespace_scope_symbols(existing_nodes);
+								} else if (global_scope) {
+									// Global still uses scope.symbols as primary; mirror into namespace_symbols_
+									NamespaceHandle mirror_ns = get_current_namespace_handle();
+									auto& ns_symbols = namespace_symbols_[mirror_ns];
+									StringHandle key = StringTable::getOrInternStringHandle(identifier);
 
-										auto ns_it = ns_symbols.find(key);
-										if (ns_it != ns_symbols.end()) {
-											// Find and replace the matching node in namespace_symbols_
-											for (size_t k = 0; k < ns_it->second.size(); ++k) {
-												const FunctionDeclarationNode* ns_func = get_function_decl_node(ns_it->second[k]);
-												if (ns_func) {
-													const auto& ns_params = ns_func->parameter_nodes();
+									auto ns_it = ns_symbols.find(key);
+									if (ns_it != ns_symbols.end()) {
+										for (size_t k = 0; k < ns_it->second.size(); ++k) {
+											const FunctionDeclarationNode* ns_func = get_function_decl_node(ns_it->second[k]);
+											if (ns_func) {
+												const auto& ns_params = ns_func->parameter_nodes();
 
-													// Check if this is the same signature
-													if (ns_params.size() == new_params.size() &&
-														ns_func->is_variadic() == new_func->is_variadic()) {
-														bool params_match = true;
-														for (size_t m = 0; m < ns_params.size(); ++m) {
-															const auto& ns_param_type = ns_params[m].as<DeclarationNode>().type_specifier_node();
-															const auto& new_param_type = new_params[m].as<DeclarationNode>().type_specifier_node();
-															if (!ns_param_type.matches_signature(new_param_type)) {
-																params_match = false;
-																break;
-															}
-														}
-														if (params_match) {
-															ns_it->second[k] = node;
+												if (ns_params.size() == new_params.size() &&
+													ns_func->is_variadic() == new_func->is_variadic()) {
+													bool params_match = true;
+													for (size_t m = 0; m < ns_params.size(); ++m) {
+														const auto& ns_param_type = ns_params[m].as<DeclarationNode>().type_specifier_node();
+														const auto& new_param_type = new_params[m].as<DeclarationNode>().type_specifier_node();
+														if (!ns_param_type.matches_signature(new_param_type)) {
+															params_match = false;
 															break;
 														}
+													}
+													if (params_match) {
+														ns_it->second[k] = node;
+														break;
 													}
 												}
 											}
 										}
 									}
 								}
-								// Otherwise, it's a duplicate declaration - just ignore it
-								return true;
 							}
+							// Otherwise, it's a duplicate declaration - just ignore it
+							return true;
 						}
 					}
 				}
 			}
-
-			// No matching signature found - add as new overload
-			existing_nodes.push_back(node);
 		}
 
-		// If we're in a namespace or global scope, also add to the persistent namespace map
-		// For global scope, use an empty namespace path (represents ::identifier)
-		if (current_scope.scope_type == ScopeType::Namespace || current_scope.scope_type == ScopeType::Global) {
-			NamespaceHandle ns_handle = get_current_namespace_handle();
-			auto& ns_symbols = namespace_symbols_[ns_handle];
+		// No matching signature found - add as new overload
+		existing_nodes.push_back(node);
+
+		if (ns_scope) {
+			// existing_nodes is namespace_symbols_; sync the full overload set into the
+			// local map so lookup that hits scope.symbols first still sees every overload.
+			sync_namespace_scope_symbols(existing_nodes);
+			return true;
+		}
+
+		// Global scope: also add to the persistent namespace map
+		if (global_scope) {
+			NamespaceHandle mirror_ns = get_current_namespace_handle();
+			auto& ns_symbols = namespace_symbols_[mirror_ns];
 			StringHandle key = StringTable::getOrInternStringHandle(identifier);
 
 			auto ns_it = ns_symbols.find(key);

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -405,26 +405,10 @@ public:
 				return symbolIt->second[0];
 			}
 
-			// Second, fall back to unresolved using declarations in this scope.
-			auto using_handle_it = scope.using_declarations_handles.find(identifier);
-			if (using_handle_it != scope.using_declarations_handles.end()) {
-				const auto& [using_namespace_handle, original_name] = using_handle_it->second;
-				auto result = lookup_qualified(using_namespace_handle, original_name);
-				if (result.has_value()) {
-					return result;
-				}
-			}
-
-			// Third, check using directives in this scope
-			auto using_result = lookup_using_directives_first(scope, identifier);
-			if (using_result.has_value()) {
-				return using_result;
-			}
-
-			// If we're in a namespace scope, also check namespace_symbols_ for symbols
-			// from other blocks of the same namespace (e.g., reopened namespace blocks).
-			// Use allocation-free first-match lookup; inline child namespaces and
-			// ambiguity diagnostics match lookup_qualified_all.
+			// For namespace scopes, probe namespace_symbols_ immediately after the local
+			// symbols map and before using-declarations/directives. Member names of the
+			// namespace itself must beat imports; once enter_namespace stops preloading,
+			// those members live only in namespace_symbols_.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
 					StringHandle key = StringTable::getOrInternStringHandle(identifier);
@@ -434,6 +418,22 @@ public:
 					}
 				}
 				scope_namespace = gNamespaceRegistry.getParent(scope_namespace);
+			}
+
+			// Fall back to unresolved using declarations in this scope.
+			auto using_handle_it = scope.using_declarations_handles.find(identifier);
+			if (using_handle_it != scope.using_declarations_handles.end()) {
+				const auto& [using_namespace_handle, original_name] = using_handle_it->second;
+				auto result = lookup_qualified(using_namespace_handle, original_name);
+				if (result.has_value()) {
+					return result;
+				}
+			}
+
+			// Check using directives in this scope
+			auto using_result = lookup_using_directives_first(scope, identifier);
+			if (using_result.has_value()) {
+				return using_result;
 			}
 		}
 
@@ -479,24 +479,10 @@ public:
 				return symbolIt->second;
 			}
 
-			// Second, fall back to unresolved using declarations in this scope.
-			auto using_handle_it = scope.using_declarations_handles.find(identifier);
-			if (using_handle_it != scope.using_declarations_handles.end()) {
-				const auto& [using_namespace_handle, original_name] = using_handle_it->second;
-				auto result = lookup_qualified_all(using_namespace_handle, original_name);
-				if (!result.empty()) {
-					return result;
-				}
-			}
-
-			// Third, check using directives in this scope
-			auto using_result = lookup_all_using_directives_first(scope, identifier);
-			if (!using_result.empty()) {
-				return using_result;
-			}
-
-			// If we're in a namespace scope, also check namespace_symbols_ for symbols
-			// from other blocks of the same namespace (e.g., reopened namespace blocks).
+			// For namespace scopes, probe namespace_symbols_ immediately after the local
+			// symbols map and before using-declarations/directives. Member names of the
+			// namespace itself must beat imports; once enter_namespace stops preloading,
+			// those members live only in namespace_symbols_.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
 					StringHandle key = StringTable::getOrInternStringHandle(identifier);
@@ -506,6 +492,22 @@ public:
 					}
 				}
 				scope_namespace = gNamespaceRegistry.getParent(scope_namespace);
+			}
+
+			// Fall back to unresolved using declarations in this scope.
+			auto using_handle_it = scope.using_declarations_handles.find(identifier);
+			if (using_handle_it != scope.using_declarations_handles.end()) {
+				const auto& [using_namespace_handle, original_name] = using_handle_it->second;
+				auto result = lookup_qualified_all(using_namespace_handle, original_name);
+				if (!result.empty()) {
+					return result;
+				}
+			}
+
+			// Check using directives in this scope
+			auto using_result = lookup_all_using_directives_first(scope, identifier);
+			if (!using_result.empty()) {
+				return using_result;
 			}
 		}
 

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -917,14 +917,9 @@ public:
 			gNamespaceRegistry.markDeclared(ns_handle);
 			const NamespaceEntry& entry = gNamespaceRegistry.getEntry(ns_handle);
 			scope.namespace_name = entry.name;
-			// Preload existing namespace symbols so unqualified lookup works when re-entering
-			auto ns_it = namespace_symbols_.find(ns_handle);
-			if (ns_it != namespace_symbols_.end()) {
-				for (const auto& [id_handle, nodes] : ns_it->second) {
-					std::string_view key = intern_string(StringTable::getStringView(id_handle));
-					scope.symbols[key] = nodes;
-				}
-			}
+			// Namespace members live in namespace_symbols_; lookup/lookup_all probe that
+			// map for Namespace scopes, and insert() uses it as the source of truth for
+			// redeclarations across reopened blocks. Do not preload into scope.symbols.
 		}
 		symbol_table_stack_.push_back(std::move(scope));
 	}


### PR DESCRIPTION
## Summary

Parsing-phase allocations on `tests/std/test_std_type_traits.cpp` were dominated by symbol-table scope
management driven by template instantiation, not by AST node creation. This branch removes the two
largest sources and the redundant per-scope symbol copy.

Parsing allocations drop from **63,172 to 48,413** and parsing bytes from **18,424,370 to 17,479,711**.
Note the count reduction is much larger than the byte reduction, so this is primarily an
allocator-pressure improvement; wall-clock benefit is not yet established.

### What changed

- **`Scope` is now cheaply movable.** `Scope` holds three `unordered_map`s, whose move constructors are
  not `noexcept` under MSVC, so `Scope` was not nothrow-move-constructible and every `vector<Scope>`
  reallocation of `symbol_table_stack_` deep-copied every live scope's hash tables via `move_if_noexcept`.
  Defaulting the move operations as `noexcept` (valid in C++20 per P1286R2) turns those into moves.
- **`TemplateParameterScope` uses one `InlineVector`** instead of two parallel `std::vector`s, making the
  common case of four or fewer template parameters allocation-free. This also fixes a latent bug where
  the move constructor dropped `previous_bindings_` while keeping `registered_types_`, which would have
  left `restoreBindings()` indexing out of bounds. No caller moves the guard today, so it was unreachable.
- **`enter_namespace` no longer preloads the namespace symbol map into every new `Scope`.** Re-entering
  `std` during template instantiation was deep-copying every symbol. Lookup already fell back to
  `namespace_symbols_`; that probe now runs immediately after the local symbols map so namespace members
  keep priority over using-directive imports, `insert()` uses `namespace_symbols_` as the source of truth
  for redeclarations across reopened blocks, and the preload is gone.
- Adds an allocation-free first-match qualified lookup path, and de-duplicates three identical copies of
  the source-namespace enter/exit helpers in template instantiation.

### Platform note

The `Scope` move fix exploits MSVC's `unordered_map` move constructor not being `noexcept`. libstdc++ may
already mark it conditionally `noexcept`, in which case `vector<Scope>` was already moving on Linux and
that particular change buys nothing there. CI only verifies correctness, not allocation counts, so the
size of the Linux win remains unmeasured.

## Test plan

- [x] `pwsh tests/run_all_tests.ps1` - 2802/2802 regular, 241/241 `_fail` as expected
- [x] Ubuntu CI (clang) build is green
- [x] MSVC CI is green

## Known follow-ups (not in this PR)

- No regression test yet pins the new lookup ordering. It was a provable no-op while the preload existed,
  but removing the preload makes it load-bearing for the first time. Tests for cross-block namespace
  overloads, using-directive vs namespace-member priority, and inline-namespace ambiguity should follow.
- `insert()` still syncs a name's full overload set into `scope.symbols` on every namespace insert,
  which is O(N^2) for N overloads of one name. Dropping the local map for namespace scopes entirely is
  the natural next step.
- `lookup_all` still allocates a `vector<ASTNode>` per call, and it is now a primary path rather than a
  fallback.
