### PR TITLE
Remove per-lookup allocations in template registry and namespace symbol storage

### DIFF
--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -181,7 +181,8 @@ public:
 		if (!existing_ptr) {
 			if (ns_scope) {
 				// Namespace scopes store members only in namespace_symbols_; do not
-				// mirror into scope.symbols (that map holds using-declarations only).
+				// mirror into scope.symbols (namespace-scope using-declarations also
+				// merge into namespace_symbols_; see materialize_using_declaration_symbols).
 				namespace_symbols_[ns_handle][ns_key] = std::vector<ASTNode>{node};
 				return true;
 			}
@@ -460,7 +461,8 @@ public:
 			const Scope& scope = *stackIt;
 
 			// For namespace scopes, probe namespace_symbols_ before the local symbols map.
-			// Members live only in namespace_symbols_; scope.symbols holds using-declarations.
+			// Members and namespace-scope using-declarations live in namespace_symbols_;
+			// scope.symbols holds block/function-scope using-declarations only.
 			// Advance scope_namespace exactly once per Namespace scope regardless of hit/miss.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
@@ -534,7 +536,8 @@ public:
 			const Scope& scope = *stackIt;
 
 			// For namespace scopes, probe namespace_symbols_ before the local symbols map.
-			// Members live only in namespace_symbols_; scope.symbols holds using-declarations.
+			// Members and namespace-scope using-declarations live in namespace_symbols_;
+			// scope.symbols holds block/function-scope using-declarations only.
 			// Advance scope_namespace exactly once per Namespace scope regardless of hit/miss.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
@@ -998,7 +1001,9 @@ public:
 		update_or_insert(current_scope.using_declarations_handles, key, std::make_pair(namespace_handle, orig_name));
 
 		// Materialize the referenced declaration(s) into the current scope so they
-		// participate in ordinary lookup and overload-set formation.
+		// participate in ordinary lookup and overload-set formation. At namespace
+		// scope this merges into namespace_symbols_ ([namespace.udecl]); elsewhere
+		// into scope.symbols.
 		materialize_using_declaration_symbols(current_scope, key, namespace_handle, orig_name);
 	}
 
@@ -1014,7 +1019,9 @@ public:
 		update_or_insert(current_scope.using_declarations_handles, key, std::make_pair(namespace_handle, orig_name));
 
 		// Materialize the referenced declaration(s) into the current scope so they
-		// participate in ordinary lookup and overload-set formation.
+		// participate in ordinary lookup and overload-set formation. At namespace
+		// scope this merges into namespace_symbols_ ([namespace.udecl]); elsewhere
+		// into scope.symbols.
 		materialize_using_declaration_symbols(current_scope, key, namespace_handle, orig_name);
 	}
 
@@ -1390,6 +1397,28 @@ private:
 	void materialize_using_declaration_symbols(Scope& current_scope, std::string_view key, NamespaceHandle namespace_handle, std::string_view original_name) {
 		auto resolved_nodes = lookup_qualified_all(namespace_handle, original_name);
 		if (resolved_nodes.empty()) {
+			return;
+		}
+
+		// C++20 [namespace.udecl]: a using-declaration at namespace scope makes the
+		// name a member of that namespace. Merge into namespace_symbols_ so ordinary
+		// lookup (which probes that map first for Namespace scopes) sees the full
+		// overload set. Block/function scopes stay local to scope.symbols.
+		if (current_scope.scope_type == ScopeType::Namespace) {
+			NamespaceHandle dest_ns = get_current_namespace_handle();
+			StringHandle ns_key = StringTable::getOrInternStringHandle(key);
+			auto& ns_symbols = namespace_symbols_[dest_ns];
+			auto ns_it = ns_symbols.find(ns_key);
+			if (ns_it == ns_symbols.end()) {
+				ns_symbols[ns_key] = std::move(resolved_nodes);
+				return;
+			}
+
+			if (!is_pure_function_set(ns_it->second) || !is_pure_function_set(resolved_nodes)) {
+				return;
+			}
+
+			append_unique_function_overloads(ns_it->second, resolved_nodes);
 			return;
 		}
 

--- a/src/SymbolTable.h
+++ b/src/SymbolTable.h
@@ -177,25 +177,22 @@ public:
 			}
 		}
 
-		auto sync_namespace_scope_symbols = [&](const std::vector<ASTNode>& nodes) {
-			std::string_view key = intern_string(identifier);
-			current_scope.symbols[key] = nodes;
-		};
-
 		// If this is a new identifier, create a new vector
 		if (!existing_ptr) {
+			if (ns_scope) {
+				// Namespace scopes store members only in namespace_symbols_; do not
+				// mirror into scope.symbols (that map holds using-declarations only).
+				namespace_symbols_[ns_handle][ns_key] = std::vector<ASTNode>{node};
+				return true;
+			}
 			std::string_view key = intern_string(identifier);
 			current_scope.symbols[key] = std::vector<ASTNode>{node};
-			if (ns_scope || global_scope) {
-				if (!ns_scope) {
-					ns_handle = get_current_namespace_handle();
-					ns_key = StringTable::getOrInternStringHandle(identifier);
-				}
+			if (global_scope) {
+				ns_handle = get_current_namespace_handle();
+				ns_key = StringTable::getOrInternStringHandle(identifier);
 				/* Global scope keys existence off scope.symbols, so namespace_symbols_ can
 				   in principle already hold entries this scope never saw. Append rather than
-				   assign so such entries are never silently dropped. For namespace scopes
-				   existing_ptr came from this very map, so absence here is authoritative and
-				   the append degenerates into a fresh vector. */
+				   assign so such entries are never silently dropped. */
 				auto& ns_symbols = namespace_symbols_[ns_handle];
 				auto ns_it = ns_symbols.find(ns_key);
 				if (ns_it == ns_symbols.end()) {
@@ -272,10 +269,7 @@ public:
 							if (new_func->is_materialized() && !existing_func->is_materialized()) {
 								existing_nodes[i] = node;
 
-								if (ns_scope) {
-									// existing_nodes is already namespace_symbols_; keep the local map in sync
-									sync_namespace_scope_symbols(existing_nodes);
-								} else if (global_scope) {
+								if (global_scope) {
 									// Global still uses scope.symbols as primary; mirror into namespace_symbols_
 									NamespaceHandle mirror_ns = get_current_namespace_handle();
 									auto& ns_symbols = namespace_symbols_[mirror_ns];
@@ -308,6 +302,7 @@ public:
 										}
 									}
 								}
+								// Namespace scopes: existing_nodes already aliases namespace_symbols_
 							}
 							// Otherwise, it's a duplicate declaration - just ignore it
 							return true;
@@ -321,9 +316,7 @@ public:
 		existing_nodes.push_back(node);
 
 		if (ns_scope) {
-			// existing_nodes is namespace_symbols_; sync the full overload set into the
-			// local map so lookup that hits scope.symbols first still sees every overload.
-			sync_namespace_scope_symbols(existing_nodes);
+			// existing_nodes already aliases namespace_symbols_; nothing else to update.
 			return true;
 		}
 
@@ -350,6 +343,23 @@ public:
 	// with the fully-initialised VariableDeclarationNode once parsing completes.
 	bool replace_variable(std::string_view identifier, ASTNode new_node) {
 		auto& current_scope = symbol_table_stack_.back();
+		if (current_scope.scope_type == ScopeType::Namespace) {
+			NamespaceHandle ns_handle = get_current_namespace_handle();
+			StringHandle key = StringTable::getOrInternStringHandle(identifier);
+			auto ns_map_it = namespace_symbols_.find(ns_handle);
+			if (ns_map_it == namespace_symbols_.end()) {
+				return false;
+			}
+			auto it = ns_map_it->second.find(key);
+			if (it == ns_map_it->second.end() || it->second.empty()) {
+				return false;
+			}
+			if (is_function_or_template_function(it->second[0])) {
+				return false;
+			}
+			it->second[0] = new_node;
+			return true;
+		}
 		auto it = current_scope.symbols.find(identifier);
 		if (it == current_scope.symbols.end() || it->second.empty()) {
 			return false;
@@ -449,18 +459,9 @@ public:
 		for (auto stackIt = symbol_table_stack_.rbegin() + (get_current_scope_handle().scope_level - scope_limit_handle.scope_level); stackIt != symbol_table_stack_.rend(); ++stackIt) {
 			const Scope& scope = *stackIt;
 
-			// First, check direct symbols in this scope. Using declarations are materialized
-			// here so they correctly participate in shadowing and overload formation.
-			auto symbolIt = scope.symbols.find(identifier);
-			if (symbolIt != scope.symbols.end() && !symbolIt->second.empty()) {
-				// Return the first match for backward compatibility
-				return symbolIt->second[0];
-			}
-
-			// For namespace scopes, probe namespace_symbols_ immediately after the local
-			// symbols map and before using-declarations/directives. Member names of the
-			// namespace itself must beat imports; once enter_namespace stops preloading,
-			// those members live only in namespace_symbols_.
+			// For namespace scopes, probe namespace_symbols_ before the local symbols map.
+			// Members live only in namespace_symbols_; scope.symbols holds using-declarations.
+			// Advance scope_namespace exactly once per Namespace scope regardless of hit/miss.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
 					StringHandle key = StringTable::getOrInternStringHandle(identifier);
@@ -470,6 +471,14 @@ public:
 					}
 				}
 				scope_namespace = gNamespaceRegistry.getParent(scope_namespace);
+			}
+
+			// Check direct symbols in this scope. Using declarations are materialized
+			// here so they correctly participate in shadowing and overload formation.
+			auto symbolIt = scope.symbols.find(identifier);
+			if (symbolIt != scope.symbols.end() && !symbolIt->second.empty()) {
+				// Return the first match for backward compatibility
+				return symbolIt->second[0];
 			}
 
 			// Fall back to unresolved using declarations in this scope.
@@ -524,17 +533,9 @@ public:
 		for (auto stackIt = symbol_table_stack_.rbegin() + (get_current_scope_handle().scope_level - scope_limit_handle.scope_level); stackIt != symbol_table_stack_.rend(); ++stackIt) {
 			const Scope& scope = *stackIt;
 
-			// First, check direct symbols in this scope. Using declarations are materialized
-			// into this map so ordinary lookup sees the full reachable overload set.
-			auto symbolIt = scope.symbols.find(identifier);
-			if (symbolIt != scope.symbols.end()) {
-				return symbolIt->second;
-			}
-
-			// For namespace scopes, probe namespace_symbols_ immediately after the local
-			// symbols map and before using-declarations/directives. Member names of the
-			// namespace itself must beat imports; once enter_namespace stops preloading,
-			// those members live only in namespace_symbols_.
+			// For namespace scopes, probe namespace_symbols_ before the local symbols map.
+			// Members live only in namespace_symbols_; scope.symbols holds using-declarations.
+			// Advance scope_namespace exactly once per Namespace scope regardless of hit/miss.
 			if (scope.scope_type == ScopeType::Namespace) {
 				if (!scope_namespace.isGlobal()) {
 					StringHandle key = StringTable::getOrInternStringHandle(identifier);
@@ -544,6 +545,13 @@ public:
 					}
 				}
 				scope_namespace = gNamespaceRegistry.getParent(scope_namespace);
+			}
+
+			// Check direct symbols in this scope. Using declarations are materialized
+			// into this map so ordinary lookup sees the full reachable overload set.
+			auto symbolIt = scope.symbols.find(identifier);
+			if (symbolIt != scope.symbols.end()) {
+				return symbolIt->second;
 			}
 
 			// Fall back to unresolved using declarations in this scope.

--- a/src/TemplateRegistry_Pattern.h
+++ b/src/TemplateRegistry_Pattern.h
@@ -928,7 +928,7 @@ struct TemplatePattern {
 
 // Key for template specializations
 struct SpecializationKey {
-	std::string template_name;
+	StringHandle template_name;
 	InlineVector<TemplateTypeArg, 4> template_args;
 
 	bool operator==(const SpecializationKey& other) const {
@@ -939,7 +939,7 @@ struct SpecializationKey {
 // Hash function for SpecializationKey
 struct SpecializationKeyHash {
 	size_t operator()(const SpecializationKey& key) const {
-		size_t hash = std::hash<std::string>{}(key.template_name);
+		size_t hash = StringHandleHash{}(key.template_name);
 		TemplateTypeArgHash arg_hasher;
 		for (const auto& arg : key.template_args) {
 			hash ^= arg_hasher(arg) + 0x9e3779b9 + (hash << 6) + (hash >> 2);

--- a/src/TemplateRegistry_Registry.h
+++ b/src/TemplateRegistry_Registry.h
@@ -732,8 +732,7 @@ public:
 
 	// Look up an exact template specialization (no pattern matching)
 	std::optional<ASTNode> lookupExactSpecialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args) const {
-		std::vector<TemplateTypeArg> owned_template_args(template_args.begin(), template_args.end());
-		SpecializationKey key{std::string(template_name), canonicalizeTemplateArgsForExactSpecialization(owned_template_args)};
+		SpecializationKey key{StringTable::getOrInternStringHandle(template_name), canonicalizeTemplateArgsForExactSpecialization(template_args)};
 
 		FLASH_LOG(Templates, Debug, "lookupExactSpecialization: '", template_name, "' with ", template_args.size(), " args");
 		if (FLASH_LOG_ENABLED(Templates, Debug)) {
@@ -754,11 +753,10 @@ public:
 
 	// Look up a template specialization (exact match first, then pattern match)
 	std::optional<ASTNode> lookupSpecialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args) const {
-		std::vector<TemplateTypeArg> owned_template_args(template_args.begin(), template_args.end());
 		FLASH_LOG(Templates, Debug, "lookupSpecialization: template_name='", template_name, "', num_args=", template_args.size());
 
 		// First, try exact match
-		auto exact = lookupExactSpecialization(template_name, owned_template_args);
+		auto exact = lookupExactSpecialization(template_name, template_args);
 		if (exact.has_value()) {
 			FLASH_LOG(Templates, Debug, "  Found exact specialization match");
 			return exact;
@@ -766,7 +764,7 @@ public:
 
 		// No exact match - try pattern matching
 		FLASH_LOG(Templates, Debug, "  No exact match, trying pattern matching...");
-		auto pattern_result = matchSpecializationPattern(template_name, owned_template_args);
+		auto pattern_result = matchSpecializationPattern(template_name, template_args);
 		if (pattern_result.has_value()) {
 			FLASH_LOG(Templates, Debug, "  Found pattern match!");
 		} else {
@@ -789,8 +787,9 @@ public:
 	}
 
 	bool hasExactSpecializationsForName(std::string_view template_name) const {
+		StringHandle name_handle = StringTable::getOrInternStringHandle(template_name);
 		for (const auto& entry : specializations_) {
-			if (entry.first.template_name == template_name) {
+			if (entry.first.template_name == name_handle) {
 				return true;
 			}
 		}
@@ -1033,7 +1032,7 @@ private:
 
 	// Register a template specialization under an already-normalized registry key.
 	void registerSpecializationByName(std::string_view template_name, std::span<const TemplateTypeArg> template_args, ASTNode specialized_node) {
-		SpecializationKey key{std::string(template_name), canonicalizeTemplateArgsForExactSpecialization(template_args)};
+		SpecializationKey key{StringTable::getOrInternStringHandle(template_name), canonicalizeTemplateArgsForExactSpecialization(template_args)};
 		specializations_[key] = specialized_node;
 		FLASH_LOG(Templates, Debug, "registerSpecialization: '", template_name, "' with ", template_args.size(), " args");
 		if (FLASH_LOG_ENABLED(Templates, Debug)) {

--- a/tests/test_using_decl_namespace_overload_merge_ret2.cpp
+++ b/tests/test_using_decl_namespace_overload_merge_ret2.cpp
@@ -1,0 +1,23 @@
+// C++20 [namespace.udecl]: a using-declaration at namespace scope introduces the
+// named declarations as members of that namespace, so they join the overload set
+// formed by the namespace's own declarations rather than being hidden by them.
+//
+// Here B::f(double) is declared before `using A::f;`. A call to f(1) inside B must
+// consider both and select the exact match A::f(int), returning 2. If the
+// using-declared overload is invisible, f(double) is selected instead and the
+// program returns 101.
+
+namespace A {
+	int f(int x) { return x + 1; }
+}
+
+namespace B {
+	int f(double x) { return static_cast<int>(x) + 100; }
+	using A::f;
+
+	int call() { return f(1); }
+}
+
+int main() {
+	return B::call();
+}


### PR DESCRIPTION
## Summary

Follow-up to #1830. Two independent allocation reductions, plus a C++20 conformance fix that the second
one turned out to require.

Parsing allocations drop from **48,413 to 47,252** and parsing bytes from **17,479,711 to
17,065,856** on `tests/std/test_std_type_traits.cpp`.

### 1. `SpecializationKey` stores a `StringHandle` instead of a `std::string`

Every exact-specialization lookup and registration heap-allocated a string just to build a lookup key.
The same path also built two entirely redundant `std::vector<TemplateTypeArg>` copies of its arguments
before forwarding them, even though the callee already takes a `std::span` and the caller already had
one. Interning maps equal content to equal handles, so keying behavior is unchanged, and
`hasExactSpecializationsForName` now compares handles rather than strings.

### 2. Namespace members are no longer mirrored into `Scope::symbols`

`insert()` was copying a name's entire overload vector into the scope-local map after every mutation,
making N overloads of one name cost O(N^2) node copies. That mirror existed only because `lookup`
checked `scope.symbols` before the `namespace_symbols_` probe, so a stale partial local entry could
shadow the real overload set.

Rather than making the copy cheaper, this removes the reason for it: the probe now runs first for
namespace scopes, `namespace_symbols_` is the sole store for members, and the mirror is gone. This is a
modest win on this benchmark (~424 allocations) but removes a quadratic scaling hazard and the last
populated per-namespace-scope hash map.

### 3. Conformance fix: namespace-scope using-declarations

Change 2 broke using-declaration overload merging. `materialize_using_declaration_symbols` merges
using-declared overloads into `scope.symbols[key]`, which only worked because the namespace's own
members were already in that map. With members moved out and the probe running first, the member-only
set won and using-declared overloads became invisible:

    namespace A { int f(int x); }
    namespace B {
        int f(double x);
        using A::f;
        int call() { return f(1); }   // must select A::f(int)
    }

This failed overload resolution and picked `f(double)`. Fixed by having namespace-scope
using-declarations merge into `namespace_symbols_`, which is what C++20 [namespace.udecl] actually
describes — such a declaration makes the name a member of that namespace. Block and function scopes
still materialize into `scope.symbols` and stay scope-local.

This is stricter than the previous behavior, not just a restoration: the using-declared name now
persists as a member across reopened blocks of the namespace and is reachable by qualified lookup.

`tests/test_using_decl_namespace_overload_merge_ret2.cpp` covers it. Verified that the reproducer passes
on `main` and failed on this branch before the fix, so the regression was introduced and resolved
entirely within this PR.

## Test plan

- [x] `pwsh tests/run_all_tests.ps1` - 2803/2803 regular, 241/241 `_fail` as expected
- [x] Ubuntu CI (clang) build is green
- [x] MSVC CI is green

## Known follow-ups (not in this PR)

- Lookup ordering still has thin regression coverage. The new test pins the using-declaration case;
  cross-block namespace overloads and inline-namespace ambiguity are still uncovered.
- `lookup_all` still allocates a `vector<ASTNode>` per call and is now a primary path, not a fallback.
- `get_scope_handle` and `merge_inline_namespace` have no callers and can be deleted.
- `insert_into_namespace` carries a default parameter value, which `AGENTS.md` forbids; all call sites
  already pass it explicitly.
