### PR TITLE
Improve C++20 standard header parsing and semantics

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1572,7 +1572,7 @@ private:
 	// Parsing functions for different constructs
 	ParseResult parse_top_level_node();
 	ParseResult parse_pragma_pack_inner();   // NEW: Parse the contents of pragma pack()
-	ParseResult parse_type_and_name();
+	ParseResult parse_type_and_name(CVQualifier leading_cv_qualifier);
 	ParseResult parse_structured_binding(CVQualifier cv_qualifiers, ReferenceQualifier ref_qualifier);  // NEW: Parse structured bindings: auto [a, b] = expr; auto& [x, y] = pair;
 	ParseResult parse_declarator(TypeSpecifierNode& base_type, Linkage linkage = Linkage::None);	 // NEW: Parse declarators (function pointers, arrays, etc.)
 	ParseResult parse_direct_declarator(TypeSpecifierNode& base_type, Token& out_identifier, Linkage linkage);  // NEW: Helper for direct declarators
@@ -3690,7 +3690,7 @@ private:	 // Resume private methods
 		bool add_functions_to_ast_nodes);
 
 	Linkage parse_declspec_attributes();			 // Parse Microsoft __declspec(...) and return linkage
-	void parse_declspec_attributes_into(AttributeInfo& info); // Parse __declspec into AttributeInfo (linkage + selectany)
+	bool tryParseDeclspecSpecifiers(AttributeInfo& info); // Parse Microsoft __declspec decl-specifiers into AttributeInfo
 	AttributeInfo parse_attributes();			  // Parse all types of attributes and return linkage + calling convention
 	[[nodiscard]] CallingConvention parse_calling_convention(CallingConvention calling_conv); // Parse calling convention keywords
 

--- a/src/ParserTypes.h
+++ b/src/ParserTypes.h
@@ -165,6 +165,9 @@ struct DeclarationSpecifiers {
 	StorageClass storage_class = StorageClass::None;
 	bool is_thread_local = false;
 
+	// CV-qualifiers are defining-type-specifiers in decl-specifier-seq.
+	CVQualifier cv_qualifier = CVQualifier::None;
+
 	// Constexpr/consteval/constinit specifiers (mutually exclusive)
 	ConstexprSpecifier constexpr_spec = ConstexprSpecifier::None;
 

--- a/src/Parser_Decl_DeclaratorCore.cpp
+++ b/src/Parser_Decl_DeclaratorCore.cpp
@@ -11,7 +11,7 @@ constexpr int kFunctionPointerSizeBits = 64; // x64 target: always 8 bytes
 
 }
 
-ParseResult Parser::parse_type_and_name() {
+ParseResult Parser::parse_type_and_name(CVQualifier leading_cv_qualifier) {
 	// Add parsing depth check to prevent infinite loops
 	if (++parsing_depth_ > MAX_PARSING_DEPTH) {
 		--parsing_depth_;
@@ -45,6 +45,7 @@ ParseResult Parser::parse_type_and_name() {
 
 	// Get the type specifier node to modify it with pointer levels
 	TypeSpecifierNode& type_spec = type_specifier_result.node()->as<TypeSpecifierNode>();
+	type_spec.add_cv_qualifier(leading_cv_qualifier);
 
 	// Check for structured binding: auto [a, b, c] = expr;
 	// Also support: auto& [a, b] = pair; and auto&& [x, y] = temp;
@@ -1352,49 +1353,80 @@ ParseResult Parser::parse_nested_function_pointer_type(
 // Phase 1 Consolidation: Parse declaration specifiers shared between
 // parse_declaration_or_function_definition() and parse_variable_declaration()
 // Handles: attributes ([[nodiscard]], __declspec), storage class (static, extern),
-// constexpr/constinit/consteval, inline specifiers
+// CV-qualifiers, constexpr/constinit/consteval, inline specifiers
 FlashCpp::DeclarationSpecifiers Parser::parse_declaration_specifiers() {
 	FlashCpp::DeclarationSpecifiers specs;
+	auto merge_attributes = [&](const AttributeInfo& attributes) {
+		if (attributes.linkage != Linkage::None) {
+			specs.linkage = attributes.linkage;
+		}
+		if (attributes.calling_convention != CallingConvention::Default) {
+			specs.calling_convention = attributes.calling_convention;
+		}
+		specs.is_selectany |= attributes.is_selectany;
+	};
+	auto tryParseMsvcDeclspec = [&]() {
+		AttributeInfo attributes;
+		if (!tryParseDeclspecSpecifiers(attributes)) {
+			return false;
+		}
+		merge_attributes(attributes);
+		return true;
+	};
+
 	// Parse any attributes before the declaration ([[nodiscard]], __declspec(dllimport), __cdecl, etc.)
-	AttributeInfo attr_info = parse_attributes();
-	specs.linkage = attr_info.linkage;
-	specs.calling_convention = attr_info.calling_convention;
-	specs.is_selectany = attr_info.is_selectany;
+	merge_attributes(parse_attributes());
 
 	// Parse storage class specifiers and constexpr/constinit/consteval keywords
 	// These can appear in any order: "static constexpr", "constexpr static", etc.
-	bool done = false;
-	while (!done && peek().is_keyword()) {
-		std::string_view kw = peek_info().value();
-		if (kw == "constexpr") {
+	while (true) {
+		if (tryParseMsvcDeclspec()) {
+			continue;
+		}
+
+		const TokenKind keyword = peek();
+		if (!keyword.is_keyword()) {
+			break;
+		}
+
+		if (keyword == "constexpr"_tok) {
 			specs.constexpr_spec = FlashCpp::ConstexprSpecifier::Constexpr;
 			advance();
-		} else if (kw == "constinit") {
+		} else if (keyword == "constinit"_tok) {
 			specs.constexpr_spec = FlashCpp::ConstexprSpecifier::Constinit;
 			advance();
-		} else if (kw == "consteval") {
+		} else if (keyword == "consteval"_tok) {
 			specs.constexpr_spec = FlashCpp::ConstexprSpecifier::Consteval;
 			advance();
-		} else if (kw == "inline" || kw == "__inline" || kw == "__forceinline") {
+		} else if (keyword == "inline"_tok ||
+				   keyword == "__inline"_tok ||
+				   keyword == "__forceinline"_tok) {
 			specs.is_inline = true;
 			advance();
-		} else if (kw == "static") {
+		} else if (keyword == "static"_tok) {
 			specs.storage_class = StorageClass::Static;
 			advance();
-		} else if (kw == "extern") {
+		} else if (keyword == "extern"_tok) {
 			specs.storage_class = StorageClass::Extern;
 			advance();
-		} else if (kw == "thread_local" || kw == "__thread") {
+		} else if (keyword == "thread_local"_tok ||
+				   keyword == "__thread"_tok) {
 			specs.is_thread_local = true;
 			advance();
-		} else if (kw == "register") {
+		} else if (keyword == "register"_tok) {
 			specs.storage_class = StorageClass::Register;
 			advance();
-		} else if (kw == "mutable") {
+		} else if (keyword == "mutable"_tok) {
 			specs.storage_class = StorageClass::Mutable;
 			advance();
+		} else if (keyword == "const"_tok) {
+			specs.cv_qualifier |= CVQualifier::Const;
+			advance();
+		} else if (keyword == "volatile"_tok) {
+			specs.cv_qualifier |= CVQualifier::Volatile;
+			advance();
 		} else {
-			done = true;
+			break;
 		}
 	}
 

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -107,6 +107,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 	// is not replaced by createStructInfo() mid-declaration.
 	if (peek().is_keyword() &&
 		(peek() == "struct"_tok || peek() == "class"_tok || peek() == "union"_tok) &&
+		specs.cv_qualifier == CVQualifier::None &&
 		!looks_like_elaborated_type_variable_declaration()) {
 		// Delegate to struct parsing which will handle the full definition
 		// and any trailing variable declarations.
@@ -139,6 +140,11 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 		if (type_it != getTypesByNameMap().end() && type_it->second->isStruct()) {
 			auto ctor_result = lookahead_constructor_or_destructor(first_id);
 			if (ctor_result.detected) {
+				if (specs.cv_qualifier != CVQualifier::None) {
+					return ParseResult::error(
+						"Constructors and destructors cannot have a cv-qualified return type",
+						peek_info());
+				}
 				return saved_position.propagate(parse_out_of_line_constructor_or_destructor(qualified_class_name, ctor_result.is_destructor, specs));
 			}
 		}
@@ -148,7 +154,7 @@ ParseResult Parser::parse_declaration_or_function_definition() {
 	// This will also extract any calling convention that appears after the type
 	SaveHandle declaration_start = save_token_position();
 	FLASH_LOG(Parser, Debug, "parse_declaration_or_function_definition: About to parse type_and_name, current token: ", !peek().is_eof() ? std::string(peek_info().value()) : "N/A");
-	ParseResult type_and_name_result = parse_type_and_name();
+	ParseResult type_and_name_result = parse_type_and_name(specs.cv_qualifier);
 	if (type_and_name_result.is_error()) {
 		discard_saved_token(declaration_start);
 		FLASH_LOG(Parser, Debug, "parse_declaration_or_function_definition: parse_type_and_name failed: ", type_and_name_result.error_message());

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -1777,16 +1777,28 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			// Check if it's const or constexpr (some may already be consumed by parse_member_leading_specifiers)
 			CVQualifier cv_qual = CVQualifier::None;
 			bool is_static_constexpr = !!(member_specs & FlashCpp::MLS_Constexpr);
-			while (peek().is_keyword()) {
-				std::string_view kw = peek_info().value();
-				if (kw == "const") {
+			while (true) {
+				AttributeInfo attributes;
+				if (tryParseDeclspecSpecifiers(attributes)) {
+					continue;
+				}
+
+				const TokenKind keyword = peek();
+				if (!keyword.is_keyword()) {
+					break;
+				}
+
+				if (keyword == "const"_tok) {
 					cv_qual |= CVQualifier::Const;
 					advance();
-				} else if (kw == "constexpr") {
+				} else if (keyword == "volatile"_tok) {
+					cv_qual |= CVQualifier::Volatile;
+					advance();
+				} else if (keyword == "constexpr"_tok) {
 					is_static_constexpr = true;
 					cv_qual |= CVQualifier::Const; // constexpr implies const
 					advance();
-				} else if (kw == "inline") {
+				} else if (keyword == "inline"_tok) {
 					advance(); // consume 'inline'
 				} else {
 					break;
@@ -1794,7 +1806,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			}
 
 			// Parse type and name
-			auto type_and_name_result = parse_type_and_name();
+			auto type_and_name_result = parse_type_and_name(cv_qual);
 			if (type_and_name_result.is_error()) {
 				return type_and_name_result;
 			}
@@ -2476,7 +2488,7 @@ ParseResult Parser::parse_struct_declaration_with_specs(bool pre_is_constexpr, b
 			member_result = ParseResult::success(decl_node);
 		} else {
 			// Regular member (data or function)
-			member_result = parse_type_and_name();
+			member_result = parse_type_and_name(CVQualifier::None);
 			if (member_result.is_error()) {
 				const bool missing_dependent_typename =
 					member_result.error_message().find(

--- a/src/Parser_Decl_TypedefUsing.cpp
+++ b/src/Parser_Decl_TypedefUsing.cpp
@@ -23,14 +23,21 @@ void Parser::bindLocalTypeAlias(
 // Returns false after restoring the token position when the next tokens are not
 // a supported alias function type.
 bool Parser::parse_type_alias_function_type(TypeSpecifierNode& type_spec, std::string_view log_context) {
+	SaveHandle func_type_saved_pos = save_token_position();
+	CallingConvention calling_conv =
+		parse_calling_convention(CallingConvention::Default);
 	if (peek() != "("_tok) {
+		restore_token_position(func_type_saved_pos);
 		return false;
 	}
 
-	SaveHandle func_type_saved_pos = save_token_position();
 	advance(); // consume '('
 
-	CallingConvention calling_conv = parse_calling_convention(CallingConvention::Default);
+	CallingConvention declarator_calling_conv =
+		parse_calling_convention(CallingConvention::Default);
+	if (declarator_calling_conv != CallingConvention::Default) {
+		calling_conv = declarator_calling_conv;
+	}
 	bool is_function_ref = false;
 	bool is_rvalue_function_ref = false;
 	bool is_function_ptr = false;

--- a/src/Parser_Expr_BinaryPrecedence.cpp
+++ b/src/Parser_Expr_BinaryPrecedence.cpp
@@ -1908,7 +1908,7 @@ ParseResult Parser::parse_static_member_block(
 	}
 
 	// Parse type and name
-	auto type_and_name = parse_type_and_name();
+	auto type_and_name = parse_type_and_name(CVQualifier::None);
 	if (type_and_name.is_error()) {
 		return type_and_name;
 	}
@@ -2076,17 +2076,20 @@ ParseResult Parser::parse_static_member_block(
 
 Linkage Parser::parse_declspec_attributes() {
 	AttributeInfo info;
-	parse_declspec_attributes_into(info);
+	tryParseDeclspecSpecifiers(info);
 	return info.linkage;
 }
 
-void Parser::parse_declspec_attributes_into(AttributeInfo& info) {
-	// Parse all __declspec attributes
+bool Parser::tryParseDeclspecSpecifiers(AttributeInfo& info) {
+	bool consumed_declspec = false;
+	// Microsoft extends decl-specifier-seq with __declspec. Keep this separate
+	// from C++ attribute-specifier-seq because their appertainment rules differ.
 	while (peek() == "__declspec"_tok) {
+		consumed_declspec = true;
 		advance(); // consume "__declspec"
 
 		if (!consume("("_tok)) {
-			return; // Invalid __declspec, return what we have
+			return true; // Invalid __declspec, but the specifier was consumed
 		}
 
 		// Parse the declspec specifier(s)
@@ -2120,9 +2123,10 @@ void Parser::parse_declspec_attributes_into(AttributeInfo& info) {
 		}
 
 		if (!consume(")"_tok)) {
-			return; // Missing closing paren
+			return true; // Missing closing paren after a consumed specifier
 		}
 	}
+	return consumed_declspec;
 }
 
 // Parse calling convention keywords and return the calling convention
@@ -2149,11 +2153,14 @@ Parser::AttributeInfo Parser::parse_attributes() {
 	AttributeInfo info;
 
 	skip_cpp_attributes();  // C++ [[...]] and GCC __attribute__(...) specifications
-	parse_declspec_attributes_into(info);
+	tryParseDeclspecSpecifiers(info);
 	info.calling_convention = parse_calling_convention(info.calling_convention);
 
 	// Handle potential interleaved attributes (e.g., __declspec(...) [[nodiscard]] __declspec(...))
-	if (!peek().is_eof() && (peek() == "["_tok || peek_info().value() == "__attribute__")) {
+	if (!peek().is_eof() &&
+		(peek() == "["_tok ||
+		 peek() == "__declspec"_tok ||
+		 peek_info().value() == "__attribute__")) {
 		// Recurse to handle more attributes (prefer more specific linkage)
 		AttributeInfo more_info = parse_attributes();
 		if (more_info.linkage != Linkage::None) {

--- a/src/Parser_Expr_QualLookup.cpp
+++ b/src/Parser_Expr_QualLookup.cpp
@@ -2096,8 +2096,21 @@ TypeIndex Parser::substitute_template_parameter(
 		return false;
 	};
 
+	bool token_names_template_parameter = false;
+	if (!type_name.empty()) {
+		for (const TemplateParameterNode& template_param : template_params) {
+			if (template_param.kind() == TemplateParameterKind::Type &&
+				template_param.name() == type_name) {
+				token_names_template_parameter = true;
+				break;
+			}
+		}
+	}
+
 	if (const TypeInfo* indexed_type_info = tryGetTypeInfo(current_type_index)) {
-		type_name = StringTable::getStringView(indexed_type_info->name());
+		if (!token_names_template_parameter) {
+			type_name = StringTable::getStringView(indexed_type_info->name());
+		}
 		FLASH_LOG(Templates, Debug, "substitute_template_parameter: type_index=", current_type_index,
 				  ", type_name='", type_name, "', underlying_type=", static_cast<int>(indexed_type_info->typeEnum()),
 				  ", underlying_type_index=", indexed_type_info->type_index_);

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -466,7 +466,7 @@ ParseResult Parser::parse_one_catch_clause(std::vector<ASTNode>& catch_clauses) 
 		advance();
 		is_catch_all = true;
 	} else {
-		auto type_result = parse_type_and_name();
+		auto type_result = parse_type_and_name(CVQualifier::None);
 		if (type_result.is_error()) {
 			return type_result;
 		}

--- a/src/Parser_FunctionHeaders.cpp
+++ b/src/Parser_FunctionHeaders.cpp
@@ -63,7 +63,7 @@ ParseResult Parser::parse_parameter_list(FlashCpp::ParsedParameterList& out_para
 		FlashCpp::ScopedState parameter_type_id_guard(
 			parsing_parameter_declaration_type_id_);
 		parsing_parameter_declaration_type_id_ = true;
-		ParseResult type_and_name_result = parse_type_and_name();
+		ParseResult type_and_name_result = parse_type_and_name(CVQualifier::None);
 		if (type_and_name_result.is_error()) {
 			return type_and_name_result;
 		}
@@ -534,6 +534,11 @@ FlashCpp::MemberLeadingSpecifiers Parser::parse_member_leading_specifiers() {
 	using enum FlashCpp::MemberLeadingSpecifiers;
 	FlashCpp::MemberLeadingSpecifiers specs = MLS_None;
 	while (true) {
+		AttributeInfo attributes;
+		if (tryParseDeclspecSpecifiers(attributes)) {
+			continue;
+		}
+
 		auto k = peek();
 		if (k == "constexpr"_tok) {
 			specs |= MLS_Constexpr;

--- a/src/Parser_Statements.cpp
+++ b/src/Parser_Statements.cpp
@@ -997,7 +997,7 @@ ParseResult Parser::parse_variable_declaration() {
 	Linkage linkage = specs.linkage;
 
 	// Parse the type specifier and identifier (name)
-	ParseResult type_and_name_result = parse_type_and_name();
+	ParseResult type_and_name_result = parse_type_and_name(specs.cv_qualifier);
 	if (type_and_name_result.is_error()) {
 		return type_and_name_result;
 	}

--- a/src/Parser_Templates_Class.cpp
+++ b/src/Parser_Templates_Class.cpp
@@ -2251,7 +2251,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 					if (!found_conversion_op) {
 						restore_token_position(conv_saved);
 						// Parse member declaration (use same logic as regular struct parsing)
-						member_result = parse_type_and_name();
+						member_result = parse_type_and_name(CVQualifier::None);
 					}
 				}
 				if (member_result.is_error()) {
@@ -3727,7 +3727,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 					if (!found_conversion_op) {
 						restore_token_position(conv_saved);
 						// Parse member declaration (use same logic as regular struct parsing)
-						member_result = parse_type_and_name();
+						member_result = parse_type_and_name(CVQualifier::None);
 					}
 				}
 				if (member_result.is_error() || !member_result.node().has_value()) {
@@ -4433,7 +4433,7 @@ ParseResult Parser::parse_template_declaration_impl(ExternTemplateDeclarationKin
 			// Pattern: template<> ReturnType FunctionName<Args>(params) { body }
 
 			// Parse return type and function name
-			auto type_and_name_result = parse_type_and_name();
+			auto type_and_name_result = parse_type_and_name(CVQualifier::None);
 			if (type_and_name_result.is_error()) {
 				return type_and_name_result;
 			}
@@ -5288,7 +5288,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 					}
 
 					// Parse type and name
-					auto type_and_name_result = parse_type_and_name();
+					auto type_and_name_result = parse_type_and_name(CVQualifier::None);
 					if (type_and_name_result.is_error()) {
 						return type_and_name_result;
 					}
@@ -5504,7 +5504,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 			}
 
 			// Parse member declaration (data member or function)
-			auto member_result = parse_type_and_name();
+			auto member_result = parse_type_and_name(CVQualifier::None);
 			if (member_result.is_error()) {
 				return member_result;
 			}
@@ -5810,7 +5810,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 				}
 
 				// Parse type and name
-				auto type_and_name_result = parse_type_and_name();
+				auto type_and_name_result = parse_type_and_name(CVQualifier::None);
 				if (type_and_name_result.is_error()) {
 					return type_and_name_result;
 				}
@@ -6048,7 +6048,7 @@ ParseResult Parser::parse_member_struct_template(StructDeclarationNode& struct_n
 		}
 
 		// Parse member declaration (data member or function)
-		auto member_result = parse_type_and_name();
+		auto member_result = parse_type_and_name(CVQualifier::None);
 		if (member_result.is_error()) {
 			return member_result;
 		}

--- a/src/Parser_Templates_Function.cpp
+++ b/src/Parser_Templates_Function.cpp
@@ -79,7 +79,7 @@ ParseResult Parser::parse_template_function_declaration_body(
 	bool is_constinit = specs.is_constinit();
 
 	// Parse the function declaration (type and name)
-	auto type_and_name_result = parse_type_and_name();
+	auto type_and_name_result = parse_type_and_name(specs.cv_qualifier);
 	if (type_and_name_result.is_error()) {
 		return type_and_name_result;
 	}

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -2952,7 +2952,7 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			auto exit_name_parse_namespace = ScopeGuard([&]() {
 				exitSourceNamespaceScopes(entered_name_parse_namespace_count);
 			});
-			auto type_and_name_result = parse_type_and_name();
+			auto type_and_name_result = parse_type_and_name(CVQualifier::None);
 			restore_lexer_position_only(current_pos);
 			if (!type_and_name_result.is_error() &&
 				type_and_name_result.node().has_value() &&

--- a/src/Parser_Templates_MemberOutOfLine.cpp
+++ b/src/Parser_Templates_MemberOutOfLine.cpp
@@ -288,6 +288,8 @@ std::optional<bool> Parser::try_parse_out_of_line_template_member(
 	}
 
 	ASTNode return_type_node = *return_type_result.node();
+	return_type_node.as<TypeSpecifierNode>().add_cv_qualifier(
+		declaration_specs.cv_qualifier);
 
 	// Skip pointer/reference modifiers after the return type
 	// Pattern: Type*, Type&, Type&&, Type* const, Type const*, etc.

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -43,6 +43,15 @@ bool isFunctionCandidateViableForArgCount(const FunctionDeclarationNode& candida
 	return argument_count >= min_required && argument_count <= max_accepted;
 }
 
+bool isCanonicalObjectConstQualified(const CanonicalTypeDesc& type) {
+	if (!type.pointer_levels.empty()) {
+		return hasCVQualifier(
+			type.pointer_levels.back().cv_qualifier,
+			CVQualifier::Const);
+	}
+	return hasCVQualifier(type.base_cv, CVQualifier::Const);
+}
+
 template <typename OverloadContainer>
 void appendUniqueOverload(OverloadContainer& target, const ASTNode& candidate) {
 	if (std::ranges::none_of(target, [&](const ASTNode& existing) {
@@ -3758,6 +3767,7 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 				const bool is_shift =
 					op == "<<" || op == ">>" || op == "<<=" || op == ">>=";
 				const bool is_compound_assign = isCompoundAssignmentOp(op);
+				const bool is_assignment = op == "=" || is_compound_assign;
 				const bool needs_binary_type_inference =
 					(is_arithmetic || is_bitwise || is_comparison || is_compound_assign || is_shift) &&
 					e.get_lhs().template is<ExpressionNode>() &&
@@ -3770,15 +3780,27 @@ SemanticExprInfo SemanticAnalysis::normalizeExpression(ASTNode node, const Seman
 					tryAnnotateContextualBool(e.get_lhs());
 					tryAnnotateContextualBool(e.get_rhs());
 				}
+				CanonicalTypeId assignment_lhs_type_id{};
+				if (is_assignment && e.get_lhs().template is<ExpressionNode>()) {
+					assignment_lhs_type_id = inferExpressionType(e.get_lhs());
+					if (assignment_lhs_type_id &&
+						isCanonicalObjectConstQualified(
+							type_context_.get(assignment_lhs_type_id))) {
+						throw CompileError(
+							"Assignment to const-qualified expression is not allowed");
+					}
+				}
 				// For simple assignment, annotate the RHS with the LHS type.
 				if (op == "=" &&
 					e.get_lhs().template is<ExpressionNode>() &&
 					e.get_rhs().template is<ExpressionNode>()) {
-					const CanonicalTypeId lhs_id = inferExpressionType(e.get_lhs());
-					if (lhs_id) {
+					if (assignment_lhs_type_id) {
 						const CanonicalTypeId rhs_id = inferExpressionType(e.get_rhs());
-						tryAnnotateConversion(e.get_rhs(), lhs_id, rhs_id);
-						diagnoseScopedEnumConversion(e.get_rhs(), lhs_id,
+						tryAnnotateConversion(
+							e.get_rhs(),
+							assignment_lhs_type_id,
+							rhs_id);
+						diagnoseScopedEnumConversion(e.get_rhs(), assignment_lhs_type_id,
 													 " in assignment", rhs_id);
 					}
 				}

--- a/tests/std/README_STANDARD_HEADERS.md
+++ b/tests/std/README_STANDARD_HEADERS.md
@@ -53,26 +53,26 @@ Language regressions that already pass belong in `tests/` (main suite), not only
 
 | Header | Test File | Status | Notes |
 |--------|-----------|--------|-------|
-| `<limits>` | `test_std_limits.cpp` | ✅ Compiled | ~6s wall (Windows/MSVC STL 14.44). ODR-use emission for free `inline`/`__inline` + `__declspec(selectany)` COMDAT. |
-| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~1221ms (`TOTAL`) / ~1.3s wall (retested 2026-07-25, Windows/MSVC STL 14.44). |
+| `<limits>` | `test_std_limits.cpp` | ✅ Compiled | ~5362ms (`TOTAL`) / ~5.4s wall (retested 2026-07-26, Windows/MSVC STL 14.44). |
+| `<type_traits>` | `test_std_type_traits.cpp` | ✅ Compiled | ~1170ms (`TOTAL`) / ~1.3s wall (retested 2026-07-26, Windows/MSVC STL 14.44). |
 | `<compare>` | `test_std_compare_ret42.cpp` | ✅ Compiled | ~0.06s (retested 2026-05-23, Linux/libstdc++-14). |
 | `<version>` | `test_std_version.cpp` | ✅ Compiled | ~41ms |
 | `<source_location>` | `test_std_source_location.cpp` | ✅ Compiled | ~41ms |
 | `<numbers>` | N/A | ✅ Compiled | ~510ms |
 | `<initializer_list>` | N/A | ✅ Compiled | ~32ms. Direct `std::initializer_list<T> values = {...}` object list-initialization is now covered by `tests/test_std_initializer_list_direct_brace_ret0.cpp` (retested 2026-04-20). |
-| `<ratio>` | `test_std_ratio.cpp` | 💥 Crash | ~2.69s wall (retested 2026-05-27, Linux/libstdc++-14). Still crashes with SIGSEGV while instantiating `__static_sign` (`__are_both_ratios` warnings appear first). |
-| `<optional>` | `test_std_optional.cpp` | 💥 Crash | ~3.30s wall (retested 2026-05-28, Linux/libstdc++-14). Current run now gets past the older `_Optional_payload_base` category-25/codegen stop and instead crashes after a constexpr/static-assert frontier: `Dependent function/variable template call in constant expression: is_same_v`. |
-| `<any>` | `test_std_any.cpp` | ✅ Compiled | ~1052ms (retested 2026-05-25, Linux/libstdc++-14). |
-| `<utility>` | `test_std_utility.cpp` | ✅ Compiled | ~1524ms (retested 2026-05-25, Linux/libstdc++-14). |
-| `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~1.3s wall (Windows/MSVC STL 14.44). |
+| `<ratio>` | `test_std_ratio.cpp` | ❌ Semantic Error | ~4169ms (`TOTAL`) / ~4.2s wall (retested 2026-07-26, Windows/MSVC STL 14.44). `ratio_equal<...>::value` is not materialized as a constant expression. |
+| `<optional>` | `test_std_optional.cpp` | ❌ Parse Error | ~8926ms (`TOTAL`) / ~9.0s wall (retested 2026-07-26, Windows/MSVC STL 14.44). First hard stop is structural class-type non-type template parameters in MSVC `optional:269`. |
+| `<any>` | `test_std_any.cpp` | ❌ Semantic Error | ~9.5s wall; full parse completes in ~7.9s (retested 2026-07-26, Windows/MSVC STL 14.44). Interleaved `__declspec(allocator)` and bare `__cdecl` function-type aliases now parse; current stop is ambiguous `_Get_rest` member lookup. |
+| `<utility>` | `test_std_utility.cpp` | ✅ Compiled | ~1697ms (`TOTAL`) / ~1.7s wall (retested 2026-07-26, Windows/MSVC STL 14.44). Template-parameter spelling now wins over stale dependent `TypeInfo`, so `pair<int, float>::first` has type `int`. Object generation succeeds; the linked probe still crashes at runtime, leaving a separate codegen issue. |
+| `<concepts>` | `test_std_concepts.cpp` | ✅ Compiled | ~1350ms (`TOTAL`) / ~1.4s wall (retested 2026-07-26, Windows/MSVC STL 14.44). |
 | `<bit>` | `test_std_bit.cpp` | ✅ Compiled | ~1083ms (retested 2026-05-23, Linux/libstdc++-14). |
-| `<string_view>` | `test_std_string_view.cpp` | ❌ Codegen Error | ~4.58s wall (retested 2026-05-27, Linux/libstdc++-14). First stop remains unresolved direct-call return type (`Type with no runtime size reached codegen in direct call return size`, type category 25) with repeated `to_address` instantiation failures; `_CharT` constructor-call struct-info failures still appear in `char_traits`. |
+| `<string_view>` | `test_std_string_view.cpp` | ❌ Lazy Replay Error | ~11.5s wall; full parse completes in ~9.8s (retested 2026-07-26, Windows/MSVC STL 14.44). Current stop is lazy member-body replay for `_String_view_iterator::operator+`. |
 | `<string>` | `test_std_string.cpp` | ❌ Compile Error | ~6.19s (`TOTAL`) / ~6.68s wall (retested 2026-05-27, Linux/libstdc++-14). Completed class-template cache hits no longer consume template-depth budget; current first hard error is now depth-guarded recursive `basic_string` instantiation. |
 | `<array>` | `test_std_array.cpp` | ✅ Compiled | ~2.64s (retested 2026-05-23, Linux/libstdc++-14). |
 | `<algorithm>` | `test_std_algorithm.cpp` | 💥 Crash | ~4.95s (retested 2026-05-21, Linux/libstdc++-14). The shared `ptr_traits` member-alias-template target now parses; current run reaches late IR/codegen (`std::partial_ordering` missing resolved constructor / unresolved semantic type category 25) and can still crash after deep template replay. |
-| `<span>` | `test_std_span.cpp` | ✅ Compiled | ~27ms (retested 2026-05-22, Linux/libstdc++-14). Statement/declaration disambiguation now keeps qualified class-template direct-initialization on the declaration path, so `std::span<int> s(arr, 5);` no longer falls through to a spurious call-expression parse. |
-| `<tuple>` | `test_std_tuple.cpp` | 💥 Codegen Crash | ~2500ms (retested 2026-05-11, Linux/libstdc++-14). The `_Head_base` default-NTTP blocker and tuple constructor pack-boundary stop are fixed; the header now reaches IR/codegen before `std::partial_ordering` unresolved semantic type category 25. |
-| `<vector>` | `test_std_vector.cpp` | ❌ Compile Error | ~2062ms (retested 2026-04-30, Linux/libstdc++-14). No longer stops at `Missing TypeInfo while computing template argument size`; it now reaches `Itanium name mangling: unknown type — cannot generate valid symbol` after several deferred/incomplete `reverse_iterator` instantiations. |
+| `<span>` | `test_std_span.cpp` | ❌ Template Default Error | ~8646ms (`TOTAL`) / ~8.7s wall (retested 2026-07-26, Windows/MSVC STL 14.44). Could not evaluate non-type template default parameter 1 of `std::span`. |
+| `<tuple>` | `test_std_tuple.cpp` | ❌ Template Replay Error | ~2032ms (`TOTAL`) / ~2.1s wall (retested 2026-07-26, Windows/MSVC STL 14.44). Partial-specialization nested out-of-line `tuple` cannot be attached through source-member identity mapping. |
+| `<vector>` | `test_std_vector.cpp` | ❌ Semantic Error | ~9708ms (`TOTAL`) / ~9.8s wall (retested 2026-07-26, Windows/MSVC STL 14.44). Interleaved `__declspec(allocator)` now parses; current stop is `auto` deduction for allocator state member `_Mylast`. |
 | `<deque>` | `test_std_deque.cpp` | 💥 Crash | ~2464ms (retested 2026-04-11). |
 | `<list>` | `test_std_list.cpp` | ❌ Compile Error | ~2940ms (retested 2026-05-12, Linux/libstdc++-14). The shared `_Head_base` default-NTTP stop remains fixed; after raising template nesting limits the first hard error is still depth-guarded, now `Max template instantiation depth (40) exceeded for 'polymorphic_allocator'`. |
 | `<queue>` | `test_std_queue.cpp` | 💥 Crash | ~2522ms (retested 2026-04-11). |
@@ -93,7 +93,7 @@ Language regressions that already pass belong in `tests/` (main suite), not only
 | `<typeinfo>` | `test_std_typeinfo_ret0.cpp` | ✅ Compiled | ~46ms (retested 2026-04-30, Linux/libstdc++-14). Sema now models pointer arithmetic (`T* + integral`, `T* - integral`, `T* - T*`) so the ternary in `type_info::name()` (`__name[0] == '*' ? __name + 1 : __name`) gets a sema-owned exact result type and codegen no longer throws. Regression: `tests/test_ternary_pointer_arithmetic_branches_ret0.cpp`. |
 | `<typeindex>` | N/A | ❌ Codegen Error | ~640ms (retested 2026-04-11). "Cannot use copy initialization with explicit constructor". |
 | `<numeric>` | `test_std_numeric.cpp` | ✅ Compiled | ~7529ms (retested 2026-05-25, Linux/libstdc++-14). **NOW WORKS**: ternary common-type fix resolved `numeric_limits` member constexpr folding. Builtin `__builtin_huge_val`/`__builtin_nan` families now handled in constexpr evaluator. |
-| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~13s wall (Windows/MSVC STL 14.44). Past `checked_array_iterator` incomplete-layout / friend emission; first hard stops are now sema return/ternary/`begin`/`end` lowering. |
+| `<iterator>` | `test_std_iterator.cpp` | ❌ Codegen Error | ~9.1s wall; full parse completes in ~7.3s (retested 2026-07-26, Windows/MSVC STL 14.44). First hard stops remain sema-normalized return lowering for `begin`/`end`, `view_interface` equality, and incomplete aggregate layout. |
 | `<variant>` | `test_std_variant.cpp` | ✅ Compiled | ~736ms (retested 2026-04-24, Linux/libstdc++). **NEW: Now compiles successfully on Linux!** The `_Variadic_union` arithmetic non-type template argument (`_Np-1`) inside a member initializer is now resolved. |
 | `<csetjmp>` | N/A | ✅ Compiled | ~35ms |
 | `<csignal>` | N/A | ✅ Compiled | ~140ms |
@@ -152,7 +152,14 @@ First stop and the language mechanism to fix. Not a session work-log.
 
 | Header | Stop | Mechanism to fix |
 |--------|------|------------------|
+| `<optional>` | Parse: structural class-type NTTP | Structural non-type template arguments and instantiation identity |
+| `<ratio>` | Sema/constexpr: missing `ratio_equal<...>::value` | Static member materialization through trait instantiation |
+| `<any>` | Sema: ambiguous `_Get_rest` member function | Dependent member overload lookup after allocator/function-type parsing |
+| `<span>` | Template default: extent parameter | Dependent non-type template default evaluation |
+| `<tuple>` | Replay: partial-spec nested out-of-line member | Stable source-member identity across partial specializations |
+| `<vector>` | Sema: cannot deduce `_Mylast` `auto` | Member-access result typing in allocator state |
+| `<string_view>` | Lazy replay: `_String_view_iterator::operator+` | Lazy member-body replay and source binding |
 | `<iterator>` | Codegen: sema return/ternary/`begin`/`end` lowering; residual `view_interface` aggregate holes | Exact result types for ternary/return; complete types for CPO/`auto` results in ranges interface members |
 | `<ranges>` | Template-depth / `invoke` recursion | Variadic `invoke` / CPO instantiation |
 
-Regressions for class-template layout/friend fixes: `tests/test_class_tmpl_cross_spec_complete_layout_ret0.cpp`, `tests/test_class_tmpl_friend_plus_byvalue_ret0.cpp`. Regressions for recent `<limits>` fixes: `tests/test_unused_inline_no_emit_ret0.cpp`, `tests/test_used_inline_still_emitted_ret0.cpp`, `tests/test_selectany_comdat_ret0.cpp`, plus earlier typedef-assign / rvalue-assign tests.
+Regressions for the 2026-07-26 Windows fixes: `tests/test_template_member_type_prefers_parameter_spelling_ret0.cpp`, `tests/test_interleaved_declspec_allocator_ret42.cpp`, `tests/test_interleaved_declspec_cv_qualifiers_ret42.cpp`, `tests/test_interleaved_declspec_const_assignment_fail.cpp`, and `tests/test_using_bare_function_type_calling_convention_ret42.cpp`. The shared declaration-specifier parser now carries `const`/`volatile` across interleaved Microsoft `__declspec` specifiers, and semantic analysis rejects assignment to the resulting const-qualified object. Regressions for class-template layout/friend fixes: `tests/test_class_tmpl_cross_spec_complete_layout_ret0.cpp`, `tests/test_class_tmpl_friend_plus_byvalue_ret0.cpp`. Regressions for recent `<limits>` fixes: `tests/test_unused_inline_no_emit_ret0.cpp`, `tests/test_used_inline_still_emitted_ret0.cpp`, `tests/test_selectany_comdat_ret0.cpp`, plus earlier typedef-assign / rvalue-assign tests.

--- a/tests/test_interleaved_declspec_allocator_ret42.cpp
+++ b/tests/test_interleaved_declspec_allocator_ret42.cpp
@@ -1,0 +1,27 @@
+// Microsoft extends decl-specifier-seq with __declspec. The MSVC STL places
+// __declspec(allocator) between constexpr and the return type.
+
+static __declspec(noinline) int freeFunction() {
+	return 1;
+}
+
+struct AllocatorLike {
+	__declspec(noinline) static constexpr int leadingAttribute() {
+		return 2;
+	}
+
+	static __declspec(noinline) constexpr int middleAttribute() {
+		return 4;
+	}
+
+	static constexpr __declspec(allocator) int allocate() {
+		return 35;
+	}
+};
+
+int main() {
+	return freeFunction() +
+		AllocatorLike::leadingAttribute() +
+		AllocatorLike::middleAttribute() +
+		AllocatorLike::allocate();
+}

--- a/tests/test_interleaved_declspec_const_assignment_fail.cpp
+++ b/tests/test_interleaved_declspec_const_assignment_fail.cpp
@@ -1,0 +1,6 @@
+const __declspec(align(16)) int immutable_value = 42;
+
+int main() {
+	immutable_value = 0;
+	return immutable_value;
+}

--- a/tests/test_interleaved_declspec_cv_qualifiers_ret42.cpp
+++ b/tests/test_interleaved_declspec_cv_qualifiers_ret42.cpp
@@ -1,0 +1,9 @@
+// Microsoft extends decl-specifier-seq with __declspec. CV qualifiers remain
+// defining-type-specifiers and may appear on either side of that extension.
+
+static const __declspec(align(16)) int const_value = 20;
+static volatile __declspec(align(16)) int volatile_value = 22;
+
+int main() {
+	return const_value + volatile_value;
+}

--- a/tests/test_template_member_type_prefers_parameter_spelling_ret0.cpp
+++ b/tests/test_template_member_type_prefers_parameter_spelling_ret0.cpp
@@ -1,0 +1,50 @@
+// An exact template-parameter spelling must take precedence over stale type
+// metadata when substituting a member type alias and a data member.
+
+namespace library {
+	template<typename... Types>
+	struct ArgTypes {};
+
+	template<typename Ty1>
+	struct ArgTypes<Ty1> {
+		using argument_type = Ty1;
+	};
+
+	template<typename Ty1, typename Ty2>
+	struct ArgTypes<Ty1, Ty2> {
+		using first_argument_type = Ty1;
+		using second_argument_type = Ty2;
+	};
+
+	template<typename Ty1>
+	struct Identity {
+		using type = Ty1;
+	};
+
+	template<typename Ty1>
+	using IdentityT = typename Identity<Ty1>::type;
+
+	using Warmup = IdentityT<unsigned long long>;
+
+	template<typename Ty1>
+	struct AliasUser {
+		using transformed = IdentityT<Ty1>;
+	};
+
+	using AliasWarmup = AliasUser<long long>;
+
+	template<typename Ty1, typename Ty2>
+	struct PairLike {
+		using first_type = Ty1;
+		using second_type = Ty2;
+
+		Ty1 first;
+		Ty2 second;
+	};
+}
+
+int main() {
+	library::PairLike<int, float> value{42, 3.5f};
+	library::PairLike<int, float>::first_type copy = value.first;
+	return copy == 42 && value.second == 3.5f ? 0 : 1;
+}

--- a/tests/test_using_bare_function_type_calling_convention_ret42.cpp
+++ b/tests/test_using_bare_function_type_calling_convention_ret42.cpp
@@ -1,0 +1,13 @@
+// A calling convention may appear between the return type and parameter list
+// of a bare function type alias.
+
+using Function = int __cdecl(int);
+
+int addOne(int value) {
+	return value + 1;
+}
+
+int main() {
+	Function* invoke = &addOne;
+	return invoke(41);
+}


### PR DESCRIPTION
## Summary
- parse Microsoft `__declspec` as a shared declaration specifier and preserve interleaved `const`/`volatile` qualifiers through AST and template paths
- reject assignment to const-qualified objects during semantic analysis while retaining correct pointer-to-const versus const-pointer behavior
- support calling conventions on bare function type aliases and preserve dependent template-parameter spelling during member type construction
- add reduced positive/negative regressions and refresh Windows/MSVC standard-header status and timings

## Standard-header progress
- `<utility>` now completes object generation; its linked probe still has a separate runtime crash
- `<any>` and `<vector>` parse past the interleaved allocator `__declspec` sites and now stop at later semantic issues

## Validation
- `build_flashcpp.bat` — succeeded with 0 warnings
- focused declaration, CV, template spelling, calling-convention, and pointer-qualification regressions — passed
- `pwsh tests/run_all_tests.ps1` — 2807/2807 regular tests passed; 242/242 negative tests failed as expected
- new valid and invalid `__declspec`/CV forms checked against MSVC 14.44