### PR TITLE
Fail loudly on codegen errors instead of soft-skipping

### DIFF
--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -26,9 +26,7 @@ public:
 
 	void generateCollectedLocalStructMembers();
 
-	std::string get_deferred_func_name(const ASTNode& node) const;
-
-	size_t generateDeferredMemberFunctions();
+	void generateDeferredMemberFunctions();
 
 	void generateCollectedTemplateInstantiations();
 	void normalizePendingSemanticRoots();
@@ -44,7 +42,7 @@ public:
 	// ODR-use emission for free inline/__inline definitions: skip bodies until
 	// a call (or other use) marks them needed, then emit from the deferred queue.
 	void requestInlineFunctionEmission(const FunctionDeclarationNode& node);
-	size_t generateDeferredInlineFunctions();
+	void generateDeferredInlineFunctions();
 	size_t deferredMemberFunctionsPending() const {
 		return deferred_member_functions_.size() - deferred_member_functions_processed_;
 	}

--- a/src/CompileError.h
+++ b/src/CompileError.h
@@ -3,17 +3,18 @@
 #include <stdexcept>
 #include <string>
 
-// Semantic compilation error - distinct from std::runtime_error so that
-// per-function codegen error recovery can let these propagate while still
-// catching internal codegen limitation errors.
+// Semantic compilation error - distinct from InternalError so convert() can let
+// these propagate unchanged while still catching internal codegen limitations.
+// At the IR-to-object boundary, InternalError is rethrown as CompileError with
+// the enclosing function name attached.
 class CompileError : public std::runtime_error {
 public:
 	using std::runtime_error::runtime_error;
 };
 
-// Internal codegen limitation error - distinct from std::runtime_error so that
-// per-function error recovery can catch these specifically while letting
-// CompileError (semantic errors) propagate.
+// Internal codegen limitation error - distinct from CompileError so convert()
+// can catch these specifically, attach function context, and surface them as
+// CompileError while letting semantic CompileError instances propagate.
 // Examples: unsupported types, register allocation failures, unimplemented features.
 class InternalError : public std::runtime_error {
 public:

--- a/src/FlashCppMain.cpp
+++ b/src/FlashCppMain.cpp
@@ -670,36 +670,19 @@ int main_impl(int argc, char* argv[]) {
 		}
 	}
 
-	// Deferred generation (lambdas and local struct member functions)
-	size_t deferred_gen_error_count = 0;
+	// Deferred generation (lambdas and local struct member functions).
+	// Failures here abort the TU — do not soft-skip missing member/lambda bodies.
 	{
 		PhaseTimer deferred_timer("Deferred Gen", false, &deferred_gen_time, FlashCpp::AllocationPhase::DeferredGen);
-		try {
-			// Generate all collected lambdas after visiting all nodes
-			converter.generateCollectedLambdas();
-		} catch (const CompileError&) {
-			throw;  // Semantic errors must propagate
-		} catch (const std::exception& e) {
-			FLASH_LOG(General, Error, "Deferred lambda generation failed: ", e.what());
-			++deferred_gen_error_count;
-		}
-
-		try {
-			// Generate all collected local struct member functions after visiting all nodes
-			converter.generateCollectedLocalStructMembers();
-		} catch (const CompileError&) {
-			throw;  // Semantic errors must propagate
-		} catch (const std::exception& e) {
-			FLASH_LOG(General, Error, "Local struct member generation failed: ", e.what());
-			++deferred_gen_error_count;
-		}
+		converter.generateCollectedLambdas();
+		converter.generateCollectedLocalStructMembers();
 
 		// Generate remaining deferred member functions and ODR-used free inlines.
 		// Emitting either queue can enqueue the other, so alternate until both drain.
 		while (converter.deferredMemberFunctionsPending() > 0 ||
 			   converter.deferredInlineFunctionsPending() > 0) {
-			deferred_gen_error_count += converter.generateDeferredMemberFunctions();
-			deferred_gen_error_count += converter.generateDeferredInlineFunctions();
+			converter.generateDeferredMemberFunctions();
+			converter.generateDeferredInlineFunctions();
 		}
 
 		// Note: Template instantiations happen during parsing, not here
@@ -715,10 +698,9 @@ int main_impl(int argc, char* argv[]) {
 		FLASH_LOG(Codegen, Debug, "=== End IR ===\n\n");
 	}
 
-	if (ir_conversion_error_count > 0 || deferred_gen_error_count > 0) {
+	if (ir_conversion_error_count > 0) {
 		FLASH_LOG(General, Error, "Compilation failed during IR generation (",
-				  ir_conversion_error_count, " top-level, ",
-				  deferred_gen_error_count, " deferred failures)");
+				  ir_conversion_error_count, " top-level failures)");
 		return 1;
 	}
 

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -71,19 +71,28 @@ void IrToObjConverter<TWriterClass>::convert(const Ir& ir, const std::string_vie
 
 	auto ir_processing_start = std::chrono::high_resolution_clock::now();
 	const auto& instructions = ir.getInstructions();
-	bool skipping_function = false;	// When true, skip until next FunctionDecl
+	// Convert IR-lowering failures into user-facing CompileError with function context.
+	// Codegen errors abort the whole translation unit rather than emitting empty symbols.
+	auto throwCodegenFailure = [&](const std::exception& e) -> void {
+		StringBuilder sb;
+		sb.append("Code generation failed"sv);
+		if (current_function_name_.isValid()) {
+			sb.append(" in function '"sv);
+			sb.append(StringTable::getStringView(current_function_name_));
+			sb.append("'"sv);
+		}
+		if (current_function_mangled_name_.isValid() &&
+			current_function_mangled_name_ != current_function_name_) {
+			sb.append(" ("sv);
+			sb.append(StringTable::getStringView(current_function_mangled_name_));
+			sb.append(")"sv);
+		}
+		sb.append(": "sv);
+		sb.append(e.what());
+		throw CompileError(std::string(sb.commit()));
+	};
 	for (size_t ir_idx = 0; ir_idx < instructions.size(); ++ir_idx) {
 		const auto& instruction = instructions[ir_idx];
-
-			// If we're skipping a failed function, only stop at the next FunctionDecl
-		if (skipping_function) {
-			if (instruction.getOpcode() == IrOpcode::FunctionDecl) {
-				skipping_function = false;
-					// fall through to process this FunctionDecl
-			} else {
-				continue;
-			}
-		}
 
 #if ENABLE_DETAILED_PROFILING
 		auto instr_start = std::chrono::high_resolution_clock::now();
@@ -474,20 +483,14 @@ void IrToObjConverter<TWriterClass>::convert(const Ir& ir, const std::string_vie
 				break;
 			}
 		} catch (const CompileError&) {
-				// Semantic errors must propagate — they are real compilation failures
+			// Semantic errors must propagate — they are real compilation failures.
 			throw;
 		} catch (const InternalError& e) {
-				// Per-function error recovery: skip to the next function declaration
-			FLASH_LOG(Codegen, Error, "Code generation error in function, skipping: ", e.what());
-			skipping_function = true;
-			skip_previous_function_finalization_ = true;
-			continue;
+			// Fail compilation with function context instead of emitting an empty symbol.
+			throwCodegenFailure(e);
 		} catch (const std::exception& e) {
-				// Per-function error recovery: skip to the next function declaration
-			FLASH_LOG(Codegen, Error, "Code generation error in function, skipping: ", e.what());
-			skipping_function = true;
-			skip_previous_function_finalization_ = true;
-			continue;
+			// Same treatment for unexpected codegen failures.
+			throwCodegenFailure(e);
 		}
 
 #if ENABLE_DETAILED_PROFILING
@@ -7469,7 +7472,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 	}
 
 		// Finalize previous function before starting new one
-	if (current_function_name_.isValid() && !skip_previous_function_finalization_) {
+	if (current_function_name_.isValid()) {
 				// Branch fixups and local labels are function-scoped. Patch and clear them now
 				// before finalizing the previous function so later functions cannot reuse or
 				// overwrite label state from this one.
@@ -7651,23 +7654,6 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 
 			// Reset for new function
 		resetFunctionState();
-	} else if (skip_previous_function_finalization_) {
-			// Previous function was skipped due to codegen error - just clean up state
-		if (!variable_scopes.empty()) {
-			variable_scopes.pop_back();
-		}
-			// Truncate textSectionData back to the start of the failed function
-		textSectionData.resize(current_function_offset_);
-			// Remove stale relocations from the failed function
-		std::erase_if(pending_global_relocations_, [this](const PendingGlobalRelocation& r) {
-			return r.offset >= current_function_offset_;
-		});
-		resetFunctionState();
-			// Clear pending branches/labels from the skipped function
-		pending_branches_.clear();
-		label_positions_.clear();
-		elf_catch_filter_patches_.clear();
-		skip_previous_function_finalization_ = false;
 	}
 
 		// align the function to 16 bytes
@@ -16896,29 +16882,15 @@ void IrToObjConverter<TWriterClass>::finalizeSections() {
 	}
 
 		// Now add pending global variable relocations (after symbols are created)
-		// First, remove stale relocations from any error-skipped last function
-	if (skip_previous_function_finalization_) {
-		std::erase_if(pending_global_relocations_, [this](const PendingGlobalRelocation& r) {
-			return r.offset >= current_function_offset_;
-		});
-			// Truncate textSectionData back to the start of the failed function
-		textSectionData.resize(current_function_offset_);
-	}
 	for (const auto& reloc : pending_global_relocations_) {
 		writer.add_text_relocation(reloc.offset, std::string(StringTable::getStringView(reloc.symbol_name)), reloc.type, reloc.addend);
 	}
 
 		// Patch all pending branches before finalizing
-		// Skip patching if the last function was error-skipped (branches may reference unresolved labels)
-	if (!skip_previous_function_finalization_) {
-		finalizeFunctionBranches();
-	} else {
-		pending_branches_.clear();
-		label_positions_.clear();
-	}
+	finalizeFunctionBranches();
 
 		// Finalize the last function (if any) since there's no subsequent handleFunctionDecl to trigger it
-	if (current_function_name_.isValid() && !skip_previous_function_finalization_) {
+	if (current_function_name_.isValid()) {
 			// Calculate actual stack space needed from scope_stack_space (which includes varargs area if present)
 			// scope_stack_space is negative (offset from RBP), so negate to get positive size
 		size_t total_stack = static_cast<size_t>(-variable_scopes.back().scope_stack_space);

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -4359,6 +4359,9 @@ void IrToObjConverter<TWriterClass>::emitSysVAggregateToRegisters(
 			X64Register target_reg = getFloatParamReg<TWriterClass>(sse_reg_index++);
 			emitMovqGprToXmm(temp_gpr, target_reg);
 			regAlloc.release(temp_gpr);
+		} else if (layout.eightbytes[0] == SysVRegisterClass::None) {
+			// Padding-only eightbyte: no register content to materialize.
+			return;
 		} else {
 			throw InternalError("Unsupported SysV constant aggregate argument register class");
 		}

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -999,7 +999,6 @@ private:
 	bool current_function_returns_pointer_ = false;  // True if function returns a pointer (any pointer depth)
 	int32_t current_function_this_offset_ = 0;  // Stack home offset of the implicit this parameter in member functions
 	int32_t current_function_varargs_reg_save_offset_ = 0;  // Offset of varargs register save area (Linux only)
-	bool skip_previous_function_finalization_ = false;  // Set when a function is skipped due to codegen error
 
 	// CFI instruction tracking for exception handling
 	std::vector<ElfFileWriter::CFIInstruction> current_function_cfi_;

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -65,8 +65,7 @@ void AstToIr::requestInlineFunctionEmission(const FunctionDeclarationNode& node)
 	}
 }
 
-size_t AstToIr::generateDeferredInlineFunctions() {
-	size_t error_count = 0;
+void AstToIr::generateDeferredInlineFunctions() {
 	while (inline_emission_worklist_processed_ < inline_emission_worklist_.size()) {
 		ASTNode function_node = inline_emission_worklist_[inline_emission_worklist_processed_++];
 		if (!function_node.is<FunctionDeclarationNode>()) {
@@ -80,22 +79,14 @@ size_t AstToIr::generateDeferredInlineFunctions() {
 			parser_.enqueuePendingSemanticRootIfNeeded(function_node);
 			normalizePendingSemanticRoots();
 			visitFunctionDeclarationNode(func);
-		} catch (const CompileError&) {
+		} catch (...) {
 			current_function_name_ = saved_function;
 			current_namespace_stack_ = saved_namespace;
 			throw;
-		} catch (const std::exception& e) {
-			FLASH_LOG(Codegen, Error,
-					  "Deferred inline function '",
-					  func.decl_node().identifier_token().value(),
-					  "' generation failed: ",
-					  e.what());
-			++error_count;
 		}
 		current_function_name_ = saved_function;
 		current_namespace_stack_ = saved_namespace;
 	}
-	return error_count;
 }
 
 bool AstToIr::shouldDeferImplicitConstructorCodegen(const StructTypeInfo& struct_info, const ConstructorDeclarationNode& ctor) const {

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -363,27 +363,7 @@ void AstToIr::generateCollectedLocalStructMembers() {
 	}
 }
 
-std::string AstToIr::get_deferred_func_name(const ASTNode& node) const {
-	if (node.is<FunctionDeclarationNode>()) {
-		return std::string(node.as<FunctionDeclarationNode>().decl_node().identifier_token().value());
-	}
-	if (node.is<ConstructorDeclarationNode>()) {
-		return std::string(StringTable::getStringView(node.as<ConstructorDeclarationNode>().struct_name())) + " constructor";
-	}
-	if (node.is<DestructorDeclarationNode>()) {
-		return std::string(StringTable::getStringView(node.as<DestructorDeclarationNode>().struct_name())) + " destructor";
-	}
-	if (node.is<TemplateFunctionDeclarationNode>()) {
-		const auto& tmpl = node.as<TemplateFunctionDeclarationNode>();
-		if (tmpl.function_declaration().is<FunctionDeclarationNode>()) {
-			return std::string(tmpl.function_declaration().as<FunctionDeclarationNode>().decl_node().identifier_token().value());
-		}
-	}
-	return "unknown";
-}
-
-size_t AstToIr::generateDeferredMemberFunctions() {
-	size_t error_count = 0;
+void AstToIr::generateDeferredMemberFunctions() {
 	while (deferred_member_functions_processed_ < deferred_member_functions_.size()) {
 		DeferredMemberFunctionInfo info = deferred_member_functions_[deferred_member_functions_processed_++];
 		StringHandle saved_function = current_function_name_;
@@ -424,21 +404,17 @@ size_t AstToIr::generateDeferredMemberFunctions() {
 					visitFunctionDeclarationNode(tmpl.function_declaration().as<FunctionDeclarationNode>());
 				}
 			}
-		} catch (const CompileError&) {
-			// Semantic errors must propagate — they are real compilation failures
+		} catch (...) {
+			// Restore caller context, then fail loudly. Soft-skipping deferred
+			// members left callers with missing definitions / silent wrong objects.
 			current_function_name_ = saved_function;
 			current_namespace_stack_ = saved_namespace;
 			throw;
-		} catch (const std::exception& e) {
-			std::string func_name = get_deferred_func_name(info.function_node);
-			FLASH_LOG(Codegen, Error, "Deferred member function '", func_name, "' generation failed: ", e.what());
-			++error_count;
 		}
 
 		current_function_name_ = saved_function;
 		current_namespace_stack_ = saved_namespace;
 	}
-	return error_count;
 }
 
 void AstToIr::generateCollectedTemplateInstantiations() {

--- a/src/TargetABI.h
+++ b/src/TargetABI.h
@@ -247,6 +247,21 @@ inline SysVAbiValueLayout classifySysVValue(TypeIndex type_index, SizeInBits siz
 		return layout;
 	}
 	layout.eightbyte_count = static_cast<uint8_t>((size_in_bytes + 7) / 8);
+	// C++ empty classes usually have size 1 and no fields, so classification leaves
+	// every eightbyte as NO_CLASS/None. SysV/Itanium practice still passes such
+	// non-zero-sized empty aggregates in INTEGER registers. Trailing padding
+	// None eightbytes after a real Integer/Sse eightbyte must stay None so they
+	// do not consume an extra register (see test_external_abi trailing padding).
+	bool any_non_none = false;
+	for (size_t i = 0; i < layout.eightbyte_count; ++i) {
+		if (layout.eightbytes[i] != SysVRegisterClass::None) {
+			any_non_none = true;
+			break;
+		}
+	}
+	if (!any_non_none && layout.eightbyte_count > 0) {
+		layout.eightbytes[0] = SysVRegisterClass::Integer;
+	}
 	return layout;
 }
 

--- a/tests/std/test_std_optional_codegen_recovery.cpp
+++ b/tests/std/test_std_optional_codegen_recovery.cpp
@@ -1,8 +1,9 @@
-// Regression test: codegen error recovery for non-struct member access
+// Regression test: member access on <optional> must compile and run.
 // Previously, generateMemberAccessIr returned {} for error cases, causing
-// downstream SIGSEGV. Now it throws std::runtime_error which is caught by
-// the per-function error recovery mechanism.
-// This test uses <optional> which exercises the fixed code path.
+// downstream SIGSEGV. Member-access failures now throw InternalError and
+// convert() surfaces them as CompileError with the enclosing function name.
+// Blocked on <optional> parsing today (structural class-type NTTP in MSVC STL);
+// see README_STANDARD_HEADERS.md.
 #include <optional>
 
 int main() {


### PR DESCRIPTION
## Summary
- Abort the translation unit on IR→object codegen failures instead of soft-skipping failed functions (which could leave zero-byte / aliased symbols and crash at runtime).
- Apply the same fail-loud policy to deferred IR generation (members, inlines, lambdas, local struct members): restore context and rethrow rather than catch-and-count.
- Keep `CompileError` propagation unchanged; update the optional recovery probe comments to match.

## Test plan
- [x] `pwsh tests/run_all_tests.ps1` — 2812 regular + 242 `_fail` all green
- [x] Smoke: pack/const regressions + `test_std_limits.cpp`
- [ ] Optional: confirm std-header probes that previously relied on convert soft-skip (none observed on current Windows/MSVC STL)
