### PR TITLE
Carry concrete owner TypeIndex through template substitution

### DIFF
--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3247,11 +3247,6 @@ public:	// Public methods for template instantiation
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
-		StringHandle current_owner_type_name);
-	ASTNode substituteTemplateParameters(
-		const ASTNode& node,
-		std::span<const TemplateParameterNode> template_params,
-		std::span<const TemplateTypeArg> template_args,
 		TypeIndex current_owner_type_index,
 		bool has_implicit_this);
 	ASTNode substituteTemplateParameters(

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -3252,7 +3252,7 @@ public:	// Public methods for template instantiation
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
-		StringHandle current_owner_type_name,
+		TypeIndex current_owner_type_index,
 		bool has_implicit_this);
 	ASTNode substituteTemplateParameters(
 		const ASTNode& node,
@@ -3269,7 +3269,7 @@ public:	// Public methods for template instantiation
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
 		const TemplateEnvironmentSnapshot& outer_snapshot,
-		StringHandle instantiated_owner_name,
+		TypeIndex instantiated_owner_type_index,
 		bool has_implicit_this);
 
 	// Helper to extract type from an expression for overload resolution.
@@ -3411,6 +3411,9 @@ private:	 // Resume private methods
 	bool expressionTypeDeductionIsStillDependent(const ASTNode& expr);
 	std::optional<TypeSpecifierNode> lookupSubstitutedLocalBindingType(
 		StringHandle name) const;
+	TemplateBodySubstitutionState makeTemplateBodySubstitutionState(
+		TypeIndex owner_type_index,
+		bool has_implicit_this) const;
 	ASTNode substituteTemplateParametersWithState(
 		const ASTNode& node,
 		std::span<const TemplateParameterNode> template_params,
@@ -3553,7 +3556,7 @@ private:	 // Resume private methods
 		const ASTNode& arg,
 		std::span<const TemplateParameterNode> template_params,
 		std::span<const TemplateTypeArg> template_args,
-		StringHandle current_owner_type_name,
+		TemplateBodySubstitutionState& state,
 		ChunkedVector<ASTNode>& out);
 
 		// Phase 3: Expression context tracking for template disambiguation

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -130,7 +130,7 @@ inline ReplaySignatureMatchResult declarationsMatchAfterTemplateSubstitution(
 	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params);
 inline const TypeSpecifierNode* getDeclarationParamTypeNode(const ASTNode& param);
@@ -143,7 +143,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params);
 inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
@@ -152,7 +152,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 	const ConstructorDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params);
 
@@ -429,7 +429,7 @@ inline OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name) {
+	TypeIndex owner_type_index) {
 	const std::string_view out_of_line_name =
 		out_of_line_decl.decl_node().identifier_token().value();
 	OutOfLineMemberStubResolution resolution;
@@ -470,7 +470,7 @@ inline OutOfLineMemberStubResolution findPlainOutOfLineMemberStubByIdentity(
 				out_of_line_decl,
 				outer_template_params,
 				outer_template_args,
-				owner_type_name,
+				owner_type_index,
 				std::span<const TemplateParameterNode>{},
 				std::span<const TemplateParameterNode>{});
 		if (signature_match == ReplaySignatureMatchResult::InsufficientEvidence) {
@@ -508,7 +508,7 @@ inline OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name) {
+	TypeIndex owner_type_index) {
 	OutOfLineConstructorStubResolution resolution;
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
 	const ASTNode* matched_source_member = nullptr;
@@ -533,7 +533,7 @@ inline OutOfLineConstructorStubResolution findPlainOutOfLineConstructorStubByIde
 				out_of_line_decl,
 				outer_template_params,
 				outer_template_args,
-				owner_type_name,
+				owner_type_index,
 				std::span<const TemplateParameterNode>{},
 				std::span<const TemplateParameterNode>{});
 		if (signature_match == ReplaySignatureMatchResult::InsufficientEvidence) {
@@ -568,7 +568,7 @@ inline OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
 	OutOfLineConstructorStubResolution resolution;
 	InlineVector<ConstructorDeclarationNode*, 4> resolved_matches;
@@ -604,7 +604,7 @@ inline OutOfLineConstructorStubResolution findOutOfLineConstructorTemplateStubBy
 			out_of_line_decl,
 			outer_template_params,
 			outer_template_args,
-			owner_type_name,
+			owner_type_index,
 			std::span<const TemplateParameterNode>(
 				inst_ctor_decl->template_parameters().data(),
 				inst_ctor_decl->template_parameters().size()),
@@ -1601,12 +1601,13 @@ inline std::optional<TypeSpecifierNode> substituteOutOfLineSignatureType(
 	const TypeSpecifierNode& original_type,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle owner_type_name) {
+	TypeIndex owner_type_index) {
 	ASTNode substituted_type_node = parser.substituteTemplateParameters(
 		ASTNode::emplace_node<TypeSpecifierNode>(original_type),
 		template_params,
 		template_args,
-		owner_type_name);
+		owner_type_index,
+		false);
 	if (!substituted_type_node.is<TypeSpecifierNode>()) {
 		return std::nullopt;
 	}
@@ -2577,7 +2578,7 @@ inline ReplaySignatureMatchResult declarationsMatchAfterTemplateSubstitution(
 	const OutOfLineDeclNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> instantiated_template_params,
 	std::span<const TemplateParameterNode> out_of_line_template_params) {
 	if (instantiated_decl.parameter_nodes().size() != out_of_line_decl.parameter_nodes().size()) {
@@ -2609,7 +2610,7 @@ inline ReplaySignatureMatchResult declarationsMatchAfterTemplateSubstitution(
 				*instantiated_param,
 				template_params,
 				template_args,
-				owner_type_name);
+				owner_type_index);
 		}
 
 		std::optional<TypeSpecifierNode> substituted_out_of_line_param;
@@ -2619,7 +2620,7 @@ inline ReplaySignatureMatchResult declarationsMatchAfterTemplateSubstitution(
 				*out_of_line_param,
 				template_params,
 				template_args,
-				owner_type_name);
+				owner_type_index);
 		}
 		if (substituted_instantiated_param.has_value() ||
 			substituted_out_of_line_param.has_value()) {
@@ -2738,7 +2739,7 @@ inline ReplaySignatureMatchResult nestedOutOfLineMemberTemplateMatchesCandidate(
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
 	if (!candidate_member.is<TemplateFunctionDeclarationNode>()) {
 		return ReplaySignatureMatchResult::Mismatch;
@@ -2760,7 +2761,7 @@ inline ReplaySignatureMatchResult nestedOutOfLineMemberTemplateMatchesCandidate(
 		out_of_line_decl,
 		outer_template_params,
 		outer_template_args,
-		owner_type_name,
+		owner_type_index,
 		candidate_inner_template_params,
 		out_of_line_inner_template_params);
 	return signature_match;
@@ -2772,7 +2773,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 	const FunctionDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
 	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
@@ -2785,7 +2786,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 		out_of_line_decl,
 		outer_template_params,
 		outer_template_args,
-		owner_type_name,
+		owner_type_index,
 		candidate_inner_template_params,
 		out_of_line_inner_template_params);
 }
@@ -2796,7 +2797,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 	const ConstructorDeclarationNode& out_of_line_decl,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name,
+	TypeIndex owner_type_index,
 	std::span<const TemplateParameterNode> candidate_inner_template_params,
 	std::span<const TemplateParameterNode> out_of_line_inner_template_params) {
 	if (candidate_inner_template_params.size() != out_of_line_inner_template_params.size()) {
@@ -2809,7 +2810,7 @@ inline ReplaySignatureMatchResult outOfLineConstructorTemplateMatchesCandidate(
 		out_of_line_decl,
 		outer_template_params,
 		outer_template_args,
-		owner_type_name,
+		owner_type_index,
 		candidate_inner_template_params,
 		out_of_line_inner_template_params);
 }
@@ -2856,7 +2857,7 @@ inline void materializeReplayAttachedFunctionParameterTypesFromDefinition(
 	std::span<const ASTNode> definition_params,
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
-	StringHandle owner_type_name) {
+	TypeIndex owner_type_index) {
 	if (instantiated_params.size() != definition_params.size()) {
 		return;
 	}
@@ -2877,7 +2878,7 @@ inline void materializeReplayAttachedFunctionParameterTypesFromDefinition(
 				definition_decl->type_specifier_node(),
 				outer_template_params,
 				outer_template_args,
-				owner_type_name);
+				owner_type_index);
 		if (!substituted_definition_type.has_value()) {
 			continue;
 		}
@@ -3928,6 +3929,7 @@ inline std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 	const SymbolTable& symbol_table,
 	Parser& parser,
 	const StructTypeInfo* struct_info,
+	TypeIndex owner_type_index,
 	const TemplateParamsContainer& template_params,
 	std::span<const TemplateTypeArg> template_args,
 	TypeIndex type_index,
@@ -3954,7 +3956,8 @@ inline std::optional<NormalizedInitializer> tryEarlyNormalizeTemplateStaticMembe
 			initializer.value(),
 			template_params,
 			template_args,
-			struct_info->getName());
+			owner_type_index,
+			false);
 	}
 
 	if (initializer->is<ExpressionNode>()) {
@@ -4030,6 +4033,12 @@ inline void retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 	if (!struct_info || !parser) {
 		return;
 	}
+	if (!struct_info->own_type_index_.has_value()) {
+		throw InternalError(
+			"Deferred template static member normalization is missing its concrete owner type");
+	}
+	const TypeIndex owner_type_index =
+		struct_info->own_type_index_->withCategory(TypeCategory::Struct);
 
 	for (auto& static_member : struct_info->static_members) {
 		if (static_member.normalized_init.has_value() || !static_member.initializer.has_value()) {
@@ -4043,6 +4052,7 @@ inline void retryNormalizeTemplateStaticMembersAfterDeferredBodies(
 				gSymbolTable,
 				*parser,
 				struct_info,
+				owner_type_index,
 				template_params,
 				template_args,
 				static_member.type_index,

--- a/src/Parser_Decl_StructEnum.cpp
+++ b/src/Parser_Decl_StructEnum.cpp
@@ -5369,7 +5369,8 @@ void Parser::materializeHiddenFriendsForClassTemplateInstantiation(
 				*pattern_func.get_definition(),
 				template_params,
 				template_args,
-				instantiated_name);
+				concrete_owner_type_index,
+				false);
 			new_func_ref.set_definition(substituted_body);
 			finalize_function_after_definition(new_func_ref);
 		} else if (pattern_func.has_template_body_position()) {

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2326,7 +2326,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*orig_ctor.get_definition(),
 							template_params,
 							template_args_for_member_copy,
-							instantiated_name,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							true));
 					}
 					pack_param_info_.resize(saved_pack_info);
@@ -2420,7 +2420,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*orig_func.get_definition(),
 							template_params,
 							template_args_for_member_copy,
-							instantiated_name,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							!orig_func.is_static());
 						if (orig_func.is_static()) {
 							substituted_body = rebindStaticMemberInitializerFunctionCalls(
@@ -3572,7 +3572,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*orig_ctor.get_definition(),
 							template_params,
 							template_args_for_pattern,
-							instantiated_name,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							true));
 					}
 					pack_param_info_.resize(saved_pack_info);
@@ -3972,7 +3972,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								*orig_func.get_definition(),
 								template_params,
 								template_args_for_pattern,
-								instantiated_name,
+								struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 								!orig_func.is_static());
 						}
 						if (orig_func.is_static()) {
@@ -4026,7 +4026,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									*block_result.node(),
 									template_params,
 									template_args_for_pattern,
-									instantiated_name,
+									struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 									!orig_func.is_static());
 								if (orig_func.is_static()) {
 									const TypeInfo* rebound_type_info = findTypeByName(instantiated_name);
@@ -9892,7 +9892,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*body_to_substitute,
 							effective_template_params,
 							effective_template_args,
-							instantiated_name,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							!func_decl.is_static());
 						if (force_eager) {
 							if (std::optional<StringHandle> unresolved_type =
@@ -10109,7 +10109,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*ctor_decl.get_definition(),
 							template_params,
 							template_args_to_use,
-							instantiated_name,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							true);
 					}
 
@@ -10248,7 +10248,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						*dtor_decl.get_definition(),
 						template_params,
 						template_args_to_use,
-						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						true);
 
 					// Create a new destructor declaration with substituted body
@@ -11709,7 +11709,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						*body_result.node(),
 						out_of_line_member.template_params,
 						template_args_to_use,
-						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						true);
 					ctor.set_definition(substituted_body);
 					// Also update the StructTypeInfo's copy (used by codegen)

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -2191,7 +2191,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							ASTNode::emplace_node<TypeSpecifierNode>(type_spec),
 							template_params,
 							template_args_for_member_copy,
-							struct_info->getName());
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
+							false);
 						if (substituted_type_node.is<TypeSpecifierNode>()) {
 							const TypeSpecifierNode& substituted_type =
 								substituted_type_node.as<TypeSpecifierNode>();
@@ -2966,8 +2967,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									template_args_for_substitution,
 									nullptr,
 									currentTemplateSubstitutionFailurePolicy());
-							substitution_context.current_instantiation_name =
-								instantiated_name;
+							substitution_context.current_instantiation_type =
+								struct_type_info.registeredTypeIndex().withCategory(
+									TypeCategory::Struct);
 
 							TemplateDefinitionLookupContext definition_lookup_context =
 								ensureReplayDefinitionLookupContext(
@@ -4152,7 +4154,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const TemplateTypeArg>(
 							template_args_for_pattern.data(),
 							template_args_for_pattern.size()),
-						instantiated_name);
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct));
 					FunctionDeclarationNode* inst_func = member_resolution.func;
 					if (inst_func != nullptr) {
 						// Copy definition-site parameter names so the body can reference them.
@@ -4173,7 +4176,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::span<const TemplateTypeArg>(
 								template_args_for_pattern.data(),
 								template_args_for_pattern.size()),
-							instantiated_name);
+							struct_type_info.registeredTypeIndex().withCategory(
+								TypeCategory::Struct));
 
 						const std::span<const ASTNode> inst_func_params =
 							inst_func->parameter_nodes();
@@ -4231,7 +4235,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									std::span<const TemplateTypeArg>(
 										template_args_for_pattern.data(),
 										template_args_for_pattern.size()),
-									instantiated_name);
+									struct_type_info.registeredTypeIndex().withCategory(
+										TypeCategory::Struct));
 								info_func_resolution.func->set_definition(*inst_func->get_definition());
 								finalize_function_after_definition(*info_func_resolution.func, true);
 							}
@@ -4338,7 +4343,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								std::span<const TemplateTypeArg>(
 									template_args_for_pattern.data(),
 									template_args_for_pattern.size()),
-								instantiated_name,
+								struct_type_info.registeredTypeIndex().withCategory(
+									TypeCategory::Struct),
 								std::span<const TemplateParameterNode>(
 									out_of_line_member.inner_template_params.data(),
 									out_of_line_member.inner_template_params.size()));
@@ -4516,7 +4522,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const TemplateTypeArg>(
 							template_args_for_pattern.data(),
 							template_args_for_pattern.size()),
-						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct),
 						std::span<const TemplateParameterNode>(
 							out_of_line_member.inner_template_params.data(),
 							out_of_line_member.inner_template_params.size()));
@@ -7184,14 +7191,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	}
 
 	auto push_replay_member_context =
-		[this](StringHandle instantiated_class_name, StructTypeInfo* instantiated_struct_info) {
-		TypeIndex struct_type_index{};
-		if (auto type_it = getTypesByNameMap().find(instantiated_class_name);
-			type_it != getTypesByNameMap().end()) {
-			struct_type_index = type_it->second->type_index_;
-		}
+		[this](
+			StringHandle instantiated_class_name,
+			TypeIndex struct_type_index,
+			StructTypeInfo* instantiated_struct_info) {
 		member_function_context_stack_.push_back(
-			{instantiated_class_name, struct_type_index, nullptr, instantiated_struct_info});
+			{instantiated_class_name, struct_type_index, nullptr, instantiated_struct_info, false});
 		return ScopeGuard([this]() {
 			if (!member_function_context_stack_.empty()) {
 				member_function_context_stack_.pop_back();
@@ -7205,6 +7210,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			const auto& template_params,
 			std::span<const TemplateTypeArg> template_args,
 			StringHandle owning_instantiated_name,
+			TypeIndex owning_type_index,
 			NamespaceHandle fallback_definition_namespace,
 			bool requires_replay_metadata) -> std::optional<ASTNode> {
 		if (!static_member.initializer_position.has_value() ||
@@ -7232,8 +7238,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				template_args,
 				nullptr,
 				currentTemplateSubstitutionFailurePolicy());
-		substitution_context.current_instantiation_name =
-			owning_instantiated_name;
+		substitution_context.current_instantiation_type =
+			owning_type_index;
 
 		TemplateDefinitionLookupContext definition_lookup_context =
 			ensureReplayDefinitionLookupContext(
@@ -7269,7 +7275,10 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			non_type_categories);
 
 		auto member_ctx_scope =
-			push_replay_member_context(owning_instantiated_name, struct_info);
+			push_replay_member_context(
+				owning_instantiated_name,
+				owning_type_index,
+				struct_info);
 
 		restore_lexer_position_only(*static_member.initializer_position);
 
@@ -7327,6 +7336,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			const auto& template_params,
 			std::span<const TemplateTypeArg> template_args,
 			StringHandle owning_instantiated_name,
+			TypeIndex owning_type_index,
 			NamespaceHandle fallback_definition_namespace,
 			const auto& fallback_template_args) -> std::optional<ASTNode> {
 		if (!static_member.initializer.has_value()) {
@@ -7350,6 +7360,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					template_params,
 					template_args,
 					owning_instantiated_name,
+					owning_type_index,
 					fallback_definition_namespace,
 					requires_replay_metadata);
 		} catch (const std::exception& ex) {
@@ -7370,7 +7381,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				*static_member.initializer,
 				template_params,
 				fallback_template_args,
-				owning_instantiated_name);
+				owning_type_index,
+				false);
 		}
 
 		return substituted_initializer;
@@ -7660,6 +7672,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						effective_template_args_vector.data(),
 						effective_template_args_vector.size()),
 					instantiated_name,
+					struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 					struct_info->getNamespaceHandle(),
 					effective_template_args);
 
@@ -7671,6 +7684,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					gSymbolTable,
 					*this,
 					struct_info,
+					struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 					effective_template_params,
 					effective_template_args_vector,
 					substituted_type_index,
@@ -7728,6 +7742,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						effective_template_args_vector.data(),
 						effective_template_args_vector.size()),
 					instantiated_name,
+					struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 					struct_info->getNamespaceHandle(),
 					effective_template_args);
 			struct_info->addStaticMember(
@@ -8131,6 +8146,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							template_params,
 							template_args_to_use,
 							qualified_name,
+							nested_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							nested_struct_info->getNamespaceHandle(),
 							template_args_to_use);
 					nested_struct_info->addStaticMember(
@@ -8245,7 +8261,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*original_ctor.get_definition(),
 							template_params,
 							template_args_to_use,
-							qualified_name));
+							nested_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
+							true));
 					}
 					pack_param_info_.resize(saved_pack_info);
 
@@ -8260,7 +8277,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							*original_ctor.requires_clause(),
 							template_params,
 							template_args_to_use,
-							qualified_name));
+							nested_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
+							true));
 					}
 					instantiated_nested_struct_ref.add_constructor(
 						substituted_ctor_node,
@@ -8304,7 +8322,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::span<const TemplateTypeArg>(
 								template_args_to_use.data(),
 								template_args_to_use.size()),
-							qualified_name,
+							nested_type_info.registeredTypeIndex().withCategory(
+								TypeCategory::Struct),
 							std::span<const TemplateParameterNode>(
 								out_of_line_member.inner_template_params.data(),
 								out_of_line_member.inner_template_params.size()));
@@ -8378,7 +8397,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							std::span<const TemplateTypeArg>(
 								template_args_to_use.data(),
 								template_args_to_use.size()),
-							qualified_name,
+							nested_type_info.registeredTypeIndex().withCategory(
+								TypeCategory::Struct),
 							std::span<const TemplateParameterNode>(
 								out_of_line_member.inner_template_params.data(),
 								out_of_line_member.inner_template_params.size()));
@@ -8513,7 +8533,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 								std::span<const TemplateTypeArg>(
 									template_args_to_use.data(),
 									template_args_to_use.size()),
-								qualified_name,
+								nested_type_info.registeredTypeIndex().withCategory(
+									TypeCategory::Struct),
 								std::span<const TemplateParameterNode>(
 									out_of_line_member.inner_template_params.data(),
 									out_of_line_member.inner_template_params.size()));
@@ -9235,6 +9256,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							effective_template_args_vector.data(),
 							effective_template_args_vector.size()),
 						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						struct_info->getNamespaceHandle(),
 						effective_template_args);
 				std::optional<NormalizedInitializer> normalized_initializer =
@@ -9243,6 +9265,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						gSymbolTable,
 						*this,
 						struct_info,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						effective_template_params,
 						effective_template_args_vector,
 						instantiated_static_member->type_index,
@@ -10996,7 +11019,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const TemplateTypeArg>(
 							template_args_to_use.data(),
 							template_args_to_use.size()),
-						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct),
 						std::span<const TemplateParameterNode>(
 							out_of_line_member.inner_template_params.data(),
 							out_of_line_member.inner_template_params.size()));
@@ -11130,7 +11154,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const TemplateTypeArg>(
 							template_args_to_use.data(),
 							template_args_to_use.size()),
-						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct),
 						std::span<const TemplateParameterNode>(
 							out_of_line_member.inner_template_params.data(),
 							out_of_line_member.inner_template_params.size()));
@@ -11300,7 +11325,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				std::span<const TemplateTypeArg>(
 					template_args_to_use.data(),
 					template_args_to_use.size()),
-				instantiated_name);
+				struct_type_info.registeredTypeIndex().withCategory(
+					TypeCategory::Struct));
 		if (FunctionDeclarationNode* inst_func = plain_member_resolution.func;
 			inst_func != nullptr) {
 			materializeReplayAttachedFunctionParameterTypesFromDefinition(
@@ -11317,7 +11343,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				std::span<const TemplateTypeArg>(
 					template_args_to_use.data(),
 					template_args_to_use.size()),
-				instantiated_name);
+				struct_type_info.registeredTypeIndex().withCategory(
+					TypeCategory::Struct));
 			const std::span<const ASTNode> inst_func_params = inst_func->parameter_nodes();
 			std::vector<ASTNode> definition_scope_params(
 				inst_func_params.begin(),
@@ -11397,7 +11424,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						std::span<const TemplateTypeArg>(
 							template_args_to_use.data(),
 							template_args_to_use.size()),
-						instantiated_name);
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct));
 					info_func_resolution.func->set_definition(*inst_func->get_definition());
 					finalize_function_after_definition(*info_func_resolution.func, true);
 				}
@@ -11456,7 +11484,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					std::span<const TemplateTypeArg>(
 						template_args_to_use.data(),
 						template_args_to_use.size()),
-					instantiated_name);
+					struct_type_info.registeredTypeIndex().withCategory(
+						TypeCategory::Struct));
 			if (ctor_resolution.ambiguous) {
 				std::string ambiguity_msg = std::string(StringBuilder()
 					.append("Could not uniquely match out-of-line constructor '")
@@ -11817,6 +11846,9 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_args_to_use,
 						nullptr,
 						currentTemplateSubstitutionFailurePolicy());
+				substitution_context.current_instantiation_type =
+					struct_type_info.registeredTypeIndex().withCategory(
+						TypeCategory::Struct);
 
 				const DeclarationNode* declaration_ptr =
 					get_decl_from_symbol(*out_of_line_var.declaration);
@@ -11859,7 +11891,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					non_type_categories);
 
 				auto member_ctx_scope =
-					push_replay_member_context(instantiated_name, struct_info_ptr);
+					push_replay_member_context(
+						instantiated_name,
+						struct_type_info.registeredTypeIndex().withCategory(
+							TypeCategory::Struct),
+						struct_info_ptr);
 
 				restore_lexer_position_only(*out_of_line_var.initializer_position);
 				ASTNode declaration_copy = *out_of_line_var.declaration;

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2086,6 +2086,11 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 		}
 	}
 	const StringHandle current_owner_type_name = StringTable::getOrInternStringHandle(struct_name);
+	TypeIndex current_owner_type_index{};
+	if (const TypeInfo* current_owner_type_info = findTypeByName(current_owner_type_name)) {
+		current_owner_type_index =
+			current_owner_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct);
+	}
 	const OuterTemplateBinding* outer_binding =
 		gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view());
 	std::optional<OuterTemplateBinding> synthesized_outer_binding;
@@ -2885,7 +2890,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			func_decl.noexcept_expression()->node(),
 			template_params,
 			inline_template_args,
-			current_owner_type_name);
+			current_owner_type_index,
+			!func_decl.is_static());
 		if (func_decl.has_outer_template_bindings()) {
 			InlineVector<StringHandle, 4> outer_param_names;
 			InlineVector<TypeInfo::TemplateArgInfo, 4> outer_arg_infos;
@@ -2905,7 +2911,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				substituted_noexcept,
 				typed_outer_params,
 				outer_args,
-				current_owner_type_name);
+				current_owner_type_index,
+				!func_decl.is_static());
 		}
 		if (outer_binding != nullptr) {
 			InlineVector<TemplateParameterNode, 4> typed_outer_params;
@@ -2930,7 +2937,8 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				substituted_noexcept,
 				typed_outer_params,
 				outer_args,
-				current_owner_type_name);
+				current_owner_type_index,
+				!func_decl.is_static());
 		}
 		new_func_ref.set_noexcept_expression(ExpressionHandle(substituted_noexcept));
 		ConstExpr::EvaluationContext eval_ctx(gSymbolTable, *this);
@@ -2957,7 +2965,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 				*orig_body,
 				template_params,
 				inline_template_args,
-				current_owner_type_name,
+				current_owner_type_index,
 				!func_decl.is_static());
 			if (func_decl.has_outer_template_bindings()) {
 				InlineVector<StringHandle, 4> outer_param_names;
@@ -2978,7 +2986,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					substituted_body,
 					typed_outer_params,
 					outer_args,
-					current_owner_type_name,
+					current_owner_type_index,
 					!func_decl.is_static());
 			}
 			if (outer_binding != nullptr) {
@@ -3004,7 +3012,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					substituted_body,
 					typed_outer_params,
 					outer_args,
-					current_owner_type_name,
+					current_owner_type_index,
 					!func_decl.is_static());
 			}
 			new_func_ref.set_definition(substituted_body);
@@ -3203,7 +3211,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 					*block_result.node(),
 					template_params,
 					inline_template_args,
-					current_owner_type_name,
+					current_owner_type_index,
 					!func_decl.is_static());
 				new_func_ref.set_definition(substituted_body);
 			}

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -46,7 +46,7 @@ ASTNode Parser::substituteLazyMemberBody(
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
 	const TemplateEnvironmentSnapshot& outer_snapshot,
-	StringHandle instantiated_owner_name,
+	TypeIndex instantiated_owner_type_index,
 	bool has_implicit_this) {
 	std::optional<TemplateEnvironment> outer_environment;
 	TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(
@@ -62,7 +62,7 @@ ASTNode Parser::substituteLazyMemberBody(
 		body,
 		template_params,
 		template_args,
-		instantiated_owner_name,
+		instantiated_owner_type_index,
 		has_implicit_this);
 }
 
@@ -115,6 +115,12 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	// Push a parser-level instantiation context so backtraces can identify this lazy-member step.
 	// Use the instantiated owner name as the origin since that is the most descriptive identifier.
 	ScopedParserInstantiationContext inst_ctx_guard(*this, template_instantiation_mode_, lazy_info.identity.instantiated_owner_name);
+	TypeIndex instantiated_owner_type_index{};
+	if (auto owner_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
+		owner_it != getTypesByNameMap().end() && owner_it->second != nullptr) {
+		instantiated_owner_type_index =
+			owner_it->second->registeredTypeIndex().withCategory(TypeCategory::Struct);
+	}
 
 	// Constructors/destructors for nested template types are also materialized lazily.
 	if (lazy_info.identity.kind == DeferredMemberIdentity::Kind::Constructor && lazy_info.identity.original_member_node.is<ConstructorDeclarationNode>()) {
@@ -144,10 +150,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		} else {
 			setOuterTemplateBindingsFromParams(new_ctor_ref, lazy_info.template_params, lazy_info.template_args);
 		}
-		TypeIndex instantiated_owner_type_index{};
-		if (auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
-			struct_it != getTypesByNameMap().end()) {
-			instantiated_owner_type_index = struct_it->second->type_index_;
+		if (instantiated_owner_type_index.is_valid()) {
 			new_ctor_ref.set_owning_type_index(instantiated_owner_type_index);
 		}
 
@@ -296,7 +299,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 						param_decl.default_value(),
 						lazy_info.template_params,
 						lazy_info.template_args,
-						lazy_info.identity.instantiated_owner_name);
+						instantiated_owner_type_index,
+						true);
 					substituted_param_decl.as<DeclarationNode>().set_default_value(substituted_default);
 				}
 				new_ctor_ref.add_parameter_node(substituted_param_decl);
@@ -320,7 +324,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				expr,
 				lazy_info.template_params,
 				converted_template_args,
-				lazy_info.identity.instantiated_owner_name);
+				instantiated_owner_type_index,
+				true);
 		};
 
 		{
@@ -449,7 +454,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			lazy_info.template_params,
 			converted_template_args,
 			lazy_info.outer_template_environment_snapshot,
-			lazy_info.identity.instantiated_owner_name,
+			instantiated_owner_type_index,
 			true);
 		new_ctor_ref.set_definition(substituted_body);
 		new_ctor_ref.set_mangled_name(NameMangling::generateMangledNameFromNode(
@@ -597,7 +602,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				dtor_decl.noexcept_expression()->node(),
 				lazy_info.template_params,
 				converted_template_args,
-				lazy_info.identity.instantiated_owner_name);
+				instantiated_owner_type_index,
+				true);
 			new_dtor_ref.set_noexcept_expression(
 				ExpressionHandle(substituted_noexcept));
 			ConstExpr::EvaluationContext ctx(gSymbolTable, *this);
@@ -630,7 +636,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			lazy_info.template_params,
 			converted_template_args,
 			lazy_info.outer_template_environment_snapshot,
-			lazy_info.identity.instantiated_owner_name,
+			instantiated_owner_type_index,
 			true);
 		new_dtor_ref.set_definition(substituted_body);
 
@@ -663,12 +669,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 	// Resolve self-referential types: when a member function's return type or parameter type
 	// refers to the template class itself (e.g., W& in W<T>::operator+=), the type_index
 	// still points to the uninstantiated template base (e.g., W with size=0). We need to
-	// resolve it to the instantiated class (e.g., W<int> with correct size).
-	TypeIndex instantiated_owner_type_index{};
-	if (auto it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
-		it != getTypesByNameMap().end()) {
-		instantiated_owner_type_index = it->second->type_index_;
-	}
+	// resolve it to the instantiated class (e.g., W<int> with correct size). The owner
+	// TypeIndex was resolved once at function entry and is reused for that purpose.
 	// Invariant: fn_identifier_token.handle() == effectiveLookupName(lazy_info.identity).
 	// This is asserted below after finalization (Slice 5).
 	// Slice 4: use the canonical instantiated lookup name (from identity) as the
@@ -964,7 +966,7 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 			std::span<const TemplateParameterNode>(substitution_params.data(), substitution_params.size()),
 			std::span<const TemplateTypeArg>(converted_template_args.data(), converted_template_args.size()),
 			lazy_info.outer_template_environment_snapshot,
-			lazy_info.identity.instantiated_owner_name,
+			instantiated_owner_type_index,
 			!func_decl.is_static());
 		std::optional<TemplateEnvironment> outer_environment;
 		TemplateEnvironment substitution_environment = buildLazySubstitutionEnvironment(

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -341,26 +341,28 @@ ASTNode Parser::substituteTemplateParameters(
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	const TemplateInstantiationContext& context) {
-	TemplateBodySubstitutionState state;
-	state.owner_type_name = context.current_instantiation_name;
-	state.owner_type_index = context.current_instantiation_type;
-	if (!state.owner_type_index.is_valid() && state.owner_type_name.isValid()) {
-		if (const TypeInfo* owner_type_info = findTypeByName(state.owner_type_name)) {
-			state.owner_type_index = owner_type_info->registeredTypeIndex();
+	TypeIndex owner_type_index = context.current_instantiation_type;
+	if (!owner_type_index.is_valid() && context.current_instantiation_name.isValid()) {
+		const TypeInfo* owner_type_info =
+			findTypeByName(context.current_instantiation_name);
+		if (owner_type_info == nullptr) {
+			throw CompileError(std::string(StringBuilder()
+				.append("Unable to resolve concrete template substitution owner '")
+				.append(StringTable::getStringView(context.current_instantiation_name))
+				.append("'")
+				.commit()));
 		}
+		owner_type_index =
+			owner_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct);
 	}
-	if (!member_function_context_stack_.empty()) {
-		state.has_implicit_this =
-			member_function_context_stack_.back().has_implicit_this;
-		if (!state.owner_type_index.is_valid()) {
-			state.owner_type_index =
-				member_function_context_stack_.back().struct_type_index;
-		}
-		if (!state.owner_type_name.isValid()) {
-			state.owner_type_name =
-				member_function_context_stack_.back().struct_name;
-		}
+	const bool has_implicit_this = !member_function_context_stack_.empty() &&
+		member_function_context_stack_.back().has_implicit_this;
+	if (!owner_type_index.is_valid() && !member_function_context_stack_.empty()) {
+		owner_type_index = member_function_context_stack_.back().struct_type_index;
 	}
+	TemplateBodySubstitutionState state = makeTemplateBodySubstitutionState(
+		owner_type_index,
+		has_implicit_this);
 	return substituteTemplateParametersWithState(
 		node,
 		context.template_parameters,
@@ -381,11 +383,28 @@ ASTNode Parser::substituteTemplateParameters(
 		// Name-only callers historically substitute non-static member bodies.
 		has_implicit_this = current_owner_type_name.isValid();
 	}
+	TypeIndex owner_type_index{};
+	if (current_owner_type_name.isValid()) {
+		const TypeInfo* owner_type_info =
+			findTypeByName(current_owner_type_name);
+		if (owner_type_info == nullptr) {
+			throw CompileError(std::string(StringBuilder()
+				.append("Unable to resolve concrete template substitution owner '")
+				.append(StringTable::getStringView(current_owner_type_name))
+				.append("'")
+				.commit()));
+		}
+		owner_type_index =
+			owner_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct);
+	}
+	if (!owner_type_index.is_valid() && !member_function_context_stack_.empty()) {
+		owner_type_index = member_function_context_stack_.back().struct_type_index;
+	}
 	return substituteTemplateParameters(
 		node,
 		template_params,
 		template_args,
-		current_owner_type_name,
+		owner_type_index,
 		has_implicit_this);
 }
 
@@ -393,31 +412,39 @@ ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle current_owner_type_name,
+	TypeIndex current_owner_type_index,
 	bool has_implicit_this) {
-	TemplateBodySubstitutionState state;
-	state.owner_type_name = current_owner_type_name;
-	state.has_implicit_this = has_implicit_this;
-	if (current_owner_type_name.isValid()) {
-		if (const TypeInfo* owner_type_info = findTypeByName(current_owner_type_name)) {
-			state.owner_type_index = owner_type_info->registeredTypeIndex();
-		}
-	}
-	if (!member_function_context_stack_.empty()) {
-		if (!state.owner_type_index.is_valid()) {
-			state.owner_type_index =
-				member_function_context_stack_.back().struct_type_index;
-		}
-		if (!state.owner_type_name.isValid()) {
-			state.owner_type_name =
-				member_function_context_stack_.back().struct_name;
-		}
-	}
+	TemplateBodySubstitutionState state = makeTemplateBodySubstitutionState(
+		current_owner_type_index,
+		has_implicit_this);
 	return substituteTemplateParametersWithState(
 		node,
 		template_params,
 		template_args,
 		state);
+}
+
+Parser::TemplateBodySubstitutionState Parser::makeTemplateBodySubstitutionState(
+	TypeIndex owner_type_index,
+	bool has_implicit_this) const {
+	TemplateBodySubstitutionState state;
+	state.owner_type_index = owner_type_index;
+	state.has_implicit_this = has_implicit_this;
+
+	if (state.owner_type_index.is_valid()) {
+		const TypeInfo* owner_type_info = tryGetTypeInfo(state.owner_type_index);
+		if (owner_type_info == nullptr) {
+			throw CompileError(std::string(StringBuilder()
+				.append("Unable to resolve concrete template substitution owner TypeIndex ")
+				.append(static_cast<uint64_t>(state.owner_type_index.index()))
+				.commit()));
+		}
+		state.owner_type_name = owner_type_info->name();
+	} else if (has_implicit_this) {
+		throw CompileError(
+			"Implicit-object template substitution requires a concrete owner TypeIndex");
+	}
+	return state;
 }
 
 ASTNode Parser::substituteTemplateParametersWithState(
@@ -608,7 +635,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				arg,
 				template_params,
 				template_args,
-				current_owner_type_name,
+				state,
 				substituted_args);
 		}
 		CallExprNode substituted_call = call.has_receiver()
@@ -962,18 +989,15 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				/*wrap_in_expression=*/true);
 		} else if (std::holds_alternative<ConstructorCallNode>(expr)) {
 			const ConstructorCallNode& constructor_call = std::get<ConstructorCallNode>(expr);
-			ASTNode substituted_type = substituteTemplateParameters(
-				ASTNode(&constructor_call.type_node()),
-				template_params,
-				template_args,
-				current_owner_type_name);
+			ASTNode substituted_type =
+				substitute_nested(ASTNode(&constructor_call.type_node()));
 			ChunkedVector<ASTNode> substituted_args;
 			for (size_t i = 0; i < constructor_call.arguments().size(); ++i) {
 				substituteArgWithPackExpansion(
 					constructor_call.arguments()[i],
 					template_params,
 					template_args,
-					current_owner_type_name,
+					state,
 					substituted_args);
 			}
 			return makeRebuiltConstructorCallNode(
@@ -983,11 +1007,10 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				/*wrap_in_expression=*/true);
 		} else if (std::holds_alternative<TypeTraitExprNode>(expr)) {
 			const TypeTraitExprNode& trait_expr = std::get<TypeTraitExprNode>(expr);
-			ASTNode substituted_type = substituteTemplateParameters(
-				trait_expr.type_node(), template_params, template_args, current_owner_type_name);
+			ASTNode substituted_type = substitute_nested(trait_expr.type_node());
 			if (trait_expr.has_second_type()) {
-				ASTNode substituted_second_type = substituteTemplateParameters(
-					trait_expr.second_type_node(), template_params, template_args, current_owner_type_name);
+				ASTNode substituted_second_type =
+					substitute_nested(trait_expr.second_type_node());
 				return emplace_node<ExpressionNode>(
 					TypeTraitExprNode(trait_expr.kind(), substituted_type, substituted_second_type, trait_expr.trait_token()));
 			}
@@ -1058,7 +1081,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 
 				if (num_pack_elements == 0) {
 					if (fold.type() == FoldExpressionNode::Type::Binary && fold.init_expr().has_value()) {
-						return substituteTemplateParameters(*fold.init_expr(), template_params, template_args);
+						return substitute_nested(*fold.init_expr());
 					}
 					// C++17: empty unary fold is allowed only for &&, || and comma
 					// For other operators, return identity values
@@ -1119,7 +1142,11 @@ ASTNode Parser::substituteTemplateParametersWithState(
 					if (!func_pack_name.empty() && expanded_pack_expr.has_value()) {
 						expanded_pack_expr = replacePackIdentifierInExpr(expanded_pack_expr, func_pack_name, i);
 					}
-					ASTNode substituted = substituteTemplateParameters(expanded_pack_expr, subst_params, subst_args);
+					ASTNode substituted = substituteTemplateParametersWithState(
+						expanded_pack_expr,
+						subst_params,
+						subst_args,
+						state);
 					pack_values.push_back(substituted);
 				}
 			} else {
@@ -1242,7 +1269,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				};
 
 				if (fold.type() == FoldExpressionNode::Type::Binary && fold.init_expr().has_value()) {
-					ASTNode init = substituteTemplateParameters(*fold.init_expr(), template_params, template_args);
+					ASTNode init = substitute_nested(*fold.init_expr());
 					if (!appendConstantOperand(init)) {
 						return std::nullopt;
 					}
@@ -1294,7 +1321,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				}
 			} else {
 				// Binary fold with init expression
-				ASTNode init = substituteTemplateParameters(*fold.init_expr(), template_params, template_args);
+				ASTNode init = substitute_nested(*fold.init_expr());
 
 				if (fold.direction() == FoldExpressionNode::Direction::Left) {
 					// Left binary fold: (init op ... op pack) = (((init op pack[0]) op pack[1]) op ...)
@@ -1462,10 +1489,8 @@ ASTNode Parser::substituteTemplateParametersWithState(
 		} else if (const auto* static_cast_node = std::get_if<StaticCastNode>(&expr)) {
 			// static_cast<Type>(expr) - recursively substitute in both target type and expression
 			const StaticCastNode& cast_node = *static_cast_node;
-			ASTNode substituted_type = substituteTemplateParameters(
-				ASTNode(&cast_node.target_type()),
-				template_params,
-				template_args);
+			ASTNode substituted_type =
+				substitute_nested(ASTNode(&cast_node.target_type()));
 			if (cast_node.expr().is<ExpressionNode>()) {
 				const ExpressionNode& cast_expr = cast_node.expr().as<ExpressionNode>();
 				if (const auto* pack_expansion_expr = std::get_if<PackExpansionExprNode>(&cast_expr)) {
@@ -1484,27 +1509,21 @@ ASTNode Parser::substituteTemplateParametersWithState(
 			return emplace_node<ExpressionNode>(StaticCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (const auto* dynamic_cast_node = std::get_if<DynamicCastNode>(&expr)) {
 			const DynamicCastNode& cast_node = *dynamic_cast_node;
-			ASTNode substituted_type = substituteTemplateParameters(
-				ASTNode(&cast_node.target_type()),
-				template_params,
-				template_args);
-			ASTNode substituted_expr = substituteTemplateParameters(cast_node.expr(), template_params, template_args);
+			ASTNode substituted_type =
+				substitute_nested(ASTNode(&cast_node.target_type()));
+			ASTNode substituted_expr = substitute_nested(cast_node.expr());
 			return emplace_node<ExpressionNode>(DynamicCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (const auto* const_cast_node = std::get_if<ConstCastNode>(&expr)) {
 			const ConstCastNode& cast_node = *const_cast_node;
-			ASTNode substituted_type = substituteTemplateParameters(
-				ASTNode(&cast_node.target_type()),
-				template_params,
-				template_args);
-			ASTNode substituted_expr = substituteTemplateParameters(cast_node.expr(), template_params, template_args);
+			ASTNode substituted_type =
+				substitute_nested(ASTNode(&cast_node.target_type()));
+			ASTNode substituted_expr = substitute_nested(cast_node.expr());
 			return emplace_node<ExpressionNode>(ConstCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (const auto* reinterpret_cast_node = std::get_if<ReinterpretCastNode>(&expr)) {
 			const ReinterpretCastNode& cast_node = *reinterpret_cast_node;
-			ASTNode substituted_type = substituteTemplateParameters(
-				ASTNode(&cast_node.target_type()),
-				template_params,
-				template_args);
-			ASTNode substituted_expr = substituteTemplateParameters(cast_node.expr(), template_params, template_args);
+			ASTNode substituted_type =
+				substitute_nested(ASTNode(&cast_node.target_type()));
+			ASTNode substituted_expr = substitute_nested(cast_node.expr());
 			return emplace_node<ExpressionNode>(ReinterpretCastNode(substituted_type.as<TypeSpecifierNode>(), substituted_expr, cast_node.cast_token()));
 		} else if (std::holds_alternative<SizeofExprNode>(expr)) {
 			// sizeof operator - substitute template parameters in the operand and try to evaluate
@@ -1610,11 +1629,8 @@ ASTNode Parser::substituteTemplateParametersWithState(
 		}
 
 		if (std::holds_alternative<ConstructorCallNode>(expr)) {
-			return substituteTemplateParameters(
-				ASTNode(&std::get<ConstructorCallNode>(expr)),
-				template_params,
-				template_args,
-				current_owner_type_name);
+			return substitute_nested(
+				ASTNode(&std::get<ConstructorCallNode>(expr)));
 		}
 
 		// For other expression types that don't contain subexpressions, return as-is
@@ -1647,7 +1663,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 						constructor_call.arguments()[i],
 						template_params,
 						template_args,
-						current_owner_type_name,
+						state,
 						substituted_args);
 				}
 				if (std::optional<ASTNode> function_symbol =
@@ -1662,18 +1678,15 @@ ASTNode Parser::substituteTemplateParametersWithState(
 				}
 			}
 		}
-		ASTNode substituted_type = substituteTemplateParameters(
-			ASTNode(&constructor_call.type_node()),
-			template_params,
-			template_args,
-			current_owner_type_name);
+		ASTNode substituted_type =
+			substitute_nested(ASTNode(&constructor_call.type_node()));
 			ChunkedVector<ASTNode> substituted_args;
 			for (size_t i = 0; i < constructor_call.arguments().size(); ++i) {
 				substituteArgWithPackExpansion(
 					constructor_call.arguments()[i],
 					template_params,
 					template_args,
-					current_owner_type_name,
+					state,
 					substituted_args);
 			}
 		return makeRebuiltConstructorCallNode(
@@ -2004,8 +2017,7 @@ ASTNode Parser::substituteTemplateParametersWithState(
 					}
 				}
 			}
-			ASTNode substituted_init = substituteTemplateParameters(
-				element, template_params, template_args, current_owner_type_name);
+			ASTNode substituted_init = substitute_nested(element);
 			if (init_list.is_designated(i)) {
 				new_init_list_ref.add_designated_initializer(init_list.member_name(i), substituted_init);
 			} else {
@@ -2527,7 +2539,7 @@ void Parser::substituteArgWithPackExpansion(
 	const ASTNode& arg,
 	std::span<const TemplateParameterNode> template_params,
 	std::span<const TemplateTypeArg> template_args,
-	StringHandle current_owner_type_name,
+	TemplateBodySubstitutionState& state,
 	ChunkedVector<ASTNode>& out) {
 	if (arg.is<ExpressionNode>()) {
 		const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
@@ -2537,11 +2549,11 @@ void Parser::substituteArgWithPackExpansion(
 			}
 		}
 	}
-	out.push_back(substituteTemplateParameters(
+	out.push_back(substituteTemplateParametersWithState(
 		arg,
 		template_params,
 		template_args,
-		current_owner_type_name));
+		state));
 }
 
 // Replace a pack parameter identifier in an expression pattern with its expanded element name.

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -335,26 +335,14 @@ ASTNode Parser::substituteTemplateParameters(
 		node,
 		template_params,
 		template_args,
-		StringHandle{});
+		TypeIndex{},
+		false);
 }
 
 ASTNode Parser::substituteTemplateParameters(
 	const ASTNode& node,
 	const TemplateInstantiationContext& context) {
 	TypeIndex owner_type_index = context.current_instantiation_type;
-	if (!owner_type_index.is_valid() && context.current_instantiation_name.isValid()) {
-		const TypeInfo* owner_type_info =
-			findTypeByName(context.current_instantiation_name);
-		if (owner_type_info == nullptr) {
-			throw CompileError(std::string(StringBuilder()
-				.append("Unable to resolve concrete template substitution owner '")
-				.append(StringTable::getStringView(context.current_instantiation_name))
-				.append("'")
-				.commit()));
-		}
-		owner_type_index =
-			owner_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct);
-	}
 	const bool has_implicit_this = !member_function_context_stack_.empty() &&
 		member_function_context_stack_.back().has_implicit_this;
 	if (!owner_type_index.is_valid() && !member_function_context_stack_.empty()) {
@@ -368,44 +356,6 @@ ASTNode Parser::substituteTemplateParameters(
 		context.template_parameters,
 		context.template_arguments,
 		state);
-}
-
-ASTNode Parser::substituteTemplateParameters(
-	const ASTNode& node,
-	std::span<const TemplateParameterNode> template_params,
-	std::span<const TemplateTypeArg> template_args,
-	StringHandle current_owner_type_name) {
-	bool has_implicit_this = false;
-	if (!member_function_context_stack_.empty()) {
-		has_implicit_this =
-			member_function_context_stack_.back().has_implicit_this;
-	} else {
-		// Name-only callers historically substitute non-static member bodies.
-		has_implicit_this = current_owner_type_name.isValid();
-	}
-	TypeIndex owner_type_index{};
-	if (current_owner_type_name.isValid()) {
-		const TypeInfo* owner_type_info =
-			findTypeByName(current_owner_type_name);
-		if (owner_type_info == nullptr) {
-			throw CompileError(std::string(StringBuilder()
-				.append("Unable to resolve concrete template substitution owner '")
-				.append(StringTable::getStringView(current_owner_type_name))
-				.append("'")
-				.commit()));
-		}
-		owner_type_index =
-			owner_type_info->registeredTypeIndex().withCategory(TypeCategory::Struct);
-	}
-	if (!owner_type_index.is_valid() && !member_function_context_stack_.empty()) {
-		owner_type_index = member_function_context_stack_.back().struct_type_index;
-	}
-	return substituteTemplateParameters(
-		node,
-		template_params,
-		template_args,
-		owner_type_index,
-		has_implicit_this);
 }
 
 ASTNode Parser::substituteTemplateParameters(

--- a/src/TemplateEnvironment.h
+++ b/src/TemplateEnvironment.h
@@ -88,7 +88,6 @@ struct TemplateInstantiationContext {
 	std::span<const TemplateTypeArg> template_arguments;
 	TemplateEnvironment environment;
 	InlineVector<TemplatePackExpansionState, 2> pack_state;
-	StringHandle current_instantiation_name{};
 	TypeIndex current_instantiation_type{};
 	TemplateLookupContext lookup_context;
 	const TemplateDefinitionLookupContext* definition_lookup_context = nullptr;


### PR DESCRIPTION
## Summary
- carry the concrete owner `TypeIndex` and explicit implicit-object state through template body substitution
- reuse the active substitution state for nested AST substitution instead of reconstructing owner context by name
- remove the name-based `substituteTemplateParameters()` overload and convert hidden-friend, static-initializer, nested-constructor, and out-of-line replay callers
- remove `TemplateInstantiationContext` owner-name fallback so unresolved owner identity fails explicitly