### PR TITLE
Fix structural NTTP member binding and lookup

### DIFF
--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1323,6 +1323,7 @@ private:
 
 	// Current function name (plain, used for friend access checks and diagnostics)
 	StringHandle current_function_name_;
+	const FunctionDeclarationNode* current_function_node_ = nullptr;
 	// Current function mangled name (used for static local variable namespacing)
 	StringHandle current_function_mangled_name_;
 	StringHandle current_struct_name_;  // For tracking which struct we're currently visiting member functions for

--- a/src/ConstExprEvalHelpers.cpp
+++ b/src/ConstExprEvalHelpers.cpp
@@ -718,6 +718,40 @@ const StructMember* findMemberInfoRecursive(const StructTypeInfo* struct_info, S
 	return nullptr;
 }
 
+const EvalResult* findConstexprObjectMemberRecursive(
+	const EvalResult& object,
+	StringHandle member_name_handle) {
+	if (!member_name_handle.isValid()) {
+		return nullptr;
+	}
+
+	if (const auto member_it = object.object_member_bindings.find(
+			StringTable::getStringView(member_name_handle));
+		member_it != object.object_member_bindings.end()) {
+		return &member_it->second;
+	}
+
+	const TypeInfo* type_info = tryGetTypeInfo(object.object_type_index);
+	const StructTypeInfo* struct_info = type_info ? type_info->getStructInfo() : nullptr;
+	if (struct_info == nullptr) {
+		return nullptr;
+	}
+
+	const size_t base_count = std::min(
+		struct_info->base_classes.size(),
+		object.object_base_values.size());
+	for (size_t base_index = 0; base_index < base_count; ++base_index) {
+		if (const EvalResult* member = findConstexprObjectMemberRecursive(
+				object.object_base_values[base_index],
+				member_name_handle);
+			member != nullptr) {
+			return member;
+		}
+	}
+
+	return nullptr;
+}
+
 TypeSpecifierNode makeMemberTypeSpecForDefaultInit(const StructMember& member) {
 	TypeSpecifierNode type_spec(
 		member.type_index,

--- a/src/ConstExprEvalHelpers.h
+++ b/src/ConstExprEvalHelpers.h
@@ -90,6 +90,9 @@ struct ShiftEvaluationInfo {
 };
 
 const StructMember* findMemberInfoRecursive(const StructTypeInfo* struct_info, StringHandle member_name_handle);
+const EvalResult* findConstexprObjectMemberRecursive(
+	const EvalResult& object,
+	StringHandle member_name_handle);
 TypeSpecifierNode makeMemberTypeSpecForDefaultInit(const StructMember& member);
 TypeSpecifierNode makeTypeSpecForDefaultInit(TypeIndex type_index);
 EvalResult makeConstructorDefaultInitFromType(const TypeSpecifierNode& type_spec, EvaluationContext& context);

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -321,6 +321,9 @@ struct EvalResult {
 
 std::optional<FlashCpp::NonTypeValueIdentity> makeStructuralClassValueIdentity(
 	const EvalResult& result);
+const TemplateTypeArg* findTemplateValueParameterBinding(
+	StringHandle param_name_handle,
+	const EvaluationContext& context);
 
 template <typename AstNodeContainer>
 inline const ASTNode* tryGetSingleExpressionInitializer(const AstNodeContainer& initializers) {

--- a/src/ConstExprEvaluator.h
+++ b/src/ConstExprEvaluator.h
@@ -324,6 +324,8 @@ std::optional<FlashCpp::NonTypeValueIdentity> makeStructuralClassValueIdentity(
 const TemplateTypeArg* findTemplateValueParameterBinding(
 	StringHandle param_name_handle,
 	const EvaluationContext& context);
+std::optional<EvalResult> tryResolveTemplateValueParameter(
+	const TemplateTypeArg& arg);
 
 template <typename AstNodeContainer>
 inline const ASTNode* tryGetSingleExpressionInitializer(const AstNodeContainer& initializers) {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -647,7 +647,7 @@ const TemplateTypeArg* findTemplateValueParameterBindingCompatibility(
 	return nullptr;
 }
 
-const TemplateTypeArg* findTemplateValueParameterBinding(StringHandle param_name_handle, const EvaluationContext& context) {
+const TemplateTypeArg* findTemplateValueParameterBindingImpl(StringHandle param_name_handle, const EvaluationContext& context) {
 	if (!param_name_handle.isValid()) {
 		return nullptr;
 	}
@@ -1013,6 +1013,12 @@ EvalResult makeConvertedEvalResult(const TypeSpecifierNode& target_type, const E
 }
 
 } // namespace
+
+const TemplateTypeArg* findTemplateValueParameterBinding(
+	StringHandle param_name_handle,
+	const EvaluationContext& context) {
+	return findTemplateValueParameterBindingImpl(param_name_handle, context);
+}
 
 std::optional<FlashCpp::NonTypeValueIdentity> makeStructuralClassValueIdentity(
 	const EvalResult& result) {

--- a/src/ConstExprEvaluator_Core.cpp
+++ b/src/ConstExprEvaluator_Core.cpp
@@ -852,7 +852,7 @@ std::optional<FlashCpp::NonTypeValueIdentity> makeStructuralClassValueIdentityIm
 		&structural_value);
 }
 
-std::optional<EvalResult> tryResolveTemplateValueParameter(const TemplateTypeArg& arg) {
+std::optional<EvalResult> tryResolveTemplateValueParameterImpl(const TemplateTypeArg& arg) {
 	if (!arg.is_value) {
 		return std::nullopt;
 	}
@@ -1018,6 +1018,10 @@ const TemplateTypeArg* findTemplateValueParameterBinding(
 	StringHandle param_name_handle,
 	const EvaluationContext& context) {
 	return findTemplateValueParameterBindingImpl(param_name_handle, context);
+}
+
+std::optional<EvalResult> tryResolveTemplateValueParameter(const TemplateTypeArg& arg) {
+	return tryResolveTemplateValueParameterImpl(arg);
 }
 
 std::optional<FlashCpp::NonTypeValueIdentity> makeStructuralClassValueIdentity(

--- a/src/ConstExprEvaluator_MemberAccess.cpp
+++ b/src/ConstExprEvaluator_MemberAccess.cpp
@@ -1576,8 +1576,13 @@ EvalResult Evaluator::evaluate_member_access(const MemberAccessNode& member_acce
 	// rather than an identifier. Resolve its structural value before the normal
 	// identifier/object-source paths so `K.member` can participate in constexpr
 	// evaluation after template argument substitution.
-	if (const TemplateParameterReferenceNode* template_param =
-			tryGetNode<TemplateParameterReferenceNode>(object_expr)) {
+	const TemplateParameterReferenceNode* template_param =
+		tryGetNode<TemplateParameterReferenceNode>(object_expr);
+	if (template_param == nullptr && object_expr.is<ExpressionNode>()) {
+		template_param = std::get_if<TemplateParameterReferenceNode>(
+			&object_expr.as<ExpressionNode>());
+	}
+	if (template_param != nullptr) {
 		const TemplateTypeArg* arg = findTemplateValueParameterBinding(
 			template_param->param_name(), context);
 		if (arg == nullptr) {
@@ -1592,14 +1597,16 @@ EvalResult Evaluator::evaluate_member_access(const MemberAccessNode& member_acce
 				"Unsupported template parameter value in member access",
 				EvalErrorType::TemplateDependentExpression);
 		}
-		auto member_it = resolved_object->object_member_bindings.find(member_name);
-		if (member_it == resolved_object->object_member_bindings.end()) {
+		const EvalResult* member_value = findConstexprObjectMemberRecursive(
+			*resolved_object,
+			StringTable::getOrInternStringHandle(member_name));
+		if (member_value == nullptr) {
 			return EvalResult::error(
 				"Member '" + std::string(member_name) +
 				"' not found on template parameter value",
 				EvalErrorType::Other);
 		}
-		return validateConstexprRead(member_it->second);
+		return validateConstexprRead(*member_value);
 	}
 
 	// Handle arrow access (ptr->member): evaluate the pointer expression to get the

--- a/src/ConstExprEvaluator_MemberAccess.cpp
+++ b/src/ConstExprEvaluator_MemberAccess.cpp
@@ -1572,6 +1572,36 @@ EvalResult Evaluator::evaluate_member_access(const MemberAccessNode& member_acce
 	const ASTNode& object_expr = member_access.object();
 	std::string_view member_name = member_access.member_name();
 
+	// A value template parameter is represented by a TemplateParameterReferenceNode,
+	// rather than an identifier. Resolve its structural value before the normal
+	// identifier/object-source paths so `K.member` can participate in constexpr
+	// evaluation after template argument substitution.
+	if (const TemplateParameterReferenceNode* template_param =
+			tryGetNode<TemplateParameterReferenceNode>(object_expr)) {
+		const TemplateTypeArg* arg = findTemplateValueParameterBinding(
+			template_param->param_name(), context);
+		if (arg == nullptr) {
+			return EvalResult::error(
+				"Template parameter in member access: " +
+				std::string(template_param->param_name().view()),
+				EvalErrorType::TemplateDependentExpression);
+		}
+		auto resolved_object = tryResolveTemplateValueParameter(*arg);
+		if (!resolved_object.has_value()) {
+			return EvalResult::error(
+				"Unsupported template parameter value in member access",
+				EvalErrorType::TemplateDependentExpression);
+		}
+		auto member_it = resolved_object->object_member_bindings.find(member_name);
+		if (member_it == resolved_object->object_member_bindings.end()) {
+			return EvalResult::error(
+				"Member '" + std::string(member_name) +
+				"' not found on template parameter value",
+				EvalErrorType::Other);
+		}
+		return validateConstexprRead(member_it->second);
+	}
+
 	// Handle arrow access (ptr->member): evaluate the pointer expression to get the
 	// pointed-to variable name, then perform member access on that variable.
 	if (member_access.is_arrow()) {

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -12,6 +12,35 @@ ConstExpr::EvaluationContext AstToIr::makeEvalContext(const SymbolTable& symbols
 	if (global_symbol_table_) {
 		ctx.global_symbols = global_symbol_table_;
 	}
+	if (current_function_node_ != nullptr &&
+		current_function_node_->has_outer_template_bindings()) {
+		OuterTemplateBinding function_binding;
+		function_binding.param_names.assign(
+			current_function_node_->outer_template_param_names().begin(),
+			current_function_node_->outer_template_param_names().end());
+		const auto function_args = toTemplateTypeArgList(
+			std::span<const TypeInfo::TemplateArgInfo>(
+				current_function_node_->outer_template_args().data(),
+				current_function_node_->outer_template_args().size()));
+		function_binding.param_args.assign(function_args.begin(), function_args.end());
+		function_binding.all_args = function_args;
+		TemplateEnvironment function_environment = buildTemplateEnvironment(function_binding);
+		function_environment.bindings.insert(
+			function_environment.bindings.end(),
+			ctx.template_environment.bindings.begin(),
+			ctx.template_environment.bindings.end());
+		ctx.template_environment = std::move(function_environment);
+		ctx.template_param_names.reserve(
+			current_function_node_->outer_template_param_names().size());
+		ctx.template_args.reserve(function_binding.all_args.size());
+		for (StringHandle param_name :
+			 current_function_node_->outer_template_param_names()) {
+			ctx.template_param_names.push_back(StringTable::getStringView(param_name));
+		}
+		ctx.template_args.assign(
+			function_binding.all_args.begin(),
+			function_binding.all_args.end());
+	}
 	if (current_struct_name_.isValid()) {
 		const auto& types_by_name = getTypesByNameMap();
 		auto struct_type_it = types_by_name.find(current_struct_name_);

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -12,8 +12,11 @@ ConstExpr::EvaluationContext AstToIr::makeEvalContext(const SymbolTable& symbols
 	if (global_symbol_table_) {
 		ctx.global_symbols = global_symbol_table_;
 	}
+	TemplateEnvironment function_environment;
+	bool has_function_environment = false;
 	if (current_function_node_ != nullptr &&
 		current_function_node_->has_outer_template_bindings()) {
+		has_function_environment = true;
 		OuterTemplateBinding function_binding;
 		function_binding.param_names.assign(
 			current_function_node_->outer_template_param_names().begin(),
@@ -24,7 +27,7 @@ ConstExpr::EvaluationContext AstToIr::makeEvalContext(const SymbolTable& symbols
 				current_function_node_->outer_template_args().size()));
 		function_binding.param_args.assign(function_args.begin(), function_args.end());
 		function_binding.all_args = function_args;
-		TemplateEnvironment function_environment = buildTemplateEnvironment(function_binding);
+		function_environment = buildTemplateEnvironment(function_binding);
 		function_environment.bindings.insert(
 			function_environment.bindings.end(),
 			ctx.template_environment.bindings.begin(),
@@ -50,7 +53,16 @@ ConstExpr::EvaluationContext AstToIr::makeEvalContext(const SymbolTable& symbols
 			if (ctx.struct_info != nullptr) {
 				ctx.struct_type_index = struct_type_info->registeredTypeIndex().withCategory(struct_type_info->typeEnum());
 				if (const auto* inst_ctx = struct_type_info->instantiationContext()) {
-					ctx.template_environment = buildTemplateEnvironment(*inst_ctx);
+					TemplateEnvironment struct_environment = buildTemplateEnvironment(*inst_ctx);
+					if (has_function_environment) {
+						function_environment.bindings.insert(
+							function_environment.bindings.end(),
+							struct_environment.bindings.begin(),
+							struct_environment.bindings.end());
+						ctx.template_environment = std::move(function_environment);
+					} else {
+						ctx.template_environment = std::move(struct_environment);
+					}
 					ctx.template_param_names.reserve(inst_ctx->param_names.size());
 					ctx.template_args.reserve(inst_ctx->param_args().size());
 					for (StringHandle param_name : inst_ctx->param_names) {

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -142,6 +142,13 @@ void AstToIr::visitFunctionDeclarationNode(const FunctionDeclarationNode& node) 
 	if (!node.is_materialized() && !node.is_implicit()) {
 		return;
 	}
+	const FunctionDeclarationNode* saved_current_function_node = current_function_node_;
+	current_function_node_ = &node;
+	struct CurrentFunctionNodeGuard {
+		const FunctionDeclarationNode*& current;
+		const FunctionDeclarationNode* saved;
+		~CurrentFunctionNodeGuard() { current = saved; }
+	} current_function_node_guard{current_function_node_, saved_current_function_node};
 
 	// C++20 [basic.def.odr]: an unused inline definition need not be emitted.
 	// Defer free inline/__inline bodies (e.g. UCRT wmemchr) until a call marks

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -3140,6 +3140,10 @@ std::optional<ASTNode> Parser::instantiateBoundFunctionTemplate(
 			instantiation_flags)) {
 		return std::nullopt;
 	}
+	setOuterTemplateBindingsFromParams(
+		new_func_ref,
+		template_params,
+		template_args);
 	if (!resolveMaterializedTrailingReturnType(new_func_ref)) {
 		return std::nullopt;
 	}

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -2094,6 +2094,7 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	const OuterTemplateBinding* outer_binding =
 		gTemplateRegistry.getOuterTemplateBinding(requested_qualified_name.view());
 	std::optional<OuterTemplateBinding> synthesized_outer_binding;
+	std::optional<OuterTemplateBinding> function_decl_outer_binding;
 	if (outer_binding == nullptr) {
 		synthesized_outer_binding = buildOuterBindingForOwner(current_owner_type_name);
 		if (synthesized_outer_binding.has_value() &&
@@ -2101,6 +2102,16 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 			 !synthesized_outer_binding->all_args.empty())) {
 			outer_binding = &*synthesized_outer_binding;
 		}
+	}
+	if (outer_binding == nullptr && func_decl.has_outer_template_bindings()) {
+		function_decl_outer_binding.emplace();
+		function_decl_outer_binding->param_names = func_decl.outer_template_param_names();
+		for (const auto& arg_info : func_decl.outer_template_args()) {
+			TemplateTypeArg arg = toTemplateTypeArg(arg_info);
+			function_decl_outer_binding->param_args.push_back(arg);
+			function_decl_outer_binding->all_args.push_back(std::move(arg));
+		}
+		outer_binding = &*function_decl_outer_binding;
 	}
 	InlineVector<TemplateTypeArg, 4> inline_template_args;
 	inline_template_args.reserve(template_args.size());
@@ -2381,6 +2392,25 @@ std::optional<ASTNode> Parser::instantiate_member_function_template_core(
 	// Create the new function declaration
 	auto [new_func_decl_node, new_func_decl_ref] = emplace_node_ref<DeclarationNode>(substituted_return_type, mangled_token);
 	auto [new_func_node, new_func_ref] = emplace_node_ref<FunctionDeclarationNode>(new_func_decl_ref, struct_name);
+	InlineVector<ASTNode, 4> instantiated_template_params;
+	InlineVector<TemplateTypeArg, 4> instantiated_template_args;
+	if (outer_binding != nullptr) {
+		appendOuterBindingSubstitutionInputs(
+			*outer_binding,
+			instantiated_template_params,
+			instantiated_template_args);
+	}
+	for (const auto& template_param : template_params) {
+		instantiated_template_params.push_back(
+			ASTNode::emplace_node<TemplateParameterNode>(template_param));
+	}
+	for (const auto& template_arg : template_args) {
+		instantiated_template_args.push_back(template_arg);
+	}
+	setOuterTemplateBindingsFromParams(
+		new_func_ref,
+		instantiated_template_params,
+		instantiated_template_args);
 
 	std::unordered_map<TypeIndex, TemplateTypeArg> default_type_sub_map;
 	std::unordered_map<std::string_view, int64_t> default_nontype_sub_map;

--- a/src/Parser_Templates_Params.cpp
+++ b/src/Parser_Templates_Params.cpp
@@ -1014,6 +1014,11 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 		ValueLike,
 		Unknown,
 	};
+	auto makeConcreteValueArg = [](const TemplateParamSubstitution& subst) {
+		return subst.typed_value_identity.has_value()
+			? TemplateTypeArg::makeValueIdentity(*subst.typed_value_identity)
+			: TemplateTypeArg::makeValue(subst.value, subst.value_type);
+	};
 
 	// Classifies a simple identifier name and – when it turns out to be ValueLike due to a
 	// concrete substitution – also returns the already-built TemplateTypeArg so the caller
@@ -1027,7 +1032,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 			// NonType param – also scan substitutions so we can return a concrete arg in one pass
 			for (const auto& subst : template_param_substitutions_) {
 				if (subst.param_name == name_handle && subst.is_value_param) {
-					return { SimpleTemplateArgKind::ValueLike, TemplateTypeArg::makeValue(subst.value, subst.value_type) };
+					return { SimpleTemplateArgKind::ValueLike, makeConcreteValueArg(subst) };
 				}
 			}
 			return { SimpleTemplateArgKind::ValueLike, std::nullopt };
@@ -1038,7 +1043,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 				continue;
 			}
 			if (subst.is_value_param) {
-				return { SimpleTemplateArgKind::ValueLike, TemplateTypeArg::makeValue(subst.value, subst.value_type) };
+				return { SimpleTemplateArgKind::ValueLike, makeConcreteValueArg(subst) };
 			}
 			if (subst.is_type_param || subst.is_template_template_param) {
 				return { SimpleTemplateArgKind::TypeLike, std::nullopt };
@@ -1050,13 +1055,18 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::parse_explicit_template_
 			if (symbol_lookup->is<VariableDeclarationNode>()) {
 				const VariableDeclarationNode& variable_decl = symbol_lookup->as<VariableDeclarationNode>();
 				if (variable_decl.initializer().has_value()) {
-					if (auto const_value = try_evaluate_constant_expression(*variable_decl.initializer())) {
-						TemplateTypeArg value_arg;
-						value_arg.is_value = true;
-						value_arg.value = const_value->value;
-						value_arg.type_index = const_value->type_index.category() != TypeCategory::Invalid
-							? const_value->type_index
-							: nativeTypeIndex(const_value->type).withCategory(const_value->type);
+					Token identifier_token(
+						Token::Type::Identifier,
+						StringTable::getStringView(name_handle),
+						0,
+						0,
+						0);
+					ASTNode identifier_expression =
+						ASTNode::emplace_node<ExpressionNode>(
+							IdentifierNode(identifier_token));
+					if (auto const_value = try_evaluate_constant_expression(identifier_expression)) {
+						TemplateTypeArg value_arg =
+							TemplateTypeArg::makeValueIdentity(const_value->identity);
 						return { SimpleTemplateArgKind::ValueLike, value_arg };
 					}
 				}

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -30,6 +30,24 @@ std::string buildMemberPointerOwnerReconstructionErrorMessage(
 			.commit());
 }
 
+bool preserveStructuralClassTemplateParameterReference(
+	const TemplateTypeArg& arg,
+	StringHandle param_name,
+	const Token& source_token,
+	std::optional<ASTNode>& result) {
+	if (!arg.has_typed_value_identity ||
+		arg.typed_value_identity.kind !=
+			FlashCpp::NonTypeValueIdentityKind::StructuralClass) {
+		return false;
+	}
+	// Structural class members are resolved by constexpr evaluation from the
+	// canonical value. Replacing the reference with its legacy integer carrier
+	// would turn `K.member` into `0.member`.
+	result = ASTNode::emplace_node<ExpressionNode>(
+		TemplateParameterReferenceNode(param_name, source_token));
+	return true;
+}
+
 size_t getSubstitutedTemplateArgumentSizeInBytes(const TemplateTypeArg& arg) {
 	if (arg.pointer_depth > 0 ||
 		arg.category() == TypeCategory::FunctionPointer ||
@@ -657,6 +675,14 @@ ASTNode Parser::substituteTemplateParametersWithState(
 						substituted_node = emplace_node<ExpressionNode>(IdentifierNode(type_token));
 						substituted_template_param_ref = true;
 					} else if (arg.is_value) {
+						if (preserveStructuralClassTemplateParameterReference(
+								arg,
+								tparam_ref.param_name(),
+								tparam_ref.token(),
+								substituted_node)) {
+							substituted_template_param_ref = true;
+							return;
+						}
 						// Pointer/reference NTTP: emit &entity_name so *P works correctly.
 						// Callable F() still needs a follow-up fix after substitution.
 						if (arg.has_typed_value_identity) {
@@ -754,6 +780,14 @@ ASTNode Parser::substituteTemplateParametersWithState(
 						substituted_node = emplace_node<ExpressionNode>(IdentifierNode(type_token));
 						substituted_identifier = true;
 					} else if (arg.is_value) {
+						if (preserveStructuralClassTemplateParameterReference(
+								arg,
+								StringTable::getOrInternStringHandle(id_name),
+								id_node.identifier_token(),
+								substituted_node)) {
+							substituted_identifier = true;
+							return;
+						}
 						// Pointer/reference NTTP: emit &entity_name so *P works correctly.
 						// Callable F() still needs a follow-up fix after substitution.
 						if (arg.has_typed_value_identity) {

--- a/tests/test_structural_class_nttp_inherited_member_access_ret0.cpp
+++ b/tests/test_structural_class_nttp_inherited_member_access_ret0.cpp
@@ -1,0 +1,19 @@
+struct Base {
+	int value;
+	constexpr Base(int v) : value(v) {}
+};
+
+struct Derived : Base {
+	constexpr Derived(int v) : Base(v) {}
+};
+
+constexpr Derived key{42};
+
+template <Derived K>
+constexpr int read_value() {
+	return K.value == 42 ? 0 : 1;
+}
+
+int main() {
+	return read_value<key>();
+}

--- a/tests/test_structural_class_nttp_member_access_ret0.cpp
+++ b/tests/test_structural_class_nttp_member_access_ret0.cpp
@@ -1,0 +1,14 @@
+struct FloatKey {
+	float value;
+};
+
+template <FloatKey K>
+constexpr int read_value() {
+	return K.value == 1.5f ? 0 : 1;
+}
+
+constexpr FloatKey key{1.5f};
+
+int main() {
+	return read_value<key>();
+}

--- a/tests/test_structural_class_nttp_member_function_access_ret0.cpp
+++ b/tests/test_structural_class_nttp_member_function_access_ret0.cpp
@@ -1,0 +1,17 @@
+struct FloatKey {
+	float value;
+};
+
+constexpr FloatKey key{1.5f};
+
+template <typename T>
+struct Reader {
+	template <FloatKey K>
+	constexpr int read() const {
+		return K.value == 1.5f ? 0 : 1;
+	}
+};
+
+int main() {
+	return Reader<int>{}.read<key>();
+}

--- a/tests/test_structural_class_nttp_member_static_access_ret0.cpp
+++ b/tests/test_structural_class_nttp_member_static_access_ret0.cpp
@@ -10,5 +10,5 @@ struct structural_tag {
 constexpr Key key{42};
 
 int main() {
-	return structural_tag<key>::value;
+	return structural_tag<key>::value == 42 ? 0 : 1;
 }

--- a/tests/test_template_class_member_function_nttp_binding_ret0.cpp
+++ b/tests/test_template_class_member_function_nttp_binding_ret0.cpp
@@ -1,0 +1,11 @@
+template <int V>
+struct Reader {
+	template <int K>
+	constexpr int read() const {
+		return V + K == 3 ? 0 : 1;
+	}
+};
+
+int main() {
+	return Reader<1>{}.read<2>();
+}


### PR DESCRIPTION
## Summary

- Preserve structural class NTTP identity through constexpr-variable evaluation and template substitution.
- Retain combined class/member NTTP bindings during member-function materialization and merge function bindings without overwriting them.
- Resolve direct and inherited structural-class member access through shared constexpr lookup logic.
- Add regression tests for member functions, inherited members, and combined outer/inner NTTP bindings.