### PR TITLE
Defer dependent overload probes until substitution

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -24,12 +24,6 @@ These are generic alias substitution/materialization bugs, not library-name
 problems. Fix the canonical return type before mangling and IR lowering; do not
 special-case standard-library or vendor helper names.
 
-The standard headers also continue to produce non-fatal template-probe noise
-around failed `swap` overloads, dependent NTTP evaluation, and missing template
-parameter substitutions. These diagnostics are separate from the fixed
-`<utility>` runtime crash and should be removed by correcting the corresponding
-generic substitution and overload-probe states.
-
 ## Non-standard layout/constexpr acceptance gaps tracked as compatibility tests
 These tests are intentionally kept in compatibility form so the current FlashCpp
 suite stays green, even though they are not strictly standard-conforming under a

--- a/src/AstNodeTypes_DeclNodes.h
+++ b/src/AstNodeTypes_DeclNodes.h
@@ -2300,7 +2300,13 @@ inline bool typeSpecStillUsesDependentPlaceholder(const TypeSpecifierNode& type_
 	// reach IR. (Abbreviated-template `auto` parameters are substituted away before
 	// codegen; intentional undeduced auto returns are gated by the same check until
 	// deduce_and_update_auto_return_type rewrites them.)
-	if (isPlaceholderAutoType(type_spec.type())) {
+	// A parser-created TypeSpecifierNode can also retain the identity of a template
+	// parameter after its TypeIndex has been normalized to a concrete-looking
+	// category. That identity is the canonical dependence marker for overload
+	// arguments until substitution rewrites the node; do not probe overloads from
+	// the category alone.
+	if (type_spec.has_template_parameter_identity() ||
+		isPlaceholderAutoType(type_spec.type())) {
 		return true;
 	}
 	if (typeIndexContainsDependentPlaceholder(type_spec.type_index())) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -633,6 +633,16 @@ std::optional<ASTNode> Parser::resolveDependentUnqualifiedCallAtPointOfInstantia
 	if (!record.callee_name.isValid()) {
 		return std::nullopt;
 	}
+	for (const TypeSpecifierNode& arg_type : arg_types) {
+		if (typeSpecStillUsesDependentPlaceholder(arg_type)) {
+			FLASH_LOG_FORMAT(
+				Templates,
+				Trace,
+				"Deferring dependent unqualified call '{}' until substitution",
+				record.callee_name.view());
+			return std::nullopt;
+		}
+	}
 
 	ScopedDefinitionLookupContext ctx_scope(
 		current_template_definition_lookup_context_,
@@ -811,6 +821,16 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 		arg_types.size());
 	if (qualified_name.empty()) {
 		return std::nullopt;
+	}
+	for (const TypeSpecifierNode& arg_type : arg_types) {
+		if (typeSpecStillUsesDependentPlaceholder(arg_type)) {
+			FLASH_LOG_FORMAT(
+				Templates,
+				Trace,
+				"Deferring dependent qualified call '{}' until substitution",
+				qualified_name);
+			return std::nullopt;
+		}
 	}
 
 	std::optional<InlineVector<TemplateTypeArg, 4>> explicit_template_args;

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -8814,7 +8814,20 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 			InlineVector<TypeSpecifierNode, 6> qualified_template_arg_types;
 			if (tryCollectOverloadResolutionArgTypes(arguments, qualified_template_arg_types)) {
 				std::optional<ASTNode> resolved_target;
-				if (call_info.definition_lookup_record != nullptr &&
+				if (call_info.dependent_qualified_lookup_record != nullptr) {
+					// The dependent-qualified record is the semantic owner of this
+					// lookup until expression substitution materializes its owner and
+					// member chain. Running ordinary qualified overload resolution here
+					// probes the spelling-level owner (for example a dependent base alias)
+					// and turns an intentionally deferred call into a false overload
+					// failure. The substitution path retries from the canonical record at
+					// the point of instantiation.
+					FLASH_LOG_FORMAT(
+						Templates,
+						Trace,
+						"Deferring dependent qualified call '{}' to substitution",
+						call_info.qualified_name.view());
+				} else if (call_info.definition_lookup_record != nullptr &&
 					call_info.definition_lookup_record->has_value() &&
 					call_info.definition_lookup_record
 						->value()

--- a/tests/test_dependent_swap_probe_ret0.cpp
+++ b/tests/test_dependent_swap_probe_ret0.cpp
@@ -1,0 +1,61 @@
+// A dependent void_t probe must not report overload failure before instantiation.
+// C++20 [temp.res] defers overload resolution for the dependent swap call.
+
+template <class T>
+struct remove_reference {
+	using type = T;
+};
+
+template <class T>
+struct remove_reference<T&> {
+	using type = T;
+};
+
+template <class T>
+struct remove_reference<T&&> {
+	using type = T;
+};
+
+template <class T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <class T>
+remove_reference_t<T>&& declval() noexcept;
+
+template <bool B>
+struct bool_constant {
+	static constexpr bool value = B;
+};
+
+using true_type = bool_constant<true>;
+using false_type = bool_constant<false>;
+
+template <class...>
+using void_t = void;
+
+template <bool B, class T = void>
+struct enable_if {};
+
+template <class T>
+struct enable_if<true, T> {
+	using type = T;
+};
+
+template <bool B, class T = void>
+using enable_if_t = typename enable_if<B, T>::type;
+
+template <class T, enable_if_t<true, int> = 0>
+void swap(T&, T&) noexcept;
+
+template <class T, unsigned long Size, enable_if_t<true, int> = 0>
+void swap(T (&)[Size], T (&)[Size]) noexcept;
+
+template <class T1, class T2, class = void>
+struct SwappableHelper : false_type {};
+
+template <class T1, class T2>
+struct SwappableHelper<T1, T2, void_t<decltype(swap(declval<T1>(), declval<T2>()))>> : true_type {};
+
+int main() {
+	return SwappableHelper<int&, int&>::value ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Preserve template-parameter identity as the generic dependence marker after type normalization.
- Defer dependent unqualified and qualified overload probes until substitution/point of instantiation.
- Add the reduced swap/void_t regression and remove the resolved known-issue note.

