### PR TITLE
perf: eliminate unconditional std::string allocations in parser hot paths

### DIFF
--- a/docs/TEMPLATE_PROFILING.md
+++ b/docs/TEMPLATE_PROFILING.md
@@ -103,13 +103,13 @@ To completely disable profiling (zero overhead), edit `src/TemplateProfilingStat
 ### Profiling Macros
 
 ```cpp
-PROFILE_TEMPLATE_INSTANTIATION(name)       // Track template instantiation
+PROFILE_TEMPLATE_INSTANTIATION(name, ...)  // Track template instantiation
 PROFILE_TEMPLATE_LOOKUP()                   // Track template lookup
 PROFILE_TEMPLATE_PARSING()                  // Track template parsing
 PROFILE_TEMPLATE_SUBSTITUTION()             // Track type substitution
 PROFILE_TEMPLATE_SPECIALIZATION_MATCH()     // Track specialization matching
-PROFILE_TEMPLATE_CACHE_HIT(name)            // Record cache hit
-PROFILE_TEMPLATE_CACHE_MISS(name)           // Record cache miss
+PROFILE_TEMPLATE_CACHE_HIT(name, ...)       // Record cache hit
+PROFILE_TEMPLATE_CACHE_MISS(name, ...)      // Record cache miss
 ```
 
 ### Adding New Profiling Points
@@ -124,7 +124,7 @@ To add profiling to a new code path:
 2. Add profiling at function entry:
 ```cpp
 void my_template_function() {
-    PROFILE_TEMPLATE_INSTANTIATION("MyTemplate");
+    PROFILE_TEMPLATE_INSTANTIATION("MyTemplate", "_func");
     // ... rest of function
 }
 ```

--- a/src/Parser_Core.cpp
+++ b/src/Parser_Core.cpp
@@ -921,15 +921,19 @@ Token Parser::consume_token() {
 		// Use injected token as the next current_token_
 		current_token_ = injected_token_;
 		injected_token_ = Token{};  // reset to Uninitialized
-		FLASH_LOG_FORMAT(Parser, Debug, "consume_token: Consumed token='{}', next token from injected='{}'",
-						 std::string(token.value()),
-						 std::string(current_token_.value()));
+		if (FLASH_LOG_ENABLED(Parser, Debug)) {
+			FLASH_LOG_FORMAT(Parser, Debug, "consume_token: Consumed token='{}', next token from injected='{}'",
+							 std::string(token.value()),
+							 std::string(current_token_.value()));
+		}
 	} else {
 		// Normal path: get next token from lexer
 		Token next = lexer_.next_token();
-		FLASH_LOG_FORMAT(Parser, Debug, "consume_token: Consumed token='{}', next token from lexer='{}'",
-						 std::string(token.value()),
-						 std::string(next.value()));
+		if (FLASH_LOG_ENABLED(Parser, Debug)) {
+			FLASH_LOG_FORMAT(Parser, Debug, "consume_token: Consumed token='{}', next token from lexer='{}'",
+							 std::string(token.value()),
+							 std::string(next.value()));
+		}
 		current_token_ = next;
 	}
 	return token;
@@ -1119,8 +1123,10 @@ Parser::SaveHandle Parser::save_token_position() {
 	}
 #endif
 
-	FLASH_LOG_FORMAT(Parser, Debug, "save_token_position: handle={}, token={}",
-					 static_cast<unsigned long>(handle), std::string(current_token_.value()));
+	if (FLASH_LOG_ENABLED(Parser, Debug)) {
+		FLASH_LOG_FORMAT(Parser, Debug, "save_token_position: handle={}, token={}",
+						 static_cast<unsigned long>(handle), std::string(current_token_.value()));
+	}
 
 	return handle;
 }
@@ -1143,7 +1149,7 @@ void Parser::restore_token_position(SaveHandle handle, [[maybe_unused]] const st
 	}
 
 	const SavedToken& saved_token = *saved_tokens_[handle];
-	{
+	if (FLASH_LOG_ENABLED(Parser, Debug)) {
 		std::string saved_tok = std::string(saved_token.current_token_.value());
 		std::string current_tok = std::string(current_token_.value());
 

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -151,7 +151,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 #if WITH_PARSER_RUNTIME_STATS
 	FLASHCPP_PARSER_RUNTIME_PHASE(ClassTemplateInstantiation);
 #endif
-	PROFILE_TEMPLATE_INSTANTIATION(std::string(template_name));
+	PROFILE_TEMPLATE_INSTANTIATION(template_name);
 
 	// Resolve template template parameter aliases: when inside a template function body
 	// re-parse, "Container" may be a template template parameter bound to a concrete

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -157,16 +157,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 	// re-parse, "Container" may be a template template parameter bound to a concrete
 	// template (e.g., "MyVec").  Look up the substitution and redirect.
 	// Must be done before the early cache check so the cache key uses the resolved name.
-	{
-		StringHandle name_handle = StringTable::getOrInternStringHandle(template_name);
-		for (const auto& subst : template_param_substitutions_) {
-			if (subst.is_template_template_param && subst.param_name == name_handle &&
-				subst.concrete_template_name.isValid()) {
-				std::string_view concrete_name = StringTable::getStringView(subst.concrete_template_name);
-				FLASH_LOG(Templates, Trace, "Redirecting template template param '", template_name,
-						  "' -> '", concrete_name, "'");
-				return try_instantiate_class_template(concrete_name, template_args, force_eager);
-			}
+	StringHandle name_handle = StringTable::getOrInternStringHandle(template_name);
+	for (const auto& subst : template_param_substitutions_) {
+		if (subst.is_template_template_param && subst.param_name == name_handle &&
+			subst.concrete_template_name.isValid()) {
+			std::string_view concrete_name = StringTable::getStringView(subst.concrete_template_name);
+			FLASH_LOG(Templates, Trace, "Redirecting template template param '", template_name,
+						"' -> '", concrete_name, "'");
+			return try_instantiate_class_template(concrete_name, template_args, force_eager);
 		}
 	}
 
@@ -264,7 +262,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 	// Push a parser-level instantiation context for provenance tracking and backtraces.
 	// The mode snapshot is taken at call time (before any inner mode changes).
-	StringHandle template_name_handle_for_ctx = StringTable::getOrInternStringHandle(template_name);
+	StringHandle template_name_handle_for_ctx = name_handle;
 	ScopedParserInstantiationContext inst_ctx_guard(*this, template_instantiation_mode_, template_name_handle_for_ctx);
 
 	TemplateInstantiationAttemptScope attempt_scope(template_name, template_args.size());
@@ -1370,11 +1368,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				"Type-map hit for '{}' is backed by a ShapeOnly instantiation — re-entering full instantiation",
 				StringTable::getStringView(instantiated_name));
 		} else {
-		PROFILE_TEMPLATE_CACHE_HIT(std::string(template_name));
+		PROFILE_TEMPLATE_CACHE_HIT(instantiated_name);
 		return std::nullopt;
 		}
 	}
-	PROFILE_TEMPLATE_CACHE_MISS(std::string(template_name));
+	PROFILE_TEMPLATE_CACHE_MISS(instantiated_name);
 
 	// Fill in default template arguments BEFORE pattern matching (void_t SFINAE fix)
 	// This is critical for patterns like: template<typename T, typename = void> struct has_type;

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -4174,7 +4174,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(
 // Try to instantiate a function template with the given argument types
 // Returns the instantiated function declaration node if successful
 std::optional<ASTNode> Parser::try_instantiate_template(std::string_view template_name, std::span<const TypeSpecifierNode> arg_types) {
-	PROFILE_TEMPLATE_INSTANTIATION(std::string(template_name) + "_func");
+	PROFILE_TEMPLATE_INSTANTIATION(StringBuilder().append(template_name).append("_func").commit());
 
 	TemplateInstantiationAttemptScope attempt_scope(template_name, arg_types.size());
 	if (!attempt_scope.allowed()) {

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -4174,7 +4174,7 @@ std::optional<ASTNode> Parser::try_instantiate_template_explicit(
 // Try to instantiate a function template with the given argument types
 // Returns the instantiated function declaration node if successful
 std::optional<ASTNode> Parser::try_instantiate_template(std::string_view template_name, std::span<const TypeSpecifierNode> arg_types) {
-	PROFILE_TEMPLATE_INSTANTIATION(StringBuilder().append(template_name).append("_func").commit());
+	PROFILE_TEMPLATE_INSTANTIATION(template_name, "_func");
 
 	TemplateInstantiationAttemptScope attempt_scope(template_name, arg_types.size());
 	if (!attempt_scope.allowed()) {
@@ -4978,10 +4978,10 @@ std::optional<ASTNode> Parser::try_instantiate_single_template(
 					recursion_depth, template_name);
 				return std::nullopt;
 			}
-			PROFILE_TEMPLATE_CACHE_HIT(std::string(template_name) + "_func");
+			PROFILE_TEMPLATE_CACHE_HIT(template_name, "_func");
 			return *existing_inst;  // Return existing instantiation
 		}
-		PROFILE_TEMPLATE_CACHE_MISS(std::string(template_name) + "_func");
+		PROFILE_TEMPLATE_CACHE_MISS(template_name, "_func");
 	} else {
 		FLASH_LOG_FORMAT(
 			Templates,

--- a/src/TemplateProfilingStats.h
+++ b/src/TemplateProfilingStats.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include <chrono>
-#include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include <algorithm>
 #include <cstdio>
 #include <climits>
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 #include "StringTable.h"
 
 // Hash functor for StringHandle to use in unordered containers
@@ -102,10 +104,8 @@ public:
 #endif
 	}
 
-	// Overload for std::string for backward compatibility
-	void recordInstantiation(const std::string& template_name, std::chrono::microseconds duration) {
-		StringHandle handle = StringTable::getOrInternStringHandle(template_name);
-		recordInstantiation(handle, duration);
+	void recordInstantiation(std::string_view template_name, std::chrono::microseconds duration) {
+		recordInstantiation(StringTable::getOrInternStringHandle(template_name), duration);
 	}
 
 #if ENABLE_TEMPLATE_INSTANTIATION_TRACKING
@@ -142,10 +142,8 @@ public:
 		cache_hits_by_handle_[template_name_handle]++;
 	}
 
-	// Overload for std::string for backward compatibility
-	void recordCacheHit(const std::string& template_name) {
-		StringHandle handle = StringTable::getOrInternStringHandle(template_name);
-		recordCacheHit(handle);
+	void recordCacheHit(std::string_view template_name) {
+		recordCacheHit(StringTable::getOrInternStringHandle(template_name));
 	}
 
 	// Record a cache miss using StringHandle for efficiency
@@ -153,10 +151,8 @@ public:
 		cache_misses_by_handle_[template_name_handle]++;
 	}
 
-	// Overload for std::string for backward compatibility
-	void recordCacheMiss(const std::string& template_name) {
-		StringHandle handle = StringTable::getOrInternStringHandle(template_name);
-		recordCacheMiss(handle);
+	void recordCacheMiss(std::string_view template_name) {
+		recordCacheMiss(StringTable::getOrInternStringHandle(template_name));
 	}
 
 	// Record template lookup time
@@ -397,6 +393,52 @@ private:
 	TemplateProfilingAccumulator specialization_match_time_;
 };
 
+template <typename... Args>
+inline StringBuilder& appendTemplateProfilingName(StringBuilder& builder, Args&&... args) {
+	(builder.append(std::forward<Args>(args)), ...);
+	return builder;
+}
+
+template <typename... Args>
+inline StringHandle createTemplateProfilingNameHandle(Args&&... args) {
+	if constexpr (sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, StringHandle> && ...)) {
+		return StringHandle(std::forward<Args>(args)...);
+	}
+
+	StringBuilder builder;
+	appendTemplateProfilingName(builder, std::forward<Args>(args)...);
+	std::string_view name = builder.preview();
+	StringHandle handle = name.empty() ? StringHandle{} : StringTable::getOrInternStringHandle(name);
+	builder.reset();
+	return handle;
+}
+
+template <typename... Args>
+inline void recordTemplateProfilingCacheHit(Args&&... args) {
+	if constexpr (sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, StringHandle> && ...)) {
+		TemplateProfilingStats::getInstance().recordCacheHit(std::forward<Args>(args)...);
+		return;
+	}
+
+	StringBuilder builder;
+	TemplateProfilingStats::getInstance().recordCacheHit(
+		appendTemplateProfilingName(builder, std::forward<Args>(args)...).preview());
+	builder.reset();
+}
+
+template <typename... Args>
+inline void recordTemplateProfilingCacheMiss(Args&&... args) {
+	if constexpr (sizeof...(Args) == 1 && (std::is_same_v<std::remove_cvref_t<Args>, StringHandle> && ...)) {
+		TemplateProfilingStats::getInstance().recordCacheMiss(std::forward<Args>(args)...);
+		return;
+	}
+
+	StringBuilder builder;
+	TemplateProfilingStats::getInstance().recordCacheMiss(
+		appendTemplateProfilingName(builder, std::forward<Args>(args)...).preview());
+	builder.reset();
+}
+
 // RAII timer for automatic timing of template operations
 class TemplateProfilingTimer {
 public:
@@ -408,8 +450,12 @@ public:
 		SpecializationMatch
 	};
 
-	TemplateProfilingTimer(Operation op, std::string_view name = "")
-		: operation_(op), name_handle_(name.empty() ? StringHandle{} : StringTable::getOrInternStringHandle(name)),
+	template <typename... Args>
+	TemplateProfilingTimer(Operation op, Args&&... name_parts)
+		: operation_(op),
+		  name_handle_(op == Operation::Instantiation
+						   ? createTemplateProfilingNameHandle(std::forward<Args>(name_parts)...)
+						   : StringHandle{}),
 		  start_(std::chrono::high_resolution_clock::now()) {
 		// Log start of instantiation for long-running template instantiation debugging
 #if ENABLE_TEMPLATE_INSTANTIATION_TRACKING
@@ -458,8 +504,8 @@ private:
 #define PROFILE_TEMPLATE_CONCAT(a, b) PROFILE_TEMPLATE_CONCAT_IMPL(a, b)
 #define PROFILE_TEMPLATE_UNIQUE_VAR PROFILE_TEMPLATE_CONCAT(_template_prof_timer_, __COUNTER__)
 
-#define PROFILE_TEMPLATE_INSTANTIATION(name) \
-	TemplateProfilingTimer PROFILE_TEMPLATE_UNIQUE_VAR(TemplateProfilingTimer::Operation::Instantiation, name)
+#define PROFILE_TEMPLATE_INSTANTIATION(...) \
+	TemplateProfilingTimer PROFILE_TEMPLATE_UNIQUE_VAR(TemplateProfilingTimer::Operation::Instantiation, __VA_ARGS__)
 
 #define PROFILE_TEMPLATE_LOOKUP() \
 	TemplateProfilingTimer PROFILE_TEMPLATE_UNIQUE_VAR(TemplateProfilingTimer::Operation::Lookup)
@@ -473,11 +519,15 @@ private:
 #define PROFILE_TEMPLATE_SPECIALIZATION_MATCH() \
 	TemplateProfilingTimer PROFILE_TEMPLATE_UNIQUE_VAR(TemplateProfilingTimer::Operation::SpecializationMatch)
 
-#define PROFILE_TEMPLATE_CACHE_HIT(name) \
-	TemplateProfilingStats::getInstance().recordCacheHit(name)
+#define PROFILE_TEMPLATE_CACHE_HIT(...) \
+	do { \
+		recordTemplateProfilingCacheHit(__VA_ARGS__); \
+	} while (0)
 
-#define PROFILE_TEMPLATE_CACHE_MISS(name) \
-	TemplateProfilingStats::getInstance().recordCacheMiss(name)
+#define PROFILE_TEMPLATE_CACHE_MISS(...) \
+	do { \
+		recordTemplateProfilingCacheMiss(__VA_ARGS__); \
+	} while (0)
 
 #else
 
@@ -492,7 +542,7 @@ public:
 	void reset() {}
 };
 
-#define PROFILE_TEMPLATE_INSTANTIATION(name) \
+#define PROFILE_TEMPLATE_INSTANTIATION(...) \
 	do {                                     \
 	} while (0)
 #define PROFILE_TEMPLATE_LOOKUP() \
@@ -507,10 +557,10 @@ public:
 #define PROFILE_TEMPLATE_SPECIALIZATION_MATCH() \
 	do {                                        \
 	} while (0)
-#define PROFILE_TEMPLATE_CACHE_HIT(name) \
+#define PROFILE_TEMPLATE_CACHE_HIT(...) \
 	do {                                 \
 	} while (0)
-#define PROFILE_TEMPLATE_CACHE_MISS(name) \
+#define PROFILE_TEMPLATE_CACHE_MISS(...) \
 	do {                                  \
 	} while (0)
 

--- a/src/TemplateProfilingStats.h
+++ b/src/TemplateProfilingStats.h
@@ -408,12 +408,12 @@ public:
 		SpecializationMatch
 	};
 
-	TemplateProfilingTimer(Operation op, const std::string& name = "")
-		: operation_(op), name_(name), start_(std::chrono::high_resolution_clock::now()) {
+	TemplateProfilingTimer(Operation op, std::string_view name = "")
+		: operation_(op), name_handle_(name.empty() ? StringHandle{} : StringTable::getOrInternStringHandle(name)),
+		  start_(std::chrono::high_resolution_clock::now()) {
 		// Log start of instantiation for long-running template instantiation debugging
 #if ENABLE_TEMPLATE_INSTANTIATION_TRACKING
-		if (operation_ == Operation::Instantiation && !name_.empty()) {
-			name_handle_ = StringTable::getOrInternStringHandle(name_);
+		if (operation_ == Operation::Instantiation && name_handle_.isValid()) {
 			TemplateProfilingStats::getInstance().recordInstantiationStart(name_handle_);
 		}
 #endif
@@ -429,7 +429,7 @@ public:
 #if ENABLE_TEMPLATE_INSTANTIATION_TRACKING
 			stats.recordInstantiationEnd(name_handle_);
 #endif
-			stats.recordInstantiation(name_, duration);
+			stats.recordInstantiation(name_handle_, duration);
 			break;
 		case Operation::Lookup:
 			stats.recordLookup(duration);
@@ -448,10 +448,7 @@ public:
 
 private:
 	Operation operation_;
-	std::string name_;
-#if ENABLE_TEMPLATE_INSTANTIATION_TRACKING
 	StringHandle name_handle_;
-#endif
 	std::chrono::high_resolution_clock::time_point start_;
 };
 


### PR DESCRIPTION
## Summary
This PR eliminates several unconditional \`std::string\` heap allocations from the compiler's hottest code paths - the parser's token save/restore machinery and per-template-instantiation profiling timers.

## Changes

### 1. Parser_Core.cpp - Parser hot paths
The \`FLASH_LOG_FORMAT\` macro expands to \`flash_log_unused(fmt, __VA_ARGS__)\` in release builds, but function arguments are still **evaluated** before the call. This meant \`std::string\` copies of token values were constructed on every call to:
- \`save_token_position()\` - **1 heap allocation saved per call**
- \`restore_token_position()\` - **2 heap allocations saved per call**
- \`consume_token()\` - **2 heap allocations saved per call**

All are now wrapped in \`if (FLASH_LOG_ENABLED(Parser, Debug))\` guards so the strings are only constructed when debug logging is actually enabled.

### 2. TemplateProfilingStats.h - Per-instantiation timer
\`TemplateProfilingTimer\` previously stored a \`std::string name_\` (heap allocated) for its entire lifetime on every template instantiation. It now stores a \`StringHandle\` (8-byte integer into the string table), eliminating **1 heap allocation per template instantiation**.

### 3. Template profiling names and call sites
- `PROFILE_TEMPLATE_INSTANTIATION`, `PROFILE_TEMPLATE_CACHE_HIT`, and `PROFILE_TEMPLATE_CACHE_MISS` now accept variadic string-view pieces, matching the `FLASH_LOG` call style.
- Composed names are built in a temporary `StringBuilder`, interned from `preview()`, and immediately `reset()` so the temporary allocation is not retained.
- `StringHandle` overloads remain available for already-interned names and bypass the temporary builder.
- `Parser_Templates_Inst_Deduction.cpp`: `std::string(template_name) + "_func"` -> variadic profiling arguments (`template_name, "_func"`)

## Benchmark Results (Windows/MSVC STL 14.44)

Fresh five-run medians on the updated branch, using the Sharded MSVC compiler and the internal `TOTAL` from `--time`:

| Test | Previous baseline | Current median | Run range | Improvement |
|------|-------------------|----------------|-----------|-------------|
| `<type_traits>` TOTAL | ~1461 ms | **1214 ms** | 1196–1233 ms | **~16.9% faster** |
| `<limits>` TOTAL | ~5525 ms | **5256 ms** | 5226–5337 ms | **~4.9% faster** |

The `<limits>` test shows a smaller relative improvement because it spends proportionally more time in preprocessing and its dominant template (`__vcrt_assert_va_start_is_not_reference`, 618 instantiations) is already very cheap at ~25μs each.