### PR TITLE
Fix dependent alias reference return materialization

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,28 +1,22 @@
 # Known Issues
 
-## Dependent alias return types in function-template materialization
+## Deferred `<tuple>` member emission and `swap` gaps
 
-Function-template return types that pass through a dependent alias are not always
-fully substituted before mangling and IR conversion.
+The full `<tuple>` header still fails during deferred member emission after the
+reduced alias/materialization cases have completed. Constructor emission and
+some `swap` overload probes remain incomplete. The reduced partial-spec nested
+typedef shape (`using Ttype = Tuple<This, Rest...>`) is covered by
+`tests/test_dependent_alias_tuple_element_get_ret0.cpp` and now materializes.
+The regression models an MSVC `tuple_element` / `get` chain with a dependent
+`ElemT = typename Elem<I, T>::type` alias and an index-zero partial
+specialization whose nested `Ttype = Tuple<This, Rest...>` must expand the
+pack and materialize a concrete `Tuple` specialization. It ODR-uses `Ttype`
+through a pointer cast so a dependent placeholder cannot survive into IR.
+Reference-returning member access through `static_cast<Ttype&>` is covered
+separately by `tests/test_static_cast_ref_member_address_ret0.cpp`.
 
-- A called `move`-shaped template returning
-  `remove_reference_t<T>&&` can retain the template parameter in its mangled
-  parameter type and fail to link with an unresolved external.
-- The full `<tuple>` header still fails later (deferred unmaterialized member
-  emission / constructor/`swap` gaps). The reduced partial-spec nested typedef
-  shape (`using Ttype = Tuple<This, Rest...>`) is covered by
-  `tests/test_dependent_alias_tuple_element_get_ret0.cpp` and now materializes.
-  The regression models an MSVC `tuple_element` / `get` chain with a dependent
-  `ElemT = typename Elem<I, T>::type` alias and an index-zero partial
-  specialization whose nested `Ttype = Tuple<This, Rest...>` must expand the
-  pack and materialize a concrete `Tuple` specialization. It ODR-uses `Ttype`
-  through a pointer cast so a dependent placeholder cannot survive into IR.
-  Reference-returning member access through `static_cast<Ttype&>` is covered
-  separately by `tests/test_static_cast_ref_member_address_ret0.cpp`.
-
-These are generic alias substitution/materialization bugs, not library-name
-problems. Fix the canonical return type before mangling and IR lowering; do not
-special-case standard-library or vendor helper names.
+These remaining failures are generic deferred-member and overload-probe gaps,
+not library-name problems.
 
 ## Non-standard layout/constexpr acceptance gaps tracked as compatibility tests
 These tests are intentionally kept in compatibility form so the current FlashCpp

--- a/src/Parser_TypeSpecifiers.cpp
+++ b/src/Parser_TypeSpecifiers.cpp
@@ -1617,6 +1617,13 @@ ParseResult Parser::parse_type_specifier() {
 				if (alias_opt.has_value()) {
 					FLASH_LOG_FORMAT(Parser, Debug, "Found alias template for '{}', is_deferred={}", type_name, alias_opt->as<TemplateAliasNode>().is_deferred());
 					const TemplateAliasNode& alias_node = alias_opt->as<TemplateAliasNode>();
+					const TypeSpecifierNode& alias_target_type_spec = alias_node.target_type_node();
+					const bool alias_target_preserves_surface =
+						alias_target_type_spec.cv_qualifier() != CVQualifier::None ||
+						alias_target_type_spec.reference_qualifier() != ReferenceQualifier::None ||
+						alias_target_type_spec.pointer_depth() != 0 ||
+						alias_target_type_spec.has_function_signature() ||
+						alias_target_type_spec.is_array();
 
 					// Check for recursion: if we're already resolving this alias, return error
 					if (resolving_aliases_.find(type_name) != resolving_aliases_.end()) {
@@ -1969,6 +1976,22 @@ ParseResult Parser::parse_type_specifier() {
 							if (materialized_alias.resolved_type_info == nullptr) {
 								materialized_alias.resolved_type_info =
 									findTypeByName(StringTable::getOrInternStringHandle(materialized_alias.instantiated_name));
+							}
+						}
+						if (alias_target_preserves_surface &&
+							materialized_alias.resolved_type_info != nullptr) {
+							ASTNode substituted_alias_target = substituteTemplateParameters(
+								ASTNode::emplace_node<TypeSpecifierNode>(alias_node.target_type_node()),
+								alias_node.template_parameters(),
+								*template_args);
+							if (substituted_alias_target.is<TypeSpecifierNode>()) {
+								const TypeSpecifierNode& substituted_target =
+									substituted_alias_target.as<TypeSpecifierNode>();
+								if (!typeSpecStillUsesDependentPlaceholder(substituted_target) &&
+									substituted_target.type() != TypeCategory::Template) {
+									return ParseResult::success(
+										emplace_node<TypeSpecifierNode>(substituted_target));
+								}
 							}
 						}
 						if (std::optional<ParseResult> finalized_alias =

--- a/tests/test_dependent_alias_return_ref_ret0.cpp
+++ b/tests/test_dependent_alias_return_ref_ret0.cpp
@@ -1,0 +1,50 @@
+template <typename T>
+struct remove_reference {
+	using type = T;
+};
+
+template <typename T>
+struct remove_reference<T&> {
+	using type = T;
+};
+
+template <typename T>
+struct remove_reference<T&&> {
+	using type = T;
+};
+
+template <typename T>
+using remove_reference_t = typename remove_reference<T>::type;
+
+template <typename T>
+using lvalue_reference_t = remove_reference_t<T>&;
+
+template <typename T>
+using rvalue_reference_t = remove_reference_t<T>&&;
+
+template <typename T>
+lvalue_reference_t<T> lvalue_identity(lvalue_reference_t<T> value) {
+	return value;
+}
+
+template <typename T>
+rvalue_reference_t<T> rvalue_identity(remove_reference_t<T>& value) {
+	return static_cast<rvalue_reference_t<T>>(value);
+}
+
+struct WideValue {
+	int first;
+	long long second;
+};
+
+int main() {
+	int value = 42;
+	int& lvalue = lvalue_identity<int&>(value);
+	lvalue = 43;
+
+	WideValue wide{7, 900};
+	WideValue&& rvalue = rvalue_identity<WideValue>(wide);
+	rvalue.second = 901;
+
+	return value == 43 && wide.second == 901 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Preserve alias-provided reference, cv, pointer, array, and function surface metadata during concrete alias-template materialization.
- Add a C++20 regression covering lvalue and rvalue reference aliases with native and aggregate types.
- Remove the resolved dependent-alias return issue from `docs/KNOWN_ISSUES.md` while retaining the unrelated tuple gap.

The fix structurally substitutes the alias target and does not use standard-library or vendor-name fallbacks.