### PR TITLE
Complete derived-to-base conversions

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,5 +1,37 @@
 # Known Issues
 
+## Virtual-base derived-to-base conversions
+
+Virtual inheritance itself is implemented and covered by the existing positive
+tests, including `tests/test_virtual_base_classes_ret160.cpp`, which constructs
+a virtual diamond and verifies the single shared base subobject. RTTI and
+exception matching through virtual bases are covered separately by the
+`test_eh_*virtual_base*` tests. These tests exercise virtual-base layout,
+member access, vtables, RTTI, and exception handling; they do not exercise every
+implicit conversion form.
+
+The remaining gap is the standard-required conversion from a complete derived
+object to a virtual base when a base subobject address must be formed, including
+cases such as:
+
+- `Base& reference = derived;`
+- `Base* pointer = &derived;`
+- `Base value = derived;`
+- passing or returning `Base` by value from a `Derived` expression.
+
+The first two require ABI-specific runtime adjustment for the actual complete
+object (for example, a vtable/vbptr lookup); a layout-time byte offset is not
+valid for arbitrary subobjects. The by-value forms additionally require the
+selected Base copy/move constructor after that adjustment. The current
+compiler therefore stops with an unsupported-conversion diagnostic at
+this boundary instead of silently emitting an incorrect fixed-offset or raw
+byte-copy implementation.
+
+This is a compiler limitation, not an intended compile-time rule. A future
+positive regression test should be added when ABI-aware virtual-base lowering
+is implemented. Until then, the existing virtual-inheritance tests remain
+positive coverage for the functionality they describe.
+
 ## Deferred `<tuple>` member emission and `swap` gaps
 
 The full `<tuple>` header still fails during deferred member emission after the

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -325,7 +325,8 @@ private:
 		const TypeSpecifierNode& target_type,
 		const ConstructorDeclarationNode& selected_ctor,
 		const Token& source_token,
-		bool use_return_slot = false);
+		bool use_return_slot,
+		std::optional<int64_t> source_base_class_offset);
 	std::optional<ExprResult> tryMaterializeSemaSelectedConvertingConstructor(
 		ExprResult source_result,
 		const ASTNode& source_expr,
@@ -1085,15 +1086,10 @@ private:
 																			  const CallArgReferenceBindingInfo* binding_info,
 																			  const Token& source_token);
 	ExprResult adjustDerivedToBaseAddress(ExprResult source_address,
-												 TypeIndex source_type_index,
-												 TypeIndex target_type_index,
-												 SizeInBits target_size_bits,
-												 const Token& source_token);
-	ExprResult materializeDerivedToBaseValue(ExprResult source_result,
-													 TypeIndex source_type_index,
-													 TypeIndex target_type_index,
-													 SizeInBits target_size_bits,
-													 const Token& source_token);
+														 TypeIndex source_type_index,
+														 TypeIndex target_type_index,
+														 SizeInBits target_size_bits,
+														 const Token& source_token);
 	const FunctionDeclarationNode* findCurrentStructStaticMemberFunction(StringHandle member_name) const {
 		if (!current_struct_name_.isValid()) {
 			return nullptr;

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -6709,38 +6709,25 @@ void IrToObjConverter<TWriterClass>::handleGlobalStore(const IrInstruction& inst
 
 template <class TWriterClass>
 std::optional<int64_t> IrToObjConverter<TWriterClass>::findBaseOffsetWithinDerived(TypeIndex base_type, TypeIndex derived_type) const {
-	if (!base_type.is_valid() || !derived_type.is_valid())
+	const DerivedBaseConversionInfo conversion =
+		classifyDerivedBaseConversion(derived_type, base_type);
+	if (conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
 		return std::nullopt;
-	if (base_type == derived_type)
-		return 0;
-	const TypeInfo* derived_info = tryGetTypeInfo(derived_type);
-	const StructTypeInfo* derived_struct = derived_info ? derived_info->getStructInfo() : nullptr;
-	if (!derived_struct)
-		return std::nullopt;
-	// Recursively search public non-virtual base classes for base_type.
-	auto findOffset = [&](const auto& self, const StructTypeInfo* cur, int64_t cur_offset) -> std::optional<int64_t> {
-		if (!cur)
-			return std::nullopt;
-		for (const auto& base : cur->base_classes) {
-			if (base.access != AccessSpecifier::Public || base.is_virtual)
-				continue;
-			int64_t off = cur_offset + static_cast<int64_t>(base.offset);
-			if (base.type_index == base_type)
-				return off;
-			const TypeInfo* b_info = tryGetTypeInfo(base.type_index);
-			const StructTypeInfo* b_struct = b_info ? b_info->getStructInfo() : nullptr;
-			if (auto nested = self(self, b_struct, off))
-				return nested;
-		}
-		return std::nullopt;
-	};
-	return findOffset(findOffset, derived_struct, 0);
+	return conversion.offset;
 }
 
 template <class TWriterClass>
 void IrToObjConverter<TWriterClass>::emitDerivedToBasePointerAdjust(X64Register ptr_reg, TypeIndex base_type, TypeIndex derived_type) {
 	if (!base_type.isStruct() || !derived_type.isStruct() || base_type == derived_type)
 		return;
+	const DerivedBaseConversionInfo conversion =
+		classifyDerivedBaseConversion(derived_type, base_type);
+	if (conversion.kind == DerivedBaseConversionKind::Ambiguous)
+		throw CompileError("Ambiguous derived-to-base pointer conversion");
+	if (conversion.kind == DerivedBaseConversionKind::Inaccessible)
+		throw CompileError("Cannot convert to an inaccessible base class");
+	if (conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+		throw CompileError("Implicit conversion through a virtual base class is not supported");
 	if (auto offset = findBaseOffsetWithinDerived(base_type, derived_type)) {
 		if (*offset > 0) {
 			FLASH_LOG(Codegen, Debug, "Derived-to-base pointer adjustment: +", *offset, " bytes");

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1400,29 +1400,8 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 						to_type == TypeCategory::Struct &&
 						param_ref_qualifier == CVReferenceQualifier::None &&
 						param_type->pointer_depth() == 0) {
-						const CanonicalTypeDesc& source_desc =
-							sema_.typeContext().get(cast_info.source_type_id);
-						const CanonicalTypeDesc& target_desc =
-							sema_.typeContext().get(cast_info.target_type_id);
-						int target_size_bits = static_cast<int>(param_type->size_in_bits());
-						if (target_size_bits <= 0) {
-							const TypeInfo* target_type_info = tryGetTypeInfo(target_desc.type_index);
-							const StructTypeInfo* target_struct_info =
-								target_type_info ? target_type_info->getStructInfo() : nullptr;
-							if (!target_struct_info || !target_struct_info->sizeInBits().is_set()) {
-								throw InternalError("Derived-to-base call argument is missing target struct size");
-							}
-							target_size_bits = static_cast<int>(target_struct_info->sizeInBits().value);
-						}
-						argumentIrOperands = materializeDerivedToBaseValue(
-							argumentIrOperands,
-							source_desc.type_index,
-							target_desc.type_index,
-							SizeInBits{target_size_bits},
-							callExprNode.called_from());
-						arg_type = argumentIrOperands.typeEnum();
-						arg_type_index = argumentIrOperands.type_index;
-						return true;
+						throw InternalError(
+							"Sema selected a derived-to-base object conversion without materializing its constructor");
 					}
 					if (cast_info.cast_kind == StandardConversionKind::UserDefined &&
 						from_type == TypeCategory::Struct) {

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -495,12 +495,21 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 	if (!source_type_index.isStruct() || !target_type_index.isStruct()) {
 		throw InternalError("Derived-to-base address adjustment requires struct type identity");
 	}
-	const std::optional<int64_t> base_offset =
-		findPublicBaseSubobjectOffset(target_type_index, source_type_index);
-	if (!base_offset.has_value()) {
+	const DerivedBaseConversionInfo base_conversion =
+		classifyDerivedBaseConversion(source_type_index, target_type_index);
+	if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous) {
+		throw CompileError("Ambiguous derived-to-base conversion");
+	}
+	if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
+		throw CompileError("Cannot convert to an inaccessible base class");
+	}
+	if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+		throw CompileError("Implicit conversion through a virtual base class is not supported");
+	}
+	if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual) {
 		throw InternalError("Missing finalized layout for public derived-to-base conversion");
 	}
-	if (*base_offset > std::numeric_limits<int>::max()) {
+	if (base_conversion.offset > std::numeric_limits<int>::max()) {
 		throw InternalError("Derived-to-base subobject offset exceeds IR range");
 	}
 	if (!std::holds_alternative<TempVar>(source_address.value) &&
@@ -521,7 +530,7 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 		},
 		source_address.value);
 	address_op.base_storage = ValueStorage::ContainsAddress;
-	address_op.total_member_offset = static_cast<int>(*base_offset);
+	address_op.total_member_offset = static_cast<int>(base_conversion.offset);
 	address_op.result_type_index = target_type_index;
 	address_op.result_size_bits = target_size_bits;
 	ir_.addInstruction(IrInstruction(IrOpcode::ComputeAddress, std::move(address_op), source_token));
@@ -538,65 +547,6 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 		IrOperand{adjusted_address},
 		PointerDepth{},
 		ValueStorage::ContainsAddress);
-}
-
-ExprResult AstToIr::materializeDerivedToBaseValue(
-	ExprResult source_result,
-	TypeIndex source_type_index,
-	TypeIndex target_type_index,
-	SizeInBits target_size_bits,
-	const Token& source_token) {
-	if (!source_type_index.isStruct() || !target_type_index.isStruct()) {
-		throw InternalError("Derived-to-base value conversion requires struct type identity");
-	}
-	ExprResult source_address;
-	if (source_result.storage == ValueStorage::ContainsAddress) {
-		if (!std::holds_alternative<TempVar>(source_result.value) &&
-			!std::holds_alternative<StringHandle>(source_result.value)) {
-			throw InternalError("Derived-to-base value conversion requires addressable storage");
-		}
-		source_address = makeExprResult(
-			source_type_index,
-			SizeInBits{POINTER_SIZE_BITS},
-			source_result.value,
-			PointerDepth{},
-			ValueStorage::ContainsAddress);
-	} else {
-		if (!std::holds_alternative<TempVar>(source_result.value) &&
-			!std::holds_alternative<StringHandle>(source_result.value)) {
-			throw InternalError("Derived-to-base value conversion requires addressable storage");
-		}
-		const TempVar source_address_temp = emitAddressOf(
-			source_result.category(),
-			source_result.size_in_bits.value,
-			toIrValue(source_result.value),
-			source_token);
-		source_address = makeExprResult(
-			source_type_index,
-			SizeInBits{POINTER_SIZE_BITS},
-			IrOperand{source_address_temp},
-			PointerDepth{},
-			ValueStorage::ContainsAddress);
-	}
-
-	const ExprResult base_address = adjustDerivedToBaseAddress(
-		std::move(source_address),
-		source_type_index,
-		target_type_index,
-		target_size_bits,
-		source_token);
-	const TempVar base_value = emitDereference(
-		TypeCategory::Struct,
-		target_size_bits.value,
-		1,
-		toIrValue(base_address.value),
-		source_token);
-	return makeExprResult(
-		target_type_index,
-		target_size_bits,
-		IrOperand{base_value},
-		PointerDepth{},
-		ValueStorage::ContainsData);
 }
 
 std::optional<AstToIr::AddressComponents> AstToIr::makeAddressComponentsFromEvaluatedResult(
@@ -2801,7 +2751,63 @@ ExprResult AstToIr::applyConstructorArgConversion(ExprResult arg_result,
 			const CanonicalTypeDesc& to_desc = sema_.typeContext().get(ci.target_type_id);
 			TypeCategory from_t = from_desc.category();
 			const TypeCategory to_t = to_desc.category();
-			if (ci.cast_kind == StandardConversionKind::UserDefined &&
+			if (ci.cast_kind == StandardConversionKind::DerivedToBase &&
+				from_desc.category() == TypeCategory::Struct &&
+				to_desc.category() == TypeCategory::Struct) {
+				const DerivedBaseConversionInfo base_conversion =
+					classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+				if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+					throw CompileError("Ambiguous derived-to-base conversion");
+				if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+					throw CompileError("Cannot convert to an inaccessible base class");
+				if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+					throw CompileError("Implicit conversion through a virtual base class is not supported");
+				if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+					throw InternalError("Sema annotated an unrelated derived-to-base constructor argument");
+
+				if (param_type.is_reference() || param_type.is_rvalue_reference()) {
+					ExprResult address_result = arg_result;
+					if (address_result.storage != ValueStorage::ContainsAddress) {
+						address_result = materializeAddressResult(
+							arg_expr.as<ExpressionNode>(),
+							address_result,
+							source_token);
+					}
+					int target_size_bits = static_cast<int>(param_type.size_in_bits());
+					if (target_size_bits <= 0) {
+						const TypeInfo* target_type_info = tryGetTypeInfo(to_desc.type_index);
+						const StructTypeInfo* target_struct_info =
+							target_type_info ? target_type_info->getStructInfo() : nullptr;
+						if (!target_struct_info || !target_struct_info->sizeInBits().is_set())
+							throw InternalError("Derived-to-base reference binding is missing target struct size");
+						target_size_bits = static_cast<int>(target_struct_info->sizeInBits().value);
+					}
+					arg_result = adjustDerivedToBaseAddress(
+						std::move(address_result),
+						from_desc.type_index,
+						to_desc.type_index,
+						SizeInBits{target_size_bits},
+						source_token);
+					sema_applied = true;
+				} else {
+					if (!ci.selected_constructor)
+						throw InternalError("Sema missed the selected base copy/move constructor");
+					TypeSpecifierNode target_object_type = param_type;
+					target_object_type.set_reference_qualifier(ReferenceQualifier::None);
+					auto materialized = materializeSelectedConvertingConstructor(
+						arg_result,
+						arg_expr,
+						target_object_type,
+						*ci.selected_constructor,
+						source_token,
+						false,
+						base_conversion.offset);
+					if (!materialized)
+						throw InternalError("Failed to materialize derived-to-base constructor argument");
+					arg_result = *materialized;
+					sema_applied = true;
+				}
+			} else if (ci.cast_kind == StandardConversionKind::UserDefined &&
 				from_desc.category() == TypeCategory::Struct) {
 				TypeIndex source_type_idx = from_desc.type_index;
 				if (const TypeInfo* src_type_info = tryGetTypeInfo(source_type_idx)) {
@@ -2940,10 +2946,19 @@ std::optional<ExprResult> AstToIr::tryApplySemaCallArgReferenceBinding(ExprResul
 		const TypeIndex source_type_index = address_result.type_index;
 		const TypeIndex target_type_index = param_type.type_index().withCategory(TypeCategory::Struct);
 		if (!source_type_index.isStruct() || !target_type_index.isStruct() ||
-			source_type_index == target_type_index ||
-			!isTransitivelyDerivedFrom(source_type_index, target_type_index)) {
+			source_type_index == target_type_index) {
 			return address_result;
 		}
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(source_type_index, target_type_index);
+		if (base_conversion.kind == DerivedBaseConversionKind::NotRelated)
+			return address_result;
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base reference binding");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot bind a reference to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+			throw CompileError("Reference binding through a virtual base class is not supported");
 
 		int target_size_bits = static_cast<int>(param_type.size_in_bits());
 		if (target_size_bits <= 0) {
@@ -3015,6 +3030,49 @@ std::optional<ExprResult> AstToIr::tryApplySemaCallArgReferenceBinding(ExprResul
 		const CanonicalTypeDesc& to_desc = sema_.typeContext().get(cast_info.target_type_id);
 		TypeCategory from_t = from_desc.category();
 		const TypeCategory to_t = to_desc.category();
+		if (cast_info.cast_kind == StandardConversionKind::DerivedToBase &&
+			from_t == TypeCategory::Struct && to_t == TypeCategory::Struct) {
+			if (!cast_info.selected_constructor)
+				throw InternalError("Sema missed the selected base copy/move constructor for reference binding");
+			const DerivedBaseConversionInfo base_conversion =
+				classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+			if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+				throw CompileError("Ambiguous derived-to-base conversion");
+			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+				throw CompileError("Cannot convert to an inaccessible base class");
+			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+				throw CompileError("Implicit conversion through a virtual base class is not supported");
+			if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+				throw InternalError("Sema annotated an unrelated derived-to-base reference binding");
+
+			TypeSpecifierNode target_object_type = param_type;
+			target_object_type.set_reference_qualifier(ReferenceQualifier::None);
+			auto materialized = materializeSelectedConvertingConstructor(
+				arg_result,
+				arg_expr,
+				target_object_type,
+				*cast_info.selected_constructor,
+				source_token,
+				false,
+				base_conversion.offset);
+			if (!materialized)
+				throw InternalError("Failed to materialize derived-to-base reference temporary");
+			registerStructTempDestructorIfNeeded(*materialized);
+			if (const auto* temp_var = std::get_if<TempVar>(&materialized->value)) {
+				const TempVar address_temp = emitAddressOf(
+					materialized->category(),
+					materialized->size_in_bits.value,
+					IrValue(*temp_var),
+					source_token);
+				return makeExprResult(
+					materialized->type_index,
+					SizeInBits{POINTER_SIZE_BITS},
+					IrOperand{address_temp},
+					PointerDepth{},
+					ValueStorage::ContainsAddress);
+			}
+			return materializeTemporaryAndTakeAddress(*materialized);
+		}
 		if (from_t == TypeCategory::Enum && from_t != arg_result.typeEnum()) {
 			from_t = arg_result.typeEnum();
 		}
@@ -3061,7 +3119,8 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 	const TypeSpecifierNode& target_type,
 	const ConstructorDeclarationNode& selected_ctor,
 	const Token& source_token,
-	bool use_return_slot) {
+	bool use_return_slot,
+	std::optional<int64_t> source_base_class_offset) {
 	if (!is_struct_type(target_type.category()) || !target_type.type_index().is_valid()) {
 		return std::nullopt;
 	}
@@ -3073,6 +3132,25 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 	const StructTypeInfo* target_struct_info = target_type_info->getStructInfo();
 	if (!target_struct_info) {
 		return std::nullopt;
+	}
+
+	std::optional<int64_t> effective_source_base_class_offset = source_base_class_offset;
+	if (!effective_source_base_class_offset.has_value() &&
+		source_result.category() == TypeCategory::Struct &&
+		source_result.type_index.is_valid() &&
+		source_result.type_index != target_type.type_index() &&
+		isSameTypeCopyOrMoveConstructorCandidate(*target_struct_info, selected_ctor)) {
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(source_result.type_index, target_type.type_index());
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base conversion");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot convert to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+			throw CompileError("Implicit conversion through a virtual base class is not supported");
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+			throw InternalError("Selected copy/move constructor has an unrelated source type");
+		effective_source_base_class_offset = base_conversion.offset;
 	}
 
 	int actual_size_bits = static_cast<int>(target_type.size_in_bits());
@@ -3097,7 +3175,15 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 	}
 
 	const TypeSpecifierNode& param_type = param_type_node.as<TypeSpecifierNode>();
-	source_result = applyConstructorArgConversion(source_result, source_expr, param_type, source_token);
+	if (effective_source_base_class_offset.has_value()) {
+		if (*effective_source_base_class_offset < std::numeric_limits<int>::min() ||
+			*effective_source_base_class_offset > std::numeric_limits<int>::max()) {
+			throw InternalError("Derived-to-base constructor argument offset exceeds IR range");
+		}
+		ctor_op.source_base_class_offset = static_cast<int>(*effective_source_base_class_offset);
+	} else {
+		source_result = applyConstructorArgConversion(source_result, source_expr, param_type, source_token);
+	}
 
 	// applyConstructorArgConversion may already have performed the pre-bind scalar conversion
 	// for reference parameters (e.g. int→double for const double&). Reuse the shared
@@ -3154,7 +3240,9 @@ std::optional<ExprResult> AstToIr::tryMaterializeSemaSelectedConvertingConstruct
 	}
 
 	const ImplicitCastInfo& cast_info = sema_.castInfoTable()[slot->cast_info_index.value - 1];
-	if (cast_info.cast_kind != StandardConversionKind::UserDefined || !cast_info.selected_constructor) {
+	if ((cast_info.cast_kind != StandardConversionKind::UserDefined &&
+		 cast_info.cast_kind != StandardConversionKind::DerivedToBase) ||
+		!cast_info.selected_constructor) {
 		return std::nullopt;
 	}
 
@@ -3164,11 +3252,28 @@ std::optional<ExprResult> AstToIr::tryMaterializeSemaSelectedConvertingConstruct
 		return std::nullopt;
 	}
 
+	std::optional<int64_t> source_base_class_offset;
+	if (cast_info.cast_kind == StandardConversionKind::DerivedToBase) {
+		const CanonicalTypeDesc& source_desc = sema_.typeContext().get(cast_info.source_type_id);
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(source_desc.type_index, target_desc.type_index);
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base conversion");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot convert to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+			throw CompileError("Implicit conversion through a virtual base class is not supported");
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+			throw InternalError("Sema selected a derived-to-base constructor for unrelated types");
+		source_base_class_offset = base_conversion.offset;
+	}
+
 	return materializeSelectedConvertingConstructor(
 		source_result,
 		source_expr,
 		target_type,
 		*cast_info.selected_constructor,
 		source_token,
-		use_return_slot);
+		use_return_slot,
+		source_base_class_offset);
 }

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -902,42 +902,25 @@ ExprResult AstToIr::generateStaticCastIr(const StaticCastNode& staticCastNode) {
 	if (target_pointer_depth > 0) {
 			// Target is a pointer type - this is a pointer cast, not a value conversion
 			// Pointer casts are bitcasts - the value stays the same, only the type changes
-			// Return the expression with the target pointer type (char64, int64, etc.)
-			// All pointers are 64-bit on x64, so size should be 64
+		// Return the expression with the target pointer type (char64, int64, etc.)
+		// All pointers are 64-bit on x64, so size should be 64
 		FLASH_LOG_FORMAT(Codegen, Debug, "[PTR_CAST_DEBUG] Pointer cast: source={}, target={}, target_ptr_depth={}",
 						 static_cast<int>(source_type), static_cast<int>(target_type), target_pointer_depth);
 		if (source_type_index.isStruct() && target_type_index.isStruct() && source_type_index != target_type_index) {
-			auto findBaseOffsetWithinDerived = [&](const auto& self,
-												   const StructTypeInfo* current_struct,
-												   int64_t current_offset) -> std::optional<int64_t> {
-				if (!current_struct) {
-					return std::nullopt;
-				}
-				for (const auto& base : current_struct->base_classes) {
-					if (base.access != AccessSpecifier::Public || base.is_virtual) {
-						continue;
-					}
-					int64_t base_offset = current_offset + static_cast<int64_t>(base.offset);
-					if (base.type_index == target_type_index) {
-						return base_offset;
-					}
-					const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
-					const StructTypeInfo* base_struct_info = base_type_info ? base_type_info->getStructInfo() : nullptr;
-					if (auto nested = self(self, base_struct_info, base_offset)) {
-						return nested;
-					}
-				}
-				return std::nullopt;
-			};
-
-			const TypeInfo* source_type_info = tryGetTypeInfo(source_type_index);
-			const StructTypeInfo* source_struct_info = source_type_info ? source_type_info->getStructInfo() : nullptr;
-			if (auto base_offset = findBaseOffsetWithinDerived(findBaseOffsetWithinDerived, source_struct_info, 0);
-				base_offset.has_value() && *base_offset > 0) {
+			const DerivedBaseConversionInfo base_conversion =
+				classifyDerivedBaseConversion(source_type_index, target_type_index);
+			if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+				throw CompileError("Ambiguous derived-to-base pointer cast");
+			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+				throw CompileError("Cannot cast to an inaccessible base class");
+			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+				throw CompileError("Pointer cast through a virtual base class is not supported");
+			if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual &&
+				base_conversion.offset > 0) {
 				TempVar adjusted_ptr = var_counter.next();
 				BinaryOp add_offset;
 				add_offset.lhs = makeTypedValue(TypeCategory::UnsignedLongLong, SizeInBits{64}, toIrValue(expr_operands.value));
-				add_offset.rhs = makeTypedValue(TypeCategory::UnsignedLongLong, SizeInBits{64}, static_cast<unsigned long long>(*base_offset));
+				add_offset.rhs = makeTypedValue(TypeCategory::UnsignedLongLong, SizeInBits{64}, static_cast<unsigned long long>(base_conversion.offset));
 				add_offset.result = adjusted_ptr;
 				ir_.addInstruction(IrInstruction(IrOpcode::Add, std::move(add_offset), staticCastNode.cast_token()));
 				return makeExprResult(target_type_index, SizeInBits{64}, IrOperand{adjusted_ptr}, PointerDepth{static_cast<int>(target_pointer_depth)}, ValueStorage::ContainsData);

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -2128,24 +2128,28 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 						}
 					}
 
-						// Pointer derived-to-base conversion in variable init: verify the
-						// base is publicly accessible per C++20 [conv.ptr]/3. Overload
-						// resolution already enforces this via isTransitivelyDerivedFrom,
-						// but direct variable initialization bypasses overload resolution
-						// and silently emits the pointer adjustment in the back end.
+					// Pointer derived-to-base conversion in variable init: verify the
+					// relationship before the backend emits an adjustment. Direct variable
+					// initialization can bypass overload-resolution diagnostics.
 					if (need_conversion && init_cat == TypeCategory::Struct &&
 						type_node.pointer_depth() > 0 && init_operands.pointer_depth.is_pointer() &&
 						init_type_index.is_valid() && type_node.type_index().is_valid() &&
-						init_type_index != type_node.type_index() &&
-						!isTransitivelyDerivedFrom(init_type_index, type_node.type_index()) &&
-						isTransitivelyDerivedFromAnyAccess(init_type_index, type_node.type_index())) {
-						const TypeInfo* src_info = tryGetTypeInfo(init_type_index);
-						const TypeInfo* tgt_info = tryGetTypeInfo(type_node.type_index());
-						std::string src_name = src_info ? std::string(StringTable::getStringView(src_info->name())) : std::string("<unknown>");
-						std::string tgt_name = tgt_info ? std::string(StringTable::getStringView(tgt_info->name())) : std::string("<unknown>");
-						throw CompileError(
-							"Cannot initialize '" + tgt_name + "*' with pointer to '" + src_name +
-								"': '" + tgt_name + "' is an inaccessible base of '" + src_name + "' [conv.ptr]/3");
+						init_type_index != type_node.type_index()) {
+						const DerivedBaseConversionInfo base_conversion =
+							classifyDerivedBaseConversion(init_type_index, type_node.type_index());
+						if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+							throw CompileError("Ambiguous derived-to-base pointer conversion");
+						if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+							throw CompileError("Implicit conversion through a virtual base class is not supported");
+						if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
+							const TypeInfo* src_info = tryGetTypeInfo(init_type_index);
+							const TypeInfo* tgt_info = tryGetTypeInfo(type_node.type_index());
+							std::string src_name = src_info ? std::string(StringTable::getStringView(src_info->name())) : std::string("<unknown>");
+							std::string tgt_name = tgt_info ? std::string(StringTable::getStringView(tgt_info->name())) : std::string("<unknown>");
+							throw CompileError(
+								"Cannot initialize '" + tgt_name + "*' with pointer to '" + src_name +
+									"': '" + tgt_name + "' is an inaccessible base of '" + src_name + "' [conv.ptr]/3");
+						}
 					}
 				}
 
@@ -2765,10 +2769,11 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								// Generate copy constructor call or converting constructor call
 							const ASTNode& init_node = *node.initializer();
 							ExprResult init_operands = cached_copy_init_expr_result.has_value()
-														  ? *cached_copy_init_expr_result
-														  : visitExpressionNode(init_node.as<ExpressionNode>());
+															  ? *cached_copy_init_expr_result
+															  : visitExpressionNode(init_node.as<ExpressionNode>());
 							const ConstructorDeclarationNode* sema_selected_converting_ctor = nullptr;
 							const TypeSpecifierNode* sema_selected_param_type = nullptr;
+							std::optional<int64_t> sema_source_base_class_offset;
 							TypeCategory init_category_for_copy_init = init_operands.category();
 
 							// Check if this is a converting constructor case (initializer type != target type)
@@ -2808,17 +2813,31 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 								if (slot.has_value() && slot->has_cast()) {
 									const ImplicitCastInfo& cast_info =
 										sema_.castInfoTable()[slot->cast_info_index.value - 1];
-									if (cast_info.cast_kind == StandardConversionKind::UserDefined &&
-										cast_info.selected_constructor) {
-										const CanonicalTypeDesc& target_desc =
-											sema_.typeContext().get(cast_info.target_type_id);
-										if (target_desc.category() == TypeCategory::Struct &&
-											isSameStructTypeForInitialization(target_desc.type_index, type_node.type_index())) {
-											const CanonicalTypeDesc& source_desc =
-												sema_.typeContext().get(cast_info.source_type_id);
-											if (source_desc.category() != TypeCategory::Invalid) {
-												sema_selected_converting_ctor = cast_info.selected_constructor;
-												const auto& ctor_params = sema_selected_converting_ctor->parameter_nodes();
+									if ((cast_info.cast_kind == StandardConversionKind::UserDefined ||
+										 cast_info.cast_kind == StandardConversionKind::DerivedToBase) &&
+									cast_info.selected_constructor) {
+									const CanonicalTypeDesc& target_desc =
+										sema_.typeContext().get(cast_info.target_type_id);
+									if (target_desc.category() == TypeCategory::Struct &&
+										isSameStructTypeForInitialization(target_desc.type_index, type_node.type_index())) {
+										const CanonicalTypeDesc& source_desc =
+											sema_.typeContext().get(cast_info.source_type_id);
+										if (source_desc.category() != TypeCategory::Invalid) {
+											sema_selected_converting_ctor = cast_info.selected_constructor;
+											if (cast_info.cast_kind == StandardConversionKind::DerivedToBase) {
+												const DerivedBaseConversionInfo base_conversion =
+													classifyDerivedBaseConversion(source_desc.type_index, target_desc.type_index);
+												if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+													throw CompileError("Ambiguous derived-to-base conversion");
+												if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+													throw CompileError("Cannot convert to an inaccessible base class");
+												if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+													throw CompileError("Implicit conversion through a virtual base class is not supported");
+												if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+													throw InternalError("Sema selected an unrelated derived-to-base constructor");
+												sema_source_base_class_offset = base_conversion.offset;
+											}
+											const auto& ctor_params = sema_selected_converting_ctor->parameter_nodes();
 												if (!ctor_params.empty() && ctor_params[0].is<DeclarationNode>()) {
 													const ASTNode& param_type_node =
 														ctor_params[0].as<DeclarationNode>().type_node();
@@ -3011,7 +3030,13 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 
 							// Add initializer as constructor parameter
 						{
-							if (sema_selected_param_type) {
+							if (sema_source_base_class_offset.has_value()) {
+								if (*sema_source_base_class_offset < std::numeric_limits<int>::min() ||
+									*sema_source_base_class_offset > std::numeric_limits<int>::max()) {
+									throw InternalError("Derived-to-base constructor argument offset exceeds IR range");
+								}
+								ctor_op.source_base_class_offset = static_cast<int>(*sema_source_base_class_offset);
+							} else if (sema_selected_param_type) {
 								init_operands = applyConstructorArgConversion(
 									init_operands, init_node, *sema_selected_param_type, decl.identifier_token());
 							}

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -303,7 +303,7 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 							}
 							if (auto materialized = materializeSelectedConvertingConstructor(
 									operands, *expr_opt, return_type_spec, *ctor,
-									node.return_token(), use_return_slot_for_ctor)) {
+									node.return_token(), use_return_slot_for_ctor, std::nullopt)) {
 								operands = *materialized;
 								expr_type = operands.typeEnum();
 								expr_category = operands.category();

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -7,6 +7,7 @@
 #include "ChunkedString.h"
 #include "TemplateTypes.h" // For FunctionSignatureKey
 #include "InlineVector.h"
+#include <algorithm>
 #include <array>
 #include <vector>
 #include <optional>
@@ -421,46 +422,121 @@ inline bool isTransitivelyDerivedFromAnyAccess(TypeIndex source_idx, TypeIndex b
 	return isTransitivelyDerivedFromImpl(source_idx, base_idx, /*public_only=*/false);
 }
 
-// Return the byte offset of a public base subobject within a complete object.
-// This is the layout counterpart of isTransitivelyDerivedFrom(): callers use
-// it after overload resolution has already established that the conversion is
-// accessible.  The compiler's finalized StructTypeInfo contains the offsets
-// for both direct and nested base classes, so the same walk also handles
-// multi-level inheritance.
-inline std::optional<int64_t> findPublicBaseSubobjectOffset(TypeIndex base_idx, TypeIndex derived_idx) {
-	if (!base_idx.is_valid() || !derived_idx.is_valid())
-		return std::nullopt;
-	if (base_idx == derived_idx)
-		return int64_t{0};
+// Relationship between a complete derived object and a requested base subobject.
+// Keep this classification separate from the byte-offset lookup: a first-match
+// walk is incorrect for ambiguous diamonds and for virtual bases.
+enum class DerivedBaseConversionKind : uint8_t {
+	NotRelated,
+	Inaccessible,
+	UniquePublicNonVirtual,
+	PublicVirtual,
+	Ambiguous,
+};
+
+struct DerivedBaseConversionInfo {
+	DerivedBaseConversionKind kind = DerivedBaseConversionKind::NotRelated;
+	int64_t offset = 0;
+};
+
+// Classify all inheritance paths from derived_idx to base_idx.  A virtual base
+// is recorded by type rather than by path because a virtual base subobject is
+// shared by a diamond.  A non-virtual path and a virtual path still describe
+// different possible subobjects and are therefore ambiguous.
+inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived_idx, TypeIndex base_idx) {
+	if (!derived_idx.is_valid() || !base_idx.is_valid())
+		return {};
+	if (derived_idx == base_idx)
+		return {DerivedBaseConversionKind::UniquePublicNonVirtual, 0};
 
 	const TypeInfo* derived_type_info = tryGetTypeInfo(derived_idx);
 	const StructTypeInfo* derived_struct =
 		derived_type_info ? derived_type_info->getStructInfo() : nullptr;
 	if (!derived_struct)
-		return std::nullopt;
+		return {};
 
-	auto find_offset = [&](const auto& self,
-						   const StructTypeInfo* current_struct,
-						   int64_t current_offset) -> std::optional<int64_t> {
+	bool saw_inaccessible = false;
+	uint32_t non_virtual_path_count = 0;
+	uint32_t public_non_virtual_path_count = 0;
+	int64_t public_non_virtual_offset = 0;
+	std::vector<TypeIndex> public_virtual_subobjects;
+	std::vector<TypeIndex> inaccessible_virtual_subobjects;
+
+	auto contains_virtual_subobject = [&](TypeIndex type_index) {
+		return std::find(public_virtual_subobjects.begin(), public_virtual_subobjects.end(), type_index) !=
+			public_virtual_subobjects.end();
+	};
+	auto contains_inaccessible_virtual_subobject = [&](TypeIndex type_index) {
+		return std::find(inaccessible_virtual_subobjects.begin(), inaccessible_virtual_subobjects.end(), type_index) !=
+			inaccessible_virtual_subobjects.end();
+	};
+
+	auto visit = [&](const auto& self,
+					const StructTypeInfo* current_struct,
+					int64_t current_offset,
+					bool public_path,
+					bool virtual_path) -> void {
 		if (!current_struct)
-			return std::nullopt;
+			return;
 		for (const auto& base : current_struct->base_classes) {
-			if (base.access != AccessSpecifier::Public)
-				continue;
-			const int64_t base_offset =
-				current_offset + static_cast<int64_t>(base.offset);
-			if (base.type_index == base_idx)
-				return base_offset;
+			const bool next_public_path = public_path && base.access == AccessSpecifier::Public;
+			const bool next_virtual_path = virtual_path || base.is_virtual;
+			const int64_t base_offset = current_offset + static_cast<int64_t>(base.offset);
+			if (base.type_index == base_idx) {
+				if (!next_public_path) {
+					saw_inaccessible = true;
+					if (next_virtual_path) {
+						if (!contains_inaccessible_virtual_subobject(base_idx))
+							inaccessible_virtual_subobjects.push_back(base_idx);
+					} else {
+						++non_virtual_path_count;
+					}
+				} else if (next_virtual_path) {
+					if (!contains_virtual_subobject(base_idx))
+						public_virtual_subobjects.push_back(base_idx);
+				} else {
+					++non_virtual_path_count;
+					++public_non_virtual_path_count;
+					public_non_virtual_offset = base_offset;
+				}
+			}
+
 			const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
 			const StructTypeInfo* base_struct =
 				base_type_info ? base_type_info->getStructInfo() : nullptr;
-			if (auto nested_offset = self(self, base_struct, base_offset))
-				return nested_offset;
+			self(self, base_struct, base_offset, next_public_path, next_virtual_path);
 		}
-		return std::nullopt;
 	};
 
-	return find_offset(find_offset, derived_struct, 0);
+	visit(visit, derived_struct, 0, true, false);
+
+	if (non_virtual_path_count > 1 ||
+		(!public_virtual_subobjects.empty() &&
+		 (non_virtual_path_count != 0 || !inaccessible_virtual_subobjects.empty()))) {
+		return {DerivedBaseConversionKind::Ambiguous, 0};
+	}
+	if (public_non_virtual_path_count == 1 && non_virtual_path_count == 1)
+		return {DerivedBaseConversionKind::UniquePublicNonVirtual, public_non_virtual_offset};
+	if (!public_virtual_subobjects.empty())
+		return {DerivedBaseConversionKind::PublicVirtual, 0};
+	if (saw_inaccessible)
+		return {DerivedBaseConversionKind::Inaccessible, 0};
+	return {};
+}
+
+inline bool hasUsablePublicDerivedBaseConversion(TypeIndex derived_idx, TypeIndex base_idx) {
+	const DerivedBaseConversionKind kind =
+		classifyDerivedBaseConversion(derived_idx, base_idx).kind;
+	return kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+		kind == DerivedBaseConversionKind::PublicVirtual;
+}
+
+// Return the byte offset only for a unique, public, non-virtual base.  Callers
+// that need diagnostics must use classifyDerivedBaseConversion() first.
+inline std::optional<int64_t> findPublicBaseSubobjectOffset(TypeIndex base_idx, TypeIndex derived_idx) {
+	const DerivedBaseConversionInfo info = classifyDerivedBaseConversion(derived_idx, base_idx);
+	if (info.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+		return std::nullopt;
+	return info.offset;
 }
 
 inline size_t countMinRequiredParameters(std::span<const ASTNode> params) {
@@ -517,7 +593,7 @@ inline bool hasConvertingConstructorFrom(TypeIndex target_idx, TypeIndex source_
 	if (!target)
 		return false;
 	// Check if source is a (transitively) derived class of target (derived-to-base conversion)
-	if (isTransitivelyDerivedFrom(source_idx, target_idx))
+	if (hasUsablePublicDerivedBaseConversion(source_idx, target_idx))
 		return true;
 	// Check constructors whose first argument consumes the source and whose
 	// remaining arguments are defaulted.
@@ -727,7 +803,7 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				from_resolved_index.is_valid() && to_resolved_index.is_valid() &&
 				from_resolved_index != to_resolved_index) {
 				// Derived* → Base* is a valid pointer conversion (C++20 [conv.ptr]/3).
-				if (isTransitivelyDerivedFrom(from_resolved_index, to_resolved_index)) {
+				if (hasUsablePublicDerivedBaseConversion(from_resolved_index, to_resolved_index)) {
 					return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 				}
 				return ConversionPlan::no_match();
@@ -743,7 +819,7 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				from_resolved_index != to_resolved_index) {
 				// Derived* → Base* is valid with const qualification adjustment too.
 				if (pointee_qualification_is_added &&
-					isTransitivelyDerivedFrom(from_resolved_index, to_resolved_index)) {
+					hasUsablePublicDerivedBaseConversion(from_resolved_index, to_resolved_index)) {
 					return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 				}
 				return ConversionPlan::no_match();
@@ -815,7 +891,7 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 						// Per C++20 [conv.ref]/4: derived lvalue ref binds to base lvalue ref
 						// (standard derived-to-base reference conversion).
 						if (!from_is_rvalue && !to_is_rvalue &&
-							isTransitivelyDerivedFrom(from.type_index(), to.type_index())) {
+							hasUsablePublicDerivedBaseConversion(from_base_index, to_base_index)) {
 							return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 						}
 						return ConversionPlan::no_match();
@@ -1261,10 +1337,10 @@ inline size_t countMinRequiredArgs(const ConstructorDeclarationNode& ctor) {
 	return min_required;
 }
 
-inline bool isImplicitCopyOrMoveConstructorCandidate(
+inline bool isSameTypeCopyOrMoveConstructorCandidate(
 	const StructTypeInfo& struct_info,
 	const ConstructorDeclarationNode& ctor_decl) {
-	if (!ctor_decl.is_implicit() || !struct_info.own_type_index_.has_value()) {
+	if (!struct_info.own_type_index_.has_value()) {
 		return false;
 	}
 
@@ -1288,6 +1364,13 @@ inline bool isImplicitCopyOrMoveConstructorCandidate(
 
 	return param_type.type_index().is_valid() &&
 		   param_type.type_index() == *struct_info.own_type_index_;
+}
+
+inline bool isImplicitCopyOrMoveConstructorCandidate(
+	const StructTypeInfo& struct_info,
+	const ConstructorDeclarationNode& ctor_decl) {
+	return ctor_decl.is_implicit() &&
+		isSameTypeCopyOrMoveConstructorCandidate(struct_info, ctor_decl);
 }
 
 inline int compareConstructorTemplatePreference(

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -6920,15 +6920,40 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 	}
 
 	// C++20 [conv] permits a public derived class object to initialize a base
-	// class object by value.  Keep this as a semantic cast even though both
-	// descriptors have TypeCategory::Struct; otherwise the later normalized-call
-	// completeness check mistakes the slicing conversion for a missing annotation.
+	// class object by value.  This must select and invoke the base copy/move
+	// constructor; a raw byte slice would skip user-defined special-member logic.
 	if (from_desc.category() == TypeCategory::Struct &&
 		to_desc.category() == TypeCategory::Struct &&
 		from_desc.type_index.is_valid() &&
 		to_desc.type_index.is_valid() &&
-		from_desc.type_index != to_desc.type_index &&
-		isTransitivelyDerivedFrom(from_desc.type_index, to_desc.type_index)) {
+		from_desc.type_index != to_desc.type_index) {
+		const bool has_reference_qualifier =
+			from_desc.ref_qualifier != ReferenceQualifier::None ||
+			to_desc.ref_qualifier != ReferenceQualifier::None;
+		if (!has_reference_qualifier &&
+			tryAnnotateCopyInitConvertingConstructor(
+				expr_node,
+				target_type_id,
+				" in derived-to-base conversion",
+				expr_type_id)) {
+			return true;
+		}
+
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base conversion");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot convert to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+			throw CompileError("Implicit conversion through a virtual base class is not supported");
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+			return false;
+
+		// Reference conversions do not construct a new Base object, so the
+		// selected offset is consumed by reference binding in codegen.
+		if (!has_reference_qualifier)
+			return false;
 		ImplicitCastInfo cast_info;
 		cast_info.source_type_id = expr_type_id;
 		cast_info.target_type_id = target_type_id;
@@ -7210,7 +7235,15 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 		return false;
 
 	const StructTypeInfo* struct_info = to_type_info->getStructInfo();
-	if (!struct_info || !struct_info->hasAnyConstructor())
+	if (!struct_info)
+		return false;
+	const bool is_struct_object_derived_to_base =
+		from_desc.category() == TypeCategory::Struct &&
+		to_desc.category() == TypeCategory::Struct &&
+		from_desc.type_index.is_valid() &&
+		to_desc.type_index.is_valid() &&
+		from_desc.type_index != to_desc.type_index;
+	if (!is_struct_object_derived_to_base && !struct_info->hasAnyConstructor())
 		return false;
 
 	auto arg_type_opt = buildOverloadResolutionArgType(expr_node, nullptr);
@@ -7282,6 +7315,44 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 		throw CompileError("Ambiguous constructor call");
 	}
 	if (!best_non_explicit) {
+		if (is_struct_object_derived_to_base) {
+			const DerivedBaseConversionInfo base_conversion =
+				classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+			if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous) {
+				throw CompileError("Ambiguous derived-to-base conversion");
+			}
+			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
+				throw CompileError("Cannot convert to an inaccessible base class");
+			}
+			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+				throw CompileError("Implicit conversion through a virtual base class is not supported");
+			}
+			if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual) {
+				const bool prefer_move_ctor = !arg_type.is_lvalue_reference();
+				const StructMemberFunction* same_type_ctor =
+					struct_info->findPreferredSameTypeConstructor(prefer_move_ctor, true);
+				if (same_type_ctor &&
+					same_type_ctor->function_decl.is<ConstructorDeclarationNode>()) {
+					ImplicitCastInfo cast_info;
+					cast_info.source_type_id = expr_type_id;
+					cast_info.target_type_id = target_type_id;
+					cast_info.cast_kind = StandardConversionKind::DerivedToBase;
+					cast_info.value_category_after = ValueCategory::PRValue;
+					cast_info.selected_constructor =
+						&same_type_ctor->function_decl.as<ConstructorDeclarationNode>();
+
+					const CastInfoIndex idx = allocateCastInfo(cast_info);
+					SemanticSlot slot;
+					slot.type_id = target_type_id;
+					slot.cast_info_index = idx;
+					slot.value_category = ValueCategory::PRValue;
+					const void* key = static_cast<const void*>(&expr_node.as<ExpressionNode>());
+					setSlot(key, slot);
+					stats_.slots_filled++;
+					return true;
+				}
+			}
+		}
 		if (found_explicit_viable || best_any) {
 			// Special case: don't error for integer -> comparison category conversions.
 			// In deferred template bodies, inferExpressionType may not fully resolve
@@ -7324,7 +7395,18 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 	ImplicitCastInfo cast_info;
 	cast_info.source_type_id = expr_type_id;
 	cast_info.target_type_id = target_type_id;
-	cast_info.cast_kind = StandardConversionKind::UserDefined;
+	const DerivedBaseConversionInfo selected_base_conversion =
+		is_struct_object_derived_to_base
+			? classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index)
+			: DerivedBaseConversionInfo{};
+	const bool selected_same_type_ctor =
+		is_struct_object_derived_to_base &&
+		(selected_base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+		 selected_base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) &&
+		isSameTypeCopyOrMoveConstructorCandidate(*struct_info, *best_non_explicit);
+	cast_info.cast_kind = selected_same_type_ctor
+		? StandardConversionKind::DerivedToBase
+		: StandardConversionKind::UserDefined;
 	cast_info.value_category_after = ValueCategory::PRValue;
 	cast_info.selected_constructor = best_non_explicit;
 
@@ -9831,7 +9913,13 @@ void SemanticAnalysis::tryAnnotateConstructorCallArgConversions(const Constructo
 			++i;
 			return;
 		}
-		tryAnnotateConversion(arg, param_type_id, arg_type_id);
+		if (!tryAnnotateCopyInitConvertingConstructor(
+				arg,
+				param_type_id,
+				" in constructor argument",
+				arg_type_id)) {
+			tryAnnotateConversion(arg, param_type_id, arg_type_id);
+		}
 		diagnoseScopedEnumConversion(arg, param_type_id, " in constructor argument", arg_type_id);
 		++i;
 	});
@@ -10228,7 +10316,13 @@ void SemanticAnalysis::tryAnnotateInitListConstructorArgs(
 		FLASH_LOG(General, Debug, "SemanticAnalysis: init-list arg param_type=", param_type_id.value, " arg_type=", arg_type_id.value, " match=", (arg_type_id && canonical_types_match(arg_type_id, param_type_id)));
 		if (arg_type_id && canonical_types_match(arg_type_id, param_type_id))
 			continue;
-		tryAnnotateConversion(arg, param_type_id, arg_type_id);
+		if (!tryAnnotateCopyInitConvertingConstructor(
+				arg,
+				param_type_id,
+				" in constructor argument",
+				arg_type_id)) {
+			tryAnnotateConversion(arg, param_type_id, arg_type_id);
+		}
 		diagnoseScopedEnumConversion(arg, param_type_id, " in constructor argument", arg_type_id);
 	}
 }

--- a/tests/test_derived_to_base_ambiguous_fail.cpp
+++ b/tests/test_derived_to_base_ambiguous_fail.cpp
@@ -1,0 +1,18 @@
+// An implicit conversion to an ambiguous base must be rejected rather than
+// selecting whichever inheritance path happens to be visited first.
+
+struct Base {
+	int value;
+};
+
+struct Left : Base {};
+struct Right : Base {};
+struct Diamond : Left, Right {};
+
+void take_base(Base value) {}
+
+int main() {
+	Diamond value;
+	take_base(value);
+	return 0;
+}

--- a/tests/test_derived_to_base_converting_ctor_ret0.cpp
+++ b/tests/test_derived_to_base_converting_ctor_ret0.cpp
@@ -1,0 +1,27 @@
+// A direct Base(Derived) converting constructor must win over Base's copy
+// constructor. Derived-to-base slicing is only the fallback when no better
+// user-defined constructor is viable.
+
+struct Derived;
+
+struct Base {
+	int value;
+
+	Base();
+	Base(const Base& other);
+	Base(const Derived& source);
+};
+
+struct Derived : Base {
+	Derived() : Base() {}
+};
+
+Base::Base() : value(7) {}
+Base::Base(const Base& other) : value(other.value + 100) {}
+Base::Base(const Derived& source) : value(200) {}
+
+int main() {
+	Derived source;
+	Base result = source;
+	return result.value == 200 ? 0 : 1;
+}

--- a/tests/test_derived_to_base_copy_constructor_ret0.cpp
+++ b/tests/test_derived_to_base_copy_constructor_ret0.cpp
@@ -1,0 +1,53 @@
+// Derived-to-base object initialization must invoke the selected Base
+// copy/move constructor on the correctly adjusted base subobject.
+
+struct Prefix {
+	int marker;
+};
+
+struct Base {
+	int value;
+
+	Base() : value(0) {}
+	Base(const Base& other) : value(other.value + 100) {}
+};
+
+struct Derived : Prefix, Base {
+	int tail;
+
+	Derived(int input) : Base(), tail(input) {
+		marker = 7;
+		value = input;
+	}
+};
+
+int take_base_by_value(Base value) {
+	return value.value;
+}
+
+Base return_base(Derived& source) {
+	return source;
+}
+
+struct BaseReferenceHolder {
+	int value;
+
+	BaseReferenceHolder(const Base& source) : value(source.value + 1) {}
+};
+
+int main() {
+	Derived source(7);
+	Base initialized = source;
+	if (initialized.value != 107) {
+		return 1;
+	}
+	if (take_base_by_value(source) != 107) {
+		return 2;
+	}
+	Base returned = return_base(source);
+	if (returned.value != 107) {
+		return 3;
+	}
+	BaseReferenceHolder holder(source);
+	return holder.value == 8 ? 0 : 4;
+}

--- a/tests/test_derived_to_base_deleted_copy_fail.cpp
+++ b/tests/test_derived_to_base_deleted_copy_fail.cpp
@@ -1,0 +1,15 @@
+// A deleted Base copy constructor makes derived-to-base object initialization
+// ill-formed; the conversion must not fall back to a raw byte copy.
+
+struct Base {
+	Base() {}
+	Base(const Base&) = delete;
+};
+
+struct Derived : Base {};
+
+int main() {
+	Derived source;
+	Base copy = source;
+	return 0;
+}

--- a/tests/test_derived_to_base_pointer_ambiguous_fail.cpp
+++ b/tests/test_derived_to_base_pointer_ambiguous_fail.cpp
@@ -1,0 +1,15 @@
+// Pointer conversion must reject an ambiguous base subobject as well.
+
+struct Base {
+	int value;
+};
+
+struct Left : Base {};
+struct Right : Base {};
+struct Diamond : Left, Right {};
+
+int main() {
+	Diamond value;
+	Base* base = &value;
+	return base->value;
+}


### PR DESCRIPTION
## Summary

- Centralize inheritance-path classification for unique public, inaccessible, ambiguous, and virtual bases.
- Route derived-to-base object initialization through Base copy/move constructors, including arguments, returns, references, and variable initialization.
- Reject ambiguous/inaccessible conversions safely and document the remaining ABI-specific virtual-base conversion limitation.
- Add regression coverage for custom/deleted copy constructors and ambiguity.

## Validation

- MSVC build: 0 warnings, 0 errors.
- Full suite: 2,849 regular tests passed; 248 expected-failure tests failed as expected; 0 unexpected failures.

Virtual-base conversion remains a documented compiler limitation until ABI-aware runtime adjustment is implemented; existing virtual-inheritance positive tests remain unchanged.