### PR TITLE
Implement C++20 virtual-base derived-to-base conversions

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,36 +1,33 @@
 # Known Issues
 
-## Virtual-base derived-to-base conversions
+## Virtual-base derived-to-base conversions (implemented)
 
 Virtual inheritance itself is implemented and covered by the existing positive
 tests, including `tests/test_virtual_base_classes_ret160.cpp`, which constructs
 a virtual diamond and verifies the single shared base subobject. RTTI and
 exception matching through virtual bases are covered separately by the
 `test_eh_*virtual_base*` tests. These tests exercise virtual-base layout,
-member access, vtables, RTTI, and exception handling; they do not exercise every
-implicit conversion form.
+member access, vtables, RTTI, and exception handling. The standard implicit
+derived-to-base conversion forms are now covered by the positive regression
+`tests/test_virtual_base_derived_to_base_ret0.cpp`, including:
 
-The remaining gap is the standard-required conversion from a complete derived
-object to a virtual base when a base subobject address must be formed, including
-cases such as:
+- reference binding to a virtual base;
+- pointer conversion through the complete object and through intermediate
+  virtual-base subobjects, including the null-pointer rule;
+- copy-initialization of a base object from a derived object;
+- passing and returning a base object by value.
 
-- `Base& reference = derived;`
-- `Base* pointer = &derived;`
-- `Base value = derived;`
-- passing or returning `Base` by value from a `Derived` expression.
+Semantic analysis classifies public, inaccessible, and ambiguous inheritance
+paths according to C++20 [conv.ptr] and [conv]. The IR carries a dedicated
+virtual-base adjustment operation. The backend resolves the actual subobject
+address at runtime from the object's virtual-base metadata, while non-virtual
+paths continue to use their fixed subobject offset. By-value conversion invokes
+the selected base copy/move constructor after forming the adjusted base
+subobject address; it does not use a raw byte-copy shortcut.
 
-The first two require ABI-specific runtime adjustment for the actual complete
-object (for example, a vtable/vbptr lookup); a layout-time byte offset is not
-valid for arbitrary subobjects. The by-value forms additionally require the
-selected Base copy/move constructor after that adjustment. The current
-compiler therefore stops with an unsupported-conversion diagnostic at
-this boundary instead of silently emitting an incorrect fixed-offset or raw
-byte-copy implementation.
-
-This is a compiler limitation, not an intended compile-time rule. A future
-positive regression test should be added when ABI-aware virtual-base lowering
-is implemented. Until then, the existing virtual-inheritance tests remain
-positive coverage for the functionality they describe.
+The runtime metadata is an implementation detail of FlashCpp's object model.
+Missing or inconsistent finalized metadata is diagnosed as an internal compiler
+error; no conversion is synthesized without the required metadata.
 
 ## Deferred `<tuple>` member emission and `swap` gaps
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,34 +1,5 @@
 # Known Issues
 
-## Virtual-base derived-to-base conversions (implemented)
-
-Virtual inheritance itself is implemented and covered by the existing positive
-tests, including `tests/test_virtual_base_classes_ret160.cpp`, which constructs
-a virtual diamond and verifies the single shared base subobject. RTTI and
-exception matching through virtual bases are covered separately by the
-`test_eh_*virtual_base*` tests. These tests exercise virtual-base layout,
-member access, vtables, RTTI, and exception handling. The standard implicit
-derived-to-base conversion forms are now covered by the positive regression
-`tests/test_virtual_base_derived_to_base_ret0.cpp`, including:
-
-- reference binding to a virtual base;
-- pointer conversion through the complete object and through intermediate
-  virtual-base subobjects, including the null-pointer rule;
-- copy-initialization of a base object from a derived object;
-- passing and returning a base object by value.
-
-Semantic analysis classifies public, inaccessible, and ambiguous inheritance
-paths according to C++20 [conv.ptr] and [conv]. The IR carries a dedicated
-virtual-base adjustment operation. The backend resolves the actual subobject
-address at runtime from the object's virtual-base metadata, while non-virtual
-paths continue to use their fixed subobject offset. By-value conversion invokes
-the selected base copy/move constructor after forming the adjusted base
-subobject address; it does not use a raw byte-copy shortcut.
-
-The runtime metadata is an implementation detail of FlashCpp's object model.
-Missing or inconsistent finalized metadata is diagnosed as an internal compiler
-error; no conversion is synthesized without the required metadata.
-
 ## Deferred `<tuple>` member emission and `swap` gaps
 
 The full `<tuple>` header still fails during deferred member emission after the

--- a/src/AstNodeTypes.cpp
+++ b/src/AstNodeTypes.cpp
@@ -2239,22 +2239,8 @@ BasePlacementDecision decideBasePlacement(const BaseClassSpecifier& base,
 struct LayoutBaseCollections {
 	std::vector<BaseClassSpecifier*> non_virtual_bases;
 	std::vector<BaseClassSpecifier> virtual_bases;
-	bool non_virtual_base_has_vtable = false;
+	bool primary_non_virtual_base_has_runtime_pointer = false;
 };
-
-bool structIntroducesVirtualMembers(const StructTypeInfo& struct_info) {
-	if (struct_info.has_vtable) {
-		return true;
-	}
-
-	for (const auto& member_function : struct_info.member_functions) {
-		if (member_function.is_virtual || member_function.is_override) {
-			return true;
-		}
-	}
-
-	return false;
-}
 
 bool hasReachableVirtualBase(const StructTypeInfo* struct_info, std::set<const StructTypeInfo*>& visited) {
 	if (!struct_info || !visited.insert(struct_info).second) {
@@ -2279,6 +2265,20 @@ bool hasReachableVirtualBase(const StructTypeInfo& struct_info) {
 	return hasReachableVirtualBase(&struct_info, visited);
 }
 
+bool structIntroducesVirtualMembers(const StructTypeInfo& struct_info) {
+	if (struct_info.has_vtable || hasReachableVirtualBase(struct_info)) {
+		return true;
+	}
+
+	for (const auto& member_function : struct_info.member_functions) {
+		if (member_function.is_virtual || member_function.is_override) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 LayoutBaseCollections collectLayoutBaseCollections(StructTypeInfo& struct_info) {
 	LayoutBaseCollections collections;
 	collections.non_virtual_bases.reserve(struct_info.base_classes.size());
@@ -2290,10 +2290,17 @@ LayoutBaseCollections collectLayoutBaseCollections(StructTypeInfo& struct_info) 
 			continue;
 		}
 
+		const bool is_primary_non_virtual_base = collections.non_virtual_bases.empty();
 		collections.non_virtual_bases.push_back(&base);
-		if (!collections.non_virtual_base_has_vtable) {
-			if (const StructTypeInfo* base_info = getBaseStructInfo(base); base_info && base_info->has_vtable) {
-				collections.non_virtual_base_has_vtable = true;
+		if (is_primary_non_virtual_base) {
+			if (const StructTypeInfo* base_info = getBaseStructInfo(base)) {
+				// A polymorphic derived object can reuse only a primary
+				// polymorphic base's vptr.  A hidden virtual-base table is a
+				// different runtime pointer when the derived object introduces
+				// virtual functions.
+				collections.primary_non_virtual_base_has_runtime_pointer =
+					base_info->has_vtable ||
+					(!struct_info.has_vtable && !base_info->virtual_bases.empty());
 			}
 		}
 	}
@@ -2332,13 +2339,13 @@ LayoutBaseCollections collectLayoutBaseCollections(StructTypeInfo& struct_info) 
 	return collections;
 }
 
-void initializeBaseAwareLayout(bool has_virtual_members,
-							   bool non_virtual_base_has_vtable,
+void initializeBaseAwareLayout(bool has_runtime_pointer,
+							   bool primary_non_virtual_base_has_runtime_pointer,
 							   size_t& current_offset,
 							   size_t& max_alignment) {
 	current_offset = 0;
 	max_alignment = 1;
-	if (has_virtual_members && !non_virtual_base_has_vtable) {
+	if (has_runtime_pointer && !primary_non_virtual_base_has_runtime_pointer) {
 		current_offset = sizeof(void*);
 		max_alignment = sizeof(void*);
 	}
@@ -2441,7 +2448,10 @@ void StructTypeInfo::recalculateLayout() {
 
 	size_t current_offset = 0;
 	size_t max_alignment = 1;
-	initializeBaseAwareLayout(has_virtual_members, base_collections.non_virtual_base_has_vtable, current_offset, max_alignment);
+	initializeBaseAwareLayout(has_virtual_members,
+		base_collections.primary_non_virtual_base_has_runtime_pointer,
+		current_offset,
+		max_alignment);
 	placeBaseSubobjects(base_collections.non_virtual_bases, current_offset, max_alignment);
 
 	total_size = toSizeInBytes(current_offset);
@@ -2503,7 +2513,11 @@ bool StructTypeInfo::finalizeWithBases() {
 	LayoutBaseCollections base_collections = collectLayoutBaseCollections(*this);
 	size_t current_offset = 0;
 	size_t max_alignment = 1;
-	initializeBaseAwareLayout(has_vtable, base_collections.non_virtual_base_has_vtable, current_offset, max_alignment);
+	initializeBaseAwareLayout(
+		has_vtable || hasReachableVirtualBase(*this),
+		base_collections.primary_non_virtual_base_has_runtime_pointer,
+		current_offset,
+		max_alignment);
 
 	// Step 1: Layout non-virtual base class subobjects
 	placeBaseSubobjects(base_collections.non_virtual_bases, current_offset, max_alignment);

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1086,10 +1086,15 @@ private:
 																			  const CallArgReferenceBindingInfo* binding_info,
 																			  const Token& source_token);
 	ExprResult adjustDerivedToBaseAddress(ExprResult source_address,
-														 TypeIndex source_type_index,
-														 TypeIndex target_type_index,
-														 SizeInBits target_size_bits,
-														 const Token& source_token);
+																	 TypeIndex source_type_index,
+																	 TypeIndex target_type_index,
+																	 SizeInBits target_size_bits,
+																	 const Token& source_token);
+	ExprResult adjustDerivedToBasePointer(ExprResult source_pointer,
+																	 TypeIndex source_type_index,
+																	 TypeIndex target_type_index,
+																	 PointerDepth target_pointer_depth,
+																	 const Token& source_token);
 	const FunctionDeclarationNode* findCurrentStructStaticMemberFunction(StringHandle member_name) const {
 		if (!current_struct_name_.isValid()) {
 			return nullptr;

--- a/src/ElfFileWriter.h
+++ b/src/ElfFileWriter.h
@@ -359,7 +359,7 @@ public:
 	std::string get_or_create_builtin_typeinfo(TypeCategory cat);
 	std::string get_or_create_class_typeinfo(std::string_view class_name);
 	std::string get_or_create_class_typeinfo(const StructTypeInfo* struct_info);
-	void add_vtable(std::string_view vtable_symbol, std::span<const std::string_view> function_symbols, std::string_view class_name, std::span<const std::string_view> base_class_names, std::span<const BaseClassDescriptorInfo> base_class_info, const RTTITypeInfo* rtti_info = nullptr, TypeIndex subobject_type_index = {}, int64_t offset_to_top = 0);
+	void add_vtable(std::string_view vtable_symbol, std::span<const std::string_view> function_symbols, std::string_view class_name, std::span<const std::string_view> base_class_names, std::span<const BaseClassDescriptorInfo> base_class_info, std::span<const int64_t> virtual_base_offsets, const RTTITypeInfo* rtti_info = nullptr, TypeIndex subobject_type_index = {}, int64_t offset_to_top = 0);
 	std::string_view generateMangledName(std::string_view name, const FunctionSignature& sig);
 	std::string_view addFunctionSignature(std::string_view name, const TypeSpecifierNode& return_type, std::span<const TypeSpecifierNode> parameter_types, Linkage linkage = Linkage::None, bool is_variadic = false);
 

--- a/src/ElfFileWriter_GlobalRTTI.cpp
+++ b/src/ElfFileWriter_GlobalRTTI.cpp
@@ -609,6 +609,7 @@ void ElfFileWriter::add_vtable(std::string_view vtable_symbol,
 							   std::string_view class_name,
 							   [[maybe_unused]] std::span<const std::string_view> base_class_names,
 							   [[maybe_unused]] std::span<const BaseClassDescriptorInfo> base_class_info,
+							   [[maybe_unused]] std::span<const int64_t> virtual_base_offsets,
 							   [[maybe_unused]] const RTTITypeInfo* rtti_info,
 							   TypeIndex subobject_type_index,
 							   int64_t offset_to_top) {

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -351,6 +351,9 @@ void IrToObjConverter<TWriterClass>::convert(const Ir& ir, const std::string_vie
 			case IrOpcode::ComputeAddress:
 				handleComputeAddress(instruction);
 				break;
+			case IrOpcode::VirtualBaseAdjust:
+				handleVirtualBaseAdjust(instruction);
+				break;
 			case IrOpcode::Dereference:
 				handleDereference(instruction);
 				break;
@@ -6726,14 +6729,85 @@ void IrToObjConverter<TWriterClass>::emitDerivedToBasePointerAdjust(X64Register 
 		throw CompileError("Ambiguous derived-to-base pointer conversion");
 	if (conversion.kind == DerivedBaseConversionKind::Inaccessible)
 		throw CompileError("Cannot convert to an inaccessible base class");
-	if (conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-		throw CompileError("Implicit conversion through a virtual base class is not supported");
+	if (conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+		if (!conversion.virtual_base_index.has_value()) {
+			throw InternalError("Finalized virtual-base pointer conversion is missing its runtime table index");
+		}
+		emitVirtualBasePointerAdjust(ptr_reg, base_type, derived_type, *conversion.virtual_base_index);
+		return;
+	}
 	if (auto offset = findBaseOffsetWithinDerived(base_type, derived_type)) {
-		if (*offset > 0) {
+		if (*offset != 0) {
 			FLASH_LOG(Codegen, Debug, "Derived-to-base pointer adjustment: +", *offset, " bytes");
+			emitTestRegReg(ptr_reg);
+			const uint32_t skip_adjustment_patch = emitJumpIfZeroRel32Placeholder();
 			emitAddImmToReg(textSectionData, ptr_reg, static_cast<int64_t>(*offset));
+			patchRel32(skip_adjustment_patch, static_cast<uint32_t>(textSectionData.size()));
 		}
 	}
+}
+
+template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::emitVirtualBasePointerAdjust(
+	X64Register ptr_reg,
+	TypeIndex base_type,
+	TypeIndex derived_type,
+	size_t virtual_base_index) {
+	if (!base_type.isStruct() || !derived_type.isStruct() || base_type == derived_type) {
+		throw InternalError("Virtual-base pointer adjustment requires distinct struct types");
+	}
+	const DerivedBaseConversionInfo conversion =
+		classifyDerivedBaseConversion(derived_type, base_type);
+	if (conversion.kind == DerivedBaseConversionKind::Ambiguous)
+		throw CompileError("Ambiguous derived-to-base pointer conversion");
+	if (conversion.kind == DerivedBaseConversionKind::Inaccessible)
+		throw CompileError("Cannot convert to an inaccessible base class");
+	if (conversion.kind != DerivedBaseConversionKind::PublicVirtual)
+		throw InternalError("Virtual-base pointer adjustment reached a non-virtual conversion");
+
+	const TypeInfo* derived_type_info = tryGetTypeInfo(derived_type);
+	const StructTypeInfo* derived_struct_info =
+		derived_type_info ? derived_type_info->getStructInfo() : nullptr;
+	if (!derived_struct_info) {
+		throw InternalError("Virtual-base pointer adjustment is missing derived struct metadata");
+	}
+	if (virtual_base_index >= derived_struct_info->virtual_bases.size() ||
+		derived_struct_info->virtual_bases[virtual_base_index].type_index != base_type) {
+		throw InternalError("Virtual-base pointer adjustment has an invalid runtime table index");
+	}
+
+	// [conv.ptr] preserves a null pointer during a derived-to-base conversion.
+	// The runtime table is only consulted for a non-null object pointer.
+	emitTestRegReg(ptr_reg);
+	const uint32_t skip_adjustment_patch = emitJumpIfZeroRel32Placeholder();
+	X64Register table_reg = allocateRegisterWithSpilling(ptr_reg);
+	// Polymorphic objects use the ABI vtable prefix.  Non-polymorphic objects
+	// use the compiler-owned table pointer stored at the runtime-dispatch slot.
+	emitMovFromMemory(table_reg, ptr_reg, 0, sizeof(void*));
+	int32_t table_entry_offset = 0;
+	if (derived_struct_info->has_vtable) {
+		// Itanium: vbase[i] is vtable[-(3+i)].
+		// MSVC: the COL pointer occupies vtable[-1], so vbase[i] is
+		// vtable[-(2+i)].
+		const int64_t entry_offset = std::is_same_v<TWriterClass, ElfFileWriter>
+			? -static_cast<int64_t>((3 + virtual_base_index) * sizeof(void*))
+			: -static_cast<int64_t>((2 + virtual_base_index) * sizeof(void*));
+		if (entry_offset < std::numeric_limits<int32_t>::min() ||
+			entry_offset > std::numeric_limits<int32_t>::max()) {
+			throw InternalError("Virtual-base vtable entry offset exceeds codegen range");
+		}
+		table_entry_offset = static_cast<int32_t>(entry_offset);
+	} else {
+		const uint64_t entry_offset = static_cast<uint64_t>(virtual_base_index) * sizeof(void*);
+		if (entry_offset > std::numeric_limits<int32_t>::max()) {
+			throw InternalError("Virtual-base table entry offset exceeds codegen range");
+		}
+		table_entry_offset = static_cast<int32_t>(entry_offset);
+	}
+	emitMovFromMemory(table_reg, table_reg, table_entry_offset, sizeof(void*));
+	emitAddRegs(textSectionData, ptr_reg, table_reg);
+	regAlloc.release(table_reg);
+	patchRel32(skip_adjustment_patch, static_cast<uint32_t>(textSectionData.size()));
 }
 
 template <class TWriterClass>
@@ -7780,6 +7854,36 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 						}
 						return "_purecall"sv;
 					}();
+					auto collectVirtualBaseOffsets = [&](TypeIndex subobject_type_index,
+						int64_t offset_to_top) {
+						std::vector<int64_t> offsets;
+						const StructTypeInfo* source_struct_info = struct_info;
+						size_t source_offset = 0;
+						if (subobject_type_index.is_valid()) {
+							const TypeInfo* source_type_info = tryGetTypeInfo(subobject_type_index);
+							source_struct_info = source_type_info ? source_type_info->getStructInfo() : nullptr;
+							if (offset_to_top < 0) {
+								source_offset = static_cast<size_t>(-offset_to_top);
+							}
+						}
+						if (!source_struct_info || source_struct_info->virtual_bases.empty()) {
+							return offsets;
+						}
+						for (const auto& virtual_base : source_struct_info->virtual_bases) {
+							const auto most_derived_virtual_base = std::find_if(
+								struct_info->virtual_bases.begin(),
+								struct_info->virtual_bases.end(),
+								[&](const BaseClassSpecifier& candidate) {
+									return candidate.type_index == virtual_base.type_index;
+								});
+							if (most_derived_virtual_base == struct_info->virtual_bases.end() ||
+								most_derived_virtual_base->offset < source_offset) {
+								throw InternalError("Vtable registration cannot resolve a virtual-base offset");
+							}
+							offsets.push_back(static_cast<int64_t>(most_derived_virtual_base->offset - source_offset));
+						}
+						return offsets;
+					};
 					auto getVirtualFunctionSymbol = [&](const StructMemberFunction* vfunc) -> std::string {
 						if (!vfunc) {
 							return {};
@@ -7809,6 +7913,7 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 						VTableInfo vtable_info;
 						vtable_info.vtable_symbol = StringTable::getOrInternStringHandle(vtable_symbol);
 						vtable_info.class_name = StringTable::getOrInternStringHandle(struct_name);
+						vtable_info.virtual_base_offsets = collectVirtualBaseOffsets({}, 0);
 
 						// Reserve space for vtable entries
 					vtable_info.function_symbols.resize(struct_info->vtable.size());
@@ -7897,6 +8002,8 @@ void IrToObjConverter<TWriterClass>::handleFunctionDecl(const IrInstruction& ins
 						secondary_vtable_info.class_name = StringTable::getOrInternStringHandle(struct_name);
 						secondary_vtable_info.subobject_type_index = base.type_index;
 						secondary_vtable_info.offset_to_top = -static_cast<int64_t>(base.offset);
+						secondary_vtable_info.virtual_base_offsets =
+							collectVirtualBaseOffsets(base.type_index, secondary_vtable_info.offset_to_top);
 						secondary_vtable_info.function_symbols.resize(base_struct_info->vtable.size());
 						for (size_t i = 0; i < base_struct_info->vtable.size(); ++i) {
 							const StructMemberFunction* vfunc = base_struct_info->vtable[i];
@@ -13629,9 +13736,42 @@ void IrToObjConverter<TWriterClass>::handleMemberStore(const IrInstruction& inst
 	// Extract typed payload - all MemberStore instructions use typed payloads
 	const MemberStoreOp& op = std::any_cast<const MemberStoreOp&>(instruction.getTypedPayload());
 
-	// Check if this is a vtable pointer initialization (vptr)
-	if (op.vtable_symbol.isValid()) {
-		// This is a vptr initialization - load vtable address and store to offset 0
+	// Check if this is a vptr or hidden virtual-base table initialization.
+	if (op.vtable_symbol.isValid() || op.virtual_base_table_symbol.isValid()) {
+		if (op.virtual_base_table_symbol.isValid()) {
+			if (op.virtual_base_table_offsets.empty()) {
+				throw InternalError("Virtual-base table initialization has no entries");
+			}
+			std::vector<char> table_data(op.virtual_base_table_offsets.size() * sizeof(int64_t));
+			for (size_t i = 0; i < op.virtual_base_table_offsets.size(); ++i) {
+				const int64_t table_offset = op.virtual_base_table_offsets[i];
+				std::memcpy(
+					table_data.data() + i * sizeof(int64_t),
+					&table_offset,
+					sizeof(int64_t));
+			}
+			const auto existing_table = std::find_if(
+				global_variables_.begin(),
+				global_variables_.end(),
+				[&](const GlobalVariableInfo& global) {
+					return global.name == op.virtual_base_table_symbol;
+				});
+			if (existing_table == global_variables_.end()) {
+				GlobalVariableInfo table_info;
+				table_info.name = op.virtual_base_table_symbol;
+				table_info.size_in_bytes = table_data.size();
+				table_info.is_initialized = true;
+				table_info.init_data = std::move(table_data);
+				table_info.is_rodata = true;
+				table_info.is_selectany = true;
+				global_variables_.push_back(std::move(table_info));
+			} else if (existing_table->init_data != table_data) {
+				throw InternalError("Virtual-base table symbol was assigned conflicting offsets");
+			}
+		}
+
+		// This is a runtime dispatch pointer initialization - load its symbol
+		// address and store it at the selected subobject offset.
 		// Get the object's base stack offset
 		int32_t object_base_offset = 0;
 		const StackVariableScope& current_scope = variable_scopes.back();
@@ -13652,8 +13792,11 @@ void IrToObjConverter<TWriterClass>::handleMemberStore(const IrInstruction& inst
 		// So we just need a standard PC-relative relocation with the default addend
 		uint32_t relocation_offset = emitLeaRipRelative(X64Register::RAX);
 
-		// Add a relocation for the vtable symbol
-		writer.add_relocation(relocation_offset, StringTable::getStringView(op.vtable_symbol));
+		// Add a relocation for the vtable/table symbol
+		const StringHandle dispatch_symbol = op.vtable_symbol.isValid()
+			? op.vtable_symbol
+			: op.virtual_base_table_symbol;
+		writer.add_relocation(relocation_offset, StringTable::getStringView(dispatch_symbol));
 
 		// Store vtable pointer to [RCX + op.offset] (this pointer is in RCX)
 		// First load 'this' pointer into RCX
@@ -14468,6 +14611,64 @@ void IrToObjConverter<TWriterClass>::handleComputeAddress(const IrInstruction& i
 		op.result_type_index,
 		op.result_size_bits.value,
 		op.result);
+}
+
+template <class TWriterClass>
+void IrToObjConverter<TWriterClass>::handleVirtualBaseAdjust(const IrInstruction& instruction) {
+	const VirtualBaseAdjustOp& op =
+		std::any_cast<const VirtualBaseAdjustOp&>(instruction.getTypedPayload());
+	X64Register source_reg = allocateRegisterWithSpilling();
+
+	if (const auto* source_name = std::get_if<StringHandle>(&op.source)) {
+		const auto& current_scope = variable_scopes.back();
+		const auto source_it = current_scope.variables.find(*source_name);
+		if (source_it == current_scope.variables.end()) {
+			throw InternalError("Virtual-base adjustment source variable is not in the current scope");
+		}
+		const int32_t source_offset = source_it->second.offset;
+		const bool source_holds_pointer =
+			!op.source_is_address || isPointerBaseStorage(source_offset);
+		if (source_holds_pointer) {
+			emitMovFromFrame(source_reg, source_offset);
+		} else {
+			emitLeaFromFrame(source_reg, source_offset);
+		}
+	} else {
+		const TempVar source_temp = std::get<TempVar>(op.source);
+		const int32_t source_offset = getStackOffsetFromTempVar(source_temp);
+		const bool source_holds_pointer =
+			!op.source_is_address || isPointerBaseStorage(source_offset, source_temp);
+		if (source_holds_pointer) {
+			emitMovFromFrame(source_reg, source_offset);
+		} else {
+			emitLeaFromFrame(source_reg, source_offset);
+		}
+	}
+
+	emitVirtualBasePointerAdjust(
+		source_reg,
+		op.target_type_index,
+		op.source_type_index,
+		op.virtual_base_index);
+
+	const int32_t result_offset = getStackOffsetFromTempVar(op.result);
+	emitMovToFrameSized(
+		SizedRegister{source_reg, 64, false},
+		SizedStackSlot{result_offset, 64, false});
+	if (op.source_is_address) {
+		const TypeInfo* target_type_info = tryGetTypeInfo(op.target_type_index);
+		const StructTypeInfo* target_struct_info =
+			target_type_info ? target_type_info->getStructInfo() : nullptr;
+		if (!target_struct_info || !target_struct_info->sizeInBits().is_set()) {
+			throw InternalError("Virtual-base address adjustment is missing target size metadata");
+		}
+		setAddressOnlyInfo(
+			result_offset,
+			op.target_type_index,
+			static_cast<int>(target_struct_info->sizeInBits().value),
+			op.result);
+	}
+	regAlloc.release(source_reg);
 }
 
 template <class TWriterClass>
@@ -16885,7 +17086,8 @@ void IrToObjConverter<TWriterClass>::finalizeSections() {
 		}
 
 		writer.add_vtable(StringTable::getStringView(vtable.vtable_symbol), func_symbols_sv, StringTable::getStringView(vtable.class_name),
-						  base_class_names_sv, vtable.base_class_info, vtable.rtti_info, vtable.subobject_type_index, vtable.offset_to_top);
+						  base_class_names_sv, vtable.base_class_info, vtable.virtual_base_offsets,
+						  vtable.rtti_info, vtable.subobject_type_index, vtable.offset_to_top);
 	}
 
 		// Now add pending global variable relocations (after symbols are created)

--- a/src/IRConverter_ConvertMain.h
+++ b/src/IRConverter_ConvertMain.h
@@ -511,6 +511,11 @@ private:
 	// Does nothing when the types are unrelated or the offset is 0.
 	void emitDerivedToBasePointerAdjust(X64Register ptr_reg, TypeIndex base_type, TypeIndex derived_type);
 
+	void emitVirtualBasePointerAdjust(X64Register ptr_reg,
+		TypeIndex base_type,
+		TypeIndex derived_type,
+		size_t virtual_base_index);
+
 	uint16_t getX64RegisterCodeViewCode(X64Register reg);
 
 	// Reset per-function state between function declarations
@@ -776,6 +781,8 @@ private:
 	void handleAddressOfMember(const IrInstruction& instruction);
 
 	void handleComputeAddress(const IrInstruction& instruction);
+
+	void handleVirtualBaseAdjust(const IrInstruction& instruction);
 
 	void handleDereference(const IrInstruction& instruction);
 
@@ -1054,6 +1061,7 @@ private:
 		std::vector<std::string> function_symbols;  // Mangled function names in vtable order
 		std::vector<std::string> base_class_names;  // Base class names for RTTI (legacy)
 		std::vector<ObjectFileWriter::BaseClassDescriptorInfo> base_class_info; // Detailed base class info for RTTI
+		std::vector<int64_t> virtual_base_offsets; // Runtime offsets indexed by the source subobject's virtual-base order
 		const RTTITypeInfo* rtti_info;  // Pointer to RTTI information for this class (nullptr if not polymorphic)
 	};
 	std::vector<VTableInfo> vtables_;

--- a/src/IRTypes_Core.h
+++ b/src/IRTypes_Core.h
@@ -143,6 +143,7 @@ enum class IrOpcode : int_fast16_t {
 	AddressOf,
 	AddressOfMember,	 // Calculate address of struct member: &obj.member
 	ComputeAddress,		// One-pass address computation for complex expressions: &arr[i].member1.member2
+	VirtualBaseAdjust,	// Runtime adjustment from a derived object/address to a virtual base
 	Dereference,
 	DereferenceStore,	  // Store through a pointer: *ptr = value
 	// Struct operations

--- a/src/IRTypes_Instructions.h
+++ b/src/IRTypes_Instructions.h
@@ -531,6 +531,19 @@ public:
 			}
 		} break;
 
+		case IrOpcode::VirtualBaseAdjust: {
+			assert(hasTypedPayload() && "VirtualBaseAdjust instruction must use typed payload");
+			const auto& op = getTypedPayload<VirtualBaseAdjustOp>();
+			oss << '%' << op.result.var_number << " = virtual_base_adjust ";
+			if (const auto* string = std::get_if<StringHandle>(&op.source)) {
+				oss << "%" << StringTable::getStringView(*string);
+			} else {
+				oss << '%' << std::get<TempVar>(op.source).var_number;
+			}
+			oss << (op.source_is_address ? " (address)" : " (pointer)")
+				<< ", base_index: " << op.virtual_base_index;
+		} break;
+
 		case IrOpcode::Dereference: {
 			assert(hasTypedPayload() && "Dereference instruction must use typed payload");
 			const auto& op = getTypedPayload<DereferenceOp>();

--- a/src/IRTypes_Ops.h
+++ b/src/IRTypes_Ops.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "IRTypes_Registers.h"
+#include "InlineVector.h"
 
 class ConstructorDeclarationNode;
 
@@ -550,6 +551,8 @@ struct MemberStoreOp {
 	const TypeInfo* struct_type_info;				  // Parent struct type (nullptr if not available)
 	CVReferenceQualifier ref_qualifier = CVReferenceQualifier::None; // Member declaration reference qualifier (not access kind)
 	StringHandle vtable_symbol;		// For vptr initialization - stores vtable symbol name
+	StringHandle virtual_base_table_symbol;	// For hidden virtual-base table initialization
+	InlineVector<int32_t, 1> virtual_base_table_offsets;
 	bool is_pointer_to_member = false;			   // True if accessing through pointer (ptr->member), false for direct (obj.member)
 	std::optional<size_t> bitfield_width;			  // Width in bits for bitfield members
 	size_t bitfield_bit_offset = 0;					// Bit offset within the storage unit for bitfield members
@@ -664,6 +667,19 @@ struct ComputeAddressOp {
 	TypeIndex result_type_index{};				   // Type of final address (TypeCategory embedded)
 	TypeCategory resultType() const { return result_type_index.category(); }
 	SizeInBits result_size_bits;							 // Size in bits
+};
+
+// Runtime derived-to-virtual-base adjustment. The source is either an object
+// address (source_is_address=true) or an already-valued pointer. The backend
+// obtains the object-dependent displacement from the source type's vtable or
+// hidden virtual-base table.
+struct VirtualBaseAdjustOp {
+	TempVar result;
+	std::variant<StringHandle, TempVar> source;
+	bool source_is_address = false;
+	TypeIndex source_type_index{};
+	TypeIndex target_type_index{};
+	size_t virtual_base_index = 0;
 };
 
 // Dereference operator (*ptr)

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -1403,6 +1403,25 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 						throw InternalError(
 							"Sema selected a derived-to-base object conversion without materializing its constructor");
 					}
+					if (cast_info.cast_kind == StandardConversionKind::DerivedToBase &&
+						from_type == TypeCategory::Struct &&
+						to_type == TypeCategory::Struct &&
+						param_ref_qualifier == CVReferenceQualifier::None &&
+						param_type->pointer_depth() > 0) {
+						const CanonicalTypeDesc& source_desc =
+							sema_.typeContext().get(cast_info.source_type_id);
+						const CanonicalTypeDesc& target_desc =
+							sema_.typeContext().get(cast_info.target_type_id);
+						argumentIrOperands = adjustDerivedToBasePointer(
+							std::move(argumentIrOperands),
+							source_desc.type_index,
+							target_desc.type_index,
+							PointerDepth{static_cast<int>(target_desc.pointer_levels.size())},
+							callExprNode.called_from());
+						arg_type = argumentIrOperands.typeEnum();
+						arg_type_index = argumentIrOperands.type_index;
+						return true;
+					}
 					if (cast_info.cast_kind == StandardConversionKind::UserDefined &&
 						from_type == TypeCategory::Struct) {
 						TypeIndex source_type_idx =

--- a/src/IrGenerator_Call_Indirect.cpp
+++ b/src/IrGenerator_Call_Indirect.cpp
@@ -1380,30 +1380,55 @@ ExprResult AstToIr::generateMemberFunctionCallIr(const CallExprNode& callExprNod
 		// so they need the same treatment as pointer access for virtual dispatch.
 		vcall_op.is_pointer_access = (object_type.pointer_depth() > 0) || object_type.is_reference() || object_type.is_rvalue_reference();
 
-		// Generate IR for function arguments
+		// Generate IR for function arguments through the same semantic conversion
+		// path as direct and non-virtual calls. Virtual dispatch changes only the
+		// call target; it does not change C++ argument conversion rules.
+		const FunctionDeclarationNode* actual_func_decl = &func_decl;
+		if (called_member_func &&
+			called_member_func->function_decl.is<FunctionDeclarationNode>()) {
+			actual_func_decl = &called_member_func->function_decl.as<FunctionDeclarationNode>();
+		}
+		size_t arg_index = 0;
 		callExprNode.arguments().visit([&](ASTNode argument) {
-			ExprResult argument_result = visitExpressionNode(argument.as<ExpressionNode>());
+			const CallParamView param_view = resolveCallParamView(
+				actual_func_decl->parameter_nodes(),
+				arg_index,
+				nullptr,
+				nullptr);
+			const TypeSpecifierNode* param_type = param_view.type();
+			const CallArgReferenceBindingInfo* sema_ref_binding = param_type
+				? sema_.getCallRefBinding(sema_call_key, arg_index)
+				: nullptr;
+			const CVReferenceQualifier param_ref_qualifier = param_view.ref_qualifier;
+			const ExpressionContext arg_context =
+				param_ref_qualifier != CVReferenceQualifier::None &&
+				(!sema_ref_binding || !sema_ref_binding->is_valid() || sema_ref_binding->binds_directly())
+					? ExpressionContext::LValueAddress
+					: ExpressionContext::Load;
+			ExprResult argument_result = visitExpressionNode(
+				argument.as<ExpressionNode>(),
+				arg_context);
 
-			// For variables, we need to add the type and size
-			if (std::holds_alternative<IdentifierNode>(argument.as<ExpressionNode>())) {
-				const auto& identifier = std::get<IdentifierNode>(argument.as<ExpressionNode>());
-				StringHandle identifier_name = identifier.nameHandle();
-				const std::optional<ASTNode> symbol = symbol_table.lookup(identifier.name());
-				const auto& decl_node = symbol->as<DeclarationNode>();
-				const auto& type_node = decl_node.type_specifier_node();
-
-				TypedValue tv;
-				tv.setType(type_node.type());
-				tv.ir_type = toIrType(type_node.type());
-				tv.size_in_bits = SizeInBits{type_node.size_in_bits()};
-				tv.value = identifier_name;
-				vcall_op.arguments.push_back(tv);
+			if (param_type) {
+				if (auto sema_bound_arg = tryBuildSemaBoundCallArgument(
+						argument_result,
+						argument,
+						*param_type,
+						sema_ref_binding,
+						callExprNode.called_from())) {
+					vcall_op.arguments.push_back(std::move(*sema_bound_arg));
+					arg_index++;
+					return;
+				}
+				vcall_op.arguments.push_back(buildOrdinaryCallArgument(
+					argument,
+					param_type,
+					argument_result,
+					callExprNode.called_from()));
 			} else {
-				// Convert from IrOperand to TypedValue
-				// Format: [type, size, value]
-				TypedValue tv = toTypedValue(argument_result);
-				vcall_op.arguments.push_back(tv);
+				vcall_op.arguments.push_back(toTypedValue(argument_result));
 			}
+			arg_index++;
 		});
 
 		// Add the virtual call instruction

--- a/src/IrGenerator_Expr_Conversions.cpp
+++ b/src/IrGenerator_Expr_Conversions.cpp
@@ -301,6 +301,9 @@ std::optional<AstToIr::AddressComponents> AstToIr::analyzeAddressExpression(
 				result.final_size_bits = SizeInBits{static_cast<int>(struct_info->sizeInBits().value)};
 			}
 		}
+		result.base_storage = (type_node->is_reference() || type_node->is_rvalue_reference())
+			? ValueStorage::ContainsAddress
+			: ValueStorage::ContainsData;
 		result.pointer_depth = PointerDepth{static_cast<int>(type_node->pointer_depth())};
 		return result;
 	}
@@ -503,24 +506,33 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 	if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
 		throw CompileError("Cannot convert to an inaccessible base class");
 	}
-	if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
-		throw CompileError("Implicit conversion through a virtual base class is not supported");
-	}
-	if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual) {
+	if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+		base_conversion.kind != DerivedBaseConversionKind::PublicVirtual) {
 		throw InternalError("Missing finalized layout for public derived-to-base conversion");
-	}
-	if (base_conversion.offset > std::numeric_limits<int>::max()) {
-		throw InternalError("Derived-to-base subobject offset exceeds IR range");
 	}
 	if (!std::holds_alternative<TempVar>(source_address.value) &&
 		!std::holds_alternative<StringHandle>(source_address.value)) {
 		throw InternalError("Derived-to-base address adjustment requires addressable storage");
 	}
+	if (const auto* source_name = std::get_if<StringHandle>(&source_address.value)) {
+		// A named lvalue denotes the object, not an address value.  Emit the
+		// language-level address operation so ordinary objects use LEA while
+		// references and `this` load their already-materialized address.
+		const TempVar address_temp = emitAddressOf(
+			source_address.category(),
+			source_address.size_in_bits.value,
+			IrValue(*source_name),
+			source_token);
+		source_address = makeExprResult(
+			source_address.type_index,
+			SizeInBits{POINTER_SIZE_BITS},
+			IrOperand{address_temp},
+			PointerDepth{},
+			ValueStorage::ContainsAddress);
+	}
 
 	TempVar adjusted_address = var_counter.next();
-	ComputeAddressOp address_op;
-	address_op.result = adjusted_address;
-	address_op.base = std::visit(
+	const std::variant<StringHandle, TempVar> source = std::visit(
 		[](const auto& value) -> std::variant<StringHandle, TempVar> {
 			using Value = std::decay_t<decltype(value)>;
 			if constexpr (std::is_same_v<Value, TempVar> || std::is_same_v<Value, StringHandle>) {
@@ -529,11 +541,31 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 			throw InternalError("Unsupported derived-to-base address operand");
 		},
 		source_address.value);
-	address_op.base_storage = ValueStorage::ContainsAddress;
-	address_op.total_member_offset = static_cast<int>(base_conversion.offset);
-	address_op.result_type_index = target_type_index;
-	address_op.result_size_bits = target_size_bits;
-	ir_.addInstruction(IrInstruction(IrOpcode::ComputeAddress, std::move(address_op), source_token));
+	if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+		if (!base_conversion.virtual_base_index.has_value()) {
+			throw InternalError("Finalized virtual-base conversion is missing its runtime table index");
+		}
+		VirtualBaseAdjustOp adjust_op;
+		adjust_op.result = adjusted_address;
+		adjust_op.source = source;
+		adjust_op.source_is_address = true;
+		adjust_op.source_type_index = source_type_index;
+		adjust_op.target_type_index = target_type_index;
+		adjust_op.virtual_base_index = *base_conversion.virtual_base_index;
+		ir_.addInstruction(IrInstruction(IrOpcode::VirtualBaseAdjust, std::move(adjust_op), source_token));
+	} else {
+		if (base_conversion.offset > std::numeric_limits<int>::max()) {
+			throw InternalError("Derived-to-base subobject offset exceeds IR range");
+		}
+		ComputeAddressOp address_op;
+		address_op.result = adjusted_address;
+		address_op.base = source;
+		address_op.base_storage = ValueStorage::ContainsAddress;
+		address_op.total_member_offset = static_cast<int>(base_conversion.offset);
+		address_op.result_type_index = target_type_index;
+		address_op.result_size_bits = target_size_bits;
+		ir_.addInstruction(IrInstruction(IrOpcode::ComputeAddress, std::move(address_op), source_token));
+	}
 	setTempVarMetadata(
 		adjusted_address,
 		TempVarMetadata::makeAddressOnly(
@@ -547,6 +579,84 @@ ExprResult AstToIr::adjustDerivedToBaseAddress(
 		IrOperand{adjusted_address},
 		PointerDepth{},
 		ValueStorage::ContainsAddress);
+}
+
+ExprResult AstToIr::adjustDerivedToBasePointer(
+	ExprResult source_pointer,
+	TypeIndex source_type_index,
+	TypeIndex target_type_index,
+	PointerDepth target_pointer_depth,
+	const Token& source_token) {
+	if (!source_type_index.isStruct() || !target_type_index.isStruct()) {
+		throw InternalError("Derived-to-base pointer adjustment requires struct type identity");
+	}
+	if (target_pointer_depth.value != 1) {
+		throw InternalError("Derived-to-base pointer adjustment requires a single target pointer level");
+	}
+	const DerivedBaseConversionInfo base_conversion =
+		classifyDerivedBaseConversion(source_type_index, target_type_index);
+	if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous) {
+		throw CompileError("Ambiguous derived-to-base pointer conversion");
+	}
+	if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
+		throw CompileError("Cannot convert to an inaccessible base class");
+	}
+	if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+		base_conversion.kind != DerivedBaseConversionKind::PublicVirtual) {
+		throw InternalError("Missing finalized layout for public derived-to-base pointer conversion");
+	}
+
+	IrOperand adjusted_value = source_pointer.value;
+	if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+		if (!base_conversion.virtual_base_index.has_value()) {
+			throw InternalError("Finalized virtual-base pointer conversion is missing its runtime table index");
+		}
+		const std::variant<StringHandle, TempVar> source = std::visit(
+			[](const auto& value) -> std::variant<StringHandle, TempVar> {
+				using Value = std::decay_t<decltype(value)>;
+				if constexpr (std::is_same_v<Value, TempVar> || std::is_same_v<Value, StringHandle>) {
+					return value;
+				}
+				throw InternalError("Virtual-base pointer conversion requires a runtime pointer value");
+			},
+			source_pointer.value);
+		VirtualBaseAdjustOp adjust_op;
+		adjust_op.result = var_counter.next();
+		adjust_op.source = source;
+		adjust_op.source_is_address = false;
+		adjust_op.source_type_index = source_type_index;
+		adjust_op.target_type_index = target_type_index;
+		adjust_op.virtual_base_index = *base_conversion.virtual_base_index;
+		const TempVar adjusted_pointer = adjust_op.result;
+		ir_.addInstruction(IrInstruction(IrOpcode::VirtualBaseAdjust, std::move(adjust_op), source_token));
+		adjusted_value = adjusted_pointer;
+	} else if (base_conversion.offset != 0) {
+		if (!std::holds_alternative<TempVar>(source_pointer.value) &&
+			!std::holds_alternative<StringHandle>(source_pointer.value) &&
+			!std::holds_alternative<unsigned long long>(source_pointer.value)) {
+			throw InternalError("Derived-to-base pointer conversion has an unsupported pointer value");
+		}
+		BinaryOp add_offset;
+		add_offset.lhs = makeTypedValue(
+			TypeCategory::UnsignedLongLong,
+			SizeInBits{POINTER_SIZE_BITS},
+			toIrValue(source_pointer.value));
+		add_offset.rhs = makeTypedValue(
+			TypeCategory::UnsignedLongLong,
+			SizeInBits{POINTER_SIZE_BITS},
+			static_cast<unsigned long long>(base_conversion.offset));
+		add_offset.result = var_counter.next();
+		const TempVar adjusted_pointer = std::get<TempVar>(add_offset.result);
+		ir_.addInstruction(IrInstruction(IrOpcode::Add, std::move(add_offset), source_token));
+		adjusted_value = adjusted_pointer;
+	}
+
+	return makeExprResult(
+		target_type_index,
+		SizeInBits{POINTER_SIZE_BITS},
+		std::move(adjusted_value),
+		target_pointer_depth,
+		ValueStorage::ContainsData);
 }
 
 std::optional<AstToIr::AddressComponents> AstToIr::makeAddressComponentsFromEvaluatedResult(
@@ -2760,9 +2870,8 @@ ExprResult AstToIr::applyConstructorArgConversion(ExprResult arg_result,
 					throw CompileError("Ambiguous derived-to-base conversion");
 				if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 					throw CompileError("Cannot convert to an inaccessible base class");
-				if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-					throw CompileError("Implicit conversion through a virtual base class is not supported");
-				if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+				if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+					base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 					throw InternalError("Sema annotated an unrelated derived-to-base constructor argument");
 
 				if (param_type.is_reference() || param_type.is_rvalue_reference()) {
@@ -2957,9 +3066,6 @@ std::optional<ExprResult> AstToIr::tryApplySemaCallArgReferenceBinding(ExprResul
 			throw CompileError("Ambiguous derived-to-base reference binding");
 		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 			throw CompileError("Cannot bind a reference to an inaccessible base class");
-		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-			throw CompileError("Reference binding through a virtual base class is not supported");
-
 		int target_size_bits = static_cast<int>(param_type.size_in_bits());
 		if (target_size_bits <= 0) {
 			const TypeInfo* target_type_info = tryGetTypeInfo(target_type_index);
@@ -3040,9 +3146,8 @@ std::optional<ExprResult> AstToIr::tryApplySemaCallArgReferenceBinding(ExprResul
 				throw CompileError("Ambiguous derived-to-base conversion");
 			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 				throw CompileError("Cannot convert to an inaccessible base class");
-			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-				throw CompileError("Implicit conversion through a virtual base class is not supported");
-			if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+			if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+				base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 				throw InternalError("Sema annotated an unrelated derived-to-base reference binding");
 
 			TypeSpecifierNode target_object_type = param_type;
@@ -3135,8 +3240,8 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 	}
 
 	std::optional<int64_t> effective_source_base_class_offset = source_base_class_offset;
-	if (!effective_source_base_class_offset.has_value() &&
-		source_result.category() == TypeCategory::Struct &&
+	std::optional<DerivedBaseConversionInfo> virtual_base_conversion;
+	if (source_result.category() == TypeCategory::Struct &&
 		source_result.type_index.is_valid() &&
 		source_result.type_index != target_type.type_index() &&
 		isSameTypeCopyOrMoveConstructorCandidate(*target_struct_info, selected_ctor)) {
@@ -3146,16 +3251,67 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 			throw CompileError("Ambiguous derived-to-base conversion");
 		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 			throw CompileError("Cannot convert to an inaccessible base class");
-		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-			throw CompileError("Implicit conversion through a virtual base class is not supported");
-		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+			base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 			throw InternalError("Selected copy/move constructor has an unrelated source type");
-		effective_source_base_class_offset = base_conversion.offset;
+		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+			virtual_base_conversion = base_conversion;
+			effective_source_base_class_offset.reset();
+		} else if (!effective_source_base_class_offset.has_value()) {
+			effective_source_base_class_offset = base_conversion.offset;
+		}
 	}
 
 	int actual_size_bits = static_cast<int>(target_type.size_in_bits());
 	if (target_struct_info->sizeInBytes().is_set()) {
 		actual_size_bits = static_cast<int>(target_struct_info->sizeInBits().value);
+	}
+
+	if (virtual_base_conversion.has_value()) {
+		if (!virtual_base_conversion->virtual_base_index.has_value()) {
+			throw InternalError("Finalized virtual-base conversion is missing its runtime table index");
+		}
+		ExprResult source_address = source_result;
+		if (source_address.storage != ValueStorage::ContainsAddress) {
+			if (source_expr.is<ExpressionNode>()) {
+				source_address = materializeAddressResult(
+					source_expr.as<ExpressionNode>(),
+					std::move(source_address),
+					source_token);
+			} else if (const auto* source_name = std::get_if<StringHandle>(&source_address.value)) {
+				TempVar address_temp = emitAddressOf(
+					source_address.category(),
+					source_address.size_in_bits.value,
+					IrValue(*source_name),
+					source_token);
+				source_address = makeExprResult(
+					source_address.type_index,
+					SizeInBits{POINTER_SIZE_BITS},
+					IrOperand{address_temp},
+					PointerDepth{},
+					ValueStorage::ContainsAddress);
+			} else if (const auto* source_temp = std::get_if<TempVar>(&source_address.value)) {
+				TempVar address_temp = emitAddressOf(
+					source_address.category(),
+					source_address.size_in_bits.value,
+					IrValue(*source_temp),
+					source_token);
+				source_address = makeExprResult(
+					source_address.type_index,
+					SizeInBits{POINTER_SIZE_BITS},
+					IrOperand{address_temp},
+					PointerDepth{},
+					ValueStorage::ContainsAddress);
+			} else {
+				throw InternalError("Virtual-base copy/move source is not addressable");
+			}
+		}
+		source_result = adjustDerivedToBaseAddress(
+			std::move(source_address),
+			source_result.type_index,
+			target_type.type_index(),
+			SizeInBits{actual_size_bits},
+			source_token);
 	}
 
 	TempVar result_var = var_counter.next();
@@ -3181,7 +3337,7 @@ std::optional<ExprResult> AstToIr::materializeSelectedConvertingConstructor(
 			throw InternalError("Derived-to-base constructor argument offset exceeds IR range");
 		}
 		ctor_op.source_base_class_offset = static_cast<int>(*effective_source_base_class_offset);
-	} else {
+	} else if (!virtual_base_conversion.has_value()) {
 		source_result = applyConstructorArgConversion(source_result, source_expr, param_type, source_token);
 	}
 
@@ -3261,9 +3417,8 @@ std::optional<ExprResult> AstToIr::tryMaterializeSemaSelectedConvertingConstruct
 			throw CompileError("Ambiguous derived-to-base conversion");
 		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 			throw CompileError("Cannot convert to an inaccessible base class");
-		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-			throw CompileError("Implicit conversion through a virtual base class is not supported");
-		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+			base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 			throw InternalError("Sema selected a derived-to-base constructor for unrelated types");
 		source_base_class_offset = base_conversion.offset;
 	}

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -826,7 +826,12 @@ TypedValue AstToIr::buildConstructorArgumentValue(
 
 		if (arg_decl) {
 			const auto& arg_type = arg_decl->type_specifier_node();
-			if (arg_type.is_reference() || arg_type.is_rvalue_reference()) {
+			if (argument_result.storage == ValueStorage::ContainsAddress) {
+				// A conversion such as derived-to-virtual-base reference binding may
+				// already have produced the final subobject address.  Preserve it;
+				// taking the identifier's address again would discard the adjustment.
+				value = toTypedValue(argument_result);
+			} else if (arg_type.is_reference() || arg_type.is_rvalue_reference()) {
 				value = toTypedValue(argument_result);
 			} else {
 				TempVar addr_var = var_counter.next();

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -883,17 +883,40 @@ ExprResult AstToIr::generateStaticCastIr(const StaticCastNode& staticCastNode) {
 		}
 		return carriesSemanticTypeIndex(semantic_type);
 	};
+	auto adjustStaticCastDerivedReference = [&]() {
+		if (!source_type_index.isStruct() || !target_type_index.isStruct() ||
+			source_type_index == target_type_index) {
+			return;
+		}
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(source_type_index, target_type_index);
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base reference cast");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot cast to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+			base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+			expr_operands = adjustDerivedToBaseAddress(
+				std::move(expr_operands),
+				source_type_index,
+				target_type_index,
+				SizeInBits{target_size},
+				staticCastNode.cast_token());
+		}
+	};
 
-		// Special handling for rvalue reference casts: static_cast<T&&>(expr)
-		// This produces an xvalue - has identity but can be moved from
+	// Special handling for rvalue reference casts: static_cast<T&&>(expr)
+	// This produces an xvalue - has identity but can be moved from
 	// Equivalent to std::move
 	if (target_type_node.is_rvalue_reference()) {
+		adjustStaticCastDerivedReference();
 		return handleRValueReferenceCast(expr_operands, target_size, target_type_index, staticCastNode.cast_token(), "static_cast");
 	}
 
-		// Special handling for lvalue reference casts: static_cast<T&>(expr)
+	// Special handling for lvalue reference casts: static_cast<T&>(expr)
 	// This produces an lvalue
 	if (target_type_node.is_lvalue_reference()) {
+		adjustStaticCastDerivedReference();
 		return handleLValueReferenceCast(expr_operands, target_size, target_type_index, staticCastNode.cast_token(), "static_cast");
 	}
 
@@ -913,8 +936,38 @@ ExprResult AstToIr::generateStaticCastIr(const StaticCastNode& staticCastNode) {
 				throw CompileError("Ambiguous derived-to-base pointer cast");
 			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 				throw CompileError("Cannot cast to an inaccessible base class");
-			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-				throw CompileError("Pointer cast through a virtual base class is not supported");
+			if ((base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+				 base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) &&
+				target_pointer_depth != 1) {
+				throw CompileError("Derived-to-base pointer casts require a single pointer level");
+			}
+			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+				if (!base_conversion.virtual_base_index.has_value()) {
+					throw InternalError("Finalized virtual-base pointer cast is missing its runtime table index");
+				}
+				if (!std::holds_alternative<TempVar>(expr_operands.value) &&
+					!std::holds_alternative<StringHandle>(expr_operands.value)) {
+					throw InternalError("Virtual-base pointer cast requires a pointer value");
+				}
+				TempVar adjusted_ptr = var_counter.next();
+				VirtualBaseAdjustOp adjust_op;
+				adjust_op.result = adjusted_ptr;
+				adjust_op.source = std::visit(
+					[](const auto& value) -> std::variant<StringHandle, TempVar> {
+						using Value = std::decay_t<decltype(value)>;
+						if constexpr (std::is_same_v<Value, TempVar> || std::is_same_v<Value, StringHandle>) {
+							return value;
+						}
+						throw InternalError("Unsupported virtual-base pointer cast operand");
+					},
+					expr_operands.value);
+				adjust_op.source_is_address = false;
+				adjust_op.source_type_index = source_type_index;
+				adjust_op.target_type_index = target_type_index;
+				adjust_op.virtual_base_index = *base_conversion.virtual_base_index;
+				ir_.addInstruction(IrInstruction(IrOpcode::VirtualBaseAdjust, std::move(adjust_op), staticCastNode.cast_token()));
+				return makeExprResult(target_type_index, SizeInBits{64}, IrOperand{adjusted_ptr}, PointerDepth{static_cast<int>(target_pointer_depth)}, ValueStorage::ContainsData);
+			}
 			if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual &&
 				base_conversion.offset > 0) {
 				TempVar adjusted_ptr = var_counter.next();

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -2078,9 +2078,29 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 
 						// Check if source and target types differ and source is a struct
 					bool need_conversion = (init_type != type_node.type()) ||
-										   (init_cat == TypeCategory::Struct && init_type_index != type_node.type_index());
+											   (init_cat == TypeCategory::Struct && init_type_index != type_node.type_index());
 
 					bool conv_op_applied = false;
+					if (need_conversion && init_cat == TypeCategory::Struct &&
+						(type_node.is_reference() || type_node.is_rvalue_reference()) &&
+						init_type_index.isStruct() && type_node.type_index().isStruct()) {
+						const DerivedBaseConversionInfo base_conversion =
+							classifyDerivedBaseConversion(init_type_index, type_node.type_index());
+						if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+							throw CompileError("Ambiguous derived-to-base reference binding");
+						if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+							throw CompileError("Cannot bind a reference to an inaccessible base class");
+						if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+							base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+							init_operands = adjustDerivedToBaseAddress(
+								std::move(init_operands),
+								init_type_index,
+								type_node.type_index(),
+								SizeInBits{static_cast<int>(type_node.size_in_bits())},
+								decl.identifier_token());
+							conv_op_applied = true;
+						}
+					}
 					if (need_conversion && init_cat == TypeCategory::Struct) {
 							// First check for a sema-annotated user-defined conversion
 						if (init_node.is<ExpressionNode>()) {
@@ -2139,8 +2159,6 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							classifyDerivedBaseConversion(init_type_index, type_node.type_index());
 						if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
 							throw CompileError("Ambiguous derived-to-base pointer conversion");
-						if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-							throw CompileError("Implicit conversion through a virtual base class is not supported");
 						if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
 							const TypeInfo* src_info = tryGetTypeInfo(init_type_index);
 							const TypeInfo* tgt_info = tryGetTypeInfo(type_node.type_index());
@@ -2788,6 +2806,21 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 							}
 
 							bool same_type_copy_init_source = false;
+							std::optional<DerivedBaseConversionInfo> derived_base_copy_init;
+							if (init_cat == TypeCategory::Struct &&
+								init_type_index.is_valid() &&
+								type_node.type_index().is_valid() &&
+								init_type_index != type_node.type_index()) {
+								const DerivedBaseConversionInfo base_conversion =
+									classifyDerivedBaseConversion(init_type_index, type_node.type_index());
+								if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+									throw CompileError("Ambiguous derived-to-base conversion");
+								if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+									throw CompileError("Cannot convert to an inaccessible base class");
+								if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+									base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
+									derived_base_copy_init = base_conversion;
+							}
 							if (auto same_type_ctor_preference = getSameTypeConstructorPreference(init_node, type_node);
 								same_type_ctor_preference.has_value()) {
 								same_type_copy_init_source = true;
@@ -2801,6 +2834,8 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 										isSameStructTypeForInitialization(init_desc.type_index, type_node.type_index());
 								}
 							}
+							if (derived_base_copy_init.has_value())
+								same_type_copy_init_source = false;
 
 								// Check if types differ
 							is_converting_ctor = !same_type_copy_init_source &&
@@ -2831,11 +2866,11 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 													throw CompileError("Ambiguous derived-to-base conversion");
 												if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 													throw CompileError("Cannot convert to an inaccessible base class");
-												if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-													throw CompileError("Implicit conversion through a virtual base class is not supported");
-												if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+												if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+													base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 													throw InternalError("Sema selected an unrelated derived-to-base constructor");
-												sema_source_base_class_offset = base_conversion.offset;
+												if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual)
+													sema_source_base_class_offset = base_conversion.offset;
 											}
 											const auto& ctor_params = sema_selected_converting_ctor->parameter_nodes();
 												if (!ctor_params.empty() && ctor_params[0].is<DeclarationNode>()) {

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -2000,51 +2000,137 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 		}
 	}
 
+	auto makeVirtualBaseTableSymbol = [](TypeIndex most_derived_type,
+		TypeIndex source_type,
+		size_t source_offset) {
+		return StringTable::getOrInternStringHandle(
+			StringBuilder()
+				.append("__flashcpp_vbase_table_")
+				.append(static_cast<uint64_t>(most_derived_type.index()))
+				.append('_')
+				.append(static_cast<uint64_t>(source_type.index()))
+				.append('_')
+				.append(static_cast<uint64_t>(source_offset))
+				.commit());
+	};
+
+	auto findMostDerivedVirtualBaseOffset = [](const StructTypeInfo* most_derived_type,
+		TypeIndex virtual_base_type) -> std::optional<size_t> {
+		if (!most_derived_type) {
+			return std::nullopt;
+		}
+		for (const auto& virtual_base : most_derived_type->virtual_bases) {
+			if (virtual_base.type_index == virtual_base_type) {
+				return virtual_base.offset;
+			}
+		}
+		return std::nullopt;
+	};
+
 	auto emitVptrStores = [&](const StructTypeInfo* struct_info, const TypeInfo* struct_type_info, bool include_virtual_base_vptrs) {
-		if (!struct_info || !struct_info->has_vtable) {
+		if (!struct_info || (!struct_info->has_vtable && struct_info->virtual_bases.empty())) {
 			return;
 		}
 
-		auto vtable_symbol = StringTable::getOrInternStringHandle(struct_info->vtable_symbol);
+		const TypeIndex most_derived_type = struct_type_info
+			? struct_type_info->type_index_
+			: struct_info->own_type_index_.value_or(TypeIndex{});
+		if (!most_derived_type.is_valid()) {
+			throw InternalError("Runtime virtual-base initialization is missing the most-derived type index");
+		}
 
-		MemberStoreOp vptr_store;
-		vptr_store.object = StringTable::getOrInternStringHandle("this");
-		vptr_store.member_name = StringTable::getOrInternStringHandle("__vptr");
-		vptr_store.offset = 0;
-		vptr_store.struct_type_info = struct_type_info;
-		vptr_store.ref_qualifier = CVReferenceQualifier::None;
-		vptr_store.vtable_symbol = vtable_symbol;
-		vptr_store.value.setType(TypeCategory::Void);
-		vptr_store.value.ir_type = IrType::Void;
-		vptr_store.value.size_in_bits = SizeInBits{64};
-		vptr_store.value.value = static_cast<unsigned long long>(0);
-		ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(vptr_store), node.name_token()));
+		auto addDispatchStore = [&](int64_t offset,
+			StringHandle vtable_symbol,
+			StringHandle virtual_base_table_symbol,
+			InlineVector<int32_t, 1> virtual_base_table_offsets) {
+			if (offset < 0 || offset > std::numeric_limits<int>::max()) {
+				throw InternalError("Runtime dispatch pointer offset exceeds IR range");
+			}
+			MemberStoreOp dispatch_store;
+			dispatch_store.object = StringTable::getOrInternStringHandle("this");
+			dispatch_store.member_name = StringTable::getOrInternStringHandle("__runtime_dispatch");
+			dispatch_store.offset = static_cast<int>(offset);
+			dispatch_store.struct_type_info = struct_type_info;
+			dispatch_store.ref_qualifier = CVReferenceQualifier::None;
+			dispatch_store.vtable_symbol = vtable_symbol;
+			dispatch_store.virtual_base_table_symbol = virtual_base_table_symbol;
+			dispatch_store.virtual_base_table_offsets = std::move(virtual_base_table_offsets);
+			dispatch_store.value.setType(TypeCategory::Void);
+			dispatch_store.value.ir_type = IrType::Void;
+			dispatch_store.value.size_in_bits = SizeInBits{64};
+			dispatch_store.value.value = static_cast<unsigned long long>(0);
+			ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(dispatch_store), node.name_token()));
+		};
+
+		auto emitVirtualBaseTable = [&](const StructTypeInfo* source_struct_info,
+			TypeIndex source_type_index,
+			size_t source_offset) {
+			if (!source_struct_info || source_struct_info->has_vtable || source_struct_info->virtual_bases.empty()) {
+				return;
+			}
+			if (!source_type_index.is_valid()) {
+				source_type_index = source_struct_info->own_type_index_.value_or(TypeIndex{});
+			}
+			if (!source_type_index.is_valid()) {
+				throw InternalError("Virtual-base table initialization is missing the source type index");
+			}
+
+			InlineVector<int32_t, 1> offsets;
+			offsets.reserve(source_struct_info->virtual_bases.size());
+			for (const auto& virtual_base : source_struct_info->virtual_bases) {
+				const std::optional<size_t> absolute_offset =
+					findMostDerivedVirtualBaseOffset(struct_info, virtual_base.type_index);
+				if (!absolute_offset.has_value() || *absolute_offset < source_offset) {
+					throw InternalError("Virtual-base table initialization cannot resolve a reachable virtual base offset");
+				}
+				const size_t relative_offset = *absolute_offset - source_offset;
+				if (relative_offset > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+					throw InternalError("Virtual-base table offset exceeds 32-bit IR range");
+				}
+				offsets.push_back(static_cast<int32_t>(relative_offset));
+			}
+
+			addDispatchStore(
+				static_cast<int64_t>(source_offset),
+				StringHandle{},
+				makeVirtualBaseTableSymbol(most_derived_type, source_type_index, source_offset),
+				std::move(offsets));
+		};
+
+		if (struct_info->has_vtable) {
+			addDispatchStore(
+				0,
+				StringTable::getOrInternStringHandle(struct_info->vtable_symbol),
+				StringHandle{},
+				{});
+		} else {
+			emitVirtualBaseTable(
+				struct_info,
+				most_derived_type,
+				0);
+		}
 
 		for (const auto& base : struct_info->base_classes) {
-			if (base.is_virtual || base.offset == 0) {
+			if (base.is_virtual) {
 				continue;
 			}
 			const TypeInfo* base_type_info = tryGetTypeInfo(base.type_index);
 			const StructTypeInfo* base_struct_info = base_type_info ? base_type_info->getStructInfo() : nullptr;
-			if (!base_struct_info || !base_struct_info->has_vtable) {
+			if (!base_struct_info || base.offset == 0) {
 				continue;
 			}
-
-			MemberStoreOp secondary_vptr_store;
-			secondary_vptr_store.object = StringTable::getOrInternStringHandle("this");
-			secondary_vptr_store.member_name = StringTable::getOrInternStringHandle("__vptr");
-			secondary_vptr_store.offset = static_cast<int>(base.offset);
-			secondary_vptr_store.struct_type_info = struct_type_info;
-			secondary_vptr_store.ref_qualifier = CVReferenceQualifier::None;
-			secondary_vptr_store.vtable_symbol = NameMangling::generateSecondaryVTableSymbol(
-				struct_name_for_ctor,
-				StringTable::getStringView(base_type_info->name()),
-				base.offset);
-			secondary_vptr_store.value.setType(TypeCategory::Void);
-			secondary_vptr_store.value.ir_type = IrType::Void;
-			secondary_vptr_store.value.size_in_bits = SizeInBits{64};
-			secondary_vptr_store.value.value = static_cast<unsigned long long>(0);
-			ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(secondary_vptr_store), node.name_token()));
+			if (base_struct_info->has_vtable) {
+				addDispatchStore(
+					static_cast<int64_t>(base.offset),
+					NameMangling::generateSecondaryVTableSymbol(
+						struct_name_for_ctor,
+						StringTable::getStringView(base_type_info->name()),
+						base.offset),
+					StringHandle{},
+					{});
+			} else {
+				emitVirtualBaseTable(base_struct_info, base.type_index, base.offset);
+			}
 		}
 
 		if (include_virtual_base_vptrs) {
@@ -2054,25 +2140,21 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 				}
 				const TypeInfo* base_type_info = tryGetTypeInfo(virtual_base.type_index);
 				const StructTypeInfo* base_struct_info = base_type_info ? base_type_info->getStructInfo() : nullptr;
-				if (!base_struct_info || !base_struct_info->has_vtable) {
+				if (!base_struct_info) {
 					continue;
 				}
-
-				MemberStoreOp secondary_vptr_store;
-				secondary_vptr_store.object = StringTable::getOrInternStringHandle("this");
-				secondary_vptr_store.member_name = StringTable::getOrInternStringHandle("__vptr");
-				secondary_vptr_store.offset = static_cast<int>(virtual_base.offset);
-				secondary_vptr_store.struct_type_info = struct_type_info;
-				secondary_vptr_store.ref_qualifier = CVReferenceQualifier::None;
-				secondary_vptr_store.vtable_symbol = NameMangling::generateSecondaryVTableSymbol(
-					struct_name_for_ctor,
-					StringTable::getStringView(base_type_info->name()),
-					virtual_base.offset);
-				secondary_vptr_store.value.setType(TypeCategory::Void);
-				secondary_vptr_store.value.ir_type = IrType::Void;
-				secondary_vptr_store.value.size_in_bits = SizeInBits{64};
-				secondary_vptr_store.value.value = static_cast<unsigned long long>(0);
-				ir_.addInstruction(IrInstruction(IrOpcode::MemberStore, std::move(secondary_vptr_store), node.name_token()));
+				if (base_struct_info->has_vtable) {
+					addDispatchStore(
+						static_cast<int64_t>(virtual_base.offset),
+						NameMangling::generateSecondaryVTableSymbol(
+						struct_name_for_ctor,
+						StringTable::getStringView(base_type_info->name()),
+						virtual_base.offset),
+						StringHandle{},
+						{});
+				} else {
+					emitVirtualBaseTable(base_struct_info, virtual_base.type_index, virtual_base.offset);
+				}
 			}
 		}
 	};

--- a/src/IrGenerator_Visitors_Namespace.cpp
+++ b/src/IrGenerator_Visitors_Namespace.cpp
@@ -377,6 +377,24 @@ void AstToIr::visitReturnStatementNode(const ReturnStatementNode& node) {
 								}
 							}
 						}
+					} else if (cast_info.cast_kind == StandardConversionKind::DerivedToBase &&
+						annotated_source_type == TypeCategory::Struct &&
+						to_type == TypeCategory::Struct &&
+						!sema_.typeContext().get(cast_info.source_type_id).pointer_levels.empty() &&
+						!sema_.typeContext().get(cast_info.target_type_id).pointer_levels.empty()) {
+						const TypeIndex source_type_index =
+							sema_.typeContext().get(cast_info.source_type_id).type_index;
+						const TypeIndex target_type_index =
+							sema_.typeContext().get(cast_info.target_type_id).type_index;
+						const size_t target_pointer_depth =
+							sema_.typeContext().get(cast_info.target_type_id).pointer_levels.size();
+						operands = adjustDerivedToBasePointer(
+							std::move(operands),
+							source_type_index,
+							target_type_index,
+							PointerDepth{static_cast<int>(target_pointer_depth)},
+							node.return_token());
+						sema_applied_conversion = true;
 					} else if (cast_info.cast_kind == StandardConversionKind::ArrayToPointer) {
 						if (std::holds_alternative<TempVar>(operands.value)) {
 							TempVar return_temp = std::get<TempVar>(operands.value);

--- a/src/ObjFileWriter.h
+++ b/src/ObjFileWriter.h
@@ -552,7 +552,7 @@ public:
 	void finalize_debug_info();
 	std::string_view add_string_literal(std::string_view str_content);
 	void add_global_variable_data(std::string_view var_name, size_t size_in_bytes, bool is_initialized, std::span<const char> init_data, bool is_rodata, bool is_selectany);
-	void add_vtable(std::string_view vtable_symbol, std::span<const std::string_view> function_symbols, std::string_view class_name, std::span<const std::string_view> base_class_names, std::span<const BaseClassDescriptorInfo> base_class_info, const RTTITypeInfo* rtti_info = nullptr, TypeIndex subobject_type_index = {}, int64_t offset_to_top = 0);
+	void add_vtable(std::string_view vtable_symbol, std::span<const std::string_view> function_symbols, std::string_view class_name, std::span<const std::string_view> base_class_names, std::span<const BaseClassDescriptorInfo> base_class_info, std::span<const int64_t> virtual_base_offsets, const RTTITypeInfo* rtti_info = nullptr, TypeIndex subobject_type_index = {}, int64_t offset_to_top = 0);
 	std::string get_or_create_builtin_throwinfo(TypeCategory type);
 	std::string get_or_create_type_descriptor(std::string_view class_name);
 	std::string get_or_create_type_descriptor(std::string_view class_name, TypeIndex type_index);

--- a/src/ObjFileWriter_RTTI.cpp
+++ b/src/ObjFileWriter_RTTI.cpp
@@ -435,6 +435,7 @@ void ObjectFileWriter::add_global_variable_data(std::string_view var_name, size_
 void ObjectFileWriter::add_vtable(std::string_view vtable_symbol, std::span<const std::string_view> function_symbols,
 								  std::string_view class_name, std::span<const std::string_view> base_class_names,
 								  std::span<const BaseClassDescriptorInfo> base_class_info,
+								  std::span<const int64_t> virtual_base_offsets,
 								  [[maybe_unused]] const RTTITypeInfo* rtti_info,
 								  [[maybe_unused]] TypeIndex subobject_type_index,
 								  [[maybe_unused]] int64_t offset_to_top) {
@@ -677,19 +678,25 @@ void ObjectFileWriter::add_vtable(std::string_view vtable_symbol, std::span<cons
 				  << col_offset << std::endl;
 
 	// Step 2: Emit vtable structure
-	// Layout: [COL pointer (8 bytes), function pointers...]
+	// Layout: [vbase offsets in reverse order][COL pointer][function pointers...]
 	uint32_t vtable_offset = static_cast<uint32_t>(rdata_section->get_data_size());
 
-	// Add COL pointer + function pointers
-	size_t vtable_size = (1 + function_symbols.size()) * 8;	// 1 COL ptr + N function ptrs
+	// The vptr points at the first function. Keeping the entries in reverse
+	// order makes virtual-base index zero the closest entry, matching the
+	// Itanium prefix convention and the backend's vtable[-(2+i)] lookup.
+	size_t vtable_size = (virtual_base_offsets.size() + 1 + function_symbols.size()) * 8;
 	std::vector<char> vtable_data(vtable_size, 0);
+	for (size_t i = 0; i < virtual_base_offsets.size(); ++i) {
+		const int64_t offset = virtual_base_offsets[virtual_base_offsets.size() - 1 - i];
+		std::memcpy(vtable_data.data() + i * sizeof(int64_t), &offset, sizeof(offset));
+	}
 
 	// Add the vtable data to .rdata section
 	add_data(vtable_data, SectionType::RDATA);
 
 	// Add relocation for COL (Complete Object Locator) pointer at vtable[0] (before actual vtable)
 	{
-		uint32_t col_reloc_offset = vtable_offset;
+		uint32_t col_reloc_offset = vtable_offset + static_cast<uint32_t>(virtual_base_offsets.size() * 8);
 
 		if (g_enable_debug_output)
 			std::cerr << "  DEBUG: Creating COL relocation at offset " << col_reloc_offset
@@ -706,8 +713,8 @@ void ObjectFileWriter::add_vtable(std::string_view vtable_symbol, std::span<cons
 			std::cerr << "  Added COL pointer relocation at vtable[-1]" << std::endl;
 	}
 
-	// Step 3: Add a symbol for vtable (points to first virtual function, AFTER RTTI pointer)
-	uint32_t vtable_symbol_offset = vtable_offset + 8;  // Skip RTTI pointer
+	// Step 3: Add a symbol for vtable (points to first virtual function, AFTER COL)
+	uint32_t vtable_symbol_offset = vtable_offset + static_cast<uint32_t>((virtual_base_offsets.size() + 1) * 8);
 	auto symbol = coffi_.add_symbol(std::string(vtable_symbol));
 	symbol->set_type(IMAGE_SYM_TYPE_NOT_FUNCTION);
 	symbol->set_storage_class(IMAGE_SYM_CLASS_EXTERNAL);	 // Vtables are external
@@ -721,7 +728,7 @@ void ObjectFileWriter::add_vtable(std::string_view vtable_symbol, std::span<cons
 			continue;
 		}
 
-		uint32_t reloc_offset = vtable_offset + 8 + static_cast<uint32_t>(i * 8);  // +8 to skip RTTI ptr
+		uint32_t reloc_offset = vtable_symbol_offset + static_cast<uint32_t>(i * 8);
 
 		// Get the symbol index (COFFI handles aux entries automatically)
 		uint32_t func_symbol_index = get_or_create_symbol_index(std::string(function_symbols[i]));

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -436,6 +436,11 @@ enum class DerivedBaseConversionKind : uint8_t {
 struct DerivedBaseConversionInfo {
 	DerivedBaseConversionKind kind = DerivedBaseConversionKind::NotRelated;
 	int64_t offset = 0;
+	// Index in the derived type's finalized virtual_bases collection.  The
+	// offset of a virtual base is object-dependent, so callers must use this
+	// index with the runtime virtual-base table/vtable rather than treating
+	// offset as a fixed adjustment.
+	std::optional<size_t> virtual_base_index;
 };
 
 // Classify all inheritance paths from derived_idx to base_idx.  A virtual base
@@ -446,7 +451,7 @@ inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived
 	if (!derived_idx.is_valid() || !base_idx.is_valid())
 		return {};
 	if (derived_idx == base_idx)
-		return {DerivedBaseConversionKind::UniquePublicNonVirtual, 0};
+		return {DerivedBaseConversionKind::UniquePublicNonVirtual, 0, std::nullopt};
 
 	const TypeInfo* derived_type_info = tryGetTypeInfo(derived_idx);
 	const StructTypeInfo* derived_struct =
@@ -512,14 +517,25 @@ inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived
 	if (non_virtual_path_count > 1 ||
 		(!public_virtual_subobjects.empty() &&
 		 (non_virtual_path_count != 0 || !inaccessible_virtual_subobjects.empty()))) {
-		return {DerivedBaseConversionKind::Ambiguous, 0};
+		return {DerivedBaseConversionKind::Ambiguous, 0, std::nullopt};
 	}
 	if (public_non_virtual_path_count == 1 && non_virtual_path_count == 1)
-		return {DerivedBaseConversionKind::UniquePublicNonVirtual, public_non_virtual_offset};
-	if (!public_virtual_subobjects.empty())
-		return {DerivedBaseConversionKind::PublicVirtual, 0};
+		return {DerivedBaseConversionKind::UniquePublicNonVirtual, public_non_virtual_offset, std::nullopt};
+	if (!public_virtual_subobjects.empty()) {
+		DerivedBaseConversionInfo result{DerivedBaseConversionKind::PublicVirtual, 0, std::nullopt};
+		const auto virtual_base_it = std::find_if(
+			derived_struct->virtual_bases.begin(),
+			derived_struct->virtual_bases.end(),
+			[&](const BaseClassSpecifier& base) { return base.type_index == base_idx; });
+		if (virtual_base_it != derived_struct->virtual_bases.end()) {
+			result.virtual_base_index = static_cast<size_t>(
+				std::distance(derived_struct->virtual_bases.begin(), virtual_base_it));
+			result.offset = static_cast<int64_t>(virtual_base_it->offset);
+		}
+		return result;
+	}
 	if (saw_inaccessible)
-		return {DerivedBaseConversionKind::Inaccessible, 0};
+		return {DerivedBaseConversionKind::Inaccessible, 0, std::nullopt};
 	return {};
 }
 
@@ -803,7 +819,8 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				from_resolved_index.is_valid() && to_resolved_index.is_valid() &&
 				from_resolved_index != to_resolved_index) {
 				// Derived* → Base* is a valid pointer conversion (C++20 [conv.ptr]/3).
-				if (hasUsablePublicDerivedBaseConversion(from_resolved_index, to_resolved_index)) {
+				if (from.pointer_depth() == 1 && to.pointer_depth() == 1 &&
+					hasUsablePublicDerivedBaseConversion(from_resolved_index, to_resolved_index)) {
 					return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 				}
 				return ConversionPlan::no_match();
@@ -818,7 +835,8 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 				from_resolved_index.is_valid() && to_resolved_index.is_valid() &&
 				from_resolved_index != to_resolved_index) {
 				// Derived* → Base* is valid with const qualification adjustment too.
-				if (pointee_qualification_is_added &&
+				if (from.pointer_depth() == 1 && to.pointer_depth() == 1 &&
+					pointee_qualification_is_added &&
 					hasUsablePublicDerivedBaseConversion(from_resolved_index, to_resolved_index)) {
 					return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 				}
@@ -891,6 +909,7 @@ inline ConversionPlan buildConversionPlan(const TypeSpecifierNode& from, const T
 						// Per C++20 [conv.ref]/4: derived lvalue ref binds to base lvalue ref
 						// (standard derived-to-base reference conversion).
 						if (!from_is_rvalue && !to_is_rvalue &&
+							from.pointer_depth() == 0 && to.pointer_depth() == 0 &&
 							hasUsablePublicDerivedBaseConversion(from_base_index, to_base_index)) {
 							return {ConversionRank::Conversion, StandardConversionKind::DerivedToBase, true};
 						}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -6884,6 +6884,46 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 		return true;
 	}
 
+	// C++20 [conv.ptr] permits a pointer to a public derived class to convert
+	// to a pointer to its base class.  Check this before looking for a
+	// user-defined conversion operator: a pointer-to-struct descriptor has the
+	// same category shape as an operator returning a struct pointer, but an
+	// inheritance conversion is a standard conversion and must win here.
+	if (from_desc.category() == TypeCategory::Struct &&
+		to_desc.category() == TypeCategory::Struct &&
+		!from_desc.pointer_levels.empty() &&
+		!to_desc.pointer_levels.empty() &&
+		from_desc.array_dimensions.empty() &&
+		to_desc.array_dimensions.empty() &&
+		from_desc.pointer_levels.size() == 1 &&
+		to_desc.pointer_levels.size() == 1 &&
+		from_desc.type_index.is_valid() &&
+		to_desc.type_index.is_valid() &&
+		from_desc.type_index != to_desc.type_index) {
+		const DerivedBaseConversionInfo base_conversion =
+			classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
+			throw CompileError("Ambiguous derived-to-base pointer conversion");
+		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
+			throw CompileError("Cannot convert to an inaccessible base class");
+		if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+			base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
+			ImplicitCastInfo cast_info;
+			cast_info.source_type_id = expr_type_id;
+			cast_info.target_type_id = target_type_id;
+			cast_info.cast_kind = StandardConversionKind::DerivedToBase;
+			cast_info.value_category_after = ValueCategory::PRValue;
+			const CastInfoIndex idx = allocateCastInfo(cast_info);
+			SemanticSlot slot;
+			slot.type_id = target_type_id;
+			slot.cast_info_index = idx;
+			slot.value_category = ValueCategory::PRValue;
+			setSlot(getExpressionKey(expr_node), slot);
+			stats_.slots_filled++;
+			return true;
+		}
+	}
+
 	if (from_desc.category() == TypeCategory::Struct &&
 		!to_desc.pointer_levels.empty() &&
 		to_desc.array_dimensions.empty()) {
@@ -6924,6 +6964,8 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 	// constructor; a raw byte slice would skip user-defined special-member logic.
 	if (from_desc.category() == TypeCategory::Struct &&
 		to_desc.category() == TypeCategory::Struct &&
+		from_desc.pointer_levels.empty() &&
+		to_desc.pointer_levels.empty() &&
 		from_desc.type_index.is_valid() &&
 		to_desc.type_index.is_valid() &&
 		from_desc.type_index != to_desc.type_index) {
@@ -6945,9 +6987,8 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 			throw CompileError("Ambiguous derived-to-base conversion");
 		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
 			throw CompileError("Cannot convert to an inaccessible base class");
-		if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual)
-			throw CompileError("Implicit conversion through a virtual base class is not supported");
-		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual)
+		if (base_conversion.kind != DerivedBaseConversionKind::UniquePublicNonVirtual &&
+			base_conversion.kind != DerivedBaseConversionKind::PublicVirtual)
 			return false;
 
 		// Reference conversions do not construct a new Base object, so the
@@ -7324,10 +7365,8 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 			if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible) {
 				throw CompileError("Cannot convert to an inaccessible base class");
 			}
-			if (base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
-				throw CompileError("Implicit conversion through a virtual base class is not supported");
-			}
-			if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual) {
+			if (base_conversion.kind == DerivedBaseConversionKind::UniquePublicNonVirtual ||
+				base_conversion.kind == DerivedBaseConversionKind::PublicVirtual) {
 				const bool prefer_move_ctor = !arg_type.is_lvalue_reference();
 				const StructMemberFunction* same_type_ctor =
 					struct_info->findPreferredSameTypeConstructor(prefer_move_ctor, true);
@@ -7537,11 +7576,11 @@ void SemanticAnalysis::tryAnnotateReturnConversion(const ASTNode& expr_node, con
 	if (isSameTypeConstructorCallInitialization(expr_node, *ctx.current_function_return_type_id)) {
 		return;
 	}
-	if (!tryAnnotateCopyInitConvertingConstructor(expr_node, *ctx.current_function_return_type_id,
-												  " in return statement")) {
+	if (!tryAnnotateCopyInitConvertingConstructor(
+			expr_node, *ctx.current_function_return_type_id, " in return statement")) {
 		tryAnnotateConversion(expr_node, *ctx.current_function_return_type_id);
 		diagnoseScopedEnumConversion(expr_node, *ctx.current_function_return_type_id,
-									 " in return statement");
+										 " in return statement");
 	}
 }
 

--- a/tests/test_virtual_base_derived_to_base_ret0.cpp
+++ b/tests/test_virtual_base_derived_to_base_ret0.cpp
@@ -1,0 +1,98 @@
+struct Base {
+	int value;
+	Base(int v) : value(v) {}
+	Base(const Base& other) : value(other.value + 1000) {}
+};
+
+struct VirtualConsumer {
+	virtual int consume(Base value) {
+		return value.value;
+	}
+};
+
+struct Left : virtual public Base {
+	Left(int v) : Base(v) {}
+};
+
+struct Right : virtual public Base {
+	Right(int v) : Base(v) {}
+};
+
+struct Diamond : public Left, public Right {
+	Diamond(int v) : Base(v), Left(v), Right(v) {}
+};
+
+struct Middle : virtual public Base {
+	Middle(int v) : Base(v) {}
+};
+
+struct MostDerived : public Middle {
+	MostDerived(int v) : Base(v), Middle(v) {}
+};
+
+Base* from_left(Left* value) {
+	return value;
+}
+
+Base* from_right(Right* value) {
+	return value;
+}
+
+Base* from_middle(Middle* value) {
+	return value;
+}
+
+int take_base(Base value) {
+	return value.value;
+}
+
+Base return_base(Diamond& value) {
+	return value;
+}
+
+int main() {
+	Diamond diamond(10);
+	Base& reference = diamond;
+	Base& explicit_reference = static_cast<Base&>(diamond);
+	Base&& explicit_rvalue_reference = static_cast<Base&&>(diamond);
+	Base* direct_pointer = &diamond;
+	Base* explicit_pointer = static_cast<Base*>(&diamond);
+	Left* left_pointer = &diamond;
+	Right* right_pointer = &diamond;
+	Left* null_left_pointer = nullptr;
+	Base* null_base_pointer = null_left_pointer;
+
+	MostDerived most_derived(20);
+	Middle* middle_pointer = &most_derived;
+
+	Base copied = diamond;
+	Base returned = return_base(diamond);
+	VirtualConsumer virtual_consumer;
+	if (reference.value != 10)
+		return 1;
+	if (explicit_reference.value != 10)
+		return 2;
+	if (explicit_rvalue_reference.value != 10)
+		return 3;
+	if (direct_pointer->value != 10)
+		return 4;
+	if (explicit_pointer->value != 10)
+		return 5;
+	if (null_base_pointer != nullptr)
+		return 6;
+	if (from_left(left_pointer)->value != 10)
+		return 7;
+	if (from_right(right_pointer)->value != 10)
+		return 8;
+	if (from_middle(middle_pointer)->value != 20)
+		return 9;
+	if (copied.value != 1010)
+		return 10;
+	if (returned.value != 1010)
+		return 11;
+	if (take_base(diamond) != 1010)
+		return 12;
+	if (virtual_consumer.consume(diamond) != 1010)
+		return 13;
+	return 0;
+}


### PR DESCRIPTION
## Summary
- implement complete C++20 derived-to-base conversions through virtual bases
- carry virtual-base metadata through semantic analysis, IR, object writers, and runtime adjustment paths
- use compact inline virtual-base table offsets and add a passing regression test
- update KNOWN_ISSUES.md to document the implemented behavior
