### PR TITLE
Fix deferred template member replay and aliases

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -2,10 +2,11 @@
 
 ## Deferred `<tuple>` member emission and `swap` gaps
 
-The full `<tuple>` header still fails during deferred member emission after the
-reduced alias/materialization cases have completed. Constructor emission and
-some `swap` overload probes remain incomplete. The reduced partial-spec nested
-typedef shape (`using Ttype = Tuple<This, Rest...>`) is covered by
+The full `<tuple>` test still reaches link time with a small set of concrete
+tuple constructors unresolved after deferred member materialization. The
+standard-header test is therefore listed as an expected link failure in
+`tests/run_all_tests.ps1` until those constructor definitions are emitted.
+The reduced partial-spec nested typedef shape (`using Ttype = Tuple<This, Rest...>`) is covered by
 `tests/test_dependent_alias_tuple_element_get_ret0.cpp` and now materializes.
 The regression models an MSVC `tuple_element` / `get` chain with a dependent
 `ElemT = typename Elem<I, T>::type` alias and an index-zero partial
@@ -15,8 +16,9 @@ through a pointer cast so a dependent placeholder cannot survive into IR.
 Reference-returning member access through `static_cast<Ttype&>` is covered
 separately by `tests/test_static_cast_ref_member_address_ret0.cpp`.
 
-These remaining failures are generic deferred-member and overload-probe gaps,
-not library-name problems.
+The remaining failure is a generic deferred-constructor emission gap, not a
+library-name problem. The recursive constructor/swap and SFINAE regressions
+cover the generic mechanisms that are now working.
 
 ## Non-standard layout/constexpr acceptance gaps tracked as compatibility tests
 These tests are intentionally kept in compatibility form so the current FlashCpp

--- a/src/AstNodeTypes_Template.h
+++ b/src/AstNodeTypes_Template.h
@@ -564,6 +564,15 @@ public:
 		delegating_initializer_.emplace(std::move(args));
 	}
 
+	void replace_initializers(
+		std::vector<MemberInitializer> member_initializers,
+		std::vector<BaseInitializer> base_initializers,
+		std::optional<DelegatingInitializer> delegating_initializer) {
+		member_initializers_ = std::move(member_initializers);
+		base_initializers_ = std::move(base_initializers);
+		delegating_initializer_ = std::move(delegating_initializer);
+	}
+
 	void set_is_implicit(bool implicit) {
 		is_implicit_ = implicit;
 	}

--- a/src/AstToIr.h
+++ b/src/AstToIr.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <unordered_map>
+#include <unordered_set>
 #include "IrGenerator.h"
 #include "InlineVector.h"
 
@@ -877,7 +878,19 @@ private:
 	template <typename ArgRange>
 	const ConstructorDeclarationNode* resolveCodegenConstructorFromArgs(
 		const StructTypeInfo& target_struct_info,
-		const ArgRange& args) const {
+		const ArgRange& args) {
+		auto queueResolvedConstructor = [this, &target_struct_info](
+			const ConstructorDeclarationNode* constructor) {
+			if (constructor != nullptr &&
+				!constructor->has_template_parameters() &&
+				constructor->is_materialized()) {
+				queueDeferredMemberFunctionFromNode(
+					target_struct_info.name,
+					ASTNode(constructor),
+					target_struct_info.namespace_handle);
+			}
+			return constructor;
+		};
 		const size_t num_args = args.size();
 		std::vector<TypeSpecifierNode> arg_types;
 		arg_types.reserve(num_args);
@@ -896,8 +909,23 @@ private:
 			if (resolution.is_ambiguous) {
 				throw CompileError("Ambiguous constructor call");
 			}
-			if (resolution.selected_overload) {
-				return resolution.selected_overload;
+			bool template_ctor_ambiguous = false;
+			const ConstructorDeclarationNode* materialized_ctor =
+				parser_.materializeMatchingConstructorTemplate(
+					target_struct_info.name,
+					target_struct_info,
+					std::span<const TypeSpecifierNode>(arg_types.data(), arg_types.size()),
+					resolution.selected_overload,
+					template_ctor_ambiguous);
+			if (template_ctor_ambiguous) {
+				throw CompileError("Ambiguous constructor call");
+			}
+			if (materialized_ctor) {
+				return queueResolvedConstructor(materialized_ctor);
+			}
+			if (resolution.selected_overload &&
+				!resolution.selected_overload->has_template_parameters()) {
+				return queueResolvedConstructor(resolution.selected_overload);
 			}
 		}
 
@@ -906,7 +934,7 @@ private:
 		}
 
 		auto arity_resolution = resolve_constructor_overload_arity(target_struct_info, num_args, false);
-		return arity_resolution.selected_overload;
+		return queueResolvedConstructor(arity_resolution.selected_overload);
 	}
 	// Materialize explicit constructor arguments for an already-selected constructor.
 	// resolved_ctor may be null, in which case arguments are lowered without parameter-
@@ -1455,6 +1483,7 @@ private:
 		NamespaceHandle namespace_handle = NamespaceRegistry::GLOBAL_NAMESPACE;
 	};
 	std::vector<DeferredMemberFunctionInfo> deferred_member_functions_;
+	std::unordered_set<const void*> deferred_member_function_nodes_;
 	size_t deferred_member_functions_processed_ = 0;
 
 	// Free inline/__inline definitions deferred until ODR-use (call / address-of).

--- a/src/ExpressionSubstitutor.cpp
+++ b/src/ExpressionSubstitutor.cpp
@@ -1233,6 +1233,13 @@ ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
 			if (owner_name.empty() || owner_name == current_owner_name) {
 				return true;
 			}
+			if (std::optional<StringHandle> owner_pattern_handle =
+					gTemplateRegistry.get_instantiation_pattern(
+						current_owner_type_name_);
+				owner_pattern_handle.has_value() &&
+				owner_name == StringTable::getStringView(*owner_pattern_handle)) {
+				return true;
+			}
 
 			const TypeInfo* current_owner_type_info =
 				findTypeByName(current_owner_type_name_);
@@ -1259,6 +1266,22 @@ ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
 			return !qualified_base_template_name.empty() &&
 				owner_name == qualified_base_template_name;
 		};
+	if (dependent_name.owner_template_arguments.empty()) {
+		if (auto owner_subst_it = param_map_.find(owner_name);
+			owner_subst_it != param_map_.end()) {
+			const TemplateTypeArg& owner_arg = owner_subst_it->second;
+			if (owner_arg.is_value || !owner_arg.type_index.is_valid()) {
+				return materialized_owner;
+			}
+			materialized_owner =
+				parser_.materializeCanonicalOwnerTypeForLookup(owner_arg);
+			if (materialized_owner.instantiated_name.empty() &&
+				materialized_owner.resolved_type_info == nullptr) {
+				assign_owner_type(tryGetTypeInfo(owner_arg.type_index));
+			}
+			return materialized_owner;
+		}
+	}
 	switch (dependent_name.owner_kind) {
 	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation:
 		if (prefer_current_owner_type_name &&
@@ -1312,18 +1335,6 @@ ExpressionSubstitutor::materializeDependentQualifiedRecordOwner(
 		break;
 	case TypeInfo::DependentQualifiedNameRecord::OwnerKind::TemplateParameter:
 		if (dependent_name.owner_template_arguments.empty()) {
-			if (auto owner_subst_it = param_map_.find(owner_name);
-				owner_subst_it != param_map_.end()) {
-				if (const TypeInfo* owner_type_info =
-						tryGetTypeInfo(owner_subst_it->second.type_index)) {
-					materialized_owner =
-						parser_.materializeCanonicalOwnerTypeForLookup(*owner_type_info, {});
-					if (materialized_owner.instantiated_name.empty() &&
-						materialized_owner.resolved_type_info == nullptr) {
-						assign_owner_type(owner_type_info);
-					}
-				}
-			}
 			break;
 		}
 		[[fallthrough]];
@@ -2058,6 +2069,27 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		? call.qualified_name()
 		: std::string_view{};
 	auto wrapOriginalCall = [&]() -> ASTNode {
+		if (call.has_dependent_qualified_lookup_record()) {
+			CallExprNode unresolved_call(
+				CalleeDescriptor::freeFunction(call.callee().declaration()),
+				substituteCallArgumentsPreservingPackExpansion(call.arguments()),
+				call.called_from());
+			CallMetadataCopyOptions copy_options;
+			copy_options.copy_mangled_name = false;
+			copy_options.copy_parser_return_type_hint = false;
+			copy_options.copy_definition_lookup_record = false;
+			copyCallMetadataWithTransformedTemplateArguments(
+				unresolved_call,
+				call,
+				[this](const ASTNode& template_arg) {
+					return substitute(template_arg);
+				},
+				copy_options);
+			ExpressionNode& new_expr =
+				gChunkedAnyStorage.emplace_back<ExpressionNode>(
+					std::move(unresolved_call));
+			return ASTNode(&new_expr);
+		}
 		ExpressionNode& new_expr = gChunkedAnyStorage.emplace_back<ExpressionNode>(call);
 		return ASTNode(&new_expr);
 	};
@@ -2235,17 +2267,30 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 		return &instantiated_member_template->as<FunctionDeclarationNode>();
 	};
 	auto materializeSubstitutedUnresolvedCall = [&](ChunkedVector<ASTNode>&& substituted_args) -> ASTNode {
+		const bool preserves_dependent_qualified_lookup =
+			call.has_dependent_qualified_lookup_record();
+		const CalleeDescriptor unresolved_callee =
+			preserves_dependent_qualified_lookup
+				? CalleeDescriptor::freeFunction(call.callee().declaration())
+				: call.callee();
 		CallExprNode substituted_call(
-			call.callee(),
+			unresolved_callee,
 			std::move(substituted_args),
 			call.called_from());
+		CallMetadataCopyOptions copy_options;
+		copy_options.copy_mangled_name =
+			!preserves_dependent_qualified_lookup;
+		copy_options.copy_parser_return_type_hint =
+			!preserves_dependent_qualified_lookup;
+		copy_options.copy_definition_lookup_record =
+			!preserves_dependent_qualified_lookup;
 		copyCallMetadataWithTransformedTemplateArguments(
 			substituted_call,
 			call,
 			[this](const ASTNode& template_arg) {
 				return substitute(template_arg);
 			},
-			CallMetadataCopyOptions{});
+			copy_options);
 		const FunctionDeclarationNode* hint_target =
 			getBestEffortDirectCallTarget(call);
 		tryAttachSubstitutedReturnTypeHint(substituted_call, hint_target);
@@ -3111,7 +3156,10 @@ ASTNode ExpressionSubstitutor::substituteFunctionCallImpl(const CallExprNode& ca
 			materializeDependentQualifiedRecordOwner(
 				dependent_record,
 				kInitialDependentMemberTypeResolutionDepth,
-				/*prefer_current_owner_type_name=*/false,
+				/*prefer_current_owner_type_name=*/
+					dependent_record.owner_kind ==
+						TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+							CurrentInstantiation,
 				/*allow_current_context_dependent_owner_materialization=*/false);
 		std::string_view materialized_owner_name =
 			materialized_owner.canonicalName();
@@ -4019,7 +4067,13 @@ ASTNode ExpressionSubstitutor::substituteQualifiedIdentifier(const QualifiedIden
 						std::move(explicit_template_arg_nodes));
 				}
 			}
-			if (!preserved_dependent_member_template_record) {
+			// Once the owner has been substituted to a different concrete type, the
+			// original dependent-qualified record must not survive on the rebound
+			// identifier.  Keeping it would make a later evaluator reinterpret the
+			// already-materialized `B::v` through the surrounding template context
+			// (for example as `A::v` while instantiating g<A>).
+			if (!preserved_dependent_member_template_record &&
+				materialized_owner_name == recorded_owner_name) {
 				new_qual_id.setDependentQualifiedName(*dependent_name);
 			}
 			FLASH_LOG(Templates, Trace, "  Record-substituted qualified-id: ",

--- a/src/IRConverter_ConvertMain.cpp
+++ b/src/IRConverter_ConvertMain.cpp
@@ -12275,9 +12275,10 @@ void IrToObjConverter<TWriterClass>::handleAssignment(const IrInstruction& instr
 		double double_value = std::get<double>(op.rhs.value);
 			// Allocate an XMM register and load the double into it
 		source_reg = allocateXMMRegisterWithSpilling();
-			// Convert double to uint64_t bit representation
-		uint64_t bits;
-		std::memcpy(&bits, &double_value, sizeof(bits));
+			// NumericLiteralNode stores floating values as double regardless of
+			// the literal's semantic type. Encode the destination width before
+			// moving the immediate into the XMM register.
+		uint64_t bits = encodeFloatingImmediateBits(double_value, op.rhs.size_in_bits.value);
 			// Load bits into a general-purpose register first
 		emitMovImm64(X64Register::RAX, bits);
 			// Move from RAX to XMM register using movq instruction

--- a/src/IrGenerator_Call_Direct.cpp
+++ b/src/IrGenerator_Call_Direct.cpp
@@ -408,9 +408,12 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		parser_resolved_direct_target != nullptr) {
 		sema_.ensureCallArgConversionsAnnotated(callExprNode);
 	}
+	const bool has_dependent_qualified_lookup =
+		callExprNode.has_dependent_qualified_lookup_record();
 	const ResolvedFunctionQueryResult sema_resolved_direct_query =
 		sema_services.getResolvedDirectCallQuery(sema_call_key);
 	const FunctionDeclarationNode* const sema_resolved_direct_target =
+		!has_dependent_qualified_lookup &&
 		sema_resolved_direct_query.state == ResolvedFunctionQueryResult::State::Available
 			? sema_resolved_direct_query.function
 			: nullptr;
@@ -854,7 +857,8 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 		function_name = "memcpy";
 	}
 
-	bool has_precomputed_mangled = callExprNode.has_mangled_name();
+	bool has_precomputed_mangled =
+		callExprNode.has_mangled_name() && !has_dependent_qualified_lookup;
 	const FunctionDeclarationNode* matched_func_decl = nullptr;
 
 		// Helper: resolve mangled name from a matched function declaration
@@ -960,6 +964,31 @@ ExprResult AstToIr::generateFunctionCallIr(const CallExprNode& callExprNode, Exp
 								member_func.is_const())) {
 						function_node = *materialized;
 					}
+				}
+			} else if (function_node.is<ConstructorDeclarationNode>()) {
+				const ConstructorDeclarationNode& ctor_decl =
+					function_node.as<ConstructorDeclarationNode>();
+				if (ctor_decl.has_template_parameters()) {
+					// Constructor templates are overload-resolution patterns.  Only a
+					// concrete specialization may enter the deferred emission queue.
+					continue;
+				}
+				if (!ctor_decl.is_materialized() && ctor_decl.has_any_body_source()) {
+					if (std::optional<ASTNode> materialized =
+							sema_.ensureMemberFunctionMaterialized(
+								struct_name,
+								ctor_decl);
+						materialized.has_value() &&
+						materialized->is<ConstructorDeclarationNode>()) {
+						function_node = *materialized;
+					}
+				}
+				// The deferred queue only accepts complete declarations. Implicit
+				// constructors without a body are emitted through the normal
+				// constructor-call path when they are actually used.
+				if (function_node.is<ConstructorDeclarationNode>() &&
+					!function_node.as<ConstructorDeclarationNode>().is_materialized()) {
+					continue;
 				}
 			}
 			DeferredMemberFunctionInfo deferred_info;

--- a/src/IrGenerator_Expr_Operators.cpp
+++ b/src/IrGenerator_Expr_Operators.cpp
@@ -153,7 +153,7 @@ ExprResult AstToIr::materializeAddressResultForValueContext(
 		: target_size.value;
 	TempVar loaded_value = emitDereference(
 		target_category,
-		64,
+		loaded_size,
 		target_pointer_depth.value + 1,
 		toIrValue(result.value),
 		token);

--- a/src/IrGenerator_Helpers.cpp
+++ b/src/IrGenerator_Helpers.cpp
@@ -82,6 +82,11 @@ void AstToIr::queueDeferredMemberFunctionFromNode(
 	StringHandle struct_name,
 	ASTNode function_node,
 	NamespaceHandle namespace_handle) {
+	const void* function_node_key = function_node.raw_pointer();
+	if (function_node_key == nullptr ||
+		!deferred_member_function_nodes_.insert(function_node_key).second) {
+		return;
+	}
 	DeferredMemberFunctionInfo deferred_info;
 	deferred_info.struct_name = struct_name;
 	deferred_info.function_node = function_node;

--- a/src/IrGenerator_NewDeleteCast.cpp
+++ b/src/IrGenerator_NewDeleteCast.cpp
@@ -855,7 +855,12 @@ ExprResult AstToIr::generateStaticCastIr(const StaticCastNode& staticCastNode) {
 		// Get the target type from the type specifier first
 	const auto& target_type_node = staticCastNode.target_type();
 	TypeCategory target_type = target_type_node.type();
-	int target_size = static_cast<int>(target_type_node.size_in_bits());
+	// A reference's stored size is the pointer size, but the xvalue produced by
+	// a reference cast denotes the referred-to object.  Keep the object size in
+	// the reference metadata so later loads use the referred type's width.
+	int target_size = target_type_node.is_reference()
+		? getTypeSpecSizeBits(target_type_node)
+		: static_cast<int>(target_type_node.size_in_bits());
 	size_t target_pointer_depth = target_type_node.pointer_depth();
 	TypeIndex target_type_index = canonicalize_conversion_target_type(target_type_node.type_index(), target_type);
 

--- a/src/IrGenerator_Stmt_Decl.cpp
+++ b/src/IrGenerator_Stmt_Decl.cpp
@@ -336,7 +336,10 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 		}
 	} full_expression_temp_flush_guard{flushFullExpressionTemps};
 	auto queue_nested_template_ctor = [this](const TypeInfo& type_info_ref, const ConstructorDeclarationNode* ctor) {
-		if (!ctor) {
+		if (!ctor || ctor->has_template_parameters()) {
+			// A constructor template is only a deduction candidate.  The concrete
+			// specialization is queued after constructor overload resolution has
+			// materialized it with the call's template arguments.
 			return;
 		}
 		const ConstructorDeclarationNode* ctor_to_queue = ctor;
@@ -357,10 +360,12 @@ void AstToIr::visitVariableDeclarationNode(const ASTNode& ast_node) {
 		// already visited during beginStructDeclarationCodegen are deduplicated by the
 		// emitted_constructor_nodes_ guard inside visitConstructorDeclarationNode, so
 		// double-emit is safe to ignore.
-		DeferredMemberFunctionInfo deferred_info;
-		deferred_info.struct_name = type_info_ref.name();
-		deferred_info.function_node = ASTNode(ctor_to_queue);
-		deferred_member_functions_.push_back(std::move(deferred_info));
+		queueDeferredMemberFunctionFromNode(
+			type_info_ref.name(),
+			ASTNode(ctor_to_queue),
+			type_info_ref.getStructInfo() != nullptr
+				? type_info_ref.getStructInfo()->namespace_handle
+				: NamespaceHandle{});
 	};
 	auto register_destructor_if_needed = [this](const DeclarationNode& inner_decl, const TypeInfo* type_info) {
 		if (!type_info || !type_info->getStructInfo() || !type_info->getStructInfo()->hasDestructor()) {

--- a/src/IrGenerator_Visitors_Decl.cpp
+++ b/src/IrGenerator_Visitors_Decl.cpp
@@ -1507,12 +1507,11 @@ bool AstToIr::beginStructDeclarationCodegen(const StructDeclarationNode& node) {
 								ctor_has_auto = true;
 								break;
 							}
-							// Skip constructors whose parameter types are still TypeCategory::UserDefined:
-							// this indicates the parser failed to record the constructor's own
-							// template parameters (e.g. template<_U1,_U2> pair(_U1&&, _U2&&) where
-							// _U1/_U2 remain unresolved).  Generating code for such a constructor would
-							// crash in reference-identifier load lowering with "Type with no runtime size".
-							if (pt.category() == TypeCategory::UserDefined) {
+							// A concrete class or alias may legitimately retain UserDefined in its
+							// source category.  Only defer a constructor when the type index still
+							// contains dependent placeholder state; category alone is not evidence
+							// that the signature needs template materialization.
+							if (typeSpecStillNeedsTemplateMaterialization(pt)) {
 								ctor_has_unresolved_param = true;
 								break;
 							}
@@ -2915,6 +2914,58 @@ void AstToIr::visitConstructorDeclarationNode(const ConstructorDeclarationNode& 
 					// Check for explicit initializer first (highest precedence)
 					auto explicit_it = explicit_inits.find(std::string(StringTable::getStringView(member.getName())));
 					if (explicit_it != explicit_inits.end()) {
+						// A member initializer for a class type constructs the member
+						// subobject; it is not a raw store of the initializer expression.
+						// This distinction matters for reference-valued expressions such
+						// as static_cast<T&&>(value), whose IR operand is an address until
+						// it is bound to a constructor parameter.
+						if (!member.is_reference() && !member.is_rvalue_reference()) {
+							const TypeInfo* member_type_info = tryGetTypeInfo(member.type_index);
+							const StructTypeInfo* member_struct_info =
+								member_type_info ? member_type_info->getStructInfo() : nullptr;
+							if (member_struct_info && member_struct_info->hasUserDefinedConstructor()) {
+								const ASTNode& init_expr = explicit_it->second->initializer_expr;
+								std::vector<ASTNode> constructor_args;
+								const ConstructorDeclarationNode* resolved_ctor = nullptr;
+
+								if (init_expr.is<InitializerListNode>()) {
+									const InitializerListNode& init_list = init_expr.as<InitializerListNode>();
+									if (const ConstructorDeclarationNode* sema_ctor = init_list.resolved_constructor();
+										sema_ctor && resolvedConstructorMatchesTargetType(*sema_ctor, member.type_index)) {
+										resolved_ctor = sema_ctor;
+									}
+									for (const ASTNode& argument : init_list.initializers()) {
+										constructor_args.push_back(argument);
+									}
+								} else if (init_expr.is<ExpressionNode>()) {
+									constructor_args.push_back(init_expr);
+								} else {
+									throw InternalError("Class member initializer is not an expression or initializer list");
+								}
+
+								if (!resolved_ctor) {
+									resolved_ctor = resolveCodegenConstructorFromArgs(*member_struct_info, constructor_args);
+								}
+								if (!resolved_ctor) {
+									throw CompileError(
+										"No matching constructor for member '" +
+										std::string(StringTable::getStringView(member.getName())) + "'");
+								}
+
+								ConstructorCallOp ctor_op;
+								ctor_op.object = StringTable::getOrInternStringHandle("this");
+								assert(member.offset <= static_cast<size_t>(std::numeric_limits<int>::max()) &&
+									"Member offset exceeds int range");
+								ctor_op.base_class_offset = static_cast<int>(member.offset);
+								appendConstructorCallArguments(
+									ctor_op, resolved_ctor, constructor_args, node.name_token());
+								finalizeConstructorCallOp(ctor_op, *member_struct_info, node.name_token());
+								ir_.addInstruction(
+									IrInstruction(IrOpcode::ConstructorCall, std::move(ctor_op), node.name_token()));
+								continue;
+							}
+						}
+
 						// Special handling for reference members initialized with reference variables/parameters
 						// When initializing a reference member (int& ref) with a reference parameter (int& r),
 						// we need to use the pointer value that the parameter holds, not dereference it

--- a/src/IrGenerator_Visitors_TypeInit.cpp
+++ b/src/IrGenerator_Visitors_TypeInit.cpp
@@ -371,7 +371,6 @@ void AstToIr::generateDeferredMemberFunctions() {
 		current_struct_name_ = info.struct_name;
 		current_function_name_ = StringHandle();
 		current_namespace_stack_ = buildNamespaceStackFromHandle(info.namespace_handle);
-
 		try {
 			if (info.function_node.is<FunctionDeclarationNode>()) {
 				const FunctionDeclarationNode& func = info.function_node.as<FunctionDeclarationNode>();
@@ -386,6 +385,24 @@ void AstToIr::generateDeferredMemberFunctions() {
 				visitFunctionDeclarationNode(func);
 			} else if (info.function_node.is<ConstructorDeclarationNode>()) {
 				const ConstructorDeclarationNode& ctor = info.function_node.as<ConstructorDeclarationNode>();
+				bool has_unresolved_template_signature = ctor.has_template_parameters();
+				for (const ASTNode& parameter : ctor.parameter_nodes()) {
+					if (!parameter.is<DeclarationNode>()) {
+						continue;
+					}
+					const TypeSpecifierNode& parameter_type =
+						parameter.as<DeclarationNode>().type_specifier_node();
+					if (typeSpecStillUsesDependentPlaceholder(parameter_type)) {
+						has_unresolved_template_signature = true;
+						break;
+					}
+				}
+				if (has_unresolved_template_signature) {
+					// A constructor template pattern is an overload-resolution
+					// candidate, not a code-generation target.  Only its concrete
+					// materializations may enter the deferred emission queue.
+					continue;
+				}
 				if (!ctor.is_materialized()) {
 					throw InternalError("Deferred constructor queue received an unmaterialized constructor");
 				}

--- a/src/OverloadResolution.h
+++ b/src/OverloadResolution.h
@@ -447,7 +447,10 @@ struct DerivedBaseConversionInfo {
 // is recorded by type rather than by path because a virtual base subobject is
 // shared by a diamond.  A non-virtual path and a virtual path still describe
 // different possible subobjects and are therefore ambiguous.
-inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived_idx, TypeIndex base_idx) {
+inline DerivedBaseConversionInfo classifyDerivedBaseConversion(
+	TypeIndex derived_idx,
+	TypeIndex base_idx,
+	TypeIndex access_context_idx) {
 	if (!derived_idx.is_valid() || !base_idx.is_valid())
 		return {};
 	if (derived_idx == base_idx)
@@ -474,6 +477,25 @@ inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived
 		return std::find(inaccessible_virtual_subobjects.begin(), inaccessible_virtual_subobjects.end(), type_index) !=
 			inaccessible_virtual_subobjects.end();
 	};
+	auto base_edge_is_accessible = [&](const StructTypeInfo& owner, AccessSpecifier access) {
+		if (access == AccessSpecifier::Public) {
+			return true;
+		}
+		if (!access_context_idx.is_valid() || !owner.own_type_index_.has_value()) {
+			return false;
+		}
+
+		const TypeIndex owner_type_idx = *owner.own_type_index_;
+		if (access_context_idx.index() == owner_type_idx.index()) {
+			return true;
+		}
+		if (const TypeInfo* access_context_info = tryGetTypeInfo(access_context_idx);
+			access_context_info != nullptr && owner.isFriendClass(access_context_info->name())) {
+			return true;
+		}
+		return access == AccessSpecifier::Protected &&
+			isTransitivelyDerivedFromAnyAccess(access_context_idx, owner_type_idx);
+	};
 
 	auto visit = [&](const auto& self,
 					const StructTypeInfo* current_struct,
@@ -483,7 +505,8 @@ inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived
 		if (!current_struct)
 			return;
 		for (const auto& base : current_struct->base_classes) {
-			const bool next_public_path = public_path && base.access == AccessSpecifier::Public;
+			const bool next_public_path =
+				public_path && base_edge_is_accessible(*current_struct, base.access);
 			const bool next_virtual_path = virtual_path || base.is_virtual;
 			const int64_t base_offset = current_offset + static_cast<int64_t>(base.offset);
 			if (base.type_index == base_idx) {
@@ -537,6 +560,12 @@ inline DerivedBaseConversionInfo classifyDerivedBaseConversion(TypeIndex derived
 	if (saw_inaccessible)
 		return {DerivedBaseConversionKind::Inaccessible, 0, std::nullopt};
 	return {};
+}
+
+inline DerivedBaseConversionInfo classifyDerivedBaseConversion(
+	TypeIndex derived_idx,
+	TypeIndex base_idx) {
+	return classifyDerivedBaseConversion(derived_idx, base_idx, TypeIndex{});
 }
 
 inline bool hasUsablePublicDerivedBaseConversion(TypeIndex derived_idx, TypeIndex base_idx) {

--- a/src/Parser.h
+++ b/src/Parser.h
@@ -1000,7 +1000,8 @@ private:
 														  // as opposed to a regular member of a template class
 		bool is_free_function = false;			   // True for non-member friend functions defined inside a class body
 		bool has_function_try = false;			   // True when body_start is at '{' inside a function-try-block
-														  // (i.e. 'try' was already consumed; catch clauses follow the body)
+												  // (i.e. 'try' was already consumed; catch clauses follow the body)
+		bool is_late_replay = false;				   // Restore lexer state without rolling back committed top-level AST nodes
 	};
 	std::vector<DelayedFunctionBody> delayed_function_bodies_;
 
@@ -2649,6 +2650,10 @@ std::optional<CallArgDeductionInfo> buildDeductionMapFromCallArgs(
 		return substituted_arg;
 	}
 	bool isReachableVirtualBaseInitializer(const StructTypeInfo* struct_info, std::string_view candidate_name) const;
+	StringHandle resolveAliasBaseInitializerName(
+		const StructTypeInfo* struct_info,
+		StringHandle candidate_name,
+		TypeIndex owner_type_index);
 	std::optional<ASTNode> try_instantiate_class_template(std::string_view template_name, std::span<const TemplateTypeArg> template_args, bool force_eager = false);	// NEW: Instantiate class template
 	std::optional<ASTNode> instantiate_full_specialization(std::string_view template_name, std::span<const TemplateTypeArg> template_args, ASTNode& spec_node);  // Instantiate full specialization
 	std::optional<ASTNode> try_instantiate_variable_template(

--- a/src/ParserTemplateClassShared.h
+++ b/src/ParserTemplateClassShared.h
@@ -504,10 +504,8 @@ TypeIndex resolveOwnerAliasTypeIndex(
 	const TypeSpecifierNode& original_type_spec,
 	const TParams& tmpl_params,
 	const TArgs& tmpl_args,
-	TypeIndex current_type_index) {
-	if (current_type_index.is_valid()) {
-		return current_type_index.withCategory(current_type_index.category());
-	}
+	TypeIndex current_type_index,
+	TypeIndex instantiated_owner_type_index) {
 	if (original_type_spec.type() != TypeCategory::UserDefined &&
 		original_type_spec.type() != TypeCategory::TypeAlias &&
 		original_type_spec.type() != TypeCategory::Template) {
@@ -516,6 +514,26 @@ TypeIndex resolveOwnerAliasTypeIndex(
 	StringHandle type_name_handle = original_type_spec.token().handle();
 	if (!type_name_handle.isValid()) {
 		return current_type_index;
+	}
+	if (instantiated_owner_type_index.is_valid()) {
+		if (const TypeInfo* owner_type_info = tryGetTypeInfo(instantiated_owner_type_index)) {
+			StringHandle qualified_alias_name = StringTable::getOrInternStringHandle(
+				StringBuilder()
+					.append(StringTable::getStringView(owner_type_info->name()))
+					.append("::")
+					.append(StringTable::getStringView(type_name_handle))
+					.commit());
+			if (const TypeInfo* instantiated_alias = findTypeByName(qualified_alias_name);
+				instantiated_alias != nullptr && instantiated_alias->isTypeAlias()) {
+				const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+					instantiated_alias->registeredTypeIndex().withCategory(
+						instantiated_alias->typeEnum()));
+				if (resolved_alias.type_index.is_valid() &&
+					!typeIndexContainsDependentPlaceholder(resolved_alias.type_index)) {
+					return resolved_alias.type_index.withCategory(resolved_alias.typeEnum());
+				}
+			}
+		}
 	}
 	for (const auto& type_alias : owner_decl.type_aliases()) {
 		if (type_alias.alias_name != type_name_handle ||
@@ -1359,6 +1377,7 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 	TypeIndex substituted_type_index = override_type_index.is_valid()
 		? override_type_index
 		: substitute_type_index(original_type_spec, template_params, template_args);
+	bool resolved_from_instantiated_owner_alias = false;
 	if (owner_decl != nullptr) {
 		substituted_type_index = resolveOwnerAliasTypeIndex(
 			substitute_type_index,
@@ -1366,17 +1385,48 @@ TypeSpecifierNode buildSubstitutedTypeSpecifier(
 			original_type_spec,
 			template_params,
 			template_args,
-			substituted_type_index);
+			substituted_type_index,
+			instantiated_owner_type_index);
+		if (instantiated_owner_type_index.is_valid()) {
+			const StringHandle type_name_handle = original_type_spec.token().handle();
+			if (type_name_handle.isValid()) {
+				for (const auto& type_alias : owner_decl->type_aliases()) {
+					if (type_alias.alias_name != type_name_handle) {
+						continue;
+					}
+					if (const TypeInfo* owner_type_info = tryGetTypeInfo(instantiated_owner_type_index)) {
+						StringHandle qualified_alias_name = StringTable::getOrInternStringHandle(
+							StringBuilder()
+								.append(StringTable::getStringView(owner_type_info->name()))
+								.append("::")
+								.append(StringTable::getStringView(type_name_handle))
+								.commit());
+						if (const TypeInfo* instantiated_alias = findTypeByName(qualified_alias_name);
+							instantiated_alias != nullptr && instantiated_alias->isTypeAlias()) {
+							const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+								instantiated_alias->registeredTypeIndex().withCategory(
+									instantiated_alias->typeEnum()));
+							resolved_from_instantiated_owner_alias =
+								resolved_alias.type_index.is_valid() &&
+								!typeIndexContainsDependentPlaceholder(resolved_alias.type_index);
+						}
+					}
+					break;
+				}
+			}
+		}
 	}
 	if (instantiated_owner_type_index.is_valid()) {
 		substituted_type_index = resolveSelfRefParamIndex(
 			substituted_type_index,
 			instantiated_owner_type_index);
 	}
-	substituted_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
-		original_type_node,
-		original_type_spec,
-		substituted_type_index);
+	if (!resolved_from_instantiated_owner_alias) {
+		substituted_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
+			original_type_node,
+			original_type_spec,
+			substituted_type_index);
+	}
 
 	TypeSpecifierNode substituted_type = full_substituted_node.is<TypeSpecifierNode>()
 		? full_substituted_node.as<TypeSpecifierNode>()

--- a/src/ParserTemplateHelpers.h
+++ b/src/ParserTemplateHelpers.h
@@ -833,6 +833,15 @@ inline StringHandle registerLazyConstructorStub(
 	std::span<const TemplateParameterNode> outer_template_params,
 	std::span<const TemplateTypeArg> outer_template_args,
 	const TemplateEnvironmentSnapshot* outer_parent_snapshot) {
+	// A constructor template is an overload-resolution pattern.  Its concrete
+	// template arguments are supplied by the call site, so it cannot be
+	// represented by a class-only lazy-member entry.  Registering that entry
+	// would replay the body with only the enclosing class bindings and leave
+	// constructor parameters such as U unresolved.
+	if (ctor_decl.has_template_parameters()) {
+		return StringHandle{};
+	}
+
 	LazyMemberFunctionInfo lazy_ctor_info;
 	{
 		auto& id = lazy_ctor_info.identity;
@@ -1061,11 +1070,17 @@ inline void buildTemplateArgSubstitutionMaps(
 
 		if (tparam->is_variadic()) {
 			std::vector<TemplateTypeArg> pack_args;
-			for (size_t j = arg_index; j < template_args.size(); ++j) {
-				pack_args.push_back(template_args[j]);
+			const size_t pack_size = countTemplatePackArguments(
+				template_params,
+				template_args,
+				i,
+				arg_index);
+			for (size_t j = 0; j < pack_size; ++j) {
+				pack_args.push_back(template_args[arg_index + j]);
 			}
 			pack_substitution_map[StringTable::getOrInternStringHandle(param_name)] = std::move(pack_args);
-			break;
+			arg_index += pack_size;
+			continue;
 		}
 
 		if (arg_index < template_args.size()) {
@@ -1566,7 +1581,8 @@ inline bool typeSpecifiersMatchForSignatureValidation(
 	const SignatureValidationIndirection rhs_effective_indirection =
 		computeSignatureValidationIndirection(rhs);
 	if (lhs_effective_type.category() != rhs_effective_type.category() ||
-		lhs_effective_type != rhs_effective_type ||
+		(!is_primitive_type(lhs_effective_type.category()) &&
+			lhs_effective_type != rhs_effective_type) ||
 		lhs_effective_indirection.pointer_depth != rhs_effective_indirection.pointer_depth ||
 		lhs_effective_indirection.reference_qualifier !=
 			rhs_effective_indirection.reference_qualifier) {
@@ -3552,7 +3568,6 @@ void Parser::substituteAndCopyMemberFunctionParameters(
 			rewritten_owner_type = self_type_to_index;
 		} else if (instantiated_owner_type_index.is_valid() &&
 				   owner_decl != nullptr &&
-				   !substituted_param_type.type_index().is_valid() &&
 				   typeTokenNamesOwnerClass(substituted_param_type, *owner_decl)) {
 			rewritten_owner_type = instantiated_owner_type_index;
 		}

--- a/src/Parser_Decl_FunctionOrVar.cpp
+++ b/src/Parser_Decl_FunctionOrVar.cpp
@@ -26,6 +26,50 @@ bool Parser::isReachableVirtualBaseInitializer(const StructTypeInfo* struct_info
 	return false;
 }
 
+StringHandle Parser::resolveAliasBaseInitializerName(
+	const StructTypeInfo* struct_info,
+	StringHandle candidate_name,
+	TypeIndex owner_type_index) {
+	if (struct_info == nullptr || !candidate_name.isValid() || !owner_type_index.is_valid()) {
+		return {};
+	}
+
+	const TypeInfo* owner_type_info = tryGetTypeInfo(owner_type_index);
+	if (owner_type_info == nullptr) {
+		return {};
+	}
+
+	const TypeInfo* alias_type_info = lookup_inherited_type_alias(
+		owner_type_info->name(),
+		candidate_name);
+	if (alias_type_info == nullptr || !alias_type_info->isTypeAlias()) {
+		return {};
+	}
+
+	const ResolvedAliasTypeInfo resolved_alias = resolveAliasTypeInfo(
+		alias_type_info->registeredTypeIndex().withCategory(alias_type_info->typeEnum()));
+	if (!resolved_alias.type_index.is_valid()) {
+		return {};
+	}
+
+	auto canonical_type_index = [](TypeIndex type_index) {
+		const ResolvedAliasTypeInfo resolved = resolveAliasTypeInfo(type_index);
+		return resolved.type_index.is_valid() ? resolved.type_index : type_index;
+	};
+	const TypeIndex canonical_alias_index = canonical_type_index(resolved_alias.type_index);
+
+	for (const auto& base : struct_info->base_classes) {
+		const TypeIndex canonical_base_index = canonical_type_index(base.type_index);
+		if (canonical_alias_index.is_valid() && canonical_base_index.is_valid() &&
+			canonical_alias_index.index() == canonical_base_index.index() &&
+			canonical_alias_index.category() == canonical_base_index.category()) {
+			return StringTable::getOrInternStringHandle(base.name);
+		}
+	}
+
+	return {};
+}
+
 // Consumes the constructor/destructor prefix at the current position:
 //   ClassName [<...>] :: [~]                 (advances past these tokens)
 // and checks that the next token is ClassName followed by (.
@@ -1377,6 +1421,16 @@ ParseResult Parser::parse_out_of_line_constructor_or_destructor(std::string_view
 							StringHandle base_name_handle = StringTable::getOrInternStringHandle(init_name);
 							ctor_ref->add_base_initializer(base_name_handle, std::move(init_args));
 							break;
+						}
+					}
+					if (!is_base_init) {
+						StringHandle alias_base_name = resolveAliasBaseInitializerName(
+							struct_info,
+							StringTable::getOrInternStringHandle(init_name),
+							type_info->type_index_);
+						if (alias_base_name.isValid()) {
+							is_base_init = true;
+							ctor_ref->add_base_initializer(alias_base_name, std::move(init_args));
 						}
 					}
 					if (!is_base_init && isReachableVirtualBaseInitializer(struct_info, init_name)) {

--- a/src/Parser_Expr_PrimaryExpr.cpp
+++ b/src/Parser_Expr_PrimaryExpr.cpp
@@ -848,8 +848,11 @@ std::optional<ASTNode> Parser::resolveDeferredQualifiedTemplateCall(
 		const std::string_view member_name = qualified_name.substr(scope_sep + 2);
 		ResolvedQualifiedOwner resolved_owner =
 			resolveQualifiedOwnerForLookup(owner_name);
-		if (!resolved_owner.resolved_from_current_context ||
-			resolved_owner.resolved_as_nested_owner_extension) {
+		if (!resolved_owner.lookup_name.empty() &&
+			(!resolved_owner.resolved_from_current_context ||
+			 resolved_owner.resolved_as_nested_owner_extension ||
+			 (resolved_owner.type_info != nullptr &&
+			  resolved_owner.type_info->getStructInfo() != nullptr))) {
 			owner_name = resolved_owner.lookup_name;
 		}
 
@@ -1260,6 +1263,17 @@ std::optional<Parser::AliasTemplateMaterializationResult> Parser::tryResolveQual
 
 			return std::nullopt;
 		};
+
+	if (active_template_body_substitution_ != nullptr &&
+		active_template_body_substitution_->owner_type_index.is_valid()) {
+		if (std::optional<AliasTemplateMaterializationResult> active_owner =
+			try_resolve_from_current_owner(
+				tryGetTypeInfo(
+					active_template_body_substitution_->owner_type_index));
+		active_owner.has_value()) {
+			return active_owner;
+		}
+	}
 
 	for (auto member_ctx_it = member_function_context_stack_.rbegin();
 		 member_ctx_it != member_function_context_stack_.rend();
@@ -4475,6 +4489,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			// Create function call node with the qualified identifier
 			auto function_call_node = emplace_node<ExpressionNode>(
 				makeCallExprFromNode(*identifierType, std::move(args), qual_id.identifier_token()));
+			if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+					qual_id.dependentQualifiedName();
+				dependent_record != nullptr) {
+				setCallDependentQualifiedLookupRecord(
+					function_call_node.as<ExpressionNode>(),
+					*dependent_record);
+			}
 			if (has_explicit_template_args) {
 				if (template_arg_nodes.empty()) {
 					template_arg_nodes = materializeTemplateArgumentNodes(*template_args, qual_id.identifier_token());
@@ -4672,6 +4693,140 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 			// Create a QualifiedIdentifierNode (stack-local; copied into ExpressionNode before returning)
 			NamespaceHandle ns_handle = gSymbolTable.resolve_namespace_handle(namespaces);
 			QualifiedIdentifierNode qual_id(ns_handle, final_identifier);
+			if (!namespaces.empty()) {
+				StringHandle owner_handle =
+					StringTable::getOrInternStringHandle(namespaces.front().c_str());
+				TypeIndex owner_type_index{};
+				bool owner_is_dependent = false;
+				auto owner_resolves_in_current_context = [&]() -> bool {
+					std::string_view current_owner_name;
+					if (!member_function_context_stack_.empty()) {
+						current_owner_name = StringTable::getStringView(
+							member_function_context_stack_.back().struct_name);
+					} else if (!struct_parsing_context_stack_.empty()) {
+						current_owner_name = struct_parsing_context_stack_.back().struct_name;
+					}
+					if (current_owner_name.empty()) {
+						return false;
+					}
+					std::vector<QualifiedTypeMemberAccess> owner_member_chain;
+					owner_member_chain.reserve(namespaces.size());
+					for (const auto& namespace_part : namespaces) {
+						QualifiedTypeMemberAccess member_access;
+						member_access.member_name =
+							StringTable::getOrInternStringHandle(
+								namespace_part.c_str());
+						owner_member_chain.push_back(std::move(member_access));
+					}
+					return resolveBaseClassMemberTypeChain(
+						current_owner_name,
+						owner_member_chain) != nullptr;
+				};
+				if (currentTemplateParamKind(owner_handle).has_value() ||
+					std::find(
+						currentTemplateParamNames().begin(),
+						currentTemplateParamNames().end(),
+						owner_handle) != currentTemplateParamNames().end()) {
+					owner_is_dependent = true;
+				}
+				if (!owner_is_dependent &&
+					!owner_resolves_in_current_context()) {
+					auto owner_type_it = getTypesByNameMap().find(owner_handle);
+					const TypeInfo* owner_type_info =
+						owner_type_it != getTypesByNameMap().end()
+							? owner_type_it->second
+							: nullptr;
+					const bool owner_has_dependent_template_args =
+						owner_type_info != nullptr &&
+						std::any_of(
+							owner_type_info->templateArgs().begin(),
+							owner_type_info->templateArgs().end(),
+							[](const TypeInfo::TemplateArgInfo& arg) {
+								return arg.dependent_name.isValid() ||
+									arg.dependent_expr().has_value() ||
+									typeIndexContainsDependentPlaceholder(arg.type_index);
+							});
+					if (owner_type_info != nullptr &&
+						(owner_type_info->isDependentPlaceholder() ||
+						 (owner_type_info->is_incomplete_instantiation_ &&
+						  (!owner_type_info->isTemplateInstantiation() ||
+						   owner_type_info->templateArgs().empty() ||
+						   owner_has_dependent_template_args)))) {
+						owner_is_dependent = true;
+						owner_type_index = owner_type_info->registeredTypeIndex();
+					}
+				}
+				if (!owner_is_dependent) {
+					std::string_view current_owner_name;
+					if (!member_function_context_stack_.empty()) {
+						const auto& member_ctx = member_function_context_stack_.back();
+						current_owner_name =
+							StringTable::getStringView(member_ctx.struct_name);
+						owner_type_index = member_ctx.struct_type_index;
+					} else if (!struct_parsing_context_stack_.empty()) {
+						const auto& struct_ctx = struct_parsing_context_stack_.back();
+						current_owner_name = struct_ctx.struct_name;
+						if (auto owner_type_it = getTypesByNameMap().find(
+								StringTable::getOrInternStringHandle(current_owner_name));
+							owner_type_it != getTypesByNameMap().end() &&
+							owner_type_it->second != nullptr) {
+							owner_type_index = owner_type_it->second->registeredTypeIndex();
+						}
+					}
+					if (!current_owner_name.empty()) {
+						std::vector<QualifiedTypeMemberAccess> owner_member_chain;
+						owner_member_chain.reserve(namespaces.size());
+						for (const auto& namespace_part : namespaces) {
+							QualifiedTypeMemberAccess member_access;
+							member_access.member_name =
+								StringTable::getOrInternStringHandle(
+									namespace_part.c_str());
+							owner_member_chain.push_back(std::move(member_access));
+						}
+						if (resolveBaseClassMemberTypeChain(
+								current_owner_name,
+								owner_member_chain) != nullptr) {
+							std::vector<StringHandle> dependent_member_names;
+							dependent_member_names.reserve(namespaces.size() + 1);
+							for (const auto& namespace_part : namespaces) {
+								dependent_member_names.push_back(
+									StringTable::getOrInternStringHandle(
+										namespace_part.c_str()));
+							}
+							dependent_member_names.push_back(final_identifier.handle());
+							qual_id.setDependentQualifiedName(
+								makeExpressionDependentQualifiedNameRecord(
+									StringTable::getOrInternStringHandle(
+										current_owner_name),
+									owner_type_index,
+									TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+										CurrentInstantiation,
+									{},
+									dependent_member_names));
+						}
+					}
+				}
+				if (owner_is_dependent) {
+					std::vector<StringHandle> dependent_member_names;
+					dependent_member_names.reserve(namespaces.size());
+					for (size_t namespace_index = 1;
+						namespace_index < namespaces.size();
+						++namespace_index) {
+						dependent_member_names.push_back(
+							StringTable::getOrInternStringHandle(
+								namespaces[namespace_index].c_str()));
+					}
+					dependent_member_names.push_back(final_identifier.handle());
+					qual_id.setDependentQualifiedName(
+						makeExpressionDependentQualifiedNameRecord(
+							owner_handle,
+							owner_type_index,
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+								UnknownSpecialization,
+							{},
+							dependent_member_names));
+				}
+			}
 
 			// Check for std::forward intrinsic
 			// std::forward<T>(arg) is a compiler intrinsic for perfect forwarding
@@ -5592,6 +5747,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// Create function call node with the qualified identifier
 				result = emplace_node<ExpressionNode>(
 					makeCallExprFromNode(*identifierType, std::move(args), qual_id.identifier_token()));
+				if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+						qual_id.dependentQualifiedName();
+					dependent_record != nullptr) {
+					setCallDependentQualifiedLookupRecord(
+						result->as<ExpressionNode>(),
+						*dependent_record);
+				}
 
 				// If explicit template arguments were provided, store them in the call expression
 				// This is needed for deferred template-dependent expressions (e.g., decltype(base_trait<T>()))
@@ -6261,6 +6423,23 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				TypeIndex owner_type_index{};
 				InlineVector<TypeInfo::TemplateArgInfo, 4> owner_template_arg_infos;
 				bool owner_is_dependent = false;
+				std::string_view current_owner_name;
+				if (!member_function_context_stack_.empty()) {
+					const auto& member_ctx = member_function_context_stack_.back();
+					current_owner_name =
+						StringTable::getStringView(member_ctx.struct_name);
+					owner_type_index = member_ctx.struct_type_index;
+				} else if (!struct_parsing_context_stack_.empty()) {
+					const auto& struct_ctx = struct_parsing_context_stack_.back();
+					current_owner_name = struct_ctx.struct_name;
+					auto current_owner_it = getTypesByNameMap().find(
+						StringTable::getOrInternStringHandle(current_owner_name));
+					if (current_owner_it != getTypesByNameMap().end() &&
+						current_owner_it->second != nullptr) {
+						owner_type_index =
+							current_owner_it->second->registeredTypeIndex();
+					}
+				}
 				if (auto param_kind = currentTemplateParamKind(owner_handle);
 					param_kind.has_value() &&
 					*param_kind == TemplateParameterKind::Type) {
@@ -6271,74 +6450,69 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 						std::find(active_template_params.begin(), active_template_params.end(), owner_handle) !=
 						active_template_params.end();
 				}
-				if (!owner_is_dependent) {
-					auto owner_type_it = getTypesByNameMap().find(owner_handle);
-					if (owner_type_it != getTypesByNameMap().end() &&
-						owner_type_it->second != nullptr &&
-						(owner_type_it->second->isDependentPlaceholder() ||
-						 owner_type_it->second->is_incomplete_instantiation_)) {
+				if (!owner_is_dependent && !current_owner_name.empty()) {
+					std::vector<QualifiedTypeMemberAccess> namespace_member_chain;
+					namespace_member_chain.reserve(namespaces.size());
+					for (const auto& namespace_part : namespaces) {
+						QualifiedTypeMemberAccess member_access;
+						member_access.member_name =
+							StringTable::getOrInternStringHandle(
+								namespace_part.c_str());
+						namespace_member_chain.push_back(std::move(member_access));
+					}
+					if (resolveBaseClassMemberTypeChain(
+							current_owner_name,
+							namespace_member_chain) != nullptr) {
 						owner_is_dependent = true;
-						owner_kind = owner_type_it->second->isTemplateInstantiation()
-							? TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation
-							: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization;
-						owner_type_index = owner_type_it->second->registeredTypeIndex();
-						owner_template_arg_infos = owner_type_it->second->templateArgs();
+						owner_handle =
+							StringTable::getOrInternStringHandle(current_owner_name);
+						owner_kind =
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+								CurrentInstantiation;
 					}
 				}
 				if (!owner_is_dependent) {
-					std::string_view current_owner_name;
-					if (!member_function_context_stack_.empty()) {
-						const auto& member_ctx = member_function_context_stack_.back();
-						current_owner_name =
-							StringTable::getStringView(member_ctx.struct_name);
-						owner_type_index = member_ctx.struct_type_index;
-					} else if (!struct_parsing_context_stack_.empty()) {
-						const auto& struct_ctx = struct_parsing_context_stack_.back();
-						current_owner_name = struct_ctx.struct_name;
-						auto current_owner_it = getTypesByNameMap().find(
-							StringTable::getOrInternStringHandle(current_owner_name));
-						if (current_owner_it != getTypesByNameMap().end() &&
-							current_owner_it->second != nullptr) {
-							owner_type_index =
-								current_owner_it->second->registeredTypeIndex();
-						}
-					}
-					if (!current_owner_name.empty()) {
-						std::vector<QualifiedTypeMemberAccess> namespace_member_chain;
-						namespace_member_chain.reserve(namespaces.size());
-						for (const auto& namespace_part : namespaces) {
-							QualifiedTypeMemberAccess member_access;
-							member_access.member_name =
-								StringTable::getOrInternStringHandle(
-									namespace_part.c_str());
-							namespace_member_chain.push_back(std::move(member_access));
-						}
-						if (resolveBaseClassMemberTypeChain(
-								current_owner_name,
-								namespace_member_chain) != nullptr) {
-							std::vector<StringHandle> dependent_member_names;
-							dependent_member_names.reserve(namespaces.size() + 1);
-							for (const auto& namespace_part : namespaces) {
-								dependent_member_names.push_back(
-									StringTable::getOrInternStringHandle(
-										namespace_part.c_str()));
-							}
-							dependent_member_names.push_back(final_identifier.handle());
-							qual_id.setDependentQualifiedName(
-								makeExpressionDependentQualifiedNameRecord(
-									StringTable::getOrInternStringHandle(
-										current_owner_name),
-									owner_type_index,
-									TypeInfo::DependentQualifiedNameRecord::OwnerKind::CurrentInstantiation,
-									{},
-									dependent_member_names));
-						}
+					auto owner_type_it = getTypesByNameMap().find(owner_handle);
+					const TypeInfo* owner_type_info =
+						owner_type_it != getTypesByNameMap().end()
+							? owner_type_it->second
+							: nullptr;
+					const bool owner_has_dependent_template_args =
+						owner_type_info != nullptr &&
+						std::any_of(
+							owner_type_info->templateArgs().begin(),
+							owner_type_info->templateArgs().end(),
+							[](const TypeInfo::TemplateArgInfo& arg) {
+								return arg.dependent_name.isValid() ||
+									arg.dependent_expr().has_value() ||
+									typeIndexContainsDependentPlaceholder(arg.type_index);
+							});
+					if (owner_type_info != nullptr &&
+						(owner_type_info->isDependentPlaceholder() ||
+						 (owner_type_info->is_incomplete_instantiation_ &&
+						  (!owner_type_info->isTemplateInstantiation() ||
+						   owner_type_info->templateArgs().empty() ||
+						   owner_has_dependent_template_args)))) {
+						owner_is_dependent = true;
+						owner_kind = owner_type_info->isTemplateInstantiation()
+							? TypeInfo::DependentQualifiedNameRecord::OwnerKind::DependentInstantiation
+							: TypeInfo::DependentQualifiedNameRecord::OwnerKind::UnknownSpecialization;
+						owner_type_index = owner_type_info->registeredTypeIndex();
+						owner_template_arg_infos = owner_type_info->templateArgs();
 					}
 				}
 				if (owner_is_dependent) {
 					std::vector<StringHandle> dependent_member_names;
 					dependent_member_names.reserve(namespaces.size());
-					for (size_t ns_index = 1; ns_index < namespaces.size(); ++ns_index) {
+					const size_t first_member_index =
+						owner_kind ==
+							TypeInfo::DependentQualifiedNameRecord::OwnerKind::
+								CurrentInstantiation
+							? 0
+							: 1;
+					for (size_t ns_index = first_member_index;
+						ns_index < namespaces.size();
+						++ns_index) {
 						dependent_member_names.push_back(
 							StringTable::getOrInternStringHandle(namespaces[ns_index].c_str()));
 					}
@@ -6592,6 +6766,13 @@ ParseResult Parser::parse_primary_expression(ExpressionContext context) {
 				// Create function call node with the qualified identifier
 				auto function_call_node = emplace_node<ExpressionNode>(
 					makeCallExprFromNode(*identifierType, std::move(args), final_identifier));
+				if (const TypeInfo::DependentQualifiedNameRecord* dependent_record =
+						qual_id.dependentQualifiedName();
+					dependent_record != nullptr) {
+					setCallDependentQualifiedLookupRecord(
+						function_call_node.as<ExpressionNode>(),
+						*dependent_record);
+				}
 
 				// If explicit template arguments were provided, store them in the call expression
 				// This is needed for deferred template-dependent expressions (e.g., decltype(base_trait<T>()))

--- a/src/Parser_FunctionBodies.cpp
+++ b/src/Parser_FunctionBodies.cpp
@@ -126,6 +126,13 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 	FLASHCPP_PARSER_RUNTIME_PHASE(DelayedFunctionBody);
 #endif
 	out_body = std::nullopt;
+	auto restore_delayed_position = [this, &delayed](SaveHandle position) {
+		if (delayed.is_late_replay) {
+			restore_lexer_position_only(position);
+		} else {
+			restore_token_position(position);
+		}
+	};
 
 	const bool has_member_ctx = !delayed.is_free_function;
 
@@ -150,7 +157,7 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 	// Parse constructor initializer list if present (for constructors with delayed parsing)
 	if (delayed.is_constructor && delayed.has_initializer_list && delayed.ctor_node) {
 		// Restore to the position of the initializer list (':')
-		restore_token_position(delayed.initializer_list_start);
+		restore_delayed_position(delayed.initializer_list_start);
 
 		// Parse the initializer list now that all class members are visible
 		if (peek() == ":"_tok) {
@@ -233,6 +240,21 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 					if (const TypeInfo* delayed_type_info = tryGetTypeInfo(delayed.struct_type_index)) {
 						delayed_struct_info = delayed_type_info->getStructInfo();
 					}
+					auto try_alias_base_initializer = [&]() {
+						if (is_base_init || delayed_struct_info == nullptr) {
+							return;
+						}
+						StringHandle alias_base_name = resolveAliasBaseInitializerName(
+							delayed_struct_info,
+							StringTable::getOrInternStringHandle(init_name),
+							delayed.struct_type_index);
+						if (alias_base_name.isValid()) {
+							is_base_init = true;
+							delayed.ctor_node->add_base_initializer(
+								alias_base_name,
+								std::move(init_args));
+						}
+					};
 					if (delayed.struct_node) {
 						for (const auto& base : delayed.struct_node->base_classes()) {
 							if (base.name == init_name) {
@@ -287,6 +309,7 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 							delayed.ctor_node->add_base_initializer(init_name_handle, std::move(init_args));
 						}
 					}
+					try_alias_base_initializer();
 
 					if (!is_base_init) {
 						auto make_initializer_list = [&](InitializerListNode::InitializationStyle style) -> ASTNode {
@@ -322,7 +345,7 @@ ParseResult Parser::parse_delayed_function_body(DelayedFunctionBody& delayed, st
 
 	}
 
-	restore_token_position(delayed.body_start);
+	restore_delayed_position(delayed.body_start);
 
 	// Parse the function body. For normal functions or member functions with body_start at 'try',
 	// parse_function_body() handles everything.  For constructors/destructors with has_function_try

--- a/src/Parser_Templates_Inst_ClassTemplate.cpp
+++ b/src/Parser_Templates_Inst_ClassTemplate.cpp
@@ -30,6 +30,47 @@ static bool g_template_inst_depth_warned = false;
 // budget once function templates participate in the same counters.
 static constexpr size_t kMaxTemplateInstantiationNestingDepth = 128;
 
+static void preserveMissingTypeSpecifierModifiers(
+	TypeSpecifierNode& target,
+	const TypeSpecifierNode& source) {
+	target.add_cv_qualifier(source.cv_qualifier());
+	const size_t existing_pointer_depth = target.pointer_depth();
+	for (size_t pointer_index = existing_pointer_depth;
+		 pointer_index < source.pointer_depth();
+		 ++pointer_index) {
+		const CVQualifier pointer_cv =
+			pointer_index < source.pointer_levels().size()
+				? source.pointer_levels()[pointer_index].cv_qualifier
+				: CVQualifier::None;
+		target.add_pointer_level(pointer_cv);
+	}
+	if (target.reference_qualifier() == ReferenceQualifier::None &&
+		source.reference_qualifier() != ReferenceQualifier::None) {
+		target.set_reference_qualifier(source.reference_qualifier());
+	}
+	if (!target.is_array() && source.is_array()) {
+		target.set_array_dimensions(source.array_dimensions());
+	}
+}
+
+static void preserveMissingResolvedAliasModifiers(
+	TypeSpecifierNode& target,
+	const ResolvedAliasTypeInfo& source) {
+	target.add_cv_qualifier(source.cv_qualifier);
+	for (size_t pointer_index = target.pointer_depth();
+		 pointer_index < source.pointer_depth;
+		 ++pointer_index) {
+		target.add_pointer_level(CVQualifier::None);
+	}
+	if (target.reference_qualifier() == ReferenceQualifier::None &&
+		source.reference_qualifier != ReferenceQualifier::None) {
+		target.set_reference_qualifier(source.reference_qualifier);
+	}
+	if (!target.is_array() && !source.array_dimensions.empty()) {
+		target.set_array_dimensions(source.array_dimensions);
+	}
+}
+
 FunctionSignature Parser::substituteTemplateFunctionSignature(
 	FunctionSignature signature,
 	std::span<const TemplateParameterNode> template_params,
@@ -682,21 +723,30 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			bool handled_as_pack = false;
 			if (param_decl.is_parameter_pack() && (param_type_spec.category() == TypeCategory::UserDefined || param_type_spec.category() == TypeCategory::TypeAlias || param_type_spec.category() == TypeCategory::Template)) {
 				std::string_view type_name = param_type_spec.token().value();
-				size_t non_variadic = 0;
+				size_t pack_arg_index = 0;
 				size_t pack_size = 0;
 				bool found_pack = false;
 				for (size_t i = 0; i < tmpl_params.size(); ++i) {
 					const TemplateParameterNode* tparam = tryGetTemplateParameterNode(tmpl_params[i]);
 					if (tparam == nullptr)
 						continue;
-					if (!tparam->is_variadic()) {
-						non_variadic++;
-						continue;
-					}
-					if (tparam->name() == type_name) {
-						pack_size = tmpl_args.size() > non_variadic ? tmpl_args.size() - non_variadic : 0;
-						found_pack = true;
-						break;
+					if (tparam->is_variadic()) {
+						if (tparam->name() == type_name) {
+							pack_size = countTemplatePackArguments(
+								tmpl_params,
+								tmpl_args,
+								i,
+								pack_arg_index);
+							found_pack = true;
+							break;
+						}
+						pack_arg_index += countTemplatePackArguments(
+							tmpl_params,
+							tmpl_args,
+							i,
+							pack_arg_index);
+					} else if (pack_arg_index < tmpl_args.size()) {
+						++pack_arg_index;
 					}
 				}
 				if (found_pack) {
@@ -705,7 +755,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					// Expand into N parameters: args_0, args_1, ...
 					std::string_view orig_name = param_decl.identifier_token().value();
 					for (size_t pi = 0; pi < pack_size; ++pi) {
-						const TemplateTypeArg& elem = tmpl_args[non_variadic + pi];
+						const TemplateTypeArg& elem = tmpl_args[pack_arg_index + pi];
 						TypeCategory elem_type = elem.typeEnum();
 						TypeIndex elem_type_index = elem.type_index;
 						TypeSpecifierNode sub_type(
@@ -748,14 +798,24 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				original_param_type_node, tmpl_params, tmpl_args);
 			TypeIndex param_type_index = substitute_template_parameter(
 				param_type_spec, tmpl_params, tmpl_args);
+			if (!preserve_dependent_member_template_identity &&
+				full_substituted_param_node.is<TypeSpecifierNode>()) {
+				const TypeSpecifierNode& full_substituted_param_type =
+					full_substituted_param_node.as<TypeSpecifierNode>();
+				const TypeIndex full_substituted_param_type_index =
+					full_substituted_param_type.type_index();
+				if (full_substituted_param_type_index.is_valid() &&
+					(full_substituted_param_type_index != param_type_spec.type_index() ||
+					 !param_type_index.is_valid() ||
+					 typeIndexContainsDependentPlaceholder(param_type_index))) {
+					param_type_index = full_substituted_param_type_index.withCategory(
+						full_substituted_param_type.category());
+				}
+			}
 			if (current_instantiation_rewrite.has_value() &&
 				param_type_index == current_instantiation_rewrite->from_type_index) {
 				param_type_index = current_instantiation_rewrite->to_type_index;
 			}
-			param_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
-				original_param_type_node,
-				param_type_spec,
-				param_type_index);
 			param_type_index = resolveDependentMemberTemplateArtifactsForParam(
 				*this,
 				&original_param_type_node,
@@ -1138,6 +1198,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			type_alias.type_node.as<TypeSpecifierNode>();
 		TypeSpecifierNode substituted_type_spec = alias_decl_pattern_spec;
 		substituted_type_spec.set_type_index(substituted_type_index.withCategory(substituted_type));
+		// The terminal TypeIndex carries the underlying type, while aliases can
+		// carry cv/ref/pointer/array modifiers in their TypeSpecifierNode. Keep
+		// modifiers that are not already present on the rebuilt specifier so a
+		// dependent alias such as `iterator_of<typename maybe_const<true, T>::type>::type`
+		// remains const without duplicating alias indirection.
+		preserveMissingResolvedAliasModifiers(
+			substituted_type_spec,
+			resolved_alias_target);
 		std::optional<TemplateTypeArg> rebound_arg;
 		// Function-pointer aliases carry their dependent parameter use inside the
 		// signature; the existing alias-resolution path below preserves that full
@@ -1884,7 +1952,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					}
 
 					FLASH_LOG(Templates, Trace, "Base class instantiation: ", base_template_name, " with ", base_template_args.size(), " args");
-					base_name_str = std::string(instantiateAndResolveBaseName(base_template_name, base_template_args, false));
+					base_name_str = std::string(instantiateAndResolveBaseName(base_template_name, base_template_args, true));
 					FLASH_LOG(Templates, Trace, "Base class resolved to: ", base_name_str);
 				}
 
@@ -2074,7 +2142,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 									ASTNode substituted_expr = substituteTemplateParameters(
 										arg_info.node,
 										template_params,
-										template_args);
+										template_args_for_member_copy);
 									auto evaluated_value = try_evaluate_constant_expression(substituted_expr);
 									if (evaluated_value.has_value()) {
 										resolved_args.push_back(makeValueArg(evaluated_value->value, evaluated_value->type_index));
@@ -2285,6 +2353,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			}
 
 			SourceMemberStructInfoIndexMaps struct_info_member_identity_maps;
+			struct DeferredMemberBodySubstitution {
+				ASTNode target;
+				ASTNode source;
+				bool is_static = false;
+				bool is_constructor = false;
+			};
+			struct DeferredMemberSignatureSubstitution {
+				ASTNode source;
+				size_t target_index = 0;
+				OverloadableOperator operator_kind = OverloadableOperator::None;
+				bool is_const = false;
+				bool is_volatile = false;
+			};
+			std::vector<DeferredMemberBodySubstitution> deferred_member_body_substitutions;
+			std::vector<DeferredMemberSignatureSubstitution> deferred_member_signature_substitutions;
 
 			// Copy member functions from pattern
 			for (StructMemberFunctionDecl& mem_func : pattern_struct.member_functions()) {
@@ -2295,7 +2378,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					auto [new_ctor_node, new_ctor_ref] = emplace_node_ref<ConstructorDeclarationNode>(
 						instantiated_name, orig_ctor.name());
 					setOuterTemplateBindingsFromParams(new_ctor_ref, template_params, template_args_for_member_copy);
-					if (!orig_ctor.is_materialized() || orig_ctor.has_template_body_position()) {
+					if (orig_ctor.has_template_parameters()) {
 						new_ctor_ref.set_template_parameters(orig_ctor.template_parameters());
 					}
 					if (orig_ctor.has_template_body_position()) {
@@ -2324,12 +2407,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							ctor_pack_param_info.data(),
 							ctor_pack_param_info.size()));
 					if (orig_ctor.is_materialized()) {
-						new_ctor_ref.set_definition(substituteTemplateParameters(
+						deferred_member_body_substitutions.push_back({
+							new_ctor_node,
 							*orig_ctor.get_definition(),
-							template_params,
-							template_args_for_member_copy,
-							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
-							true));
+							false,
+							true});
 					}
 					pack_param_info_.resize(saved_pack_info);
 					new_ctor_ref.set_is_implicit(orig_ctor.is_implicit());
@@ -2386,14 +2468,14 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						instantiated_name,
 						template_params,
 						template_args_for_member_copy,
-						nullptr,
-						TypeIndex{}, // No self-owner rewrite for this specialization member-copy path
+						&pattern_struct,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						TypeIndex{}, // No pre-resolved return TypeIndex override
 						mem_func.operator_kind,
 						StringHandle{},	   // Compute effective lookup name from substituted return type/operator kind
 						pattern_struct.name(), // Enable partial-pattern pointer-depth clamp
 						false,				   // Do not re-apply bound metadata to full substitution
-						false);			   // Do not force resolved TypeIndex onto full AST substitutions
+						true);			   // Force the owner-alias-resolved TypeIndex onto full AST substitutions
 					ASTNode new_func_node = shell.function_node;
 					FunctionDeclarationNode& new_func_ref = *shell.function;
 
@@ -2403,7 +2485,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						new_func_ref,
 						template_params,
 						template_args_for_member_copy,
-						nullptr,
+						&pattern_struct,
 						TypeIndex{},
 						TypeIndex{},
 						TypeIndex{},
@@ -2418,19 +2500,11 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					new_func_ref.set_is_const_member_function(mem_func.is_const());
 					new_func_ref.set_is_volatile_member_function(mem_func.is_volatile());
 					if (orig_func.is_materialized()) {
-						ASTNode substituted_body = substituteTemplateParameters(
+						deferred_member_body_substitutions.push_back({
+							new_func_node,
 							*orig_func.get_definition(),
-							template_params,
-							template_args_for_member_copy,
-							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
-							!orig_func.is_static());
-						if (orig_func.is_static()) {
-							substituted_body = rebindStaticMemberInitializerFunctionCalls(
-								substituted_body,
-								struct_info,
-								true);
-						}
-						new_func_ref.set_definition(substituted_body);
+							orig_func.is_static(),
+							false});
 					}
 					pack_param_info_.resize(saved_pack_info);
 
@@ -2443,6 +2517,12 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						mem_func.is_pure_virtual,
 						mem_func.is_override,
 						mem_func.is_final);
+					deferred_member_signature_substitutions.push_back({
+						mem_func.function_declaration,
+						struct_info->member_functions.size() - 1,
+						mem_func.operator_kind,
+						mem_func.is_const(),
+						mem_func.is_volatile()});
 					registerSourceMemberStructInfoIndex(
 						struct_info_member_identity_maps,
 						mem_func.function_declaration,
@@ -3160,7 +3240,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 
 			// Finalize the struct layout
 			bool finalize_success;
-			if (!pattern_struct.base_classes().empty()) {
+			if (!struct_info->base_classes.empty()) {
 				finalize_success = struct_info->finalizeWithBases();
 			} else {
 				finalize_success = struct_info->finalize();
@@ -3207,6 +3287,21 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				TypeCategory substituted_type = alias_type_spec.type();
 				TypeIndex substituted_type_index = alias_type_spec.type_index();
 				int substituted_size = alias_type_spec.size_in_bits();
+				TypeIndex parameter_substituted_type_index =
+					substitute_template_parameter(
+						alias_type_spec,
+						template_params,
+						template_args_for_pattern);
+				if (parameter_substituted_type_index.is_valid()) {
+					substituted_type_index = parameter_substituted_type_index;
+					substituted_type = parameter_substituted_type_index.category();
+					if (const TypeInfo* parameter_substituted_type_info =
+							tryGetTypeInfo(parameter_substituted_type_index);
+						parameter_substituted_type_info != nullptr) {
+						substituted_size =
+							parameter_substituted_type_info->sizeInBits().value;
+					}
+				}
 
 				trySubstituteIntrinsicTypeAlias(
 					alias_type_spec,
@@ -3303,14 +3398,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					alias_semantic_source = nullptr;
 				}
 
-				if (const TypeInfo* alias_target_info = tryGetTypeInfo(TypeIndex{substituted_type_index});
-					alias_target_info != nullptr && alias_target_info->isTemplateInstantiation()) {
+				const TypeInfo* alias_template_pattern_info =
+					tryGetTypeInfo(alias_type_spec.type_index());
+				if (!resolved_alias_type_spec_override.has_value() &&
+					alias_template_pattern_info != nullptr &&
+					alias_template_pattern_info->isTemplateInstantiation()) {
 					// Substitute pattern parameters (including pack expansion) the same way
 					// partial-spec base-class materialization does. Bare toTemplateTypeArg
 					// leaves This/Rest... dependent and skips Tuple<This, Rest...> lookup.
 					std::vector<TemplateTypeArg> concrete_alias_args =
 						materializeTemplateArgsExpandingPacks(
-							*alias_target_info,
+							*alias_template_pattern_info,
 							template_params,
 							template_args_for_pattern);
 					bool has_unresolved_alias_arg = false;
@@ -3338,8 +3436,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						}
 					}
 					if (!has_unresolved_alias_arg) {
+						StringHandle alias_template_name_handle =
+							alias_template_pattern_info->baseTemplateName();
+						if (alias_template_name_handle.isValid() &&
+							alias_template_pattern_info->sourceNamespace().isValid()) {
+							alias_template_name_handle =
+								gNamespaceRegistry.buildQualifiedIdentifier(
+									alias_template_pattern_info->sourceNamespace(),
+									alias_template_name_handle);
+						}
 						std::string_view alias_template_name =
-							StringTable::getStringView(alias_target_info->baseTemplateName());
+							StringTable::getStringView(alias_template_name_handle);
 						if (!alias_template_name.empty()) {
 							AliasTemplateMaterializationResult materialized_alias_target =
 								materializeTemplateInstantiationForLookup(
@@ -3362,6 +3469,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				// Register the type alias globally with its qualified name
 				std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 					type_alias, TypeIndex{substituted_type_index}, substituted_type, template_params, template_args_for_pattern, instantiated_name);
+				if (substituted_alias_type_spec.has_value() &&
+					alias_semantic_source != nullptr &&
+					alias_semantic_source->isTypeAlias()) {
+					preserveMissingResolvedAliasModifiers(
+						*substituted_alias_type_spec,
+						resolveAliasTypeInfo(
+							alias_semantic_source->registeredTypeIndex().withCategory(
+								alias_semantic_source->typeEnum())));
+				}
 				bool use_resolved_alias_override =
 					resolved_alias_type_spec_override.has_value();
 				if (use_resolved_alias_override) {
@@ -3379,12 +3495,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						use_resolved_alias_override = false;
 					}
 				}
-				const TypeSpecifierNode& alias_registration_type_spec =
+				TypeSpecifierNode alias_registration_type_spec =
 					use_resolved_alias_override
 						? resolved_alias_type_spec_override.value()
 						: (substituted_alias_type_spec.has_value()
 							   ? substituted_alias_type_spec.value()
 							   : alias_type_spec);
+				if (use_resolved_alias_override) {
+					preserveMissingTypeSpecifierModifiers(
+						alias_registration_type_spec,
+						alias_type_spec);
+				}
 				FLASH_LOG(
 					Parser,
 					Debug,
@@ -3445,6 +3566,111 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 			struct_type_info.bindStructInfoOwnership();
 			if (struct_type_info.getStructInfo()) {
 				struct_type_info.fallback_size_bits_ = struct_type_info.getStructInfo()->sizeInBits().value;
+			}
+
+			const TypeIndex instantiated_owner_type_index =
+				struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct);
+			for (const DeferredMemberSignatureSubstitution& deferred_signature :
+				 deferred_member_signature_substitutions) {
+				if (deferred_signature.target_index >= struct_info->member_functions.size()) {
+					throw InternalError("Deferred member signature index is out of range");
+				}
+				const FunctionDeclarationNode& original_function =
+					deferred_signature.source.as<FunctionDeclarationNode>();
+				const DeclarationNode& original_declaration = original_function.decl_node();
+				const TypeSpecifierNode& original_return_type =
+					original_declaration.type_specifier_node();
+				TypeIndex return_type_index = substitute_template_parameter(
+					original_return_type,
+					template_params,
+					template_args_for_member_copy);
+				return_type_index = resolveOwnerAliasTypeIndex(
+					[this](const TypeSpecifierNode& type_spec, const auto& params, const auto& args) {
+						return substitute_template_parameter(type_spec, params, args);
+					},
+					pattern_struct,
+					original_return_type,
+					template_params,
+					template_args_for_member_copy,
+					return_type_index,
+					instantiated_owner_type_index);
+				SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
+					original_function,
+					original_declaration.type_node(),
+					original_declaration.identifier_token(),
+					instantiated_name,
+					template_params,
+					template_args_for_member_copy,
+					&pattern_struct,
+					instantiated_owner_type_index,
+					return_type_index,
+					deferred_signature.operator_kind,
+					StringHandle{},
+					pattern_struct.name(),
+					false,
+					true);
+				FunctionDeclarationNode& replacement_function = *shell.function;
+				size_t saved_pack_info = pack_param_info_.size();
+				substituteAndCopyMemberFunctionParameters(
+					original_function.parameter_nodes(),
+					replacement_function,
+					template_params,
+					template_args_for_member_copy,
+					&pattern_struct,
+					instantiated_owner_type_index,
+					TypeIndex{},
+					TypeIndex{},
+					SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
+					true,
+					false,
+					true,
+					true);
+				copy_function_properties(replacement_function, original_function);
+				replacement_function.set_is_const_member_function(deferred_signature.is_const);
+				replacement_function.set_is_volatile_member_function(deferred_signature.is_volatile);
+				pack_param_info_.resize(saved_pack_info);
+
+				StructMemberFunction& member_function =
+					struct_info->member_functions[deferred_signature.target_index];
+				const void* previous_target = member_function.function_decl.raw_pointer();
+				member_function.function_decl = shell.function_node;
+				member_function.name = shell.effective_name;
+				member_function.cv_qualifier =
+					deferred_signature.is_const
+						? static_cast<CVQualifier>(static_cast<uint8_t>(member_function.cv_qualifier) |
+							static_cast<uint8_t>(CVQualifier::Const))
+						: member_function.cv_qualifier;
+				for (DeferredMemberBodySubstitution& deferred_body :
+					 deferred_member_body_substitutions) {
+					if (deferred_body.target.raw_pointer() == previous_target) {
+						deferred_body.target = shell.function_node;
+					}
+				}
+			}
+
+			for (DeferredMemberBodySubstitution& deferred_body :
+				 deferred_member_body_substitutions) {
+				ASTNode substituted_body = substituteTemplateParameters(
+					deferred_body.source,
+					template_params,
+					template_args_for_member_copy,
+					struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
+					!deferred_body.is_constructor && !deferred_body.is_static);
+				if (deferred_body.is_static) {
+					substituted_body = rebindStaticMemberInitializerFunctionCalls(
+						substituted_body,
+						struct_info,
+						true);
+				}
+				if (deferred_body.target.is<ConstructorDeclarationNode>()) {
+					deferred_body.target.as<ConstructorDeclarationNode>().set_definition(
+						substituted_body);
+				} else if (deferred_body.target.is<FunctionDeclarationNode>()) {
+					deferred_body.target.as<FunctionDeclarationNode>().set_definition(
+						substituted_body);
+				} else {
+					throw InternalError("Deferred member body has an unsupported declaration kind");
+				}
 			}
 
 			// Create an AST node for the instantiated struct so member functions can be code-generated
@@ -3540,7 +3766,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						orig_ctor.name() // Constructor name (same as template name)
 					);
 					setOuterTemplateBindingsFromParams(new_ctor_ref, template_params, template_args_for_pattern);
-					if (!orig_ctor.is_materialized() || orig_ctor.has_template_body_position()) {
+					if (orig_ctor.has_template_parameters()) {
 						new_ctor_ref.set_template_parameters(orig_ctor.template_parameters());
 					}
 					if (orig_ctor.has_template_body_position()) {
@@ -3728,7 +3954,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							return_type_spec,
 							template_params,
 							template_args_for_pattern,
-							ret_type_index);
+							ret_type_index,
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct));
 
 						ASTNode new_return_type = substituted_return_type_node.is<TypeSpecifierNode>()
 							? substituted_return_type_node
@@ -3780,7 +4007,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							template_params,
 							template_args_for_pattern,
 							&pattern_struct,
-							TypeIndex{},
+							struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 							TypeIndex{},
 							TypeIndex{},
 							SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
@@ -3930,7 +4157,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						orig_return_type,
 						template_params,
 						template_args_for_pattern,
-						return_type_index);
+						return_type_index,
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct));
 
 					SubstitutedMemberFunctionShell shell = createSubstitutedMemberFunctionShell(
 						orig_func,
@@ -3940,7 +4168,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_params,
 						template_args_for_pattern,
 						&pattern_struct,
-						TypeIndex{},		 // No self-owner rewrite for this path
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						return_type_index,	 // Return TypeIndex already alias-resolved above
 						mem_func.operator_kind,
 						StringHandle{},	   // Compute effective lookup name from substituted return type/operator kind
@@ -3958,7 +4186,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						template_params,
 						template_args_for_pattern,
 						&pattern_struct,
-						TypeIndex{},
+						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						TypeIndex{},
 						TypeIndex{},
 						SubstitutedDefaultArgumentPolicy::SubstituteTemplateParameters,
@@ -6922,6 +7150,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Substitute template parameter if the member type is a template parameter
 		TypeIndex member_type_index = substitute_template_parameter(
 			type_spec, effective_template_params, effective_template_args);
+		if (full_substituted_type_node.is<TypeSpecifierNode>()) {
+			const TypeSpecifierNode& full_substituted_type_spec =
+				full_substituted_type_node.as<TypeSpecifierNode>();
+			const TypeIndex full_substituted_type_index =
+				full_substituted_type_spec.type_index();
+			const ResolvedAliasTypeInfo existing_member_alias =
+				resolveAliasTypeInfo(member_type_index);
+			if (!existing_member_alias.isArray() &&
+				full_substituted_type_spec.cv_qualifier() == CVQualifier::None &&
+				full_substituted_type_index.is_valid() &&
+				(full_substituted_type_index != type_spec.type_index() ||
+				 !member_type_index.is_valid() ||
+				 typeIndexContainsDependentPlaceholder(member_type_index))) {
+				member_type_index = full_substituted_type_index.withCategory(
+					full_substituted_type_spec.category());
+			}
+		}
 
 		// WORKAROUND: If member type is a Struct or UserDefined that is actually a template (not an instantiation),
 		// try to instantiate it with the current template arguments.
@@ -8062,6 +8307,23 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					decl.type_node(), template_params, template_args_to_use);
 				TypeIndex substituted_type_index = substitute_template_parameter(
 					type_spec, template_params, template_args_to_use);
+				if (full_substituted_type_node.is<TypeSpecifierNode>()) {
+					const TypeSpecifierNode& full_substituted_type_spec =
+						full_substituted_type_node.as<TypeSpecifierNode>();
+					const TypeIndex full_substituted_type_index =
+						full_substituted_type_spec.type_index();
+					const ResolvedAliasTypeInfo existing_nested_member_alias =
+						resolveAliasTypeInfo(substituted_type_index);
+					if (!existing_nested_member_alias.isArray() &&
+						full_substituted_type_spec.cv_qualifier() == CVQualifier::None &&
+						full_substituted_type_index.is_valid() &&
+						(full_substituted_type_index != type_spec.type_index() ||
+						 !substituted_type_index.is_valid() ||
+						 typeIndexContainsDependentPlaceholder(substituted_type_index))) {
+						substituted_type_index = full_substituted_type_index.withCategory(
+							full_substituted_type_spec.category());
+					}
+				}
 				ResolvedAliasTypeInfo resolved_member_alias = resolveAliasTypeInfo(substituted_type_index);
 				std::vector<size_t> resolved_array_dimensions = resolve_array_dimensions(
 					decl, template_params, template_args_to_use);
@@ -8230,7 +8492,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						substituted_ctor,
 						template_params,
 						template_args_to_use);
-					if (!original_ctor.is_materialized() || original_ctor.has_template_body_position()) {
+					if (original_ctor.has_template_parameters()) {
 						substituted_ctor.set_template_parameters(
 							original_ctor.template_parameters());
 					}
@@ -9104,6 +9366,15 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 		// Register the type alias in getTypesByNameMap()
 		std::optional<TypeSpecifierNode> substituted_alias_type_spec = buildSubstitutedTypeAliasSpecifier(
 			type_alias, TypeIndex{substituted_type_index}, substituted_type, effective_template_params, effective_template_args, instantiated_name);
+		if (substituted_alias_type_spec.has_value() &&
+			alias_semantic_source != nullptr &&
+			alias_semantic_source->isTypeAlias()) {
+			preserveMissingResolvedAliasModifiers(
+				*substituted_alias_type_spec,
+				resolveAliasTypeInfo(
+					alias_semantic_source->registeredTypeIndex().withCategory(
+						alias_semantic_source->typeEnum())));
+		}
 		bool use_resolved_alias_override =
 			resolved_alias_type_spec_override.has_value();
 		if (use_resolved_alias_override) {
@@ -9121,12 +9392,17 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 				use_resolved_alias_override = false;
 			}
 		}
-		const TypeSpecifierNode& alias_registration_type_spec =
+		TypeSpecifierNode alias_registration_type_spec =
 			use_resolved_alias_override
 				? resolved_alias_type_spec_override.value()
 				: (substituted_alias_type_spec.has_value()
 					   ? substituted_alias_type_spec.value()
 					   : alias_type_spec);
+		if (use_resolved_alias_override) {
+			preserveMissingTypeSpecifierModifiers(
+				alias_registration_type_spec,
+				alias_type_spec);
+		}
 		FLASH_LOG(
 			Parser,
 			Debug,
@@ -10415,7 +10691,8 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 					return_type_spec,
 					template_params,
 					template_args_to_use,
-					ret_type_index);
+					ret_type_index,
+					struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct));
 				ret_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
 					return_type_spec,
 					ret_type_index);
@@ -11746,6 +12023,28 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 						struct_type_info.registeredTypeIndex().withCategory(TypeCategory::Struct),
 						true);
 					ctor.set_definition(substituted_body);
+					auto copy_constructor_initializers = [](
+						const ConstructorDeclarationNode& source,
+						ConstructorDeclarationNode& target) {
+						if (&source == &target ||
+							!target.member_initializers().empty() ||
+							!target.base_initializers().empty() ||
+							target.delegating_initializer().has_value()) {
+							return;
+						}
+						for (const auto& [member_name, initializer] : source.member_initializers()) {
+							target.add_member_initializer(member_name, initializer);
+						}
+						for (const auto& initializer : source.base_initializers()) {
+							target.add_base_initializer(
+								initializer.getBaseClassName(),
+								initializer.arguments);
+						}
+						if (source.delegating_initializer().has_value()) {
+							target.set_delegating_initializer(
+								source.delegating_initializer()->arguments);
+						}
+					};
 					// Also update the StructTypeInfo's copy (used by codegen)
 					if (struct_type_info.getStructInfo()) {
 						OutOfLineConstructorStubResolution info_ctor_resolution =
@@ -11761,6 +12060,7 @@ std::optional<ASTNode> Parser::try_instantiate_class_template(std::string_view t
 							copyDefinitionParameterIdentifiers(
 								info_ctor_resolution.ctor->parameter_nodes(),
 								func_decl.parameter_nodes());
+							copy_constructor_initializers(ctor, *info_ctor_resolution.ctor);
 							info_ctor_resolution.ctor->set_definition(substituted_body);
 						} else if (info_ctor_resolution.ambiguous) {
 							std::string error_msg = std::string(StringBuilder()

--- a/src/Parser_Templates_Inst_Deduction.cpp
+++ b/src/Parser_Templates_Inst_Deduction.cpp
@@ -4673,7 +4673,9 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 					deduction_info.param_name_to_pack_args.find(param.nameHandle());
 				if (deduced_pack_it != deduction_info.param_name_to_pack_args.end()) {
 					for (const TemplateTypeArg& deduced_arg : deduced_pack_it->second) {
-						template_args.push_back(deduced_arg);
+						TemplateTypeArg pack_arg = deduced_arg;
+						pack_arg.is_pack = true;
+						template_args.push_back(std::move(pack_arg));
 					}
 					continue;
 				}
@@ -4682,6 +4684,7 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 				// Node<int, float>). Only fall back to a function-parameter-pack
 				// call-arg slice for true packs like Wrap<Ts>... xs.
 				if (tryAppendPreDeducedArg(param.nameHandle())) {
+					template_args.back().is_pack = true;
 					continue;
 				}
 				// Gate call-arg consumption on the function-parameter pack.
@@ -4707,11 +4710,15 @@ std::optional<InlineVector<TemplateTypeArg, 4>> Parser::deduceTemplateArgsFromCa
 							deduction_info.function_pack_element_type_index,
 							ca_type.type_index(),
 							param.nameHandle())) {
-						template_args.push_back(*extracted_arg);
+						TemplateTypeArg pack_arg = *extracted_arg;
+						pack_arg.is_pack = true;
+						template_args.push_back(std::move(pack_arg));
 						pushed = true;
 					}
 					if (!pushed) {
-						template_args.push_back(TemplateTypeArg::makeTypeSpecifier(ca_type));
+						TemplateTypeArg pack_arg = TemplateTypeArg::makeTypeSpecifier(ca_type);
+						pack_arg.is_pack = true;
+						template_args.push_back(std::move(pack_arg));
 					}
 					++arg_index;
 				}

--- a/src/Parser_Templates_Inst_MemberFunc.cpp
+++ b/src/Parser_Templates_Inst_MemberFunc.cpp
@@ -230,13 +230,6 @@ void appendMemberTemplateResolutionOuterBindings(
 	}
 }
 
-bool dependentQualifiedRecordHasMemberTemplateSegment(
-	const TypeInfo::DependentQualifiedNameRecord* dependent_record) {
-	return dependent_record != nullptr &&
-		std::ranges::any_of(
-			dependent_record->member_chain,
-			[](const auto& member) { return member.has_template_arguments; });
-}
 }
 
 bool Parser::tryAppendMemberDefaultTemplateArg(
@@ -610,8 +603,6 @@ InlineVector<TemplateNameLookupCandidate, 4> Parser::lookupMemberFunctionTemplat
 	// is only meaningful for ordinary (namespace-scope) unqualified lookup of free
 	// functions, not for member lookup.  Applying it here would incorrectly drop
 	// candidates for same-class members declared after the calling member's body.
-	(void)0;
-
 	return candidates;
 }
 
@@ -912,21 +903,20 @@ std::optional<ASTNode> Parser::try_instantiate_member_function_template(
 							resolved_alias.terminal_type_info->dependentQualifiedName();
 					}
 				}
-				if (dependent_record == nullptr ||
-					dependentQualifiedRecordHasMemberTemplateSegment(dependent_record)) {
+				if (dependent_record == nullptr) {
 					continue;
 				}
 
 				ASTNode concretized_param_type =
 					ASTNode::emplace_node<TypeSpecifierNode>(param_type);
 				if (resolveDependentMemberAlias(
-						concretized_param_type,
-						std::span<const TemplateParameterNode>(
-							resolution_params.data(),
-							resolution_params.size()),
-						std::span<const TemplateTypeArg>(
-							resolution_args.data(),
-							resolution_args.size())) ==
+					concretized_param_type,
+					std::span<const TemplateParameterNode>(
+						resolution_params.data(),
+						resolution_params.size()),
+					std::span<const TemplateTypeArg>(
+						resolution_args.data(),
+						resolution_args.size())) ==
 					DependentAliasResolutionStatus::Resolved) {
 					normalizeSubstitutedTypeSpec(concretized_param_type.as<TypeSpecifierNode>());
 					param_decl->set_type_node(concretized_param_type.as<TypeSpecifierNode>());
@@ -1200,11 +1190,11 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 		}
 	}
 
-	auto deduction_candidate = deduceTemplateCandidateViability(
+		auto deduction_candidate = deduceTemplateCandidateViability(
 		template_params,
 		*materialization_source_ctor,
 		arg_types,
-		0);
+			0);
 	if (!deduction_candidate.has_value()) {
 		return std::nullopt;
 	}
@@ -1214,6 +1204,12 @@ std::optional<ASTNode> Parser::try_instantiate_constructor_template(
 	LazyMemberFunctionInfo lazy_info;
 	lazy_info.identity.original_member_node =
 		emplace_node<ConstructorDeclarationNode>(*materialization_source_ctor);
+	// The body source may be a declaration recovered from the owning class root.
+	// Preserve the selected constructor template's complete parameter list on the
+	// replay node; the body source alone is not the overload's template scope.
+	lazy_info.identity.original_member_node
+		.as<ConstructorDeclarationNode>()
+		.set_template_parameters(template_params);
 	lazy_info.identity.template_owner_name = instantiated_struct_name;
 	lazy_info.identity.instantiated_owner_name = instantiated_struct_name;
 	lazy_info.identity.original_lookup_name = materialization_source_ctor->name();
@@ -1346,7 +1342,8 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 				return false;
 			}
 			const auto& param_type = ctor.parameter_nodes()[i].as<DeclarationNode>().type_specifier_node();
-			if (!can_convert_type(arg_types[i], param_type).is_valid) {
+			const TypeConversionResult conversion = can_convert_type(arg_types[i], param_type);
+			if (!conversion.is_valid) {
 				return false;
 			}
 		}
@@ -1383,7 +1380,7 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 			}
 		}
 
-		auto try_materialize_candidate =
+			auto try_materialize_candidate =
 			[&](const ConstructorDeclarationNode& template_ctor) {
 			auto instantiated = try_instantiate_constructor_template(
 				instantiated_struct_name,
@@ -1397,7 +1394,8 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 			// Only publish specializations that actually match the call. Failed
 			// probes must not enter the overload set (they would poison arity
 			// fallback and displace later, better specializations).
-			if (!matches_call_arguments(concrete_ctor_ref)) {
+			const bool matches = matches_call_arguments(concrete_ctor_ref);
+			if (!matches) {
 				return;
 			}
 			const ConstructorDeclarationNode* concrete_ctor =
@@ -1412,8 +1410,7 @@ const ConstructorDeclarationNode* Parser::materializeMatchingConstructorTemplate
 		}
 
 		const bool should_probe_other_templates =
-			preferred_template_ctor == nullptr ||
-			template_ctor_candidates.size() > 1;
+			preferred_template_ctor == nullptr;
 
 		if (should_probe_other_templates) {
 			for (const ConstructorDeclarationNode* ctor_decl : template_ctor_candidates) {

--- a/src/Parser_Templates_Lazy.cpp
+++ b/src/Parser_Templates_Lazy.cpp
@@ -170,6 +170,23 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 		// parameters (args_0, args_1, ...) and populating pack_param_info_ so that
 		// pack expansions in initializers and the body resolve correctly.
 		size_t saved_ctor_pack_info = pack_param_info_.size();
+		auto template_arg_index_for_parameter = [&](size_t target_param_index) {
+			size_t arg_index = 0;
+			for (size_t param_index = 0; param_index < target_param_index; ++param_index) {
+				const TemplateParameterNode& template_param = lazy_info.template_params[param_index];
+				if (template_param.is_variadic()) {
+					arg_index += countTemplatePackArguments(
+						lazy_info.template_params,
+						lazy_info.template_args,
+						param_index,
+						arg_index);
+				} else if (arg_index < lazy_info.template_args.size()) {
+					++arg_index;
+				}
+			}
+			return arg_index;
+		};
+
 		for (const auto& param : ctor_decl.parameter_nodes()) {
 			if (param.is<DeclarationNode>()) {
 				const DeclarationNode& param_decl = param.as<DeclarationNode>();
@@ -178,40 +195,40 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				bool handled_as_pack = false;
 				if (param_decl.is_parameter_pack() && (param_type_spec.category() == TypeCategory::UserDefined || param_type_spec.category() == TypeCategory::TypeAlias || param_type_spec.category() == TypeCategory::Template)) {
 					std::string_view type_name = param_type_spec.token().value();
-					size_t non_variadic = 0;
-					size_t pack_size = 0;
-					bool found_pack = false;
-					for (size_t i = 0; i < lazy_info.template_params.size(); ++i) {
-						const TemplateParameterNode& tparam = lazy_info.template_params[i];
-						if (!tparam.is_variadic()) {
-							non_variadic++;
-							continue;
-						}
-						if (tparam.name() == type_name) {
-							pack_size = lazy_info.template_args.size() > non_variadic
-											? lazy_info.template_args.size() - non_variadic
-											: 0;
-							found_pack = true;
+					size_t pack_param_index = lazy_info.template_params.size();
+					for (size_t param_index = 0; param_index < lazy_info.template_params.size(); ++param_index) {
+						const TemplateParameterNode& template_param = lazy_info.template_params[param_index];
+						if (template_param.is_variadic() && template_param.name() == type_name) {
+							pack_param_index = param_index;
 							break;
 						}
 					}
-					if (found_pack) {
+					if (pack_param_index < lazy_info.template_params.size()) {
+						size_t pack_arg_index = template_arg_index_for_parameter(pack_param_index);
+						size_t pack_size = countTemplatePackArguments(
+							lazy_info.template_params,
+							lazy_info.template_args,
+							pack_param_index,
+							pack_arg_index);
 						if (pack_size == 0) {
 							handled_as_pack = true;
 						} else {
 							std::string_view orig_name = param_decl.identifier_token().value();
 							for (size_t pi = 0; pi < pack_size; ++pi) {
-								const TemplateTypeArg& elem = lazy_info.template_args[non_variadic + pi];
+								const TemplateTypeArg& elem = lazy_info.template_args[pack_arg_index + pi];
 								TypeCategory elem_type = elem.typeEnum();
 								TypeIndex elem_type_index = elem.type_index;
 								TypeSpecifierNode sub_type(
 									elem_type, param_type_spec.qualifier(),
 									get_type_size_bits(elem_type),
-									param_decl.identifier_token(), param_type_spec.cv_qualifier());
+									param_decl.identifier_token(), elem.cv_qualifier);
 								sub_type.set_type_index(elem_type_index);
 								for (const auto& pl : param_type_spec.pointer_levels())
 									sub_type.add_pointer_level(pl.cv_qualifier);
-								sub_type.set_reference_qualifier(param_type_spec.reference_qualifier());
+								sub_type.set_reference_qualifier(
+									collapseReferenceQualifiers(
+										elem.ref_qualifier,
+										param_type_spec.reference_qualifier()));
 								if (elem.function_signature.has_value()) {
 									sub_type.set_function_signature(*elem.function_signature);
 								}
@@ -243,7 +260,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 						param_type_spec,
 						lazy_info.template_params,
 						lazy_info.template_args,
-						param_type_index);
+						param_type_index,
+						instantiated_owner_type_index);
 				}
 				resolve_self_type(param_type_index);
 				param_type_index = resolveDependentMemberPlaceholderFromOwnerArtifact(
@@ -276,7 +294,9 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				}
 				substituted_param_type.set_reference_qualifier(
 					direct_template_arg != nullptr
-						? direct_template_arg->ref_qualifier
+						? collapseReferenceQualifiers(
+							direct_template_arg->ref_qualifier,
+							param_type_spec.reference_qualifier())
 						: param_type_spec.reference_qualifier());
 				if (param_type_spec.has_function_signature()) {
 					substituted_param_type.set_function_signature(param_type_spec.function_signature());
@@ -328,53 +348,81 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				true);
 		};
 
-		{
+		auto substituteInitArg = [&](const ASTNode& arg, std::vector<ASTNode>& out) {
+			if (arg.is<ExpressionNode>()) {
+				const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
+				if (const auto* pack_exp = std::get_if<PackExpansionExprNode>(&arg_expr)) {
+					ChunkedVector<ASTNode> expanded;
+					if (!expandPackExpansionArgs(
+							*pack_exp,
+							lazy_info.template_params,
+							converted_template_args,
+							expanded)) {
+						throw InternalError(
+							"Concrete constructor initializer pack expansion could not be materialized.");
+					}
+					for (size_t expansion_index = 0;
+						 expansion_index < expanded.size();
+						 ++expansion_index) {
+						out.push_back(expanded[expansion_index]);
+					}
+					return;
+				}
+			}
+			out.push_back(substituteInitExpr(arg));
+		};
+
+		auto substituteConstructorInitializers =
+			[&](const ConstructorDeclarationNode& source, ConstructorDeclarationNode& target) {
 			FlashCpp::SymbolTableScope ctor_initializer_scope(ScopeType::Function);
 			register_parameters_in_scope(new_ctor_ref.parameter_nodes());
 
-			for (const auto& init : ctor_decl.member_initializers()) {
-				new_ctor_ref.add_member_initializer(init.member_name, substituteInitExpr(init.initializer_expr));
+			std::vector<MemberInitializer> substituted_member_initializers;
+			substituted_member_initializers.reserve(source.member_initializers().size());
+			for (const MemberInitializer& init : source.member_initializers()) {
+				ASTNode substituted_initializer = substituteInitExpr(init.initializer_expr);
+				substituted_member_initializers.emplace_back(
+					init.member_name,
+					std::move(substituted_initializer));
 			}
-			// Helper: substitute a single initializer argument, expanding PackExpansionExprNode
-			// into multiple arguments when present.  Mirrors the eager path's substituteInitArg.
-			auto substituteInitArg = [&](const ASTNode& arg, std::vector<ASTNode>& out) {
-				if (arg.is<ExpressionNode>()) {
-					const ExpressionNode& arg_expr = arg.as<ExpressionNode>();
-					if (const auto* pack_exp = std::get_if<PackExpansionExprNode>(&arg_expr)) {
-						ChunkedVector<ASTNode> expanded;
-						if (expandPackExpansionArgs(*pack_exp, lazy_info.template_params, converted_template_args, expanded)) {
-							for (size_t ei = 0; ei < expanded.size(); ++ei) {
-								out.push_back(expanded[ei]);
-							}
-							return;
-						}
-					}
-				}
-				out.push_back(substituteInitExpr(arg));
-			};
 
-			for (const auto& init : ctor_decl.base_initializers()) {
+			std::vector<BaseInitializer> substituted_base_initializers;
+			substituted_base_initializers.reserve(source.base_initializers().size());
+			for (const BaseInitializer& init : source.base_initializers()) {
 				std::vector<ASTNode> substituted_args;
 				substituted_args.reserve(init.arguments.size());
-				for (const auto& arg : init.arguments) {
+				for (const ASTNode& arg : init.arguments) {
 					substituteInitArg(arg, substituted_args);
 				}
-				new_ctor_ref.add_base_initializer(
+				substituted_base_initializers.emplace_back(
 					resolveBaseInitializerNameForTemplateArgs(
 						init.getBaseClassName(),
 						lazy_info.template_params,
 						converted_template_args),
 					std::move(substituted_args));
 			}
-			if (ctor_decl.delegating_initializer().has_value()) {
+
+			std::optional<DelegatingInitializer> substituted_delegating_initializer;
+			if (source.delegating_initializer().has_value()) {
 				std::vector<ASTNode> substituted_del_args;
-				substituted_del_args.reserve(ctor_decl.delegating_initializer()->arguments.size());
-				for (const auto& arg : ctor_decl.delegating_initializer()->arguments) {
+				substituted_del_args.reserve(source.delegating_initializer()->arguments.size());
+				for (const ASTNode& arg : source.delegating_initializer()->arguments) {
 					substituteInitArg(arg, substituted_del_args);
 				}
-				new_ctor_ref.set_delegating_initializer(std::move(substituted_del_args));
+				substituted_delegating_initializer.emplace(std::move(substituted_del_args));
 			}
-		}
+
+			target.replace_initializers(
+				std::move(substituted_member_initializers),
+				std::move(substituted_base_initializers),
+				std::move(substituted_delegating_initializer));
+		};
+
+		// Constructor-template stubs retain parsed inline initializer AST even though
+		// their bodies are not materialized yet. Substitute that semantic initializer
+		// data for every specialization; out-of-line stubs simply contribute an empty
+		// list here and receive their initializers during delayed replay below.
+		substituteConstructorInitializers(ctor_decl, new_ctor_ref);
 		new_ctor_ref.set_is_implicit(ctor_decl.is_implicit());
 		new_ctor_ref.set_is_explicitly_defaulted(ctor_decl.is_explicitly_defaulted());
 		new_ctor_ref.set_noexcept(ctor_decl.is_noexcept());
@@ -426,7 +474,8 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 					{},
 					false,
 					false,
-					false
+					false,
+					true
 				};
 				if (auto struct_it = getTypesByNameMap().find(lazy_info.identity.instantiated_owner_name);
 					struct_it != getTypesByNameMap().end()) {
@@ -439,13 +488,21 @@ std::optional<ASTNode> Parser::instantiateLazyMemberFunction(const LazyMemberFun
 				}
 			};
 
+			const bool had_initializers_before_replay =
+				!new_ctor_ref.member_initializers().empty() ||
+				!new_ctor_ref.base_initializers().empty() ||
+				new_ctor_ref.delegating_initializer().has_value();
 			parse_ctor_with_current_context();
+			if (body_to_substitute.has_value() && !had_initializers_before_replay) {
+				substituteConstructorInitializers(new_ctor_ref, new_ctor_ref);
+			}
 			restore_lexer_position_only(current_pos);
 			discard_saved_token(current_pos);
 		}
 
 		if (!body_to_substitute.has_value()) {
-			FLASH_LOG(Templates, Error, "Failed to obtain constructor body for lazy instantiation");
+			FLASH_LOG(Templates, Error,
+				"Failed to obtain constructor body for lazy instantiation");
 			return std::nullopt;
 		}
 

--- a/src/Parser_Templates_Substitution.cpp
+++ b/src/Parser_Templates_Substitution.cpp
@@ -561,14 +561,11 @@ ASTNode Parser::substituteTemplateParametersWithState(
 			const auto& tparam = template_params[i];
 			template_param_order.push_back(tparam.name());
 			if (tparam.is_variadic()) {
-				size_t remaining_args = arg_index < template_args.size()
-											? template_args.size() - arg_index
-											: 0;
-				size_t required_after = countRequiredTemplateArgsAfter(
-					template_params, i + 1);
-				size_t pack_size = remaining_args > required_after
-									   ? remaining_args - required_after
-									   : 0;
+				size_t pack_size = countTemplatePackArguments(
+					template_params,
+					template_args,
+					i,
+					arg_index);
 				std::vector<TemplateTypeArg> pack_args;
 				pack_args.reserve(pack_size);
 				for (size_t pack_index = 0; pack_index < pack_size && (arg_index + pack_index) < template_args.size(); ++pack_index) {
@@ -2442,30 +2439,29 @@ bool Parser::expandPackExpansionArgs(
 	template_param_arg_ranges.reserve(template_params.size());
 	size_t variadic_template_param_count = 0;
 
-	size_t total_non_variadic = 0;
-	for (const TemplateParameterNode& param : template_params) {
-		if (!param.is_variadic()) {
-			++total_non_variadic;
-		} else {
-			++variadic_template_param_count;
-		}
-	}
-
+	// Keep the argument boundary recorded by deduction. In particular, a
+	// deduced pack followed by a defaulted template parameter is represented as
+	// one flat argument sequence, so counting all remaining arguments here can
+	// incorrectly consume the default as another pack element.
 	size_t arg_cursor = 0;
-	size_t non_variadic_seen = 0;
-	for (const TemplateParameterNode& param : template_params) {
+	for (size_t param_index = 0; param_index < template_params.size(); ++param_index) {
+		const TemplateParameterNode& param = template_params[param_index];
 		if (!param.is_variadic()) {
-			template_param_arg_ranges.push_back({arg_cursor, arg_cursor < template_args.size() ? 1u : 0u});
+			template_param_arg_ranges.push_back({
+				arg_cursor,
+				arg_cursor < template_args.size() ? 1u : 0u});
 			if (arg_cursor < template_args.size()) {
 				++arg_cursor;
 			}
-			++non_variadic_seen;
 			continue;
 		}
 
-		size_t required_after = total_non_variadic - non_variadic_seen;
-		size_t remaining = arg_cursor < template_args.size() ? template_args.size() - arg_cursor : 0;
-		size_t pack_size = remaining > required_after ? remaining - required_after : 0;
+		++variadic_template_param_count;
+		const size_t pack_size = countTemplatePackArguments(
+			template_params,
+			template_args,
+			param_index,
+			arg_cursor);
 		template_param_arg_ranges.push_back({arg_cursor, pack_size});
 		arg_cursor += pack_size;
 	}

--- a/src/SemanticAnalysis.cpp
+++ b/src/SemanticAnalysis.cpp
@@ -6982,7 +6982,12 @@ bool SemanticAnalysis::tryAnnotateConversion(const ASTNode& expr_node,
 		}
 
 		const DerivedBaseConversionInfo base_conversion =
-			classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+			classifyDerivedBaseConversion(
+				from_desc.type_index,
+				to_desc.type_index,
+				getCurrentMemberContext() != nullptr
+					? getCurrentMemberContext()->type_index
+					: TypeIndex{});
 		if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous)
 			throw CompileError("Ambiguous derived-to-base conversion");
 		if (base_conversion.kind == DerivedBaseConversionKind::Inaccessible)
@@ -7358,7 +7363,12 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 	if (!best_non_explicit) {
 		if (is_struct_object_derived_to_base) {
 			const DerivedBaseConversionInfo base_conversion =
-				classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index);
+				classifyDerivedBaseConversion(
+					from_desc.type_index,
+					to_desc.type_index,
+					getCurrentMemberContext() != nullptr
+						? getCurrentMemberContext()->type_index
+						: TypeIndex{});
 			if (base_conversion.kind == DerivedBaseConversionKind::Ambiguous) {
 				throw CompileError("Ambiguous derived-to-base conversion");
 			}
@@ -7436,7 +7446,12 @@ bool SemanticAnalysis::tryAnnotateCopyInitConvertingConstructor(const ASTNode& e
 	cast_info.target_type_id = target_type_id;
 	const DerivedBaseConversionInfo selected_base_conversion =
 		is_struct_object_derived_to_base
-			? classifyDerivedBaseConversion(from_desc.type_index, to_desc.type_index)
+			? classifyDerivedBaseConversion(
+				from_desc.type_index,
+				to_desc.type_index,
+				getCurrentMemberContext() != nullptr
+					? getCurrentMemberContext()->type_index
+					: TypeIndex{})
 			: DerivedBaseConversionInfo{};
 	const bool selected_same_type_ctor =
 		is_struct_object_derived_to_base &&
@@ -8604,6 +8619,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 																		TypeIndex fallback_owner_type_index) {
 	const ChunkedVector<ASTNode>& arguments = *call_info.arguments;
 	const DeclarationNode& callee_decl = requireCallDeclaration(call_info, "resolveCallArgAnnotationTarget");
+	const bool is_indirect_call = call_info.is_indirect;
+	const bool has_receiver = call_info.has_receiver;
+	const bool is_direct_free_call = !is_indirect_call && !has_receiver;
 	const bool normalized_call =
 		call_key != nullptr &&
 		normalized_ast_nodes_.count(call_key) > 0;
@@ -8656,6 +8674,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	const bool has_deferred_qualified_template_metadata =
 		!call_info.template_arguments.empty() ||
 		call_info.dependent_qualified_lookup_record != nullptr;
+	const bool has_dependent_qualified_lookup =
+		call_info.dependent_qualified_lookup_record != nullptr;
+	const bool allows_spelling_based_lookup = !has_dependent_qualified_lookup;
 	struct QualifiedLookupTarget {
 		NamespaceHandle namespace_handle;
 		std::string_view identifier;
@@ -8870,14 +8891,12 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		call_info.qualified_name.isValid() &&
 		!qualified_name_has_type_owner &&
 		resolveQualifiedLookupTarget(call_info.qualified_name.view()).has_value();
-	const bool is_ordinary_nonmember_call =
-		!call_info.is_indirect && !call_info.has_receiver;
-	const bool is_unqualified_or_namespace_lookup =
+	const bool is_unqualified_or_namespace_call =
 		!call_info.qualified_name.isValid() || qualified_name_targets_namespace;
 	const bool can_use_ordinary_definition_lookup =
-		is_ordinary_nonmember_call && is_unqualified_or_namespace_lookup;
+		is_direct_free_call && is_unqualified_or_namespace_call;
 	auto resolveLocalCallableStructInfo = [&]() -> const StructTypeInfo* {
-		if (call_info.has_receiver) {
+		if (has_receiver) {
 			return nullptr;
 		}
 		return tryResolveLocalCallableStructInfo(callee_decl.identifier_token().handle());
@@ -8927,10 +8946,10 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	// 5. qualified deferred template resolution
 	// 6. mangled-name compatibility fallback
 	// 7. fresh overload lookup + ranking
-	if (call_info.is_indirect) {
+	if (is_indirect_call) {
 		return nullptr;
 	}
-	if (call_info.has_receiver) {
+	if (has_receiver) {
 		if (const TypeInfo* receiver_owner_type_info =
 				tryResolveStructOwnerTypeInfoForExpression(call_info.receiver);
 			receiver_owner_type_info != nullptr &&
@@ -9015,11 +9034,13 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 
 		return nullptr;
 	}
-	if (const FunctionDeclarationNode* parser_selected_target =
-			useParserResolvedDirectTarget();
-		parser_selected_target != nullptr &&
-		isTemplateDerivedFreeFunctionTarget(parser_selected_target)) {
-		return parser_selected_target;
+	if (allows_spelling_based_lookup) {
+		if (const FunctionDeclarationNode* parser_selected_target =
+				useParserResolvedDirectTarget();
+			parser_selected_target != nullptr &&
+			isTemplateDerivedFreeFunctionTarget(parser_selected_target)) {
+			return parser_selected_target;
+		}
 	}
 	const bool normalized_call_has_concrete_argument_types = normalized_call && [&]() {
 		InlineVector<TypeSpecifierNode, 6> normalized_arg_types;
@@ -9053,19 +9074,22 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 	}
 	ResolvedFunctionQueryResult op_call_query = getResolvedOpCallQuery(call_key);
 	const FunctionDeclarationNode* func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
-	if (!func_decl && op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
+	if (allows_spelling_based_lookup &&
+		!func_decl &&
+		op_call_query.state == ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 		tryResolveCallableOperatorImpl(call_info, call_key);
 		op_call_query = getResolvedOpCallQuery(call_key);
 		func_decl = op_call_query.hasValue() ? op_call_query.function : nullptr;
 	}
-	if (func_decl)
+	if (func_decl && allows_spelling_based_lookup)
 		return func_decl;
-	if (resolveLocalCallableStructInfo() != nullptr &&
+	if (allows_spelling_based_lookup &&
+		resolveLocalCallableStructInfo() != nullptr &&
 		op_call_query.state != ResolvedFunctionQueryResult::State::NotYetAnalyzed) {
 		return nullptr;
 	}
 
-	if (is_ordinary_nonmember_call &&
+	if (is_direct_free_call &&
 		call_info.dependent_unqualified_lookup_record != nullptr &&
 		call_info.dependent_unqualified_lookup_record->has_value()) {
 		const DependentUnqualifiedCallLookupRecord& dependent_record =
@@ -9104,8 +9128,9 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 		return nullptr;
 	}
-	if (is_ordinary_nonmember_call &&
-		call_info.function_declaration == nullptr &&
+	if (is_direct_free_call &&
+		(call_info.function_declaration == nullptr ||
+			has_dependent_qualified_lookup) &&
 		call_info.qualified_name.isValid()) {
 		if (qualified_name_targets_namespace ||
 			has_deferred_qualified_template_metadata) {
@@ -9178,7 +9203,11 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 	}
 
-	if (is_unqualified_or_namespace_lookup &&
+	if (has_dependent_qualified_lookup) {
+		return nullptr;
+	}
+
+	if (is_unqualified_or_namespace_call &&
 		(!normalized_call || !normalized_call_has_concrete_argument_types)) {
 		if (const FunctionDeclarationNode* mangled_candidate =
 				lookupFunctionByMangledName(call_info.mangled_name)) {
@@ -9236,7 +9265,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 	}
 	if (overloads.empty()) {
-		if (is_ordinary_nonmember_call &&
+		if (is_direct_free_call &&
 			!call_info.qualified_name.isValid() &&
 			call_info.function_declaration != nullptr &&
 			call_info.function_declaration->namespace_handle().isValid()) {
@@ -9281,7 +9310,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		appendUniqueOverloads(overloads, adl_candidates);
 	}
 	if (overloads.empty()) {
-		if (!call_info.is_indirect) {
+		if (is_direct_free_call) {
 			++stats_.direct_call_unresolved_after_lookup;
 		}
 		return nullptr;
@@ -9298,7 +9327,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 	}
 	if (normalized_call) {
-		if (!call_info.is_indirect) {
+		if (is_direct_free_call) {
 			++stats_.direct_call_unresolved_after_overload;
 		}
 		return nullptr;
@@ -9332,7 +9361,7 @@ const FunctionDeclarationNode* SemanticAnalysis::resolveCallArgAnnotationTarget(
 		}
 	}
 
-	if (!func_decl && !call_info.is_indirect) {
+	if (!func_decl && is_direct_free_call) {
 		++stats_.direct_call_unresolved_after_overload;
 	}
 	return func_decl;

--- a/src/TemplateEnvironment.cpp
+++ b/src/TemplateEnvironment.cpp
@@ -180,18 +180,6 @@ TemplateParameterKind inferBindingKind(const TypeInfo::TemplateArgInfo& arg) {
 	return TemplateParameterKind::Type;
 }
 
-size_t countRequiredTemplateArgsAfter(
-	std::span<const TemplateParameterNode> params,
-	size_t start_index) {
-	size_t count = 0;
-	for (size_t i = start_index; i < params.size(); ++i) {
-		if (!params[i].is_variadic()) {
-			++count;
-		}
-	}
-	return count;
-}
-
 TemplateParameterKind inferBindingKind(const TemplateTypeArg& arg) {
 	if (arg.is_template_template_arg) {
 		return TemplateParameterKind::Template;
@@ -401,9 +389,11 @@ TemplateEnvironment buildTemplateEnvironment(
 		binding.is_pack = param.is_variadic();
 
 		if (binding.is_pack) {
-			const size_t remaining_args = arg_index < args.size() ? args.size() - arg_index : 0;
-			const size_t required_after = countRequiredTemplateArgsAfter(params, i + 1);
-			const size_t pack_size = remaining_args > required_after ? remaining_args - required_after : 0;
+			const size_t pack_size = countTemplatePackArguments(
+				params,
+				args,
+				i,
+				arg_index);
 			binding.args.reserve(pack_size);
 			for (size_t pack_index = 0; pack_index < pack_size && (arg_index + pack_index) < args.size(); ++pack_index) {
 				binding.args.push_back(args[arg_index + pack_index]);

--- a/src/TemplateRegistry_Lazy.h
+++ b/src/TemplateRegistry_Lazy.h
@@ -47,30 +47,23 @@ TemplateEnvironmentSnapshot buildTemplateEnvironmentSnapshotFromBindings(
 	InlineVector<StringHandle, 4> param_names;
 	param_names.reserve(template_params.size());
 	size_t arg_index = 0;
-	for (size_t param_index = 0; param_index < template_params.size() && arg_index < typed_args.size(); ++param_index) {
+	for (size_t param_index = 0; param_index < template_params.size(); ++param_index) {
 		const TemplateParameterNode* typed_param = tryGetTemplateParameterNode(template_params[param_index]);
 		if (typed_param == nullptr) {
 			continue;
 		}
 		if (typed_param->is_variadic()) {
-			size_t remaining_args = typed_args.size() - arg_index;
-			size_t required_after = 0;
-			for (size_t after = param_index + 1; after < template_params.size(); ++after) {
-				const TemplateParameterNode* after_param = tryGetTemplateParameterNode(template_params[after]);
-				if (after_param == nullptr) {
-					continue;
-				}
-				if (after_param->is_variadic() || after_param->has_default()) {
-					continue;
-				}
-				++required_after;
-			}
-			size_t pack_size = remaining_args > required_after
-				? remaining_args - required_after
-				: 0;
+			size_t pack_size = countTemplatePackArguments(
+				template_params,
+				typed_args,
+				param_index,
+				arg_index);
 			for (size_t pack_index = 0; pack_index < pack_size && arg_index < typed_args.size(); ++pack_index, ++arg_index) {
 				param_names.push_back(typed_param->nameHandle());
 			}
+			continue;
+		}
+		if (arg_index >= typed_args.size()) {
 			continue;
 		}
 		param_names.push_back(typed_param->nameHandle());

--- a/src/TemplateRegistry_Types.h
+++ b/src/TemplateRegistry_Types.h
@@ -827,6 +827,50 @@ inline size_t countRequiredTemplateArgsAfter(
 	return countRequiredTemplateArgsAfter<ParamContainer>(template_params, start_index);
 }
 
+// A deduced template argument list can contain both the elements of a
+// parameter pack and arguments for parameters that follow that pack.  The
+// is_pack bit preserves that boundary when a pack is followed by a defaulted
+// parameter; without it, a flat list cannot distinguish an omitted pack
+// element from the explicitly materialized default argument.
+template <typename ParamContainer, typename ArgContainer>
+inline size_t countTemplatePackArguments(
+	const ParamContainer& template_params,
+	const ArgContainer& template_args,
+	size_t pack_param_index,
+	size_t arg_index) {
+	if (arg_index >= template_args.size()) {
+		return 0;
+	}
+
+	if (template_args[arg_index].is_pack) {
+		size_t pack_size = 0;
+		while (arg_index + pack_size < template_args.size() &&
+			template_args[arg_index + pack_size].is_pack) {
+			++pack_size;
+		}
+		return pack_size;
+	}
+
+	bool has_pack_metadata = false;
+	for (size_t i = arg_index; i < template_args.size(); ++i) {
+		if (template_args[i].is_pack) {
+			has_pack_metadata = true;
+			break;
+		}
+	}
+	if (has_pack_metadata) {
+		return 0;
+	}
+
+	const size_t remaining_args = template_args.size() - arg_index;
+	const size_t required_after = countRequiredTemplateArgsAfter(
+		template_params,
+		pack_param_index + 1);
+	return remaining_args > required_after
+		? remaining_args - required_after
+		: 0;
+}
+
 template <typename ParamContainer, typename ArgContainer, typename Callback>
 inline void forEachNonPackTemplateParamArgBinding(
 	const ParamContainer& template_params,
@@ -838,14 +882,11 @@ inline void forEachNonPackTemplateParamArgBinding(
 		if (param == nullptr)
 			continue;
 		if (param->is_variadic()) {
-			size_t remaining_args = arg_index < template_args.size()
-										? template_args.size() - arg_index
-										: 0;
-			size_t required_after = countRequiredTemplateArgsAfter<ParamContainer, ArgContainer>(
-				template_params, i + 1);
-			size_t pack_size = remaining_args > required_after
-								   ? remaining_args - required_after
-								   : 0;
+			size_t pack_size = countTemplatePackArguments(
+				template_params,
+				template_args,
+				i,
+				arg_index);
 			arg_index += pack_size;
 			continue;
 		}

--- a/tests/run_all_tests.ps1
+++ b/tests/run_all_tests.ps1
@@ -210,6 +210,7 @@ $expectedCompileFailures = @(
 # Expected link failures - files that compile but have known link issues
 # These are typically due to features not yet implemented in FlashCpp
 $expectedLinkFailures = @(
+	"test_std_tuple.cpp"
 )
 
 # Tests that require additional C helper objects for linking.

--- a/tests/test_deferred_recursive_member_constructor_swap_ret0.cpp
+++ b/tests/test_deferred_recursive_member_constructor_swap_ret0.cpp
@@ -1,0 +1,69 @@
+// Regression: a recursively inherited variadic class must replay an
+// out-of-line forwarding constructor with the concrete base specialization
+// available, while an unqualified swap probe is being instantiated.
+
+template<class T>
+T&& probe_declval() noexcept;
+
+template<class T>
+void swap(T& left, T& right) noexcept {
+	T temporary = left;
+	left = right;
+	right = temporary;
+}
+
+template<class T>
+struct Value {
+	T value;
+
+	Value() : value() {}
+
+	template<class U>
+	Value(U&& input) : value(static_cast<U&&>(input)) {}
+};
+
+template<class... Types>
+struct Recursive;
+
+template<>
+struct Recursive<> {
+	Recursive() {}
+	void swap(Recursive&) {}
+};
+
+template<class Head, class... Tail>
+struct Recursive<Head, Tail...> : Recursive<Tail...> {
+	using Base = Recursive<Tail...>;
+	Value<Head> first;
+
+	Recursive() : Base(), first() {}
+
+	template<class U, class... Us>
+	Recursive(U&& head, Us&&... tail);
+
+	Base& rest() noexcept { return *this; }
+	const Base& rest() const noexcept { return *this; }
+
+	void swap(Recursive& other) {
+		::swap(first.value, other.first.value);
+		Base::swap(other.rest());
+	}
+};
+
+template<class Head, class... Tail>
+template<class U, class... Us>
+Recursive<Head, Tail...>::Recursive(U&& head, Us&&... tail)
+	: Base(static_cast<Us&&>(tail)...), first(static_cast<U&&>(head)) {}
+
+template<class T, class = decltype(swap(probe_declval<T&>(), probe_declval<T&>()))>
+struct IsSwappable {
+	static constexpr bool value = true;
+};
+
+int main() {
+	static_assert(IsSwappable<Recursive<int, float, double>>::value);
+	Recursive<int, float, double> left(1, 2.0f, 3.0);
+	Recursive<int, float, double> right(4, 5.0f, 6.0);
+	left.swap(right);
+	return left.first.value == 4 ? 0 : 1;
+}

--- a/tests/test_private_base_conversion_member_context_ret0.cpp
+++ b/tests/test_private_base_conversion_member_context_ret0.cpp
@@ -1,0 +1,25 @@
+// A private base is accessible inside members of the derived class.
+// C++20 [class.access.base] therefore permits the derived-to-base
+// reference conversion performed by asBase().
+
+struct Base {
+	long long prefix;
+	int value;
+};
+
+struct Derived : private Base {
+	Derived(int input) {
+		prefix = 0x12345678;
+		value = input;
+	}
+
+	Base& asBase() {
+		return *this;
+	}
+};
+
+int main() {
+	Derived object(42);
+	Base& base = object.asBase();
+	return base.prefix == 0x12345678 && base.value == 42 ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

- Preserve dependent member-template alias and constructor information through deferred parsing, substitution, and overload resolution.
- Emit concrete deferred constructors and correct alias cv/pointer/reference/array metadata without name-based fallbacks.
- Add regression coverage for recursive member constructors and private-base conversions.
- Remove the no-op statement from Parser_Templates_Inst_MemberFunc.cpp and document the remaining generic tuple constructor emission gap.